### PR TITLE
Better handle process death for all confirmation flow cases in `DefaultConfirmationHandler`

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -2931,6 +2931,7 @@ internal class PaymentSheetViewModelTest {
         val savedStateHandle = SavedStateHandle(
             initialState = mapOf(
                 "AwaitingConfirmationResult" to DefaultConfirmationHandler.AwaitingConfirmationResultData(
+                    key = "Intent",
                     confirmationOption = option,
                     receivesResultInProcess = false,
                 ),


### PR DESCRIPTION
# Summary
Better handle process death for all confirmation flow cases in `DefaultConfirmationHandler`.

# Motivation
Our current process death handling works fine when a result is received in process but not great when a result is not received in process and results in a next step action

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified