### PR TITLE
support edge to edge on android 15

### DIFF
--- a/3ds2playground/src/main/res/layout/activity_challenge_progress.xml
+++ b/3ds2playground/src/main/res/layout/activity_challenge_progress.xml
@@ -4,4 +4,5 @@
     android:id="@+id/fragment_container"
     android:name="com.stripe.android.stripe3ds2.views.ChallengeProgressFragment"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" />
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true"/>

--- a/3ds2playground/src/main/res/layout/activity_main.xml
+++ b/3ds2playground/src/main/res/layout/activity_main.xml
@@ -6,7 +6,8 @@
     android:id="@+id/coordinator"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".MainActivity">
+    tools:context=".MainActivity"
+    android:fitsSystemWindows="true">
 
     <ScrollView
         android:layout_width="match_parent"

--- a/3ds2sdk/res/layout/stripe_challenge_activity.xml
+++ b/3ds2sdk/res/layout/stripe_challenge_activity.xml
@@ -2,6 +2,7 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     xmlns:tools="http://schemas.android.com/tools">
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fragment_container"

--- a/connect-example/src/main/java/com/stripe/android/connect/example/ui/common/ConnectExampleScaffold.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/ui/common/ConnectExampleScaffold.kt
@@ -2,8 +2,11 @@ package com.stripe.android.connect.example.ui.common
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
@@ -21,9 +24,11 @@ fun ConnectExampleScaffold(
     content: @Composable () -> Unit,
 ) {
     Scaffold(
+        contentWindowInsets = WindowInsets.systemBars,
         modifier = Modifier.fillMaxSize(),
         topBar = {
             TopAppBar(
+                windowInsets = WindowInsets.statusBars,
                 title = {
                     Text(
                         text = title,

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsComposeExampleActivity.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsComposeExampleActivity.kt
@@ -5,8 +5,13 @@ import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.material.Button
 import androidx.compose.material.Divider
 import androidx.compose.material.LinearProgressIndicator
@@ -56,7 +61,15 @@ class FinancialConnectionsComposeExampleActivity : AppCompatActivity() {
         state: FinancialConnectionsExampleState,
         onButtonClick: () -> Unit
     ) {
-        Column(modifier = Modifier.padding(horizontal = 10.dp)) {
+        Column(
+            modifier = Modifier
+                .padding(horizontal = 10.dp)
+                .padding(
+                    paddingValues = WindowInsets.systemBars.only(
+                        WindowInsetsSides.Horizontal + WindowInsetsSides.Top
+                    ).asPaddingValues()
+                )
+        ) {
             if (state.loading) {
                 LinearProgressIndicator(
                     modifier = Modifier.fillMaxWidth(),

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsLauncherActivity.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsLauncherActivity.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.financialconnections.example
 
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -10,9 +11,14 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -87,6 +93,9 @@ class FinancialConnectionsLauncherActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
 
         setContent {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                window.isNavigationBarContrastEnforced = false
+            }
             FinancialConnectionsExampleTheme {
                 MainScreen(items = items)
             }
@@ -100,7 +109,14 @@ class FinancialConnectionsLauncherActivity : AppCompatActivity() {
             groupedItems.keys.map { key -> key to key.collapsable.takeIf { it } }.toMutableStateMap()
         }
 
-        LazyColumn {
+        LazyColumn(
+            modifier = Modifier
+                .padding(
+                    paddingValues = WindowInsets.systemBars.only(
+                        WindowInsetsSides.Horizontal + WindowInsetsSides.Top
+                    ).asPaddingValues()
+                )
+        ) {
             groupedItems.forEach {
                 section(
                     section = it.key,

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundActivity.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundActivity.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.financialconnections.example
 
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
@@ -7,9 +8,12 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.selection.SelectionContainer
@@ -92,6 +96,9 @@ class FinancialConnectionsPlaygroundActivity : AppCompatActivity() {
         )
 
         setContent {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                window.isNavigationBarContrastEnforced = false
+            }
             FinancialConnectionsExampleTheme {
                 FinancialConnectionsScreen()
             }
@@ -223,6 +230,7 @@ class FinancialConnectionsPlaygroundActivity : AppCompatActivity() {
         }
 
         Scaffold(
+            contentWindowInsets = WindowInsets.systemBars,
             topBar = {
                 PlaygroundTopBar(
                     settings = state.settings,
@@ -327,6 +335,7 @@ class FinancialConnectionsPlaygroundActivity : AppCompatActivity() {
         val (showMenu, setShowMenu) = remember { mutableStateOf(false) }
         val context = LocalContext.current
         TopAppBar(
+            windowInsets = WindowInsets.statusBars,
             title = { Text("Connections Playground") },
             actions = {
                 IconButton(onClick = { setShowMenu(true) }) {

--- a/financial-connections-example/src/main/res/layout/activity_financialconnections_example.xml
+++ b/financial-connections-example/src/main/res/layout/activity_financialconnections_example.xml
@@ -4,12 +4,14 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     tools:context="com.stripe.android.financialconnections.example.FinancialConnectionsDataExampleActivity"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true">
 
     <com.google.android.material.appbar.AppBarLayout
         android:layout_height="wrap_content"
         android:layout_width="match_parent"
-        android:theme="@style/AppTheme.AppBarOverlay">
+        android:theme="@style/AppTheme.AppBarOverlay"
+        android:fitsSystemWindows="true">
 
         <androidx.appcompat.widget.Toolbar
             android:id="@+id/toolbar"

--- a/identity-example/src/main/java/com/stripe/android/identity/example/ComposeExampleActivity.kt
+++ b/identity-example/src/main/java/com/stripe/android/identity/example/ComposeExampleActivity.kt
@@ -2,11 +2,12 @@ package com.stripe.android.identity.example
 
 import android.content.ContentResolver
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
-import com.google.accompanist.themeadapter.material.MdcTheme
+import androidx.compose.material.MaterialTheme
 import com.stripe.android.identity.IdentityVerificationSheet
 import com.stripe.android.identity.example.ui.ExampleScreen
 
@@ -30,7 +31,10 @@ abstract class ComposeExampleActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            MdcTheme {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                window.isNavigationBarContrastEnforced = false
+            }
+            MaterialTheme {
                 ExampleScreen(
                     configuration = configuration,
                     viewModel = viewModel

--- a/identity-example/src/main/java/com/stripe/android/identity/example/ui/ComposeExampleUI.kt
+++ b/identity-example/src/main/java/com/stripe/android/identity/example/ui/ComposeExampleUI.kt
@@ -10,9 +10,12 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.rememberScrollState
@@ -107,8 +110,11 @@ internal fun ExampleScreen(
 
     Scaffold(
         scaffoldState = scaffoldState,
+        contentWindowInsets = WindowInsets.systemBars,
         topBar = {
-            TopAppBar {
+            TopAppBar(
+                windowInsets = WindowInsets.statusBars
+            ) {
                 Row {
                     Text(
                         text = stringResource(id = R.string.identity_example),

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityNavGraph.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityNavGraph.kt
@@ -1,7 +1,9 @@
 package com.stripe.android.identity.navigation
 
 import android.util.Log
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.MaterialTheme
@@ -77,6 +79,7 @@ internal fun IdentityNavGraph(
         onNavControllerCreated(navController)
     }
     Scaffold(
+        contentWindowInsets = WindowInsets.systemBars,
         topBar = {
             IdentityTopAppBar(topBarState, onTopBarNavigationClick)
         }

--- a/identity/src/main/java/com/stripe/android/identity/ui/IdentityTopAppBar.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/IdentityTopAppBar.kt
@@ -1,5 +1,7 @@
 package com.stripe.android.identity.ui
 
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.LocalTextStyle
@@ -42,7 +44,8 @@ internal fun IdentityTopAppBar(
                     }
                 )
             }
-        }
+        },
+        windowInsets = WindowInsets.statusBars
     )
 }
 

--- a/payments-core/res/layout/stripe_payment_auth_web_view_activity.xml
+++ b/payments-core/res/layout/stripe_payment_auth_web_view_activity.xml
@@ -22,6 +22,7 @@
     </FrameLayout>
 
     <com.google.android.material.appbar.AppBarLayout
+        android:fitsSystemWindows="true"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:elevation="@dimen/stripe_toolbar_elevation">

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/MainActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.example
 
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.appcompat.app.AppCompatActivity
@@ -102,6 +103,9 @@ class MainActivity : AppCompatActivity() {
         setContentView(viewBinding.root)
         setSupportActionBar(viewBinding.toolbar)
 
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            window.isNavigationBarContrastEnforced = false
+        }
         viewBinding.content.setContent {
             PaymentSheetExampleTheme {
                 MainScreen(items = items)

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
@@ -1,9 +1,11 @@
 package com.stripe.android.paymentsheet.example.playground
 
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.animation.AnimatedContent
@@ -14,9 +16,14 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Button
@@ -93,9 +100,13 @@ internal class PaymentSheetPlaygroundActivity : AppCompatActivity(), ExternalPay
     @OptIn(ExperimentalCustomerSessionApi::class)
     @Suppress("LongMethod")
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
 
         setContent {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                window.isNavigationBarContrastEnforced = false
+            }
             val paymentSheet = PaymentSheet.Builder(viewModel::onPaymentSheetResult)
                 .externalPaymentMethodConfirmHandler(this)
                 .createIntentCallback(viewModel::createIntentCallback)
@@ -571,6 +582,11 @@ private fun PlaygroundTheme(
                             .fillMaxWidth()
                             .background(MaterialTheme.colors.surface)
                             .animateContentSize()
+                            .padding(
+                                paddingValues = WindowInsets.systemBars.only(
+                                    WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom
+                                ).asPaddingValues()
+                            )
                     ) {
                         Divider()
                         Column(
@@ -581,8 +597,12 @@ private fun PlaygroundTheme(
                         )
                     }
                 },
+                contentWindowInsets = WindowInsets.systemBars
             ) { paddingValues ->
-                Box(modifier = Modifier.padding(paddingValues)) {
+                Box(
+                    modifier = Modifier
+                        .padding(paddingValues)
+                ) {
                     Column(
                         modifier = Modifier
                             .verticalScroll(rememberScrollState())

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/customersheet/CustomerSheetExampleActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/customersheet/CustomerSheetExampleActivity.kt
@@ -8,10 +8,15 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.material.LinearProgressIndicator
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -57,6 +62,11 @@ internal class CustomerSheetExampleActivity : AppCompatActivity() {
 
                 Column(
                     modifier = Modifier
+                        .padding(
+                            paddingValues = WindowInsets.systemBars.only(
+                                WindowInsetsSides.Horizontal + WindowInsetsSides.Top
+                            ).asPaddingValues()
+                        )
                         .fillMaxSize()
                         .padding(16.dp)
                 ) {

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/paymentsheet/complete_flow/CompleteFlowActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/paymentsheet/complete_flow/CompleteFlowActivity.kt
@@ -5,9 +5,16 @@ import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 import com.google.android.material.snackbar.Snackbar
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.example.samples.ui.shared.BuyButton
@@ -57,6 +64,12 @@ internal class CompleteFlowActivity : AppCompatActivity() {
                 }
 
                 Receipt(
+                    modifier = Modifier
+                        .padding(
+                            paddingValues = WindowInsets.systemBars.only(
+                                WindowInsetsSides.Horizontal + WindowInsetsSides.Top
+                            ).asPaddingValues()
+                        ),
                     isLoading = uiState.isProcessing,
                     cartState = uiState.cartState,
                 ) {

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/paymentsheet/custom_flow/CustomFlowActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/paymentsheet/custom_flow/CustomFlowActivity.kt
@@ -5,11 +5,19 @@ import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import com.google.android.material.snackbar.Snackbar
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -32,6 +40,7 @@ internal class CustomFlowActivity : AppCompatActivity() {
 
     private val viewModel by viewModels<CustomFlowViewModel>()
 
+    @SuppressWarnings("LongMethod")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -64,26 +73,35 @@ internal class CustomFlowActivity : AppCompatActivity() {
                     }
                 }
 
-                if (uiState.isError) {
-                    ErrorScreen(onRetry = viewModel::retry)
-                } else {
-                    Receipt(
-                        isLoading = uiState.isProcessing,
-                        cartState = uiState.cartState,
-                    ) {
-                        PaymentMethodSelector(
-                            isEnabled = uiState.isPaymentMethodButtonEnabled,
-                            paymentMethodLabel = paymentMethodLabel,
-                            paymentMethodPainter = uiState.paymentOption?.iconPainter,
-                            onClick = flowController::presentPaymentOptions,
-                        )
-                        BuyButton(
-                            buyButtonEnabled = uiState.isBuyButtonEnabled,
-                            onClick = {
-                                viewModel.handleBuyButtonPressed()
-                                flowController.confirm()
-                            }
-                        )
+                Box(
+                    modifier = Modifier
+                        .padding(
+                            paddingValues = WindowInsets.systemBars.only(
+                                WindowInsetsSides.Horizontal + WindowInsetsSides.Top
+                            ).asPaddingValues()
+                        ),
+                ) {
+                    if (uiState.isError) {
+                        ErrorScreen(onRetry = viewModel::retry)
+                    } else {
+                        Receipt(
+                            isLoading = uiState.isProcessing,
+                            cartState = uiState.cartState,
+                        ) {
+                            PaymentMethodSelector(
+                                isEnabled = uiState.isPaymentMethodButtonEnabled,
+                                paymentMethodLabel = paymentMethodLabel,
+                                paymentMethodPainter = uiState.paymentOption?.iconPainter,
+                                onClick = flowController::presentPaymentOptions,
+                            )
+                            BuyButton(
+                                buyButtonEnabled = uiState.isBuyButtonEnabled,
+                                onClick = {
+                                    viewModel.handleBuyButtonPressed()
+                                    flowController.confirm()
+                                }
+                            )
+                        }
                     }
                 }
             }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/paymentsheet/server_side_confirm/complete_flow/ServerSideConfirmationCompleteFlowActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/paymentsheet/server_side_confirm/complete_flow/ServerSideConfirmationCompleteFlowActivity.kt
@@ -5,9 +5,17 @@ import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 import com.google.android.material.snackbar.Snackbar
 import com.stripe.android.paymentsheet.example.samples.model.toIntentConfiguration
 import com.stripe.android.paymentsheet.example.samples.ui.shared.BuyButton
@@ -53,29 +61,38 @@ internal class ServerSideConfirmationCompleteFlowActivity : AppCompatActivity() 
                     }
                 }
 
-                if (uiState.isError) {
-                    ErrorScreen(onRetry = viewModel::retry)
-                } else {
-                    Receipt(
-                        isLoading = uiState.isProcessing,
-                        cartState = uiState.cartState,
-                        isEditable = true,
-                        onQuantityChanged = viewModel::updateQuantity,
-                    ) {
-                        SubscriptionToggle(
-                            checked = uiState.cartState.isSubscription,
-                            onCheckedChange = viewModel::updateSubscription,
-                        )
+                Box(
+                    modifier = Modifier
+                        .padding(
+                            paddingValues = WindowInsets.systemBars.only(
+                                WindowInsetsSides.Horizontal + WindowInsetsSides.Top
+                            ).asPaddingValues()
+                        ),
+                ) {
+                    if (uiState.isError) {
+                        ErrorScreen(onRetry = viewModel::retry)
+                    } else {
+                        Receipt(
+                            isLoading = uiState.isProcessing,
+                            cartState = uiState.cartState,
+                            isEditable = true,
+                            onQuantityChanged = viewModel::updateQuantity,
+                        ) {
+                            SubscriptionToggle(
+                                checked = uiState.cartState.isSubscription,
+                                onCheckedChange = viewModel::updateSubscription,
+                            )
 
-                        BuyButton(
-                            buyButtonEnabled = uiState.isBuyButtonEnabled,
-                            onClick = {
-                                paymentSheet.presentWithIntentConfiguration(
-                                    intentConfiguration = uiState.cartState.toIntentConfiguration(),
-                                    configuration = uiState.paymentSheetConfig,
-                                )
-                            }
-                        )
+                            BuyButton(
+                                buyButtonEnabled = uiState.isBuyButtonEnabled,
+                                onClick = {
+                                    paymentSheet.presentWithIntentConfiguration(
+                                        intentConfiguration = uiState.cartState.toIntentConfiguration(),
+                                        configuration = uiState.paymentSheetConfig,
+                                    )
+                                }
+                            )
+                        }
                     }
                 }
             }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/paymentsheet/server_side_confirm/custom_flow/ServerSideConfirmationCustomFlowActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/paymentsheet/server_side_confirm/custom_flow/ServerSideConfirmationCustomFlowActivity.kt
@@ -5,12 +5,20 @@ import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import com.google.android.material.snackbar.Snackbar
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -37,6 +45,7 @@ internal class ServerSideConfirmationCustomFlowActivity : AppCompatActivity() {
 
     private val viewModel by viewModels<ServerSideConfirmationCustomFlowViewModel>()
 
+    @SuppressWarnings("LongMethod")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -66,34 +75,43 @@ internal class ServerSideConfirmationCustomFlowActivity : AppCompatActivity() {
                     }
                 }
 
-                if (uiState.isError) {
-                    ErrorScreen(onRetry = viewModel::retry)
-                } else {
-                    Receipt(
-                        isLoading = uiState.isProcessing,
-                        cartState = uiState.cartState,
-                        isEditable = true,
-                        onQuantityChanged = viewModel::updateQuantity,
-                    ) {
-                        PaymentMethodSelector(
-                            isEnabled = uiState.isPaymentMethodButtonEnabled,
-                            paymentMethodLabel = paymentMethodLabel,
-                            paymentMethodPainter = uiState.paymentOption?.iconPainter,
-                            onClick = flowController::presentPaymentOptions,
-                        )
+                Box(
+                    modifier = Modifier
+                        .padding(
+                            paddingValues = WindowInsets.systemBars.only(
+                                WindowInsetsSides.Horizontal + WindowInsetsSides.Top
+                            ).asPaddingValues()
+                        ),
+                ) {
+                    if (uiState.isError) {
+                        ErrorScreen(onRetry = viewModel::retry)
+                    } else {
+                        Receipt(
+                            isLoading = uiState.isProcessing,
+                            cartState = uiState.cartState,
+                            isEditable = true,
+                            onQuantityChanged = viewModel::updateQuantity,
+                        ) {
+                            PaymentMethodSelector(
+                                isEnabled = uiState.isPaymentMethodButtonEnabled,
+                                paymentMethodLabel = paymentMethodLabel,
+                                paymentMethodPainter = uiState.paymentOption?.iconPainter,
+                                onClick = flowController::presentPaymentOptions,
+                            )
 
-                        SubscriptionToggle(
-                            checked = uiState.cartState.isSubscription,
-                            onCheckedChange = viewModel::updateSubscription,
-                        )
+                            SubscriptionToggle(
+                                checked = uiState.cartState.isSubscription,
+                                onCheckedChange = viewModel::updateSubscription,
+                            )
 
-                        BuyButton(
-                            buyButtonEnabled = uiState.isBuyButtonEnabled,
-                            onClick = {
-                                viewModel.handleBuyButtonPressed()
-                                flowController.confirm()
-                            }
-                        )
+                            BuyButton(
+                                buyButtonEnabled = uiState.isBuyButtonEnabled,
+                                onClick = {
+                                    viewModel.handleBuyButtonPressed()
+                                    flowController.confirm()
+                                }
+                            )
+                        }
                     }
                 }
             }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/shared/Receipt.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/shared/Receipt.kt
@@ -38,8 +38,10 @@ import com.stripe.android.paymentsheet.example.samples.ui.PADDING
 import com.stripe.android.paymentsheet.example.samples.ui.ROW_START
 import com.stripe.android.paymentsheet.example.samples.ui.SUB_FONT_SIZE
 
+@SuppressWarnings("LongMethod")
 @Composable
 fun Receipt(
+    modifier: Modifier = Modifier,
     isLoading: Boolean,
     cartState: CartState,
     isEditable: Boolean = false,
@@ -48,6 +50,7 @@ fun Receipt(
 ) {
     val scrollState = rememberScrollState()
     Surface(
+        modifier = modifier,
         color = MaterialTheme.colors.background,
     ) {
         Column(

--- a/paymentsheet-example/src/main/res/layout/activity_main.xml
+++ b/paymentsheet-example/src/main/res/layout/activity_main.xml
@@ -10,6 +10,7 @@
     <com.google.android.material.appbar.AppBarLayout
         android:layout_height="wrap_content"
         android:layout_width="match_parent"
+        android:fitsSystemWindows="true"
         android:theme="@style/AppTheme.AppBarOverlay">
 
         <androidx.appcompat.widget.Toolbar

--- a/stripecardscan-example/src/main/res/layout/activity_card_scan_demo.xml
+++ b/stripecardscan-example/src/main/res/layout/activity_card_scan_demo.xml
@@ -6,7 +6,8 @@
     android:id="@+id/coordinator"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".CardScanDemoActivity">
+    tools:context=".CardScanDemoActivity"
+    android:fitsSystemWindows="true">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"

--- a/stripecardscan-example/src/main/res/layout/activity_card_scan_fragment_demo.xml
+++ b/stripecardscan-example/src/main/res/layout/activity_card_scan_fragment_demo.xml
@@ -6,7 +6,8 @@
     android:id="@+id/coordinator"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".CardScanFragmentDemoActivity">
+    tools:context=".CardScanFragmentDemoActivity"
+    android:fitsSystemWindows="true">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"

--- a/stripecardscan-example/src/main/res/layout/activity_main.xml
+++ b/stripecardscan-example/src/main/res/layout/activity_main.xml
@@ -4,7 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".MainActivity">
+    tools:context=".MainActivity"
+    android:fitsSystemWindows="true">
 
     <LinearLayout
         android:id="@+id/iinLayout"

--- a/stripecardscan/res/layout/stripe_activity_cardscan.xml
+++ b/stripecardscan/res/layout/stripe_activity_cardscan.xml
@@ -4,7 +4,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    tools:context=".cardscan.CardScanActivity">
+    tools:context=".cardscan.CardScanActivity"
+    android:fitsSystemWindows="true">
 
     <com.stripe.android.camera.scanui.CameraView
         android:id="@+id/camera_view"


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Android 35 enforces edge-to-edge displays on all activities. We need to modify our screens to support this.

This is what an app that doesn't support edge to edge looks like on android 35
![edge-to-edge-6](https://github.com/user-attachments/assets/75a11963-82a3-4ba0-80a2-a9a5cc4c4c3b)

This is what edge to edge support looks like
![edge-to-edge-2](https://github.com/user-attachments/assets/3275eb8f-9b46-4b43-a224-6be66df866b0)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
[JIRA](https://jira.corp.stripe.com/browse/MOBILESDK-2779)


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Recordings

PaymentSheeet  With edge to edge update
https://github.com/user-attachments/assets/696f06ea-973f-4cb1-a873-e823ad65b84d

PaymentSheeet  Without edge to edge update
https://github.com/user-attachments/assets/84943f6e-d91e-426a-bb60-c2e2c349b9eb

Identity With edge to edge update
https://github.com/user-attachments/assets/657e2c5e-7edc-4338-af4b-fc85a4a7a6fb

Identity Without edge to edge update
https://github.com/user-attachments/assets/b34878d0-d07c-4e12-811d-cd88e52d1584

Connect With edge to edge update
https://github.com/user-attachments/assets/77e1c9ce-4892-4424-a354-69f4c908aa27

Connect Without edge to edge update
https://github.com/user-attachments/assets/ef7b440b-9f4b-4d0e-b7c5-f5497ee66144

3ds With edge to edge update
https://github.com/user-attachments/assets/b58ca04f-9e79-499d-8316-874fa3a1a334

3ds Without edge to edge update
https://github.com/user-attachments/assets/1e924eee-7089-466c-a01f-92aecb6ce4a9

Financial Connections With edge to edge update
https://github.com/user-attachments/assets/6c34a376-9b18-4d35-aec1-4989270bc43a

Financial Connections Without edge to edge update
https://github.com/user-attachments/assets/74ccedee-75c0-430a-ba2a-771fc75c7584

CardScan With edge to edge update
https://github.com/user-attachments/assets/ed8477b1-9b58-4c22-84ec-92c12068fea1

CardScan Without edge to edge update
https://github.com/user-attachments/assets/92361939-a905-48f9-8cf6-3dfd1bd49038


# TODO
[JIRA](https://jira.corp.stripe.com/browse/MOBILESDK-2873) - Screens that use `supportActionBar` have a transparent status bar. These only appear on the example apps, but they need to be resolved.


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
