### PR TITLE
[Connect] Default to using the first account if no account is selected

### DIFF
--- a/connect-example/src/main/java/com/stripe/android/connect/example/data/EmbeddedComponentService.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/data/EmbeddedComponentService.kt
@@ -66,6 +66,12 @@ class EmbeddedComponentService @Inject constructor(
                 .apply {
                     _publishableKey.value = publishableKey
                     _accounts.value = availableMerchants
+
+                    // if we have no selected merchant, default to the first one
+                    val firstMerchant = availableMerchants.firstOrNull()?.merchantId
+                    if (settingsService.getSelectedMerchant() == null && firstMerchant != null) {
+                        settingsService.setSelectedMerchant(firstMerchant)
+                    }
                 }
         }
     }


### PR DESCRIPTION
# Summary
To make things easier for testing, if you haven't selected an account you should get the first account in the EmbeddedComponents

# Motivation
This makes the example app easier to use and test

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
### After

https://github.com/user-attachments/assets/5c7abac1-83dd-41d8-8baa-b744e94bda95



### Before


https://github.com/user-attachments/assets/41850f3e-e7fd-4376-adcf-33d8f0f9f46b

