### PR TITLE
Don't show remove spinner until the user has confirmed removal

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
@@ -301,7 +301,7 @@ private fun DeletePaymentMethodUi(interactor: UpdatePaymentMethodInteractor) {
         title = R.string.stripe_remove.resolvableString,
         borderColor = MaterialTheme.colors.error,
         idle = status == UpdatePaymentMethodInteractor.Status.Idle,
-        removing = openDialogValue.value || status == UpdatePaymentMethodInteractor.Status.Removing,
+        removing = status == UpdatePaymentMethodInteractor.Status.Removing,
         onRemove = { openDialogValue.value = true },
         testTag = UPDATE_PM_REMOVE_BUTTON_TEST_TAG,
     )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Don't show remove spinner until the user has confirmed removal

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Bug bash feedback -- this was an unintended change from our current behavior

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

# Screen recording
[Remove spinner update.webm](https://github.com/user-attachments/assets/0b9cece2-721b-4e74-9404-068f486d7247)
