### PR TITLE
Add a selection holder for embedded.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedSelectionHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedSelectionHolder.kt
@@ -1,0 +1,22 @@
+package com.stripe.android.paymentelement.embedded
+
+import androidx.lifecycle.SavedStateHandle
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import kotlinx.coroutines.flow.StateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+internal class EmbeddedSelectionHolder @Inject constructor(
+    private val savedStateHandle: SavedStateHandle,
+) {
+    val selection: StateFlow<PaymentSelection?> = savedStateHandle.getStateFlow(EMBEDDED_SELECTION_KEY, null)
+
+    fun set(updatedSelection: PaymentSelection?) {
+        savedStateHandle[EMBEDDED_SELECTION_KEY] = updatedSelection
+    }
+
+    companion object {
+        const val EMBEDDED_SELECTION_KEY = "EMBEDDED_SELECTION_KEY"
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/EmbeddedSelectionHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/EmbeddedSelectionHolderTest.kt
@@ -1,0 +1,59 @@
+package com.stripe.android.paymentelement.embedded
+
+import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.model.paymentMethodType
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+internal class EmbeddedSelectionHolderTest {
+    @Test
+    fun `setting selection emits value in selection state flow`() = testScenario {
+        selectionHolder.selection.test {
+            assertThat(awaitItem()).isNull()
+            selectionHolder.set(PaymentSelection.GooglePay)
+            assertThat(awaitItem()?.paymentMethodType).isEqualTo("google_pay")
+        }
+    }
+
+    @Test
+    fun `setting selection updates savedStateHandle`() = testScenario {
+        assertThat(savedStateHandle.get<PaymentSelection?>(EmbeddedSelectionHolder.EMBEDDED_SELECTION_KEY))
+            .isNull()
+        selectionHolder.set(PaymentSelection.GooglePay)
+        assertThat(savedStateHandle.get<PaymentSelection?>(EmbeddedSelectionHolder.EMBEDDED_SELECTION_KEY))
+            .isEqualTo(PaymentSelection.GooglePay)
+    }
+
+    @Test
+    fun `initializing with selection in savedStateHandle sets initial value`() = testScenario(
+        setup = {
+            set(EmbeddedSelectionHolder.EMBEDDED_SELECTION_KEY, PaymentSelection.GooglePay)
+        },
+    ) {
+        assertThat(savedStateHandle.get<PaymentSelection?>(EmbeddedSelectionHolder.EMBEDDED_SELECTION_KEY))
+            .isEqualTo(PaymentSelection.GooglePay)
+        selectionHolder.set(null)
+        assertThat(savedStateHandle.get<PaymentSelection?>(EmbeddedSelectionHolder.EMBEDDED_SELECTION_KEY))
+            .isNull()
+    }
+
+    private class Scenario(
+        val selectionHolder: EmbeddedSelectionHolder,
+        val savedStateHandle: SavedStateHandle,
+    )
+
+    private fun testScenario(
+        setup: SavedStateHandle.() -> Unit = {},
+        block: suspend Scenario.() -> Unit,
+    ) = runTest {
+        val savedStateHandle = SavedStateHandle()
+        setup(savedStateHandle)
+        Scenario(
+            selectionHolder = EmbeddedSelectionHolder(savedStateHandle),
+            savedStateHandle = savedStateHandle,
+        ).block()
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Selection is one of the things that's shared throughout many components, and acts as the glue between loading, user actions, and confirmation. This makes that glue clear.
