### PR TITLE
Navigate to new update PM screen when editing card brand from vertical mode screen

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -412,7 +412,11 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
                 }
             }
             is ViewAction.EditPaymentMethod -> {
-                onEditPaymentMethod(viewAction.savedPaymentMethod)
+                if (FeatureFlags.useNewUpdateCardScreen.isEnabled) {
+                    onUpdatePaymentMethod(viewAction.savedPaymentMethod)
+                } else {
+                    onEditPaymentMethod(viewAction.savedPaymentMethod)
+                }
             }
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -816,6 +816,21 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
     }
 
     @Test
+    fun handleViewAction_OnEditPaymentMethod_transitionsToUpdateScreen_whenFeatureEnabled() {
+        var updatedPaymentMethod: DisplayableSavedPaymentMethod? = null
+        runScenario(
+            onUpdatePaymentMethod = {
+                updatedPaymentMethod = it
+            },
+            useNewUpdatePaymentMethodScreen = true,
+        ) {
+            val paymentMethod = PaymentMethodFixtures.displayableCard()
+            interactor.handleViewAction(ViewAction.EditPaymentMethod(paymentMethod))
+            assertThat(updatedPaymentMethod).isEqualTo(paymentMethod)
+        }
+    }
+
+    @Test
     fun handleViewAction_SelectSavedPaymentMethod_selectsSavedPm() {
         val savedPaymentMethod = PaymentMethodFixtures.displayableCard()
         var selectedSavedPaymentMethod: PaymentMethod? = null


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Navigate to new update PM screen when editing card brand from vertical mode screen

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
We should always be navigating to this screen when the relevant feature flag is enabled

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified