### PR TITLE
Fix country utils cache.

### DIFF
--- a/stripe-core/src/main/java/com/stripe/android/core/model/CountryUtils.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/model/CountryUtils.kt
@@ -110,8 +110,6 @@ object CountryUtils {
         return if (currentLocale == cachedCountriesLocale) {
             cachedOrderedLocalizedCountries
         } else {
-            cachedCountriesLocale = currentLocale
-
             val localizedCountries = localizedCountries(currentLocale)
             cachedOrderedLocalizedCountries = listOfNotNull(
                 localizedCountries.firstOrNull {
@@ -122,6 +120,8 @@ object CountryUtils {
                     .filterNot { it.code == currentLocale.getCountryCode() }
                     .sortedBy { formatNameForSorting(it.name) }
             )
+
+            cachedCountriesLocale = currentLocale
 
             cachedOrderedLocalizedCountries
         }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
I'm not sure if this fix works, and I don't have a way to reproduce it. But my hunch is that we have a race condition here where we didn't actually cache the field, before we start returning the "cached" results.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fixes #9834

