### PR TITLE
Re-enable US bank tests

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestUSBankAccount.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestUSBankAccount.kt
@@ -19,12 +19,10 @@ import com.stripe.android.test.core.DEFAULT_UI_TIMEOUT
 import com.stripe.android.test.core.TestParameters
 import com.stripe.android.test.core.ui.ComposeButton
 import com.stripe.android.test.core.ui.PaymentSelection
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-@Ignore
 internal class TestUSBankAccount : BasePlaygroundTest() {
     private val testParameters = TestParameters.create(
         paymentMethodCode = "us_bank_account",

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestUsBankAccountInCustomerSheet.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestUsBankAccountInCustomerSheet.kt
@@ -8,10 +8,8 @@ import com.stripe.android.paymentsheet.example.playground.settings.CustomerSheet
 import com.stripe.android.paymentsheet.example.playground.settings.PaymentMethodMode
 import com.stripe.android.test.core.AuthorizeAction
 import com.stripe.android.test.core.TestParameters
-import org.junit.Ignore
 import org.junit.Test
 
-@Ignore
 internal class TestUsBankAccountInCustomerSheet : BasePlaygroundTest() {
     private val testParameters = TestParameters.create(
         paymentMethodCode = "us_bank_account",


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request re-enables the US Bank Account tests. The failures were due to a gating issue on the backend, not due to client-side issues.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
