### PR TITLE
Move common confirmation option parameters to `ConfirmationHandler.Args`

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -324,6 +324,14 @@ public final class com/stripe/android/paymentelement/EmbeddedPaymentElement$Conf
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/paymentelement/confirmation/ConfirmationDefinition$Parameters$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentelement/confirmation/ConfirmationDefinition$Parameters;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentelement/confirmation/ConfirmationDefinition$Parameters;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/paymentelement/confirmation/ConfirmationHandler$Args$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentelement/confirmation/ConfirmationHandler$Args;

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -1032,15 +1032,16 @@ internal class CustomerSheetViewModel(
     ) {
         confirmationHandler.start(
             arguments = ConfirmationHandler.Args(
-                intent = stripeIntent,
                 confirmationOption = PaymentMethodConfirmationOption.Saved(
-                    initializationMode = PaymentElementLoader.InitializationMode.SetupIntent(
-                        clientSecret = clientSecret
-                    ),
-                    shippingDetails = null,
                     paymentMethod = paymentMethod,
                     optionsParams = null,
                 ),
+                intent = stripeIntent,
+                initializationMode = PaymentElementLoader.InitializationMode.SetupIntent(
+                    clientSecret = clientSecret
+                ),
+                shippingDetails = null,
+                appearance = configuration.appearance,
             )
         )
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationDefinition.kt
@@ -5,6 +5,10 @@ import androidx.activity.result.ActivityResultCaller
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.addresselement.AddressDetails
+import com.stripe.android.paymentsheet.state.PaymentElementLoader
+import kotlinx.parcelize.Parcelize
 
 internal interface ConfirmationDefinition<
     TConfirmationOption : ConfirmationHandler.Option,
@@ -20,14 +24,14 @@ internal interface ConfirmationDefinition<
 
     suspend fun action(
         confirmationOption: TConfirmationOption,
-        intent: StripeIntent,
+        confirmationParameters: Parameters,
     ): Action<TLauncherArgs>
 
     fun launch(
         launcher: TLauncher,
         arguments: TLauncherArgs,
         confirmationOption: TConfirmationOption,
-        intent: StripeIntent,
+        confirmationParameters: Parameters,
     )
 
     fun createLauncher(
@@ -41,10 +45,18 @@ internal interface ConfirmationDefinition<
 
     fun toResult(
         confirmationOption: TConfirmationOption,
+        confirmationParameters: Parameters,
         deferredIntentConfirmationType: DeferredIntentConfirmationType?,
-        intent: StripeIntent,
         result: TLauncherResult,
     ): Result
+
+    @Parcelize
+    data class Parameters(
+        val intent: StripeIntent,
+        val appearance: PaymentSheet.Appearance,
+        val initializationMode: PaymentElementLoader.InitializationMode,
+        val shippingDetails: AddressDetails?
+    ) : Parcelable
 
     sealed interface Result {
         data class Canceled(
@@ -57,8 +69,8 @@ internal interface ConfirmationDefinition<
         ) : Result
 
         data class NextStep(
-            val intent: StripeIntent,
             val confirmationOption: ConfirmationHandler.Option,
+            val parameters: Parameters,
         ) : Result
 
         data class Failed(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandler.kt
@@ -6,6 +6,9 @@ import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.addresselement.AddressDetails
+import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.parcelize.Parcelize
@@ -69,7 +72,22 @@ internal interface ConfirmationHandler {
         /**
          * The confirmation option used to in order to potentially confirm the intent
          */
-        val confirmationOption: Option
+        val confirmationOption: Option,
+
+        /**
+         * Appearance values to be used when styling the launched activities
+         */
+        val appearance: PaymentSheet.Appearance,
+
+        /**
+         * The mode that a Payment Element product was initialized with
+         */
+        val initializationMode: PaymentElementLoader.InitializationMode,
+
+        /**
+         * The shipping details of the customer that can be attached during the confirmation flow
+         */
+        val shippingDetails: AddressDetails?
     ) : Parcelable
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediator.kt
@@ -46,7 +46,7 @@ internal class ConfirmationMediator<
             val confirmationResult = persistedParameters?.let { params ->
                 definition.toResult(
                     confirmationOption = params.confirmationOption,
-                    intent = params.intent,
+                    confirmationParameters = params.confirmationParameters,
                     result = result,
                     deferredIntentConfirmationType = params.deferredIntentConfirmationType
                 )
@@ -76,7 +76,7 @@ internal class ConfirmationMediator<
 
     suspend fun action(
         option: ConfirmationHandler.Option,
-        intent: StripeIntent
+        parameters: ConfirmationDefinition.Parameters,
     ): Action {
         val confirmationOption = definition.option(option)
             ?: return Action.Fail(
@@ -88,14 +88,14 @@ internal class ConfirmationMediator<
                 errorType = ConfirmationHandler.Result.Failed.ErrorType.Internal,
             )
 
-        return when (val action = definition.action(confirmationOption, intent)) {
+        return when (val action = definition.action(confirmationOption, parameters)) {
             is ConfirmationDefinition.Action.Launch -> {
                 launcher?.let {
                     Action.Launch(
                         launch = {
                             persistedParameters = Parameters(
                                 confirmationOption = confirmationOption,
-                                intent = intent,
+                                confirmationParameters = parameters,
                                 deferredIntentConfirmationType = action.deferredIntentConfirmationType,
                             )
 
@@ -103,7 +103,7 @@ internal class ConfirmationMediator<
                                 launcher = it,
                                 arguments = action.launcherArguments,
                                 confirmationOption = confirmationOption,
-                                intent = intent,
+                                confirmationParameters = parameters,
                             )
                         },
                         receivesResultInProcess = action.receivesResultInProcess,
@@ -159,7 +159,7 @@ internal class ConfirmationMediator<
     @Parcelize
     internal data class Parameters<TConfirmationOption : ConfirmationHandler.Option>(
         val confirmationOption: TConfirmationOption,
-        val intent: StripeIntent,
+        val confirmationParameters: ConfirmationDefinition.Parameters,
         val deferredIntentConfirmationType: DeferredIntentConfirmationType?,
     ) : Parcelable
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationOptionKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationOptionKtx.kt
@@ -8,20 +8,14 @@ import com.stripe.android.paymentelement.confirmation.bacs.BacsConfirmationOptio
 import com.stripe.android.paymentelement.confirmation.epms.ExternalPaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayConfirmationOption
 import com.stripe.android.paymentelement.confirmation.link.LinkConfirmationOption
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 
 internal fun PaymentSelection.toConfirmationOption(
-    initializationMode: PaymentElementLoader.InitializationMode,
     configuration: CommonConfiguration,
-    appearance: PaymentSheet.Appearance,
     linkConfiguration: LinkConfiguration?,
 ): ConfirmationHandler.Option? {
     return when (this) {
         is PaymentSelection.Saved -> PaymentMethodConfirmationOption.Saved(
-            initializationMode = initializationMode,
-            shippingDetails = configuration.shippingDetails,
             paymentMethod = paymentMethod,
             optionsParams = paymentMethodOptionsParams,
         )
@@ -34,15 +28,11 @@ internal fun PaymentSelection.toConfirmationOption(
                 // For Instant Debits, we create the PaymentMethod inside the bank auth flow. Therefore,
                 // we can just use the already created object here.
                 PaymentMethodConfirmationOption.Saved(
-                    initializationMode = initializationMode,
-                    shippingDetails = configuration.shippingDetails,
                     paymentMethod = instantDebits.paymentMethod,
                     optionsParams = paymentMethodOptionsParams,
                 )
             } else {
                 PaymentMethodConfirmationOption.New(
-                    initializationMode = initializationMode,
-                    shippingDetails = configuration.shippingDetails,
                     createParams = paymentMethodCreateParams,
                     optionsParams = paymentMethodOptionsParams,
                     shouldSave = customerRequestedSave == PaymentSelection.CustomerRequestedSave.RequestReuse,
@@ -52,16 +42,11 @@ internal fun PaymentSelection.toConfirmationOption(
         is PaymentSelection.New -> {
             if (paymentMethodCreateParams.typeCode == PaymentMethod.Type.BacsDebit.code) {
                 BacsConfirmationOption(
-                    initializationMode = initializationMode,
-                    shippingDetails = configuration.shippingDetails,
                     createParams = paymentMethodCreateParams,
                     optionsParams = paymentMethodOptionsParams,
-                    appearance = appearance,
                 )
             } else {
                 PaymentMethodConfirmationOption.New(
-                    initializationMode = initializationMode,
-                    shippingDetails = configuration.shippingDetails,
                     createParams = paymentMethodCreateParams,
                     optionsParams = paymentMethodOptionsParams,
                     shouldSave = customerRequestedSave == PaymentSelection.CustomerRequestedSave.RequestReuse,
@@ -70,8 +55,6 @@ internal fun PaymentSelection.toConfirmationOption(
         }
         is PaymentSelection.GooglePay -> configuration.googlePay?.let { googlePay ->
             GooglePayConfirmationOption(
-                initializationMode = initializationMode,
-                shippingDetails = configuration.shippingDetails,
                 config = GooglePayConfirmationOption.Config(
                     environment = googlePay.environment,
                     merchantName = configuration.merchantDisplayName,
@@ -85,11 +68,7 @@ internal fun PaymentSelection.toConfirmationOption(
             )
         }
         is PaymentSelection.Link -> linkConfiguration?.let {
-            LinkConfirmationOption(
-                initializationMode = initializationMode,
-                shippingDetails = configuration.shippingDetails,
-                configuration = linkConfiguration,
-            )
+            LinkConfirmationOption(configuration = linkConfiguration)
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/PaymentMethodConfirmationOption.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/PaymentMethodConfirmationOption.kt
@@ -2,26 +2,17 @@ package com.stripe.android.paymentelement.confirmation
 
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodOptionsParams
-import com.stripe.android.paymentsheet.addresselement.AddressDetails
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import kotlinx.parcelize.Parcelize
 
 internal sealed interface PaymentMethodConfirmationOption : ConfirmationHandler.Option {
-    val initializationMode: PaymentElementLoader.InitializationMode
-    val shippingDetails: AddressDetails?
-
     @Parcelize
     data class Saved(
-        override val initializationMode: PaymentElementLoader.InitializationMode,
-        override val shippingDetails: AddressDetails?,
         val paymentMethod: com.stripe.android.model.PaymentMethod,
         val optionsParams: PaymentMethodOptionsParams?,
     ) : PaymentMethodConfirmationOption
 
     @Parcelize
     data class New(
-        override val initializationMode: PaymentElementLoader.InitializationMode,
-        override val shippingDetails: AddressDetails?,
         val createParams: PaymentMethodCreateParams,
         val optionsParams: PaymentMethodOptionsParams?,
         val shouldSave: Boolean

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationDefinition.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentelement.confirmation.bacs
 import androidx.activity.result.ActivityResultCaller
 import com.stripe.android.core.strings.resolvableString
-import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
@@ -29,7 +28,7 @@ internal class BacsConfirmationDefinition(
 
     override suspend fun action(
         confirmationOption: BacsConfirmationOption,
-        intent: StripeIntent
+        confirmationParameters: ConfirmationDefinition.Parameters,
     ): ConfirmationDefinition.Action<BacsMandateData> {
         return BacsMandateData.fromConfirmationOption(confirmationOption)?.let { data ->
             ConfirmationDefinition.Action.Launch(
@@ -64,33 +63,31 @@ internal class BacsConfirmationDefinition(
         launcher: BacsMandateConfirmationLauncher,
         arguments: BacsMandateData,
         confirmationOption: BacsConfirmationOption,
-        intent: StripeIntent,
+        confirmationParameters: ConfirmationDefinition.Parameters,
     ) {
         launcher.launch(
             data = arguments,
-            appearance = confirmationOption.appearance
+            appearance = confirmationParameters.appearance
         )
     }
 
     override fun toResult(
         confirmationOption: BacsConfirmationOption,
+        confirmationParameters: ConfirmationDefinition.Parameters,
         deferredIntentConfirmationType: DeferredIntentConfirmationType?,
-        intent: StripeIntent,
         result: BacsMandateConfirmationResult,
     ): ConfirmationDefinition.Result {
         return when (result) {
             is BacsMandateConfirmationResult.Confirmed -> {
                 val nextConfirmationOption = PaymentMethodConfirmationOption.New(
-                    initializationMode = confirmationOption.initializationMode,
-                    shippingDetails = confirmationOption.shippingDetails,
                     createParams = confirmationOption.createParams,
                     optionsParams = null,
                     shouldSave = false,
                 )
 
                 ConfirmationDefinition.Result.NextStep(
-                    intent = intent,
                     confirmationOption = nextConfirmationOption,
+                    parameters = confirmationParameters,
                 )
             }
             is BacsMandateConfirmationResult.ModifyDetails -> ConfirmationDefinition.Result.Canceled(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationOption.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationOption.kt
@@ -3,16 +3,10 @@ package com.stripe.android.paymentelement.confirmation.bacs
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
-import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.paymentsheet.addresselement.AddressDetails
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
 internal data class BacsConfirmationOption(
-    val initializationMode: PaymentElementLoader.InitializationMode,
-    val shippingDetails: AddressDetails?,
     val createParams: PaymentMethodCreateParams,
     val optionsParams: PaymentMethodOptionsParams?,
-    val appearance: PaymentSheet.Appearance,
 ) : ConfirmationHandler.Option

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationDefinition.kt
@@ -3,7 +3,6 @@ package com.stripe.android.paymentelement.confirmation.epms
 import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
 import com.stripe.android.common.exception.stripeErrorMessage
-import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
@@ -34,7 +33,7 @@ internal class ExternalPaymentMethodConfirmationDefinition(
 
     override suspend fun action(
         confirmationOption: ExternalPaymentMethodConfirmationOption,
-        intent: StripeIntent
+        confirmationParameters: ConfirmationDefinition.Parameters,
     ): ConfirmationDefinition.Action<Unit> {
         val externalPaymentMethodType = confirmationOption.type
         val externalPaymentMethodConfirmHandler = externalPaymentMethodConfirmHandlerProvider.get()
@@ -78,7 +77,7 @@ internal class ExternalPaymentMethodConfirmationDefinition(
         launcher: ActivityResultLauncher<ExternalPaymentMethodInput>,
         arguments: Unit,
         confirmationOption: ExternalPaymentMethodConfirmationOption,
-        intent: StripeIntent,
+        confirmationParameters: ConfirmationDefinition.Parameters,
     ) {
         errorReporter.report(
             ErrorReporter.SuccessEvent.EXTERNAL_PAYMENT_METHODS_LAUNCH_SUCCESS,
@@ -95,13 +94,13 @@ internal class ExternalPaymentMethodConfirmationDefinition(
 
     override fun toResult(
         confirmationOption: ExternalPaymentMethodConfirmationOption,
+        confirmationParameters: ConfirmationDefinition.Parameters,
         deferredIntentConfirmationType: DeferredIntentConfirmationType?,
-        intent: StripeIntent,
         result: PaymentResult
     ): ConfirmationDefinition.Result {
         return when (result) {
             is PaymentResult.Completed -> ConfirmationDefinition.Result.Succeeded(
-                intent = intent,
+                intent = confirmationParameters.intent,
                 deferredIntentConfirmationType = null,
             )
             is PaymentResult.Failed -> ConfirmationDefinition.Result.Failed(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationOption.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationOption.kt
@@ -4,14 +4,10 @@ import android.os.Parcelable
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.paymentsheet.addresselement.AddressDetails
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
 internal data class GooglePayConfirmationOption(
-    val initializationMode: PaymentElementLoader.InitializationMode,
-    val shippingDetails: AddressDetails?,
     val config: Config,
 ) : ConfirmationHandler.Option {
     @Parcelize

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptorKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptorKtx.kt
@@ -1,27 +1,31 @@
 package com.stripe.android.paymentelement.confirmation.intent
 
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
+import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.addresselement.toConfirmPaymentIntentShipping
+import com.stripe.android.paymentsheet.state.PaymentElementLoader
 
 internal suspend fun IntentConfirmationInterceptor.intercept(
     confirmationOption: PaymentMethodConfirmationOption,
+    initializationMode: PaymentElementLoader.InitializationMode,
+    shippingDetails: AddressDetails?
 ): IntentConfirmationInterceptor.NextStep {
     return when (confirmationOption) {
         is PaymentMethodConfirmationOption.New -> {
             intercept(
-                initializationMode = confirmationOption.initializationMode,
+                initializationMode = initializationMode,
                 paymentMethodOptionsParams = confirmationOption.optionsParams,
                 paymentMethodCreateParams = confirmationOption.createParams,
-                shippingValues = confirmationOption.shippingDetails?.toConfirmPaymentIntentShipping(),
+                shippingValues = shippingDetails?.toConfirmPaymentIntentShipping(),
                 customerRequestedSave = confirmationOption.shouldSave,
             )
         }
         is PaymentMethodConfirmationOption.Saved -> {
             intercept(
-                initializationMode = confirmationOption.initializationMode,
+                initializationMode = initializationMode,
                 paymentMethod = confirmationOption.paymentMethod,
                 paymentMethodOptionsParams = confirmationOption.optionsParams,
-                shippingValues = confirmationOption.shippingDetails?.toConfirmPaymentIntentShipping(),
+                shippingValues = shippingDetails?.toConfirmPaymentIntentShipping(),
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinition.kt
@@ -5,7 +5,6 @@ import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.account.LinkStore
-import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
@@ -36,7 +35,7 @@ internal class LinkConfirmationDefinition(
 
     override suspend fun action(
         confirmationOption: LinkConfirmationOption,
-        intent: StripeIntent
+        confirmationParameters: ConfirmationDefinition.Parameters,
     ): ConfirmationDefinition.Action<Unit> {
         return ConfirmationDefinition.Action.Launch(
             launcherArguments = Unit,
@@ -49,15 +48,15 @@ internal class LinkConfirmationDefinition(
         launcher: LinkPaymentLauncher,
         arguments: Unit,
         confirmationOption: LinkConfirmationOption,
-        intent: StripeIntent
+        confirmationParameters: ConfirmationDefinition.Parameters,
     ) {
         launcher.present(confirmationOption.configuration)
     }
 
     override fun toResult(
         confirmationOption: LinkConfirmationOption,
+        confirmationParameters: ConfirmationDefinition.Parameters,
         deferredIntentConfirmationType: DeferredIntentConfirmationType?,
-        intent: StripeIntent,
         result: LinkActivityResult
     ): ConfirmationDefinition.Result {
         if (
@@ -70,12 +69,10 @@ internal class LinkConfirmationDefinition(
         return when (result) {
             is LinkActivityResult.Completed -> ConfirmationDefinition.Result.NextStep(
                 confirmationOption = PaymentMethodConfirmationOption.Saved(
-                    initializationMode = confirmationOption.initializationMode,
-                    shippingDetails = confirmationOption.shippingDetails,
                     paymentMethod = result.paymentMethod,
                     optionsParams = null,
                 ),
-                intent = intent,
+                parameters = confirmationParameters,
             )
             is LinkActivityResult.Failed -> ConfirmationDefinition.Result.Failed(
                 cause = result.error,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationOption.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationOption.kt
@@ -2,13 +2,9 @@ package com.stripe.android.paymentelement.confirmation.link
 
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
-import com.stripe.android.paymentsheet.addresselement.AddressDetails
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
 internal data class LinkConfirmationOption(
-    val initializationMode: PaymentElementLoader.InitializationMode,
-    val shippingDetails: AddressDetails?,
     val configuration: LinkConfiguration,
 ) : ConfirmationHandler.Option

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedConfirmationHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedConfirmationHelper.kt
@@ -52,15 +52,16 @@ internal class EmbeddedConfirmationHelper(
     private fun confirmationArgs(): ConfirmationHandler.Args? {
         val loadedState = confirmationStateSupplier() ?: return null
         val confirmationOption = loadedState.selection?.toConfirmationOption(
-            initializationMode = loadedState.initializationMode,
             configuration = loadedState.configuration.asCommonConfiguration(),
-            appearance = loadedState.configuration.appearance,
             linkConfiguration = null,
         ) ?: return null
 
         return ConfirmationHandler.Args(
             intent = loadedState.paymentMethodMetadata.stripeIntent,
             confirmationOption = confirmationOption,
+            initializationMode = loadedState.initializationMode,
+            appearance = loadedState.configuration.appearance,
+            shippingDetails = loadedState.configuration.shippingDetails,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -477,9 +477,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         viewModelScope.launch(workContext) {
             val confirmationOption = paymentSelectionWithCvcIfEnabled(paymentSelection)
                 ?.toConfirmationOption(
-                    initializationMode = args.initializationMode,
                     configuration = config.asCommonConfiguration(),
-                    appearance = config.appearance,
                     linkConfiguration = linkHandler.linkConfiguration.value,
                 )
 
@@ -490,6 +488,9 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                     arguments = ConfirmationHandler.Args(
                         intent = stripeIntent,
                         confirmationOption = option,
+                        initializationMode = args.initializationMode,
+                        appearance = config.appearance,
+                        shippingDetails = config.shippingDetails,
                     ),
                 )
             } ?: run {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -348,9 +348,7 @@ internal class DefaultFlowController @Inject internal constructor(
             val initializationMode = requireNotNull(initializationMode)
 
             val confirmationOption = paymentSelection?.toConfirmationOption(
-                initializationMode = initializationMode,
                 configuration = state.config,
-                appearance = appearance,
                 linkConfiguration = state.linkState?.configuration,
             )
 
@@ -361,6 +359,9 @@ internal class DefaultFlowController @Inject internal constructor(
                     arguments = ConfirmationHandler.Args(
                         confirmationOption = option,
                         intent = stripeIntent,
+                        initializationMode = initializationMode,
+                        appearance = appearance,
+                        shippingDetails = state.config.shippingDetails,
                     )
                 )
             } ?: run {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
@@ -38,15 +38,11 @@ class ConfirmationHandlerOptionKtxTest {
 
         assertThat(
             paymentSelection.toConfirmationOption(
-                initializationMode = PI_INITIALIZATION_MODE,
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
-                appearance = PaymentSheetFixtures.CONFIG_CUSTOMER.appearance,
                 linkConfiguration = null,
             )
         ).isEqualTo(
             PaymentMethodConfirmationOption.New(
-                initializationMode = PI_INITIALIZATION_MODE,
-                shippingDetails = null,
                 createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                 optionsParams = PaymentMethodOptionsParams.Card(network = "cartes_bancaires"),
                 shouldSave = false,
@@ -62,15 +58,11 @@ class ConfirmationHandlerOptionKtxTest {
 
         assertThat(
             paymentSelection.toConfirmationOption(
-                initializationMode = SI_INITIALIZATION_MODE,
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
-                appearance = PaymentSheetFixtures.CONFIG_CUSTOMER.appearance,
                 linkConfiguration = null,
             )
         ).isEqualTo(
             PaymentMethodConfirmationOption.New(
-                initializationMode = SI_INITIALIZATION_MODE,
-                shippingDetails = null,
                 createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                 optionsParams = null,
                 shouldSave = false,
@@ -86,15 +78,11 @@ class ConfirmationHandlerOptionKtxTest {
 
         assertThat(
             paymentSelection.toConfirmationOption(
-                initializationMode = PI_INITIALIZATION_MODE,
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
-                appearance = PaymentSheetFixtures.CONFIG_CUSTOMER.appearance,
                 linkConfiguration = null,
             )
         ).isEqualTo(
             PaymentMethodConfirmationOption.New(
-                initializationMode = PI_INITIALIZATION_MODE,
-                shippingDetails = null,
                 createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                 optionsParams = null,
                 shouldSave = true,
@@ -121,18 +109,13 @@ class ConfirmationHandlerOptionKtxTest {
 
         assertThat(
             paymentSelection.toConfirmationOption(
-                initializationMode = PI_INITIALIZATION_MODE,
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
-                appearance = PaymentSheetFixtures.CONFIG_CUSTOMER.appearance,
                 linkConfiguration = null,
             )
         ).isEqualTo(
             BacsConfirmationOption(
-                initializationMode = PI_INITIALIZATION_MODE,
-                shippingDetails = null,
                 createParams = bacsDebitParams,
                 optionsParams = null,
-                appearance = PaymentSheetFixtures.CONFIG_CUSTOMER.appearance,
             )
         )
     }
@@ -145,15 +128,11 @@ class ConfirmationHandlerOptionKtxTest {
 
         assertThat(
             paymentSelection.toConfirmationOption(
-                initializationMode = SI_INITIALIZATION_MODE,
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
-                appearance = PaymentSheetFixtures.CONFIG_CUSTOMER.appearance,
                 linkConfiguration = null,
             )
         ).isEqualTo(
             PaymentMethodConfirmationOption.New(
-                initializationMode = SI_INITIALIZATION_MODE,
-                shippingDetails = null,
                 createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                 optionsParams = null,
                 shouldSave = false,
@@ -172,15 +151,11 @@ class ConfirmationHandlerOptionKtxTest {
 
         assertThat(
             paymentSelection.toConfirmationOption(
-                initializationMode = PI_INITIALIZATION_MODE,
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
-                appearance = PaymentSheetFixtures.CONFIG_CUSTOMER.appearance,
                 linkConfiguration = null,
             )
         ).isEqualTo(
             PaymentMethodConfirmationOption.Saved(
-                initializationMode = PI_INITIALIZATION_MODE,
-                shippingDetails = null,
                 paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
                 optionsParams = PaymentMethodOptionsParams.Card(
                     cvc = "505"
@@ -207,9 +182,7 @@ class ConfirmationHandlerOptionKtxTest {
 
         assertThat(
             paymentSelection.toConfirmationOption(
-                initializationMode = PI_INITIALIZATION_MODE,
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
-                appearance = PaymentSheetFixtures.CONFIG_CUSTOMER.appearance,
                 linkConfiguration = null,
             )
         ).isEqualTo(
@@ -229,9 +202,7 @@ class ConfirmationHandlerOptionKtxTest {
     fun `On Google Pay selection with config with null google pay config, should return null`() {
         assertThat(
             PaymentSelection.GooglePay.toConfirmationOption(
-                initializationMode = PI_INITIALIZATION_MODE,
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
-                appearance = PaymentSheetFixtures.CONFIG_CUSTOMER.appearance,
                 linkConfiguration = null,
             )
         ).isNull()
@@ -241,7 +212,6 @@ class ConfirmationHandlerOptionKtxTest {
     fun `On Google Pay selection with config with google pay config, should return expected option`() {
         assertThat(
             PaymentSelection.GooglePay.toConfirmationOption(
-                initializationMode = SI_INITIALIZATION_MODE,
                 configuration = PaymentSheetFixtures.CONFIG_GOOGLEPAY.copy(
                     googlePay = PaymentSheetFixtures.CONFIG_GOOGLEPAY.googlePay?.copy(
                         label = "Merchant Payments",
@@ -249,13 +219,10 @@ class ConfirmationHandlerOptionKtxTest {
                         environment = PaymentSheet.GooglePayConfiguration.Environment.Production
                     )
                 ).asCommonConfiguration(),
-                appearance = PaymentSheetFixtures.CONFIG_CUSTOMER.appearance,
                 linkConfiguration = null,
             )
         ).isEqualTo(
             GooglePayConfirmationOption(
-                initializationMode = SI_INITIALIZATION_MODE,
-                shippingDetails = null,
                 config = GooglePayConfirmationOption.Config(
                     environment = PaymentSheet.GooglePayConfiguration.Environment.Production,
                     merchantName = "Merchant, Inc.",
@@ -276,9 +243,7 @@ class ConfirmationHandlerOptionKtxTest {
     fun `On Link selection but with no configuration, should return null`() {
         assertThat(
             PaymentSelection.Link.toConfirmationOption(
-                initializationMode = PI_INITIALIZATION_MODE,
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
-                appearance = PaymentSheetFixtures.CONFIG_CUSTOMER.appearance,
                 linkConfiguration = null,
             )
         ).isNull()
@@ -288,16 +253,12 @@ class ConfirmationHandlerOptionKtxTest {
     fun `On Link selection with configuration, should return Link confirmation option`() {
         assertThat(
             PaymentSelection.Link.toConfirmationOption(
-                initializationMode = PI_INITIALIZATION_MODE,
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
-                appearance = PaymentSheetFixtures.CONFIG_CUSTOMER.appearance,
                 linkConfiguration = LINK_CONFIGURATION,
             )
         ).isEqualTo(
             LinkConfirmationOption(
-                initializationMode = PI_INITIALIZATION_MODE,
                 configuration = LINK_CONFIGURATION,
-                shippingDetails = PaymentSheetFixtures.CONFIG_CUSTOMER.shippingDetails,
             )
         )
     }
@@ -310,15 +271,11 @@ class ConfirmationHandlerOptionKtxTest {
 
         assertThat(
             paymentSelection.toConfirmationOption(
-                initializationMode = PI_INITIALIZATION_MODE,
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
-                appearance = PaymentSheetFixtures.CONFIG_CUSTOMER.appearance,
                 linkConfiguration = null,
             )
         ).isEqualTo(
             PaymentMethodConfirmationOption.Saved(
-                initializationMode = PI_INITIALIZATION_MODE,
-                shippingDetails = null,
                 optionsParams = null,
                 paymentMethod = expectedPaymentMethod,
             )
@@ -333,15 +290,11 @@ class ConfirmationHandlerOptionKtxTest {
 
         assertThat(
             paymentSelection.toConfirmationOption(
-                initializationMode = PI_INITIALIZATION_MODE,
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
-                appearance = PaymentSheetFixtures.CONFIG_CUSTOMER.appearance,
                 linkConfiguration = null,
             )
         ).isEqualTo(
             PaymentMethodConfirmationOption.Saved(
-                initializationMode = PI_INITIALIZATION_MODE,
-                shippingDetails = null,
                 optionsParams = null,
                 paymentMethod = expectedPaymentMethod,
             )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediatorTest.kt
@@ -8,7 +8,10 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.isInstanceOf
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.addresselement.AddressDetails
+import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import kotlinx.coroutines.test.runTest
 import kotlinx.parcelize.Parcelize
 import org.junit.Test
@@ -108,7 +111,7 @@ class ConfirmationMediatorTest {
 
         val action = mediator.action(
             option = InvalidTestConfirmationOption,
-            intent = PaymentIntentFixtures.PI_SUCCEEDED,
+            parameters = CONFIRMATION_PARAMETERS,
         )
 
         assertThat(optionCalls.awaitItem().option).isEqualTo(InvalidTestConfirmationOption)
@@ -139,7 +142,7 @@ class ConfirmationMediatorTest {
 
         val action = mediator.action(
             option = TestConfirmationDefinition.Option,
-            intent = INTENT,
+            parameters = CONFIRMATION_PARAMETERS,
         )
 
         assertThat(optionCalls.awaitItem().option).isEqualTo(TestConfirmationDefinition.Option)
@@ -147,7 +150,7 @@ class ConfirmationMediatorTest {
         val actionCall = actionCalls.awaitItem()
 
         assertThat(actionCall.confirmationOption).isEqualTo(TestConfirmationDefinition.Option)
-        assertThat(actionCall.intent).isEqualTo(INTENT)
+        assertThat(actionCall.confirmationParameters).isEqualTo(CONFIRMATION_PARAMETERS)
 
         val completeAction = action.asComplete()
 
@@ -171,7 +174,7 @@ class ConfirmationMediatorTest {
 
         val action = mediator.action(
             option = TestConfirmationDefinition.Option,
-            intent = INTENT,
+            parameters = CONFIRMATION_PARAMETERS,
         )
 
         assertThat(optionCalls.awaitItem().option).isEqualTo(TestConfirmationDefinition.Option)
@@ -179,7 +182,7 @@ class ConfirmationMediatorTest {
         val actionCall = actionCalls.awaitItem()
 
         assertThat(actionCall.confirmationOption).isEqualTo(TestConfirmationDefinition.Option)
-        assertThat(actionCall.intent).isEqualTo(INTENT)
+        assertThat(actionCall.confirmationParameters).isEqualTo(CONFIRMATION_PARAMETERS)
 
         val failAction = action.asFail()
 
@@ -213,7 +216,7 @@ class ConfirmationMediatorTest {
 
         val action = mediator.action(
             option = TestConfirmationDefinition.Option,
-            intent = INTENT,
+            parameters = CONFIRMATION_PARAMETERS,
         )
 
         assertThat(optionCalls.awaitItem().option).isEqualTo(TestConfirmationDefinition.Option)
@@ -221,7 +224,7 @@ class ConfirmationMediatorTest {
         val actionCall = actionCalls.awaitItem()
 
         assertThat(actionCall.confirmationOption).isEqualTo(TestConfirmationDefinition.Option)
-        assertThat(actionCall.intent).isEqualTo(INTENT)
+        assertThat(actionCall.confirmationParameters).isEqualTo(CONFIRMATION_PARAMETERS)
 
         val launchAction = action.asLaunch()
 
@@ -233,7 +236,7 @@ class ConfirmationMediatorTest {
 
         assertThat(launchCall.confirmationOption).isEqualTo(TestConfirmationDefinition.Option)
         assertThat(launchCall.arguments).isEqualTo(TestConfirmationDefinition.LauncherArgs)
-        assertThat(launchCall.intent).isEqualTo(INTENT)
+        assertThat(launchCall.confirmationParameters).isEqualTo(CONFIRMATION_PARAMETERS)
         assertThat(launchCall.launcher).isEqualTo(TestConfirmationDefinition.Launcher)
 
         val parameters = savedStateHandle
@@ -242,7 +245,7 @@ class ConfirmationMediatorTest {
             )
 
         assertThat(parameters?.confirmationOption).isEqualTo(TestConfirmationDefinition.Option)
-        assertThat(parameters?.intent).isEqualTo(INTENT)
+        assertThat(parameters?.confirmationParameters).isEqualTo(CONFIRMATION_PARAMETERS)
         assertThat(parameters?.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Client)
     }
 
@@ -269,7 +272,7 @@ class ConfirmationMediatorTest {
 
             val action = mediator.action(
                 option = TestConfirmationDefinition.Option,
-                intent = INTENT,
+                parameters = CONFIRMATION_PARAMETERS,
             )
 
             assertThat(optionCalls.awaitItem().option).isEqualTo(TestConfirmationDefinition.Option)
@@ -277,7 +280,7 @@ class ConfirmationMediatorTest {
             val actionCall = actionCalls.awaitItem()
 
             assertThat(actionCall.confirmationOption).isEqualTo(TestConfirmationDefinition.Option)
-            assertThat(actionCall.intent).isEqualTo(INTENT)
+            assertThat(actionCall.confirmationParameters).isEqualTo(CONFIRMATION_PARAMETERS)
 
             val launchAction = action.asLaunch()
 
@@ -299,7 +302,7 @@ class ConfirmationMediatorTest {
 
         val action = mediator.action(
             option = TestConfirmationDefinition.Option,
-            intent = INTENT,
+            parameters = CONFIRMATION_PARAMETERS,
         )
 
         assertThat(optionCalls.awaitItem().option).isEqualTo(TestConfirmationDefinition.Option)
@@ -307,7 +310,7 @@ class ConfirmationMediatorTest {
         val actionCall = actionCalls.awaitItem()
 
         assertThat(actionCall.confirmationOption).isEqualTo(TestConfirmationDefinition.Option)
-        assertThat(actionCall.intent).isEqualTo(INTENT)
+        assertThat(actionCall.confirmationParameters).isEqualTo(CONFIRMATION_PARAMETERS)
 
         val failAction = action.asFail()
 
@@ -343,7 +346,7 @@ class ConfirmationMediatorTest {
 
         val action = mediator.action(
             option = TestConfirmationDefinition.Option,
-            intent = INTENT,
+            parameters = CONFIRMATION_PARAMETERS,
         )
 
         assertThat(optionCalls.awaitItem().option).isEqualTo(TestConfirmationDefinition.Option)
@@ -351,7 +354,7 @@ class ConfirmationMediatorTest {
         val actionCall = actionCalls.awaitItem()
 
         assertThat(actionCall.confirmationOption).isEqualTo(TestConfirmationDefinition.Option)
-        assertThat(actionCall.intent).isEqualTo(INTENT)
+        assertThat(actionCall.confirmationParameters).isEqualTo(CONFIRMATION_PARAMETERS)
 
         val failAction = action.asFail()
 
@@ -396,7 +399,7 @@ class ConfirmationMediatorTest {
         val createLauncherCall = createLauncherCalls.awaitItem()
 
         val action = mediator.action(
-            intent = INTENT,
+            parameters = CONFIRMATION_PARAMETERS,
             option = TestConfirmationDefinition.Option,
         )
 
@@ -405,7 +408,7 @@ class ConfirmationMediatorTest {
         val actionCall = actionCalls.awaitItem()
 
         assertThat(actionCall.confirmationOption).isEqualTo(TestConfirmationDefinition.Option)
-        assertThat(actionCall.intent).isEqualTo(INTENT)
+        assertThat(actionCall.confirmationParameters).isEqualTo(CONFIRMATION_PARAMETERS)
 
         assertThat(action).isInstanceOf<ConfirmationMediator.Action.Launch>()
 
@@ -417,7 +420,7 @@ class ConfirmationMediatorTest {
 
         assertThat(launchCall.confirmationOption).isEqualTo(TestConfirmationDefinition.Option)
         assertThat(launchCall.arguments).isEqualTo(TestConfirmationDefinition.LauncherArgs)
-        assertThat(launchCall.intent).isEqualTo(INTENT)
+        assertThat(launchCall.confirmationParameters).isEqualTo(CONFIRMATION_PARAMETERS)
         assertThat(launchCall.launcher).isEqualTo(TestConfirmationDefinition.Launcher)
 
         createLauncherCall.onResult(TestConfirmationDefinition.LauncherResult)
@@ -427,7 +430,7 @@ class ConfirmationMediatorTest {
         val toPaymentConfirmationResultCall = toResultCalls.awaitItem()
 
         assertThat(toPaymentConfirmationResultCall.confirmationOption).isEqualTo(TestConfirmationDefinition.Option)
-        assertThat(toPaymentConfirmationResultCall.intent).isEqualTo(INTENT)
+        assertThat(toPaymentConfirmationResultCall.confirmationParameters).isEqualTo(CONFIRMATION_PARAMETERS)
         assertThat(toPaymentConfirmationResultCall.result).isEqualTo(TestConfirmationDefinition.LauncherResult)
         assertThat(toPaymentConfirmationResultCall.deferredIntentConfirmationType)
             .isEqualTo(DeferredIntentConfirmationType.Client)
@@ -542,5 +545,16 @@ class ConfirmationMediatorTest {
 
     private companion object {
         private val INTENT = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD
+
+        private val CONFIRMATION_PARAMETERS = ConfirmationDefinition.Parameters(
+            intent = INTENT,
+            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
+                clientSecret = "pi_123_secret_123",
+            ),
+            appearance = PaymentSheet.Appearance(),
+            shippingDetails = AddressDetails(
+                name = "John Doe",
+            )
+        )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationTestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationTestUtils.kt
@@ -5,7 +5,6 @@ import androidx.activity.result.ActivityResultCallback
 import androidx.lifecycle.SavedStateHandle
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.isInstanceOf
-import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentelement.confirmation.ConfirmationMediator.Parameters
 import com.stripe.android.utils.DummyActivityResultCaller
 import kotlinx.coroutines.test.runTest
@@ -20,7 +19,7 @@ internal fun <
     > runLaunchTest(
     definition: ConfirmationDefinition<TConfirmationOption, TLauncher, TLauncherArgs, TLauncherResult>,
     confirmationOption: ConfirmationHandler.Option,
-    intent: StripeIntent,
+    parameters: ConfirmationDefinition.Parameters
 ) = runTest {
     val savedStateHandle = SavedStateHandle()
     val mediator = ConfirmationMediator(savedStateHandle, definition)
@@ -35,7 +34,7 @@ internal fun <
 
         val action = mediator.action(
             option = confirmationOption,
-            intent = intent,
+            parameters = parameters,
         )
 
         assertThat(action).isInstanceOf<ConfirmationMediator.Action.Launch>()
@@ -44,12 +43,12 @@ internal fun <
 
         launchAction.launch()
 
-        val parameters = savedStateHandle
+        val savedParameters = savedStateHandle
             .get<Parameters<TConfirmationOption>>("${definition.key}Parameters")
 
-        assertThat(parameters?.confirmationOption).isEqualTo(confirmationOption)
-        assertThat(parameters?.intent).isEqualTo(intent)
-        assertThat(parameters?.deferredIntentConfirmationType).isNull()
+        assertThat(savedParameters?.confirmationOption).isEqualTo(confirmationOption)
+        assertThat(savedParameters?.confirmationParameters).isEqualTo(parameters)
+        assertThat(savedParameters?.deferredIntentConfirmationType).isNull()
 
         assertThat(awaitRegisterCall()).isNotNull()
         assertThat(awaitLaunchCall()).isNotNull()
@@ -64,7 +63,7 @@ internal fun <
     > runResultTest(
     definition: ConfirmationDefinition<TConfirmationOption, TLauncher, TLauncherArgs, TLauncherResult>,
     confirmationOption: ConfirmationHandler.Option,
-    intent: StripeIntent,
+    parameters: ConfirmationDefinition.Parameters,
     launcherResult: TLauncherResult,
     definitionResult: ConfirmationDefinition.Result,
 ) = runTest {
@@ -75,7 +74,7 @@ internal fun <
             "${definition.key}Parameters",
             Parameters(
                 confirmationOption = confirmationOption,
-                intent = intent,
+                confirmationParameters = parameters,
                 deferredIntentConfirmationType = null,
             )
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandlerTest.kt
@@ -12,7 +12,10 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.isInstanceOf
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
 import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.addresselement.AddressDetails
+import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.PaymentMethodFactory
@@ -84,12 +87,7 @@ class DefaultConfirmationHandlerTest {
         confirmationHandler.state.test {
             assertIdleState()
 
-            confirmationHandler.start(
-                ConfirmationHandler.Args(
-                    confirmationOption = SomeConfirmationDefinition.Option,
-                    intent = PAYMENT_INTENT,
-                )
-            )
+            confirmationHandler.start(createArguments(SomeConfirmationDefinition.Option))
 
             assertSomeDefinitionActionCalled()
             assertSomeDefinitionConfirmingState()
@@ -104,12 +102,7 @@ class DefaultConfirmationHandlerTest {
                 .isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
             assertThat(someDefinitionFailedResult.type).isEqualTo(ConfirmationHandler.Result.Failed.ErrorType.Fatal)
 
-            confirmationHandler.start(
-                ConfirmationHandler.Args(
-                    confirmationOption = SomeOtherConfirmationDefinition.Option,
-                    intent = PAYMENT_INTENT,
-                )
-            )
+            confirmationHandler.start(createArguments(SomeOtherConfirmationDefinition.Option))
 
             assertSomeOtherDefinitionActionCalled()
             assertSomeOtherDefinitionConfirmingState()
@@ -132,12 +125,7 @@ class DefaultConfirmationHandlerTest {
         confirmationHandler.state.test {
             assertIdleState()
 
-            confirmationHandler.start(
-                ConfirmationHandler.Args(
-                    confirmationOption = InvalidConfirmationOption,
-                    intent = PAYMENT_INTENT,
-                )
-            )
+            confirmationHandler.start(createArguments(InvalidConfirmationOption))
 
             // Should check all passed definitions
             assertThat(someDefinitionScenario.optionCalls.awaitItem().option)
@@ -181,12 +169,7 @@ class DefaultConfirmationHandlerTest {
         confirmationHandler.state.test {
             assertIdleState()
 
-            confirmationHandler.start(
-                ConfirmationHandler.Args(
-                    confirmationOption = SomeConfirmationDefinition.Option,
-                    intent = PAYMENT_INTENT,
-                )
-            )
+            confirmationHandler.start(createArguments(SomeConfirmationDefinition.Option))
 
             assertSomeDefinitionActionCalled()
             assertSomeDefinitionConfirmingState()
@@ -214,12 +197,7 @@ class DefaultConfirmationHandlerTest {
         confirmationHandler.state.test {
             assertIdleState()
 
-            confirmationHandler.start(
-                ConfirmationHandler.Args(
-                    confirmationOption = SomeOtherConfirmationDefinition.Option,
-                    intent = PAYMENT_INTENT,
-                )
-            )
+            confirmationHandler.start(createArguments(SomeOtherConfirmationDefinition.Option))
 
             assertSomeOtherDefinitionActionCalled()
             assertSomeOtherDefinitionConfirmingState()
@@ -247,12 +225,7 @@ class DefaultConfirmationHandlerTest {
         confirmationHandler.state.test {
             assertIdleState()
 
-            confirmationHandler.start(
-                ConfirmationHandler.Args(
-                    confirmationOption = SomeConfirmationDefinition.Option,
-                    intent = PAYMENT_INTENT,
-                )
-            )
+            confirmationHandler.start(createArguments(SomeConfirmationDefinition.Option))
 
             assertSomeDefinitionActionCalled()
             assertSomeDefinitionConfirmingState()
@@ -324,8 +297,8 @@ class DefaultConfirmationHandlerTest {
             deferredIntentConfirmationType = null,
         ),
         someDefinitionResult = ConfirmationDefinition.Result.NextStep(
-            intent = PAYMENT_INTENT,
             confirmationOption = SomeOtherConfirmationDefinition.Option,
+            parameters = CONFIRMATION_PARAMETERS,
         ),
         someOtherDefinitionAction = ConfirmationDefinition.Action.Launch(
             launcherArguments = SomeOtherConfirmationDefinition.LauncherArgs,
@@ -340,12 +313,7 @@ class DefaultConfirmationHandlerTest {
         confirmationHandler.state.test {
             assertIdleState()
 
-            confirmationHandler.start(
-                ConfirmationHandler.Args(
-                    confirmationOption = SomeConfirmationDefinition.Option,
-                    intent = PAYMENT_INTENT,
-                )
-            )
+            confirmationHandler.start(createArguments(SomeConfirmationDefinition.Option))
 
             assertSomeDefinitionActionCalled()
             assertSomeDefinitionConfirmingState()
@@ -472,7 +440,7 @@ class DefaultConfirmationHandlerTest {
         test(
             savedStateHandle = createPrepopulatedSavedStateHandle(receivesResultInProcess = false),
             someDefinitionResult = ConfirmationDefinition.Result.NextStep(
-                intent = PAYMENT_INTENT,
+                parameters = CONFIRMATION_PARAMETERS,
                 confirmationOption = SomeOtherConfirmationDefinition.Option,
             ),
             someOtherDefinitionAction = ConfirmationDefinition.Action.Launch(
@@ -538,12 +506,7 @@ class DefaultConfirmationHandlerTest {
             ),
             dispatcher = dispatcher,
         ) {
-            confirmationHandler.start(
-                ConfirmationHandler.Args(
-                    confirmationOption = SomeConfirmationDefinition.Option,
-                    intent = PAYMENT_INTENT,
-                )
-            )
+            confirmationHandler.start(createArguments(SomeConfirmationDefinition.Option))
 
             val job = CoroutineScope(dispatcher).launch {
                 val result = confirmationHandler.awaitResult().assertSucceeded()
@@ -590,12 +553,7 @@ class DefaultConfirmationHandlerTest {
         confirmationHandler.state.test {
             assertIdleState()
 
-            confirmationHandler.start(
-                ConfirmationHandler.Args(
-                    confirmationOption = SomeConfirmationDefinition.Option,
-                    intent = PAYMENT_INTENT,
-                )
-            )
+            confirmationHandler.start(createArguments(SomeConfirmationDefinition.Option))
 
             assertSomeDefinitionActionCalled()
             assertSomeDefinitionConfirmingState()
@@ -621,12 +579,7 @@ class DefaultConfirmationHandlerTest {
         confirmationHandler.state.test {
             assertIdleState()
 
-            confirmationHandler.start(
-                ConfirmationHandler.Args(
-                    confirmationOption = SomeConfirmationDefinition.Option,
-                    intent = PAYMENT_INTENT,
-                )
-            )
+            confirmationHandler.start(createArguments(SomeConfirmationDefinition.Option))
 
             assertSomeDefinitionActionCalled()
             assertSomeDefinitionConfirmingState()
@@ -646,7 +599,7 @@ class DefaultConfirmationHandlerTest {
                 SOME_DEFINITION_PERSISTED_KEY
             )
 
-            assertThat(parameters?.intent).isEqualTo(PAYMENT_INTENT)
+            assertThat(parameters?.confirmationParameters).isEqualTo(CONFIRMATION_PARAMETERS)
             assertThat(parameters?.confirmationOption).isEqualTo(SomeConfirmationDefinition.Option)
             assertThat(parameters?.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Client)
         }
@@ -776,6 +729,16 @@ class DefaultConfirmationHandlerTest {
         )
     }
 
+    private fun createArguments(option: ConfirmationHandler.Option): ConfirmationHandler.Args {
+        return ConfirmationHandler.Args(
+            confirmationOption = option,
+            intent = CONFIRMATION_PARAMETERS.intent,
+            appearance = CONFIRMATION_PARAMETERS.appearance,
+            initializationMode = CONFIRMATION_PARAMETERS.initializationMode,
+            shippingDetails = CONFIRMATION_PARAMETERS.shippingDetails,
+        )
+    }
+
     private fun createPrepopulatedSavedStateHandle(
         receivesResultInProcess: Boolean,
     ) = SavedStateHandle().apply {
@@ -791,7 +754,7 @@ class DefaultConfirmationHandlerTest {
             "SomeParameters",
             ConfirmationMediator.Parameters(
                 confirmationOption = SomeConfirmationDefinition.Option,
-                intent = PAYMENT_INTENT,
+                confirmationParameters = CONFIRMATION_PARAMETERS,
                 deferredIntentConfirmationType = null,
             )
         )
@@ -820,7 +783,7 @@ class DefaultConfirmationHandlerTest {
         val actionCall = someDefinitionScenario.actionCalls.awaitItem()
 
         assertThat(actionCall.confirmationOption).isEqualTo(SomeConfirmationDefinition.Option)
-        assertThat(actionCall.intent).isEqualTo(PAYMENT_INTENT)
+        assertThat(actionCall.confirmationParameters).isEqualTo(CONFIRMATION_PARAMETERS)
     }
 
     private suspend fun Scenario.assertSomeDefinitionLaunchCalled() {
@@ -829,7 +792,7 @@ class DefaultConfirmationHandlerTest {
         assertThat(launchCall.launcher).isEqualTo(SomeConfirmationDefinition.Launcher)
         assertThat(launchCall.confirmationOption).isEqualTo(SomeConfirmationDefinition.Option)
         assertThat(launchCall.arguments).isEqualTo(SomeConfirmationDefinition.LauncherArgs)
-        assertThat(launchCall.intent).isEqualTo(PAYMENT_INTENT)
+        assertThat(launchCall.confirmationParameters).isEqualTo(CONFIRMATION_PARAMETERS)
     }
 
     private suspend fun Scenario.assertSomeDefinitionToResultCalled() {
@@ -837,7 +800,7 @@ class DefaultConfirmationHandlerTest {
 
         assertThat(toResultCall.confirmationOption).isEqualTo(SomeConfirmationDefinition.Option)
         assertThat(toResultCall.result).isEqualTo(SomeConfirmationDefinition.LauncherResult)
-        assertThat(toResultCall.intent).isEqualTo(PAYMENT_INTENT)
+        assertThat(toResultCall.confirmationParameters).isEqualTo(CONFIRMATION_PARAMETERS)
     }
 
     private fun Scenario.sendSomeOtherDefinitionLauncherResult() {
@@ -859,7 +822,7 @@ class DefaultConfirmationHandlerTest {
         val actionCall = someOtherDefinitionScenario.actionCalls.awaitItem()
 
         assertThat(actionCall.confirmationOption).isEqualTo(SomeOtherConfirmationDefinition.Option)
-        assertThat(actionCall.intent).isEqualTo(PAYMENT_INTENT)
+        assertThat(actionCall.confirmationParameters).isEqualTo(CONFIRMATION_PARAMETERS)
     }
 
     private suspend fun Scenario.assertSomeOtherDefinitionLaunchCalled() {
@@ -868,7 +831,7 @@ class DefaultConfirmationHandlerTest {
         assertThat(launchCall.launcher).isEqualTo(SomeOtherConfirmationDefinition.Launcher)
         assertThat(launchCall.confirmationOption).isEqualTo(SomeOtherConfirmationDefinition.Option)
         assertThat(launchCall.arguments).isEqualTo(SomeOtherConfirmationDefinition.LauncherArgs)
-        assertThat(launchCall.intent).isEqualTo(PAYMENT_INTENT)
+        assertThat(launchCall.confirmationParameters).isEqualTo(CONFIRMATION_PARAMETERS)
     }
 
     private suspend fun Scenario.assertSomeOtherDefinitionToResultCalled() {
@@ -876,7 +839,7 @@ class DefaultConfirmationHandlerTest {
 
         assertThat(toResultCall.confirmationOption).isEqualTo(SomeOtherConfirmationDefinition.Option)
         assertThat(toResultCall.result).isEqualTo(SomeOtherConfirmationDefinition.LauncherResult)
-        assertThat(toResultCall.intent).isEqualTo(PAYMENT_INTENT)
+        assertThat(toResultCall.confirmationParameters).isEqualTo(CONFIRMATION_PARAMETERS)
     }
 
     private suspend fun TurbineTestContext<ConfirmationHandler.State>.assertIdleState() {
@@ -1032,6 +995,15 @@ class DefaultConfirmationHandlerTest {
         const val AWAITING_CONFIRMATION_RESULT_KEY = "AwaitingConfirmationResult"
 
         val PAYMENT_INTENT = PaymentIntentFactory.create()
+
+        val CONFIRMATION_PARAMETERS = ConfirmationDefinition.Parameters(
+            intent = PAYMENT_INTENT,
+            appearance = PaymentSheet.Appearance(),
+            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
+                clientSecret = "pi_123_secret_123",
+            ),
+            shippingDetails = AddressDetails(),
+        )
 
         val UPDATED_PAYMENT_INTENT = PAYMENT_INTENT.copy(
             paymentMethod = PaymentMethodFactory.card(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultIntentConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultIntentConfirmationInterceptorTest.kt
@@ -101,13 +101,13 @@ class DefaultIntentConfirmationInterceptorTest {
 
             val nextStep = interceptor.intercept(
                 confirmationOption = PaymentMethodConfirmationOption.Saved(
-                    initializationMode = InitializationMode.PaymentIntent("pi_1234_secret_4321"),
-                    shippingDetails = null,
                     paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
                     optionsParams = PaymentMethodOptionsParams.Card(
                         setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
                     )
                 ),
+                initializationMode = InitializationMode.PaymentIntent("pi_1234_secret_4321"),
+                shippingDetails = null,
             )
 
             val confirmNextStep = nextStep as? IntentConfirmationInterceptor.NextStep.Confirm

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/FakeConfirmationDefinition.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/FakeConfirmationDefinition.kt
@@ -3,7 +3,6 @@ package com.stripe.android.paymentelement.confirmation
 import android.os.Parcelable
 import androidx.activity.result.ActivityResultCaller
 import com.stripe.android.core.strings.resolvableString
-import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
 import com.stripe.android.paymentsheet.R
 
@@ -30,7 +29,7 @@ internal abstract class FakeConfirmationDefinition<
     > {
     override suspend fun action(
         confirmationOption: TConfirmationOption,
-        intent: StripeIntent
+        confirmationParameters: ConfirmationDefinition.Parameters,
     ): ConfirmationDefinition.Action<TLauncherArgs> {
         return action
     }
@@ -39,7 +38,7 @@ internal abstract class FakeConfirmationDefinition<
         launcher: TLauncher,
         arguments: TLauncherArgs,
         confirmationOption: TConfirmationOption,
-        intent: StripeIntent
+        confirmationParameters: ConfirmationDefinition.Parameters,
     ) {
         // Do nothing
     }
@@ -53,8 +52,8 @@ internal abstract class FakeConfirmationDefinition<
 
     override fun toResult(
         confirmationOption: TConfirmationOption,
+        confirmationParameters: ConfirmationDefinition.Parameters,
         deferredIntentConfirmationType: DeferredIntentConfirmationType?,
-        intent: StripeIntent,
         result: TLauncherResult
     ): ConfirmationDefinition.Result {
         return this.result

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/RecordingConfirmationDefinition.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/RecordingConfirmationDefinition.kt
@@ -4,7 +4,6 @@ import android.os.Parcelable
 import androidx.activity.result.ActivityResultCaller
 import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
-import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
 
 internal class RecordingConfirmationDefinition<
@@ -37,13 +36,25 @@ internal class RecordingConfirmationDefinition<
 
     override fun toResult(
         confirmationOption: TConfirmationOption,
+        confirmationParameters: ConfirmationDefinition.Parameters,
         deferredIntentConfirmationType: DeferredIntentConfirmationType?,
-        intent: StripeIntent,
         result: TLauncherResult
     ): ConfirmationDefinition.Result {
-        toResultCalls.add(ToResultCall(confirmationOption, deferredIntentConfirmationType, intent, result))
+        toResultCalls.add(
+            ToResultCall(
+                confirmationOption = confirmationOption,
+                deferredIntentConfirmationType = deferredIntentConfirmationType,
+                confirmationParameters = confirmationParameters,
+                result = result
+            )
+        )
 
-        return definition.toResult(confirmationOption, deferredIntentConfirmationType, intent, result)
+        return definition.toResult(
+            confirmationOption = confirmationOption,
+            deferredIntentConfirmationType = deferredIntentConfirmationType,
+            confirmationParameters = confirmationParameters,
+            result = result
+        )
     }
 
     override fun createLauncher(
@@ -63,20 +74,20 @@ internal class RecordingConfirmationDefinition<
         launcher: TLauncher,
         arguments: TLauncherArgs,
         confirmationOption: TConfirmationOption,
-        intent: StripeIntent
+        confirmationParameters: ConfirmationDefinition.Parameters,
     ) {
-        launchCalls.add(LaunchCall(launcher, arguments, confirmationOption, intent))
+        launchCalls.add(LaunchCall(launcher, arguments, confirmationOption, confirmationParameters))
 
-        definition.launch(launcher, arguments, confirmationOption, intent)
+        definition.launch(launcher, arguments, confirmationOption, confirmationParameters)
     }
 
     override suspend fun action(
         confirmationOption: TConfirmationOption,
-        intent: StripeIntent
+        confirmationParameters: ConfirmationDefinition.Parameters,
     ): ConfirmationDefinition.Action<TLauncherArgs> {
-        actionCalls.add(ActionCall(confirmationOption, intent))
+        actionCalls.add(ActionCall(confirmationOption, confirmationParameters))
 
-        return definition.action(confirmationOption, intent)
+        return definition.action(confirmationOption, confirmationParameters)
     }
 
     class OptionCall(
@@ -85,8 +96,8 @@ internal class RecordingConfirmationDefinition<
 
     class ToResultCall<TConfirmationOption : ConfirmationHandler.Option, TLauncherResult>(
         val confirmationOption: TConfirmationOption,
+        val confirmationParameters: ConfirmationDefinition.Parameters,
         val deferredIntentConfirmationType: DeferredIntentConfirmationType?,
-        val intent: StripeIntent,
         val result: TLauncherResult,
     )
 
@@ -103,12 +114,12 @@ internal class RecordingConfirmationDefinition<
         val launcher: TLauncher,
         val arguments: TLauncherArgs,
         val confirmationOption: TConfirmationOption,
-        val intent: StripeIntent,
+        val confirmationParameters: ConfirmationDefinition.Parameters,
     )
 
     class ActionCall<TConfirmationOption : ConfirmationHandler.Option>(
         val confirmationOption: TConfirmationOption,
-        val intent: StripeIntent,
+        val confirmationParameters: ConfirmationDefinition.Parameters,
     )
 
     class Scenario<

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationDefinitionTest.kt
@@ -17,6 +17,7 @@ import com.stripe.android.paymentelement.confirmation.asLaunch
 import com.stripe.android.paymentelement.confirmation.asNextStep
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateConfirmationContract
 import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateConfirmationLauncherFactory
 import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateConfirmationResult
@@ -94,7 +95,7 @@ class BacsConfirmationDefinitionTest {
 
         val result = definition.toResult(
             confirmationOption = createBacsConfirmationOption(),
-            intent = PAYMENT_INTENT,
+            confirmationParameters = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
             result = BacsMandateConfirmationResult.Confirmed,
         )
@@ -103,7 +104,7 @@ class BacsConfirmationDefinitionTest {
 
         val successResult = result.asNextStep()
 
-        assertThat(successResult.intent).isEqualTo(PAYMENT_INTENT)
+        assertThat(successResult.parameters).isEqualTo(CONFIRMATION_PARAMETERS)
 
         val confirmationOption = successResult.confirmationOption
 
@@ -113,8 +114,6 @@ class BacsConfirmationDefinitionTest {
 
         assertThat(newPaymentMethodOption.createParams).isEqualTo(bacsConfirmationOption.createParams)
         assertThat(newPaymentMethodOption.optionsParams).isEqualTo(bacsConfirmationOption.optionsParams)
-        assertThat(newPaymentMethodOption.initializationMode).isEqualTo(bacsConfirmationOption.initializationMode)
-        assertThat(newPaymentMethodOption.shippingDetails).isEqualTo(bacsConfirmationOption.shippingDetails)
         assertThat(newPaymentMethodOption.shouldSave).isFalse()
     }
 
@@ -125,7 +124,7 @@ class BacsConfirmationDefinitionTest {
 
             val result = definition.toResult(
                 confirmationOption = createBacsConfirmationOption(),
-                intent = PAYMENT_INTENT,
+                confirmationParameters = CONFIRMATION_PARAMETERS,
                 deferredIntentConfirmationType = null,
                 result = BacsMandateConfirmationResult.Cancelled,
             )
@@ -144,7 +143,7 @@ class BacsConfirmationDefinitionTest {
 
             val result = definition.toResult(
                 confirmationOption = createBacsConfirmationOption(),
-                intent = PAYMENT_INTENT,
+                confirmationParameters = CONFIRMATION_PARAMETERS,
                 deferredIntentConfirmationType = null,
                 result = BacsMandateConfirmationResult.ModifyDetails,
             )
@@ -165,7 +164,7 @@ class BacsConfirmationDefinitionTest {
             confirmationOption = createBacsConfirmationOption(
                 name = null,
             ),
-            intent = PAYMENT_INTENT,
+            confirmationParameters = CONFIRMATION_PARAMETERS,
         )
 
         assertThat(action).isInstanceOf<ConfirmationDefinition.Action.Fail<BacsMandateData>>()
@@ -188,7 +187,7 @@ class BacsConfirmationDefinitionTest {
             confirmationOption = createBacsConfirmationOption(
                 email = null,
             ),
-            intent = PAYMENT_INTENT,
+            confirmationParameters = CONFIRMATION_PARAMETERS,
         )
 
         assertThat(action).isInstanceOf<ConfirmationDefinition.Action.Fail<BacsMandateData>>()
@@ -209,7 +208,7 @@ class BacsConfirmationDefinitionTest {
 
         val action = definition.action(
             confirmationOption = createBacsConfirmationOption(),
-            intent = PAYMENT_INTENT,
+            confirmationParameters = CONFIRMATION_PARAMETERS,
         )
 
         assertThat(action).isInstanceOf<ConfirmationDefinition.Action.Launch<BacsMandateData>>()
@@ -246,8 +245,8 @@ class BacsConfirmationDefinitionTest {
         )
 
         definition.launch(
-            confirmationOption = createBacsConfirmationOption().copy(appearance = appearance),
-            intent = PAYMENT_INTENT,
+            confirmationOption = createBacsConfirmationOption(),
+            confirmationParameters = CONFIRMATION_PARAMETERS.copy(appearance = appearance),
             arguments = bacsMandateData,
             launcher = launcher,
         )
@@ -272,9 +271,6 @@ class BacsConfirmationDefinitionTest {
         email: String? = "johndoe@email.com",
     ): BacsConfirmationOption {
         return BacsConfirmationOption(
-            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
-                clientSecret = "pi_123_secret_123"
-            ),
             createParams = PaymentMethodCreateParams.create(
                 bacsDebit = PaymentMethodCreateParams.BacsDebit(
                     accountNumber = "00012345",
@@ -286,8 +282,6 @@ class BacsConfirmationDefinitionTest {
                 )
             ),
             optionsParams = null,
-            shippingDetails = null,
-            appearance = PaymentSheet.Appearance(),
         )
     }
 
@@ -297,5 +291,14 @@ class BacsConfirmationDefinitionTest {
 
     private companion object {
         private val PAYMENT_INTENT = PaymentIntentFactory.create()
+
+        private val CONFIRMATION_PARAMETERS = ConfirmationDefinition.Parameters(
+            intent = PAYMENT_INTENT,
+            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
+                clientSecret = "pi_123_secret_123",
+            ),
+            appearance = PaymentSheet.Appearance(),
+            shippingDetails = AddressDetails(),
+        )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationFlowTest.kt
@@ -17,7 +17,7 @@ class BacsConfirmationFlowTest {
     @Test
     fun `on launch, should persist parameters & launch using launcher as expected`() = runLaunchTest(
         confirmationOption = BACS_CONFIRMATION_OPTION,
-        intent = PAYMENT_INTENT,
+        parameters = CONFIRMATION_PARAMETERS,
         definition = BacsConfirmationDefinition(
             bacsMandateConfirmationLauncherFactory = DefaultBacsMandateConfirmationLauncherFactory,
         ),
@@ -26,28 +26,23 @@ class BacsConfirmationFlowTest {
     @Test
     fun `on result, should return confirmation result as expected`() = runResultTest(
         confirmationOption = BACS_CONFIRMATION_OPTION,
-        intent = PAYMENT_INTENT,
         definition = BacsConfirmationDefinition(
             bacsMandateConfirmationLauncherFactory = FakeBacsMandateConfirmationLauncherFactory(),
         ),
         launcherResult = BacsMandateConfirmationResult.Confirmed,
+        parameters = CONFIRMATION_PARAMETERS,
         definitionResult = ConfirmationDefinition.Result.NextStep(
-            intent = PAYMENT_INTENT,
             confirmationOption = PaymentMethodConfirmationOption.New(
-                initializationMode = BACS_CONFIRMATION_OPTION.initializationMode,
                 createParams = BACS_CONFIRMATION_OPTION.createParams,
                 optionsParams = BACS_CONFIRMATION_OPTION.optionsParams,
-                shippingDetails = BACS_CONFIRMATION_OPTION.shippingDetails,
                 shouldSave = false,
             ),
+            parameters = CONFIRMATION_PARAMETERS,
         ),
     )
 
     private companion object {
         private val BACS_CONFIRMATION_OPTION = BacsConfirmationOption(
-            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
-                clientSecret = "pi_123_secret_123"
-            ),
             createParams = PaymentMethodCreateParams.create(
                 bacsDebit = PaymentMethodCreateParams.BacsDebit(
                     accountNumber = "00012345",
@@ -59,10 +54,17 @@ class BacsConfirmationFlowTest {
                 )
             ),
             optionsParams = null,
-            shippingDetails = null,
-            appearance = PaymentSheet.Appearance(),
         )
 
         private val PAYMENT_INTENT = PaymentIntentFactory.create()
+
+        private val CONFIRMATION_PARAMETERS = ConfirmationDefinition.Parameters(
+            intent = PAYMENT_INTENT,
+            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
+                clientSecret = "pi_123_secret_123"
+            ),
+            shippingDetails = null,
+            appearance = PaymentSheet.Appearance(),
+        )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationDefinitionTest.kt
@@ -21,7 +21,10 @@ import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.paymentsheet.ExternalPaymentMethodConfirmHandler
 import com.stripe.android.paymentsheet.ExternalPaymentMethodContract
 import com.stripe.android.paymentsheet.ExternalPaymentMethodInput
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.addresselement.AddressDetails
+import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.utils.DummyActivityResultCaller
@@ -91,7 +94,7 @@ class ExternalPaymentMethodConfirmationDefinitionTest {
 
         val result = definition.toResult(
             confirmationOption = EPM_CONFIRMATION_OPTION,
-            intent = PAYMENT_INTENT,
+            confirmationParameters = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
             result = PaymentResult.Completed,
         )
@@ -111,7 +114,7 @@ class ExternalPaymentMethodConfirmationDefinitionTest {
         val exception = IllegalStateException("Failed!")
         val result = definition.toResult(
             confirmationOption = EPM_CONFIRMATION_OPTION,
-            intent = PAYMENT_INTENT,
+            confirmationParameters = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
             result = PaymentResult.Failed(exception),
         )
@@ -131,7 +134,7 @@ class ExternalPaymentMethodConfirmationDefinitionTest {
 
         val result = definition.toResult(
             confirmationOption = EPM_CONFIRMATION_OPTION,
-            intent = PAYMENT_INTENT,
+            confirmationParameters = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
             result = PaymentResult.Canceled,
         )
@@ -152,7 +155,7 @@ class ExternalPaymentMethodConfirmationDefinitionTest {
 
         val action = definition.action(
             confirmationOption = EPM_CONFIRMATION_OPTION,
-            intent = PAYMENT_INTENT,
+            confirmationParameters = CONFIRMATION_PARAMETERS,
         )
 
         assertThat(action).isInstanceOf<ConfirmationDefinition.Action.Fail<Unit>>()
@@ -188,7 +191,7 @@ class ExternalPaymentMethodConfirmationDefinitionTest {
 
         val action = definition.action(
             confirmationOption = EPM_CONFIRMATION_OPTION,
-            intent = PAYMENT_INTENT,
+            confirmationParameters = CONFIRMATION_PARAMETERS,
         )
 
         assertThat(action).isInstanceOf<ConfirmationDefinition.Action.Launch<Unit>>()
@@ -210,7 +213,7 @@ class ExternalPaymentMethodConfirmationDefinitionTest {
 
         definition.launch(
             confirmationOption = EPM_CONFIRMATION_OPTION,
-            intent = PAYMENT_INTENT,
+            confirmationParameters = CONFIRMATION_PARAMETERS,
             arguments = Unit,
             launcher = launcher,
         )
@@ -264,5 +267,14 @@ class ExternalPaymentMethodConfirmationDefinitionTest {
         )
 
         private val PAYMENT_INTENT = PaymentIntentFactory.create()
+
+        private val CONFIRMATION_PARAMETERS = ConfirmationDefinition.Parameters(
+            intent = PAYMENT_INTENT,
+            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
+                clientSecret = "pi_123_secret_123",
+            ),
+            appearance = PaymentSheet.Appearance(),
+            shippingDetails = AddressDetails(),
+        )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationFlowTest.kt
@@ -7,6 +7,9 @@ import com.stripe.android.paymentelement.confirmation.runLaunchTest
 import com.stripe.android.paymentelement.confirmation.runResultTest
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.paymentsheet.ExternalPaymentMethodConfirmHandler
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.addresselement.AddressDetails
+import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.PaymentIntentFactory
 import org.junit.Test
@@ -15,7 +18,7 @@ class ExternalPaymentMethodConfirmationFlowTest {
     @Test
     fun `on launch, should persist parameters & launch using launcher as expected`() = runLaunchTest(
         confirmationOption = EPM_CONFIRMATION_OPTION,
-        intent = PAYMENT_INTENT,
+        parameters = CONFIRMATION_PARAMETERS,
         definition = ExternalPaymentMethodConfirmationDefinition(
             externalPaymentMethodConfirmHandlerProvider = {
                 ExternalPaymentMethodConfirmHandler { _, _ ->
@@ -29,7 +32,7 @@ class ExternalPaymentMethodConfirmationFlowTest {
     @Test
     fun `on result, should return confirmation result as expected`() = runResultTest(
         confirmationOption = EPM_CONFIRMATION_OPTION,
-        intent = PAYMENT_INTENT,
+        parameters = CONFIRMATION_PARAMETERS,
         definition = ExternalPaymentMethodConfirmationDefinition(
             externalPaymentMethodConfirmHandlerProvider = {
                 ExternalPaymentMethodConfirmHandler { _, _ ->
@@ -60,5 +63,14 @@ class ExternalPaymentMethodConfirmationFlowTest {
         )
 
         private val PAYMENT_INTENT = PaymentIntentFactory.create()
+
+        private val CONFIRMATION_PARAMETERS = ConfirmationDefinition.Parameters(
+            intent = PAYMENT_INTENT,
+            appearance = PaymentSheet.Appearance(),
+            shippingDetails = AddressDetails(),
+            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
+                clientSecret = "pi_123_secret_123",
+            ),
+        )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationActivityTest.kt
@@ -29,6 +29,7 @@ import com.stripe.android.paymentelement.confirmation.assertSucceeded
 import com.stripe.android.payments.paymentlauncher.InternalPaymentResult
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.createTestActivityRule
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.PaymentIntentFactory
@@ -66,12 +67,7 @@ internal class GooglePayConfirmationActivityTest {
         confirmationHandler.state.test {
             awaitItem().assertIdle()
 
-            confirmationHandler.start(
-                ConfirmationHandler.Args(
-                    intent = PAYMENT_INTENT,
-                    confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION,
-                )
-            )
+            confirmationHandler.start(CONFIRMATION_ARGUMENTS)
 
             val confirmingWithGooglePay = awaitItem().assertConfirming()
 
@@ -84,8 +80,6 @@ internal class GooglePayConfirmationActivityTest {
             assertThat(confirmingWithSavedPaymentMethod.option)
                 .isEqualTo(
                     PaymentMethodConfirmationOption.Saved(
-                        initializationMode = GOOGLE_PAY_CONFIRMATION_OPTION.initializationMode,
-                        shippingDetails = GOOGLE_PAY_CONFIRMATION_OPTION.shippingDetails,
                         paymentMethod = paymentMethod,
                         optionsParams = null,
                     )
@@ -112,12 +106,7 @@ internal class GooglePayConfirmationActivityTest {
                 )
             )
 
-            confirmationHandler.start(
-                ConfirmationHandler.Args(
-                    intent = PAYMENT_INTENT,
-                    confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION,
-                )
-            )
+            confirmationHandler.start(CONFIRMATION_ARGUMENTS)
 
             val confirmingWithGooglePay = awaitItem().assertConfirming()
 
@@ -149,12 +138,7 @@ internal class GooglePayConfirmationActivityTest {
                 )
             )
 
-            confirmationHandler.start(
-                ConfirmationHandler.Args(
-                    intent = PAYMENT_INTENT,
-                    confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION,
-                )
-            )
+            confirmationHandler.start(CONFIRMATION_ARGUMENTS)
 
             val confirmingWithGooglePay = awaitItem().assertConfirming()
 
@@ -167,8 +151,6 @@ internal class GooglePayConfirmationActivityTest {
             assertThat(confirmingWithSavedPaymentMethod.option)
                 .isEqualTo(
                     PaymentMethodConfirmationOption.Saved(
-                        initializationMode = GOOGLE_PAY_CONFIRMATION_OPTION.initializationMode,
-                        shippingDetails = GOOGLE_PAY_CONFIRMATION_OPTION.shippingDetails,
                         paymentMethod = paymentMethod,
                         optionsParams = null,
                     )
@@ -191,12 +173,7 @@ internal class GooglePayConfirmationActivityTest {
 
             intendingGooglePayToBeLaunched(GooglePayPaymentMethodLauncher.Result.Canceled)
 
-            confirmationHandler.start(
-                ConfirmationHandler.Args(
-                    intent = PAYMENT_INTENT,
-                    confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION,
-                )
-            )
+            confirmationHandler.start(CONFIRMATION_ARGUMENTS)
 
             val confirmingWithGooglePay = awaitItem().assertConfirming()
 
@@ -220,12 +197,7 @@ internal class GooglePayConfirmationActivityTest {
             intendingGooglePayToBeLaunched(GooglePayPaymentMethodLauncher.Result.Completed(paymentMethod))
             intendingPaymentConfirmationToBeLaunched(InternalPaymentResult.Canceled)
 
-            confirmationHandler.start(
-                ConfirmationHandler.Args(
-                    intent = PAYMENT_INTENT,
-                    confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION,
-                )
-            )
+            confirmationHandler.start(CONFIRMATION_ARGUMENTS)
 
             val confirmingWithGooglePay = awaitItem().assertConfirming()
 
@@ -238,8 +210,6 @@ internal class GooglePayConfirmationActivityTest {
             assertThat(confirmingWithSavedPaymentMethod.option)
                 .isEqualTo(
                     PaymentMethodConfirmationOption.Saved(
-                        initializationMode = GOOGLE_PAY_CONFIRMATION_OPTION.initializationMode,
-                        shippingDetails = GOOGLE_PAY_CONFIRMATION_OPTION.shippingDetails,
                         paymentMethod = paymentMethod,
                         optionsParams = null,
                     )
@@ -306,10 +276,6 @@ internal class GooglePayConfirmationActivityTest {
         )
 
         val GOOGLE_PAY_CONFIRMATION_OPTION = GooglePayConfirmationOption(
-            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
-                clientSecret = "pi_123_secret_123"
-            ),
-            shippingDetails = null,
             config = GooglePayConfirmationOption.Config(
                 environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
                 merchantName = "Test merchant Inc.",
@@ -321,6 +287,16 @@ internal class GooglePayConfirmationActivityTest {
                     .BillingDetailsCollectionConfiguration(),
                 cardBrandFilter = DefaultCardBrandFilter,
             )
+        )
+
+        val CONFIRMATION_ARGUMENTS = ConfirmationHandler.Args(
+            confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION,
+            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
+                clientSecret = "pi_123_secret_123"
+            ),
+            shippingDetails = AddressDetails(),
+            intent = PAYMENT_INTENT,
+            appearance = PaymentSheet.Appearance(),
         )
 
         const val GOOGLE_PAY_ACTIVITY_NAME =

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinitionTest.kt
@@ -103,7 +103,7 @@ class GooglePayConfirmationDefinitionTest {
         }
         val result = definition.toResult(
             confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION,
-            intent = PAYMENT_INTENT,
+            confirmationParameters = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
             result = GooglePayPaymentMethodLauncher.Result.Completed(
                 paymentMethod = paymentMethod,
@@ -114,7 +114,7 @@ class GooglePayConfirmationDefinitionTest {
 
         val successResult = result.asNextStep()
 
-        assertThat(successResult.intent).isEqualTo(PAYMENT_INTENT)
+        assertThat(successResult.parameters).isEqualTo(CONFIRMATION_PARAMETERS)
         assertThat(successResult.confirmationOption).isInstanceOf<PaymentMethodConfirmationOption.Saved>()
     }
 
@@ -125,7 +125,7 @@ class GooglePayConfirmationDefinitionTest {
         val exception = IllegalStateException("Failed!")
         val result = definition.toResult(
             confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION,
-            intent = PAYMENT_INTENT,
+            confirmationParameters = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
             result = GooglePayPaymentMethodLauncher.Result.Failed(
                 errorCode = 400,
@@ -149,7 +149,7 @@ class GooglePayConfirmationDefinitionTest {
         val exception = IllegalStateException("Failed!")
         val result = definition.toResult(
             confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION,
-            intent = PAYMENT_INTENT,
+            confirmationParameters = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
             result = GooglePayPaymentMethodLauncher.Result.Failed(
                 errorCode = GooglePayPaymentMethodLauncher.NETWORK_ERROR,
@@ -175,7 +175,7 @@ class GooglePayConfirmationDefinitionTest {
 
         val result = definition.toResult(
             confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION,
-            intent = PAYMENT_INTENT,
+            confirmationParameters = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
             result = GooglePayPaymentMethodLauncher.Result.Canceled,
         )
@@ -289,7 +289,7 @@ class GooglePayConfirmationDefinitionTest {
 
             definition.launch(
                 confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION,
-                intent = PAYMENT_INTENT,
+                confirmationParameters = CONFIRMATION_PARAMETERS,
                 arguments = Unit,
                 launcher = launcher,
             )
@@ -385,7 +385,9 @@ class GooglePayConfirmationDefinitionTest {
                         merchantCurrencyCode = "USD",
                     ),
                 ),
-                intent = PAYMENT_INTENT.copy(currency = "CAD"),
+                confirmationParameters = CONFIRMATION_PARAMETERS.copy(
+                    intent = PAYMENT_INTENT.copy(currency = "CAD"),
+                ),
                 arguments = Unit,
                 launcher = launcher,
             )
@@ -416,7 +418,9 @@ class GooglePayConfirmationDefinitionTest {
                         customLabel = "Merchant Inc."
                     ),
                 ),
-                intent = PAYMENT_INTENT.copy(currency = "CAD"),
+                confirmationParameters = CONFIRMATION_PARAMETERS.copy(
+                    intent = PAYMENT_INTENT.copy(currency = "CAD"),
+                ),
                 arguments = Unit,
                 launcher = launcher,
             )
@@ -448,7 +452,9 @@ class GooglePayConfirmationDefinitionTest {
                         customLabel = "Merchant Inc."
                     ),
                 ),
-                intent = SetupIntentFactory.create(),
+                confirmationParameters = CONFIRMATION_PARAMETERS.copy(
+                    intent = SetupIntentFactory.create(),
+                ),
                 arguments = Unit,
                 launcher = launcher,
             )
@@ -474,12 +480,14 @@ class GooglePayConfirmationDefinitionTest {
 
         val action = definition.action(
             confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION.copy(
-                initializationMode = initializationMode,
                 config = GOOGLE_PAY_CONFIRMATION_OPTION.config.copy(
                     merchantCurrencyCode = merchantCurrencyCode,
                 ),
             ),
-            intent = SetupIntentFactory.create(),
+            confirmationParameters = CONFIRMATION_PARAMETERS.copy(
+                initializationMode = initializationMode,
+                intent = SetupIntentFactory.create(),
+            ),
         )
 
         test(
@@ -507,7 +515,7 @@ class GooglePayConfirmationDefinitionTest {
 
             definition.launch(
                 confirmationOption = confirmationOption,
-                intent = PAYMENT_INTENT,
+                confirmationParameters = CONFIRMATION_PARAMETERS,
                 arguments = Unit,
                 launcher = launcher,
             )
@@ -594,10 +602,6 @@ class GooglePayConfirmationDefinitionTest {
 
     private companion object {
         private val GOOGLE_PAY_CONFIRMATION_OPTION = GooglePayConfirmationOption(
-            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
-                clientSecret = "pi_123_secret_123",
-            ),
-            shippingDetails = null,
             config = GooglePayConfirmationOption.Config(
                 environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
                 merchantName = "Test merchant Inc.",
@@ -613,5 +617,18 @@ class GooglePayConfirmationDefinitionTest {
         )
 
         private val PAYMENT_INTENT = PaymentIntentFactory.create()
+
+        private val APPEARANCE = PaymentSheet.Appearance().copy(
+            colorsDark = PaymentSheet.Colors.defaultLight,
+        )
+
+        private val CONFIRMATION_PARAMETERS = ConfirmationDefinition.Parameters(
+            intent = PAYMENT_INTENT,
+            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
+                clientSecret = "pi_123_secret_123",
+            ),
+            appearance = APPEARANCE,
+            shippingDetails = null,
+        )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationFlowTest.kt
@@ -49,7 +49,7 @@ class GooglePayConfirmationFlowTest {
 
                 val action = mediator.action(
                     option = GOOGLE_PAY_CONFIRMATION_OPTION,
-                    intent = PAYMENT_INTENT,
+                    parameters = CONFIRMATION_PARAMETERS,
                 )
 
                 assertThat(action).isInstanceOf<ConfirmationMediator.Action.Launch>()
@@ -64,7 +64,7 @@ class GooglePayConfirmationFlowTest {
                     .get<Parameters<GooglePayConfirmationOption>>("GooglePayParameters")
 
                 assertThat(parameters?.confirmationOption).isEqualTo(GOOGLE_PAY_CONFIRMATION_OPTION)
-                assertThat(parameters?.intent).isEqualTo(PAYMENT_INTENT)
+                assertThat(parameters?.confirmationParameters).isEqualTo(CONFIRMATION_PARAMETERS)
                 assertThat(parameters?.deferredIntentConfirmationType).isNull()
 
                 verify(googlePayPaymentMethodLauncher, times(1)).present(
@@ -80,31 +80,23 @@ class GooglePayConfirmationFlowTest {
     @Test
     fun `on result, should return confirmation result as expected`() = runResultTest(
         confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION,
-        intent = PAYMENT_INTENT,
+        parameters = CONFIRMATION_PARAMETERS,
         definition = GooglePayConfirmationDefinition(
             googlePayPaymentMethodLauncherFactory = RecordingGooglePayPaymentMethodLauncherFactory.noOp(mock()),
             userFacingLogger = null,
         ),
         launcherResult = GooglePayPaymentMethodLauncher.Result.Completed(PAYMENT_METHOD),
         definitionResult = ConfirmationDefinition.Result.NextStep(
-            intent = PAYMENT_INTENT,
             confirmationOption = PaymentMethodConfirmationOption.Saved(
-                initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
-                    clientSecret = "pi_123_secret_123",
-                ),
                 paymentMethod = PAYMENT_METHOD,
                 optionsParams = null,
-                shippingDetails = null,
-            )
+            ),
+            parameters = CONFIRMATION_PARAMETERS,
         )
     )
 
     private companion object {
         private val GOOGLE_PAY_CONFIRMATION_OPTION = GooglePayConfirmationOption(
-            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
-                clientSecret = "pi_123_secret_123",
-            ),
-            shippingDetails = null,
             config = GooglePayConfirmationOption.Config(
                 environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
                 merchantName = "Test merchant Inc.",
@@ -122,5 +114,14 @@ class GooglePayConfirmationFlowTest {
         private val PAYMENT_METHOD = PaymentMethodFactory.card()
 
         private val PAYMENT_INTENT = PaymentIntentFactory.create()
+
+        private val CONFIRMATION_PARAMETERS = ConfirmationDefinition.Parameters(
+            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
+                clientSecret = "pi_123_secret_123",
+            ),
+            shippingDetails = null,
+            intent = PAYMENT_INTENT,
+            appearance = PaymentSheet.Appearance()
+        )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationActivityTest.kt
@@ -17,6 +17,7 @@ import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.link.LinkConfiguration
+import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.PaymentElementConfirmationTestActivity
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
@@ -25,6 +26,7 @@ import com.stripe.android.paymentelement.confirmation.assertConfirming
 import com.stripe.android.paymentelement.confirmation.assertIdle
 import com.stripe.android.paymentelement.confirmation.assertSucceeded
 import com.stripe.android.payments.paymentlauncher.InternalPaymentResult
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.createTestActivityRule
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.FeatureFlagTestRule
@@ -71,8 +73,11 @@ internal class LinkConfirmationActivityTest(private val nativeLinkEnabled: Boole
 
             confirmationHandler.start(
                 ConfirmationHandler.Args(
-                    intent = PAYMENT_INTENT,
                     confirmationOption = LINK_CONFIRMATION_OPTION,
+                    appearance = CONFIRMATION_PARAMETERS.appearance,
+                    intent = CONFIRMATION_PARAMETERS.intent,
+                    shippingDetails = CONFIRMATION_PARAMETERS.shippingDetails,
+                    initializationMode = CONFIRMATION_PARAMETERS.initializationMode,
                 )
             )
 
@@ -110,8 +115,6 @@ internal class LinkConfirmationActivityTest(private val nativeLinkEnabled: Boole
             assertThat(confirmingWithSavedPaymentMethod.option)
                 .isEqualTo(
                     PaymentMethodConfirmationOption.Saved(
-                        initializationMode = LINK_CONFIRMATION_OPTION.initializationMode,
-                        shippingDetails = LINK_CONFIRMATION_OPTION.shippingDetails,
                         paymentMethod = paymentMethod,
                         optionsParams = null,
                     )
@@ -209,10 +212,6 @@ internal class LinkConfirmationActivityTest(private val nativeLinkEnabled: Boole
         )
 
         val LINK_CONFIRMATION_OPTION = LinkConfirmationOption(
-            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
-                clientSecret = "pi_123_secret_123"
-            ),
-            shippingDetails = null,
             configuration = LinkConfiguration(
                 stripeIntent = PAYMENT_INTENT,
                 merchantName = "Merchant, Inc.",
@@ -228,6 +227,15 @@ internal class LinkConfirmationActivityTest(private val nativeLinkEnabled: Boole
                 flags = mapOf(),
                 cardBrandChoice = null,
             ),
+        )
+
+        val CONFIRMATION_PARAMETERS = ConfirmationDefinition.Parameters(
+            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
+                clientSecret = "pi_123_secret_123"
+            ),
+            shippingDetails = null,
+            intent = PAYMENT_INTENT,
+            appearance = PaymentSheet.Appearance(),
         )
 
         const val LINK_COMPLETE_CODE = 49871

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinitionTest.kt
@@ -16,7 +16,9 @@ import com.stripe.android.paymentelement.confirmation.asFailed
 import com.stripe.android.paymentelement.confirmation.asLaunch
 import com.stripe.android.paymentelement.confirmation.asNextStep
 import com.stripe.android.paymentelement.confirmation.asSaved
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.PaymentMethodFactory
@@ -82,7 +84,7 @@ class LinkConfirmationDefinitionTest {
 
         val action = definition.action(
             confirmationOption = LINK_CONFIRMATION_OPTION,
-            intent = PAYMENT_INTENT,
+            confirmationParameters = CONFIRMATION_PARAMETERS,
         )
 
         assertThat(action).isInstanceOf<ConfirmationDefinition.Action.Launch<Unit>>()
@@ -100,7 +102,7 @@ class LinkConfirmationDefinitionTest {
 
         definition.launch(
             confirmationOption = LINK_CONFIRMATION_OPTION,
-            intent = PAYMENT_INTENT,
+            confirmationParameters = CONFIRMATION_PARAMETERS,
             launcher = launcherScenario.launcher,
             arguments = Unit,
         )
@@ -118,7 +120,7 @@ class LinkConfirmationDefinitionTest {
 
         val result = definition.toResult(
             confirmationOption = LINK_CONFIRMATION_OPTION,
-            intent = PAYMENT_INTENT,
+            confirmationParameters = CONFIRMATION_PARAMETERS,
             result = LinkActivityResult.Completed(paymentMethod),
             deferredIntentConfirmationType = null,
         )
@@ -128,13 +130,12 @@ class LinkConfirmationDefinitionTest {
         val nextStepResult = result.asNextStep()
 
         assertThat(nextStepResult.confirmationOption).isInstanceOf<PaymentMethodConfirmationOption.Saved>()
+        assertThat(nextStepResult.parameters).isEqualTo(CONFIRMATION_PARAMETERS)
 
         val savedOption = nextStepResult.confirmationOption.asSaved()
 
         assertThat(savedOption.paymentMethod).isEqualTo(paymentMethod)
         assertThat(savedOption.optionsParams).isNull()
-        assertThat(savedOption.shippingDetails).isEqualTo(LINK_CONFIRMATION_OPTION.shippingDetails)
-        assertThat(savedOption.initializationMode).isEqualTo(LINK_CONFIRMATION_OPTION.initializationMode)
 
         assertThat(storeScenario.markAsUsedCalls.awaitItem()).isNotNull()
     }
@@ -147,7 +148,7 @@ class LinkConfirmationDefinitionTest {
 
         val result = definition.toResult(
             confirmationOption = LINK_CONFIRMATION_OPTION,
-            intent = PAYMENT_INTENT,
+            confirmationParameters = CONFIRMATION_PARAMETERS,
             result = LinkActivityResult.Failed(exception),
             deferredIntentConfirmationType = null
         )
@@ -169,7 +170,7 @@ class LinkConfirmationDefinitionTest {
 
         val result = definition.toResult(
             confirmationOption = LINK_CONFIRMATION_OPTION,
-            intent = PAYMENT_INTENT,
+            confirmationParameters = CONFIRMATION_PARAMETERS,
             result = LinkActivityResult.Canceled(LinkActivityResult.Canceled.Reason.LoggedOut),
             deferredIntentConfirmationType = null,
         )
@@ -190,7 +191,7 @@ class LinkConfirmationDefinitionTest {
 
         val result = definition.toResult(
             confirmationOption = LINK_CONFIRMATION_OPTION,
-            intent = PAYMENT_INTENT,
+            confirmationParameters = CONFIRMATION_PARAMETERS,
             result = LinkActivityResult.Canceled(LinkActivityResult.Canceled.Reason.BackPressed),
             deferredIntentConfirmationType = null
         )
@@ -236,11 +237,17 @@ class LinkConfirmationDefinitionTest {
 
     private companion object {
         private val PAYMENT_INTENT = PaymentIntentFactory.create()
-        private val LINK_CONFIRMATION_OPTION = LinkConfirmationOption(
+
+        private val CONFIRMATION_PARAMETERS = ConfirmationDefinition.Parameters(
             initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
                 clientSecret = "pi_123_secret_123",
             ),
-            shippingDetails = null,
+            intent = PAYMENT_INTENT,
+            appearance = PaymentSheet.Appearance(),
+            shippingDetails = AddressDetails(),
+        )
+
+        private val LINK_CONFIRMATION_OPTION = LinkConfirmationOption(
             configuration = LinkConfiguration(
                 stripeIntent = PAYMENT_INTENT,
                 merchantName = "Merchant Inc.",

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationFlowTest.kt
@@ -10,6 +10,7 @@ import com.stripe.android.paymentelement.confirmation.ConfirmationMediator
 import com.stripe.android.paymentelement.confirmation.ConfirmationMediator.Parameters
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.asLaunch
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.PaymentMethodFactory
@@ -46,7 +47,7 @@ class LinkConfirmationFlowTest {
 
         val action = mediator.action(
             option = LINK_CONFIRMATION_OPTION,
-            intent = PAYMENT_INTENT,
+            parameters = CONFIRMATION_PARAMETERS,
         )
 
         assertThat(action).isInstanceOf<ConfirmationMediator.Action.Launch>()
@@ -62,7 +63,7 @@ class LinkConfirmationFlowTest {
         val parameters = savedStateHandle.get<Parameters<LinkConfirmationOption>>("LinkParameters")
 
         assertThat(parameters?.confirmationOption).isEqualTo(LINK_CONFIRMATION_OPTION)
-        assertThat(parameters?.intent).isEqualTo(PAYMENT_INTENT)
+        assertThat(parameters?.confirmationParameters).isEqualTo(CONFIRMATION_PARAMETERS)
         assertThat(parameters?.deferredIntentConfirmationType).isNull()
     }
 
@@ -75,8 +76,8 @@ class LinkConfirmationFlowTest {
                 "LinkParameters",
                 Parameters(
                     confirmationOption = LINK_CONFIRMATION_OPTION,
-                    intent = PAYMENT_INTENT,
                     deferredIntentConfirmationType = null,
+                    confirmationParameters = CONFIRMATION_PARAMETERS,
                 )
             )
         }
@@ -113,13 +114,11 @@ class LinkConfirmationFlowTest {
 
         assertThat(result).isEqualTo(
             ConfirmationDefinition.Result.NextStep(
-                intent = PAYMENT_INTENT,
                 confirmationOption = PaymentMethodConfirmationOption.Saved(
-                    initializationMode = LINK_CONFIRMATION_OPTION.initializationMode,
-                    shippingDetails = LINK_CONFIRMATION_OPTION.shippingDetails,
                     paymentMethod = PAYMENT_METHOD,
                     optionsParams = null,
-                )
+                ),
+                parameters = CONFIRMATION_PARAMETERS,
             )
         )
     }
@@ -137,11 +136,16 @@ class LinkConfirmationFlowTest {
 
         private val PAYMENT_INTENT = PaymentIntentFactory.create()
 
-        private val LINK_CONFIRMATION_OPTION = LinkConfirmationOption(
+        private val CONFIRMATION_PARAMETERS = ConfirmationDefinition.Parameters(
             initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
                 clientSecret = "pi_123_secret_123",
             ),
             shippingDetails = null,
+            intent = PAYMENT_INTENT,
+            appearance = PaymentSheet.Appearance()
+        )
+
+        private val LINK_CONFIRMATION_OPTION = LinkConfirmationOption(
             configuration = LinkConfiguration(
                 stripeIntent = PAYMENT_INTENT,
                 merchantName = "Merchant Inc.",

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -55,6 +55,7 @@ import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.model.PaymentMethodUpdateParams
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationMediator
 import com.stripe.android.paymentelement.confirmation.DefaultConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
@@ -2930,10 +2931,8 @@ internal class PaymentSheetViewModelTest {
     private suspend fun testProcessDeathRestorationAfterPaymentSuccess(loadStateBeforePaymentResult: Boolean) {
         val stripeIntent = PaymentIntentFactory.create(status = StripeIntent.Status.Succeeded)
         val option = PaymentMethodConfirmationOption.Saved(
-            initializationMode = ARGS_CUSTOMER_WITH_GOOGLEPAY.initializationMode,
             paymentMethod = CARD_PAYMENT_METHOD,
             optionsParams = null,
-            shippingDetails = null,
         )
         val savedStateHandle = SavedStateHandle(
             initialState = mapOf(
@@ -2943,9 +2942,14 @@ internal class PaymentSheetViewModelTest {
                     receivesResultInProcess = false,
                 ),
                 "IntentConfirmationParameters" to ConfirmationMediator.Parameters(
-                    intent = PAYMENT_INTENT,
                     confirmationOption = option,
                     deferredIntentConfirmationType = null,
+                    confirmationParameters = ConfirmationDefinition.Parameters(
+                        intent = PAYMENT_INTENT,
+                        initializationMode = ARGS_CUSTOMER_WITH_GOOGLEPAY.initializationMode,
+                        shippingDetails = null,
+                        appearance = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.appearance,
+                    )
                 )
             )
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateDataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateDataTest.kt
@@ -4,8 +4,6 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentelement.confirmation.bacs.BacsConfirmationOption
-import com.stripe.android.paymentsheet.PaymentSheetFixtures
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import org.junit.Test
 
 class BacsMandateDataTest {
@@ -65,13 +63,8 @@ class BacsMandateDataTest {
         createParams: PaymentMethodCreateParams,
     ): BacsConfirmationOption {
         return BacsConfirmationOption(
-            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
-                clientSecret = "pi_123",
-            ),
-            shippingDetails = null,
             createParams = createParams,
             optionsParams = null,
-            appearance = PaymentSheetFixtures.CONFIG_CUSTOMER.appearance,
         )
     }
 }


### PR DESCRIPTION
# Summary
Move common confirmation option parameters to `ConfirmationHandler.Args`

# Motivation
A lot of these parameters are shared through a majority amount of the confirmation flows. Making them default paramters makes it easier while simplifying the confirmation option definitions.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified