### PR TITLE
Remove restrict to from card brand filtering in embedded.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
@@ -322,7 +322,6 @@ class EmbeddedPaymentElement private constructor(
              * **Note**: Card brand filtering is not currently supported in Link.
              */
             @ExperimentalCardBrandFilteringApi
-            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
             fun cardBrandAcceptance(
                 cardBrandAcceptance: PaymentSheet.CardBrandAcceptance
             ) = apply {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
I copied this over from PaymentSheet. But now it's in private beta, and no longer needs it's own restrict to.
