### PR TITLE
Avoid force casting state on onRestoreInstanceState of StripeEditText - Fix #8742

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/view/StripeEditText.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/StripeEditText.kt
@@ -252,10 +252,12 @@ open class StripeEditText @JvmOverloads constructor(
     }
 
     override fun onRestoreInstanceState(state: Parcelable?) {
-        (state as StripeEditTextState).let {
-            super.onRestoreInstanceState(it.superState)
-            errorMessage = it.errorMessage
-            shouldShowError = it.shouldShowError
+        if (state is StripeEditTextState) {
+            super.onRestoreInstanceState(state.superState)
+            errorMessage = state.errorMessage
+            shouldShowError = state.shouldShowError
+        } else {
+            super.onRestoreInstanceState(state)
         }
     }
 


### PR DESCRIPTION
# Summary & Motivation
<!-- Simple summary of what was changed. -->
As reported in https://github.com/stripe/stripe-android/issues/8742, when changing from light/dark mode, we noticed a crash because the restored state was not of type `StripeEditTextState`.

![image](https://github.com/user-attachments/assets/dd7203b5-cb24-4ac4-93cd-e5d4ad21ee57)

So, I'm checking if the state is `StripeEditTextState`, otherwise I'll delegate to `super`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

I've tested the change in our app and it's not crashing anymore


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
[Fixed] Avoid force casting state on onRestoreInstanceState of StripeEditText
