### PR TITLE
Remove CustomerSheetViewState#OnItemRemoved

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewAction.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewAction.kt
@@ -3,7 +3,6 @@ package com.stripe.android.customersheet
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.model.CardBrand
-import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -20,7 +19,6 @@ internal sealed class CustomerSheetViewAction {
     class OnDisallowedCardBrandEntered(val brand: CardBrand) : CustomerSheetViewAction()
     class OnItemSelected(val selection: PaymentSelection?) : CustomerSheetViewAction()
     class OnModifyItem(val paymentMethod: DisplayableSavedPaymentMethod) : CustomerSheetViewAction()
-    class OnItemRemoved(val paymentMethod: PaymentMethod) : CustomerSheetViewAction()
     class OnAddPaymentMethodItemChanged(
         val paymentMethod: SupportedPaymentMethod,
     ) : CustomerSheetViewAction()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Remove CustomerSheetViewState#OnItemRemoved

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
This view action is no longer used. It previously was used to delete PMs directly from the select PMs screen, but now all deletion happens via the update PM screen.

https://jira.corp.stripe.com/browse/MOBILESDK-2874

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [ ] Manually verified