### PR TITLE
[FC] Adds attestation analytics events.

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/analytics/FinancialConnectionsAnalyticsEvent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/analytics/FinancialConnectionsAnalyticsEvent.kt
@@ -6,6 +6,7 @@ import com.stripe.android.financialconnections.exception.FinancialConnectionsErr
 import com.stripe.android.financialconnections.exception.WebAuthFlowFailedException
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
 import com.stripe.android.financialconnections.utils.filterNotNullValues
+import com.stripe.attestation.AttestationError
 
 /**
  * Event definitions for Financial Connections.
@@ -410,6 +411,48 @@ internal sealed class FinancialConnectionsAnalyticsEvent(
         ).filterNotNullValues()
     )
 
+    class AttestationInitSkipped(pane: Pane) : FinancialConnectionsAnalyticsEvent(
+        name = "attestation.init_skipped",
+        mapOf(
+            "pane" to pane.analyticsValue,
+        ).filterNotNullValues()
+    )
+
+    class AttestationInitFailed(
+        pane: Pane,
+        error: Throwable
+    ) : FinancialConnectionsAnalyticsEvent(
+        name = "attestation.init_failed",
+        mapOf(
+            "pane" to pane.analyticsValue,
+            "error_reason" to if (error is AttestationError) error.errorType.name else "unknown"
+        ).filterNotNullValues()
+    )
+
+    class AttestationRequestSucceeded(
+        pane: Pane,
+        endpoint: AttestationEndpoint
+    ) : FinancialConnectionsAnalyticsEvent(
+        name = "attestation.request_token_succeeded",
+        mapOf(
+            "pane" to pane.analyticsValue,
+            "api" to endpoint.analyticsValue
+        ).filterNotNullValues()
+    )
+
+    class AttestationRequestFailed(
+        pane: Pane,
+        endpoint: AttestationEndpoint,
+        error: Throwable,
+    ) : FinancialConnectionsAnalyticsEvent(
+        name = "attestation.request_token_failed",
+        mapOf(
+            "pane" to pane.analyticsValue,
+            "api" to endpoint.analyticsValue,
+            "error_reason" to if (error is AttestationError) error.errorType.name else "unknown"
+        )
+    )
+
     internal val Pane.analyticsValue
         get() = when (this) {
             // We want to log partner_auth regardless of the pane being shown full-screen or as a drawer.
@@ -442,6 +485,11 @@ internal sealed class FinancialConnectionsAnalyticsEvent(
         result = 31 * result + includePrefix.hashCode()
         result = 31 * result + eventName.hashCode()
         return result
+    }
+
+    enum class AttestationEndpoint(val analyticsValue: String) {
+        LOOKUP("consumer_session_lookup"),
+        SIGNUP("link_sign_up"),
     }
 }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/analytics/FinancialConnectionsAnalyticsTracker.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/analytics/FinancialConnectionsAnalyticsTracker.kt
@@ -122,6 +122,7 @@ internal class FinancialConnectionsAnalyticsTrackerImpl(
             "is_stripe_direct" to manifest.isStripeDirect.toString(),
             "single_account" to manifest.singleAccount.toString(),
             "allow_manual_entry" to manifest.allowManualEntry.toString(),
+            "app_verification_enabled" to manifest.appVerificationEnabled.toString(),
             "account_holder_id" to manifest.accountholderToken,
         )
     }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/RequestIntegrityToken.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/RequestIntegrityToken.kt
@@ -1,0 +1,37 @@
+package com.stripe.android.financialconnections.domain
+
+import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.AttestationEndpoint
+import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.AttestationRequestFailed
+import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.AttestationRequestSucceeded
+import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsTracker
+import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
+import com.stripe.attestation.IntegrityRequestManager
+import jakarta.inject.Inject
+
+internal class RequestIntegrityToken @Inject constructor(
+    private val integrityRequestManager: IntegrityRequestManager,
+    private val analyticsTracker: FinancialConnectionsAnalyticsTracker
+) {
+    suspend operator fun invoke(
+        endpoint: AttestationEndpoint,
+        pane: FinancialConnectionsSessionManifest.Pane
+    ): String = integrityRequestManager.requestToken()
+        .onSuccess {
+            analyticsTracker.track(
+                AttestationRequestSucceeded(
+                    pane = pane,
+                    endpoint = endpoint
+                )
+            )
+        }
+        .onFailure {
+            analyticsTracker.track(
+                AttestationRequestFailed(
+                    pane = pane,
+                    endpoint = endpoint,
+                    error = it
+                )
+            )
+        }
+        .getOrThrow()
+}

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkloginwarmup/NetworkingLinkLoginWarmupViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkloginwarmup/NetworkingLinkLoginWarmupViewModel.kt
@@ -95,6 +95,7 @@ internal class NetworkingLinkLoginWarmupViewModel @AssistedInject constructor(
             eventTracker.track(Click("click.continue", PANE))
             // Trigger a lookup call to ensure we cache a consumer session for posterior verification.
             lookupAccount(
+                pane = PANE,
                 email = payload.email,
                 emailSource = EmailSource.CUSTOMER_OBJECT,
                 sessionId = payload.sessionId,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModel.kt
@@ -213,6 +213,7 @@ internal class NetworkingLinkSignupViewModel @AssistedInject constructor(
                 delay(getLookupDelayMs(validEmail))
                 val payload = stateFlow.value.payload()
                 lookupAccount(
+                    pane = pane,
                     email = validEmail,
                     emailSource = if (payload?.prefilledEmail == validEmail) CUSTOMER_OBJECT else USER_ACTION,
                     sessionId = payload?.sessionId ?: "",

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinkloginwarmup/NetworkingLinkLoginWarmupViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinkloginwarmup/NetworkingLinkLoginWarmupViewModelTest.kt
@@ -82,7 +82,8 @@ class NetworkingLinkLoginWarmupViewModelTest {
                 email = anyOrNull(),
                 emailSource = anyOrNull(),
                 verifiedFlow = anyOrNull(),
-                sessionId = anyOrNull()
+                sessionId = anyOrNull(),
+                pane = any()
             )
         ).thenReturn(
             ConsumerSessionLookup(
@@ -95,7 +96,7 @@ class NetworkingLinkLoginWarmupViewModelTest {
         val viewModel = buildViewModel(NetworkingLinkLoginWarmupState())
         viewModel.onContinueClick()
 
-        verify(lookupAccount).invoke(any(), any(), any(), any())
+        verify(lookupAccount).invoke(any(), any(), any(), any(), any())
         navigationManager.assertNavigatedTo(
             destination = Destination.NetworkingLinkVerification,
             pane = Pane.NETWORKING_LINK_LOGIN_WARMUP

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinksignup/LinkSignupHandlerForInstantDebitsTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinksignup/LinkSignupHandlerForInstantDebitsTest.kt
@@ -6,12 +6,12 @@ import com.stripe.android.financialconnections.ApiKeyFixtures.syncResponse
 import com.stripe.android.financialconnections.domain.AttachConsumerToLinkAccountSession
 import com.stripe.android.financialconnections.domain.GetOrFetchSync
 import com.stripe.android.financialconnections.domain.HandleError
+import com.stripe.android.financialconnections.domain.RequestIntegrityToken
 import com.stripe.android.financialconnections.features.networkinglinksignup.NetworkingLinkSignupState.Payload
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
 import com.stripe.android.financialconnections.navigation.NavigationManager
 import com.stripe.android.financialconnections.presentation.Async
 import com.stripe.android.financialconnections.repository.FinancialConnectionsConsumerSessionRepository
-import com.stripe.android.financialconnections.utils.TestIntegrityRequestManager
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.mockito.kotlin.any
@@ -29,7 +29,7 @@ class LinkSignupHandlerForInstantDebitsTest {
     private val consumerRepository = mock<FinancialConnectionsConsumerSessionRepository>()
     private val getOrFetchSync = mock<GetOrFetchSync>()
     private val attachConsumerToLinkAccountSession = mock<AttachConsumerToLinkAccountSession>()
-    private val integrityRequestManager = TestIntegrityRequestManager()
+    private val requestIntegrityToken = mock<RequestIntegrityToken>()
     private val navigationManager = mock<NavigationManager>()
     private val handleError = mock<HandleError>()
 
@@ -38,7 +38,7 @@ class LinkSignupHandlerForInstantDebitsTest {
         handler = LinkSignupHandlerForInstantDebits(
             consumerRepository,
             attachConsumerToLinkAccountSession,
-            integrityRequestManager,
+            requestIntegrityToken,
             getOrFetchSync,
             navigationManager,
             "applicationId",
@@ -61,6 +61,8 @@ class LinkSignupHandlerForInstantDebitsTest {
 
     @Test
     fun `performSignup should navigate to next pane on success`() = runTest {
+        val expectedToken = "token"
+        val expectedPane = Pane.INSTITUTION_PICKER
         val testState = NetworkingLinkSignupState(
             validEmail = "test@example.com",
             validPhone = "+123456789",
@@ -68,7 +70,7 @@ class LinkSignupHandlerForInstantDebitsTest {
             payload = Async.Success(validPayload)
         )
 
-        val expectedPane = Pane.INSTITUTION_PICKER
+        whenever(requestIntegrityToken(anyOrNull(), anyOrNull())).thenReturn(expectedToken)
         whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(
             syncResponse(
                 sessionManifest().copy(

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModelTest.kt
@@ -96,7 +96,7 @@ class NetworkingLinkSignupViewModelTest {
                 )
             )
         )
-        whenever(lookupAccount(any(), any(), any(), any())).thenReturn(ConsumerSessionLookup(exists = false))
+        whenever(lookupAccount(any(), any(), any(), any(), any())).thenReturn(ConsumerSessionLookup(exists = false))
 
         val viewModel = buildViewModel(NetworkingLinkSignupState())
         val state = viewModel.stateFlow.value
@@ -117,7 +117,7 @@ class NetworkingLinkSignupViewModelTest {
                 )
             )
         )
-        whenever(lookupAccount(any(), any(), any(), any())).thenReturn(ConsumerSessionLookup(exists = false))
+        whenever(lookupAccount(any(), any(), any(), any(), any())).thenReturn(ConsumerSessionLookup(exists = false))
 
         val viewModel = buildViewModel(
             state = NetworkingLinkSignupState(),
@@ -201,7 +201,7 @@ class NetworkingLinkSignupViewModelTest {
             )
         )
         whenever(getOrFetchSync().manifest).thenReturn(manifest)
-        whenever(lookupAccount(any(), any(), any(), any())).thenReturn(ConsumerSessionLookup(exists = true))
+        whenever(lookupAccount(any(), any(), any(), any(), any())).thenReturn(ConsumerSessionLookup(exists = true))
 
         val viewModel = buildViewModel(NetworkingLinkSignupState())
 
@@ -236,7 +236,7 @@ class NetworkingLinkSignupViewModelTest {
             )
         )
 
-        whenever(lookupAccount(any(), any(), any(), any())).thenReturn(ConsumerSessionLookup(exists = true))
+        whenever(lookupAccount(any(), any(), any(), any(), any())).thenReturn(ConsumerSessionLookup(exists = true))
 
         val viewModel = buildViewModel(
             state = NetworkingLinkSignupState(isInstantDebits = true),
@@ -274,7 +274,7 @@ class NetworkingLinkSignupViewModelTest {
             )
         )
         whenever(getOrFetchSync().manifest).thenReturn(manifest)
-        whenever(lookupAccount(any(), any(), any(), any())).thenReturn(ConsumerSessionLookup(exists = true))
+        whenever(lookupAccount(any(), any(), any(), any(), any())).thenReturn(ConsumerSessionLookup(exists = true))
 
         val viewModel = buildViewModel(
             state = NetworkingLinkSignupState(),
@@ -368,7 +368,7 @@ class NetworkingLinkSignupViewModelTest {
         )
 
         whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(syncResponse)
-        whenever(lookupAccount(any(), any(), any(), any())).thenReturn(ConsumerSessionLookup(exists = false))
+        whenever(lookupAccount(any(), any(), any(), any(), any())).thenReturn(ConsumerSessionLookup(exists = false))
 
         val viewModel = buildViewModel(
             state = NetworkingLinkSignupState(isInstantDebits = false),
@@ -402,7 +402,7 @@ class NetworkingLinkSignupViewModelTest {
         )
 
         whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(initialSyncResponse)
-        whenever(lookupAccount(any(), any(), any(), any())).thenReturn(ConsumerSessionLookup(exists = false))
+        whenever(lookupAccount(any(), any(), any(), any(), any())).thenReturn(ConsumerSessionLookup(exists = false))
 
         val viewModel = buildViewModel(
             state = NetworkingLinkSignupState(isInstantDebits = true),
@@ -436,7 +436,7 @@ class NetworkingLinkSignupViewModelTest {
         )
 
         whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(syncResponse)
-        whenever(lookupAccount(any(), any(), any(), any())).thenReturn(ConsumerSessionLookup(exists = false))
+        whenever(lookupAccount(any(), any(), any(), any(), any())).thenReturn(ConsumerSessionLookup(exists = false))
 
         val viewModel = buildViewModel(
             state = NetworkingLinkSignupState(isInstantDebits = false),
@@ -470,7 +470,7 @@ class NetworkingLinkSignupViewModelTest {
         )
 
         whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(initialSyncResponse)
-        whenever(lookupAccount(any(), any(), any(), any())).thenReturn(ConsumerSessionLookup(exists = false))
+        whenever(lookupAccount(any(), any(), any(), any(), any())).thenReturn(ConsumerSessionLookup(exists = false))
 
         val viewModel = buildViewModel(
             state = NetworkingLinkSignupState(isInstantDebits = true),
@@ -502,7 +502,7 @@ class NetworkingLinkSignupViewModelTest {
         val permissionException = PermissionException(stripeError = StripeError())
 
         whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(initialSyncResponse)
-        whenever(lookupAccount(any(), any(), any(), any())).then {
+        whenever(lookupAccount(any(), any(), any(), any(), any())).then {
             throw permissionException
         }
 
@@ -534,7 +534,7 @@ class NetworkingLinkSignupViewModelTest {
         val apiException = APIConnectionException()
 
         whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(initialSyncResponse)
-        whenever(lookupAccount(any(), any(), any(), any())).then {
+        whenever(lookupAccount(any(), any(), any(), any(), any())).then {
             throw apiException
         }
 
@@ -566,7 +566,7 @@ class NetworkingLinkSignupViewModelTest {
         val permissionException = PermissionException(stripeError = StripeError())
 
         whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(initialSyncResponse)
-        whenever(lookupAccount(any(), any(), any(), any())).then {
+        whenever(lookupAccount(any(), any(), any(), any(), any())).then {
             throw permissionException
         }
 
@@ -624,7 +624,7 @@ class NetworkingLinkSignupViewModelTest {
             saveAccountToLink = saveAccountToLink,
             eventTracker = eventTracker,
             navigationManager = navigationManager,
-            integrityRequestManager = mock(),
+            requestIntegrityToken = mock(),
             applicationId = "test",
             logger = Logger.noop(),
         )
@@ -659,7 +659,7 @@ class NetworkingLinkSignupViewModelTest {
             },
             navigationManager = navigationManager,
             handleError = handleError,
-            integrityRequestManager = mock(),
+            requestIntegrityToken = mock(),
             applicationId = "test",
         )
     }


### PR DESCRIPTION
# Summary
Added analytics events to track Play Integrity attestation initialization and token requests on lookup and signup mobile endpoints.

See list of new events: https://docs.google.com/document/d/1joKz5UZHLVazmecfMHbq6gB6n4wj5u8To6AtqYgq_tc/edit?tab=t.0#bookmark=id.kilcsiiwj5sk

# Motivation
https://jira.corp.stripe.com/browse/CONSUMERBANK-652

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified