### PR TITLE
Fix & stabilize `CustomerSheet` tests

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetActivity.kt
@@ -95,11 +95,7 @@ internal class CustomerSheetActivity : AppCompatActivity() {
                     state = bottomSheetState,
                     onDismissed = { viewModel.handleViewAction(OnDismissed) },
                 ) {
-                    CustomerSheetScreen(
-                        viewState = viewState,
-                        viewActionHandler = viewModel::handleViewAction,
-                        paymentMethodNameProvider = viewModel::providePaymentMethodName,
-                    )
+                    CustomerSheetScreen(viewModel)
                 }
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
@@ -18,6 +19,7 @@ import com.stripe.android.common.ui.BottomSheetLoadingIndicator
 import com.stripe.android.common.ui.PrimaryButton
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.customersheet.CustomerSheetViewAction
+import com.stripe.android.customersheet.CustomerSheetViewModel
 import com.stripe.android.customersheet.CustomerSheetViewState
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethodCode
@@ -39,7 +41,21 @@ import com.stripe.android.ui.core.elements.events.CardNumberCompletedEventReport
 import com.stripe.android.ui.core.elements.events.LocalCardBrandDisallowedReporter
 import com.stripe.android.ui.core.elements.events.LocalCardNumberCompletedEventReporter
 import com.stripe.android.uicore.strings.resolve
+import com.stripe.android.uicore.utils.collectAsState
 import com.stripe.android.R as PaymentsCoreR
+
+@Composable
+internal fun CustomerSheetScreen(
+    viewModel: CustomerSheetViewModel,
+) {
+    val viewState by viewModel.viewState.collectAsState()
+
+    CustomerSheetScreen(
+        viewState = viewState,
+        viewActionHandler = viewModel::handleViewAction,
+        paymentMethodNameProvider = viewModel::providePaymentMethodName,
+    )
+}
 
 @Composable
 internal fun CustomerSheetScreen(

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSessionCustomerSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSessionCustomerSheetActivityTest.kt
@@ -23,7 +23,6 @@ import com.stripe.android.networktesting.ResponseReplacement
 import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentsheet.EditPage
 import com.stripe.android.paymentsheet.ExperimentalCustomerSessionApi
-import com.stripe.android.paymentsheet.PaymentSheetActivity
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.RemoveDialog
 import com.stripe.android.paymentsheet.SavedPaymentMethodsPage
@@ -40,13 +39,15 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 @OptIn(ExperimentalCustomerSessionApi::class)
 @RunWith(AndroidJUnit4::class)
 class CustomerSessionCustomerSheetActivityTest {
     private val application = ApplicationProvider.getApplicationContext<Application>()
 
-    private val composeTestRule = createAndroidComposeRule<PaymentSheetActivity>()
+    private val composeTestRule = createAndroidComposeRule<CustomerSheetActivity>()
     private val networkRule = NetworkRule()
 
     @get:Rule
@@ -347,6 +348,8 @@ class CustomerSessionCustomerSheetActivityTest {
             )
         )
 
+        val countDownLatch = CountDownLatch(1)
+
         enqueueElementsSession(cards, isPaymentMethodRemoveEnabled)
 
         ActivityScenario.launch<CustomerSheetActivity>(
@@ -375,7 +378,12 @@ class CustomerSessionCustomerSheetActivityTest {
                 }
 
                 test(activity)
+
+                countDownLatch.countDown()
             }
+
+            countDownLatch.await(10, TimeUnit.SECONDS)
+            networkRule.validate()
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodsPage.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodsPage.kt
@@ -17,7 +17,7 @@ import com.stripe.android.paymentsheet.ui.TEST_TAG_REMOVE_BADGE
 
 class SavedPaymentMethodsPage(private val composeTestRule: ComposeTestRule) {
     fun waitUntilVisible() {
-        composeTestRule.waitUntil {
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
             composeTestRule
                 .onAllNodes(hasTestTag(SAVED_PAYMENT_OPTION_TAB_LAYOUT_TEST_TAG))
                 .fetchSemanticsNodes()


### PR DESCRIPTION
# Summary
Fix & stabilize `CustomerSheet` tests

# Motivation
About to introduce new `CustomerSheet` tests for `Customer Session` and don't to further destabilize them with more tests. Should no longer see unrelated CI failures from these.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified