### PR TITLE
Fix Link Activity Result crash

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivity.kt
@@ -88,10 +88,10 @@ internal class LinkActivity : ComponentActivity() {
 
     private fun dismissWithResult(result: LinkActivityResult) {
         val bundle = bundleOf(
-            LinkActivityContract.EXTRA_RESULT to LinkActivityContract.Result(result)
+            LinkActivityContract.EXTRA_RESULT to result
         )
         this@LinkActivity.setResult(
-            Activity.RESULT_OK,
+            RESULT_COMPLETE,
             Intent().putExtras(bundle)
         )
         this@LinkActivity.finish()
@@ -104,6 +104,7 @@ internal class LinkActivity : ComponentActivity() {
 
     companion object {
         internal const val EXTRA_ARGS = "native_link_args"
+        internal const val RESULT_COMPLETE = 73563
 
         internal fun createIntent(
             context: Context,

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityResult.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityResult.kt
@@ -86,10 +86,21 @@ internal fun createLinkActivityResult(resultCode: Int, intent: Intent?): LinkAct
             }
         }
 
+        LinkActivity.RESULT_COMPLETE -> {
+            handleNativeLinkResult(intent)
+        }
+
         else -> {
             LinkActivityResult.Canceled()
         }
     }
+}
+
+private fun handleNativeLinkResult(intent: Intent?): LinkActivityResult {
+    val result = intent?.extras?.let {
+        BundleCompat.getParcelable(it, LinkActivityContract.EXTRA_RESULT, LinkActivityResult::class.java)
+    }
+    return result ?: LinkActivityResult.Canceled()
 }
 
 private fun String.parsePaymentMethod(): PaymentMethod? = try {

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityResultTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityResultTest.kt
@@ -3,7 +3,9 @@ package com.stripe.android.link
 import android.app.Activity
 import android.content.Intent
 import androidx.core.net.toUri
+import androidx.core.os.bundleOf
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.PaymentMethodFixtures
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -91,5 +93,23 @@ class LinkActivityResultTest {
         assertThat(result).isInstanceOf(LinkActivityResult.Canceled::class.java)
         val canceled = result as LinkActivityResult.Canceled
         assertThat(canceled.reason).isEqualTo(LinkActivityResult.Canceled.Reason.BackPressed)
+    }
+
+    @Test
+    fun `complete with result from native link`() {
+        val bundle = bundleOf(
+            LinkActivityContract.EXTRA_RESULT to LinkActivityResult.Completed(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+        )
+        val intent = Intent()
+        intent.putExtras(bundle)
+        val result = createLinkActivityResult(LinkActivity.RESULT_COMPLETE, intent)
+        assertThat(result).isEqualTo(LinkActivityResult.Completed(PaymentMethodFixtures.CARD_PAYMENT_METHOD))
+    }
+
+    @Test
+    fun `complete with canceled result when native link result not found`() {
+        val intent = Intent()
+        val result = createLinkActivityResult(LinkActivity.RESULT_COMPLETE, intent)
+        assertThat(result).isEqualTo(LinkActivityResult.Canceled())
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Link activity was not sending results correctly. This fixes that. This also updates logic used to handle the result.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
## Before

https://github.com/user-attachments/assets/f53b41ec-59e8-4ca1-941f-2a1b18f4e606

## After

https://github.com/user-attachments/assets/113ac2ef-1b44-4ed1-b773-55d2764e000f



# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
