### PR TITLE
[connect] Add support for more Account Onboarding settings

### DIFF
--- a/connect-example/src/main/java/com/stripe/android/connect/example/data/SettingsService.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/data/SettingsService.kt
@@ -3,6 +3,8 @@ package com.stripe.android.connect.example.data
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
+import com.stripe.android.connect.AccountOnboardingProps
+import com.stripe.android.connect.PrivateBetaConnectSDK
 import com.stripe.android.connect.example.ui.appearance.AppearanceInfo
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.channels.awaitClose
@@ -159,7 +161,33 @@ data class OnboardingSettings(
     val skipTermsOfService: SkipTermsOfService = SkipTermsOfService.DEFAULT,
     val fieldOption: FieldOption = FieldOption.DEFAULT,
     val futureRequirement: FutureRequirement = FutureRequirement.DEFAULT,
-)
+) {
+    @OptIn(PrivateBetaConnectSDK::class)
+    fun toProps(): AccountOnboardingProps {
+        return AccountOnboardingProps(
+            fullTermsOfServiceUrl = fullTermsOfServiceString,
+            recipientTermsOfServiceUrl = recipientTermsOfServiceString,
+            privacyPolicyUrl = privacyPolicyString,
+            skipTermsOfServiceCollection = when (skipTermsOfService) {
+                SkipTermsOfService.DEFAULT -> null
+                SkipTermsOfService.SKIP -> true
+                SkipTermsOfService.SHOW -> false
+            },
+            collectionOptions = AccountOnboardingProps.CollectionOptions(
+                fields = when (fieldOption) {
+                    FieldOption.DEFAULT -> null
+                    FieldOption.CURRENTLY_DUE -> AccountOnboardingProps.FieldOption.CURRENTLY_DUE
+                    FieldOption.EVENTUALLY_DUE -> AccountOnboardingProps.FieldOption.EVENTUALLY_DUE
+                },
+                futureRequirements = when (futureRequirement) {
+                    FutureRequirement.DEFAULT -> null
+                    FutureRequirement.OMIT -> AccountOnboardingProps.FutureRequirementOption.OMIT
+                    FutureRequirement.INCLUDE -> AccountOnboardingProps.FutureRequirementOption.INCLUDE
+                }
+            ),
+        )
+    }
+}
 
 data class PresentationSettings(
     val presentationStyleIsPush: Boolean = false,
@@ -169,5 +197,5 @@ data class PresentationSettings(
 )
 
 enum class SkipTermsOfService { DEFAULT, SKIP, SHOW }
-enum class FieldOption { DEFAULT, OPTIONAL, REQUIRED }
-enum class FutureRequirement { DEFAULT, INCLUDE, EXCLUDE }
+enum class FieldOption { DEFAULT, CURRENTLY_DUE, EVENTUALLY_DUE }
+enum class FutureRequirement { DEFAULT, OMIT, INCLUDE }

--- a/connect-example/src/main/java/com/stripe/android/connect/example/ui/features/accountonboarding/AccountOnboardingExampleActivity.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/ui/features/accountonboarding/AccountOnboardingExampleActivity.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import androidx.activity.viewModels
-import com.stripe.android.connect.AccountOnboardingProps
 import com.stripe.android.connect.EmbeddedComponentManager
 import com.stripe.android.connect.PrivateBetaConnectSDK
 import com.stripe.android.connect.example.R
@@ -23,29 +22,20 @@ class AccountOnboardingExampleActivity : BasicExampleComponentActivity() {
     override fun createComponentView(context: Context, embeddedComponentManager: EmbeddedComponentManager): View {
         val settings = settingsViewModel.state.value
         val onboardingSettings = settings.onboardingSettings
-        val settingsProps = AccountOnboardingProps(
-            fullTermsOfServiceUrl = onboardingSettings.fullTermsOfServiceString,
-            recipientTermsOfServiceUrl = onboardingSettings.recipientTermsOfServiceString,
-            privacyPolicyUrl = onboardingSettings.privacyPolicyString,
-        )
+        val props = onboardingSettings.toProps()
         return if (settings.presentationSettings.useXmlViews) {
             ViewAccountOnboardingExampleBinding.inflate(LayoutInflater.from(context)).root
                 .apply {
-                    val props = AccountOnboardingProps(
-                        fullTermsOfServiceUrl = settingsProps.fullTermsOfServiceUrl,
-                        recipientTermsOfServiceUrl = settingsProps.recipientTermsOfServiceUrl,
-                        privacyPolicyUrl = settingsProps.privacyPolicyUrl,
-                    )
                     initialize(
                         embeddedComponentManager = embeddedComponentManager,
                         listener = null,
-                        props = props
+                        props = props,
                     )
                 }
         } else {
             embeddedComponentManager.createAccountOnboardingView(
                 context = context,
-                props = settingsProps
+                props = props
             )
         }
     }

--- a/connect-example/src/main/java/com/stripe/android/connect/example/ui/settings/AccountOnboardingSettingsView.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/ui/settings/AccountOnboardingSettingsView.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.stripe.android.connect.example.R
 import com.stripe.android.connect.example.data.OnboardingSettings
+import com.stripe.android.connect.example.data.SkipTermsOfService
 import com.stripe.android.connect.example.ui.common.BackIconButton
 import com.stripe.android.connect.example.ui.common.ConnectExampleScaffold
 
@@ -55,6 +56,9 @@ private fun AccountOnboardingSettingsView(
     var privacyPolicy by rememberSaveable {
         mutableStateOf(onboardingSettings.privacyPolicyString ?: "")
     }
+    var skipTermsOfService by rememberSaveable {
+        mutableStateOf(onboardingSettings.skipTermsOfService)
+    }
     ConnectExampleScaffold(
         title = stringResource(R.string.onboarding_settings),
         navigationIcon = { BackIconButton(onBack) },
@@ -66,7 +70,7 @@ private fun AccountOnboardingSettingsView(
                             fullTermsOfServiceString = fullTermsOfService.trim().takeIf { it.isNotEmpty() },
                             recipientTermsOfServiceString = recipientTermsOfService.trim().takeIf { it.isNotEmpty() },
                             privacyPolicyString = privacyPolicy.trim().takeIf { it.isNotEmpty() },
-                            skipTermsOfService = onboardingSettings.skipTermsOfService,
+                            skipTermsOfService = skipTermsOfService,
                             fieldOption = onboardingSettings.fieldOption,
                             futureRequirement = onboardingSettings.futureRequirement,
                         )
@@ -106,6 +110,13 @@ private fun AccountOnboardingSettingsView(
                 placeholder = stringResource(R.string.server_url_placeholder),
                 value = privacyPolicy,
                 onValueChange = { privacyPolicy = it },
+            )
+            Spacer(Modifier.requiredHeight(9.dp))
+            SettingsDropdownField(
+                label = "Skip terms of service",
+                options = SkipTermsOfService.entries.toList(),
+                selectedOption = skipTermsOfService,
+                onSelectOption = { skipTermsOfService = it }
             )
         }
     }

--- a/connect-example/src/main/java/com/stripe/android/connect/example/ui/settings/AccountOnboardingSettingsView.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/ui/settings/AccountOnboardingSettingsView.kt
@@ -21,10 +21,13 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.stripe.android.connect.example.R
+import com.stripe.android.connect.example.data.FieldOption
+import com.stripe.android.connect.example.data.FutureRequirement
 import com.stripe.android.connect.example.data.OnboardingSettings
 import com.stripe.android.connect.example.data.SkipTermsOfService
 import com.stripe.android.connect.example.ui.common.BackIconButton
 import com.stripe.android.connect.example.ui.common.ConnectExampleScaffold
+import com.stripe.android.connect.example.ui.common.ConnectSdkExampleTheme
 
 @Composable
 fun AccountOnboardingSettingsView(
@@ -59,6 +62,12 @@ private fun AccountOnboardingSettingsView(
     var skipTermsOfService by rememberSaveable {
         mutableStateOf(onboardingSettings.skipTermsOfService)
     }
+    var fieldOption by rememberSaveable {
+        mutableStateOf(onboardingSettings.fieldOption)
+    }
+    var futureRequirement by rememberSaveable {
+        mutableStateOf(onboardingSettings.futureRequirement)
+    }
     ConnectExampleScaffold(
         title = stringResource(R.string.onboarding_settings),
         navigationIcon = { BackIconButton(onBack) },
@@ -71,8 +80,8 @@ private fun AccountOnboardingSettingsView(
                             recipientTermsOfServiceString = recipientTermsOfService.trim().takeIf { it.isNotEmpty() },
                             privacyPolicyString = privacyPolicy.trim().takeIf { it.isNotEmpty() },
                             skipTermsOfService = skipTermsOfService,
-                            fieldOption = onboardingSettings.fieldOption,
-                            futureRequirement = onboardingSettings.futureRequirement,
+                            fieldOption = fieldOption,
+                            futureRequirement = futureRequirement,
                         )
                     )
                     onBack()
@@ -111,12 +120,26 @@ private fun AccountOnboardingSettingsView(
                 value = privacyPolicy,
                 onValueChange = { privacyPolicy = it },
             )
-            Spacer(Modifier.requiredHeight(9.dp))
+            Spacer(Modifier.requiredHeight(8.dp))
             SettingsDropdownField(
                 label = "Skip terms of service",
                 options = SkipTermsOfService.entries.toList(),
                 selectedOption = skipTermsOfService,
                 onSelectOption = { skipTermsOfService = it }
+            )
+            Spacer(Modifier.requiredHeight(8.dp))
+            SettingsDropdownField(
+                label = "Field option",
+                options = FieldOption.entries.toList(),
+                selectedOption = fieldOption,
+                onSelectOption = { fieldOption = it }
+            )
+            Spacer(Modifier.requiredHeight(8.dp))
+            SettingsDropdownField(
+                label = "Future requirement",
+                options = FutureRequirement.entries.toList(),
+                selectedOption = futureRequirement,
+                onSelectOption = { futureRequirement = it }
             )
         }
     }
@@ -125,9 +148,11 @@ private fun AccountOnboardingSettingsView(
 @Preview
 @Composable
 private fun AccountOnboardingSettingsViewPreview() {
-    AccountOnboardingSettingsView(
-        onboardingSettings = OnboardingSettings(),
-        onBack = {},
-        onSave = {}
-    )
+    ConnectSdkExampleTheme {
+        AccountOnboardingSettingsView(
+            onboardingSettings = OnboardingSettings(),
+            onBack = {},
+            onSave = {}
+        )
+    }
 }

--- a/connect-example/src/main/java/com/stripe/android/connect/example/ui/settings/SettingsComponents.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/ui/settings/SettingsComponents.kt
@@ -1,18 +1,29 @@
 package com.stripe.android.connect.example.ui.settings
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.material.DropdownMenu
+import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -106,4 +117,98 @@ fun SettingsNavigationItem(
 @Preview(showBackground = true)
 private fun SettingsNavigationItemPreview() {
     SettingsNavigationItem(text = "Settings", onClick = {})
+}
+
+@Suppress("LongMethod")
+@Composable
+fun <T> SettingsDropdownField(
+    label: String,
+    options: List<T>,
+    selectedOption: T,
+    onSelectOption: (T) -> Unit,
+    modifier: Modifier = Modifier,
+    optionToString: (T) -> String = { it.toString() },
+) {
+    var isExpanded by remember { mutableStateOf(false) }
+    Row(
+        modifier = modifier
+            .padding(
+                start = 16.dp,
+                end = 8.dp,
+                top = 8.dp,
+                bottom = 8.dp,
+            ),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            modifier = Modifier
+                .weight(1f),
+            text = label,
+            color = MaterialTheme.colors.onSurface,
+        )
+        Box(
+            modifier = Modifier
+                .clickable { isExpanded = true }
+                .padding(4.dp)
+        ) {
+            Row {
+                Text(
+                    text = optionToString(selectedOption),
+                    color = MaterialTheme.colors.onSurface,
+                )
+                Icon(
+                    imageVector = Icons.Default.ArrowDropDown,
+                    tint = MaterialTheme.colors.onSurface,
+                    contentDescription = null,
+                )
+            }
+            DropdownMenu(
+                expanded = isExpanded,
+                onDismissRequest = { isExpanded = false },
+            ) {
+                options.forEach { option ->
+                    DropdownMenuItem(
+                        onClick = {
+                            onSelectOption(option)
+                            isExpanded = false
+                        },
+                    ) {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Text(text = optionToString(option))
+                            Spacer(
+                                Modifier
+                                    .sizeIn(minWidth = 8.dp)
+                                    .weight(1f)
+                            )
+                            val iconSize = 16.dp
+                            if (option == selectedOption) {
+                                Icon(
+                                    modifier = Modifier.size(iconSize),
+                                    imageVector = Icons.Default.Check,
+                                    tint = MaterialTheme.colors.onSurface,
+                                    contentDescription = null,
+                                )
+                            } else {
+                                Spacer(modifier = Modifier.size(iconSize))
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SettingsDropdownFieldPreview() {
+    ConnectSdkExampleTheme {
+        SettingsDropdownField(
+            label = "Label",
+            options = listOf("Option 1", "Option 2"),
+            selectedOption = "Option 1",
+            onSelectOption = {},
+            optionToString = { it },
+        )
+    }
 }

--- a/connect/api/connect.api
+++ b/connect/api/connect.api
@@ -1,3 +1,11 @@
+public final class com/stripe/android/connect/AccountOnboardingProps$CollectionOptions$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/connect/AccountOnboardingProps$CollectionOptions;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/connect/AccountOnboardingProps$CollectionOptions;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/connect/AccountOnboardingProps$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/connect/AccountOnboardingProps;

--- a/connect/src/main/java/com/stripe/android/connect/AccountOnboardingView.kt
+++ b/connect/src/main/java/com/stripe/android/connect/AccountOnboardingView.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.connect
 
 import android.content.Context
+import android.os.Parcelable
 import android.util.AttributeSet
 import android.widget.FrameLayout
 import androidx.annotation.RestrictTo
@@ -82,7 +83,45 @@ class AccountOnboardingProps(
      * Absolute URL to your privacy policy.
      */
     val privacyPolicyUrl: String? = null,
-) : ComponentProps
+
+    /**
+     * If true, embedded onboarding skips terms of service collection and you must
+     * [collect terms acceptance yourself](https://docs.stripe.com/connect/updating-service-agreements#indicating-acceptance).
+     */
+    @Suppress("MaxLineLength")
+    val skipTermsOfServiceCollection: Boolean? = null,
+
+    /**
+     * Customizes collecting `currently_due` or `eventually_due` requirements and controls whether to include
+     * [future requirements](https://docs.stripe.com/api/accounts/object#account_object-future_requirements).
+     * Specifying `eventually_due` collects both `eventually_due` and `currently_due` requirements.
+     */
+    val collectionOptions: CollectionOptions? = null,
+) : ComponentProps {
+
+    @PrivateBetaConnectSDK
+    @RestrictTo(RestrictTo.Scope.LIBRARY)
+    @Parcelize
+    @Poko
+    class CollectionOptions(
+        val fields: FieldOption? = null,
+        val futureRequirements: FutureRequirementOption? = null,
+    ) : Parcelable
+
+    @PrivateBetaConnectSDK
+    @RestrictTo(RestrictTo.Scope.LIBRARY)
+    enum class FieldOption(internal val value: String) {
+        CURRENTLY_DUE("currently_due"),
+        EVENTUALLY_DUE("eventually_due"),
+    }
+
+    @PrivateBetaConnectSDK
+    @RestrictTo(RestrictTo.Scope.LIBRARY)
+    enum class FutureRequirementOption(internal val value: String) {
+        OMIT("omit"),
+        INCLUDE("include"),
+    }
+}
 
 @PrivateBetaConnectSDK
 @RestrictTo(RestrictTo.Scope.LIBRARY)

--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainer.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainer.kt
@@ -227,7 +227,10 @@ internal class StripeConnectWebViewContainerImpl<Listener, Props>(
     }
 
     internal fun setPropsFromXml(props: Props) {
-        this.propsJson = props.toJsonObject()
+        // Only set props if uninitialized.
+        if (controller == null) {
+            this.propsJson = props.toJsonObject()
+        }
     }
 
     override fun updateConnectInstance(appearance: Appearance) {

--- a/connect/src/main/java/com/stripe/android/connect/webview/serialization/AccountOnboardingPropsJs.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/serialization/AccountOnboardingPropsJs.kt
@@ -9,7 +9,15 @@ internal data class AccountOnboardingPropsJs(
     val setFullTermsOfServiceUrl: String?,
     val setRecipientTermsOfServiceUrl: String?,
     val setPrivacyPolicyUrl: String?,
-)
+    val setSkipTermsOfServiceCollection: Boolean?,
+    val setCollectionOptions: CollectionOptionsJs?,
+) {
+    @Serializable
+    data class CollectionOptionsJs(
+        val fields: String?,
+        val futureRequirements: String?,
+    )
+}
 
 @OptIn(PrivateBetaConnectSDK::class)
 internal fun AccountOnboardingProps.toJs(): AccountOnboardingPropsJs {
@@ -17,5 +25,12 @@ internal fun AccountOnboardingProps.toJs(): AccountOnboardingPropsJs {
         setFullTermsOfServiceUrl = fullTermsOfServiceUrl,
         setPrivacyPolicyUrl = privacyPolicyUrl,
         setRecipientTermsOfServiceUrl = recipientTermsOfServiceUrl,
+        setSkipTermsOfServiceCollection = skipTermsOfServiceCollection,
+        setCollectionOptions = collectionOptions?.let {
+            AccountOnboardingPropsJs.CollectionOptionsJs(
+                fields = it.fields?.value,
+                futureRequirements = it.futureRequirements?.value,
+            )
+        }
     )
 }


### PR DESCRIPTION
# Summary
Adds the rest of onboarding settings in scope. Includes adding dropdown UI components in the Example app.

# Motivation
https://jira.corp.stripe.com/browse/MXMOBILE-2512

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
https://github.com/user-attachments/assets/6d9057ae-227d-475b-b972-747720e7d548

![Screenshot 2024-12-13 at 12 13 18 PM](https://github.com/user-attachments/assets/e0806f06-bcb2-4b79-8dcc-aad446b8851d)
