### PR TITLE
Remove default horizontal padding in embedded.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedContent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedContent.kt
@@ -6,10 +6,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.unit.dp
 import com.stripe.android.core.strings.ResolvableString
-import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.ui.Mandate
 import com.stripe.android.paymentsheet.verticalmode.PaymentMethodVerticalLayoutInteractor
 import com.stripe.android.paymentsheet.verticalmode.PaymentMethodVerticalLayoutUI
@@ -22,10 +20,8 @@ internal data class EmbeddedContent(
 ) {
     @Composable
     fun Content() {
-        val horizontalPadding = dimensionResource(R.dimen.stripe_paymentsheet_outer_spacing_horizontal)
         Column(
             modifier = Modifier
-                .padding(horizontal = horizontalPadding)
                 .padding(top = 8.dp)
         ) {
             EmbeddedVerticalList()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/EmbeddedContentScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/EmbeddedContentScreenshotTest.kt
@@ -1,5 +1,8 @@
 package com.stripe.android.paymentelement.embedded
 
+import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.paymentsheet.verticalmode.FakePaymentMethodVerticalLayoutInteractor
@@ -9,7 +12,7 @@ import kotlin.test.Test
 
 internal class EmbeddedContentScreenshotTest {
     @get:Rule
-    val paparazziRule = PaparazziRule()
+    val paparazziRule = PaparazziRule(boxModifier = Modifier.padding(horizontal = 20.dp))
 
     @Test
     fun displaysVerticalModeList() {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
I expect merchants to add this padding, and if we want to do something by default, we can add a modifier property later.
