### PR TITLE
[MOBILESDK-2658] [MOBILESDK-2659] Add variable to indicate whether a “default” badge should be shown for a given payment method

### DIFF
--- a/payments-core-testing/src/main/java/com/stripe/android/testing/PaymentMethodFactory.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/PaymentMethodFactory.kt
@@ -48,7 +48,7 @@ object PaymentMethodFactory {
         } else {
             "pm_1234"
         }
-        return card(id)
+        return card(id = id)
     }
 
     fun card(id: String?): PaymentMethod {

--- a/payments-core-testing/src/main/java/com/stripe/android/testing/PaymentMethodFactory.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/PaymentMethodFactory.kt
@@ -51,7 +51,7 @@ object PaymentMethodFactory {
         return card(id)
     }
 
-    fun card(id: String): PaymentMethod {
+    fun card(id: String?): PaymentMethod {
         return PaymentMethod(
             id = id,
             created = 123456789L,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
@@ -149,6 +149,7 @@ internal fun SelectPaymentMethod(
             nameProvider = paymentMethodNameProvider,
             canRemovePaymentMethods = viewState.canRemovePaymentMethods,
             isCbcEligible = viewState.isCbcEligible,
+            defaultPaymentMethodId = null
         )
 
         SavedPaymentMethodTabLayoutUI(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethod.kt
@@ -11,6 +11,7 @@ internal data class DisplayableSavedPaymentMethod private constructor(
     val paymentMethod: PaymentMethod,
     val savedPaymentMethod: SavedPaymentMethod,
     val isCbcEligible: Boolean = false,
+    val isDefaultPaymentMethod: Boolean = false
 ) {
     fun isModifiable(): Boolean {
         return when (savedPaymentMethod) {
@@ -76,6 +77,7 @@ internal data class DisplayableSavedPaymentMethod private constructor(
             displayName: ResolvableString,
             paymentMethod: PaymentMethod,
             isCbcEligible: Boolean = false,
+            isDefaultPaymentMethod: Boolean = false
         ): DisplayableSavedPaymentMethod {
             val savedPaymentMethod = when (paymentMethod.type) {
                 PaymentMethod.Type.Card -> paymentMethod.card?.let { SavedPaymentMethod.Card(it) }
@@ -93,6 +95,7 @@ internal data class DisplayableSavedPaymentMethod private constructor(
                 paymentMethod = paymentMethod,
                 savedPaymentMethod = savedPaymentMethod ?: SavedPaymentMethod.Unexpected,
                 isCbcEligible = isCbcEligible,
+                isDefaultPaymentMethod = isDefaultPaymentMethod
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethod.kt
@@ -11,7 +11,7 @@ internal data class DisplayableSavedPaymentMethod private constructor(
     val paymentMethod: PaymentMethod,
     val savedPaymentMethod: SavedPaymentMethod,
     val isCbcEligible: Boolean = false,
-    val isDefaultPaymentMethod: Boolean = false
+    val shouldShowDefaultBadge: Boolean = false
 ) {
     fun isModifiable(): Boolean {
         return when (savedPaymentMethod) {
@@ -77,7 +77,7 @@ internal data class DisplayableSavedPaymentMethod private constructor(
             displayName: ResolvableString,
             paymentMethod: PaymentMethod,
             isCbcEligible: Boolean = false,
-            isDefaultPaymentMethod: Boolean = false
+            shouldShowDefaultBadge: Boolean = false
         ): DisplayableSavedPaymentMethod {
             val savedPaymentMethod = when (paymentMethod.type) {
                 PaymentMethod.Type.Card -> paymentMethod.card?.let { SavedPaymentMethod.Card(it) }
@@ -95,7 +95,7 @@ internal data class DisplayableSavedPaymentMethod private constructor(
                 paymentMethod = paymentMethod,
                 savedPaymentMethod = savedPaymentMethod ?: SavedPaymentMethod.Unexpected,
                 isCbcEligible = isCbcEligible,
-                isDefaultPaymentMethod = isDefaultPaymentMethod
+                shouldShowDefaultBadge = shouldShowDefaultBadge
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactory.kt
@@ -31,7 +31,7 @@ internal object PaymentOptionsStateFactory {
                     displayName = nameProvider(it.type?.code),
                     paymentMethod = it,
                     isCbcEligible = isCbcEligible,
-                    isDefaultPaymentMethod = it.id != null && it.id == defaultPaymentMethodId
+                    shouldShowDefaultBadge = it.id != null && it.id == defaultPaymentMethodId
                 ),
                 canRemovePaymentMethods = canRemovePaymentMethods,
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactory.kt
@@ -18,7 +18,8 @@ internal object PaymentOptionsStateFactory {
         showLink: Boolean,
         nameProvider: (PaymentMethodCode?) -> ResolvableString,
         canRemovePaymentMethods: Boolean,
-        isCbcEligible: Boolean
+        isCbcEligible: Boolean,
+        defaultPaymentMethodId: String?
     ): List<PaymentOptionsItem> {
         return listOfNotNull(
             PaymentOptionsItem.AddCard,
@@ -29,7 +30,8 @@ internal object PaymentOptionsStateFactory {
                 DisplayableSavedPaymentMethod.create(
                     displayName = nameProvider(it.type?.code),
                     paymentMethod = it,
-                    isCbcEligible = isCbcEligible
+                    isCbcEligible = isCbcEligible,
+                    isDefaultPaymentMethod = it.id != null && it.id == defaultPaymentMethodId
                 ),
                 canRemovePaymentMethods = canRemovePaymentMethods,
             )
@@ -52,7 +54,8 @@ internal object PaymentOptionsStateFactory {
         currentSelection: PaymentSelection?,
         nameProvider: (PaymentMethodCode?) -> ResolvableString,
         canRemovePaymentMethods: Boolean,
-        isCbcEligible: Boolean
+        isCbcEligible: Boolean,
+        defaultPaymentMethodId: String?
     ): PaymentOptionsState {
         val items = createPaymentOptionsList(
             paymentMethods = paymentMethods,
@@ -61,6 +64,7 @@ internal object PaymentOptionsStateFactory {
             nameProvider = nameProvider,
             isCbcEligible = isCbcEligible,
             canRemovePaymentMethods = canRemovePaymentMethods,
+            defaultPaymentMethodId = defaultPaymentMethodId
         )
 
         val selectedItem = getSelectedItem(items, currentSelection)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -71,6 +71,12 @@ internal class SavedPaymentMethodMutator(
         } ?: false
     }
 
+    val defaultPaymentMethodId: StateFlow<String?> = customerStateHolder.customer.mapAsStateFlow { customerState ->
+        customerState?.run {
+            customerState.defaultPaymentMethodId
+        }
+    }
+
     private val paymentOptionsItemsMapper: PaymentOptionsItemsMapper by lazy {
         PaymentOptionsItemsMapper(
             customerState = customerStateHolder.customer,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -72,9 +72,7 @@ internal class SavedPaymentMethodMutator(
     }
 
     val defaultPaymentMethodId: StateFlow<String?> = customerStateHolder.customer.mapAsStateFlow { customerState ->
-        customerState?.run {
-            customerState.defaultPaymentMethodId
-        }
+        customerState?.defaultPaymentMethodId
     }
 
     private val paymentOptionsItemsMapper: PaymentOptionsItemsMapper by lazy {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CustomerState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CustomerState.kt
@@ -13,6 +13,7 @@ internal data class CustomerState(
     val ephemeralKeySecret: String,
     val paymentMethods: List<PaymentMethod>,
     val permissions: Permissions,
+    val defaultPaymentMethodId: String?
 ) : Parcelable {
     @Parcelize
     data class Permissions(
@@ -61,7 +62,8 @@ internal data class CustomerState(
                     canRemoveLastPaymentMethod = canRemoveLastPaymentMethod,
                     // Should always remove duplicates when using `customer_session`
                     canRemoveDuplicates = true,
-                )
+                ),
+                defaultPaymentMethodId = customer.defaultPaymentMethod
             )
         }
 
@@ -102,7 +104,8 @@ internal data class CustomerState(
                      * un-scoped ephemeral keys.
                      */
                     canRemoveDuplicates = false,
-                )
+                ),
+                defaultPaymentMethodId = null
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageOneSavedPaymentMethodInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageOneSavedPaymentMethodInteractor.kt
@@ -30,11 +30,13 @@ internal class DefaultManageOneSavedPaymentMethodInteractor(
     providePaymentMethodName: (PaymentMethodCode?) -> ResolvableString,
     private val onDeletePaymentMethod: (PaymentMethod) -> Unit,
     private val navigateBack: () -> Unit,
+    private val defaultPaymentMethodId: String?,
 ) : ManageOneSavedPaymentMethodInteractor {
     override val state = ManageOneSavedPaymentMethodInteractor.State(
         paymentMethod = paymentMethod.toDisplayableSavedPaymentMethod(
             providePaymentMethodName,
             paymentMethodMetadata,
+            defaultPaymentMethodId
         ),
         isLiveMode = paymentMethodMetadata.stripeIntent.isLiveMode,
     )
@@ -55,12 +57,15 @@ internal class DefaultManageOneSavedPaymentMethodInteractor(
             customerStateHolder: CustomerStateHolder,
             savedPaymentMethodMutator: SavedPaymentMethodMutator,
         ): ManageOneSavedPaymentMethodInteractor {
+            val defaultPaymentMethodId = savedPaymentMethodMutator.defaultPaymentMethodId.value
+                ?: customerStateHolder.customer.value?.defaultPaymentMethodId
             return DefaultManageOneSavedPaymentMethodInteractor(
                 paymentMethod = customerStateHolder.paymentMethods.value.first(),
                 paymentMethodMetadata = paymentMethodMetadata,
                 providePaymentMethodName = savedPaymentMethodMutator.providePaymentMethodName,
                 onDeletePaymentMethod = savedPaymentMethodMutator::removePaymentMethod,
                 navigateBack = viewModel::handleBackPressed,
+                defaultPaymentMethodId = defaultPaymentMethodId
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenInteractor.kt
@@ -10,7 +10,6 @@ import com.stripe.android.paymentsheet.SavedPaymentMethodMutator
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.uicore.utils.combineAsStateFlow
-import com.stripe.android.uicore.utils.mapAsStateFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -61,6 +60,7 @@ internal class DefaultManageScreenInteractor(
     private val onUpdatePaymentMethod: (DisplayableSavedPaymentMethod) -> Unit,
     private val navigateBack: (withDelay: Boolean) -> Unit,
     override val isLiveMode: Boolean,
+    private val defaultPaymentMethodId: StateFlow<String?>,
     dispatcher: CoroutineContext = Dispatchers.Default,
 ) : ManageScreenInteractor {
 
@@ -69,9 +69,13 @@ internal class DefaultManageScreenInteractor(
     private val hasNavigatedBack: AtomicBoolean = AtomicBoolean(false)
 
     private val displayableSavedPaymentMethods: StateFlow<List<DisplayableSavedPaymentMethod>> =
-        paymentMethods.mapAsStateFlow { paymentMethods ->
+        combineAsStateFlow(paymentMethods, defaultPaymentMethodId) { paymentMethods, defaultPaymentMethodId ->
             paymentMethods.map {
-                it.toDisplayableSavedPaymentMethod(providePaymentMethodName, paymentMethodMetadata)
+                it.toDisplayableSavedPaymentMethod(
+                    providePaymentMethodName,
+                    paymentMethodMetadata,
+                    defaultPaymentMethodId
+                )
             }
         }
 
@@ -173,6 +177,7 @@ internal class DefaultManageScreenInteractor(
                     }
                 },
                 isLiveMode = paymentMethodMetadata.stripeIntent.isLiveMode,
+                defaultPaymentMethodId = savedPaymentMethodMutator.defaultPaymentMethodId
             )
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -90,7 +90,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
     private val reportFormShown: (PaymentMethodCode) -> Unit,
     private val onUpdatePaymentMethod: (DisplayableSavedPaymentMethod) -> Unit,
     override val isLiveMode: Boolean,
-    private val defaultPaymentMethodId: String?,
+    private val shouldShowDefaultBadge: Boolean,
     dispatcher: CoroutineContext = Dispatchers.Default,
 ) : PaymentMethodVerticalLayoutInteractor {
 
@@ -179,7 +179,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
                 reportPaymentMethodTypeSelected = viewModel.eventReporter::onSelectPaymentMethod,
                 reportFormShown = viewModel.eventReporter::onPaymentMethodFormShown,
                 isLiveMode = paymentMethodMetadata.stripeIntent.isLiveMode,
-                defaultPaymentMethodId = customerStateHolder.customer.value?.defaultPaymentMethodId
+                shouldShowDefaultBadge = false
             )
         }
     }
@@ -346,7 +346,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
         return paymentMethodToDisplay?.toDisplayableSavedPaymentMethod(
             providePaymentMethodName,
             paymentMethodMetadata,
-            this.defaultPaymentMethodId
+            null
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -90,6 +90,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
     private val reportFormShown: (PaymentMethodCode) -> Unit,
     private val onUpdatePaymentMethod: (DisplayableSavedPaymentMethod) -> Unit,
     override val isLiveMode: Boolean,
+    private val defaultPaymentMethodId: String?,
     dispatcher: CoroutineContext = Dispatchers.Default,
 ) : PaymentMethodVerticalLayoutInteractor {
 
@@ -178,6 +179,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
                 reportPaymentMethodTypeSelected = viewModel.eventReporter::onSelectPaymentMethod,
                 reportFormShown = viewModel.eventReporter::onPaymentMethodFormShown,
                 isLiveMode = paymentMethodMetadata.stripeIntent.isLiveMode,
+                defaultPaymentMethodId = customerStateHolder.customer.value?.defaultPaymentMethodId
             )
         }
     }
@@ -341,7 +343,11 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
         mostRecentlySelectedSavedPaymentMethod: PaymentMethod?,
     ): DisplayableSavedPaymentMethod? {
         val paymentMethodToDisplay = mostRecentlySelectedSavedPaymentMethod ?: paymentMethods?.firstOrNull()
-        return paymentMethodToDisplay?.toDisplayableSavedPaymentMethod(providePaymentMethodName, paymentMethodMetadata)
+        return paymentMethodToDisplay?.toDisplayableSavedPaymentMethod(
+            providePaymentMethodName,
+            paymentMethodMetadata,
+            this.defaultPaymentMethodId
+        )
     }
 
     private fun getAvailableSavedPaymentMethodAction(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -90,7 +90,6 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
     private val reportFormShown: (PaymentMethodCode) -> Unit,
     private val onUpdatePaymentMethod: (DisplayableSavedPaymentMethod) -> Unit,
     override val isLiveMode: Boolean,
-    private val shouldShowDefaultBadge: Boolean,
     dispatcher: CoroutineContext = Dispatchers.Default,
 ) : PaymentMethodVerticalLayoutInteractor {
 
@@ -178,8 +177,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
                 },
                 reportPaymentMethodTypeSelected = viewModel.eventReporter::onSelectPaymentMethod,
                 reportFormShown = viewModel.eventReporter::onPaymentMethodFormShown,
-                isLiveMode = paymentMethodMetadata.stripeIntent.isLiveMode,
-                shouldShowDefaultBadge = false
+                isLiveMode = paymentMethodMetadata.stripeIntent.isLiveMode
             )
         }
     }
@@ -346,7 +344,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
         return paymentMethodToDisplay?.toDisplayableSavedPaymentMethod(
             providePaymentMethodName,
             paymentMethodMetadata,
-            null
+            defaultPaymentMethodId = null
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodsExtension.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodsExtension.kt
@@ -16,6 +16,6 @@ internal fun PaymentMethod.toDisplayableSavedPaymentMethod(
         displayName = providePaymentMethodName(type?.code),
         paymentMethod = this,
         isCbcEligible = paymentMethodMetadata?.cbcEligibility is CardBrandChoiceEligibility.Eligible,
-        isDefaultPaymentMethod = this.id != null && this.id == defaultPaymentMethodId
+        shouldShowDefaultBadge = this.id != null && this.id == defaultPaymentMethodId
     )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodsExtension.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodsExtension.kt
@@ -10,10 +10,12 @@ import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 internal fun PaymentMethod.toDisplayableSavedPaymentMethod(
     providePaymentMethodName: (PaymentMethodCode?) -> ResolvableString,
     paymentMethodMetadata: PaymentMethodMetadata?,
+    defaultPaymentMethodId: String?
 ): DisplayableSavedPaymentMethod {
     return DisplayableSavedPaymentMethod.create(
         displayName = providePaymentMethodName(type?.code),
         paymentMethod = this,
         isCbcEligible = paymentMethodMetadata?.cbcEligibility is CardBrandChoiceEligibility.Eligible,
+        isDefaultPaymentMethod = this.id != null && this.id == defaultPaymentMethodId
     )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsItemsMapper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsItemsMapper.kt
@@ -31,6 +31,7 @@ internal class PaymentOptionsItemsMapper(
                 isLinkEnabled = isLinkEnabled,
                 isGooglePayReady = isGooglePayReady,
                 canRemovePaymentMethods = canRemove,
+                defaultPaymentMethodId = customerState?.defaultPaymentMethodId
             ) ?: emptyList()
         }
     }
@@ -41,6 +42,7 @@ internal class PaymentOptionsItemsMapper(
         isLinkEnabled: Boolean?,
         isGooglePayReady: Boolean,
         canRemovePaymentMethods: Boolean,
+        defaultPaymentMethodId: String?
     ): List<PaymentOptionsItem>? {
         if (isLinkEnabled == null) return null
 
@@ -51,6 +53,7 @@ internal class PaymentOptionsItemsMapper(
             nameProvider = nameProvider,
             isCbcEligible = isCbcEligible(),
             canRemovePaymentMethods = canRemovePaymentMethods,
+            defaultPaymentMethodId = defaultPaymentMethodId
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactoryTest.kt
@@ -31,6 +31,7 @@ class PaymentOptionsStateFactoryTest {
             nameProvider = { it!!.resolvableString },
             isCbcEligible = false,
             canRemovePaymentMethods = true,
+            defaultPaymentMethodId = null
         )
 
         val selectedPaymentMethod = state.selectedItem as? PaymentOptionsItem.SavedPaymentMethod
@@ -49,6 +50,7 @@ class PaymentOptionsStateFactoryTest {
             nameProvider = { it!!.resolvableString },
             isCbcEligible = false,
             canRemovePaymentMethods = true,
+            defaultPaymentMethodId = null
         )
 
         assertThat(state.selectedItem).isNull()
@@ -78,6 +80,7 @@ class PaymentOptionsStateFactoryTest {
             nameProvider = { it!!.resolvableString },
             isCbcEligible = true,
             canRemovePaymentMethods = true,
+            defaultPaymentMethodId = null
         )
 
         assertThat(
@@ -183,6 +186,7 @@ class PaymentOptionsStateFactoryTest {
             nameProvider = { it!!.resolvableString },
             isCbcEligible = true,
             canRemovePaymentMethods = canRemovePaymentMethods,
+            defaultPaymentMethodId = null
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactoryTest.kt
@@ -181,7 +181,7 @@ class PaymentOptionsStateFactoryTest {
         val selectedPaymentMethod = paymentMethods.random()
         val defaultPaymentMethodId = selectedPaymentMethod.id
 
-        assert(defaultPaymentMethodId!=null)
+        assert(defaultPaymentMethodId != null)
 
         val state = PaymentOptionsStateFactory.create(
             paymentMethods = paymentMethods,
@@ -214,7 +214,7 @@ class PaymentOptionsStateFactoryTest {
         val defaultPaymentMethod = paymentMethods[1]
         val defaultPaymentMethodId = defaultPaymentMethod.id
 
-        assert(defaultPaymentMethodId!=null)
+        assert(defaultPaymentMethodId != null)
 
         val state = PaymentOptionsStateFactory.create(
             paymentMethods = paymentMethods,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactoryTest.kt
@@ -175,52 +175,19 @@ class PaymentOptionsStateFactoryTest {
     }
 
     @Test
-    fun `State is correct when given non null defaultPaymentMethodId and it is selected`() {
+    fun `State is correct when given non null defaultPaymentMethodId`() {
         val paymentMethods = PaymentMethodFixtures.createCards(3)
 
-        val selectedPaymentMethod = paymentMethods.random()
-        val defaultPaymentMethodId = selectedPaymentMethod.id
-
-        assert(defaultPaymentMethodId != null)
-
-        val state = PaymentOptionsStateFactory.create(
-            paymentMethods = paymentMethods,
-            showGooglePay = true,
-            showLink = true,
-            currentSelection = PaymentSelection.Saved(selectedPaymentMethod),
-            nameProvider = { it!!.resolvableString },
-            isCbcEligible = false,
-            canRemovePaymentMethods = true,
-            defaultPaymentMethodId = defaultPaymentMethodId
-        )
-
-        val options = state.items.filterIsInstance<PaymentOptionsItem.SavedPaymentMethod>()
-
-        val selectedPaymentOptionItem = options.find {
-            it.paymentMethod.id == defaultPaymentMethodId
-        }
-
-        assert(selectedPaymentOptionItem != null)
-        assert(selectedPaymentOptionItem!!.displayableSavedPaymentMethod.shouldShowDefaultBadge)
-    }
-
-    @Test
-    fun `State is correct when given non null defaultPaymentMethodId and it is not selected`() {
-        val paymentMethods = PaymentMethodFixtures.createCards(3)
-
-        val selectedPaymentMethod = paymentMethods[0]
-        val selectedPaymentMethodId = selectedPaymentMethod.id
-
-        val defaultPaymentMethod = paymentMethods[1]
+        val defaultPaymentMethod = paymentMethods[0]
         val defaultPaymentMethodId = defaultPaymentMethod.id
 
-        assert(defaultPaymentMethodId != null)
+        assertThat(defaultPaymentMethodId).isNotNull()
 
         val state = PaymentOptionsStateFactory.create(
             paymentMethods = paymentMethods,
             showGooglePay = true,
             showLink = true,
-            currentSelection = PaymentSelection.Saved(selectedPaymentMethod),
+            currentSelection = PaymentSelection.Saved(defaultPaymentMethod),
             nameProvider = { it!!.resolvableString },
             isCbcEligible = false,
             canRemovePaymentMethods = true,
@@ -229,21 +196,10 @@ class PaymentOptionsStateFactoryTest {
 
         val options = state.items.filterIsInstance<PaymentOptionsItem.SavedPaymentMethod>()
 
-        val selectedPaymentOptionItem = options.find {
-            it.paymentMethod.id == selectedPaymentMethodId
-        }
-
-        assert(selectedPaymentOptionItem != null)
-        assert(!selectedPaymentOptionItem!!.displayableSavedPaymentMethod.shouldShowDefaultBadge)
-
-        val defaultPaymentOptionItem = options.find {
-            it.paymentMethod.id == defaultPaymentMethodId
-        }
-
-        assert(defaultPaymentOptionItem != null)
-        assert(selectedPaymentOptionItem != defaultPaymentOptionItem)
-
-        assert(defaultPaymentOptionItem!!.displayableSavedPaymentMethod.shouldShowDefaultBadge)
+        assertThat(options[0].paymentMethod.id).isEqualTo(defaultPaymentMethodId)
+        assertThat(options[0].displayableSavedPaymentMethod.shouldShowDefaultBadge).isTrue()
+        assertThat(options[1].displayableSavedPaymentMethod.shouldShowDefaultBadge).isFalse()
+        assertThat(options[2].displayableSavedPaymentMethod.shouldShowDefaultBadge).isFalse()
     }
 
     private fun createPaymentOptionsState(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactoryTest.kt
@@ -174,6 +174,78 @@ class PaymentOptionsStateFactoryTest {
         assertThat(options[2].isEnabledDuringEditing).isTrue()
     }
 
+    @Test
+    fun `State is correct when given non null defaultPaymentMethodId and it is selected`() {
+        val paymentMethods = PaymentMethodFixtures.createCards(3)
+
+        val selectedPaymentMethod = paymentMethods.random()
+        val defaultPaymentMethodId = selectedPaymentMethod.id
+
+        assert(defaultPaymentMethodId!=null)
+
+        val state = PaymentOptionsStateFactory.create(
+            paymentMethods = paymentMethods,
+            showGooglePay = true,
+            showLink = true,
+            currentSelection = PaymentSelection.Saved(selectedPaymentMethod),
+            nameProvider = { it!!.resolvableString },
+            isCbcEligible = false,
+            canRemovePaymentMethods = true,
+            defaultPaymentMethodId = defaultPaymentMethodId
+        )
+
+        val options = state.items.filterIsInstance<PaymentOptionsItem.SavedPaymentMethod>()
+
+        val selectedPaymentOptionItem = options.find {
+            it.paymentMethod.id == defaultPaymentMethodId
+        }
+
+        assert(selectedPaymentOptionItem != null)
+        assert(selectedPaymentOptionItem!!.displayableSavedPaymentMethod.shouldShowDefaultBadge)
+    }
+
+    @Test
+    fun `State is correct when given non null defaultPaymentMethodId and it is not selected`() {
+        val paymentMethods = PaymentMethodFixtures.createCards(3)
+
+        val selectedPaymentMethod = paymentMethods[0]
+        val selectedPaymentMethodId = selectedPaymentMethod.id
+
+        val defaultPaymentMethod = paymentMethods[1]
+        val defaultPaymentMethodId = defaultPaymentMethod.id
+
+        assert(defaultPaymentMethodId!=null)
+
+        val state = PaymentOptionsStateFactory.create(
+            paymentMethods = paymentMethods,
+            showGooglePay = true,
+            showLink = true,
+            currentSelection = PaymentSelection.Saved(selectedPaymentMethod),
+            nameProvider = { it!!.resolvableString },
+            isCbcEligible = false,
+            canRemovePaymentMethods = true,
+            defaultPaymentMethodId = defaultPaymentMethodId
+        )
+
+        val options = state.items.filterIsInstance<PaymentOptionsItem.SavedPaymentMethod>()
+
+        val selectedPaymentOptionItem = options.find {
+            it.paymentMethod.id == selectedPaymentMethodId
+        }
+
+        assert(selectedPaymentOptionItem != null)
+        assert(!selectedPaymentOptionItem!!.displayableSavedPaymentMethod.shouldShowDefaultBadge)
+
+        val defaultPaymentOptionItem = options.find {
+            it.paymentMethod.id == defaultPaymentMethodId
+        }
+
+        assert(defaultPaymentOptionItem != null)
+        assert(selectedPaymentOptionItem != defaultPaymentOptionItem)
+
+        assert(defaultPaymentOptionItem!!.displayableSavedPaymentMethod.shouldShowDefaultBadge)
+    }
+
     private fun createPaymentOptionsState(
         paymentMethods: List<PaymentMethod>,
         canRemovePaymentMethods: Boolean,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
@@ -99,7 +99,8 @@ internal object PaymentSheetFixtures {
             canRemovePaymentMethods = true,
             canRemoveLastPaymentMethod = true,
             canRemoveDuplicates = false,
-        )
+        ),
+        defaultPaymentMethodId = null
     )
 
     internal val CONFIG_GOOGLEPAY
@@ -162,7 +163,8 @@ internal object PaymentSheetFixtures {
                         canRemovePaymentMethods = true,
                         canRemoveLastPaymentMethod = true,
                         canRemoveDuplicates = false,
-                    )
+                    ),
+                    defaultPaymentMethodId = null
                 ),
                 config = config.asCommonConfiguration(),
                 paymentSelection = paymentSelection,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -312,6 +312,7 @@ internal class PaymentSheetViewModelTest {
     }
 
     @Test
+    @Suppress("LongMethod")
     fun `modifyPaymentMethod should use loaded customer info when modifying payment methods`() = runTest {
         val paymentMethods = listOf(CARD_WITH_NETWORKS_PAYMENT_METHOD)
 
@@ -340,6 +341,7 @@ internal class PaymentSheetViewModelTest {
                     canRemoveLastPaymentMethod = true,
                     canRemoveDuplicates = false,
                 ),
+                defaultPaymentMethodId = null
             ),
             customerRepository = customerRepository
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
@@ -743,7 +743,8 @@ class SavedPaymentMethodMutatorTest {
                 canRemovePaymentMethods = isRemoveEnabled,
                 canRemoveDuplicates = true,
                 canRemoveLastPaymentMethod = canRemoveLastPaymentMethod,
-            )
+            ),
+            defaultPaymentMethodId = null
         )
     }
 
@@ -760,7 +761,8 @@ class SavedPaymentMethodMutatorTest {
                         canRemovePaymentMethods = true,
                         canRemoveLastPaymentMethod = true,
                         canRemoveDuplicates = shouldRemoveDuplicates,
-                    )
+                    ),
+                    defaultPaymentMethodId = null
                 )
             )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodsExtensionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodsExtensionTest.kt
@@ -2,7 +2,6 @@ package com.stripe.android.paymentsheet
 
 import android.content.Context
 import com.stripe.android.core.strings.ResolvableString
-import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentsheet.verticalmode.toDisplayableSavedPaymentMethod
 import com.stripe.android.testing.PaymentMethodFactory
@@ -19,7 +18,7 @@ class SavedPaymentMethodsExtensionTest {
         val resolvableStringValue = "abcde123"
         val resolvableString = mock<ResolvableString>()
         `when`(resolvableString.resolve(context)).thenReturn(resolvableStringValue)
-        val providePaymentMethodName: (PaymentMethodCode?) -> ResolvableString = {pmc ->
+        val providePaymentMethodName: (PaymentMethodCode?) -> ResolvableString = { pmc ->
             resolvableString
         }
 
@@ -42,12 +41,12 @@ class SavedPaymentMethodsExtensionTest {
     }
 
     @Test
-    fun `DisplayableSavedPaymentMethod is created correctly when defaultPaymentMethodId not equal to paymentMethod id`() {
+    fun `DisplayableSavedPaymentMethod created correctly when defaultPaymentMethodId != paymentMethod id`() {
         val context = mock<Context>()
         val resolvableStringValue = "abcde123"
         val resolvableString = mock<ResolvableString>()
         `when`(resolvableString.resolve(context)).thenReturn(resolvableStringValue)
-        val providePaymentMethodName: (PaymentMethodCode?) -> ResolvableString = {pmc ->
+        val providePaymentMethodName: (PaymentMethodCode?) -> ResolvableString = { pmc ->
             resolvableString
         }
 
@@ -77,7 +76,7 @@ class SavedPaymentMethodsExtensionTest {
         val resolvableStringValue = "abcde123"
         val resolvableString = mock<ResolvableString>()
         `when`(resolvableString.resolve(context)).thenReturn(resolvableStringValue)
-        val providePaymentMethodName: (PaymentMethodCode?) -> ResolvableString = {pmc ->
+        val providePaymentMethodName: (PaymentMethodCode?) -> ResolvableString = { pmc ->
             resolvableString
         }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodsExtensionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodsExtensionTest.kt
@@ -42,13 +42,7 @@ class SavedPaymentMethodsExtensionTest {
     private fun testSetup(paymentMethodId: String?, defaultPaymentMethodId: String?): DisplayableSavedPaymentMethod {
         val resolvableString = "acbde123".resolvableString
 
-        val paymentMethod = if (paymentMethodId == null) {
-            PaymentMethodFactory.card("test").copy(
-                id = null
-            )
-        } else {
-            PaymentMethodFactory.card(paymentMethodId)
-        }
+        val paymentMethod = PaymentMethodFactory.card(paymentMethodId)
 
         val providePaymentMethodName: (PaymentMethodCode?) -> ResolvableString = { pmc ->
             resolvableString

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodsExtensionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodsExtensionTest.kt
@@ -1,100 +1,63 @@
 package com.stripe.android.paymentsheet
 
-import android.content.Context
 import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentsheet.verticalmode.toDisplayableSavedPaymentMethod
 import com.stripe.android.testing.PaymentMethodFactory
 import org.junit.Test
-import org.mockito.Mockito.mock
-import org.mockito.Mockito.`when`
 import kotlin.test.assertEquals
 
 class SavedPaymentMethodsExtensionTest {
-
     @Test
-    fun `DisplayableSavedPaymentMethod is created correctly when metadata & defaultPaymentMethodId is null`() {
-        val context = mock<Context>()
-        val resolvableStringValue = "abcde123"
-        val resolvableString = mock<ResolvableString>()
-        `when`(resolvableString.resolve(context)).thenReturn(resolvableStringValue)
-        val providePaymentMethodName: (PaymentMethodCode?) -> ResolvableString = { pmc ->
-            resolvableString
-        }
-
+    fun `shouldShowDefaultBadge is false when defaultPaymentMethodId is null and paymentMethod not null`() {
         val paymentMethodId = "aaa111"
-        val paymentMethod = PaymentMethodFactory.card(paymentMethodId)
+        val defaultPaymentMethodId = null
 
-        assertEquals(
-            expected = DisplayableSavedPaymentMethod.create(
-                displayName = resolvableString,
-                paymentMethod = paymentMethod,
-                isCbcEligible = false,
-                shouldShowDefaultBadge = false
-            ),
-            actual = paymentMethod.toDisplayableSavedPaymentMethod(
-                providePaymentMethodName = providePaymentMethodName,
-                paymentMethodMetadata = null,
-                defaultPaymentMethodId = null
-            )
-        )
+        val actual = testSetup(paymentMethodId, defaultPaymentMethodId)
+        assertEquals(actual.shouldShowDefaultBadge, false)
     }
 
     @Test
-    fun `DisplayableSavedPaymentMethod created correctly when defaultPaymentMethodId != paymentMethod id`() {
-        val context = mock<Context>()
-        val resolvableStringValue = "abcde123"
-        val resolvableString = mock<ResolvableString>()
-        `when`(resolvableString.resolve(context)).thenReturn(resolvableStringValue)
-        val providePaymentMethodName: (PaymentMethodCode?) -> ResolvableString = { pmc ->
-            resolvableString
-        }
-
+    fun `shouldShowDefaultBadge false when defaultPaymentMethodId != paymentMethod id and both not null`() {
         val paymentMethodId = "aaa111"
-        val paymentMethod = PaymentMethodFactory.card(paymentMethodId)
-
         val defaultPaymentMethodId = "bbb222"
 
-        assertEquals(
-            expected = DisplayableSavedPaymentMethod.create(
-                displayName = resolvableString,
-                paymentMethod = paymentMethod,
-                isCbcEligible = false,
-                shouldShowDefaultBadge = false
-            ),
-            actual = paymentMethod.toDisplayableSavedPaymentMethod(
-                providePaymentMethodName = providePaymentMethodName,
-                paymentMethodMetadata = null,
-                defaultPaymentMethodId = defaultPaymentMethodId
-            )
-        )
+        val actual = testSetup(paymentMethodId, defaultPaymentMethodId)
+        assertEquals(actual.shouldShowDefaultBadge, false)
     }
 
     @Test
-    fun `DisplayableSavedPaymentMethod is created correctly when defaultPaymentMethodId equal to paymentMethod id`() {
-        val context = mock<Context>()
-        val resolvableStringValue = "abcde123"
-        val resolvableString = mock<ResolvableString>()
-        `when`(resolvableString.resolve(context)).thenReturn(resolvableStringValue)
+    fun `shouldShowDefaultBadge is false when defaultPaymentMethodId is null and paymentMethod id null`() {
+        val actual = testSetup(null, null)
+        assertEquals(actual.shouldShowDefaultBadge, false)
+    }
+
+    @Test
+    fun `shouldShowDefaultBadge is true when defaultPaymentMethodId == paymentMethod id and both are not null`() {
+        val actual = testSetup("aaa111", "aaa111")
+        assertEquals(actual.shouldShowDefaultBadge, true)
+    }
+
+    private fun testSetup(paymentMethodId: String?, defaultPaymentMethodId: String?): DisplayableSavedPaymentMethod {
+        val resolvableString = "acbde123".resolvableString
+
+        val paymentMethod = if (paymentMethodId == null) {
+            PaymentMethodFactory.card("test").copy(
+                id = null
+            )
+        } else {
+            PaymentMethodFactory.card(paymentMethodId)
+        }
+
         val providePaymentMethodName: (PaymentMethodCode?) -> ResolvableString = { pmc ->
             resolvableString
         }
 
-        val paymentMethodId = "aaa111"
-        val paymentMethod = PaymentMethodFactory.card(paymentMethodId)
-
-        assertEquals(
-            expected = DisplayableSavedPaymentMethod.create(
-                displayName = resolvableString,
-                paymentMethod = paymentMethod,
-                isCbcEligible = false,
-                shouldShowDefaultBadge = true
-            ),
-            actual = paymentMethod.toDisplayableSavedPaymentMethod(
-                providePaymentMethodName = providePaymentMethodName,
-                paymentMethodMetadata = null,
-                defaultPaymentMethodId = paymentMethodId
-            )
+        return paymentMethod.toDisplayableSavedPaymentMethod(
+            providePaymentMethodName = providePaymentMethodName,
+            paymentMethodMetadata = null,
+            defaultPaymentMethodId = defaultPaymentMethodId
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodsExtensionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodsExtensionTest.kt
@@ -1,0 +1,101 @@
+package com.stripe.android.paymentsheet
+
+import android.content.Context
+import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodCode
+import com.stripe.android.paymentsheet.verticalmode.toDisplayableSavedPaymentMethod
+import com.stripe.android.testing.PaymentMethodFactory
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import kotlin.test.assertEquals
+
+class SavedPaymentMethodsExtensionTest {
+
+    @Test
+    fun `DisplayableSavedPaymentMethod is created correctly when metadata & defaultPaymentMethodId is null`() {
+        val context = mock<Context>()
+        val resolvableStringValue = "abcde123"
+        val resolvableString = mock<ResolvableString>()
+        `when`(resolvableString.resolve(context)).thenReturn(resolvableStringValue)
+        val providePaymentMethodName: (PaymentMethodCode?) -> ResolvableString = {pmc ->
+            resolvableString
+        }
+
+        val paymentMethodId = "aaa111"
+        val paymentMethod = PaymentMethodFactory.card(paymentMethodId)
+
+        assertEquals(
+            expected = DisplayableSavedPaymentMethod.create(
+                displayName = resolvableString,
+                paymentMethod = paymentMethod,
+                isCbcEligible = false,
+                shouldShowDefaultBadge = false
+            ),
+            actual = paymentMethod.toDisplayableSavedPaymentMethod(
+                providePaymentMethodName = providePaymentMethodName,
+                paymentMethodMetadata = null,
+                defaultPaymentMethodId = null
+            )
+        )
+    }
+
+    @Test
+    fun `DisplayableSavedPaymentMethod is created correctly when defaultPaymentMethodId not equal to paymentMethod id`() {
+        val context = mock<Context>()
+        val resolvableStringValue = "abcde123"
+        val resolvableString = mock<ResolvableString>()
+        `when`(resolvableString.resolve(context)).thenReturn(resolvableStringValue)
+        val providePaymentMethodName: (PaymentMethodCode?) -> ResolvableString = {pmc ->
+            resolvableString
+        }
+
+        val paymentMethodId = "aaa111"
+        val paymentMethod = PaymentMethodFactory.card(paymentMethodId)
+
+        val defaultPaymentMethodId = "bbb222"
+
+        assertEquals(
+            expected = DisplayableSavedPaymentMethod.create(
+                displayName = resolvableString,
+                paymentMethod = paymentMethod,
+                isCbcEligible = false,
+                shouldShowDefaultBadge = false
+            ),
+            actual = paymentMethod.toDisplayableSavedPaymentMethod(
+                providePaymentMethodName = providePaymentMethodName,
+                paymentMethodMetadata = null,
+                defaultPaymentMethodId = defaultPaymentMethodId
+            )
+        )
+    }
+
+    @Test
+    fun `DisplayableSavedPaymentMethod is created correctly when defaultPaymentMethodId equal to paymentMethod id`() {
+        val context = mock<Context>()
+        val resolvableStringValue = "abcde123"
+        val resolvableString = mock<ResolvableString>()
+        `when`(resolvableString.resolve(context)).thenReturn(resolvableStringValue)
+        val providePaymentMethodName: (PaymentMethodCode?) -> ResolvableString = {pmc ->
+            resolvableString
+        }
+
+        val paymentMethodId = "aaa111"
+        val paymentMethod = PaymentMethodFactory.card(paymentMethodId)
+
+        assertEquals(
+            expected = DisplayableSavedPaymentMethod.create(
+                displayName = resolvableString,
+                paymentMethod = paymentMethod,
+                isCbcEligible = false,
+                shouldShowDefaultBadge = true
+            ),
+            actual = paymentMethod.toDisplayableSavedPaymentMethod(
+                providePaymentMethodName = providePaymentMethodName,
+                paymentMethodMetadata = null,
+                defaultPaymentMethodId = paymentMethodId
+            )
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CustomerStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CustomerStateTest.kt
@@ -121,18 +121,22 @@ class CustomerStateTest {
 
     @Test
     fun `Should create 'CustomerState' for customer session properly with nonnull defaultPaymentMethodId`() {
+        val customerId = "cus_3"
+        val ephemeralKeySecret = "ek_3"
         val paymentMethods = PaymentMethodFactory.cards(3)
+        val mobilePaymentElementComponent = ElementsSession.Customer.Components.MobilePaymentElement.Enabled(
+            isPaymentMethodSaveEnabled = false,
+            isPaymentMethodRemoveEnabled = false,
+            canRemoveLastPaymentMethod = false,
+            allowRedisplayOverride = null,
+        )
+        val defaultPaymentMethodId = "aaa111"
         val customer = createElementsSessionCustomer(
-            customerId = "cus_3",
-            ephemeralKeySecret = "ek_3",
+            customerId = customerId,
+            ephemeralKeySecret = ephemeralKeySecret,
             paymentMethods = paymentMethods,
-            mobilePaymentElementComponent = ElementsSession.Customer.Components.MobilePaymentElement.Enabled(
-                isPaymentMethodSaveEnabled = false,
-                isPaymentMethodRemoveEnabled = false,
-                canRemoveLastPaymentMethod = false,
-                allowRedisplayOverride = null,
-            ),
-            defaultPaymentMethodId = "aaa111"
+            mobilePaymentElementComponent = mobilePaymentElementComponent,
+            defaultPaymentMethodId = defaultPaymentMethodId
         )
 
         val customerState = CustomerState.createForCustomerSession(
@@ -141,20 +145,18 @@ class CustomerStateTest {
             supportedSavedPaymentMethodTypes = listOf(PaymentMethod.Type.Card)
         )
 
-        assertThat(customerState).isEqualTo(
-            CustomerState(
-                id = "cus_3",
-                ephemeralKeySecret = "ek_3",
-                paymentMethods = paymentMethods,
-                permissions = CustomerState.Permissions(
-                    canRemovePaymentMethods = false,
-                    canRemoveLastPaymentMethod = false,
-                    // Always true for `customer_session`
-                    canRemoveDuplicates = true,
-                ),
-                defaultPaymentMethodId = "aaa111"
+        assertThat(customerState.id).isEqualTo(customerId)
+        assertThat(customerState.ephemeralKeySecret).isEqualTo(ephemeralKeySecret)
+        assertThat(customerState.paymentMethods).isEqualTo(paymentMethods)
+        assertThat(customerState.permissions).isEqualTo(
+            CustomerState.Permissions(
+                canRemovePaymentMethods = false,
+                canRemoveLastPaymentMethod = false,
+                // Always true for `customer_session`
+                canRemoveDuplicates = true,
             )
         )
+        assertThat(customerState.defaultPaymentMethodId).isEqualTo(defaultPaymentMethodId)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CustomerStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CustomerStateTest.kt
@@ -119,6 +119,45 @@ class CustomerStateTest {
         )
     }
 
+
+    @Test
+    fun `Should create 'CustomerState' for customer session properly with nonnull defaultPaymentMethodId`() {
+        val paymentMethods = PaymentMethodFactory.cards(3)
+        val customer = createElementsSessionCustomer(
+            customerId = "cus_3",
+            ephemeralKeySecret = "ek_3",
+            paymentMethods = paymentMethods,
+            mobilePaymentElementComponent = ElementsSession.Customer.Components.MobilePaymentElement.Enabled(
+                isPaymentMethodSaveEnabled = false,
+                isPaymentMethodRemoveEnabled = false,
+                canRemoveLastPaymentMethod = false,
+                allowRedisplayOverride = null,
+            ),
+            defaultPaymentMethodId = "aaa111"
+        )
+
+        val customerState = CustomerState.createForCustomerSession(
+            customer = customer,
+            configuration = createConfiguration(),
+            supportedSavedPaymentMethodTypes = listOf(PaymentMethod.Type.Card)
+        )
+
+        assertThat(customerState).isEqualTo(
+            CustomerState(
+                id = "cus_3",
+                ephemeralKeySecret = "ek_3",
+                paymentMethods = paymentMethods,
+                permissions = CustomerState.Permissions(
+                    canRemovePaymentMethods = false,
+                    canRemoveLastPaymentMethod = false,
+                    // Always true for `customer_session`
+                    canRemoveDuplicates = true,
+                ),
+                defaultPaymentMethodId = "aaa111"
+            )
+        )
+    }
+
     @Test
     fun `Should create 'CustomerState' for legacy ephemeral keys properly`() {
         val paymentMethods = PaymentMethodFactory.cards(7)
@@ -291,11 +330,12 @@ class CustomerStateTest {
         customerId: String = "cus_1",
         ephemeralKeySecret: String = "ek_1",
         paymentMethods: List<PaymentMethod> = listOf(),
-        mobilePaymentElementComponent: ElementsSession.Customer.Components.MobilePaymentElement
+        mobilePaymentElementComponent: ElementsSession.Customer.Components.MobilePaymentElement,
+        defaultPaymentMethodId: String? = null,
     ): ElementsSession.Customer {
         return ElementsSession.Customer(
             paymentMethods = paymentMethods,
-            defaultPaymentMethod = null,
+            defaultPaymentMethod = defaultPaymentMethodId,
             session = ElementsSession.Customer.Session(
                 id = "cuss_1",
                 customerId = customerId,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CustomerStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CustomerStateTest.kt
@@ -119,7 +119,6 @@ class CustomerStateTest {
         )
     }
 
-
     @Test
     fun `Should create 'CustomerState' for customer session properly with nonnull defaultPaymentMethodId`() {
         val paymentMethods = PaymentMethodFactory.cards(3)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CustomerStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CustomerStateTest.kt
@@ -40,6 +40,7 @@ class CustomerStateTest {
                     // Always true for `customer_session`
                     canRemoveDuplicates = true,
                 ),
+                defaultPaymentMethodId = null
             )
         )
     }
@@ -76,6 +77,7 @@ class CustomerStateTest {
                     // Always true for `customer_session`
                     canRemoveDuplicates = true,
                 ),
+                defaultPaymentMethodId = null
             )
         )
     }
@@ -112,6 +114,7 @@ class CustomerStateTest {
                     // Always true for `customer_session`
                     canRemoveDuplicates = true,
                 ),
+                defaultPaymentMethodId = null
             )
         )
     }
@@ -141,6 +144,7 @@ class CustomerStateTest {
                     // Always 'false' for legacy ephemeral keys
                     canRemoveDuplicates = false,
                 ),
+                defaultPaymentMethodId = null
             )
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -130,6 +130,7 @@ internal class DefaultPaymentElementLoaderTest {
                         canRemoveLastPaymentMethod = true,
                         canRemoveDuplicates = false,
                     ),
+                    defaultPaymentMethodId = null
                 ),
                 paymentSelection = PaymentSelection.Saved(
                     paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
@@ -1384,6 +1385,7 @@ internal class DefaultPaymentElementLoaderTest {
                         canRemoveLastPaymentMethod = false,
                         canRemoveDuplicates = true,
                     ),
+                    defaultPaymentMethodId = null
                 )
             )
         }
@@ -1663,6 +1665,7 @@ internal class DefaultPaymentElementLoaderTest {
                         canRemoveLastPaymentMethod = true,
                         canRemoveDuplicates = false,
                     ),
+                    defaultPaymentMethodId = null
                 )
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultSelectSavedPaymentMethodsInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultSelectSavedPaymentMethodsInteractorTest.kt
@@ -474,6 +474,7 @@ class DefaultSelectSavedPaymentMethodsInteractorTest {
             nameProvider = { it!!.resolvableString },
             isCbcEligible = true,
             canRemovePaymentMethods = true,
+            defaultPaymentMethodId = null
         ).items
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultManageOneSavedPaymentMethodInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultManageOneSavedPaymentMethodInteractorTest.kt
@@ -20,7 +20,8 @@ class DefaultManageOneSavedPaymentMethodInteractorTest {
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
             providePaymentMethodName = { it!!.resolvableString },
             onDeletePaymentMethod = { deletedPm = it },
-            navigateBack = { hasNavigatedBack = true }
+            navigateBack = { hasNavigatedBack = true },
+            defaultPaymentMethodId = null
         )
 
         interactor.handleViewAction(ManageOneSavedPaymentMethodInteractor.ViewAction.DeletePaymentMethod)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultManageScreenInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultManageScreenInteractorTest.kt
@@ -245,6 +245,38 @@ class DefaultManageScreenInteractorTest {
         }
     }
 
+    @Test
+    fun `displayableSavedPaymentMethods updated correctly when defaultPaymentMethodId updated`() {
+        val initialPaymentMethods = PaymentMethodFixtures.createCards(3)
+        runScenario(initialPaymentMethods, currentSelection = null, handleBackPressed = {}) {
+            interactor.state.test {
+                defaultPaymentMethodSource.value = null
+                var updatedState = awaitItem()
+                assertThat(updatedState.paymentMethods[0].shouldShowDefaultBadge).isFalse()
+                assertThat(updatedState.paymentMethods[1].shouldShowDefaultBadge).isFalse()
+                assertThat(updatedState.paymentMethods[2].shouldShowDefaultBadge).isFalse()
+
+                defaultPaymentMethodSource.value = initialPaymentMethods[0].id
+                updatedState = awaitItem()
+                assertThat(updatedState.paymentMethods[0].shouldShowDefaultBadge).isTrue()
+                assertThat(updatedState.paymentMethods[1].shouldShowDefaultBadge).isFalse()
+                assertThat(updatedState.paymentMethods[2].shouldShowDefaultBadge).isFalse()
+
+                defaultPaymentMethodSource.value = initialPaymentMethods[1].id
+                updatedState = awaitItem()
+                assertThat(updatedState.paymentMethods[0].shouldShowDefaultBadge).isFalse()
+                assertThat(updatedState.paymentMethods[1].shouldShowDefaultBadge).isTrue()
+                assertThat(updatedState.paymentMethods[2].shouldShowDefaultBadge).isFalse()
+
+                defaultPaymentMethodSource.value = null
+                updatedState = awaitItem()
+                assertThat(updatedState.paymentMethods[0].shouldShowDefaultBadge).isFalse()
+                assertThat(updatedState.paymentMethods[1].shouldShowDefaultBadge).isFalse()
+                assertThat(updatedState.paymentMethods[2].shouldShowDefaultBadge).isFalse()
+            }
+        }
+    }
+
     private val notImplemented: () -> Nothing = { throw AssertionError("Not implemented") }
 
     private fun runScenario(
@@ -262,7 +294,7 @@ class DefaultManageScreenInteractorTest {
         val canEdit = MutableStateFlow(true)
         val canRemove = MutableStateFlow(true)
         val dispatcher = UnconfinedTestDispatcher()
-        val defaultPaymentMethodId = MutableStateFlow(null)
+        val defaultPaymentMethodId: MutableStateFlow<String?> = MutableStateFlow(null)
 
         val interactor = DefaultManageScreenInteractor(
             paymentMethods = paymentMethods,
@@ -292,6 +324,7 @@ class DefaultManageScreenInteractorTest {
             editingSource = editing,
             canEditSource = canEdit,
             canRemoveSource = canRemove,
+            defaultPaymentMethodSource = defaultPaymentMethodId
         ).apply {
             runTest {
                 testBlock()
@@ -304,6 +337,7 @@ class DefaultManageScreenInteractorTest {
         val paymentMethodsSource: MutableStateFlow<List<PaymentMethod>>,
         val editingSource: MutableStateFlow<Boolean>,
         val canEditSource: MutableStateFlow<Boolean>,
-        val canRemoveSource: MutableStateFlow<Boolean,>
+        val canRemoveSource: MutableStateFlow<Boolean>,
+        val defaultPaymentMethodSource: MutableStateFlow<String?>,
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultManageScreenInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultManageScreenInteractorTest.kt
@@ -262,6 +262,7 @@ class DefaultManageScreenInteractorTest {
         val canEdit = MutableStateFlow(true)
         val canRemove = MutableStateFlow(true)
         val dispatcher = UnconfinedTestDispatcher()
+        val defaultPaymentMethodId = MutableStateFlow(null)
 
         val interactor = DefaultManageScreenInteractor(
             paymentMethods = paymentMethods,
@@ -282,6 +283,7 @@ class DefaultManageScreenInteractorTest {
             navigateBack = handleBackPressed,
             dispatcher = dispatcher,
             isLiveMode = true,
+            defaultPaymentMethodId = defaultPaymentMethodId
         )
 
         TestParams(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultManageScreenInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultManageScreenInteractorTest.kt
@@ -248,7 +248,7 @@ class DefaultManageScreenInteractorTest {
     @Test
     fun `displayableSavedPaymentMethods updated correctly when defaultPaymentMethodId updated`() {
         val initialPaymentMethods = PaymentMethodFixtures.createCards(3)
-        runScenario(initialPaymentMethods, currentSelection = null, handleBackPressed = {}) {
+        runScenario(initialPaymentMethods, currentSelection = null) {
             interactor.state.test {
                 defaultPaymentMethodSource.value = null
                 var updatedState = awaitItem()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -1084,8 +1084,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
             canRemove = canRemove,
             reportPaymentMethodTypeSelected = reportPaymentMethodTypeSelected,
             reportFormShown = reportFormShown,
-            isLiveMode = true,
-            shouldShowDefaultBadge = false
+            isLiveMode = true
         )
 
         TestParams(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -1085,6 +1085,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
             reportPaymentMethodTypeSelected = reportPaymentMethodTypeSelected,
             reportFormShown = reportFormShown,
             isLiveMode = true,
+            defaultPaymentMethodId = null
         )
 
         TestParams(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -1085,7 +1085,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
             reportPaymentMethodTypeSelected = reportPaymentMethodTypeSelected,
             reportFormShown = reportFormShown,
             isLiveMode = true,
-            defaultPaymentMethodId = null
+            shouldShowDefaultBadge = null
         )
 
         TestParams(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -1085,7 +1085,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
             reportPaymentMethodTypeSelected = reportPaymentMethodTypeSelected,
             reportFormShown = reportFormShown,
             isLiveMode = true,
-            shouldShowDefaultBadge = null
+            shouldShowDefaultBadge = false
         )
 
         TestParams(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactoryTest.kt
@@ -76,7 +76,8 @@ class VerticalModeInitialScreenFactoryTest {
                         canRemovePaymentMethods = true,
                         canRemoveLastPaymentMethod = true,
                         canRemoveDuplicates = true,
-                    )
+                    ),
+                    defaultPaymentMethodId = null
                 )
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsItemsMapperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsItemsMapperTest.kt
@@ -93,7 +93,8 @@ class PaymentOptionsItemsMapperTest {
                 canRemovePaymentMethods = true,
                 canRemoveLastPaymentMethod = true,
                 canRemoveDuplicates = false,
-            )
+            ),
+            defaultPaymentMethodId = null
         )
     }
 }


### PR DESCRIPTION
# Summary
defaultPaymentMethodId is already being read by ElementsSessionJsonParser.

This PR adds defaultPaymentMethodId to CustomerState and passes that information to interactors

Plumbing goes as follows

ElementsSession.Customer ->
CustomerState ->
CustomerStateHolder ->
Interactor.DisplayableSavedPaymentMethod ->
UI (eventually)

# Motivation
We will be adding a badge to show default payment method and this work is required for that.
https://jira.corp.stripe.com/browse/MOBILESDK-2659
https://jira.corp.stripe.com/browse/MOBILESDK-2658

Epic Link
https://jira.corp.stripe.com/browse/MOBILESDK-2586

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [ ] Manually verified

# Screenshots
No ui changes

# Changelog
NA, will update changelog in subsequent PRs