### PR TITLE
[FC] Add app verification to `signup` flows (Networking+ID)

### DIFF
--- a/financial-connections/detekt-baseline.xml
+++ b/financial-connections/detekt-baseline.xml
@@ -31,6 +31,8 @@
     <ID>SwallowedException:PollAttachPaymentAccount.kt$PollAttachPaymentAccount$e: StripeException</ID>
     <ID>SwallowedException:PollAuthorizationSessionAccounts.kt$PollAuthorizationSessionAccounts$e: StripeException</ID>
     <ID>SwallowedException:PostAuthorizationSession.kt$PostAuthorizationSession$e: StripeException</ID>
+    <ID>TooManyFunctions:FinancialConnectionsConsumerSessionRepository.kt$FinancialConnectionsConsumerSessionRepository</ID>
+    <ID>TooManyFunctions:FinancialConnectionsConsumerSessionRepository.kt$FinancialConnectionsConsumerSessionRepositoryImpl : FinancialConnectionsConsumerSessionRepository</ID>
     <ID>TooManyFunctions:FinancialConnectionsManifestRepository.kt$FinancialConnectionsManifestRepository</ID>
     <ID>TooManyFunctions:FinancialConnectionsManifestRepository.kt$FinancialConnectionsManifestRepositoryImpl : FinancialConnectionsManifestRepository</ID>
     <ID>TooManyFunctions:FinancialConnectionsSheetNativeViewModel.kt$FinancialConnectionsSheetNativeViewModel : FinancialConnectionsViewModelTopAppBarHost</ID>

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinksignup/LinkSignupHandlerForInstantDebitsTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinksignup/LinkSignupHandlerForInstantDebitsTest.kt
@@ -1,0 +1,143 @@
+package com.stripe.android.financialconnections.features.networkinglinksignup
+
+import com.stripe.android.financialconnections.ApiKeyFixtures.consumerSessionSignup
+import com.stripe.android.financialconnections.ApiKeyFixtures.sessionManifest
+import com.stripe.android.financialconnections.ApiKeyFixtures.syncResponse
+import com.stripe.android.financialconnections.domain.AttachConsumerToLinkAccountSession
+import com.stripe.android.financialconnections.domain.GetOrFetchSync
+import com.stripe.android.financialconnections.domain.HandleError
+import com.stripe.android.financialconnections.features.networkinglinksignup.NetworkingLinkSignupState.Payload
+import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
+import com.stripe.android.financialconnections.navigation.NavigationManager
+import com.stripe.android.financialconnections.presentation.Async
+import com.stripe.android.financialconnections.repository.FinancialConnectionsConsumerSessionRepository
+import com.stripe.android.financialconnections.utils.TestIntegrityRequestManager
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class LinkSignupHandlerForInstantDebitsTest {
+
+    private lateinit var handler: LinkSignupHandlerForInstantDebits
+    private val consumerRepository = mock<FinancialConnectionsConsumerSessionRepository>()
+    private val getOrFetchSync = mock<GetOrFetchSync>()
+    private val attachConsumerToLinkAccountSession = mock<AttachConsumerToLinkAccountSession>()
+    private val integrityRequestManager = TestIntegrityRequestManager()
+    private val navigationManager = mock<NavigationManager>()
+    private val handleError = mock<HandleError>()
+
+    @Before
+    fun setUp() {
+        handler = LinkSignupHandlerForInstantDebits(
+            consumerRepository,
+            attachConsumerToLinkAccountSession,
+            integrityRequestManager,
+            getOrFetchSync,
+            navigationManager,
+            "applicationId",
+            handleError
+        )
+    }
+
+    private val validPayload = Payload(
+        merchantName = "Mock Merchant",
+        emailController = mock(),
+        prefilledEmail = "test@stripe.com",
+        sessionId = "fcsess_1234",
+        appVerificationEnabled = false,
+        phoneController = mock {
+            whenever(it.getCountryCode()).thenReturn("US")
+        },
+        isInstantDebits = true,
+        content = mock()
+    )
+
+    @Test
+    fun `performSignup should navigate to next pane on success`() = runTest {
+        val testState = NetworkingLinkSignupState(
+            validEmail = "test@example.com",
+            validPhone = "+123456789",
+            isInstantDebits = true,
+            payload = Async.Success(validPayload)
+        )
+
+        val expectedPane = Pane.INSTITUTION_PICKER
+        whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(
+            syncResponse(
+                sessionManifest().copy(
+                    nextPane = expectedPane,
+                    appVerificationEnabled = true
+                )
+            )
+        )
+        whenever(
+            consumerRepository.mobileSignUp(
+                email = any(),
+                phoneNumber = any(),
+                country = any(),
+                verificationToken = any(),
+                appId = any()
+            )
+        ).thenReturn(consumerSessionSignup())
+
+        val result = handler.performSignup(testState)
+
+        verify(attachConsumerToLinkAccountSession).invoke(any())
+        assertEquals(expectedPane, result)
+    }
+
+    @Test
+    fun `handleSignupFailure should call handleError with correct parameters`() = runTest {
+        val error = RuntimeException("Test Error")
+        handler.handleSignupFailure(error)
+
+        verify(handleError).invoke(
+            extraMessage = "Error creating a Link account",
+            error = error,
+            pane = Pane.LINK_LOGIN,
+            displayErrorScreen = true
+        )
+    }
+
+    @Test
+    fun `performSignup should proceed without verification when appVerificationEnabled is false`() = runTest {
+        val testState = NetworkingLinkSignupState(
+            validEmail = "test@instantdebits.com",
+            validPhone = "+1234567890",
+            isInstantDebits = true,
+            payload = Async.Success(validPayload)
+        )
+
+        whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(
+            syncResponse(
+                sessionManifest().copy(
+                    appVerificationEnabled = false,
+                    nextPane = Pane.INSTITUTION_PICKER
+                )
+            )
+        )
+
+        whenever(consumerRepository.signUp(any(), any(), any()))
+            .thenReturn(consumerSessionSignup())
+
+        val expectedNextPane = Pane.INSTITUTION_PICKER
+        val result = handler.performSignup(testState)
+
+        verify(consumerRepository).signUp(
+            email = eq("test@instantdebits.com"),
+            phoneNumber = eq("+1234567890"),
+            country = eq("US")
+        )
+
+        verify(attachConsumerToLinkAccountSession).invoke(any())
+
+        assertEquals(expectedNextPane, result)
+    }
+}

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinksignup/LinkSignupHandlerForNetworkingTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinksignup/LinkSignupHandlerForNetworkingTest.kt
@@ -1,0 +1,157 @@
+package com.stripe.android.financialconnections.features.networkinglinksignup
+
+import com.stripe.android.core.Logger
+import com.stripe.android.financialconnections.ApiKeyFixtures.consumerSessionSignup
+import com.stripe.android.financialconnections.ApiKeyFixtures.sessionManifest
+import com.stripe.android.financialconnections.ApiKeyFixtures.syncResponse
+import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsTracker
+import com.stripe.android.financialconnections.analytics.logError
+import com.stripe.android.financialconnections.domain.CachedPartnerAccount
+import com.stripe.android.financialconnections.domain.GetCachedAccounts
+import com.stripe.android.financialconnections.domain.GetOrFetchSync
+import com.stripe.android.financialconnections.domain.SaveAccountToLink
+import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
+import com.stripe.android.financialconnections.navigation.Destination
+import com.stripe.android.financialconnections.presentation.Async
+import com.stripe.android.financialconnections.repository.FinancialConnectionsConsumerSessionRepository
+import com.stripe.android.financialconnections.utils.TestIntegrityRequestManager
+import com.stripe.android.financialconnections.utils.TestNavigationManager
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class LinkSignupHandlerForNetworkingTest {
+
+    private lateinit var handler: LinkSignupHandlerForNetworking
+    private val consumerRepository = mock<FinancialConnectionsConsumerSessionRepository>()
+    private val getOrFetchSync = mock<GetOrFetchSync>()
+    private val getCachedAccounts = mock<GetCachedAccounts>()
+    private val saveAccountToLink = mock<SaveAccountToLink>()
+    private val integrityRequestManager = TestIntegrityRequestManager()
+    private val navigationManager = TestNavigationManager()
+    private val eventTracker = mock<FinancialConnectionsAnalyticsTracker>()
+    private val logger = mock<Logger>()
+
+    @Before
+    fun setUp() {
+        handler = LinkSignupHandlerForNetworking(
+            consumerRepository,
+            getOrFetchSync,
+            getCachedAccounts,
+            integrityRequestManager,
+            saveAccountToLink,
+            eventTracker,
+            navigationManager,
+            "applicationId",
+            logger
+        )
+    }
+
+    private val validPayload = NetworkingLinkSignupState.Payload(
+        merchantName = "Mock Merchant",
+        emailController = mock(),
+        prefilledEmail = "test@networking.com",
+        sessionId = "fcsess_5678",
+        appVerificationEnabled = true,
+        phoneController = mock {
+            whenever(it.getCountryCode()).thenReturn("US")
+        },
+        isInstantDebits = false,
+        content = mock()
+    )
+
+    @Test
+    fun `performSignup on verified flows should save account and return success pane on success`() = runTest {
+        val testState = NetworkingLinkSignupState(
+            validEmail = "test@networking.com",
+            validPhone = "+1987654321",
+            isInstantDebits = false,
+            payload = Async.Success(validPayload)
+        )
+
+        val expectedPane = Pane.SUCCESS
+
+        whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(
+            syncResponse(sessionManifest().copy(appVerificationEnabled = true))
+        )
+        whenever(getCachedAccounts()).thenReturn(listOf(mock())) // Mock a list of cached accounts
+        whenever(
+            consumerRepository.mobileSignUp(
+                email = any(),
+                phoneNumber = any(),
+                country = any(),
+                verificationToken = any(),
+                appId = any()
+            )
+        ).thenReturn(consumerSessionSignup())
+
+        val result = handler.performSignup(testState)
+
+        verify(consumerRepository).mobileSignUp(
+            email = eq("test@networking.com"),
+            phoneNumber = eq("+1987654321"),
+            country = eq("US"),
+            verificationToken = eq(integrityRequestManager.requestTokenResult.getOrThrow()),
+            appId = eq("applicationId")
+        )
+        verify(saveAccountToLink).existing(any(), any(), any())
+        assertEquals(expectedPane, result)
+    }
+
+    @Test
+    fun `handleSignupFailure should log error and navigate to Success pane`() = runTest {
+        val error = RuntimeException("Test Error")
+
+        handler.handleSignupFailure(error)
+
+        verify(eventTracker).logError(
+            extraMessage = "Error saving account to Link",
+            error = error,
+            logger = logger,
+            pane = Pane.NETWORKING_LINK_SIGNUP_PANE
+        )
+
+        navigationManager.assertNavigatedTo(
+            destination = Destination.Success,
+            pane = Pane.NETWORKING_LINK_SIGNUP_PANE
+        )
+    }
+
+    @Test
+    fun `performSignup should use legacy signup flow when verification is false`() = runTest {
+        val testState = NetworkingLinkSignupState(
+            validEmail = "legacy@example.com",
+            validPhone = "+1987654321",
+            isInstantDebits = false,
+            payload = Async.Success(validPayload)
+        )
+
+        whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(
+            syncResponse(sessionManifest().copy(appVerificationEnabled = false))
+        )
+        val cachedAccounts = listOf(mock<CachedPartnerAccount>()) // Ensure this matches what you return
+        whenever(getCachedAccounts()).thenReturn(cachedAccounts)
+
+        val expectedPane = Pane.SUCCESS
+
+        val result = handler.performSignup(testState)
+
+        verifyNoInteractions(consumerRepository)
+        verify(saveAccountToLink).new(
+            email = eq("legacy@example.com"),
+            phoneNumber = eq("+1987654321"),
+            selectedAccounts = eq(cachedAccounts),
+            country = eq("US"),
+            shouldPollAccountNumbers = eq(true)
+        )
+        assertEquals(expectedPane, result)
+    }
+}

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepositoryImplTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepositoryImplTest.kt
@@ -26,7 +26,9 @@ import com.stripe.android.repository.ConsumersApiService
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argThat
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -81,17 +83,8 @@ class FinancialConnectionsConsumerSessionRepositoryImplTest {
 
         whenever(
             consumersApiService.signUp(
-                email = anyOrNull(),
-                phoneNumber = anyOrNull(),
-                country = anyOrNull(),
-                name = anyOrNull(),
-                locale = anyOrNull(),
-                amount = anyOrNull(),
-                currency = anyOrNull(),
-                incentiveEligibilitySession = anyOrNull(),
-                consentAction = anyOrNull(),
-                requestSurface = anyOrNull(),
-                requestOptions = anyOrNull(),
+                params = any(),
+                requestOptions = anyOrNull()
             )
         ).thenReturn(Result.success(consumerSessionSignup))
 
@@ -138,16 +131,10 @@ class FinancialConnectionsConsumerSessionRepositoryImplTest {
 
         whenever(
             consumersApiService.signUp(
-                email = anyOrNull(),
-                phoneNumber = anyOrNull(),
-                country = anyOrNull(),
-                name = anyOrNull(),
-                locale = anyOrNull(),
-                amount = eq(1234),
-                currency = eq("cad"),
-                incentiveEligibilitySession = eq(IncentiveEligibilitySession.PaymentIntent("pi_123")),
-                consentAction = anyOrNull(),
-                requestSurface = anyOrNull(),
+                params = argThat {
+                    currency == "cad" &&
+                        incentiveEligibilitySession == IncentiveEligibilitySession.PaymentIntent("pi_123")
+                },
                 requestOptions = anyOrNull(),
             )
         ).thenReturn(
@@ -331,17 +318,8 @@ class FinancialConnectionsConsumerSessionRepositoryImplTest {
 
         whenever(
             consumersApiService.signUp(
-                email = anyOrNull(),
-                phoneNumber = anyOrNull(),
-                country = anyOrNull(),
-                name = anyOrNull(),
-                locale = anyOrNull(),
-                amount = anyOrNull(),
-                currency = anyOrNull(),
-                incentiveEligibilitySession = anyOrNull(),
-                consentAction = anyOrNull(),
-                requestSurface = anyOrNull(),
-                requestOptions = anyOrNull(),
+                params = any(),
+                requestOptions = anyOrNull()
             )
         ).thenReturn(Result.success(consumerSessionSignup()))
 
@@ -352,17 +330,8 @@ class FinancialConnectionsConsumerSessionRepositoryImplTest {
         )
 
         verify(consumersApiService).signUp(
-            email = anyOrNull(),
-            phoneNumber = anyOrNull(),
-            country = anyOrNull(),
-            name = anyOrNull(),
-            locale = anyOrNull(),
-            amount = anyOrNull(),
-            currency = anyOrNull(),
-            incentiveEligibilitySession = anyOrNull(),
-            requestSurface = eq("android_connections"),
-            consentAction = anyOrNull(),
-            requestOptions = anyOrNull(),
+            params = argThat { requestSurface == "android_connections" },
+            requestOptions = anyOrNull()
         )
     }
 
@@ -372,17 +341,8 @@ class FinancialConnectionsConsumerSessionRepositoryImplTest {
 
         whenever(
             consumersApiService.signUp(
-                email = anyOrNull(),
-                phoneNumber = anyOrNull(),
-                country = anyOrNull(),
-                name = anyOrNull(),
-                locale = anyOrNull(),
-                amount = anyOrNull(),
-                currency = anyOrNull(),
-                incentiveEligibilitySession = anyOrNull(),
-                consentAction = anyOrNull(),
-                requestSurface = anyOrNull(),
-                requestOptions = anyOrNull(),
+                params = any(),
+                requestOptions = anyOrNull()
             )
         ).thenReturn(Result.success(consumerSessionSignup()))
 
@@ -393,17 +353,10 @@ class FinancialConnectionsConsumerSessionRepositoryImplTest {
         )
 
         verify(consumersApiService).signUp(
-            email = anyOrNull(),
-            phoneNumber = anyOrNull(),
-            country = anyOrNull(),
-            name = anyOrNull(),
-            locale = anyOrNull(),
-            amount = anyOrNull(),
-            currency = anyOrNull(),
-            incentiveEligibilitySession = anyOrNull(),
-            requestSurface = eq("android_instant_debits"),
-            consentAction = anyOrNull(),
-            requestOptions = anyOrNull(),
+            params = argThat {
+                requestSurface == "android_instant_debits"
+            },
+            requestOptions = anyOrNull()
         )
     }
 

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/utils/TestIntegrityRequestManager.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/utils/TestIntegrityRequestManager.kt
@@ -6,6 +6,7 @@ internal class TestIntegrityRequestManager(
     val prepareResult: Result<Unit> = Result.success(Unit),
     val requestTokenResult: Result<String> = Result.success("token")
 ) : IntegrityRequestManager {
+
     override suspend fun prepare(): Result<Unit> = prepareResult
 
     override suspend fun requestToken(requestIdentifier: String?): Result<String> = requestTokenResult

--- a/payments-model/src/main/java/com/stripe/android/model/SignUpParams.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/SignUpParams.kt
@@ -1,0 +1,53 @@
+package com.stripe.android.model
+
+import androidx.annotation.RestrictTo
+import java.util.Locale
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
+data class SignUpParams(
+    val email: String,
+    val phoneNumber: String,
+    val country: String,
+    val name: String?,
+    val locale: Locale?,
+    val amount: Long?,
+    val currency: String?,
+    val incentiveEligibilitySession: IncentiveEligibilitySession?,
+    val requestSurface: String,
+    val consentAction: ConsumerSignUpConsentAction,
+    val verificationToken: String? = null,
+    val appId: String? = null
+) {
+    fun toParamMap(): Map<String, *> {
+        val params = mutableMapOf(
+            "email_address" to email.lowercase(),
+            "phone_number" to phoneNumber,
+            "country" to country,
+            "country_inferring_method" to "PHONE_NUMBER",
+            "amount" to amount,
+            "currency" to currency,
+            "consent_action" to consentAction.value,
+            "request_surface" to requestSurface
+        )
+
+        locale?.let {
+            params["locale"] = it.toLanguageTag()
+        }
+
+        name?.let {
+            params["legal_name"] = it
+        }
+
+        verificationToken?.let {
+            params["android_verification_token"] = it
+        }
+
+        appId?.let {
+            params["app_id"] = it
+        }
+
+        params.putAll(incentiveEligibilitySession?.toParamMap().orEmpty())
+
+        return params.toMap()
+    }
+}

--- a/payments-model/src/test/java/com/stripe/android/repository/ConsumersApiServiceImplTest.kt
+++ b/payments-model/src/test/java/com/stripe/android/repository/ConsumersApiServiceImplTest.kt
@@ -13,6 +13,7 @@ import com.stripe.android.model.ConsumerPaymentDetailsCreateParams
 import com.stripe.android.model.ConsumerSession
 import com.stripe.android.model.ConsumerSignUpConsentAction
 import com.stripe.android.model.IncentiveEligibilitySession
+import com.stripe.android.model.SignUpParams
 import com.stripe.android.model.VerificationType
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
@@ -61,16 +62,18 @@ class ConsumersApiServiceImplTest {
         }
 
         val signup = consumersApiService.signUp(
-            email = email,
-            phoneNumber = "+15555555568",
-            country = "US",
-            name = null,
-            locale = Locale.US,
-            amount = 1234,
-            currency = "cad",
-            incentiveEligibilitySession = IncentiveEligibilitySession.PaymentIntent("pi_123"),
-            consentAction = ConsumerSignUpConsentAction.Checkbox,
-            requestSurface = requestSurface,
+            SignUpParams(
+                email = email,
+                phoneNumber = "+15555555568",
+                country = "US",
+                name = null,
+                locale = Locale.US,
+                amount = 1234,
+                currency = "cad",
+                incentiveEligibilitySession = IncentiveEligibilitySession.PaymentIntent("pi_123"),
+                consentAction = ConsumerSignUpConsentAction.Checkbox,
+                requestSurface = requestSurface,
+            ),
             requestOptions = DEFAULT_OPTIONS,
         ).getOrThrow()
 

--- a/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
@@ -15,6 +15,7 @@ import com.stripe.android.model.ConsumerSessionLookup
 import com.stripe.android.model.ConsumerSessionSignup
 import com.stripe.android.model.ConsumerSignUpConsentAction
 import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.model.SignUpParams
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.VerificationType
 import com.stripe.android.networking.StripeRepository
@@ -61,17 +62,19 @@ internal class LinkApiRepository @Inject constructor(
         consentAction: ConsumerSignUpConsentAction
     ): Result<ConsumerSessionSignup> = withContext(workContext) {
         consumersApiService.signUp(
-            email = email,
-            phoneNumber = phone,
-            country = country,
-            name = name,
-            locale = locale,
-            amount = null,
-            currency = null,
-            incentiveEligibilitySession = null,
-            consentAction = consentAction,
+            SignUpParams(
+                email = email,
+                phoneNumber = phone,
+                country = country,
+                name = name,
+                locale = locale,
+                amount = null,
+                currency = null,
+                incentiveEligibilitySession = null,
+                consentAction = consentAction,
+                requestSurface = REQUEST_SURFACE
+            ),
             requestOptions = buildRequestOptions(),
-            requestSurface = REQUEST_SURFACE,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
@@ -14,6 +14,7 @@ import com.stripe.android.model.ConsumerSessionSignup
 import com.stripe.android.model.ConsumerSignUpConsentAction
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.model.SignUpParams
 import com.stripe.android.model.VerificationType
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.core.analytics.ErrorReporter
@@ -124,16 +125,18 @@ class LinkApiRepositoryTest {
         )
 
         verify(consumersApiService).signUp(
-            email = email,
-            phoneNumber = phone,
-            country = country,
-            name = name,
-            locale = Locale.US,
-            amount = null,
-            currency = null,
-            incentiveEligibilitySession = null,
-            requestSurface = "android_payment_element",
-            consentAction = ConsumerSignUpConsentAction.Checkbox,
+            SignUpParams(
+                email = email,
+                phoneNumber = phone,
+                country = country,
+                name = name,
+                locale = Locale.US,
+                amount = null,
+                currency = null,
+                incentiveEligibilitySession = null,
+                requestSurface = "android_payment_element",
+                consentAction = ConsumerSignUpConsentAction.Checkbox,
+            ),
             requestOptions = ApiRequest.Options(PUBLISHABLE_KEY, STRIPE_ACCOUNT_ID),
         )
     }
@@ -143,16 +146,7 @@ class LinkApiRepositoryTest {
         val consumerSession = mock<ConsumerSessionSignup>()
         whenever(
             consumersApiService.signUp(
-                email = any(),
-                phoneNumber = any(),
-                country = any(),
-                name = anyOrNull(),
-                locale = anyOrNull(),
-                amount = anyOrNull(),
-                currency = anyOrNull(),
-                incentiveEligibilitySession = anyOrNull(),
-                requestSurface = any(),
-                consentAction = any(),
+                params = any(),
                 requestOptions = any()
             )
         ).thenReturn(Result.success(consumerSession))
@@ -173,16 +167,7 @@ class LinkApiRepositoryTest {
     fun `consumerSignUp catches exception and returns failure`() = runTest {
         whenever(
             consumersApiService.signUp(
-                email = any(),
-                phoneNumber = any(),
-                country = any(),
-                name = anyOrNull(),
-                locale = anyOrNull(),
-                amount = anyOrNull(),
-                currency = anyOrNull(),
-                incentiveEligibilitySession = anyOrNull(),
-                requestSurface = any(),
-                consentAction = any(),
+                params = any(),
                 requestOptions = any()
             )
         ).thenReturn(Result.failure(RuntimeException("error")))


### PR DESCRIPTION
# Summary
Added mobile signup endpoint and shared `SignUpParams`. 

We'll be calling the new mobile signup endpoint on verified flows (`manifest.app_verification_enabled`). 

To better understand the changes see this tables of endpoint changes for Networking and IBP:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/j4QBGdjO6ik9hWPXw0HE/4dea1a8a-1ec9-4232-a822-28e418492329.png)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/j4QBGdjO6ik9hWPXw0HE/5bfbbb28-e559-4325-af73-623263b9bafc.png)

# Motivation
Creating the foundation for implementing user sign up functionality in the Stripe Android SDK

# Testing
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Changelog
[Added] Created SignUpParams class structure for upcoming sign up implementation