### PR TITLE
[FC] Prepares integrity on first sync call

### DIFF
--- a/example/dependencies/dependencies.txt
+++ b/example/dependencies/dependencies.txt
@@ -956,6 +956,13 @@
 |    +--- project :stripe-ui-core (*)
 |    +--- project :payments-model (*)
 |    +--- org.jetbrains.kotlin:kotlin-stdlib:2.0.21 (*)
+|    +--- project :stripe-attestation
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:2.0.21 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0 (*)
+|    |    \--- com.google.android.play:integrity:1.4.0
+|    |         +--- com.google.android.gms:play-services-basement:18.4.0 (*)
+|    |         +--- com.google.android.gms:play-services-tasks:18.2.0 (*)
+|    |         \--- com.google.android.play:core-common:2.0.4
 |    +--- androidx.activity:activity-ktx:1.8.2 (*)
 |    +--- androidx.annotation:annotation:1.9.0 (*)
 |    +--- androidx.appcompat:appcompat:1.7.0 (*)

--- a/financial-connections-example/dependencies/dependencies.txt
+++ b/financial-connections-example/dependencies/dependencies.txt
@@ -594,6 +594,17 @@
 |    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3 (*)
 |    |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.0.21 (*)
 |    +--- org.jetbrains.kotlin:kotlin-stdlib:2.0.21 (*)
+|    +--- project :stripe-attestation
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:2.0.21 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0 (*)
+|    |    \--- com.google.android.play:integrity:1.4.0
+|    |         +--- com.google.android.gms:play-services-basement:18.4.0
+|    |         |    +--- androidx.collection:collection:1.0.0 -> 1.4.0 (*)
+|    |         |    +--- androidx.core:core:1.2.0 -> 1.13.1 (*)
+|    |         |    \--- androidx.fragment:fragment:1.1.0 -> 1.8.4 (*)
+|    |         +--- com.google.android.gms:play-services-tasks:18.2.0
+|    |         |    \--- com.google.android.gms:play-services-basement:18.4.0 (*)
+|    |         \--- com.google.android.play:core-common:2.0.4
 |    +--- androidx.activity:activity-ktx:1.8.2 (*)
 |    +--- androidx.annotation:annotation:1.9.0 (*)
 |    +--- androidx.appcompat:appcompat:1.7.0 (*)
@@ -847,11 +858,7 @@
 |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3 -> 1.9.0
 |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0 (*)
 |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.9.0 (*)
-|    |    +--- com.google.android.gms:play-services-tasks:16.0.1 -> 18.2.0
-|    |    |    \--- com.google.android.gms:play-services-basement:18.4.0
-|    |    |         +--- androidx.collection:collection:1.0.0 -> 1.4.0 (*)
-|    |    |         +--- androidx.core:core:1.2.0 -> 1.13.1 (*)
-|    |    |         \--- androidx.fragment:fragment:1.1.0 -> 1.8.4 (*)
+|    |    +--- com.google.android.gms:play-services-tasks:16.0.1 -> 18.2.0 (*)
 |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:2.0.0 -> 2.0.21 (*)
 |    +--- com.google.android.material:material:1.12.0 (*)
 |    +--- com.google.android.gms:play-services-wallet:19.4.0

--- a/financial-connections/build.gradle
+++ b/financial-connections/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     api project(":stripe-core")
     api project(":stripe-ui-core")
     api project(":payments-model")
+    implementation project(":stripe-attestation")
 
     implementation libs.androidx.activity
     implementation libs.androidx.annotation

--- a/financial-connections/dependencies/dependencies.txt
+++ b/financial-connections/dependencies/dependencies.txt
@@ -542,6 +542,17 @@
 |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3 (*)
 |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.0.21 (*)
 +--- org.jetbrains.kotlin:kotlin-stdlib:2.0.21 (*)
++--- project :stripe-attestation
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:2.0.21 (*)
+|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0 (*)
+|    \--- com.google.android.play:integrity:1.4.0
+|         +--- com.google.android.gms:play-services-basement:18.4.0
+|         |    +--- androidx.collection:collection:1.0.0 -> 1.4.0 (*)
+|         |    +--- androidx.core:core:1.2.0 -> 1.13.1 (*)
+|         |    \--- androidx.fragment:fragment:1.1.0 -> 1.5.4 (*)
+|         +--- com.google.android.gms:play-services-tasks:18.2.0
+|         |    \--- com.google.android.gms:play-services-basement:18.4.0 (*)
+|         \--- com.google.android.play:core-common:2.0.4
 +--- androidx.activity:activity-ktx:1.8.2 (*)
 +--- androidx.annotation:annotation:1.9.0 (*)
 +--- androidx.appcompat:appcompat:1.7.0 (*)

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSingletonSharedComponentHolder.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSingletonSharedComponentHolder.kt
@@ -1,9 +1,15 @@
 package com.stripe.android.financialconnections.di
 
 import android.app.Application
