### PR TITLE
Move `statusBarColor` from function injection to value injection

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelComponent.kt
@@ -7,9 +7,11 @@ import com.stripe.android.customersheet.CustomerSheetIntegration
 import com.stripe.android.customersheet.CustomerSheetViewModel
 import com.stripe.android.googlepaylauncher.injection.GooglePayLauncherModule
 import com.stripe.android.paymentelement.confirmation.ConfirmationModule
+import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import dagger.BindsInstance
 import dagger.Component
+import javax.inject.Named
 
 @CustomerSheetViewModelScope
 @Component(
@@ -33,7 +35,7 @@ internal interface CustomerSheetViewModelComponent {
         fun configuration(configuration: CustomerSheet.Configuration): Builder
 
         @BindsInstance
-        fun statusBarColor(statusBarColor: Int?): Builder
+        fun statusBarColor(@Named(STATUS_BAR_COLOR) statusBarColor: Int?): Builder
 
         @BindsInstance
         fun integrationType(integrationType: CustomerSheetIntegration.Type): Builder

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
@@ -23,7 +23,6 @@ import com.stripe.android.customersheet.DefaultCustomerSheetLoader
 import com.stripe.android.customersheet.analytics.CustomerSheetEventReporter
 import com.stripe.android.customersheet.analytics.DefaultCustomerSheetEventReporter
 import com.stripe.android.paymentelement.confirmation.ALLOWS_MANUAL_CONFIRMATION
-import com.stripe.android.paymentelement.confirmation.STATUS_BAR_COLOR_PROVIDER
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.analytics.RealErrorReporter
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
@@ -101,10 +100,6 @@ internal interface CustomerSheetViewModelModule {
         fun isLiveMode(
             paymentConfiguration: Provider<PaymentConfiguration>
         ): () -> Boolean = { paymentConfiguration.get().publishableKey.startsWith("pk_live") }
-
-        @Provides
-        @Named(STATUS_BAR_COLOR_PROVIDER)
-        fun providesStatusBarColor(statusBarColor: Int?): () -> Int? = { statusBarColor }
 
         @Provides
         fun providesUserFacingLogger(): UserFacingLogger? = null

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationConstants.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationConstants.kt
@@ -4,8 +4,3 @@ package com.stripe.android.paymentelement.confirmation
  * Whether the integration allows for manual confirmation
  */
 internal const val ALLOWS_MANUAL_CONFIRMATION = "ALLOWS_MANUAL_CONFIRMATION"
-
-/**
- * Color of the status bar on the user's device
- */
-internal const val STATUS_BAR_COLOR_PROVIDER = "STATUS_BAR_COLOR_PROVIDER"

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandler.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentelement.confirmation
 
 import android.os.Parcelable
 import androidx.activity.result.ActivityResultCaller
+import androidx.annotation.ColorInt
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.SavedStateHandle
@@ -17,6 +18,7 @@ import com.stripe.android.paymentelement.confirmation.gpay.GooglePayConfirmation
 import com.stripe.android.paymentelement.confirmation.intent.IntentConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.intent.IntentConfirmationInterceptor
 import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncherAssistedFactory
 import com.stripe.android.paymentsheet.ExternalPaymentMethodInterceptor
 import com.stripe.android.paymentsheet.R
@@ -259,7 +261,7 @@ internal class DefaultConfirmationHandler(
         private val stripePaymentLauncherAssistedFactory: StripePaymentLauncherAssistedFactory,
         private val googlePayPaymentMethodLauncherFactory: GooglePayPaymentMethodLauncherFactory?,
         private val savedStateHandle: SavedStateHandle,
-        @Named(STATUS_BAR_COLOR_PROVIDER) private val statusBarColor: () -> Int?,
+        @Named(STATUS_BAR_COLOR) @ColorInt private val statusBarColor: Int?,
         private val errorReporter: ErrorReporter,
         private val logger: UserFacingLogger?
     ) : ConfirmationHandler.Factory {
@@ -273,7 +275,7 @@ internal class DefaultConfirmationHandler(
                                 publishableKey = { paymentConfigurationProvider.get().publishableKey },
                                 stripeAccountId = { paymentConfigurationProvider.get().stripeAccountId },
                                 hostActivityLauncher = hostActivityLauncher,
-                                statusBarColor = statusBarColor(),
+                                statusBarColor = statusBarColor,
                                 includePaymentSheetNextHandlers = true,
                             )
                         },

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -123,7 +123,7 @@ internal class DefaultFlowController @Inject internal constructor(
     private val confirmationHandler = DefaultConfirmationHandler.Factory(
         intentConfirmationInterceptor = intentConfirmationInterceptor,
         paymentConfigurationProvider = lazyPaymentConfiguration,
-        statusBarColor = { null },
+        statusBarColor = statusBarColor(),
         savedStateHandle = viewModel.handle,
         bacsMandateConfirmationLauncherFactory = bacsMandateConfirmationLauncherFactory,
         stripePaymentLauncherAssistedFactory = paymentLauncherFactory,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
@@ -2,7 +2,7 @@ package com.stripe.android.paymentsheet.injection
 
 import android.content.Context
 import com.stripe.android.core.injection.IOContext
-import com.stripe.android.paymentelement.confirmation.STATUS_BAR_COLOR_PROVIDER
+import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.PaymentSheetContractV2
 import com.stripe.android.paymentsheet.PrefsRepository
@@ -20,9 +20,9 @@ internal class PaymentSheetViewModelModule(private val starterArgs: PaymentSheet
     }
 
     @Provides
-    @Named(STATUS_BAR_COLOR_PROVIDER)
-    fun providesStatusBarColor(): () -> Int? {
-        return { starterArgs.statusBarColor }
+    @Named(STATUS_BAR_COLOR)
+    fun providesStatusBarColor(): Int? {
+        return starterArgs.statusBarColor
     }
 
     @Provides

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -145,7 +145,7 @@ internal object CustomerSheetTestHelper {
                         cardBrandFilter: CardBrandFilter
                     ): GooglePayPaymentMethodLauncher = mock()
                 },
-                statusBarColor = { null },
+                statusBarColor = null,
                 savedStateHandle = SavedStateHandle(),
                 errorReporter = FakeErrorReporter(),
                 logger = FakeUserFacingLogger(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationActivity.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationActivity.kt
@@ -26,6 +26,7 @@ import com.stripe.android.networking.StripeApiRepository
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
+import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.utils.FakeUserFacingLogger
 import com.stripe.android.testing.FakeAnalyticsRequestExecutor
 import com.stripe.android.testing.FakeErrorReporter
@@ -65,7 +66,7 @@ internal class ConfirmationActivity : AppCompatActivity() {
                 val component = DaggerConfirmationTestComponent.builder()
                     .application(extras.requireApplication())
                     .allowsManualConfirmation(allowsManualConfirmation = false)
-                    .statusBarColor { null }
+                    .statusBarColor(null)
                     .savedStateHandle(extras.createSavedStateHandle())
                     .build()
 
@@ -96,7 +97,7 @@ internal interface ConfirmationTestComponent {
         fun savedStateHandle(savedStateHandle: SavedStateHandle): Builder
 
         @BindsInstance
-        fun statusBarColor(@Named(STATUS_BAR_COLOR_PROVIDER) statusBarColor: () -> Int?): Builder
+        fun statusBarColor(@Named(STATUS_BAR_COLOR) statusBarColor: Int?): Builder
 
         @BindsInstance
         fun allowsManualConfirmation(@Named(ALLOWS_MANUAL_CONFIRMATION) allowsManualConfirmation: Boolean): Builder

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -1158,7 +1158,7 @@ internal class PaymentSheetActivityTest {
                     bacsMandateConfirmationLauncherFactory = { FakeBacsMandateConfirmationLauncher() },
                     googlePayPaymentMethodLauncherFactory = googlePayPaymentMethodLauncherFactory,
                     paymentConfigurationProvider = { PaymentConfiguration(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY) },
-                    statusBarColor = { args.statusBarColor },
+                    statusBarColor = args.statusBarColor,
                     errorReporter = FakeErrorReporter(),
                     logger = FakeUserFacingLogger(),
                 ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -3102,7 +3102,7 @@ internal class PaymentSheetViewModelTest {
                     stripePaymentLauncherAssistedFactory = paymentLauncherFactory,
                     googlePayPaymentMethodLauncherFactory = googlePayLauncherFactory,
                     paymentConfigurationProvider = { paymentConfiguration },
-                    statusBarColor = { args.statusBarColor },
+                    statusBarColor = args.statusBarColor,
                     errorReporter = FakeErrorReporter(),
                     logger = FakeUserFacingLogger(),
                 ),


### PR DESCRIPTION
# Summary
Move `statusBarColor` from function injection to value injection.

# Motivation
We don't really fetch the `statusBarColor` from the activity but rather from the immutable arguments passed to the view model. We should just make this value passed directly rather than maintain as a function argument.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified