### PR TITLE
[MOBILESDK-1770] Adding ephemeralKey validity check

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
@@ -719,7 +719,7 @@ internal class FlowControllerTest {
                     merchantDisplayName = "Merchant, Inc.",
                     customer = PaymentSheet.CustomerConfiguration(
                         id = "cus_1",
-                        ephemeralKeySecret = "123",
+                        ephemeralKeySecret = "ek_123",
                     ),
                     paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
                 ),
@@ -785,7 +785,7 @@ internal class FlowControllerTest {
                     .customer(
                         PaymentSheet.CustomerConfiguration(
                             id = "cus_1",
-                            ephemeralKeySecret = "123",
+                            ephemeralKeySecret = "ek_123",
                         )
                     )
                     .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Vertical)

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/LinkTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/LinkTest.kt
@@ -166,7 +166,7 @@ internal class LinkTest {
                     merchantDisplayName = "Merchant, Inc.",
                     customer = PaymentSheet.CustomerConfiguration(
                         id = "cus_1",
-                        ephemeralKeySecret = "123"
+                        ephemeralKeySecret = "ek_123"
                     ),
                     paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
                 )
@@ -447,7 +447,7 @@ internal class LinkTest {
                     merchantDisplayName = "Merchant, Inc.",
                     customer = PaymentSheet.CustomerConfiguration(
                         id = "cus_1",
-                        ephemeralKeySecret = "123"
+                        ephemeralKeySecret = "ek_123"
                     ),
                     paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
                 )

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
@@ -346,7 +346,7 @@ internal class PaymentSheetTest {
                     merchantDisplayName = "Merchant, Inc.",
                     customer = PaymentSheet.CustomerConfiguration(
                         id = "cus_1",
-                        ephemeralKeySecret = "123",
+                        ephemeralKeySecret = "ek_123",
                     ),
                     paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
                 ),

--- a/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
@@ -34,7 +34,7 @@ internal data class CommonConfiguration(
         }
     }
 
