### PR TITLE
[FC] Adds ActivityRetainedScope and broader singleton component

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
@@ -30,6 +30,7 @@ import com.stripe.android.financialconnections.analytics.logError
 import com.stripe.android.financialconnections.browser.BrowserManager
 import com.stripe.android.financialconnections.di.APPLICATION_ID
 import com.stripe.android.financialconnections.di.DaggerFinancialConnectionsSheetComponent
+import com.stripe.android.financialconnections.di.FinancialConnectionsSingletonSharedComponentHolder
 import com.stripe.android.financialconnections.domain.FetchFinancialConnectionsSession
 import com.stripe.android.financialconnections.domain.FetchFinancialConnectionsSessionForToken
 import com.stripe.android.financialconnections.domain.GetOrFetchSync
@@ -529,6 +530,7 @@ internal class FinancialConnectionsSheetViewModel @Inject constructor(
                     .builder()
                     .application(app)
                     .savedStateHandle(savedStateHandle)
+                    .sharedComponent(FinancialConnectionsSingletonSharedComponentHolder.getComponent(app))
                     .initialState(state)
                     .configuration(state.initialArgs.configuration)
                     .build().viewModel

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/ActivityRetainedScope.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/ActivityRetainedScope.kt
@@ -1,0 +1,12 @@
+package com.stripe.android.financialconnections.di
+
+import javax.inject.Scope
+
+/**
+ * Scope annotation for bindings that should exist for the life of an activity, surviving configuration.
+ *
+ * Note: Dependencies scoped to this won't be shared across activities.
+ */
+@Scope
+@Retention(AnnotationRetention.RUNTIME)
+internal annotation class ActivityRetainedScope

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetComponent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetComponent.kt
@@ -2,22 +2,18 @@ package com.stripe.android.financialconnections.di
 
 import android.app.Application
 import androidx.lifecycle.SavedStateHandle
-import com.stripe.android.core.injection.CoreCommonModule
-import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
 import com.stripe.android.financialconnections.FinancialConnectionsSheetState
 import com.stripe.android.financialconnections.FinancialConnectionsSheetViewModel
 import dagger.BindsInstance
 import dagger.Component
-import javax.inject.Singleton
 
-@Singleton
+@ActivityRetainedScope
 @Component(
+    dependencies = [FinancialConnectionsSingletonSharedComponent::class],
     modules = [
         FinancialConnectionsSheetModule::class,
         FinancialConnectionsSheetSharedModule::class,
-        CoroutineContextModule::class,
-        CoreCommonModule::class
     ]
 )
 internal interface FinancialConnectionsSheetComponent {
@@ -36,6 +32,8 @@ internal interface FinancialConnectionsSheetComponent {
 
         @BindsInstance
         fun configuration(configuration: FinancialConnectionsSheet.Configuration): Builder
+
+        fun sharedComponent(component: FinancialConnectionsSingletonSharedComponent): Builder
 
         fun build(): FinancialConnectionsSheetComponent
     }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetConfigurationModule.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetConfigurationModule.kt
@@ -9,39 +9,38 @@ import com.stripe.android.financialconnections.FinancialConnectionsSheet
 import dagger.Module
 import dagger.Provides
 import javax.inject.Named
-import javax.inject.Singleton
 
 @Module
 internal object FinancialConnectionsSheetConfigurationModule {
 
     @Provides
     @Named(PUBLISHABLE_KEY)
-    @Singleton
+    @ActivityRetainedScope
     fun providesPublishableKey(
         configuration: FinancialConnectionsSheet.Configuration
     ): String = configuration.publishableKey
 
     @Provides
     @Named(STRIPE_ACCOUNT_ID)
-    @Singleton
+    @ActivityRetainedScope
     fun providesStripeAccountId(
         configuration: FinancialConnectionsSheet.Configuration
     ): String? = configuration.stripeAccountId
 
     @Provides
     @Named(ENABLE_LOGGING)
-    @Singleton
+    @ActivityRetainedScope
     fun providesEnableLogging(): Boolean = BuildConfig.DEBUG
 
     @Provides
-    @Singleton
+    @ActivityRetainedScope
     @Named(APPLICATION_ID)
     fun providesApplicationId(
         application: Application
     ): String = application.packageName
 
     @Provides
-    @Singleton
+    @ActivityRetainedScope
     fun providesApiVersion(): ApiVersion = ApiVersion(
         betas = setOf("financial_connections_client_api_beta=v1")
     )

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetModule.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetModule.kt
@@ -8,12 +8,11 @@ import com.stripe.android.financialconnections.repository.api.ProvideApiRequestO
 import dagger.Module
 import dagger.Provides
 import java.util.Locale
-import javax.inject.Singleton
 
 @Module
 internal object FinancialConnectionsSheetModule {
 
-    @Singleton
+    @ActivityRetainedScope
     @Provides
     internal fun providesProvideApiRequestOptions(
         apiRequestOptions: ApiRequest.Options,
@@ -22,7 +21,7 @@ internal object FinancialConnectionsSheetModule {
         return ProvideApiRequestOptions { apiRequestOptions }
     }
 
-    @Singleton
+    @ActivityRetainedScope
     @Provides
     fun providesFinancialConnectionsManifestRepository(
         requestExecutor: FinancialConnectionsRequestExecutor,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeComponent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeComponent.kt
@@ -2,8 +2,6 @@ package com.stripe.android.financialconnections.di
 
 import android.app.Application
 import androidx.lifecycle.SavedStateHandle
-import com.stripe.android.core.injection.CoreCommonModule
-import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
 import com.stripe.android.financialconnections.features.accountpicker.AccountPickerViewModel
 import com.stripe.android.financialconnections.features.accountupdate.AccountUpdateRequiredViewModel
@@ -32,15 +30,13 @@ import com.stripe.android.financialconnections.ui.FinancialConnectionsSheetNativ
 import dagger.BindsInstance
 import dagger.Component
 import javax.inject.Named
-import javax.inject.Singleton
 
-@Singleton
+@ActivityRetainedScope
 @Component(
+    dependencies = [FinancialConnectionsSingletonSharedComponent::class],
     modules = [
         FinancialConnectionsSheetNativeModule::class,
-        FinancialConnectionsSheetSharedModule::class,
-        CoreCommonModule::class,
-        CoroutineContextModule::class
+        FinancialConnectionsSheetSharedModule::class
     ]
 )
 internal interface FinancialConnectionsSheetNativeComponent {
@@ -90,6 +86,8 @@ internal interface FinancialConnectionsSheetNativeComponent {
 
         @BindsInstance
         fun configuration(configuration: FinancialConnectionsSheet.Configuration): Builder
+
+        fun sharedComponent(component: FinancialConnectionsSingletonSharedComponent): Builder
 
         fun build(): FinancialConnectionsSheetNativeComponent
     }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule.kt
@@ -43,7 +43,6 @@ import dagger.Provides
 import java.util.Locale
 import javax.inject.Named
 import javax.inject.Provider
-import javax.inject.Singleton
 
 @Module
 internal interface FinancialConnectionsSheetNativeModule {
@@ -51,7 +50,7 @@ internal interface FinancialConnectionsSheetNativeModule {
     @Binds
     fun bindsPresentNoticeSheet(impl: RealPresentSheet): PresentSheet
 
-    @Singleton
+    @ActivityRetainedScope
     @Binds
     fun bindsNavigationManager(
         impl: NavigationManagerImpl
@@ -63,7 +62,7 @@ internal interface FinancialConnectionsSheetNativeModule {
     ): HandleError
 
     @Binds
-    @Singleton
+    @ActivityRetainedScope
     fun bindsProvideApiRequestOptions(impl: RealProvideApiRequestOptions): ProvideApiRequestOptions
 
     @Binds
@@ -78,7 +77,7 @@ internal interface FinancialConnectionsSheetNativeModule {
 
     companion object {
         @Provides
-        @Singleton
+        @ActivityRetainedScope
         fun provideConsumersApiService(
             apiVersion: ApiVersion,
             stripeNetworkClient: StripeNetworkClient,
@@ -89,7 +88,7 @@ internal interface FinancialConnectionsSheetNativeModule {
             stripeNetworkClient = stripeNetworkClient
         )
 
-        @Singleton
+        @ActivityRetainedScope
         @Provides
         fun providesImageLoader(
             context: Application
@@ -98,7 +97,7 @@ internal interface FinancialConnectionsSheetNativeModule {
             diskCache = null,
         )
 
-        @Singleton
+        @ActivityRetainedScope
         @Provides
         fun providesFinancialConnectionsManifestRepository(
             requestExecutor: FinancialConnectionsRequestExecutor,
@@ -116,7 +115,7 @@ internal interface FinancialConnectionsSheetNativeModule {
             initialSync = initialSynchronizeSessionResponse
         )
 
-        @Singleton
+        @ActivityRetainedScope
         @Provides
         fun providesFinancialConnectionsConsumerSessionRepository(
             consumersApiService: ConsumersApiService,
@@ -140,7 +139,7 @@ internal interface FinancialConnectionsSheetNativeModule {
             elementsSessionContext = elementsSessionContext,
         )
 
-        @Singleton
+        @ActivityRetainedScope
         @Provides
         fun providesFinancialConnectionsAccountsRepository(
             requestExecutor: FinancialConnectionsRequestExecutor,
@@ -156,7 +155,7 @@ internal interface FinancialConnectionsSheetNativeModule {
             savedStateHandle = savedStateHandle,
         )
 
-        @Singleton
+        @ActivityRetainedScope
         @Provides
         fun providesFinancialConnectionsInstitutionsRepository(
             requestExecutor: FinancialConnectionsRequestExecutor,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetSharedModule.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetSharedModule.kt
@@ -1,11 +1,14 @@
 package com.stripe.android.financialconnections.di
 
 import android.app.Application
+import androidx.core.os.LocaleListCompat
 import com.stripe.android.core.ApiVersion
 import com.stripe.android.core.Logger
 import com.stripe.android.core.frauddetection.FraudDetectionDataRepository
+import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
+import com.stripe.android.core.injection.UIContext
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.core.networking.AnalyticsRequestV2Executor
@@ -43,7 +46,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.serialization.json.Json
 import java.util.Locale
 import javax.inject.Named
-import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -66,19 +68,19 @@ import kotlin.coroutines.CoroutineContext
 internal interface FinancialConnectionsSheetSharedModule {
 
     @Binds
-    @Singleton
+    @ActivityRetainedScope
     fun bindsAnalyticsRequestV2Storage(impl: RealAnalyticsRequestV2Storage): AnalyticsRequestV2Storage
 
     @Binds
-    @Singleton
+    @ActivityRetainedScope
     fun bindsAnalyticsRequestV2Executor(impl: DefaultAnalyticsRequestV2Executor): AnalyticsRequestV2Executor
 
     @Binds
-    @Singleton
+    @ActivityRetainedScope
     fun bindsConsumerSessionRepository(impl: RealConsumerSessionRepository): ConsumerSessionRepository
 
     @Binds
-    @Singleton
+    @ActivityRetainedScope
     fun bindsConsumerSessionProvider(impl: RealConsumerSessionRepository): ConsumerSessionProvider
 
     @Binds
@@ -87,7 +89,27 @@ internal interface FinancialConnectionsSheetSharedModule {
     companion object {
 
         @Provides
-        @Singleton
+        @ActivityRetainedScope
+        @IOContext
+        fun provideWorkContext(): CoroutineContext = Dispatchers.IO
+
+        @Provides
+        @ActivityRetainedScope
+        @UIContext
+        fun provideUIContext(): CoroutineContext = Dispatchers.Main
+
+        @Provides
+        @ActivityRetainedScope
+        internal fun provideLogger(@Named(ENABLE_LOGGING) enableLogging: Boolean) =
+            Logger.getInstance(enableLogging)
+
+        @Provides
+        @ActivityRetainedScope
+        internal fun provideLocale() =
+            LocaleListCompat.getAdjustedDefault().takeUnless { it.isEmpty }?.get(0)
+
+        @Provides
+        @ActivityRetainedScope
         internal fun providesApiOptions(
             @Named(PUBLISHABLE_KEY) publishableKey: String,
             @Named(STRIPE_ACCOUNT_ID) stripeAccountId: String?
@@ -97,7 +119,7 @@ internal interface FinancialConnectionsSheetSharedModule {
         )
 
         @Provides
-        @Singleton
+        @ActivityRetainedScope
         internal fun providesJson(): Json = Json {
             coerceInputValues = true
             ignoreUnknownKeys = true
@@ -106,7 +128,7 @@ internal interface FinancialConnectionsSheetSharedModule {
         }
 
         @Provides
-        @Singleton
+        @ActivityRetainedScope
         fun provideStripeNetworkClient(
             @IOContext context: CoroutineContext,
             logger: Logger
@@ -115,8 +137,8 @@ internal interface FinancialConnectionsSheetSharedModule {
             logger = logger
         )
 
-        @Singleton
         @Provides
+        @ActivityRetainedScope
         fun providesAnalyticsTracker(
             context: Application,
             getOrFetchSync: GetOrFetchSync,
@@ -132,7 +154,7 @@ internal interface FinancialConnectionsSheetSharedModule {
         )
 
         @Provides
-        @Singleton
+        @ActivityRetainedScope
         fun providesApiRequestFactory(
             apiVersion: ApiVersion
         ): ApiRequest.Factory = ApiRequest.Factory(
@@ -140,25 +162,25 @@ internal interface FinancialConnectionsSheetSharedModule {
         )
 
         @Provides
-        @Singleton
+        @ActivityRetainedScope
         fun provideConnectionsRepository(
             repository: FinancialConnectionsRepositoryImpl
         ): FinancialConnectionsRepository = repository
 
         @Provides
-        @Singleton
+        @ActivityRetainedScope
         fun provideEventReporter(
             defaultFinancialConnectionsEventReporter: DefaultFinancialConnectionsEventReporter
         ): FinancialConnectionsEventReporter = defaultFinancialConnectionsEventReporter
 
         @Provides
-        @Singleton
+        @ActivityRetainedScope
         internal fun providesAnalyticsRequestExecutor(
             executor: DefaultAnalyticsRequestExecutor
         ): AnalyticsRequestExecutor = executor
 
         @Provides
-        @Singleton
+        @ActivityRetainedScope
         internal fun provideAnalyticsRequestFactory(
             application: Application,
             @Named(PUBLISHABLE_KEY) publishableKey: String
@@ -171,7 +193,7 @@ internal interface FinancialConnectionsSheetSharedModule {
         )
 
         @Provides
-        @Singleton
+        @ActivityRetainedScope
         internal fun providesIsWorkManagerAvailable(
             getOrFetchSync: GetOrFetchSync,
         ): IsWorkManagerAvailable {
@@ -181,7 +203,7 @@ internal interface FinancialConnectionsSheetSharedModule {
         }
 
         @Provides
-        @Singleton
+        @ActivityRetainedScope
         internal fun providesIoDispatcher(): CoroutineDispatcher {
             return Dispatchers.IO
         }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSingletonSharedComponentHolder.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSingletonSharedComponentHolder.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.financialconnections.di
+
+import android.app.Application
+import dagger.BindsInstance
+import dagger.Component
+import dagger.Module
+import javax.inject.Singleton
+
+/**
+ * A singleton holder for the [FinancialConnectionsSingletonSharedComponent], ensuring it is initialized only once and
+ * shared across activities.
+ */
+internal object FinancialConnectionsSingletonSharedComponentHolder {
+
+    @Volatile
+    private var component: FinancialConnectionsSingletonSharedComponent? = null
+
+    fun getComponent(application: Application): FinancialConnectionsSingletonSharedComponent {
+        return component ?: synchronized(this) {
+            component ?: buildComponent(application).also { component = it }
+        }
+    }
+
+    private fun buildComponent(application: Application): FinancialConnectionsSingletonSharedComponent {
+        return DaggerFinancialConnectionsSingletonSharedComponent
+            .factory()
+            .create(application)
+    }
+}
+
+@Singleton
+@Component(modules = [FinancialConnectionsSingletonSharedModule::class])
+internal interface FinancialConnectionsSingletonSharedComponent {
+
+    @Component.Factory
+    interface Factory {
+        fun create(@BindsInstance application: Application): FinancialConnectionsSingletonSharedComponent
+    }
+}
+
+@Module
+internal class FinancialConnectionsSingletonSharedModule

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/NativeAuthFlowCoordinator.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/NativeAuthFlowCoordinator.kt
@@ -1,9 +1,9 @@
 package com.stripe.android.financialconnections.domain
 
+import com.stripe.android.financialconnections.di.ActivityRetainedScope
 import com.stripe.android.financialconnections.navigation.topappbar.TopAppBarStateUpdate
 import kotlinx.coroutines.flow.MutableSharedFlow
 import javax.inject.Inject
-import javax.inject.Singleton
 
 /**
  * The AuthFlow state is centralized in the parent viewModel.
@@ -12,7 +12,7 @@ import javax.inject.Singleton
  * [com.stripe.android.financialconnections.presentation.FinancialConnectionsSheetNativeViewModel]
  *
  */
-@Singleton
+@ActivityRetainedScope
 internal class NativeAuthFlowCoordinator @Inject constructor() {
     private val flow = MutableSharedFlow<Message>()
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
@@ -26,8 +26,10 @@ import com.stripe.android.financialconnections.analytics.FinancialConnectionsAna
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsEvent.Metadata
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsEvent.Name
 import com.stripe.android.financialconnections.di.APPLICATION_ID
+import com.stripe.android.financialconnections.di.ActivityRetainedScope
 import com.stripe.android.financialconnections.di.DaggerFinancialConnectionsSheetNativeComponent
 import com.stripe.android.financialconnections.di.FinancialConnectionsSheetNativeComponent
+import com.stripe.android.financialconnections.di.FinancialConnectionsSingletonSharedComponentHolder
 import com.stripe.android.financialconnections.domain.CompleteFinancialConnectionsSession
 import com.stripe.android.financialconnections.domain.CreateInstantDebitsResult
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
@@ -73,9 +75,8 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 import javax.inject.Named
-import javax.inject.Singleton
 
-@Singleton
+@ActivityRetainedScope
 internal class FinancialConnectionsSheetNativeViewModel @Inject constructor(
     /**
      * Exposes parent dagger component (activity viewModel scoped so that it survives config changes)
@@ -493,6 +494,7 @@ internal class FinancialConnectionsSheetNativeViewModel @Inject constructor(
                     .initialSyncResponse(args.initialSyncResponse.takeIf { state.firstInit })
                     .application(app)
                     .configuration(state.configuration)
+                    .sharedComponent(FinancialConnectionsSingletonSharedComponentHolder.getComponent(app))
                     .savedStateHandle(savedStateHandle)
                     .initialState(state)
                     .build()

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/AccountUpdateRequiredContentRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/AccountUpdateRequiredContentRepository.kt
@@ -2,13 +2,13 @@ package com.stripe.android.financialconnections.repository
 
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
+import com.stripe.android.financialconnections.di.ActivityRetainedScope
 import com.stripe.android.financialconnections.features.notice.NoticeSheetState.NoticeSheetContent.UpdateRequired
 import com.stripe.android.financialconnections.repository.AccountUpdateRequiredContentRepository.State
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
-import javax.inject.Singleton
 
-@Singleton
+@ActivityRetainedScope
 internal class AccountUpdateRequiredContentRepository @Inject constructor(
     savedStateHandle: SavedStateHandle,
 ) : PersistingRepository<State>(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/AttachedPaymentAccountRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/AttachedPaymentAccountRepository.kt
@@ -3,15 +3,15 @@ package com.stripe.android.financialconnections.repository
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.core.Logger
+import com.stripe.android.financialconnections.di.ActivityRetainedScope
 import com.stripe.android.financialconnections.model.PaymentAccountParams
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
-import javax.inject.Singleton
 
 /**
  * Repository for attached payment accounts.
  */
-@Singleton
+@ActivityRetainedScope
 internal class AttachedPaymentAccountRepository @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val logger: Logger,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsErrorRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsErrorRepository.kt
@@ -2,12 +2,12 @@ package com.stripe.android.financialconnections.repository
 
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
+import com.stripe.android.financialconnections.di.ActivityRetainedScope
 import com.stripe.android.financialconnections.repository.FinancialConnectionsErrorRepository.State
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
-import javax.inject.Singleton
 
-@Singleton
+@ActivityRetainedScope
 internal class FinancialConnectionsErrorRepository @Inject constructor(
     savedStateHandle: SavedStateHandle,
 ) : PersistingRepository<State>(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/NoticeSheetContentRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/NoticeSheetContentRepository.kt
@@ -2,13 +2,13 @@ package com.stripe.android.financialconnections.repository
 
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
+import com.stripe.android.financialconnections.di.ActivityRetainedScope
 import com.stripe.android.financialconnections.features.notice.NoticeSheetState.NoticeSheetContent
 import com.stripe.android.financialconnections.repository.NoticeSheetContentRepository.State
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
-import javax.inject.Singleton
 
-@Singleton
+@ActivityRetainedScope
 internal class NoticeSheetContentRepository @Inject constructor(
     savedStateHandle: SavedStateHandle,
 ) : PersistingRepository<State>(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/SuccessContentRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/SuccessContentRepository.kt
@@ -2,13 +2,13 @@ package com.stripe.android.financialconnections.repository
 
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
+import com.stripe.android.financialconnections.di.ActivityRetainedScope
 import com.stripe.android.financialconnections.repository.SuccessContentRepository.State
 import com.stripe.android.financialconnections.ui.TextResource
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
-import javax.inject.Singleton
 
-@Singleton
+@ActivityRetainedScope
 internal class SuccessContentRepository @Inject constructor(
     savedStateHandle: SavedStateHandle,
 ) : PersistingRepository<State>(


### PR DESCRIPTION
# Summary
Today, we're using the `@Singleton` dagger scope wrongly, as dependencies are not shared across activities or match the app's lifecycle ([see docs](https://dagger.dev/dev-guide/subcomponents.html#:~:text=The%20standard%20scope%20is%20%40Singleton,so%20they%20can%20be%20reused.)).

This PR replaces current `Singleton` scope usages by `ActivityRetainedScope`, that clearly defines the real scope of existing dependencies.

Additionally, this PR includes a way to share dependencies across activities (real `@Singleton` scope), by defining a thread-safe singleton pattern for `SharedComponentHolder` to manage shared dependencies (e.g., Play Integrity API) across activities. 

# Motivation
We're preparing the ground to share the Integrity component across activities. 

The idea is to call `Integrity#prepare` on Activity A (`FinancialConnectionsSheetActivity`) and reuse the same Integrity instance in Activity B (`FinancialConnectionsNativeActivity`) when generating tokens.

Took the opportunity to fix our current scope setup. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified
