### PR TITLE
Replace references to identity cards with identity document (fixes #9829)

### DIFF
--- a/identity/res/values/strings.xml
+++ b/identity/res/values/strings.xml
@@ -12,10 +12,8 @@
   <string name="stripe_back_of_dl">Back of driver\'s license</string>
   <!-- Description of the checkmark to indicate back of driver's license is uploaded, used for A11Y -->
   <string name="stripe_back_of_dl_selected">Back of driver license is selected</string>
-  <!-- Description of back of identity card image -->
-  <string name="stripe_back_of_id">Back of identity card</string>
-  <!-- Title of ID document scanning screen when scanning the back of an identity card -->
-  <string name="stripe_back_of_id_document">Back of identity document</string>
+  <!-- Description of back of identity document image -->
+  <string name="stripe_back_of_id">Back of identity document</string>
   <!-- Description of the checkmark to indicate back of ID is uploaded, used for A11Y -->
   <string name="stripe_back_of_id_selected">Back of ID is selected</string>
   <!-- Title displayed when requesting camera permissions -->
@@ -94,8 +92,8 @@
   <string name="stripe_file_upload">File Upload</string>
   <!-- Instructions for uploading images of drivers license -->
   <string name="stripe_file_upload_content_dl">Please upload images of the front and back of your driver\'s license</string>
-  <!-- Instructions for uploading images of identity card -->
-  <string name="stripe_file_upload_content_id">Please upload images of the front and back of your identity card</string>
+  <!-- Instructions for uploading images of identity document -->
+  <string name="stripe_file_upload_content_id">Please upload images of the front and back of your identity document</string>
   <!-- Instructions for uploading images of passport -->
   <string name="stripe_file_upload_content_passport">Please upload an image of your passport</string>
   <!-- Label for first (given) name field -->
@@ -106,10 +104,8 @@
   <string name="stripe_front_of_dl">Front of driver\'s license</string>
   <!-- Description of the checkmark to indicate front of driver's license is uploaded, used for A11Y -->
   <string name="stripe_front_of_dl_selected">Front of driver license is selected</string>
-  <!-- Description of front of identity card image -->
-  <string name="stripe_front_of_id">Front of identity card</string>
-  <!-- Title of ID document scanning screen when scanning the front of an identity card -->
-  <string name="stripe_front_of_id_document">Front of identity document</string>
+  <!-- Description of front of identity document image -->
+  <string name="stripe_front_of_id">Front of identity document</string>
   <!-- Description of the checkmark to indicate front of ID is uploaded, used for A11Y -->
   <string name="stripe_front_of_id_selected">Front of ID is selected</string>
   <!-- Button to go back to the previous screen -->
@@ -164,10 +160,10 @@
   <string name="stripe_position_dl_back">Flip your driver\'s license over to the other side</string>
   <!-- Instructional text for scanning front of a driver's license -->
   <string name="stripe_position_dl_front">Position your driver\'s license in the center of the frame</string>
-  <!-- Instructional text for scanning back of a identity card -->
-  <string name="stripe_position_id_back">Flip your identity card over to the other side</string>
-  <!-- Instructional text for scanning front of a identity card -->
-  <string name="stripe_position_id_front">Position your identity card in the center of the frame</string>
+  <!-- Instructional text for scanning back of a identity document -->
+  <string name="stripe_position_id_back">Flip your identity document over to the other side</string>
+  <!-- Instructional text for scanning front of a identity document -->
+  <string name="stripe_position_id_front">Position your identity document in the center of the frame</string>
   <!-- Instructional text for scanning a passport -->
   <string name="stripe_position_passport">Position your passport in the center of the frame</string>
   <!-- Instructional text for capturing selfie -->

--- a/identity/res/values/strings.xml
+++ b/identity/res/values/strings.xml
@@ -12,8 +12,10 @@
   <string name="stripe_back_of_dl">Back of driver\'s license</string>
   <!-- Description of the checkmark to indicate back of driver's license is uploaded, used for A11Y -->
   <string name="stripe_back_of_dl_selected">Back of driver license is selected</string>
-  <!-- Description of back of identity document image -->
-  <string name="stripe_back_of_id">Back of identity document</string>
+  <!-- Description of back of identity card image -->
+  <string name="stripe_back_of_id">Back of identity card</string>
+  <!-- Title of ID document scanning screen when scanning the back of an identity card -->
+  <string name="stripe_back_of_id_document">Back of identity document</string>
   <!-- Description of the checkmark to indicate back of ID is uploaded, used for A11Y -->
   <string name="stripe_back_of_id_selected">Back of ID is selected</string>
   <!-- Title displayed when requesting camera permissions -->
@@ -92,8 +94,8 @@
   <string name="stripe_file_upload">File Upload</string>
   <!-- Instructions for uploading images of drivers license -->
   <string name="stripe_file_upload_content_dl">Please upload images of the front and back of your driver\'s license</string>
-  <!-- Instructions for uploading images of identity document -->
-  <string name="stripe_file_upload_content_id">Please upload images of the front and back of your identity document</string>
+  <!-- Instructions for uploading images of identity card -->
+  <string name="stripe_file_upload_content_id">Please upload images of the front and back of your identity card</string>
   <!-- Instructions for uploading images of passport -->
   <string name="stripe_file_upload_content_passport">Please upload an image of your passport</string>
   <!-- Label for first (given) name field -->
@@ -104,8 +106,10 @@
   <string name="stripe_front_of_dl">Front of driver\'s license</string>
   <!-- Description of the checkmark to indicate front of driver's license is uploaded, used for A11Y -->
   <string name="stripe_front_of_dl_selected">Front of driver license is selected</string>
-  <!-- Description of front of identity document image -->
-  <string name="stripe_front_of_id">Front of identity document</string>
+  <!-- Description of front of identity card image -->
+  <string name="stripe_front_of_id">Front of identity card</string>
+  <!-- Title of ID document scanning screen when scanning the front of an identity card -->
+  <string name="stripe_front_of_id_document">Front of identity document</string>
   <!-- Description of the checkmark to indicate front of ID is uploaded, used for A11Y -->
   <string name="stripe_front_of_id_selected">Front of ID is selected</string>
   <!-- Button to go back to the previous screen -->
@@ -160,10 +164,10 @@
   <string name="stripe_position_dl_back">Flip your driver\'s license over to the other side</string>
   <!-- Instructional text for scanning front of a driver's license -->
   <string name="stripe_position_dl_front">Position your driver\'s license in the center of the frame</string>
-  <!-- Instructional text for scanning back of a identity document -->
-  <string name="stripe_position_id_back">Flip your identity document over to the other side</string>
-  <!-- Instructional text for scanning front of a identity document -->
-  <string name="stripe_position_id_front">Position your identity document in the center of the frame</string>
+  <!-- Instructional text for scanning back of a identity card -->
+  <string name="stripe_position_id_back">Flip your identity card over to the other side</string>
+  <!-- Instructional text for scanning front of a identity card -->
+  <string name="stripe_position_id_front">Position your identity card in the center of the frame</string>
   <!-- Instructional text for scanning a passport -->
   <string name="stripe_position_passport">Position your passport in the center of the frame</string>
   <!-- Instructional text for capturing selfie -->

--- a/identity/src/main/java/com/stripe/android/identity/ui/DocumentScanScreen.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/DocumentScanScreen.kt
@@ -179,9 +179,9 @@ private fun DocumentCaptureScreen(
     }
 
     val title = if (targetScanType.isNullOrFront()) {
-        stringResource(id = R.string.stripe_front_of_id)
+        stringResource(id = R.string.stripe_front_of_id_document)
     } else {
-        stringResource(id = R.string.stripe_back_of_id)
+        stringResource(id = R.string.stripe_back_of_id_document)
     }
 
     Column(

--- a/identity/src/main/java/com/stripe/android/identity/ui/UploadScreen.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/UploadScreen.kt
@@ -389,7 +389,13 @@ private fun SingleSideUploadRow(
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
         Text(
-            text = stringResource(id = if (isFront) R.string.stripe_front_of_id_document else R.string.stripe_back_of_id_document),
+            text = stringResource(
+                id = if (isFront) {
+                    R.string.stripe_front_of_id_document
+                } else {
+                    R.string.stripe_back_of_id_document
+                }
+            ),
             modifier = Modifier.align(CenterVertically)
         )
         when (uploadUiState) {

--- a/identity/src/main/java/com/stripe/android/identity/ui/UploadScreen.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/UploadScreen.kt
@@ -314,7 +314,7 @@ internal fun UploadImageDialog(
                         end = 24.dp
                     ),
                     text = stringResource(
-                        id = if (isFront) R.string.stripe_front_of_id else R.string.stripe_back_of_id
+                        id = if (isFront) R.string.stripe_front_of_id_document else R.string.stripe_back_of_id_document
                     ),
                     style = MaterialTheme.typography.subtitle1,
                     fontWeight = FontWeight.Bold
@@ -389,7 +389,7 @@ private fun SingleSideUploadRow(
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
         Text(
-            text = stringResource(id = if (isFront) R.string.stripe_front_of_id else R.string.stripe_back_of_id),
+            text = stringResource(id = if (isFront) R.string.stripe_front_of_id_document else R.string.stripe_back_of_id_document),
             modifier = Modifier.align(CenterVertically)
         )
         when (uploadUiState) {

--- a/identity/src/test/java/com/stripe/android/identity/ui/DocumentScanScreenTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/ui/DocumentScanScreenTest.kt
@@ -98,7 +98,7 @@ class DocumentScanScreenTest {
         testDocumentScanScreen(
             scannerState = IdentityScanViewModel.State.Scanning(),
         ) {
-            onNodeWithTag(SCAN_TITLE_TAG).assertTextEquals(context.getString(R.string.stripe_front_of_id))
+            onNodeWithTag(SCAN_TITLE_TAG).assertTextEquals(context.getString(R.string.stripe_front_of_id_document))
             onNodeWithTag(SCAN_MESSAGE_TAG).assertTextEquals(context.getString(R.string.stripe_position_id_front))
             onNodeWithTag(CHECK_MARK_TAG).assertDoesNotExist()
             onNodeWithTag(CONTINUE_BUTTON_TAG).onChildAt(0).assertIsNotEnabled()
@@ -116,7 +116,7 @@ class DocumentScanScreenTest {
                 eq(IdentityScanState.ScanType.DOC_FRONT),
                 any()
             )
-            onNodeWithTag(SCAN_TITLE_TAG).assertTextEquals(context.getString(R.string.stripe_front_of_id))
+            onNodeWithTag(SCAN_TITLE_TAG).assertTextEquals(context.getString(R.string.stripe_front_of_id_document))
             onNodeWithTag(SCAN_MESSAGE_TAG).assertTextEquals(context.getString(R.string.stripe_hold_still))
             onNodeWithTag(CHECK_MARK_TAG).assertDoesNotExist()
             onNodeWithTag(CONTINUE_BUTTON_TAG).onChildAt(0).assertIsNotEnabled()
@@ -135,7 +135,7 @@ class DocumentScanScreenTest {
                 eq(IdentityScanState.ScanType.DOC_BACK),
                 any()
             )
-            onNodeWithTag(SCAN_TITLE_TAG).assertTextEquals(context.getString(R.string.stripe_back_of_id))
+            onNodeWithTag(SCAN_TITLE_TAG).assertTextEquals(context.getString(R.string.stripe_back_of_id_document))
             onNodeWithTag(SCAN_MESSAGE_TAG).assertTextEquals(context.getString(R.string.stripe_hold_still))
             onNodeWithTag(CHECK_MARK_TAG).assertDoesNotExist()
             onNodeWithTag(CONTINUE_BUTTON_TAG).onChildAt(0).assertIsNotEnabled()
@@ -156,7 +156,7 @@ class DocumentScanScreenTest {
             messageId = R.string.stripe_scanned
         ) {
             verify(mockDocumentScanViewModel).stopScan(any())
-            onNodeWithTag(SCAN_TITLE_TAG).assertTextEquals(context.getString(R.string.stripe_front_of_id))
+            onNodeWithTag(SCAN_TITLE_TAG).assertTextEquals(context.getString(R.string.stripe_front_of_id_document))
             onNodeWithTag(SCAN_MESSAGE_TAG).assertTextEquals(context.getString(R.string.stripe_scanned))
             onNodeWithTag(CHECK_MARK_TAG).assertExists()
             onNodeWithTag(CONTINUE_BUTTON_TAG).onChildAt(0).assertIsEnabled()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Instead of referring to an ID as "Identity Card" we use the term "Identity Document" to avoid confusion when only one type non-card identity is permitted.

Also remove unused definitions of `stripe_back_of_id_document` and `stripe_front_of_id_document` messages.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Addresses https://github.com/stripe/stripe-android/issues/8511

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
|  <img width="378" alt="CleanShot 2024-12-24 at 14 35 47@2x" src="https://github.com/user-attachments/assets/adff9068-ec3d-4574-8834-4494c5a3864f" /> |  <img width="377" alt="image" src="https://github.com/user-attachments/assets/6a5dad26-06e4-4c87-a0da-f9473f824ed5" /> |




# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
- [Changed] all references to "Identity Card" to say "Identity Document"