### PR TITLE
[connect] Cleanup `EmbeddedComponentManager` scope and setup

### DIFF
--- a/connect-example/src/main/java/com/stripe/android/connect/example/App.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/App.kt
@@ -3,7 +3,6 @@ package com.stripe.android.connect.example
 import android.app.Application
 import android.os.StrictMode
 import com.github.kittinunf.fuel.core.FuelError
-import com.stripe.android.connect.example.data.EmbeddedComponentManagerProvider
 import com.stripe.android.connect.example.data.EmbeddedComponentService
 import com.stripe.android.core.Logger
 import dagger.hilt.android.HiltAndroidApp
@@ -18,8 +17,6 @@ import javax.inject.Inject
 class App : Application() {
 
     @Inject lateinit var embeddedComponentService: EmbeddedComponentService
-
-    @Inject lateinit var embeddedComponentManagerProvider: EmbeddedComponentManagerProvider
 
     private val logger: Logger = Logger.getInstance(enableLogging = BuildConfig.DEBUG)
 
@@ -44,7 +41,6 @@ class App : Application() {
         )
 
         attemptLoadPublishableKey()
-        embeddedComponentManagerProvider.initialize(GlobalScope)
     }
 
     private fun attemptLoadPublishableKey() {

--- a/connect-example/src/main/java/com/stripe/android/connect/example/BaseActivity.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/BaseActivity.kt
@@ -1,0 +1,25 @@
+package com.stripe.android.connect.example
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.viewModels
+import androidx.annotation.CallSuper
+import com.stripe.android.connect.EmbeddedComponentManager
+import com.stripe.android.connect.PrivateBetaConnectSDK
+import com.stripe.android.connect.example.ui.embeddedcomponentmanagerloader.EmbeddedComponentLoaderViewModel
+import dagger.hilt.android.AndroidEntryPoint
+
+@OptIn(PrivateBetaConnectSDK::class)
+@AndroidEntryPoint
+abstract class BaseActivity : ComponentActivity() {
+
+    protected val loaderViewModel: EmbeddedComponentLoaderViewModel by viewModels()
+
+    @CallSuper
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        EmbeddedComponentManager.onActivityCreate(this)
+        lifecycle.addObserver(loaderViewModel)
+    }
+}

--- a/connect-example/src/main/java/com/stripe/android/connect/example/MainActivity.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/MainActivity.kt
@@ -1,38 +1,29 @@
 package com.stripe.android.connect.example
 
 import android.os.Bundle
-import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
-import com.stripe.android.connect.EmbeddedComponentManager
-import com.stripe.android.connect.PrivateBetaConnectSDK
 import com.stripe.android.connect.example.ui.common.ConnectSdkExampleTheme
 import com.stripe.android.connect.example.ui.componentpicker.ComponentPickerContent
-import com.stripe.android.connect.example.ui.embeddedcomponentmanagerloader.EmbeddedComponentLoaderViewModel
 import com.stripe.android.connect.example.ui.settings.SettingsDestination
 import com.stripe.android.connect.example.ui.settings.settingsComposables
 import dagger.hilt.android.AndroidEntryPoint
 
-@OptIn(PrivateBetaConnectSDK::class)
 @AndroidEntryPoint
