### PR TITLE
[connect] Remove JS bridge workaround

### DIFF
--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainer.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainer.kt
@@ -176,7 +176,6 @@ internal class StripeConnectWebViewContainerImpl<Listener : StripeEmbeddedCompon
     }
 
     override fun loadUrl(url: String) {
-        webView?.clearCache(true)
         webView?.loadUrl(url)
     }
 


### PR DESCRIPTION
# Summary
Remove the JS bridge workaround, which should be no longer necessary after the related JS changes have merged.

See linked PR in the Jira ticket.

# Motivation
https://jira.corp.stripe.com/browse/MXMOBILE-2970

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

See linked PR in the Jira ticket.