-    // These exception messages are not localized as they are not intended to be displayed to a user."
+    // These exception messages are not localized as they are not intended to be displayed to a user.
     @Suppress("ThrowsCount")
     private fun customerAndMerchantValidate() {
         when {
@@ -64,7 +64,7 @@ internal data class CommonConfiguration(
         }
     }
 
-    // These exception messages are not localized as they are not intended to be displayed to a user."
+    // These exception messages are not localized as they are not intended to be displayed to a user.
     @Suppress("ThrowsCount")
     private fun customerSessionValidate(customerAccessType: PaymentSheet.CustomerAccessType.CustomerSession) {
         val result = CustomerSessionClientSecretValidator
@@ -93,7 +93,7 @@ internal data class CommonConfiguration(
         }
     }
 
-    // These exception messages are not localized as they are not intended to be displayed to a user."
+    // These exception messages are not localized as they are not intended to be displayed to a user.
     @Suppress("ThrowsCount")
     private fun legacyCustomerEphemeralKeyValidate(
         customerAccessType: PaymentSheet.CustomerAccessType.LegacyCustomerEphemeralKey

--- a/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
@@ -90,7 +90,8 @@ internal data class CommonConfiguration(
     ) {
         if (customerAccessType.ephemeralKeySecret != customer?.ephemeralKeySecret) {
             throw IllegalArgumentException(
-                "Conflicting ephemeralKeySecrets between CustomerConfiguration and CustomerConfiguration.customerAccessType"
+                "Conflicting ephemeralKeySecrets between CustomerConfiguration " +
+                    "and CustomerConfiguration.customerAccessType"
             )
         } else if (customerAccessType.ephemeralKeySecret.isBlank() || customer.ephemeralKeySecret.isBlank()) {
             throw IllegalArgumentException(

--- a/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
@@ -10,6 +10,7 @@ import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import kotlinx.parcelize.Parcelize
 
 const val isEKClientSecretValidRegexPattern = "^ek_[^_](.)+$"
+
 @Parcelize
 internal data class CommonConfiguration(
     val merchantDisplayName: String,

--- a/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
@@ -9,6 +9,7 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import kotlinx.parcelize.Parcelize
 
+const val isEKClientSecretValidRegexPattern = "^ek_[^_](.)+$"
 @Parcelize
 internal data class CommonConfiguration(
     val merchantDisplayName: String,
@@ -25,11 +26,6 @@ internal data class CommonConfiguration(
     val externalPaymentMethods: List<String>,
     val cardBrandAcceptance: PaymentSheet.CardBrandAcceptance,
 ) : Parcelable {
-    private val isEKClientSecretValidRegexPattern = "^ek_[^_](.)+$"
-    private fun String.isEKClientSecretValid(): Boolean {
-        return Regex(isEKClientSecretValidRegexPattern).matches(this)
-    }
-
     fun validate() {
         // These are not localized as they are not intended to be displayed to a user.
         when {
@@ -90,6 +86,10 @@ internal data class CommonConfiguration(
             }
         }
     }
+}
+
+internal fun String.isEKClientSecretValid(): Boolean {
+    return Regex(isEKClientSecretValidRegexPattern).matches(this)
 }
 
 internal fun PaymentSheet.Configuration.asCommonConfiguration(): CommonConfiguration = CommonConfiguration(

--- a/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.common.model
 
 import android.os.Parcelable
+import android.util.Log
 import com.stripe.android.common.validation.CustomerSessionClientSecretValidator
 import com.stripe.android.model.CardBrand
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
@@ -25,6 +26,11 @@ internal data class CommonConfiguration(
     val externalPaymentMethods: List<String>,
     val cardBrandAcceptance: PaymentSheet.CardBrandAcceptance,
 ) : Parcelable {
+    private val isEKClientSecretValidRegexPattern = "^ek_[^_](.)+$"
+    private fun String.isEKClientSecretValid(): Boolean {
+        return Regex(isEKClientSecretValidRegexPattern).matches(this)
+    }
+
     fun validate() {
         // These are not localized as they are not intended to be displayed to a user.
         when {
@@ -49,6 +55,10 @@ internal data class CommonConfiguration(
                         throw IllegalArgumentException(
                             "When a CustomerConfiguration is passed to PaymentSheet, " +
                                 "the ephemeralKeySecret cannot be an empty string."
+                        )
+                    } else if (customerAccessType.ephemeralKeySecret.isEKClientSecretValid().not() || customer.ephemeralKeySecret.isEKClientSecretValid().not()) {
+                        throw IllegalArgumentException(
+                            "`ephemeralKeySecret` format does not match expected client secret formatting"
                         )
                     }
                 }

--- a/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
@@ -90,7 +90,7 @@ internal data class CommonConfiguration(
     ) {
         if (customerAccessType.ephemeralKeySecret != customer?.ephemeralKeySecret) {
             throw IllegalArgumentException(
-                "Conflicting ephemeralKeySecrets"
+                "Conflicting ephemeralKeySecrets between CustomerConfiguration and CustomerConfiguration.customerAccessType"
             )
         } else if (customerAccessType.ephemeralKeySecret.isBlank() || customer.ephemeralKeySecret.isBlank()) {
             throw IllegalArgumentException(

--- a/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.common.model
 
 import android.os.Parcelable
+import androidx.annotation.RestrictTo
 import com.stripe.android.common.validation.CustomerSessionClientSecretValidator
 import com.stripe.android.model.CardBrand
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
@@ -9,7 +10,8 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import kotlinx.parcelize.Parcelize
 
-const val isEKClientSecretValidRegexPattern = "^ek_[^_](.)+$"
+@RestrictTo(RestrictTo.Scope.LIBRARY)
+const val IsEKClientSecretValidRegexPattern = "^ek_[^_](.)+$"
 
 @Parcelize
 internal data class CommonConfiguration(
@@ -27,6 +29,7 @@ internal data class CommonConfiguration(
     val externalPaymentMethods: List<String>,
     val cardBrandAcceptance: PaymentSheet.CardBrandAcceptance,
 ) : Parcelable {
+    @Suppress("LongMethod", "ThrowsCount")
     fun validate() {
         // These are not localized as they are not intended to be displayed to a user.
         when {
@@ -52,7 +55,10 @@ internal data class CommonConfiguration(
                             "When a CustomerConfiguration is passed to PaymentSheet, " +
                                 "the ephemeralKeySecret cannot be an empty string."
                         )
-                    } else if (customerAccessType.ephemeralKeySecret.isEKClientSecretValid().not() || customer.ephemeralKeySecret.isEKClientSecretValid().not()) {
+                    } else if (
+                        customerAccessType.ephemeralKeySecret.isEKClientSecretValid().not() ||
+                        customer.ephemeralKeySecret.isEKClientSecretValid().not()
+                    ) {
                         throw IllegalArgumentException(
                             "`ephemeralKeySecret` format does not match expected client secret formatting"
                         )
@@ -89,8 +95,9 @@ internal data class CommonConfiguration(
     }
 }
 
+@RestrictTo(RestrictTo.Scope.LIBRARY)
 internal fun String.isEKClientSecretValid(): Boolean {
-    return Regex(isEKClientSecretValidRegexPattern).matches(this)
+    return Regex(IsEKClientSecretValidRegexPattern).matches(this)
 }
 
 internal fun PaymentSheet.Configuration.asCommonConfiguration(): CommonConfiguration = CommonConfiguration(

--- a/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
@@ -9,8 +9,6 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import kotlinx.parcelize.Parcelize
 
-private const val IsEKClientSecretValidRegexPattern = "^ek_[^_](.)+$"
-
 @Parcelize
 internal data class CommonConfiguration(
     val merchantDisplayName: String,
@@ -27,6 +25,16 @@ internal data class CommonConfiguration(
     val externalPaymentMethods: List<String>,
     val cardBrandAcceptance: PaymentSheet.CardBrandAcceptance,
 ) : Parcelable {
+
+    fun validate() {
+        customerAndMerchantValidate()
+
+        customer?.accessType?.let { customerAccessType ->
+            customerAccessTypeValidate(customerAccessType)
+        }
+    }
+
+    // These exception messages are not localized as they are not intended to be displayed to a user."
     @Suppress("ThrowsCount")
     private fun customerAndMerchantValidate() {
         when {
@@ -56,6 +64,7 @@ internal data class CommonConfiguration(
         }
     }
 
+    // These exception messages are not localized as they are not intended to be displayed to a user."
     @Suppress("ThrowsCount")
     private fun customerSessionValidate(customerAccessType: PaymentSheet.CustomerAccessType.CustomerSession) {
         val result = CustomerSessionClientSecretValidator
@@ -84,6 +93,7 @@ internal data class CommonConfiguration(
         }
     }
 
+    // These exception messages are not localized as they are not intended to be displayed to a user."
     @Suppress("ThrowsCount")
     private fun legacyCustomerEphemeralKeyValidate(
         customerAccessType: PaymentSheet.CustomerAccessType.LegacyCustomerEphemeralKey
@@ -107,19 +117,6 @@ internal data class CommonConfiguration(
             )
         }
     }
-
-    fun validate() {
-        // These are not localized as they are not intended to be displayed to a user.
-        customerAndMerchantValidate()
-
-        customer?.accessType?.let { customerAccessType ->
-            customerAccessTypeValidate(customerAccessType)
-        }
-    }
-}
-
-private fun String.isEKClientSecretValid(): Boolean {
-    return Regex(IsEKClientSecretValidRegexPattern).matches(this)
 }
 
 internal fun PaymentSheet.Configuration.asCommonConfiguration(): CommonConfiguration = CommonConfiguration(
@@ -154,3 +151,9 @@ internal fun EmbeddedPaymentElement.Configuration.asCommonConfiguration(): Commo
     externalPaymentMethods = externalPaymentMethods,
     cardBrandAcceptance = cardBrandAcceptance,
 )
+
+private fun String.isEKClientSecretValid(): Boolean {
+    return Regex(EK_CLIENT_SECRET_VALID_REGEX_PATTERN).matches(this)
+}
+
+private const val EK_CLIENT_SECRET_VALID_REGEX_PATTERN = "^ek_[^_](.)+$"

--- a/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.common.model
 
 import android.os.Parcelable
-import android.util.Log
 import com.stripe.android.common.validation.CustomerSessionClientSecretValidator
 import com.stripe.android.model.CardBrand
 import com.stripe.android.paymentelement.EmbeddedPaymentElement

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtxTest.kt
@@ -127,7 +127,7 @@ class PaymentSheetConfigurationKtxTest {
         getConfig("ek_test_iiuwfhdaiuhasdvkcjn32n").validate()
     }
 
-        @Test
+    @Test
     fun `'validate' should fail when ephemeral key secret is of wrong format`() {
         fun assertFailsWithEphemeralKeySecret(ephemeralKeySecret: String) {
             assertFailsWith(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtxTest.kt
@@ -208,7 +208,7 @@ class PaymentSheetConfigurationKtxTest {
             merchantDisplayName = "Merchant, Inc.",
             customer = PaymentSheet.CustomerConfiguration(
                 id = "1",
-                ephemeralKeySecret = "secret",
+                ephemeralKeySecret = "ek_123",
             ),
             googlePay = PaymentSheet.GooglePayConfiguration(
                 environment = PaymentSheet.GooglePayConfiguration.Environment.Test,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtxTest.kt
@@ -125,39 +125,28 @@ class PaymentSheetConfigurationKtxTest {
 
     @Test
     fun `'validate' should succeed when ephemeral key secret is of correct format`() {
-        val validEphemeralKeys = listOf(
-            "ek_askljdlkasfhgasdfjls",
-            "ek_test_iiuwfhdaiuhasdvkcjn32n"
-        )
-
-        // Basically assert there is no crash
-        validEphemeralKeys.forEach {
-            getConfig(it).validate()
-        }
+        getConfig("ek_askljdlkasfhgasdfjls").validate()
+        getConfig("ek_test_iiuwfhdaiuhasdvkcjn32n").validate()
     }
 
         @Test
     fun `'validate' should fail when ephemeral key secret is of wrong format`() {
 
-        val invalidEphemeralKeys = listOf(
-            "eph_askjdfhajkshdfjkashdjkfhsakjdhfkjashfd",
-            "eph_test_askjdfhajkshdfjkashdjkfhsakjdhfkjashfd",
-            "sk_askjdfhajkshdfjkashdjkfhsakjdhfkjashfd",
-            "ek_",
-            "ek",
-            "eeek_aldkfjalskdjflkasjbvdkjds"
-        )
-
-
-        invalidEphemeralKeys.forEach{
+        fun assertFailsWithEphemeralKeySecret(ephemeralKeySecret: String) {
             assertFailsWith(
                 IllegalArgumentException::class,
                 message = "`ephemeralKeySecret` format does not match expected client secret formatting"
             ) {
-                getConfig(it).validate()
+                getConfig(ephemeralKeySecret).validate()
             }
         }
 
+        assertFailsWithEphemeralKeySecret("eph_askjdfhajkshdfjkashdjkfhsakjdhfkjashfd")
+        assertFailsWithEphemeralKeySecret("eph_test_askjdfhajkshdfjkashdjkfhsakjdhfkjashfd")
+        assertFailsWithEphemeralKeySecret("sk_askjdfhajkshdfjkashdjkfhsakjdhfkjashfd")
+        assertFailsWithEphemeralKeySecret("ek_")
+        assertFailsWithEphemeralKeySecret("ek")
+        assertFailsWithEphemeralKeySecret("eeek_aldkfjalskdjflkasjbvdkjds")
     }
 
     @OptIn(ExperimentalCustomerSessionApi::class)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtxTest.kt
@@ -3,11 +3,13 @@ package com.stripe.android.paymentsheet
 import android.content.res.ColorStateList
 import android.graphics.Color
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import org.junit.Test
 import java.lang.IllegalArgumentException
 import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
 
 class PaymentSheetConfigurationKtxTest {
     @Test
@@ -109,6 +111,53 @@ class PaymentSheetConfigurationKtxTest {
         ) {
             configWithBlankEphemeralKeySecret.validate()
         }
+    }
+
+    private fun getConfig(eKey: String): CommonConfiguration {
+        return configuration.copy(
+            customer = PaymentSheet.CustomerConfiguration(
+                id = "cus_1",
+                ephemeralKeySecret = eKey
+            ),
+        ).asCommonConfiguration()
+    }
+
+
+    @Test
+    fun `'validate' should succeed when ephemeral key secret is of correct format`() {
+        val validEphemeralKeys = listOf(
+            "ek_askljdlkasfhgasdfjls",
+            "ek_test_iiuwfhdaiuhasdvkcjn32n"
+        )
+
+        // Basically assert there is no crash
+        validEphemeralKeys.forEach {
+            getConfig(it).validate()
+        }
+    }
+
+        @Test
+    fun `'validate' should fail when ephemeral key secret is of wrong format`() {
+
+        val invalidEphemeralKeys = listOf(
+            "eph_askjdfhajkshdfjkashdjkfhsakjdhfkjashfd",
+            "eph_test_askjdfhajkshdfjkashdjkfhsakjdhfkjashfd",
+            "sk_askjdfhajkshdfjkashdjkfhsakjdhfkjashfd",
+            "ek_",
+            "ek",
+            "eeek_aldkfjalskdjflkasjbvdkjds"
+        )
+
+
+        invalidEphemeralKeys.forEach{
+            assertFailsWith(
+                IllegalArgumentException::class,
+                message = "`ephemeralKeySecret` format does not match expected client secret formatting"
+            ) {
+                getConfig(it).validate()
+            }
+        }
+
     }
 
     @OptIn(ExperimentalCustomerSessionApi::class)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtxTest.kt
@@ -9,7 +9,6 @@ import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import org.junit.Test
 import java.lang.IllegalArgumentException
 import kotlin.test.assertFailsWith
-import kotlin.test.assertSame
 
 class PaymentSheetConfigurationKtxTest {
     @Test
@@ -122,7 +121,6 @@ class PaymentSheetConfigurationKtxTest {
         ).asCommonConfiguration()
     }
 
-
     @Test
     fun `'validate' should succeed when ephemeral key secret is of correct format`() {
         getConfig("ek_askljdlkasfhgasdfjls").validate()
@@ -131,7 +129,6 @@ class PaymentSheetConfigurationKtxTest {
 
         @Test
     fun `'validate' should fail when ephemeral key secret is of wrong format`() {
-
         fun assertFailsWithEphemeralKeySecret(ephemeralKeySecret: String) {
             assertFailsWith(
                 IllegalArgumentException::class,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
@@ -82,7 +82,7 @@ internal object PaymentSheetFixtures {
 
     private val defaultCustomerConfig = PaymentSheet.CustomerConfiguration(
         id = "customer_id",
-        ephemeralKeySecret = "ephemeral_key"
+        ephemeralKeySecret = "ek_6bpdbs8volf6ods1y6tf8oy9p9g64ehr"
     )
 
     internal val CONFIG_CUSTOMER = PaymentSheet.Configuration(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
@@ -39,7 +39,7 @@ internal object PaymentSheetFixtures {
         merchantDisplayName = MERCHANT_DISPLAY_NAME,
         customer = PaymentSheet.CustomerConfiguration(
             "customer_id",
-            "ephemeral_key"
+            "ek_123"
         ),
         googlePay = ConfigFixtures.GOOGLE_PAY,
         primaryButtonColor = ColorStateList.valueOf(Color.BLACK),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -324,7 +324,7 @@ internal class PaymentSheetViewModelTest {
                 config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.copy(
                     customer = PaymentSheet.CustomerConfiguration(
                         id = "cus_1",
-                        ephemeralKeySecret = "ephemeral_key_1"
+                        ephemeralKeySecret = "ek_123",
                     )
                 )
             ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -324,13 +324,13 @@ internal class PaymentSheetViewModelTest {
                 config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.copy(
                     customer = PaymentSheet.CustomerConfiguration(
                         id = "cus_1",
-                        ephemeralKeySecret = "ek_123",
+                        ephemeralKeySecret = "ek_123"
                     )
                 )
             ),
             customer = CustomerState(
                 id = "cus_2",
-                ephemeralKeySecret = "ephemeral_key_2",
+                ephemeralKeySecret = "ek_123",
                 paymentMethods = paymentMethods,
                 permissions = CustomerState.Permissions(
                     canRemovePaymentMethods = true,
@@ -375,7 +375,7 @@ internal class PaymentSheetViewModelTest {
         assertThat(customerInfoCaptor.firstValue).isEqualTo(
             CustomerRepository.CustomerInfo(
                 id = "cus_2",
-                ephemeralKeySecret = "ephemeral_key_2",
+                ephemeralKeySecret = "ek_123",
             )
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandlerTest.kt
@@ -41,6 +41,8 @@ import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.robolectric.RobolectricTestRunner
+import java.lang.IllegalArgumentException
+import kotlin.test.assertFailsWith
 import kotlin.time.Duration.Companion.seconds
 
 @RunWith(RobolectricTestRunner::class)
@@ -308,7 +310,7 @@ class FlowControllerConfigurationHandlerTest {
         }
 
         assertThat(configureErrors.awaitItem()?.message)
-            .isEqualTo("When a CustomerConfiguration is passed to PaymentSheet, the ephemeralKeySecret cannot be an empty string.")
+            .isEqualTo("Conflicting ephemeralKeySecrets between CustomerConfiguration and CustomerConfiguration.customerAccessType")
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandlerTest.kt
@@ -41,8 +41,6 @@ import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.robolectric.RobolectricTestRunner
-import java.lang.IllegalArgumentException
-import kotlin.test.assertFailsWith
 import kotlin.time.Duration.Companion.seconds
 
 @RunWith(RobolectricTestRunner::class)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdaterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdaterTest.kt
@@ -328,7 +328,7 @@ class PaymentSelectionUpdaterTest {
         val newConfig = defaultPaymentSheetConfiguration.copy(
             customer = PaymentSheet.CustomerConfiguration(
                 id = "id1",
-                ephemeralKeySecret = "000"
+                ephemeralKeySecret = "ek_123",
             )
         )
         val newState = mockPaymentSheetStateWithPaymentIntent(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerRepositoryTest.kt
@@ -710,7 +710,7 @@ internal class CustomerRepositoryTest {
     private companion object {
         val FAKE_CUSTOMER_INFO = CustomerRepository.CustomerInfo(
             id = "customer_id",
-            ephemeralKeySecret = "ephemeral_key"
+            ephemeralKeySecret = "ek_123"
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -1647,7 +1647,7 @@ internal class DefaultPaymentElementLoaderTest {
             assertThat(state.customer).isEqualTo(
                 CustomerState(
                     id = "cus_1",
-                    ephemeralKeySecret = "ephemeral_key_secret",
+                    ephemeralKeySecret = "ek_123",
                     paymentMethods = cards,
                     permissions = CustomerState.Permissions(
                         canRemovePaymentMethods = true,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -487,7 +487,7 @@ internal class DefaultPaymentElementLoaderTest {
             paymentSheetConfiguration = mockConfiguration(
                 customer = PaymentSheet.CustomerConfiguration(
                     id = "some_id",
-                    ephemeralKeySecret = "some_key"
+                    ephemeralKeySecret = "ek_123",
                 )
             ),
             initializedViaCompose = false,
@@ -911,7 +911,7 @@ internal class DefaultPaymentElementLoaderTest {
             paymentSheetConfiguration = mockConfiguration(
                 customer = PaymentSheet.CustomerConfiguration(
                     id = "id",
-                    ephemeralKeySecret = "key"
+                    ephemeralKeySecret = "ek_123",
                 ),
             ),
             initializedViaCompose = false,
@@ -935,7 +935,7 @@ internal class DefaultPaymentElementLoaderTest {
             paymentSheetConfiguration = mockConfiguration(
                 customer = PaymentSheet.CustomerConfiguration(
                     id = "id",
-                    ephemeralKeySecret = "key",
+                    ephemeralKeySecret = "ek_123",
                 ),
             ),
             initializedViaCompose = false,
@@ -981,7 +981,7 @@ internal class DefaultPaymentElementLoaderTest {
                 merchantDisplayName = "Some Name",
                 customer = PaymentSheet.CustomerConfiguration(
                     id = "cus_123",
-                    ephemeralKeySecret = "some_secret",
+                    ephemeralKeySecret = "ek_123",
                 ),
             ),
             initializedViaCompose = false,
@@ -1191,7 +1191,7 @@ internal class DefaultPaymentElementLoaderTest {
                 merchantDisplayName = "Some Name",
                 customer = PaymentSheet.CustomerConfiguration(
                     id = "cus_123",
-                    ephemeralKeySecret = "some_secret",
+                    ephemeralKeySecret = "ek_123",
                 ),
             ),
             initializedViaCompose = false,
@@ -1519,7 +1519,7 @@ internal class DefaultPaymentElementLoaderTest {
                     merchantDisplayName = "Merchant, Inc.",
                     customer = PaymentSheet.CustomerConfiguration(
                         id = "cus_1",
-                        ephemeralKeySecret = "ephemeral_key",
+                        ephemeralKeySecret = "ek_123",
                     ),
                 ),
                 initializedViaCompose = false,
@@ -1636,7 +1636,7 @@ internal class DefaultPaymentElementLoaderTest {
                     merchantDisplayName = "Merchant, Inc.",
                     customer = PaymentSheet.CustomerConfiguration(
                         id = "cus_1",
-                        ephemeralKeySecret = "ephemeral_key_secret",
+                        ephemeralKeySecret = "ek_123",
                     ),
                 ),
                 initializedViaCompose = false,
@@ -2147,7 +2147,7 @@ internal class DefaultPaymentElementLoaderTest {
                 merchantDisplayName = "Some Name",
                 customer = PaymentSheet.CustomerConfiguration(
                     id = "cus_123",
-                    ephemeralKeySecret = "some_secret",
+                    ephemeralKeySecret = "ek_123",
                 ),
             ),
             initializedViaCompose = false,
@@ -2294,7 +2294,7 @@ internal class DefaultPaymentElementLoaderTest {
             merchantDisplayName = "Some Name",
             customer = PaymentSheet.CustomerConfiguration(
                 id = "cus_123",
-                ephemeralKeySecret = "some_secret",
+                ephemeralKeySecret = "ek_123",
             ),
         )
         private val DEFAULT_INITIALIZATION_MODE = PaymentElementLoader.InitializationMode.PaymentIntent(


### PR DESCRIPTION

# Summary
https://jira.corp.stripe.com/browse/MOBILESDK-1770
This is as per the jira ticket to match the behavior on iOS, Android would ignore an invalid Ephemeral Key and just continuing on with initializing the Payment Sheet without it. This fixes that by adding a check

# Motivation
Prevent users from using an invalid ephemeral key when initializing to prevent bad states

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified