### PR TITLE
[Connect] Only emit main page load errors in the Connect listener

### DIFF
--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainer.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainer.kt
@@ -205,7 +205,7 @@ internal class StripeConnectWebViewContainerImpl<Listener : StripeEmbeddedCompon
                 requestUrl = request.url.toString(),
                 httpStatusCode = errorResponse.statusCode,
                 errorMessage = errorResponse.reasonPhrase,
-                isForMainFrame = request.isForMainFrame
+                isMainPageLoad = request.isForMainFrame
             )
         }
 
@@ -220,7 +220,7 @@ internal class StripeConnectWebViewContainerImpl<Listener : StripeEmbeddedCompon
             controller?.onReceivedError(
                 requestUrl = request.url.toString(),
                 errorMessage = errorMessage,
-                isForMainFrame = request.isForMainFrame
+                isMainPageLoad = request.isForMainFrame
             )
         }
 

--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainer.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainer.kt
@@ -201,7 +201,12 @@ internal class StripeConnectWebViewContainerImpl<Listener : StripeEmbeddedCompon
             request: WebResourceRequest,
             errorResponse: WebResourceResponse
         ) {
-            controller?.onReceivedError(request.url.toString(), errorResponse.statusCode, errorResponse.reasonPhrase)
+            controller?.onReceivedError(
+                requestUrl = request.url.toString(),
+                httpStatusCode = errorResponse.statusCode,
+                errorMessage = errorResponse.reasonPhrase,
+                isForMainFrame = request.isForMainFrame
+            )
         }
 
         override fun onReceivedError(view: WebView, request: WebResourceRequest, error: WebResourceError) {
@@ -212,7 +217,11 @@ internal class StripeConnectWebViewContainerImpl<Listener : StripeEmbeddedCompon
             } else {
                 null
             }
-            controller?.onReceivedError(request.url.toString(), errorMessage = errorMessage)
+            controller?.onReceivedError(
+                requestUrl = request.url.toString(),
+                errorMessage = errorMessage,
+                isForMainFrame = request.isForMainFrame
+            )
         }
 
         override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {

--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerController.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerController.kt
@@ -64,7 +64,7 @@ internal class StripeConnectWebViewContainerController<Listener : StripeEmbedded
         requestUrl: String,
         httpStatusCode: Int? = null,
         errorMessage: String? = null,
-        isForMainFrame: Boolean, // whether this request is for the main page load
+        isMainPageLoad: Boolean,
     ) {
         val errorString = buildString {
             if (httpStatusCode != null) {
@@ -79,7 +79,7 @@ internal class StripeConnectWebViewContainerController<Listener : StripeEmbedded
         logger.debug("($loggerTag) $errorString")
 
         // don't send errors for requests that aren't for the main page load
-        if (isForMainFrame) {
+        if (isMainPageLoad) {
             listener?.onLoadError(RuntimeException(errorString)) // TODO - wrap error better
         }
     }

--- a/connect/src/test/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerControllerTest.kt
+++ b/connect/src/test/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerControllerTest.kt
@@ -173,7 +173,7 @@ class StripeConnectWebViewContainerControllerTest {
             requestUrl = "https://stripe.com",
             httpStatusCode = 404,
             errorMessage = "Not Found",
-            isForMainFrame = true
+            isMainPageLoad = true
         )
 
         verify(listener).onLoadError(any())
@@ -185,7 +185,7 @@ class StripeConnectWebViewContainerControllerTest {
             requestUrl = "https://stripe.com",
             httpStatusCode = 404,
             errorMessage = "Not Found",
-            isForMainFrame = false
+            isMainPageLoad = false
         )
 
         verify(listener, never()).onLoadError(any())

--- a/connect/src/test/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerControllerTest.kt
+++ b/connect/src/test/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerControllerTest.kt
@@ -169,9 +169,26 @@ class StripeConnectWebViewContainerControllerTest {
 
     @Test
     fun `onReceivedError should forward to listener`() = runTest {
-        controller.onReceivedError("https://stripe.com", 404, "Not Found")
+        controller.onReceivedError(
+            requestUrl = "https://stripe.com",
+            httpStatusCode = 404,
+            errorMessage = "Not Found",
+            isForMainFrame = true
+        )
 
         verify(listener).onLoadError(any())
+    }
+
+    @Test
+    fun `onReceivedError should not forward errors outside of main page load to listener`() = runTest {
+        controller.onReceivedError(
+            requestUrl = "https://stripe.com",
+            httpStatusCode = 404,
+            errorMessage = "Not Found",
+            isForMainFrame = false
+        )
+
+        verify(listener, never()).onLoadError(any())
     }
 
     @Test


### PR DESCRIPTION
# Summary
When we emit http/loading errors in the Connect SDK, only do so for main page loads. For example, when loading `connect-js.stripe.com/v1.0/android_webview.html` we should emit errors, but when loading `r.stripe.com` (analytics) we shouldn't emit any errors.

[MXMOBILE-2978](https://jira.corp.stripe.com/browse/MXMOBILE-2978)

# Motivation
There are errors. We're still logging these internally, but not forwarding them to the SDK consumer

# Testing
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots

**The main page fails to load, and we still emit a toast** 


https://github.com/user-attachments/assets/d2e6cf66-1c7c-407e-958a-7708eedc06d9

**The 413 error toast in the "Before" goes away in the "After" because it's for analytics, not the main page**

### Before

https://github.com/user-attachments/assets/5264e735-e7d9-4ca0-9677-f8eb3d88c64c

### After

https://github.com/user-attachments/assets/7504a064-f0ab-47cc-95e3-63c0534c130b