+import com.stripe.android.core.Logger
+import com.stripe.attestation.BuildConfig
+import com.stripe.attestation.IntegrityRequestManager
+import com.stripe.attestation.IntegrityStandardRequestManager
+import com.stripe.attestation.RealStandardIntegrityManagerFactory
 import dagger.BindsInstance
 import dagger.Component
 import dagger.Module
+import dagger.Provides
 import javax.inject.Singleton
 
 /**
@@ -32,6 +38,8 @@ internal object FinancialConnectionsSingletonSharedComponentHolder {
 @Component(modules = [FinancialConnectionsSingletonSharedModule::class])
 internal interface FinancialConnectionsSingletonSharedComponent {
 
+    fun providesIntegrityRequestManager(): IntegrityRequestManager
+
     @Component.Factory
     interface Factory {
         fun create(@BindsInstance application: Application): FinancialConnectionsSingletonSharedComponent
@@ -39,4 +47,15 @@ internal interface FinancialConnectionsSingletonSharedComponent {
 }
 
 @Module
-internal class FinancialConnectionsSingletonSharedModule
+internal class FinancialConnectionsSingletonSharedModule {
+
+    @Provides
+    @Singleton
+    fun providesIntegrityStandardRequestManager(
+        context: Application
+    ): IntegrityRequestManager = IntegrityStandardRequestManager(
+        cloudProjectNumber = 527113280969, // stripe-financial-connections
+        logError = { message, error -> Logger.getInstance(BuildConfig.DEBUG).error(message, error) },
+        factory = RealStandardIntegrityManagerFactory(context)
+    )
+}

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModelTest.kt
@@ -821,6 +821,7 @@ class FinancialConnectionsSheetViewModelTest {
             browserManager = browserManager,
             savedStateHandle = SavedStateHandle(),
             nativeAuthFlowCoordinator = mock(),
+            integrityRequestManager = mock(),
             logger = Logger.noop()
         )
     }

--- a/paymentsheet-example/dependencies/dependencies.txt
+++ b/paymentsheet-example/dependencies/dependencies.txt
@@ -1100,6 +1100,13 @@
 |    +--- project :stripe-ui-core (*)
 |    +--- project :payments-model (*)
 |    +--- org.jetbrains.kotlin:kotlin-stdlib:2.0.21 (*)
+|    +--- project :stripe-attestation
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:2.0.21 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0 (*)
+|    |    \--- com.google.android.play:integrity:1.4.0
+|    |         +--- com.google.android.gms:play-services-basement:18.4.0 (*)
+|    |         +--- com.google.android.gms:play-services-tasks:18.2.0 (*)
+|    |         \--- com.google.android.play:core-common:2.0.4
 |    +--- androidx.activity:activity-ktx:1.8.2 (*)
 |    +--- androidx.annotation:annotation:1.9.0 (*)
 |    +--- androidx.appcompat:appcompat:1.7.0 (*)

--- a/stripe-attestation/src/main/java/com/stripe/attestation/IntegrityStandardRequestManager.kt
+++ b/stripe-attestation/src/main/java/com/stripe/attestation/IntegrityStandardRequestManager.kt
@@ -40,6 +40,10 @@ class IntegrityStandardRequestManager(
     private var integrityTokenProvider: StandardIntegrityTokenProvider? = null
 
     override suspend fun prepare(): Result<Unit> = runCatching {
+        if (integrityTokenProvider != null) {
+            return Result.success(Unit)
+        }
+
         val finishedTask: Task<StandardIntegrityTokenProvider> = standardIntegrityManager
             .prepareIntegrityToken(
                 PrepareIntegrityTokenRequest.builder()


### PR DESCRIPTION
# Summary
Call `Integrity#prepare` on Activity A (`FinancialConnectionsSheetActivity`) and reuse the same Integrity instance in Activity B (`FinancialConnectionsNativeActivity`) when generating tokens.

# Motivation

https://docs.google.com/document/d/1joKz5UZHLVazmecfMHbq6gB6n4wj5u8To6AtqYgq_tc/edit?tab=t.0#heading=h.cz1xkpga7giy

# Testing
- [x] Manually verified
- [x] Added error tracking for failed integrity checks