### PR TITLE
Pass composition to TextFieldUi.value to prevent render loop

### DIFF
--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldUI.kt
@@ -161,10 +161,15 @@ fun TextField(
         mutableStateOf<TextRange?>(null)
     }
 
+    var composition by remember {
+        mutableStateOf<TextRange?>(null)
+    }
+
     TextFieldUi(
         value = TextFieldValue(
             text = value,
             selection = selection ?: TextRange(value.length),
+            composition = composition
         ),
         loading = loading,
         onValueChange = { newValue ->
@@ -173,6 +178,7 @@ fun TextField(
 
             if (newTextValue == value || acceptInput) {
                 selection = newValue.selection
+                composition = newValue.composition
             }
 
             if (acceptInput) {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Remember composition and pass to `TextFieldValue` in `TextFieldUi`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Prevent some IME implementations from causing a render loop by setting composition which triggers onValueChanged

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

Testing doesn't appear possible as this bug requires interaction with the IME directly. All SemanticsNodeInteraction relating to text field manipulation e.g. `performTextInput` send the events directly to the component. They do not perform an interaction with the soft keyboard. `UiDevice.getInstance(getInstrumentation()).pressKeyCode(keyEvent)` behaves the same. At the moment, there is not a behavior similar to Espresso's `onView().perform(pressKey())` which does interact with the IME directly. Since espresso expects views on and not composables, we cannot match the TextField and perform text input using espresso.

# Before

https://github.com/user-attachments/assets/331fa239-ad4b-47c1-b723-8bb05711854e


# After


https://github.com/user-attachments/assets/bcc17713-6a43-492e-b9ad-d73552403735


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
