### PR TITLE
Add Completed result to LinkActivityResult

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -292,6 +292,14 @@ public final class com/stripe/android/link/LinkActivityResult$Failed$Creator : a
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/link/LinkActivityResult$PaymentMethodObtained$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/link/LinkActivityResult$PaymentMethodObtained;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/link/LinkActivityResult$PaymentMethodObtained;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/link/LinkConfiguration$CardBrandChoice$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/link/LinkConfiguration$CardBrandChoice;

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityResult.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityResult.kt
@@ -12,10 +12,16 @@ import org.json.JSONObject
 
 internal sealed class LinkActivityResult : Parcelable {
     /**
-     * Indicates that the flow was completed successfully.
+     * Indicates that the flow was completed successfully
      */
     @Parcelize
-    data class Completed(
+    data object Completed : LinkActivityResult()
+
+    /**
+     * Indicates that the user selected a payment method. This payment method should be used for confirmation.
+     */
+    @Parcelize
+    data class PaymentMethodObtained(
         val paymentMethod: PaymentMethod
     ) : LinkActivityResult()
 
@@ -72,7 +78,7 @@ internal fun createLinkActivityResult(resultCode: Int, intent: Intent?): LinkAct
                     if (paymentMethod == null) {
                         LinkActivityResult.Canceled()
                     } else {
-                        LinkActivityResult.Completed(paymentMethod)
+                        LinkActivityResult.PaymentMethodObtained(paymentMethod)
                     }
                 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityResult.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityResult.kt
@@ -12,13 +12,13 @@ import org.json.JSONObject
 
 internal sealed class LinkActivityResult : Parcelable {
     /**
-     * Indicates that the flow was completed successfully
+     * Indicates that the flow was completed successfully.
      */
     @Parcelize
     data object Completed : LinkActivityResult()
 
     /**
-     * Indicates that the user selected a payment method. This payment method should be used for confirmation.
+     * Indicates that the user selected a payment method. This payment method has not yet been confirmed.
      */
     @Parcelize
     data class PaymentMethodObtained(

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
@@ -3,7 +3,7 @@ package com.stripe.android.link
 import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.ActivityResultRegistry
-import com.stripe.android.link.LinkActivityResult.Completed
+import com.stripe.android.link.LinkActivityResult.PaymentMethodObtained
 import com.stripe.android.link.account.LinkStore
 import com.stripe.android.link.injection.LinkAnalyticsComponent
 import javax.inject.Inject
@@ -32,8 +32,11 @@ internal class LinkPaymentLauncher @Inject internal constructor(
             linkActivityContract,
         ) { linkActivityResult ->
             analyticsHelper.onLinkResult(linkActivityResult)
-            if (linkActivityResult is Completed) {
-                linkStore.markLinkAsUsed()
+            when (linkActivityResult) {
+                is PaymentMethodObtained, LinkActivityResult.Completed -> {
+                    linkStore.markLinkAsUsed()
+                }
+                is LinkActivityResult.Canceled, is LinkActivityResult.Failed -> Unit
             }
             callback(linkActivityResult)
         }
@@ -47,8 +50,11 @@ internal class LinkPaymentLauncher @Inject internal constructor(
             linkActivityContract
         ) { linkActivityResult ->
             analyticsHelper.onLinkResult(linkActivityResult)
-            if (linkActivityResult is Completed) {
-                linkStore.markLinkAsUsed()
+            when (linkActivityResult) {
+                is PaymentMethodObtained, LinkActivityResult.Completed -> {
+                    linkStore.markLinkAsUsed()
+                }
+                is LinkActivityResult.Canceled, is LinkActivityResult.Failed -> Unit
             }
             callback(linkActivityResult)
         }

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
@@ -31,14 +31,7 @@ internal class LinkPaymentLauncher @Inject internal constructor(
             "LinkPaymentLauncher",
             linkActivityContract,
         ) { linkActivityResult ->
-            analyticsHelper.onLinkResult(linkActivityResult)
-            when (linkActivityResult) {
-                is PaymentMethodObtained, LinkActivityResult.Completed -> {
-                    linkStore.markLinkAsUsed()
-                }
-                is LinkActivityResult.Canceled, is LinkActivityResult.Failed -> Unit
-            }
-            callback(linkActivityResult)
+            handleActivityResult(linkActivityResult, callback)
         }
     }
 
@@ -49,15 +42,22 @@ internal class LinkPaymentLauncher @Inject internal constructor(
         linkActivityResultLauncher = activityResultCaller.registerForActivityResult(
             linkActivityContract
         ) { linkActivityResult ->
-            analyticsHelper.onLinkResult(linkActivityResult)
-            when (linkActivityResult) {
-                is PaymentMethodObtained, LinkActivityResult.Completed -> {
-                    linkStore.markLinkAsUsed()
-                }
-                is LinkActivityResult.Canceled, is LinkActivityResult.Failed -> Unit
-            }
-            callback(linkActivityResult)
+            handleActivityResult(linkActivityResult, callback)
         }
+    }
+
+    private fun handleActivityResult(
+        linkActivityResult: LinkActivityResult,
+        nextStep: (LinkActivityResult) -> Unit
+    ) {
+        analyticsHelper.onLinkResult(linkActivityResult)
+        when (linkActivityResult) {
+            is PaymentMethodObtained, LinkActivityResult.Completed -> {
+                linkStore.markLinkAsUsed()
+            }
+            is LinkActivityResult.Canceled, is LinkActivityResult.Failed -> Unit
+        }
+        nextStep(linkActivityResult)
     }
 
     fun unregister() {

--- a/paymentsheet/src/main/java/com/stripe/android/link/analytics/DefaultLinkAnalyticsHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/analytics/DefaultLinkAnalyticsHelper.kt
@@ -25,14 +25,13 @@ internal class DefaultLinkAnalyticsHelper @Inject internal constructor(
                 }
             }
 
-            is LinkActivityResult.PaymentMethodObtained -> {
+            is LinkActivityResult.PaymentMethodObtained, LinkActivityResult.Completed -> {
                 linkEventsReporter.onPopupSuccess()
             }
 
             is LinkActivityResult.Failed -> {
                 linkEventsReporter.onPopupError(linkActivityResult.error)
             }
-            LinkActivityResult.Completed -> Unit
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/link/analytics/DefaultLinkAnalyticsHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/analytics/DefaultLinkAnalyticsHelper.kt
@@ -5,7 +5,7 @@ import javax.inject.Inject
 
 internal class DefaultLinkAnalyticsHelper @Inject internal constructor(
     private val linkEventsReporter: LinkEventsReporter,
-): LinkAnalyticsHelper {
+) : LinkAnalyticsHelper {
     override fun onLinkLaunched() {
         linkEventsReporter.onPopupShow()
     }

--- a/paymentsheet/src/main/java/com/stripe/android/link/analytics/DefaultLinkAnalyticsHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/analytics/DefaultLinkAnalyticsHelper.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.link.analytics
+
+import com.stripe.android.link.LinkActivityResult
+import javax.inject.Inject
+
+internal class DefaultLinkAnalyticsHelper @Inject internal constructor(
+    private val linkEventsReporter: LinkEventsReporter,
+): LinkAnalyticsHelper {
+    override fun onLinkLaunched() {
+        linkEventsReporter.onPopupShow()
+    }
+
+    override fun onLinkResult(linkActivityResult: LinkActivityResult) {
+        when (linkActivityResult) {
+            is LinkActivityResult.Canceled -> {
+                when (linkActivityResult.reason) {
+                    LinkActivityResult.Canceled.Reason.BackPressed -> {
+                        linkEventsReporter.onPopupCancel()
+                    }
+
+                    LinkActivityResult.Canceled.Reason.LoggedOut -> {
+                        linkEventsReporter.onPopupLogout()
+                    }
+                    LinkActivityResult.Canceled.Reason.PayAnotherWay -> Unit
+                }
+            }
+
+            is LinkActivityResult.PaymentMethodObtained -> {
+                linkEventsReporter.onPopupSuccess()
+            }
+
+            is LinkActivityResult.Failed -> {
+                linkEventsReporter.onPopupError(linkActivityResult.error)
+            }
+            LinkActivityResult.Completed -> Unit
+        }
+    }
+
+    override fun onLinkPopupSkipped() {
+        linkEventsReporter.onPopupSkipped()
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/link/analytics/LinkAnalyticsHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/analytics/LinkAnalyticsHelper.kt
@@ -25,13 +25,14 @@ internal class LinkAnalyticsHelper @Inject internal constructor(
                 }
             }
 
-            is LinkActivityResult.Completed -> {
+            is LinkActivityResult.PaymentMethodObtained -> {
                 linkEventsReporter.onPopupSuccess()
             }
 
             is LinkActivityResult.Failed -> {
                 linkEventsReporter.onPopupError(linkActivityResult.error)
             }
+            LinkActivityResult.Completed -> Unit
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/link/analytics/LinkAnalyticsHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/analytics/LinkAnalyticsHelper.kt
@@ -1,42 +1,11 @@
 package com.stripe.android.link.analytics
 
 import com.stripe.android.link.LinkActivityResult
-import javax.inject.Inject
 
-internal class LinkAnalyticsHelper @Inject internal constructor(
-    private val linkEventsReporter: LinkEventsReporter,
-) {
-    fun onLinkLaunched() {
-        linkEventsReporter.onPopupShow()
-    }
+internal interface LinkAnalyticsHelper {
+    fun onLinkLaunched()
 
-    fun onLinkResult(linkActivityResult: LinkActivityResult) {
-        when (linkActivityResult) {
-            is LinkActivityResult.Canceled -> {
-                when (linkActivityResult.reason) {
-                    LinkActivityResult.Canceled.Reason.BackPressed -> {
-                        linkEventsReporter.onPopupCancel()
-                    }
+    fun onLinkResult(linkActivityResult: LinkActivityResult)
 
-                    LinkActivityResult.Canceled.Reason.LoggedOut -> {
-                        linkEventsReporter.onPopupLogout()
-                    }
-                    LinkActivityResult.Canceled.Reason.PayAnotherWay -> Unit
-                }
-            }
-
-            is LinkActivityResult.PaymentMethodObtained -> {
-                linkEventsReporter.onPopupSuccess()
-            }
-
-            is LinkActivityResult.Failed -> {
-                linkEventsReporter.onPopupError(linkActivityResult.error)
-            }
-            LinkActivityResult.Completed -> Unit
-        }
-    }
-
-    fun onLinkPopupSkipped() {
-        linkEventsReporter.onPopupSkipped()
-    }
+    fun onLinkPopupSkipped()
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkAnalyticsComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkAnalyticsComponent.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.link.injection
 
+import com.stripe.android.link.analytics.DefaultLinkAnalyticsHelper
 import com.stripe.android.link.analytics.DefaultLinkEventsReporter
 import com.stripe.android.link.analytics.LinkAnalyticsHelper
 import com.stripe.android.link.analytics.LinkEventsReporter
@@ -33,4 +34,8 @@ internal interface LinkAnalyticsModule {
     @Binds
     @LinkAnalyticsScope
     fun bindLinkEventsReporter(linkEventsReporter: DefaultLinkEventsReporter): LinkEventsReporter
+
+    @Binds
+    @LinkAnalyticsScope
+    fun bindLinkAnalyticsHelper(linkAnalyticsHelper: DefaultLinkAnalyticsHelper): LinkAnalyticsHelper
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinition.kt
@@ -67,7 +67,7 @@ internal class LinkConfirmationDefinition(
         }
 
         return when (result) {
-            is LinkActivityResult.Completed -> ConfirmationDefinition.Result.NextStep(
+            is LinkActivityResult.PaymentMethodObtained -> ConfirmationDefinition.Result.NextStep(
                 confirmationOption = PaymentMethodConfirmationOption.Saved(
                     paymentMethod = result.paymentMethod,
                     optionsParams = null,
@@ -82,6 +82,12 @@ internal class LinkConfirmationDefinition(
             is LinkActivityResult.Canceled -> ConfirmationDefinition.Result.Canceled(
                 action = ConfirmationHandler.Result.Canceled.Action.InformCancellation,
             )
+            LinkActivityResult.Completed -> {
+                ConfirmationDefinition.Result.Succeeded(
+                    intent = confirmationParameters.intent,
+                    deferredIntentConfirmationType = deferredIntentConfirmationType
+                )
+            }
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -431,7 +431,7 @@ internal class DefaultFlowController @Inject internal constructor(
     fun onLinkActivityResult(result: LinkActivityResult): Unit = when (result) {
         is LinkActivityResult.Canceled -> onPaymentResult(PaymentResult.Canceled)
         is LinkActivityResult.Failed -> onPaymentResult(PaymentResult.Failed(result.error))
-        is LinkActivityResult.Completed -> {
+        is LinkActivityResult.PaymentMethodObtained -> {
             runCatching {
                 requireNotNull(viewModel.state)
             }.fold(
@@ -457,6 +457,13 @@ internal class DefaultFlowController @Inject internal constructor(
                     )
                 }
             )
+        }
+        LinkActivityResult.Completed -> {
+            eventReporter.onPaymentSuccess(
+                paymentSelection = PaymentSelection.Link,
+                deferredIntentConfirmationType = null
+            )
+            onPaymentResult(PaymentResult.Completed)
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityResultTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityResultTest.kt
@@ -20,11 +20,11 @@ class LinkActivityResultTest {
         val intent = Intent()
         intent.data = redirectUrl.toUri()
         val result = createLinkActivityResult(LinkForegroundActivity.RESULT_COMPLETE, intent)
-        assertThat(result).isInstanceOf(LinkActivityResult.Completed::class.java)
-        val completed = result as LinkActivityResult.Completed
-        assertThat(completed.paymentMethod.type?.code).isEqualTo("card")
-        assertThat(completed.paymentMethod.card?.last4).isEqualTo("0000")
-        assertThat(completed.paymentMethod.id).isEqualTo("pm_1NJeErLu5o3P18ZpmXpCtIrR")
+        assertThat(result).isInstanceOf(LinkActivityResult.PaymentMethodObtained::class.java)
+        val paymentMethodObtained = result as LinkActivityResult.PaymentMethodObtained
+        assertThat(paymentMethodObtained.paymentMethod.type?.code).isEqualTo("card")
+        assertThat(paymentMethodObtained.paymentMethod.card?.last4).isEqualTo("0000")
+        assertThat(paymentMethodObtained.paymentMethod.id).isEqualTo("pm_1NJeErLu5o3P18ZpmXpCtIrR")
     }
 
     @Test
@@ -98,12 +98,15 @@ class LinkActivityResultTest {
     @Test
     fun `complete with result from native link`() {
         val bundle = bundleOf(
-            LinkActivityContract.EXTRA_RESULT to LinkActivityResult.Completed(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+            LinkActivityContract.EXTRA_RESULT to LinkActivityResult.PaymentMethodObtained(
+                paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
+            )
         )
         val intent = Intent()
         intent.putExtras(bundle)
         val result = createLinkActivityResult(LinkActivity.RESULT_COMPLETE, intent)
-        assertThat(result).isEqualTo(LinkActivityResult.Completed(PaymentMethodFixtures.CARD_PAYMENT_METHOD))
+        assertThat(result)
+            .isEqualTo(LinkActivityResult.PaymentMethodObtained(PaymentMethodFixtures.CARD_PAYMENT_METHOD))
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkPaymentLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkPaymentLauncherTest.kt
@@ -20,7 +20,7 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
-class LinkPaymentLauncherTest {
+internal class LinkPaymentLauncherTest {
 
     @Test
     fun `register with ActivityResultRegistry should set up correct launcher`() {
@@ -128,7 +128,8 @@ class LinkPaymentLauncherTest {
             val activityResultRegistry: ActivityResultRegistry = mock()
             val linkAnalyticsHelper = TrackingLinkAnalyticsHelper()
 
-            val linkPaymentLauncher = createLinkPaymentLauncher(linkStore = linkStore, linkAnalyticsHelper = linkAnalyticsHelper)
+            val linkPaymentLauncher =
+                createLinkPaymentLauncher(linkStore = linkStore, linkAnalyticsHelper = linkAnalyticsHelper)
 
             whenever(
                 activityResultRegistry.register(
@@ -160,7 +161,8 @@ class LinkPaymentLauncherTest {
             val activityResultCaller: ActivityResultCaller = mock()
             val linkAnalyticsHelper = TrackingLinkAnalyticsHelper()
 
-            val linkPaymentLauncher = createLinkPaymentLauncher(linkStore = linkStore, linkAnalyticsHelper = linkAnalyticsHelper)
+            val linkPaymentLauncher =
+                createLinkPaymentLauncher(linkStore = linkStore, linkAnalyticsHelper = linkAnalyticsHelper)
 
             whenever(
                 activityResultCaller.registerForActivityResult(
@@ -181,7 +183,8 @@ class LinkPaymentLauncherTest {
             verify(linkStore).markLinkAsUsed()
             assertThat(callbackParam).isInstanceOf(LinkActivityResult.PaymentMethodObtained::class.java)
             assertThat(markAsUsedCalls.cancelAndConsumeRemainingEvents().size).isEqualTo(1)
-            assertThat(linkAnalyticsHelper.lastResult).isInstanceOf(LinkActivityResult.PaymentMethodObtained::class.java)
+            assertThat(linkAnalyticsHelper.lastResult)
+                .isInstanceOf(LinkActivityResult.PaymentMethodObtained::class.java)
         }
     }
 
@@ -191,7 +194,8 @@ class LinkPaymentLauncherTest {
             val activityResultRegistry: ActivityResultRegistry = mock()
             val linkAnalyticsHelper = TrackingLinkAnalyticsHelper()
 
-            val linkPaymentLauncher = createLinkPaymentLauncher(linkStore = linkStore, linkAnalyticsHelper = linkAnalyticsHelper)
+            val linkPaymentLauncher =
+                createLinkPaymentLauncher(linkStore = linkStore, linkAnalyticsHelper = linkAnalyticsHelper)
 
             whenever(
                 activityResultRegistry.register(
@@ -223,7 +227,8 @@ class LinkPaymentLauncherTest {
             val activityResultCaller: ActivityResultCaller = mock()
             val linkAnalyticsHelper = TrackingLinkAnalyticsHelper()
 
-            val linkPaymentLauncher = createLinkPaymentLauncher(linkStore = linkStore, linkAnalyticsHelper = linkAnalyticsHelper)
+            val linkPaymentLauncher =
+                createLinkPaymentLauncher(linkStore = linkStore, linkAnalyticsHelper = linkAnalyticsHelper)
 
             whenever(
                 activityResultCaller.registerForActivityResult(

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkPaymentLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkPaymentLauncherTest.kt
@@ -1,0 +1,277 @@
+package com.stripe.android.link
+
+import androidx.activity.result.ActivityResultCallback
+import androidx.activity.result.ActivityResultCaller
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.ActivityResultRegistry
+import androidx.activity.result.contract.ActivityResultContract
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.link.account.LinkStore
+import com.stripe.android.link.analytics.FakeLinkAnalyticsHelper
+import com.stripe.android.link.analytics.LinkAnalyticsHelper
+import com.stripe.android.link.injection.LinkAnalyticsComponent
+import com.stripe.android.utils.RecordingLinkStore
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class LinkPaymentLauncherTest {
+
+    @Test
+    fun `register with ActivityResultRegistry should set up correct launcher`() {
+        val linkActivityContract: LinkActivityContract = mock()
+        val activityResultRegistry: ActivityResultRegistry = mock()
+        val activityResultLauncher: ActivityResultLauncher<LinkActivityContract.Args> = mock()
+
+        val linkPaymentLauncher = createLinkPaymentLauncher(linkActivityContract = linkActivityContract)
+
+        whenever(
+            activityResultRegistry.register(
+                eq("LinkPaymentLauncher"),
+                any<ActivityResultContract<LinkActivityContract.Args, LinkActivityResult>>(),
+                any()
+            )
+        ).thenReturn(activityResultLauncher)
+
+        linkPaymentLauncher.register(activityResultRegistry) {}
+
+        verify(activityResultRegistry).register(
+            eq("LinkPaymentLauncher"),
+            eq(linkActivityContract),
+            any()
+        )
+    }
+
+    @Test
+    fun `register with ActivityResultCaller should set up correct launcher`() {
+        val linkActivityContract: LinkActivityContract = mock()
+        val activityResultCaller: ActivityResultCaller = mock()
+        val activityResultLauncher: ActivityResultLauncher<LinkActivityContract.Args> = mock()
+
+        val linkPaymentLauncher = createLinkPaymentLauncher(linkActivityContract = linkActivityContract)
+
+        whenever(
+            activityResultCaller.registerForActivityResult(
+                eq(linkActivityContract),
+                any()
+            )
+        ).thenReturn(activityResultLauncher)
+
+        linkPaymentLauncher.register(activityResultCaller) {}
+
+        verify(activityResultCaller).registerForActivityResult(
+            eq(linkActivityContract),
+            any()
+        )
+    }
+
+    @Test
+    fun `unregister should call unregister on ActivityResultLauncher`() {
+        val linkActivityContract: LinkActivityContract = mock()
+        val activityResultCaller: ActivityResultCaller = mock()
+        val activityResultLauncher: ActivityResultLauncher<LinkActivityContract.Args> = mock()
+
+        val linkPaymentLauncher = createLinkPaymentLauncher(linkActivityContract = linkActivityContract)
+
+        whenever(
+            activityResultCaller.registerForActivityResult(
+                eq(linkActivityContract),
+                any()
+            )
+        ).thenReturn(activityResultLauncher)
+
+        linkPaymentLauncher.register(activityResultCaller) {}
+
+        linkPaymentLauncher.unregister()
+
+        verify(activityResultLauncher).unregister()
+    }
+
+    @Test
+    fun `present should launch with correct args and trigger analytics`() {
+        val linkAnalyticsHelper = object : LauncherLinkAnalyticsHelper() {
+            var callCount = 0
+            override fun onLinkLaunched() {
+                callCount += 1
+            }
+        }
+        val activityResultCaller: ActivityResultCaller = mock()
+        val activityResultLauncher: ActivityResultLauncher<LinkActivityContract.Args> = mock()
+
+        val linkPaymentLauncher = createLinkPaymentLauncher(linkAnalyticsHelper = linkAnalyticsHelper)
+
+        whenever(
+            activityResultCaller.registerForActivityResult(
+                any<LinkActivityContract>(),
+                any()
+            )
+        ).thenReturn(activityResultLauncher)
+
+        linkPaymentLauncher.register(activityResultCaller) {}
+
+        linkPaymentLauncher.present(TestFactory.LINK_CONFIGURATION)
+
+        verify(activityResultLauncher).launch(
+            LinkActivityContract.Args(TestFactory.LINK_CONFIGURATION)
+        )
+        assertThat(linkAnalyticsHelper.callCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `ActivityResultRegistry callback should handle completed result correctly`() = runTest {
+        RecordingLinkStore.test {
+            val activityResultRegistry: ActivityResultRegistry = mock()
+            val linkAnalyticsHelper = TrackingLinkAnalyticsHelper()
+
+            val linkPaymentLauncher = createLinkPaymentLauncher(linkStore = linkStore, linkAnalyticsHelper = linkAnalyticsHelper)
+
+            whenever(
+                activityResultRegistry.register(
+                    any(),
+                    any<ActivityResultContract<LinkActivityContract.Args, LinkActivityResult>>(),
+                    any()
+                )
+            ).thenAnswer { invocation ->
+                val callback = invocation.getArgument<ActivityResultCallback<LinkActivityResult>>(2)
+                callback.onActivityResult(LinkActivityResult.Completed)
+                mock<ActivityResultLauncher<LinkActivityContract.Args>>()
+            }
+
+            var callbackParam: LinkActivityResult? = null
+            linkPaymentLauncher.register(activityResultRegistry) {
+                callbackParam = it
+            }
+
+            verify(linkStore).markLinkAsUsed()
+            assertThat(callbackParam).isEqualTo(LinkActivityResult.Completed)
+            assertThat(markAsUsedCalls.cancelAndConsumeRemainingEvents().size).isEqualTo(1)
+            assertThat(linkAnalyticsHelper.lastResult).isEqualTo(LinkActivityResult.Completed)
+        }
+    }
+
+    @Test
+    fun `ActivityResultCaller callback should handle PaymentMethodObtained result correctly`() = runTest {
+        RecordingLinkStore.test {
+            val activityResultCaller: ActivityResultCaller = mock()
+            val linkAnalyticsHelper = TrackingLinkAnalyticsHelper()
+
+            val linkPaymentLauncher = createLinkPaymentLauncher(linkStore = linkStore, linkAnalyticsHelper = linkAnalyticsHelper)
+
+            whenever(
+                activityResultCaller.registerForActivityResult(
+                    any<LinkActivityContract>(),
+                    any()
+                )
+            ).thenAnswer { invocation ->
+                val callback = invocation.getArgument<ActivityResultCallback<LinkActivityResult>>(1)
+                callback.onActivityResult(LinkActivityResult.PaymentMethodObtained(mock()))
+                mock<ActivityResultLauncher<LinkActivityContract.Args>>()
+            }
+
+            var callbackParam: LinkActivityResult? = null
+            linkPaymentLauncher.register(activityResultCaller) {
+                callbackParam = it
+            }
+
+            verify(linkStore).markLinkAsUsed()
+            assertThat(callbackParam).isInstanceOf(LinkActivityResult.PaymentMethodObtained::class.java)
+            assertThat(markAsUsedCalls.cancelAndConsumeRemainingEvents().size).isEqualTo(1)
+            assertThat(linkAnalyticsHelper.lastResult).isInstanceOf(LinkActivityResult.PaymentMethodObtained::class.java)
+        }
+    }
+
+    @Test
+    fun `ActivityResultRegistry callback should handle Canceled result correctly`() = runTest {
+        RecordingLinkStore.test {
+            val activityResultRegistry: ActivityResultRegistry = mock()
+            val linkAnalyticsHelper = TrackingLinkAnalyticsHelper()
+
+            val linkPaymentLauncher = createLinkPaymentLauncher(linkStore = linkStore, linkAnalyticsHelper = linkAnalyticsHelper)
+
+            whenever(
+                activityResultRegistry.register(
+                    any(),
+                    any<ActivityResultContract<LinkActivityContract.Args, LinkActivityResult>>(),
+                    any()
+                )
+            ).thenAnswer { invocation ->
+                val callback = invocation.getArgument<ActivityResultCallback<LinkActivityResult>>(2)
+                callback.onActivityResult(LinkActivityResult.Canceled())
+                mock<ActivityResultLauncher<LinkActivityContract.Args>>()
+            }
+
+            var callbackParam: LinkActivityResult? = null
+            linkPaymentLauncher.register(activityResultRegistry) {
+                callbackParam = it
+            }
+
+            verify(linkStore, never()).markLinkAsUsed()
+            assertThat(callbackParam).isInstanceOf(LinkActivityResult.Canceled::class.java)
+            assertThat(markAsUsedCalls.cancelAndConsumeRemainingEvents()).isEmpty()
+            assertThat(linkAnalyticsHelper.lastResult).isInstanceOf(LinkActivityResult.Canceled::class.java)
+        }
+    }
+
+    @Test
+    fun `ActivityResultCaller callback should handle Failed result correctly`() = runTest {
+        RecordingLinkStore.test {
+            val activityResultCaller: ActivityResultCaller = mock()
+            val linkAnalyticsHelper = TrackingLinkAnalyticsHelper()
+
+            val linkPaymentLauncher = createLinkPaymentLauncher(linkStore = linkStore, linkAnalyticsHelper = linkAnalyticsHelper)
+
+            whenever(
+                activityResultCaller.registerForActivityResult(
+                    any<LinkActivityContract>(),
+                    any()
+                )
+            ).thenAnswer { invocation ->
+                val callback = invocation.getArgument<ActivityResultCallback<LinkActivityResult>>(1)
+                callback.onActivityResult(LinkActivityResult.Failed(Exception("Test exception")))
+                mock<ActivityResultLauncher<LinkActivityContract.Args>>()
+            }
+
+            var callbackParam: LinkActivityResult? = null
+            linkPaymentLauncher.register(activityResultCaller) {
+                callbackParam = it
+            }
+
+            verify(linkStore, never()).markLinkAsUsed()
+            assertThat(callbackParam).isInstanceOf(LinkActivityResult.Failed::class.java)
+            assertThat(markAsUsedCalls.cancelAndConsumeRemainingEvents()).isEmpty()
+            assertThat(linkAnalyticsHelper.lastResult).isInstanceOf(LinkActivityResult.Failed::class.java)
+        }
+    }
+
+    private fun createLinkPaymentLauncher(
+        linkActivityContract: LinkActivityContract = mock(),
+        linkAnalyticsHelper: LinkAnalyticsHelper = LauncherLinkAnalyticsHelper(),
+        linkStore: LinkStore = mock()
+    ): LinkPaymentLauncher {
+        return LinkPaymentLauncher(
+            linkAnalyticsComponentBuilder = object : LinkAnalyticsComponent.Builder {
+                override fun build() = object : LinkAnalyticsComponent {
+                    override val linkAnalyticsHelper = linkAnalyticsHelper
+                }
+            },
+            linkActivityContract = linkActivityContract,
+            linkStore = linkStore
+        )
+    }
+}
+
+private open class LauncherLinkAnalyticsHelper : FakeLinkAnalyticsHelper() {
+    override fun onLinkLaunched() = Unit
+}
+
+private class TrackingLinkAnalyticsHelper : LauncherLinkAnalyticsHelper() {
+    var lastResult: LinkActivityResult? = null
+    override fun onLinkResult(linkResult: LinkActivityResult) {
+        lastResult = linkResult
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkPaymentLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkPaymentLauncherTest.kt
@@ -10,6 +10,9 @@ import com.stripe.android.link.account.LinkStore
 import com.stripe.android.link.analytics.FakeLinkAnalyticsHelper
 import com.stripe.android.link.analytics.LinkAnalyticsHelper
 import com.stripe.android.link.injection.LinkAnalyticsComponent
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.utils.DummyActivityResultCaller
+import com.stripe.android.utils.FakeActivityResultRegistry
 import com.stripe.android.utils.RecordingLinkStore
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -17,29 +20,259 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 internal class LinkPaymentLauncherTest {
 
     @Test
-    fun `register with ActivityResultRegistry should set up correct launcher`() {
+    fun `register call should register ActivityResultLauncher with ActivityResultRegistry`() {
         val linkActivityContract: LinkActivityContract = mock()
         val activityResultRegistry: ActivityResultRegistry = mock()
         val activityResultLauncher: ActivityResultLauncher<LinkActivityContract.Args> = mock()
 
         val linkPaymentLauncher = createLinkPaymentLauncher(linkActivityContract = linkActivityContract)
 
+        setupActivityResultRegistryMock(activityResultRegistry, activityResultLauncher)
+
+        linkPaymentLauncher.register(activityResultRegistry) {}
+
+        verifyActivityResultRegistryRegister(activityResultRegistry, linkActivityContract)
+    }
+
+    @Test
+    fun `register call should register ActivityResultLauncher with ActivityResultCaller`() = runTest {
+        DummyActivityResultCaller.test {
+            val linkPaymentLauncher = createLinkPaymentLauncher()
+
+            linkPaymentLauncher.register(activityResultCaller) {}
+
+            val registerCall = awaitRegisterCall()
+            assertThat(registerCall).isNotNull()
+
+            awaitNextRegisteredLauncher()
+        }
+    }
+
+    @Test
+    fun `unregister call should unregister ActivityResultLauncher`() = runTest {
+        DummyActivityResultCaller.test {
+            val linkPaymentLauncher = createLinkPaymentLauncher()
+
+            linkPaymentLauncher.register(activityResultCaller) {}
+
+            awaitRegisterCall()
+
+            linkPaymentLauncher.unregister()
+
+            val unregisterCall = awaitUnregisterCall()
+            assertThat(unregisterCall).isNotNull()
+
+            awaitNextRegisteredLauncher()
+        }
+    }
+
+    @Test
+    fun `present should launch with correct args and trigger analytics`() = runTest {
+        DummyActivityResultCaller.test {
+            val linkPaymentLauncher = createLinkPaymentLauncher()
+
+            linkPaymentLauncher.register(activityResultCaller) {}
+
+            val registerCall = awaitRegisterCall()
+            assertThat(registerCall).isNotNull()
+
+            linkPaymentLauncher.present(TestFactory.LINK_CONFIGURATION)
+
+            val launchCall = awaitLaunchCall()
+
+            assertThat(launchCall).isEqualTo(LinkActivityContract.Args(TestFactory.LINK_CONFIGURATION))
+
+            awaitNextRegisteredLauncher()
+        }
+    }
+
+    @Test
+    fun `ActivityResultRegistry callback should handle Completed result correctly`() {
+        testActivityResultCallbackWithActivityResultRegistry(
+            linkActivityResult = LinkActivityResult.Completed,
+            expectedMarkAsUsedCalls = 1,
+        )
+    }
+
+    @Test
+    fun `ActivityResultRegistry callback should handle PaymentMethodObtained result correctly`() {
+        testActivityResultCallbackWithActivityResultRegistry(
+            linkActivityResult = LinkActivityResult.PaymentMethodObtained(PaymentMethodFixtures.LINK_PAYMENT_METHOD),
+            expectedMarkAsUsedCalls = 1,
+        )
+    }
+
+    @Test
+    fun `ActivityResultRegistry callback should handle Canceled result correctly`() {
+        testActivityResultCallbackWithActivityResultRegistry(
+            linkActivityResult = LinkActivityResult.Canceled(),
+            expectedMarkAsUsedCalls = 0,
+        )
+    }
+
+    @Test
+    fun `ActivityResultRegistry callback should handle Failed result correctly`() {
+        testActivityResultCallbackWithActivityResultRegistry(
+            linkActivityResult = LinkActivityResult.Failed(Exception("oops")),
+            expectedMarkAsUsedCalls = 0,
+        )
+    }
+
+    @Test
+    fun `ActivityResultCaller callback should handle Completed result correctly`() {
+        testActivityResultCallbackWithResultCaller(
+            linkActivityResult = LinkActivityResult.Completed,
+            expectedMarkAsUsedCalls = 1,
+        )
+    }
+
+    @Test
+    fun `ActivityResultCaller callback should handle PaymentMethodObtained result correctly`() {
+        testActivityResultCallbackWithResultCaller(
+            linkActivityResult = LinkActivityResult.PaymentMethodObtained(PaymentMethodFixtures.LINK_PAYMENT_METHOD),
+            expectedMarkAsUsedCalls = 1,
+        )
+    }
+
+    @Test
+    fun `ActivityResultCaller callback should handle Canceled result correctly`() {
+        testActivityResultCallbackWithResultCaller(
+            linkActivityResult = LinkActivityResult.Canceled(),
+            expectedMarkAsUsedCalls = 0,
+        )
+    }
+
+    @Test
+    fun `ActivityResultCaller callback should handle Failed result correctly`() {
+        testActivityResultCallbackWithResultCaller(
+            linkActivityResult = LinkActivityResult.Failed(Exception("oops")),
+            expectedMarkAsUsedCalls = 0,
+        )
+    }
+
+    private fun testActivityResultCallbackWithActivityResultRegistry(
+        linkActivityResult: LinkActivityResult,
+        expectedMarkAsUsedCalls: Int,
+    ) = runTest {
+        RecordingLinkStore.test {
+            val activityResultRegistry: ActivityResultRegistry = FakeActivityResultRegistry(linkActivityResult)
+
+            val linkAnalyticsHelper = TrackingLinkAnalyticsHelper()
+            val linkPaymentLauncher = createLinkPaymentLauncher(
+                linkAnalyticsHelper = linkAnalyticsHelper,
+                linkStore = linkStore
+            )
+
+            var callbackParam: LinkActivityResult? = null
+            linkPaymentLauncher.register(activityResultRegistry) { callbackParam = it }
+
+            linkPaymentLauncher.present(TestFactory.LINK_CONFIGURATION)
+
+            verifyActivityResultCallback(
+                linkActivityResult = linkActivityResult,
+                linkStore = linkStore,
+                linkAnalyticsHelper = linkAnalyticsHelper,
+                expectedMarkAsUsedCalls = expectedMarkAsUsedCalls,
+                callbackResult = callbackParam,
+            )
+        }
+    }
+
+    private fun testActivityResultCallbackWithResultCaller(
+        linkActivityResult: LinkActivityResult,
+        expectedMarkAsUsedCalls: Int,
+    ) = runTest {
+        RecordingLinkStore.test {
+            val activityResultCaller: ActivityResultCaller = mock()
+            val activityResultLauncher: ActivityResultLauncher<LinkActivityContract.Args> = mock()
+
+            val linkAnalyticsHelper = TrackingLinkAnalyticsHelper()
+            val linkPaymentLauncher = createLinkPaymentLauncher(
+                linkAnalyticsHelper = linkAnalyticsHelper,
+                linkStore = linkStore
+            )
+
+            setupActivityResultCallerMock(
+                activityResultCaller = activityResultCaller,
+                linkActivityContractProvider = { any() },
+                activityResultLauncher = activityResultLauncher
+            )
+
+            setupActivityResultCallerCallback(
+                activityResultCaller = activityResultCaller,
+                linkActivityResult = linkActivityResult
+            )
+
+            var callbackParam: LinkActivityResult? = null
+            linkPaymentLauncher.register(activityResultCaller) { callbackParam = it }
+
+            linkPaymentLauncher.present(TestFactory.LINK_CONFIGURATION)
+
+            verifyActivityResultCallback(
+                linkActivityResult = linkActivityResult,
+                linkStore = linkStore,
+                linkAnalyticsHelper = linkAnalyticsHelper,
+                expectedMarkAsUsedCalls = expectedMarkAsUsedCalls,
+                callbackResult = callbackParam,
+            )
+        }
+    }
+
+    private suspend fun RecordingLinkStore.Scenario.verifyActivityResultCallback(
+        linkActivityResult: LinkActivityResult,
+        linkStore: LinkStore,
+        linkAnalyticsHelper: TrackingLinkAnalyticsHelper,
+        expectedMarkAsUsedCalls: Int,
+        callbackResult: LinkActivityResult?,
+    ) {
+        if (expectedMarkAsUsedCalls > 0) {
+            verify(linkStore, times(expectedMarkAsUsedCalls)).markLinkAsUsed()
+        } else {
+            verify(linkStore, never()).markLinkAsUsed()
+        }
+
+        assertThat(callbackResult).isEqualTo(linkActivityResult)
+        assertThat(markAsUsedCalls.cancelAndConsumeRemainingEvents().size).isEqualTo(expectedMarkAsUsedCalls)
+        assertThat(linkAnalyticsHelper.results).containsExactly(linkActivityResult)
+    }
+
+    private fun setupActivityResultRegistryMock(
+        activityResultRegistry: ActivityResultRegistry,
+        launcher: ActivityResultLauncher<LinkActivityContract.Args>
+    ) {
         whenever(
             activityResultRegistry.register(
                 eq("LinkPaymentLauncher"),
                 any<ActivityResultContract<LinkActivityContract.Args, LinkActivityResult>>(),
                 any()
             )
+        ).thenReturn(launcher)
+    }
+
+    private fun setupActivityResultCallerMock(
+        activityResultCaller: ActivityResultCaller,
+        activityResultLauncher: ActivityResultLauncher<LinkActivityContract.Args>,
+        linkActivityContractProvider: () -> LinkActivityContract
+    ) {
+        whenever(
+            activityResultCaller.registerForActivityResult(
+                linkActivityContractProvider(),
+                any()
+            )
         ).thenReturn(activityResultLauncher)
+    }
 
-        linkPaymentLauncher.register(activityResultRegistry) {}
-
+    private fun verifyActivityResultRegistryRegister(
+        activityResultRegistry: ActivityResultRegistry,
+        linkActivityContract: LinkActivityContract
+    ) {
         verify(activityResultRegistry).register(
             eq("LinkPaymentLauncher"),
             eq(linkActivityContract),
@@ -47,215 +280,25 @@ internal class LinkPaymentLauncherTest {
         )
     }
 
-    @Test
-    fun `register with ActivityResultCaller should set up correct launcher`() {
-        val linkActivityContract: LinkActivityContract = mock()
-        val activityResultCaller: ActivityResultCaller = mock()
-        val activityResultLauncher: ActivityResultLauncher<LinkActivityContract.Args> = mock()
-
-        val linkPaymentLauncher = createLinkPaymentLauncher(linkActivityContract = linkActivityContract)
-
+    private fun setupActivityResultCallerCallback(
+        activityResultCaller: ActivityResultCaller,
+        linkActivityResult: LinkActivityResult
+    ) {
         whenever(
             activityResultCaller.registerForActivityResult(
-                eq(linkActivityContract),
+                any<ActivityResultContract<LinkActivityContract.Args, LinkActivityResult>>(),
                 any()
             )
-        ).thenReturn(activityResultLauncher)
-
-        linkPaymentLauncher.register(activityResultCaller) {}
-
-        verify(activityResultCaller).registerForActivityResult(
-            eq(linkActivityContract),
-            any()
-        )
-    }
-
-    @Test
-    fun `unregister should call unregister on ActivityResultLauncher`() {
-        val linkActivityContract: LinkActivityContract = mock()
-        val activityResultCaller: ActivityResultCaller = mock()
-        val activityResultLauncher: ActivityResultLauncher<LinkActivityContract.Args> = mock()
-
-        val linkPaymentLauncher = createLinkPaymentLauncher(linkActivityContract = linkActivityContract)
-
-        whenever(
-            activityResultCaller.registerForActivityResult(
-                eq(linkActivityContract),
-                any()
-            )
-        ).thenReturn(activityResultLauncher)
-
-        linkPaymentLauncher.register(activityResultCaller) {}
-
-        linkPaymentLauncher.unregister()
-
-        verify(activityResultLauncher).unregister()
-    }
-
-    @Test
-    fun `present should launch with correct args and trigger analytics`() {
-        val linkAnalyticsHelper = object : LauncherLinkAnalyticsHelper() {
-            var callCount = 0
-            override fun onLinkLaunched() {
-                callCount += 1
-            }
-        }
-        val activityResultCaller: ActivityResultCaller = mock()
-        val activityResultLauncher: ActivityResultLauncher<LinkActivityContract.Args> = mock()
-
-        val linkPaymentLauncher = createLinkPaymentLauncher(linkAnalyticsHelper = linkAnalyticsHelper)
-
-        whenever(
-            activityResultCaller.registerForActivityResult(
-                any<LinkActivityContract>(),
-                any()
-            )
-        ).thenReturn(activityResultLauncher)
-
-        linkPaymentLauncher.register(activityResultCaller) {}
-
-        linkPaymentLauncher.present(TestFactory.LINK_CONFIGURATION)
-
-        verify(activityResultLauncher).launch(
-            LinkActivityContract.Args(TestFactory.LINK_CONFIGURATION)
-        )
-        assertThat(linkAnalyticsHelper.callCount).isEqualTo(1)
-    }
-
-    @Test
-    fun `ActivityResultRegistry callback should handle completed result correctly`() = runTest {
-        RecordingLinkStore.test {
-            val activityResultRegistry: ActivityResultRegistry = mock()
-            val linkAnalyticsHelper = TrackingLinkAnalyticsHelper()
-
-            val linkPaymentLauncher =
-                createLinkPaymentLauncher(linkStore = linkStore, linkAnalyticsHelper = linkAnalyticsHelper)
-
-            whenever(
-                activityResultRegistry.register(
-                    any(),
-                    any<ActivityResultContract<LinkActivityContract.Args, LinkActivityResult>>(),
-                    any()
-                )
-            ).thenAnswer { invocation ->
-                val callback = invocation.getArgument<ActivityResultCallback<LinkActivityResult>>(2)
-                callback.onActivityResult(LinkActivityResult.Completed)
-                mock<ActivityResultLauncher<LinkActivityContract.Args>>()
-            }
-
-            var callbackParam: LinkActivityResult? = null
-            linkPaymentLauncher.register(activityResultRegistry) {
-                callbackParam = it
-            }
-
-            verify(linkStore).markLinkAsUsed()
-            assertThat(callbackParam).isEqualTo(LinkActivityResult.Completed)
-            assertThat(markAsUsedCalls.cancelAndConsumeRemainingEvents().size).isEqualTo(1)
-            assertThat(linkAnalyticsHelper.lastResult).isEqualTo(LinkActivityResult.Completed)
-        }
-    }
-
-    @Test
-    fun `ActivityResultCaller callback should handle PaymentMethodObtained result correctly`() = runTest {
-        RecordingLinkStore.test {
-            val activityResultCaller: ActivityResultCaller = mock()
-            val linkAnalyticsHelper = TrackingLinkAnalyticsHelper()
-
-            val linkPaymentLauncher =
-                createLinkPaymentLauncher(linkStore = linkStore, linkAnalyticsHelper = linkAnalyticsHelper)
-
-            whenever(
-                activityResultCaller.registerForActivityResult(
-                    any<LinkActivityContract>(),
-                    any()
-                )
-            ).thenAnswer { invocation ->
-                val callback = invocation.getArgument<ActivityResultCallback<LinkActivityResult>>(1)
-                callback.onActivityResult(LinkActivityResult.PaymentMethodObtained(mock()))
-                mock<ActivityResultLauncher<LinkActivityContract.Args>>()
-            }
-
-            var callbackParam: LinkActivityResult? = null
-            linkPaymentLauncher.register(activityResultCaller) {
-                callbackParam = it
-            }
-
-            verify(linkStore).markLinkAsUsed()
-            assertThat(callbackParam).isInstanceOf(LinkActivityResult.PaymentMethodObtained::class.java)
-            assertThat(markAsUsedCalls.cancelAndConsumeRemainingEvents().size).isEqualTo(1)
-            assertThat(linkAnalyticsHelper.lastResult)
-                .isInstanceOf(LinkActivityResult.PaymentMethodObtained::class.java)
-        }
-    }
-
-    @Test
-    fun `ActivityResultRegistry callback should handle Canceled result correctly`() = runTest {
-        RecordingLinkStore.test {
-            val activityResultRegistry: ActivityResultRegistry = mock()
-            val linkAnalyticsHelper = TrackingLinkAnalyticsHelper()
-
-            val linkPaymentLauncher =
-                createLinkPaymentLauncher(linkStore = linkStore, linkAnalyticsHelper = linkAnalyticsHelper)
-
-            whenever(
-                activityResultRegistry.register(
-                    any(),
-                    any<ActivityResultContract<LinkActivityContract.Args, LinkActivityResult>>(),
-                    any()
-                )
-            ).thenAnswer { invocation ->
-                val callback = invocation.getArgument<ActivityResultCallback<LinkActivityResult>>(2)
-                callback.onActivityResult(LinkActivityResult.Canceled())
-                mock<ActivityResultLauncher<LinkActivityContract.Args>>()
-            }
-
-            var callbackParam: LinkActivityResult? = null
-            linkPaymentLauncher.register(activityResultRegistry) {
-                callbackParam = it
-            }
-
-            verify(linkStore, never()).markLinkAsUsed()
-            assertThat(callbackParam).isInstanceOf(LinkActivityResult.Canceled::class.java)
-            assertThat(markAsUsedCalls.cancelAndConsumeRemainingEvents()).isEmpty()
-            assertThat(linkAnalyticsHelper.lastResult).isInstanceOf(LinkActivityResult.Canceled::class.java)
-        }
-    }
-
-    @Test
-    fun `ActivityResultCaller callback should handle Failed result correctly`() = runTest {
-        RecordingLinkStore.test {
-            val activityResultCaller: ActivityResultCaller = mock()
-            val linkAnalyticsHelper = TrackingLinkAnalyticsHelper()
-
-            val linkPaymentLauncher =
-                createLinkPaymentLauncher(linkStore = linkStore, linkAnalyticsHelper = linkAnalyticsHelper)
-
-            whenever(
-                activityResultCaller.registerForActivityResult(
-                    any<LinkActivityContract>(),
-                    any()
-                )
-            ).thenAnswer { invocation ->
-                val callback = invocation.getArgument<ActivityResultCallback<LinkActivityResult>>(1)
-                callback.onActivityResult(LinkActivityResult.Failed(Exception("Test exception")))
-                mock<ActivityResultLauncher<LinkActivityContract.Args>>()
-            }
-
-            var callbackParam: LinkActivityResult? = null
-            linkPaymentLauncher.register(activityResultCaller) {
-                callbackParam = it
-            }
-
-            verify(linkStore, never()).markLinkAsUsed()
-            assertThat(callbackParam).isInstanceOf(LinkActivityResult.Failed::class.java)
-            assertThat(markAsUsedCalls.cancelAndConsumeRemainingEvents()).isEmpty()
-            assertThat(linkAnalyticsHelper.lastResult).isInstanceOf(LinkActivityResult.Failed::class.java)
+        ).thenAnswer { invocation ->
+            val callback = invocation.getArgument<ActivityResultCallback<LinkActivityResult>>(1)
+            callback.onActivityResult(linkActivityResult)
+            mock<ActivityResultLauncher<LinkActivityContract.Args>>()
         }
     }
 
     private fun createLinkPaymentLauncher(
         linkActivityContract: LinkActivityContract = mock(),
-        linkAnalyticsHelper: LinkAnalyticsHelper = LauncherLinkAnalyticsHelper(),
+        linkAnalyticsHelper: LinkAnalyticsHelper = TrackingLinkAnalyticsHelper(),
         linkStore: LinkStore = mock()
     ): LinkPaymentLauncher {
         return LinkPaymentLauncher(
@@ -270,13 +313,15 @@ internal class LinkPaymentLauncherTest {
     }
 }
 
-private open class LauncherLinkAnalyticsHelper : FakeLinkAnalyticsHelper() {
-    override fun onLinkLaunched() = Unit
-}
+private class TrackingLinkAnalyticsHelper : FakeLinkAnalyticsHelper() {
+    val results = arrayListOf<LinkActivityResult>()
+    var launchCount = 0
 
-private class TrackingLinkAnalyticsHelper : LauncherLinkAnalyticsHelper() {
-    var lastResult: LinkActivityResult? = null
-    override fun onLinkResult(linkResult: LinkActivityResult) {
-        lastResult = linkResult
+    override fun onLinkLaunched() {
+        launchCount++
+    }
+
+    override fun onLinkResult(linkActivityResult: LinkActivityResult) {
+        results.add(linkActivityResult)
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/link/analytics/DefaultLinkAnalyticsHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/analytics/DefaultLinkAnalyticsHelperTest.kt
@@ -7,7 +7,7 @@ import org.junit.Test
 
 internal class DefaultLinkAnalyticsHelperTest {
     @Test
-    fun testOnLinkLaunchedCalls_onPopupShow() {
+    fun `test onLinkLaunched calls onPopupShow`() {
         val eventReporter = object : FakeLinkEventsReporter() {
             override fun onPopupShow() {
                 calledCount++
@@ -19,7 +19,7 @@ internal class DefaultLinkAnalyticsHelperTest {
     }
 
     @Test
-    fun testOnLinkResultCalls_onPopupSuccess() {
+    fun `test onLinkResult with PaymentMethodObtained calls onPopupSuccess`() {
         val eventReporter = object : FakeLinkEventsReporter() {
             override fun onPopupSuccess() {
                 calledCount++
@@ -41,7 +41,19 @@ internal class DefaultLinkAnalyticsHelperTest {
     }
 
     @Test
-    fun testOnLinkResultCalls_onPopupError() {
+    fun `test onLinkResult with Completed calls onPopupSuccess`() {
+        val eventReporter = object : FakeLinkEventsReporter() {
+            override fun onPopupSuccess() {
+                calledCount++
+            }
+        }
+        val analyticsHelper = DefaultLinkAnalyticsHelper(eventReporter)
+        analyticsHelper.onLinkResult(LinkActivityResult.Completed)
+        assertThat(eventReporter.calledCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `test onLinkResult with Failed calls onPopupError`() {
         val eventReporter = object : FakeLinkEventsReporter() {
             override fun onPopupError(error: Throwable) {
                 calledCount++
@@ -53,7 +65,7 @@ internal class DefaultLinkAnalyticsHelperTest {
     }
 
     @Test
-    fun testOnLinkResultCalls_onPopupCancel() {
+    fun `test onLinkResult with CanceledBackPressed calls onPopupCancel`() {
         val eventReporter = object : FakeLinkEventsReporter() {
             override fun onPopupCancel() {
                 calledCount++
@@ -65,7 +77,7 @@ internal class DefaultLinkAnalyticsHelperTest {
     }
 
     @Test
-    fun testOnLinkResultCalls_onPopupLogout() {
+    fun `test onLinkResult with CanceledLoggedOut calls onPopupLogout`() {
         val eventReporter = object : FakeLinkEventsReporter() {
             override fun onPopupLogout() {
                 calledCount++
@@ -77,7 +89,7 @@ internal class DefaultLinkAnalyticsHelperTest {
     }
 
     @Test
-    fun testOnLinkSkippedCalls_onPopupSkipped() {
+    fun `test onLinkPopupSkipped calls onPopupSkipped`() {
         val eventReporter = object : FakeLinkEventsReporter() {
             override fun onPopupSkipped() {
                 calledCount++

--- a/paymentsheet/src/test/java/com/stripe/android/link/analytics/DefaultLinkAnalyticsHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/analytics/DefaultLinkAnalyticsHelperTest.kt
@@ -5,7 +5,7 @@ import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.model.PaymentMethod
 import org.junit.Test
 
-internal class LinkAnalyticsHelperTest {
+internal class DefaultLinkAnalyticsHelperTest {
     @Test
     fun testOnLinkLaunchedCalls_onPopupShow() {
         val eventReporter = object : FakeLinkEventsReporter() {
@@ -13,7 +13,7 @@ internal class LinkAnalyticsHelperTest {
                 calledCount++
             }
         }
-        val analyticsHelper = LinkAnalyticsHelper(eventReporter)
+        val analyticsHelper = DefaultLinkAnalyticsHelper(eventReporter)
         analyticsHelper.onLinkLaunched()
         assertThat(eventReporter.calledCount).isEqualTo(1)
     }
@@ -25,7 +25,7 @@ internal class LinkAnalyticsHelperTest {
                 calledCount++
             }
         }
-        val analyticsHelper = LinkAnalyticsHelper(eventReporter)
+        val analyticsHelper = DefaultLinkAnalyticsHelper(eventReporter)
         analyticsHelper.onLinkResult(
             linkActivityResult = LinkActivityResult.PaymentMethodObtained(
                 paymentMethod = PaymentMethod(
@@ -47,7 +47,7 @@ internal class LinkAnalyticsHelperTest {
                 calledCount++
             }
         }
-        val analyticsHelper = LinkAnalyticsHelper(eventReporter)
+        val analyticsHelper = DefaultLinkAnalyticsHelper(eventReporter)
         analyticsHelper.onLinkResult(LinkActivityResult.Failed(IllegalStateException()))
         assertThat(eventReporter.calledCount).isEqualTo(1)
     }
@@ -59,7 +59,7 @@ internal class LinkAnalyticsHelperTest {
                 calledCount++
             }
         }
-        val analyticsHelper = LinkAnalyticsHelper(eventReporter)
+        val analyticsHelper = DefaultLinkAnalyticsHelper(eventReporter)
         analyticsHelper.onLinkResult(LinkActivityResult.Canceled(LinkActivityResult.Canceled.Reason.BackPressed))
         assertThat(eventReporter.calledCount).isEqualTo(1)
     }
@@ -71,7 +71,7 @@ internal class LinkAnalyticsHelperTest {
                 calledCount++
             }
         }
-        val analyticsHelper = LinkAnalyticsHelper(eventReporter)
+        val analyticsHelper = DefaultLinkAnalyticsHelper(eventReporter)
         analyticsHelper.onLinkResult(LinkActivityResult.Canceled(LinkActivityResult.Canceled.Reason.LoggedOut))
         assertThat(eventReporter.calledCount).isEqualTo(1)
     }
@@ -83,7 +83,7 @@ internal class LinkAnalyticsHelperTest {
                 calledCount++
             }
         }
-        val analyticsHelper = LinkAnalyticsHelper(eventReporter)
+        val analyticsHelper = DefaultLinkAnalyticsHelper(eventReporter)
         analyticsHelper.onLinkPopupSkipped()
         assertThat(eventReporter.calledCount).isEqualTo(1)
     }

--- a/paymentsheet/src/test/java/com/stripe/android/link/analytics/FakeLinkAnalyticsHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/analytics/FakeLinkAnalyticsHelper.kt
@@ -1,0 +1,18 @@
+package com.stripe.android.link.analytics
+
+import com.stripe.android.link.LinkActivityResult
+
+internal open class FakeLinkAnalyticsHelper : LinkAnalyticsHelper {
+    override fun onLinkLaunched() {
+        TODO("Not yet implemented")
+    }
+
+    override fun onLinkResult(linkActivityResult: LinkActivityResult) {
+        TODO("Not yet implemented")
+    }
+
+    override fun onLinkPopupSkipped() {
+        TODO("Not yet implemented")
+    }
+
+}

--- a/paymentsheet/src/test/java/com/stripe/android/link/analytics/FakeLinkAnalyticsHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/analytics/FakeLinkAnalyticsHelper.kt
@@ -14,5 +14,4 @@ internal open class FakeLinkAnalyticsHelper : LinkAnalyticsHelper {
     override fun onLinkPopupSkipped() {
         TODO("Not yet implemented")
     }
-
 }

--- a/paymentsheet/src/test/java/com/stripe/android/link/analytics/LinkAnalyticsHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/analytics/LinkAnalyticsHelperTest.kt
@@ -27,7 +27,7 @@ internal class LinkAnalyticsHelperTest {
         }
         val analyticsHelper = LinkAnalyticsHelper(eventReporter)
         analyticsHelper.onLinkResult(
-            linkActivityResult = LinkActivityResult.Completed(
+            linkActivityResult = LinkActivityResult.PaymentMethodObtained(
                 paymentMethod = PaymentMethod(
                     id = null,
                     created = null,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinitionTest.kt
@@ -113,7 +113,7 @@ internal class LinkConfirmationDefinitionTest {
     }
 
     @Test
-    fun `'toResult' should return 'NextStep' when result is 'Complete' & also mark Link as used`() = test {
+    fun `'toResult' should return 'NextStep' when result is 'PaymentMethodObtained' & also mark Link as used`() = test {
         val definition = createLinkConfirmationDefinition(linkStore = storeScenario.linkStore)
 
         val paymentMethod = PaymentMethodFactory.card()
@@ -121,7 +121,7 @@ internal class LinkConfirmationDefinitionTest {
         val result = definition.toResult(
             confirmationOption = LINK_CONFIRMATION_OPTION,
             confirmationParameters = CONFIRMATION_PARAMETERS,
-            result = LinkActivityResult.Completed(paymentMethod),
+            result = LinkActivityResult.PaymentMethodObtained(paymentMethod),
             deferredIntentConfirmationType = null,
         )
 
@@ -137,6 +137,26 @@ internal class LinkConfirmationDefinitionTest {
         assertThat(savedOption.paymentMethod).isEqualTo(paymentMethod)
         assertThat(savedOption.optionsParams).isNull()
 
+        assertThat(storeScenario.markAsUsedCalls.awaitItem()).isNotNull()
+    }
+
+    @Test
+    fun `'toResult' should return 'Succeeded' when result is 'Completed' & also mark Link as used`() = test {
+        val definition = createLinkConfirmationDefinition(linkStore = storeScenario.linkStore)
+
+        val result = definition.toResult(
+            confirmationOption = LINK_CONFIRMATION_OPTION,
+            confirmationParameters = CONFIRMATION_PARAMETERS,
+            result = LinkActivityResult.Completed,
+            deferredIntentConfirmationType = null,
+        )
+
+        assertThat(result).isEqualTo(
+            ConfirmationDefinition.Result.Succeeded(
+                intent = CONFIRMATION_PARAMETERS.intent,
+                deferredIntentConfirmationType = null
+            )
+        )
         assertThat(storeScenario.markAsUsedCalls.awaitItem()).isNotNull()
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationFlowTest.kt
@@ -108,7 +108,7 @@ class LinkConfirmationFlowTest {
 
         assertThat(registerCall.activityResultCaller).isEqualTo(activityResultCaller)
 
-        registerCall.callback(LinkActivityResult.Completed(PAYMENT_METHOD))
+        registerCall.callback(LinkActivityResult.PaymentMethodObtained(PAYMENT_METHOD))
 
         assertThat(countDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -737,7 +737,7 @@ internal class PaymentSheetActivityTest {
 
             assertThat(viewModel.walletsProcessingState.value).isEqualTo(WalletsProcessingState.Processing)
 
-            registerCall.callback(LinkActivityResult.Completed(PAYMENT_METHODS.first()))
+            registerCall.callback(LinkActivityResult.PaymentMethodObtained(PAYMENT_METHODS.first()))
 
             assertThat(viewModel.walletsProcessingState.value).isEqualTo(WalletsProcessingState.Processing)
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -969,7 +969,7 @@ internal class PaymentSheetViewModelTest {
                 assertThat(presentCalls.awaitItem()).isNotNull()
 
                 registerCall.callback(
-                    LinkActivityResult.Completed(
+                    LinkActivityResult.PaymentMethodObtained(
                         paymentMethod = CARD_WITH_NETWORKS_PAYMENT_METHOD
                     )
                 )

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeActivityResultRegistry.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeActivityResultRegistry.kt
@@ -1,0 +1,22 @@
+package com.stripe.android.utils
+
+import androidx.activity.result.ActivityResultRegistry
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.core.app.ActivityOptionsCompat
+
+internal class FakeActivityResultRegistry<T>(
+    private val result: T
+) : ActivityResultRegistry() {
+
+    override fun <I : Any?, O : Any?> onLaunch(
+        requestCode: Int,
+        contract: ActivityResultContract<I, O>,
+        input: I,
+        options: ActivityOptionsCompat?
+    ) {
+        dispatchResult(
+            requestCode,
+            result
+        )
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Current result set is [`completed(paymentMethod)`, `canceled`, `failed`].
New result set is [`completed`, `paymentMethodObtained(paymentMethod)`, `canceled`, `failed`].

This accounts for Link handling the payment confirmation. In this scenario, we don't need to send a payment method as part of the result.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
[JIRA](https://jira.corp.stripe.com/browse/MOBILESDK-2948)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
