### PR TITLE
Replace PaymentOptionEditState type with a boolean

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentOptionEditState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentOptionEditState.kt
@@ -1,6 +1,0 @@
-package com.stripe.android.paymentsheet.ui
-
-internal enum class PaymentOptionEditState {
-    None,
-    Modifiable
-}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTab.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTab.kt
@@ -61,7 +61,7 @@ internal val SavedPaymentMethodsTopContentPadding = 12.dp
 internal fun SavedPaymentMethodTab(
     viewWidth: Dp,
     isSelected: Boolean,
-    editState: PaymentOptionEditState,
+    shouldShowModifyBadge: Boolean,
     isEnabled: Boolean,
     isClickable: Boolean = isEnabled,
     iconRes: Int,
@@ -78,7 +78,7 @@ internal fun SavedPaymentMethodTab(
         badge = {
             SavedPaymentMethodBadge(
                 isSelected = isSelected,
-                editState = editState,
+                shouldShowModifyBadge = shouldShowModifyBadge,
                 onModifyListener = onModifyListener,
                 onModifyAccessibilityDescription = onModifyAccessibilityDescription
             )
@@ -117,20 +117,17 @@ internal fun SavedPaymentMethodTab(
 @Composable
 private fun SavedPaymentMethodBadge(
     isSelected: Boolean,
-    editState: PaymentOptionEditState,
+    shouldShowModifyBadge: Boolean,
     onModifyListener: (() -> Unit)? = null,
     onModifyAccessibilityDescription: String = ""
 ) {
-    when (editState) {
-        PaymentOptionEditState.Modifiable -> ModifyBadge(
+    if (shouldShowModifyBadge) {
+        ModifyBadge(
             onModifyAccessibilityDescription = onModifyAccessibilityDescription,
             onPressed = { onModifyListener?.invoke() },
             modifier = Modifier.offset(x = (-14).dp, y = 1.dp),
         )
-        PaymentOptionEditState.None -> Unit
-    }
-
-    if (isSelected) {
+    } else if (isSelected) {
         SelectedBadge(
             modifier = Modifier.offset(x = (-18).dp, y = 58.dp),
         )
@@ -219,7 +216,7 @@ private fun SavedPaymentMethodTabUISelected() {
         SavedPaymentMethodTab(
             viewWidth = 100.dp,
             isSelected = true,
-            editState = PaymentOptionEditState.None,
+            shouldShowModifyBadge = false,
             isEnabled = true,
             iconRes = R.drawable.stripe_ic_paymentsheet_card_visa,
             labelText = "MasterCard",
@@ -236,7 +233,7 @@ private fun SavedPaymentMethodTabUIModifiable() {
         SavedPaymentMethodTab(
             viewWidth = 100.dp,
             isSelected = false,
-            editState = PaymentOptionEditState.Modifiable,
+            shouldShowModifyBadge = true,
             isEnabled = true,
             iconRes = R.drawable.stripe_ic_paymentsheet_card_visa,
             labelText = "MasterCard",

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
@@ -290,7 +290,7 @@ private fun AddCardTab(
 
     SavedPaymentMethodTab(
         viewWidth = width,
-        editState = PaymentOptionEditState.None,
+        shouldShowModifyBadge = false,
         isSelected = false,
         labelText = stringResource(R.string.stripe_paymentsheet_add_payment_method_button_label),
         isEnabled = isEnabled,
@@ -311,7 +311,7 @@ private fun GooglePayTab(
 ) {
     SavedPaymentMethodTab(
         viewWidth = width,
-        editState = PaymentOptionEditState.None,
+        shouldShowModifyBadge = false,
         isSelected = isSelected,
         isEnabled = isEnabled,
         iconRes = R.drawable.stripe_google_pay_mark,
@@ -332,7 +332,7 @@ private fun LinkTab(
 ) {
     SavedPaymentMethodTab(
         viewWidth = width,
-        editState = PaymentOptionEditState.None,
+        shouldShowModifyBadge = false,
         isSelected = isSelected,
         isEnabled = isEnabled,
         iconRes = R.drawable.stripe_ic_paymentsheet_link,
@@ -371,10 +371,7 @@ private fun SavedPaymentMethodTab(
     ) {
         SavedPaymentMethodTab(
             viewWidth = width,
-            editState = when {
-                isEnabled && isEditing -> PaymentOptionEditState.Modifiable
-                else -> PaymentOptionEditState.None
-            },
+            shouldShowModifyBadge = isEnabled && isEditing,
             isSelected = isSelected,
             isEnabled = isEnabled,
             isClickable = !isEditing,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentOptionScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentOptionScreenshotTest.kt
@@ -25,7 +25,7 @@ class PaymentOptionScreenshotTest {
             SavedPaymentMethodTab(
                 viewWidth = 160.dp,
                 isSelected = false,
-                editState = PaymentOptionEditState.None,
+                shouldShowModifyBadge = false,
                 isEnabled = true,
                 iconRes = R.drawable.stripe_ic_paymentsheet_card_visa,
                 labelText = "••••4242",
@@ -41,7 +41,7 @@ class PaymentOptionScreenshotTest {
             SavedPaymentMethodTab(
                 viewWidth = 160.dp,
                 isSelected = false,
-                editState = PaymentOptionEditState.None,
+                shouldShowModifyBadge = false,
                 isEnabled = false,
                 iconRes = R.drawable.stripe_ic_paymentsheet_card_visa,
                 labelText = "••••4242",
@@ -57,7 +57,7 @@ class PaymentOptionScreenshotTest {
             SavedPaymentMethodTab(
                 viewWidth = 160.dp,
                 isSelected = true,
-                editState = PaymentOptionEditState.None,
+                shouldShowModifyBadge = false,
                 isEnabled = true,
                 iconRes = R.drawable.stripe_ic_paymentsheet_card_visa,
                 labelText = "••••4242",
@@ -73,7 +73,7 @@ class PaymentOptionScreenshotTest {
             SavedPaymentMethodTab(
                 viewWidth = 160.dp,
                 isSelected = true,
-                editState = PaymentOptionEditState.None,
+                shouldShowModifyBadge = false,
                 isEnabled = false,
                 iconRes = R.drawable.stripe_ic_paymentsheet_card_visa,
                 labelText = "••••4242",
@@ -89,7 +89,7 @@ class PaymentOptionScreenshotTest {
             SavedPaymentMethodTab(
                 viewWidth = 160.dp,
                 isSelected = false,
-                editState = PaymentOptionEditState.Modifiable,
+                shouldShowModifyBadge = true,
                 isEnabled = true,
                 iconRes = R.drawable.stripe_ic_paymentsheet_card_visa,
                 labelText = "••••4242",

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentOptionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentOptionTest.kt
@@ -28,7 +28,7 @@ class PaymentOptionTest {
             SavedPaymentMethodTab(
                 viewWidth = 100.dp,
                 isSelected = false,
-                editState = PaymentOptionEditState.None,
+                shouldShowModifyBadge = false,
                 isEnabled = true,
                 iconRes = R.drawable.stripe_ic_paymentsheet_card_visa,
                 labelText = label,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Replace PaymentOptionEditState type with a boolean

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Since this is now an enum with just two values, we can replace it with a boolean. Follow up to https://github.com/stripe/stripe-android/pull/9779#discussion_r1889292829

https://jira.corp.stripe.com/browse/MOBILESDK-2874

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

Behavior is covered by tests, change is fully mechanical.