### PR TITLE
[FC] Sends supports_app_verification to sync call when Integrity available

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
@@ -116,8 +116,11 @@ internal class FinancialConnectionsSheetViewModel @Inject constructor(
     private fun initAuthFlow() {
         viewModelScope.launch {
             kotlin.runCatching {
-                prepareStandardRequestManager()
-                getOrFetchSync(refetchCondition = Always)
+                val attestationInitialized = prepareStandardRequestManager()
+                getOrFetchSync(
+                    refetchCondition = Always,
+                    attestationInitialized = attestationInitialized
+                )
             }.onFailure {
                 finishWithResult(stateFlow.value, Failed(it))
             }.onSuccess {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/GetOrFetchSync.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/GetOrFetchSync.kt
@@ -18,12 +18,14 @@ internal class GetOrFetchSync @Inject constructor(
 ) {
 
     suspend operator fun invoke(
-        refetchCondition: RefetchCondition = RefetchCondition.None
+        refetchCondition: RefetchCondition = RefetchCondition.None,
+        attestationInitialized: Boolean = false
     ): SynchronizeSessionResponse {
         return repository.getOrSynchronizeFinancialConnectionsSession(
             clientSecret = configuration.financialConnectionsSessionClientSecret,
             applicationId = applicationId,
             reFetchCondition = refetchCondition::shouldReFetch,
+            attestationInitialized = attestationInitialized
         )
     }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsManifestRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsManifestRepository.kt
@@ -40,6 +40,7 @@ internal interface FinancialConnectionsManifestRepository {
     suspend fun getOrSynchronizeFinancialConnectionsSession(
         clientSecret: String,
         applicationId: String,
+        attestationInitialized: Boolean,
         reFetchCondition: (SynchronizeSessionResponse) -> Boolean
     ): SynchronizeSessionResponse
 
@@ -206,15 +207,17 @@ private class FinancialConnectionsManifestRepositoryImpl(
     override suspend fun getOrSynchronizeFinancialConnectionsSession(
         clientSecret: String,
         applicationId: String,
+        attestationInitialized: Boolean,
         reFetchCondition: (SynchronizeSessionResponse) -> Boolean
     ): SynchronizeSessionResponse = mutex.withLock {
         val cachedSync = cachedSynchronizeSessionResponse?.takeUnless(reFetchCondition)
-        return cachedSync ?: synchronize(applicationId, clientSecret)
+        return cachedSync ?: synchronize(applicationId, clientSecret, attestationInitialized)
     }
 
     private suspend fun synchronize(
         applicationId: String,
         clientSecret: String,
+        attestationInitialized: Boolean,
     ): SynchronizeSessionResponse = requestExecutor.execute(
         apiRequestFactory.createPost(
             url = synchronizeSessionUrl,
@@ -228,6 +231,8 @@ private class FinancialConnectionsManifestRepositoryImpl(
                     "forced_authflow_version" to "v3",
                     PARAMS_FULLSCREEN to true,
                     PARAMS_HIDE_CLOSE_BUTTON to true,
+                    PARAMS_SUPPORT_APP_VERIFICATION to attestationInitialized,
+                    PARAMS_VERIFY_APP_ID to applicationId.takeIf { attestationInitialized },
                     NetworkConstants.PARAMS_APPLICATION_ID to applicationId
                 ),
                 NetworkConstants.PARAMS_CLIENT_SECRET to clientSecret
@@ -523,6 +528,8 @@ private class FinancialConnectionsManifestRepositoryImpl(
     companion object {
         internal const val PARAMS_FULLSCREEN = "fullscreen"
         internal const val PARAMS_HIDE_CLOSE_BUTTON = "hide_close_button"
+        internal const val PARAMS_SUPPORT_APP_VERIFICATION = "supports_app_verification"
+        internal const val PARAMS_VERIFY_APP_ID = "verified_app_id"
 
         internal const val synchronizeSessionUrl: String =
             "${ApiRequest.API_HOST}/v1/financial_connections/sessions/synchronize"

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/linkstepupverification/LinkStepUpVerificationViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/linkstepupverification/LinkStepUpVerificationViewModelTest.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -137,7 +138,7 @@ class LinkStepUpVerificationViewModelTest {
     private suspend fun givenGetSyncReturns(
         syncResponse: SynchronizeSessionResponse = syncResponse()
     ) {
-        whenever(getOrFetchSync(any())).thenReturn(syncResponse)
+        whenever(getOrFetchSync(any(), anyOrNull())).thenReturn(syncResponse)
     }
 
     private suspend fun markLinkVerifiedReturns(

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinkloginwarmup/NetworkingLinkLoginWarmupViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinkloginwarmup/NetworkingLinkLoginWarmupViewModelTest.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -49,7 +50,7 @@ class NetworkingLinkLoginWarmupViewModelTest {
     @Test
     fun `init - payload error navigates to error screen`() = runTest {
         val error = RuntimeException("Failed to fetch manifest")
-        whenever(getOrFetchSync(any())).thenAnswer { throw error }
+        whenever(getOrFetchSync(any(), anyOrNull())).thenAnswer { throw error }
 
         buildViewModel(NetworkingLinkLoginWarmupState())
 

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModelTest.kt
@@ -42,6 +42,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
@@ -86,7 +87,7 @@ class NetworkingLinkSignupViewModelTest {
             accountholderCustomerEmailAddress = "test@test.com"
         )
 
-        whenever(getOrFetchSync(any())).thenReturn(
+        whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(
             syncResponse().copy(
                 manifest = manifest,
                 text = TextUpdate(
@@ -107,7 +108,7 @@ class NetworkingLinkSignupViewModelTest {
     fun `init - creates controllers with Elements billing details`() = runTest {
         val manifest = sessionManifest()
 
-        whenever(getOrFetchSync(any())).thenReturn(
+        whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(
             syncResponse().copy(
                 manifest = manifest,
                 text = TextUpdate(
@@ -148,7 +149,7 @@ class NetworkingLinkSignupViewModelTest {
             accountholderCustomerEmailAddress = "",
         )
 
-        whenever(getOrFetchSync(any())).thenReturn(
+        whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(
             syncResponse().copy(
                 manifest = manifest.copy(isLinkWithStripe = true),
                 text = TextUpdate(
@@ -171,7 +172,7 @@ class NetworkingLinkSignupViewModelTest {
             accountholderCustomerEmailAddress = "",
         )
 
-        whenever(getOrFetchSync(any())).thenReturn(
+        whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(
             syncResponse().copy(
                 manifest = manifest.copy(isLinkWithStripe = false),
                 text = TextUpdate(
@@ -191,7 +192,7 @@ class NetworkingLinkSignupViewModelTest {
     fun `Redirects to save-to-link verification screen if entering returning user email`() = runTest {
         val manifest = sessionManifest()
 
-        whenever(getOrFetchSync(any())).thenReturn(
+        whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(
             syncResponse().copy(
                 text = TextUpdate(
                     consent = null,
@@ -225,7 +226,7 @@ class NetworkingLinkSignupViewModelTest {
             isLinkWithStripe = true,
         )
 
-        whenever(getOrFetchSync(any())).thenReturn(
+        whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(
             syncResponse().copy(
                 manifest = manifest,
                 text = TextUpdate(
@@ -264,7 +265,7 @@ class NetworkingLinkSignupViewModelTest {
     fun `Enables Save To Link button if we encounter a returning user`() = runTest {
         val manifest = sessionManifest()
 
-        whenever(getOrFetchSync(any())).thenReturn(
+        whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(
             syncResponse().copy(
                 text = TextUpdate(
                     consent = null,
@@ -315,7 +316,7 @@ class NetworkingLinkSignupViewModelTest {
             isLinkWithStripe = false,
         )
 
-        whenever(getOrFetchSync(any())).thenReturn(
+        whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(
             syncResponse().copy(
                 manifest = manifest,
                 text = TextUpdate(
@@ -340,7 +341,7 @@ class NetworkingLinkSignupViewModelTest {
             isLinkWithStripe = true,
         )
 
-        whenever(getOrFetchSync(any())).thenReturn(
+        whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(
             syncResponse().copy(
                 manifest = manifest,
                 text = TextUpdate(
@@ -366,7 +367,7 @@ class NetworkingLinkSignupViewModelTest {
             text = TextUpdate(networkingLinkSignupPane = networkingLinkSignupPane()),
         )
 
-        whenever(getOrFetchSync(any())).thenReturn(syncResponse)
+        whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(syncResponse)
         whenever(lookupAccount(any())).thenReturn(ConsumerSessionLookup(exists = false))
 
         val viewModel = buildViewModel(
@@ -400,7 +401,7 @@ class NetworkingLinkSignupViewModelTest {
             text = TextUpdate(linkLoginPane = linkLoginPane()),
         )
 
-        whenever(getOrFetchSync(any())).thenReturn(initialSyncResponse)
+        whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(initialSyncResponse)
         whenever(lookupAccount(any())).thenReturn(ConsumerSessionLookup(exists = false))
 
         val viewModel = buildViewModel(
@@ -434,7 +435,7 @@ class NetworkingLinkSignupViewModelTest {
             text = TextUpdate(networkingLinkSignupPane = networkingLinkSignupPane()),
         )
 
-        whenever(getOrFetchSync(any())).thenReturn(syncResponse)
+        whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(syncResponse)
         whenever(lookupAccount(any())).thenReturn(ConsumerSessionLookup(exists = false))
 
         val viewModel = buildViewModel(
@@ -468,7 +469,7 @@ class NetworkingLinkSignupViewModelTest {
             text = TextUpdate(linkLoginPane = linkLoginPane()),
         )
 
-        whenever(getOrFetchSync(any())).thenReturn(initialSyncResponse)
+        whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(initialSyncResponse)
         whenever(lookupAccount(any())).thenReturn(ConsumerSessionLookup(exists = false))
 
         val viewModel = buildViewModel(
@@ -500,7 +501,7 @@ class NetworkingLinkSignupViewModelTest {
 
         val permissionException = PermissionException(stripeError = StripeError())
 
-        whenever(getOrFetchSync(any())).thenReturn(initialSyncResponse)
+        whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(initialSyncResponse)
         whenever(lookupAccount(any())).then {
             throw permissionException
         }
@@ -532,7 +533,7 @@ class NetworkingLinkSignupViewModelTest {
 
         val apiException = APIConnectionException()
 
-        whenever(getOrFetchSync(any())).thenReturn(initialSyncResponse)
+        whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(initialSyncResponse)
         whenever(lookupAccount(any())).then {
             throw apiException
         }
@@ -564,7 +565,7 @@ class NetworkingLinkSignupViewModelTest {
 
         val permissionException = PermissionException(stripeError = StripeError())
 
-        whenever(getOrFetchSync(any())).thenReturn(initialSyncResponse)
+        whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(initialSyncResponse)
         whenever(lookupAccount(any())).then {
             throw permissionException
         }
@@ -593,7 +594,7 @@ class NetworkingLinkSignupViewModelTest {
         )
 
         val getOrFetchSync = mock<GetOrFetchSync> {
-            onBlocking { invoke(any()) } doReturn syncResponse().copy(
+            onBlocking { invoke(any(), anyOrNull()) } doReturn syncResponse().copy(
                 manifest = manifest,
                 text = TextUpdate(
                     consent = null,
@@ -636,7 +637,7 @@ class NetworkingLinkSignupViewModelTest {
         )
 
         val getOrFetchSync = mock<GetOrFetchSync> {
-            onBlocking { invoke(any()) } doReturn syncResponse().copy(
+            onBlocking { invoke(any(), anyOrNull()) } doReturn syncResponse().copy(
                 manifest = manifest,
                 text = TextUpdate(
                     consent = null,

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinkverification/NetworkingLinkVerificationViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinkverification/NetworkingLinkVerificationViewModelTest.kt
@@ -311,7 +311,7 @@ class NetworkingLinkVerificationViewModelTest {
         val onStartVerificationCaptor = argumentCaptor<suspend () -> Unit>()
         val onVerificationStartedCaptor = argumentCaptor<suspend (ConsumerSession) -> Unit>()
 
-        whenever(getOrFetchSync(any())).thenReturn(
+        whenever(getOrFetchSync(any(), anyOrNull())).thenReturn(
             syncResponse(sessionManifest().copy(accountholderCustomerEmailAddress = consumerSession.emailAddress))
         )
         whenever(attachConsumerToLinkAccountSession.invoke(any())).thenReturn(Unit)
@@ -356,7 +356,7 @@ class NetworkingLinkVerificationViewModelTest {
         val onStartVerificationCaptor = argumentCaptor<suspend () -> Unit>()
         val onVerificationStartedCaptor = argumentCaptor<suspend (ConsumerSession) -> Unit>()
 
-        whenever(getOrFetchSync(any())).thenReturn(
+        whenever(getOrFetchSync(any(), anyOrNull())).thenReturn(
             syncResponse(sessionManifest().copy(accountholderCustomerEmailAddress = consumerSession.emailAddress))
         )
 

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/partnerauth/SupportabilityViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/partnerauth/SupportabilityViewModelTest.kt
@@ -69,7 +69,7 @@ internal class SupportabilityViewModelTest {
                 showManualEntry = false,
                 stripeException = APIException()
             )
-            whenever(getOrFetchSync(anyOrNull())).thenReturn(
+            whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(
                 syncResponse(sessionManifest().copy(activeInstitution = institution()))
             )
             whenever(createAuthorizationSession(any(), any())).thenAnswer {
@@ -94,7 +94,7 @@ internal class SupportabilityViewModelTest {
             activeInstitution = activeInstitution,
             activeAuthSession = activeAuthSession
         )
-        whenever(getOrFetchSync(anyOrNull())).thenReturn(syncResponse(manifest))
+        whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(syncResponse(manifest))
 
         val viewModel = createViewModel(SharedPartnerAuthState(Pane.PARTNER_AUTH_DRAWER))
 
@@ -124,7 +124,7 @@ internal class SupportabilityViewModelTest {
                 publicToken = "123456"
             )
 
-            whenever(getOrFetchSync(anyOrNull())).thenReturn(
+            whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(
                 syncResponse(
                     sessionManifest().copy(activeAuthSession = activeAuthSession)
                 )
@@ -149,7 +149,7 @@ internal class SupportabilityViewModelTest {
         val activeAuthSession = authorizationSession()
         val viewModel = createViewModel()
 
-        whenever(getOrFetchSync(anyOrNull())).thenReturn(
+        whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(
             syncResponse(
                 manifest = sessionManifest().copy(activeAuthSession = activeAuthSession)
             )
@@ -169,7 +169,7 @@ internal class SupportabilityViewModelTest {
             val activeAuthSession = authorizationSession().copy(_isOAuth = false)
             val viewModel = createViewModel()
 
-            whenever(getOrFetchSync(anyOrNull()))
+            whenever(getOrFetchSync(anyOrNull(), anyOrNull()))
                 .thenReturn(
                     syncResponse(
                         sessionManifest().copy(
@@ -203,7 +203,7 @@ internal class SupportabilityViewModelTest {
                 activeInstitution = activeInstitution
             )
             val syncResponse = syncResponse(manifest)
-            whenever(getOrFetchSync(anyOrNull())).thenReturn(syncResponse)
+            whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(syncResponse)
             whenever(createAuthorizationSession.invoke(any(), any())).thenReturn(activeAuthSession)
             // simulate that auth session succeeded in abstract auth:
             whenever(retrieveAuthorizationSession.invoke(any()))
@@ -232,7 +232,7 @@ internal class SupportabilityViewModelTest {
                 )
             )
             val syncResponse = syncResponse(manifest)
-            whenever(getOrFetchSync(anyOrNull())).thenReturn(syncResponse)
+            whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(syncResponse)
             whenever(createAuthorizationSession.invoke(any(), any())).thenReturn(activeAuthSession)
             // simulate that auth session succeeded in abstract auth:
             whenever(retrieveAuthorizationSession.invoke(any()))
@@ -270,7 +270,7 @@ internal class SupportabilityViewModelTest {
                 activeInstitution = activeInstitution
             )
             val syncResponse = syncResponse(manifest)
-            whenever(getOrFetchSync(anyOrNull())).thenReturn(syncResponse)
+            whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(syncResponse)
             whenever(createAuthorizationSession.invoke(any(), any())).thenReturn(activeAuthSession)
             // simulate that auth session succeeded in abstract auth:
             whenever(retrieveAuthorizationSession.invoke(any()))

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/networking/AbsFinancialConnectionsManifestRepository.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/networking/AbsFinancialConnectionsManifestRepository.kt
@@ -94,6 +94,7 @@ internal abstract class AbsFinancialConnectionsManifestRepository : FinancialCon
     override suspend fun getOrSynchronizeFinancialConnectionsSession(
         clientSecret: String,
         applicationId: String,
+        attestationInitialized: Boolean,
         reFetchCondition: (SynchronizeSessionResponse) -> Boolean
     ): SynchronizeSessionResponse {
         TODO("Not yet implemented")

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/networking/FakeFinancialConnectionsManifestRepository.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/networking/FakeFinancialConnectionsManifestRepository.kt
@@ -27,6 +27,7 @@ internal class FakeFinancialConnectionsManifestRepository : FinancialConnections
     override suspend fun getOrSynchronizeFinancialConnectionsSession(
         clientSecret: String,
         applicationId: String,
+        attestationInitialized: Boolean,
         reFetchCondition: (SynchronizeSessionResponse) -> Boolean
     ): SynchronizeSessionResponse = getSynchronizeSessionResponseProvider()
 

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/FinancialConnectionsManifestRepositoryImplTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/FinancialConnectionsManifestRepositoryImplTest.kt
@@ -55,8 +55,22 @@ internal class FinancialConnectionsManifestRepositoryImplTest {
 
             // simulates to concurrent accesses to manifest.
             awaitAll(
-                async { repository.getOrSynchronizeFinancialConnectionsSession("", "", None::shouldReFetch) },
-                async { repository.getOrSynchronizeFinancialConnectionsSession("", "", None::shouldReFetch) }
+                async {
+                    repository.getOrSynchronizeFinancialConnectionsSession(
+                        clientSecret = "",
+                        applicationId = "",
+                        attestationInitialized = false,
+                        reFetchCondition = None::shouldReFetch
+                    )
+                },
+                async {
+                    repository.getOrSynchronizeFinancialConnectionsSession(
+                        clientSecret = "",
+                        applicationId = "",
+                        attestationInitialized = false,
+                        reFetchCondition = None::shouldReFetch
+                    )
+                }
             )
 
             verify(mockRequestExecutor, times(1)).execute(any(), any<KSerializer<*>>())
@@ -69,7 +83,12 @@ internal class FinancialConnectionsManifestRepositoryImplTest {
             val repository = buildRepository(initialSync = initialSync)
 
             val returnedManifest =
-                repository.getOrSynchronizeFinancialConnectionsSession("", "", None::shouldReFetch)
+                repository.getOrSynchronizeFinancialConnectionsSession(
+                    clientSecret = "",
+                    applicationId = "",
+                    attestationInitialized = false,
+                    reFetchCondition = None::shouldReFetch
+                )
 
             assertThat(returnedManifest).isEqualTo(initialSync)
             verifyNoInteractions(mockRequestExecutor)

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/utils/TestIntegrityRequestManager.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/utils/TestIntegrityRequestManager.kt
@@ -1,0 +1,12 @@
+package com.stripe.android.financialconnections.utils
+
+import com.stripe.attestation.IntegrityRequestManager
+
+internal class TestIntegrityRequestManager(
+    val prepareResult: Result<Unit> = Result.success(Unit),
+    val requestTokenResult: Result<String> = Result.success("token")
+) : IntegrityRequestManager {
+    override suspend fun prepare(): Result<Unit> = prepareResult
+
+    override suspend fun requestToken(requestIdentifier: String?): Result<String> = requestTokenResult
+}


### PR DESCRIPTION
# Summary
When making the first `/sync` request, warm up the integrity request calling  manager `prepare` to check if Integrity API is available. If no errors occur, Pass `supports_app_verification: true` on the first sync call.

Note: This gets recorded on the session so even if future sync calls pass this field it'd get ignored, as the session verified state is immutable on backend. 

We also pass `verified_app_id`, matching the package name.

# Motivation
https://docs.google.com/document/d/1joKz5UZHLVazmecfMHbq6gB6n4wj5u8To6AtqYgq_tc/edit?tab=t.0#heading=h.cz1xkpga7giy

# Testing
- [x] Modified tests
- [x] Manually verified