-class MainActivity : ComponentActivity() {
+class MainActivity : BaseActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        EmbeddedComponentManager.onActivityCreate(this@MainActivity)
-
         setContent {
-            val viewModel = hiltViewModel<EmbeddedComponentLoaderViewModel>(this@MainActivity)
             val navController = rememberNavController()
             ConnectSdkExampleTheme {
                 NavHost(navController = navController, startDestination = MainDestination.ComponentPicker) {
                     composable(MainDestination.ComponentPicker) {
                         ComponentPickerContent(
-                            viewModel = viewModel,
+                            viewModel = loaderViewModel,
                             openSettings = { navController.navigate(SettingsDestination.Settings) },
                         )
                     }

--- a/connect-example/src/main/java/com/stripe/android/connect/example/ui/embeddedcomponentmanagerloader/EmbeddedComponentLoaderViewModel.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/ui/embeddedcomponentmanagerloader/EmbeddedComponentLoaderViewModel.kt
@@ -1,6 +1,10 @@
 package com.stripe.android.connect.example.ui.embeddedcomponentmanagerloader
 
+import androidx.activity.ComponentActivity
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.viewModelScope
 import com.github.kittinunf.fuel.core.FuelError
 import com.stripe.android.connect.PrivateBetaConnectSDK
@@ -8,13 +12,19 @@ import com.stripe.android.connect.example.BuildConfig
 import com.stripe.android.connect.example.core.Fail
 import com.stripe.android.connect.example.core.Loading
 import com.stripe.android.connect.example.core.Success
-import com.stripe.android.connect.example.data.EmbeddedComponentManagerProvider
+import com.stripe.android.connect.example.data.EmbeddedComponentManagerFactory
 import com.stripe.android.connect.example.data.EmbeddedComponentService
+import com.stripe.android.connect.example.data.SettingsService
+import com.stripe.android.connect.example.ui.appearance.AppearanceInfo
 import com.stripe.android.core.Logger
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -23,8 +33,9 @@ import javax.inject.Inject
 @HiltViewModel
 class EmbeddedComponentLoaderViewModel @Inject constructor(
     private val embeddedComponentService: EmbeddedComponentService,
-    private val embeddedComponentManagerProvider: EmbeddedComponentManagerProvider,
-) : ViewModel() {
+    private val embeddedComponentManagerFactory: EmbeddedComponentManagerFactory,
+    private val settingsService: SettingsService,
+) : ViewModel(), DefaultLifecycleObserver {
 
     private val logger: Logger = Logger.getInstance(enableLogging = BuildConfig.DEBUG)
     private val loggingTag = this::class.java.simpleName
@@ -33,27 +44,42 @@ class EmbeddedComponentLoaderViewModel @Inject constructor(
     val state: StateFlow<EmbeddedComponentManagerLoaderState> = _state.asStateFlow()
 
     init {
-        initializeManager()
+        loadManagerIfNecessary()
     }
-
-    // Public methods
 
     fun reload() {
         loadManager()
     }
 
-    // Private methods
+    override fun onCreate(owner: LifecycleOwner) {
+        val activity = owner as? ComponentActivity
+            ?: return
 
-    private fun initializeManager() {
-        val manager = embeddedComponentManagerProvider.provideEmbeddedComponentManager()
-        if (manager == null) {
-            loadManager()
+        // Bind appearance settings to the manager.
+        activity.lifecycleScope.launch {
+            val managerFlow = _state
+                .map { it.embeddedComponentManagerAsync() }
+                .filterNotNull()
+            val appearanceFlow = settingsService.getAppearanceIdFlow()
+                .filterNotNull()
+                .map { id -> AppearanceInfo.getAppearance(id, activity).appearance }
+            combine(managerFlow, appearanceFlow, ::Pair).collectLatest { (manager, appearance) ->
+                logger.debug("($loggingTag) Updating appearance in $activity")
+                manager.update(appearance)
+            }
+        }
+    }
+
+    private fun loadManagerIfNecessary() {
+        if (_state.value.embeddedComponentManagerAsync() != null) {
             return
         }
-
-        _state.update {
-            it.copy(embeddedComponentManagerAsync = Success(manager))
+        val manager = embeddedComponentManagerFactory.createEmbeddedComponentManager()
+        if (manager != null) {
+            _state.update { it.copy(embeddedComponentManagerAsync = Success(manager)) }
+            return
         }
+        loadManager()
     }
 
     private fun loadManager() {
@@ -68,7 +94,7 @@ class EmbeddedComponentLoaderViewModel @Inject constructor(
                 embeddedComponentService.getAccounts()
 
                 // initialize the SDK, or throw an error if we're unable to
-                val manager = embeddedComponentManagerProvider.provideEmbeddedComponentManager()
+                val manager = embeddedComponentManagerFactory.createEmbeddedComponentManager()
                 val async = if (manager != null) {
                     Success(manager)
                 } else {

--- a/connect-example/src/main/java/com/stripe/android/connect/example/ui/embeddedcomponentmanagerloader/EmbeddedComponentManagerLoader.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/ui/embeddedcomponentmanagerloader/EmbeddedComponentManagerLoader.kt
@@ -37,7 +37,10 @@ fun EmbeddedComponentManagerLoader(
 ) {
     val embeddedComponentManager = embeddedComponentAsync()
     when (embeddedComponentAsync) {
-        is Uninitialized, is Loading -> LoadingScreen()
+        is Uninitialized -> {
+            // Don't show anything to avoid flicker.
+        }
+        is Loading -> LoadingScreen()
         is Fail -> ErrorScreen(
             errorMessage = embeddedComponentAsync.error.message ?: stringResource(R.string.error_initializing),
             onReloadRequested = reload,

--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainer.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainer.kt
@@ -248,6 +248,8 @@ internal class StripeConnectWebViewContainerImpl<Listener, Props>(
 
     private fun bindViewState(state: StripeConnectWebViewContainerState) {
         val viewBinding = this.viewBinding ?: return
+        logger.debug("Binding view state: $state")
+        viewBinding.root.setBackgroundColor(state.backgroundColor)
         viewBinding.stripeWebView.setBackgroundColor(state.backgroundColor)
         viewBinding.stripeWebViewProgressBar.isVisible = state.isNativeLoadingIndicatorVisible
         viewBinding.stripeWebView.isVisible = !state.isNativeLoadingIndicatorVisible


### PR DESCRIPTION
# Summary
Addresses [this PR comment](https://github.com/stripe/stripe-android/pull/9785/files#r1884533643).

Instead of having a singleton `EmbeddedComponentManager` app instance in the Example app:
 1. Create and cache `EmbeddedComponentManager` instances in `EmbeddedComponentLoaderViewModel`
 2. `EmbeddedComponentManagerProvider` has been demoted to a `Factory`, simplifying its role
 3. `EmbeddedComponentLoaderViewModel` is also responsible for binding app appearance settings to the manager in `Activity#onCreate()`. It does so by being being a lifecycle observer that Activities must register. This is aided by introducing a `BaseActivity` that our activities should extend.

Also, fixed a minor visual glitch with embedded component backgrounds.

# Motivation
See [comment](https://github.com/stripe/stripe-android/pull/9785/files#r1884533643). Overall, I think this eliminates some confusing state logic we had between `EmbeddedComponentManagerProvider` and `EmbeddedComponentLoaderViewModel`. There are clearer separations of concerns.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots

https://github.com/user-attachments/assets/c227401d-5992-4645-995b-6e93fdde0ed3
