### PR TITLE
Avoid force casting state on onRestoreInstanceState - Fix #8742

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/view/StripeEditText.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/StripeEditText.kt
@@ -252,10 +252,12 @@ open class StripeEditText @JvmOverloads constructor(
     }
 
     override fun onRestoreInstanceState(state: Parcelable?) {
-        (state as StripeEditTextState).let {
-            super.onRestoreInstanceState(it.superState)
-            errorMessage = it.errorMessage
-            shouldShowError = it.shouldShowError
+        if (state is StripeEditTextState) {
+            super.onRestoreInstanceState(state.superState)
+            errorMessage = state.errorMessage
+            shouldShowError = state.shouldShowError
+        } else {
+            super.onRestoreInstanceState(state)
         }
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
#9736
