### PR TITLE
Use a builder to create the embedded payment element.

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/embedded/EmbeddedPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/embedded/EmbeddedPlaygroundActivity.kt
@@ -54,14 +54,14 @@ internal class EmbeddedPlaygroundActivity : AppCompatActivity(), ExternalPayment
             return
         }
 
+        val embeddedBuilder = EmbeddedPaymentElement.Builder(
+            createIntentCallback = { _, _ ->
+                CreateIntentResult.Success(playgroundState.clientSecret)
+            },
+            resultCallback = ::handleEmbeddedResult,
+        ).externalPaymentMethodConfirmHandler(this)
         setContent {
-            val embeddedPaymentElement = rememberEmbeddedPaymentElement(
-                createIntentCallback = { _, _ ->
-                    CreateIntentResult.Success(playgroundState.clientSecret)
-                },
-                externalPaymentMethodConfirmHandler = this,
-                resultCallback = ::handleEmbeddedResult,
-            )
+            val embeddedPaymentElement = rememberEmbeddedPaymentElement(embeddedBuilder)
 
             LaunchedEffect(embeddedPaymentElement) {
                 embeddedPaymentElement.configure(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
@@ -22,6 +22,7 @@ import com.stripe.android.model.SetupIntent
 import com.stripe.android.paymentelement.confirmation.intent.IntentConfirmationInterceptor
 import com.stripe.android.paymentelement.embedded.EmbeddedConfirmationHelper
 import com.stripe.android.paymentelement.embedded.SharedPaymentElementViewModel
+import com.stripe.android.paymentsheet.CreateIntentCallback
 import com.stripe.android.paymentsheet.ExternalPaymentMethodConfirmHandler
 import com.stripe.android.paymentsheet.ExternalPaymentMethodInterceptor
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -83,6 +84,34 @@ class EmbeddedPaymentElement private constructor(
      */
     fun clearPaymentOption() {
         sharedViewModel.clearPaymentOption()
+    }
+
+    /**
+     * Builder used in the creation of the [EmbeddedPaymentElement].
+     *
+     * Creation can be completed with [rememberEmbeddedPaymentElement].
+     */
+    @ExperimentalEmbeddedPaymentElementApi
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    class Builder(
+        /**
+         * Called when the customer confirms the payment or setup.
+         */
+        internal val createIntentCallback: CreateIntentCallback,
+        /**
+         * Called with the result of the payment.
+         */
+        internal val resultCallback: ResultCallback,
+    ) {
+        internal var externalPaymentMethodConfirmHandler: ExternalPaymentMethodConfirmHandler? = null
+            private set
+
+        /**
+         * Called when a user confirms payment for an external payment method.
+         */
+        fun externalPaymentMethodConfirmHandler(handler: ExternalPaymentMethodConfirmHandler) = apply {
+            this.externalPaymentMethodConfirmHandler = handler
+        }
     }
 
     /** Configuration for [EmbeddedPaymentElement] **/

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElementKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElementKtx.kt
@@ -11,40 +11,32 @@ import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import com.stripe.android.common.ui.PaymentElementActivityResultCaller
 import com.stripe.android.common.ui.UpdateExternalPaymentMethodConfirmHandler
 import com.stripe.android.common.ui.UpdateIntentConfirmationInterceptor
-import com.stripe.android.paymentsheet.CreateIntentCallback
-import com.stripe.android.paymentsheet.ExternalPaymentMethodConfirmHandler
 import com.stripe.android.utils.rememberActivity
 
 /**
  * Creates an [EmbeddedPaymentElement] that is remembered across compositions.
  *
  * This *must* be called unconditionally, as part of the initialization path.
- *
- * @param createIntentCallback Called when the customer confirms the payment or setup.
- * @param externalPaymentMethodConfirmHandler Called when a user confirms payment for an external payment method.
- * @param resultCallback Called with the result of the payment.
  */
 @ExperimentalEmbeddedPaymentElementApi
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Composable
 fun rememberEmbeddedPaymentElement(
-    createIntentCallback: CreateIntentCallback,
-    externalPaymentMethodConfirmHandler: ExternalPaymentMethodConfirmHandler? = null,
-    resultCallback: EmbeddedPaymentElement.ResultCallback,
+    builder: EmbeddedPaymentElement.Builder
 ): EmbeddedPaymentElement {
     val viewModelStoreOwner = requireNotNull(LocalViewModelStoreOwner.current) {
         "EmbeddedPaymentElement must have a ViewModelStoreOwner."
     }
 
-    UpdateExternalPaymentMethodConfirmHandler(externalPaymentMethodConfirmHandler)
-    UpdateIntentConfirmationInterceptor(createIntentCallback)
+    UpdateExternalPaymentMethodConfirmHandler(builder.externalPaymentMethodConfirmHandler)
+    UpdateIntentConfirmationInterceptor(builder.createIntentCallback)
 
     val lifecycleOwner = LocalLifecycleOwner.current
     val activityResultRegistryOwner = requireNotNull(LocalActivityResultRegistryOwner.current) {
         "EmbeddedPaymentElement must have an ActivityResultRegistryOwner."
     }
 
-    val onResult by rememberUpdatedState(newValue = resultCallback::onResult)
+    val onResult by rememberUpdatedState(newValue = builder.resultCallback::onResult)
 
     val activity = rememberActivity {
         "EmbeddedPaymentElement must be created in the context of an Activity."


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Default params, and adding new params in the future is next to impossible with `@Composable` functions. I'm adding the builder to future proof the construction of `EmbeddedPaymentElement`.

This hasn't yet gone through API, but I'm planning to take this (and everything else) through API review before opening it up.
