### PR TITLE
Fix updated intent not being used with a complete action in `DefaultConfirmationHandler`.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandler.kt
@@ -160,7 +160,7 @@ internal class DefaultConfirmationHandler(
             is ConfirmationMediator.Action.Complete -> {
                 onHandlerResult(
                     ConfirmationHandler.Result.Succeeded(
-                        intent = intent,
+                        intent = action.intent,
                         deferredIntentConfirmationType = action.deferredIntentConfirmationType,
                     )
                 )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandlerTest.kt
@@ -15,6 +15,7 @@ import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.PaymentIntentFactory
+import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.utils.DummyActivityResultCaller
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -235,7 +236,7 @@ class DefaultConfirmationHandlerTest {
     @Test
     fun `On complete action, should complete with success result`() = test(
         someDefinitionAction = ConfirmationDefinition.Action.Complete(
-            intent = PAYMENT_INTENT,
+            intent = UPDATED_PAYMENT_INTENT,
             confirmationOption = SomeConfirmationDefinition.Option,
             deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
         ),
@@ -256,7 +257,7 @@ class DefaultConfirmationHandlerTest {
             val completeState = awaitCompleteState()
             val successResult = completeState.result.assertSucceeded()
 
-            assertThat(successResult.intent).isEqualTo(PAYMENT_INTENT)
+            assertThat(successResult.intent).isEqualTo(UPDATED_PAYMENT_INTENT)
             assertThat(successResult.deferredIntentConfirmationType)
                 .isEqualTo(DeferredIntentConfirmationType.Client)
 
@@ -275,13 +276,13 @@ class DefaultConfirmationHandlerTest {
     @Test
     fun `On success result from launched action, should complete with success result`() = launcherResultTest(
         result = ConfirmationDefinition.Result.Succeeded(
-            intent = PAYMENT_INTENT,
+            intent = UPDATED_PAYMENT_INTENT,
             deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
         ),
     ) { completeState ->
         val successResult = completeState.result.assertSucceeded()
 
-        assertThat(successResult.intent).isEqualTo(PAYMENT_INTENT)
+        assertThat(successResult.intent).isEqualTo(UPDATED_PAYMENT_INTENT)
         assertThat(successResult.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Server)
     }
 
@@ -979,5 +980,9 @@ class DefaultConfirmationHandlerTest {
         const val AWAITING_CONFIRMATION_RESULT_KEY = "AwaitingConfirmationResult"
 
         val PAYMENT_INTENT = PaymentIntentFactory.create()
+
+        val UPDATED_PAYMENT_INTENT = PAYMENT_INTENT.copy(
+            paymentMethod = PaymentMethodFactory.card(),
+        )
     }
 }


### PR DESCRIPTION
# Summary
Fix updated intent not being used with a complete action in `DefaultConfirmationHandler`.

# Motivation
We should always return the updated intent when a complete action occurs.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified