### PR TITLE
[Connect] Emit analytic events

### DIFF
--- a/connect/src/main/java/com/stripe/android/connect/analytics/ConnectAnalyticsEvent.kt
+++ b/connect/src/main/java/com/stripe/android/connect/analytics/ConnectAnalyticsEvent.kt
@@ -132,20 +132,17 @@ internal sealed class ConnectAnalyticsEvent(
      *
      * @param message The name of the message. If this message has a setter, concatenate it using {message}.{setter}
      * @param error The error identifier
-     * @param errorDescription The error's description, if there is one.
      * @param pageViewId The pageViewID from the web view. May be null if not yet sent from web
      */
     data class WebErrorDeserializeMessage(
         val message: String,
         val error: String,
-        val errorDescription: String?,
         val pageViewId: String?
     ) : ConnectAnalyticsEvent(
         "component.web.error.deserialize_message",
         mapOf(
             "message" to message,
             "error" to error,
-            "error_description" to errorDescription,
             "page_view_id" to pageViewId
         )
     )
@@ -239,12 +236,12 @@ internal sealed class ConnectAnalyticsEvent(
      * Catch-all event for unexpected client-side errors.
      */
     data class ClientError(
-        val error: String,
+        val errorCode: String,
         val errorMessage: String? = null,
     ) : ConnectAnalyticsEvent(
         "client_error",
         mapOf(
-            "error" to error,
+            "error_code" to errorCode,
             "error_message" to errorMessage,
         )
     )

--- a/connect/src/main/java/com/stripe/android/connect/analytics/ConnectAnalyticsEvent.kt
+++ b/connect/src/main/java/com/stripe/android/connect/analytics/ConnectAnalyticsEvent.kt
@@ -49,20 +49,20 @@ internal sealed class ConnectAnalyticsEvent(
      * @param pageViewId The pageViewID from the web view
      * @param timeToLoadMs Elapsed time in milliseconds it took the web page to load (starting when it first began
      *   loading).
-     * @param perceivedTimeToLoad Elapsed time in seconds in took between when the component was initially viewed
+     * @param perceivedTimeToLoadMs Elapsed time in milliseconds it took between when the component was initially viewed
      *   on screen (`component.viewed`) to when the component finished loading. This value will be `0` if the
      *   component finished loading before being viewed on screen.
      */
     data class WebComponentLoaded(
         val pageViewId: String,
         val timeToLoadMs: Long,
-        val perceivedTimeToLoad: Long
+        val perceivedTimeToLoadMs: Long
     ) : ConnectAnalyticsEvent(
         "component.web.component_loaded",
         mapOf(
             "page_view_id" to pageViewId,
             "time_to_load" to msToSecs(timeToLoadMs),
-            "perceived_time_to_load" to perceivedTimeToLoad.toString()
+            "perceived_time_to_load" to msToSecs(perceivedTimeToLoadMs)
         )
     )
 

--- a/connect/src/main/java/com/stripe/android/connect/analytics/ConnectAnalyticsEvent.kt
+++ b/connect/src/main/java/com/stripe/android/connect/analytics/ConnectAnalyticsEvent.kt
@@ -183,7 +183,7 @@ internal sealed class ConnectAnalyticsEvent(
 
     /**
      * The web page navigated somewhere other than the component wrapper URL
-     * (e.g. https://connect-js.stripe.com/v1.0/ios-webview.html)
+     * (e.g. https://connect-js.stripe.com/v1.0/android_webview.html)
      */
     data class WebErrorUnexpectedNavigation(
         val url: String
@@ -196,17 +196,13 @@ internal sealed class ConnectAnalyticsEvent(
      * Catch-all event for unexpected client-side errors.
      */
     data class ClientError(
-        val domain: String,
-        val code: Int,
-        val file: String,
-        val line: Int
+        val error: String,
+        val errorMessage: String? = null,
     ) : ConnectAnalyticsEvent(
         "client_error",
         mapOf(
-            "domain" to domain,
-            "code" to code.toString(),
-            "file" to file,
-            "line" to line.toString()
+            "error" to error,
+            "errorMessage" to errorMessage,
         )
     )
 }

--- a/connect/src/main/java/com/stripe/android/connect/analytics/ConnectAnalyticsEvent.kt
+++ b/connect/src/main/java/com/stripe/android/connect/analytics/ConnectAnalyticsEvent.kt
@@ -247,4 +247,5 @@ internal sealed class ConnectAnalyticsEvent(
     )
 }
 
+@SuppressWarnings("MagicNumber")
 private fun msToSecs(ms: Long): String = (ms / 1_000.0).toString()

--- a/connect/src/main/java/com/stripe/android/connect/analytics/ConnectAnalyticsEvent.kt
+++ b/connect/src/main/java/com/stripe/android/connect/analytics/ConnectAnalyticsEvent.kt
@@ -8,15 +8,17 @@ internal sealed class ConnectAnalyticsEvent(
     val params: Map<String, Any?> = mapOf(),
 ) {
     /**
-     * A component was instantiated via create{ComponentType}.
+     * A component was instantiated via `create{ComponentType}`.
      *
-     * The delta between this and component.viewed could tell us if apps are instantiating
+     * The delta between this and `component.viewed` could tell us if apps are instantiating
      * components but never rendering them on screen.
      */
     data object ComponentCreated : ConnectAnalyticsEvent("component.created")
 
     /**
      * The component is viewed on screen (viewDidAppear lifecycle event on iOS)
+     *
+     * @param pageViewId The pageViewID from the web view. May be null if not yet sent from web
      */
     data class ComponentViewed(
         val pageViewId: String?
@@ -28,28 +30,38 @@ internal sealed class ConnectAnalyticsEvent(
     /**
      * The web page finished loading (didFinish navigation on iOS).
      *
-     * Note: This should happen before component_loaded, so we won't yet have a page_view_id.
+     * Note: This should happen before `component_loaded`, so we won't yet have a `page_view_id`.
+     *
+     * @param timeToLoadMs Elapsed time in milliseconds it took the web page to load (starting when it first began
+     *   loading).
      */
     data class WebPageLoaded(
         val timeToLoadMs: Long
     ) : ConnectAnalyticsEvent(
         "component.web.page_loaded",
-        mapOf("time_to_load" to (timeToLoadMs.toDouble() / 1_000.0).toString())
+        mapOf("time_to_load" to msToSecs(timeToLoadMs))
     )
 
     /**
-     * The component is successfully loaded within the web view. Triggered from componentDidLoad
+     * The component is successfully loaded within the web view. Triggered from `pageDidLoad`
      * message handler from the web view.
+     *
+     * @param pageViewId The pageViewID from the web view
+     * @param timeToLoadMs Elapsed time in milliseconds it took the web page to load (starting when it first began
+     *   loading).
+     * @param perceivedTimeToLoad Elapsed time in seconds in took between when the component was initially viewed
+     *   on screen (`component.viewed`) to when the component finished loading. This value will be `0` if the
+     *   component finished loading before being viewed on screen.
      */
     data class WebComponentLoaded(
         val pageViewId: String,
-        val timeToLoad: Long,
+        val timeToLoadMs: Long,
         val perceivedTimeToLoad: Long
     ) : ConnectAnalyticsEvent(
         "component.web.component_loaded",
         mapOf(
             "page_view_id" to pageViewId,
-            "time_to_load" to timeToLoad.toString(),
+            "time_to_load" to msToSecs(timeToLoadMs),
             "perceived_time_to_load" to perceivedTimeToLoad.toString()
         )
     )
@@ -59,6 +71,10 @@ internal sealed class ConnectAnalyticsEvent(
      *
      * Intent is to alert if the URL the mobile client expects is suddenly unreachable.
      * The web view should always return a 200, even when displaying an error state.
+     *
+     * @param status HTTP status code. This will be null if the error is not an http status type of error
+     * @param error Identifier of the error if it's not an http status error (e.g. CORS issue, SSL error, etc)
+     * @param url The URL of the page, excluding hash params
      */
     data class WebErrorPageLoad(
         val status: Int?,
@@ -74,13 +90,16 @@ internal sealed class ConnectAnalyticsEvent(
     )
 
     /**
-     * If the web view sends an onLoadError that can't be deserialized by the SDK.
+     * If the web view sends an `onLoadError` that can't be deserialized by the SDK.
+     *
+     * @param errorType The error `type` property from web
+     * @param pageViewId The pageViewID from the web view. May be null if not yet sent from web
      */
-    data class WebWarnErrorUnexpectedLoad(
+    data class WebWarnUnexpectedLoad(
         val errorType: String,
         val pageViewId: String?
     ) : ConnectAnalyticsEvent(
-        "component.web.warnerror.unexpected_load_error_type",
+        "component.web.warn.unexpected_load_error_type",
         mapOf(
             "error_type" to errorType,
             "page_view_id" to pageViewId
@@ -88,11 +107,14 @@ internal sealed class ConnectAnalyticsEvent(
     )
 
     /**
-     * If the web view calls onSetterFunctionCalled with a setter argument the SDK doesn't know how to handle.
+     * If the web view calls `onSetterFunctionCalled` with a `setter` argument the SDK doesn't know how to handle.
      *
      * Note: It's expected to get this warning when web adds support for new setter functions not handled
      * in older SDK versions. But logging it could help us debug issues where we expect the SDK to handle
      * something it isn't.
+     *
+     * @param setter `setter` property sent from web
+     * @param pageViewId The pageViewID from the web view. May be null if not yet sent from web
      */
     data class WebWarnUnrecognizedSetter(
         val setter: String,
@@ -107,6 +129,11 @@ internal sealed class ConnectAnalyticsEvent(
 
     /**
      * An error occurred deserializing the JSON payload from a web message.
+     *
+     * @param message The name of the message. If this message has a setter, concatenate it using {message}.{setter}
+     * @param error The error identifier
+     * @param errorDescription The error's description, if there is one.
+     * @param pageViewId The pageViewID from the web view. May be null if not yet sent from web
      */
     data class WebErrorDeserializeMessage(
         val message: String,
@@ -124,7 +151,10 @@ internal sealed class ConnectAnalyticsEvent(
     )
 
     /**
-     * A web view was opened when openWebView was called.
+     * A web view was opened when `openWebView` was called.
+     *
+     * @param pageViewId The pageViewID from the web view. May be null if not yet sent from web
+     * @param authenticatedViewId The id for this secure web view session (sent in `openWebView` message)
      */
     data class AuthenticatedWebOpened(
         val pageViewId: String?,
@@ -139,6 +169,9 @@ internal sealed class ConnectAnalyticsEvent(
 
     /**
      * The web view successfully redirected back to the app.
+     *
+     * @param pageViewId The pageViewID from the web view. May be null if not yet sent from web
+     * @param authenticatedViewId The id for this secure web view session (sent in `openWebView` message)
      */
     data class AuthenticatedWebRedirected(
         val pageViewId: String?,
@@ -153,37 +186,47 @@ internal sealed class ConnectAnalyticsEvent(
 
     /**
      * The user closed the web view before getting redirected back to the app.
+     *
+     * @param pageViewId The pageViewID from the web view. May be null if not yet sent from web
+     * @param authenticatedViewId The id for this secure web view session (sent in `openWebView` message)
      */
     data class AuthenticatedWebCanceled(
         val pageViewId: String?,
-        val viewId: String
+        val authenticatedViewId: String
     ) : ConnectAnalyticsEvent(
         "component.authenticated_web.canceled",
         mapOf(
             "page_view_id" to pageViewId,
-            "view_id" to viewId
+            "authenticated_view_id" to authenticatedViewId
         )
     )
 
     /**
      * The web view threw an error and was not successfully redirected back to the app.
+     *
+     * @param error The error identifier
+     * @param pageViewId The pageViewID from the web view. May be null if not yet sent from web
+     * @param authenticatedViewId The id for this secure web view session (sent in `openWebView` message)
      */
     data class AuthenticatedWebError(
         val error: String,
         val pageViewId: String?,
-        val viewId: String
+        val authenticatedViewId: String
     ) : ConnectAnalyticsEvent(
         "component.authenticated_web.error",
         mapOf(
             "error" to error,
             "page_view_id" to pageViewId,
-            "view_id" to viewId
+            "authenticated_view_id" to authenticatedViewId
         )
     )
 
     /**
      * The web page navigated somewhere other than the component wrapper URL
      * (e.g. https://connect-js.stripe.com/v1.0/android_webview.html)
+     *
+     * @param url The base URL that was navigated to. The url should have all query params and hash params removed
+     * since these could potentially contain sensitive data
      */
     data class WebErrorUnexpectedNavigation(
         val url: String
@@ -202,7 +245,9 @@ internal sealed class ConnectAnalyticsEvent(
         "client_error",
         mapOf(
             "error" to error,
-            "errorMessage" to errorMessage,
+            "error_message" to errorMessage,
         )
     )
 }
+
+private fun msToSecs(ms: Long): String = (ms / 1_000.0).toString()

--- a/connect/src/main/java/com/stripe/android/connect/analytics/ConnectAnalyticsEvent.kt
+++ b/connect/src/main/java/com/stripe/android/connect/analytics/ConnectAnalyticsEvent.kt
@@ -31,7 +31,7 @@ internal sealed class ConnectAnalyticsEvent(
      * Note: This should happen before component_loaded, so we won't yet have a page_view_id.
      */
     data class WebPageLoaded(
-        val timeToLoad: Double
+        val timeToLoad: Long
     ) : ConnectAnalyticsEvent(
         "component.web.page_loaded",
         mapOf("time_to_load" to timeToLoad.toString())
@@ -43,8 +43,8 @@ internal sealed class ConnectAnalyticsEvent(
      */
     data class WebComponentLoaded(
         val pageViewId: String,
-        val timeToLoad: Double,
-        val perceivedTimeToLoad: Double
+        val timeToLoad: Long,
+        val perceivedTimeToLoad: Long
     ) : ConnectAnalyticsEvent(
         "component.web.component_loaded",
         mapOf(

--- a/connect/src/main/java/com/stripe/android/connect/analytics/ConnectAnalyticsEvent.kt
+++ b/connect/src/main/java/com/stripe/android/connect/analytics/ConnectAnalyticsEvent.kt
@@ -31,10 +31,10 @@ internal sealed class ConnectAnalyticsEvent(
      * Note: This should happen before component_loaded, so we won't yet have a page_view_id.
      */
     data class WebPageLoaded(
-        val timeToLoad: Long
+        val timeToLoadMs: Long
     ) : ConnectAnalyticsEvent(
         "component.web.page_loaded",
-        mapOf("time_to_load" to timeToLoad.toString())
+        mapOf("time_to_load" to (timeToLoadMs.toDouble() / 1_000.0).toString())
     )
 
     /**

--- a/connect/src/main/java/com/stripe/android/connect/util/AndroidClock.kt
+++ b/connect/src/main/java/com/stripe/android/connect/util/AndroidClock.kt
@@ -1,0 +1,23 @@
+package com.stripe.android.connect.util
+
+/**
+ * [Clock] interface to be used to provide compatible `Clock` functionality,
+ * and one day be replaced by `java.time.Clock` when all consumers support > SDK 26.
+ *
+ * Also useful for mocking in tests.
+ */
+interface Clock {
+
+    /**
+     * Return the current system time in milliseconds
+     */
+    fun millis(): Long
+}
+
+/**
+ * A [Clock] that depends on Android APIs. To be replaced by java.time.Clock when all consumers
+ * support > SDK 26.
+ */
+class AndroidClock : Clock {
+    override fun millis(): Long = System.currentTimeMillis()
+}

--- a/connect/src/main/java/com/stripe/android/connect/util/AndroidClock.kt
+++ b/connect/src/main/java/com/stripe/android/connect/util/AndroidClock.kt
@@ -6,7 +6,7 @@ package com.stripe.android.connect.util
  *
  * Also useful for mocking in tests.
  */
-interface Clock {
+internal interface Clock {
 
     /**
      * Return the current system time in milliseconds
@@ -18,6 +18,6 @@ interface Clock {
  * A [Clock] that depends on Android APIs. To be replaced by java.time.Clock when all consumers
  * support > SDK 26.
  */
-class AndroidClock : Clock {
+internal class AndroidClock : Clock {
     override fun millis(): Long = System.currentTimeMillis()
 }

--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainer.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainer.kt
@@ -268,7 +268,7 @@ internal class StripeConnectWebViewContainerImpl<Listener, Props>(
     @VisibleForTesting
     internal inner class StripeConnectWebViewClient : WebViewClient() {
         override fun onPageStarted(view: WebView, url: String?, favicon: Bitmap?) {
-            controller?.onPageStarted()
+            controller?.onPageStarted(url)
         }
 
         override fun onPageFinished(view: WebView?, url: String?) {

--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainer.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainer.kt
@@ -433,9 +433,8 @@ internal class StripeConnectWebViewContainerImpl<Listener, Props>(
             ConnectJson.decodeFromString<T>(message)
         } catch (e: IllegalArgumentException) {
             controller?.onErrorDeserializingWebMessage(
-                webMessage = message,
-                error = "Unable to deserialize message from $webFunctionName",
-                errorMessage = e.message,
+                webFunctionName = webFunctionName,
+                error = e,
             )
             null
         }

--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainer.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainer.kt
@@ -33,6 +33,7 @@ import com.stripe.android.connect.StripeEmbeddedComponentListener
 import com.stripe.android.connect.appearance.Appearance
 import com.stripe.android.connect.databinding.StripeConnectWebviewBinding
 import com.stripe.android.connect.toJsonObject
+import com.stripe.android.connect.util.AndroidClock
 import com.stripe.android.connect.webview.serialization.AccountSessionClaimedMessage
 import com.stripe.android.connect.webview.serialization.ConnectInstanceJs
 import com.stripe.android.connect.webview.serialization.ConnectJson
@@ -202,6 +203,7 @@ internal class StripeConnectWebViewContainerImpl<Listener, Props>(
         this.controller = StripeConnectWebViewContainerController(
             view = this,
             analyticsService = analyticsService,
+            clock = AndroidClock(),
             embeddedComponentManager = embeddedComponentManager,
             embeddedComponent = embeddedComponent,
             listener = listener,
@@ -267,6 +269,10 @@ internal class StripeConnectWebViewContainerImpl<Listener, Props>(
     internal inner class StripeConnectWebViewClient : WebViewClient() {
         override fun onPageStarted(view: WebView, url: String?, favicon: Bitmap?) {
             controller?.onPageStarted()
+        }
+
+        override fun onPageFinished(view: WebView?, url: String?) {
+            controller?.onPageFinished()
         }
 
         override fun onReceivedHttpError(
@@ -388,7 +394,7 @@ internal class StripeConnectWebViewContainerImpl<Listener, Props>(
             val pageLoadMessage = ConnectJson.decodeFromString<PageLoadMessage>(message)
             logger.debug("Page did load: $pageLoadMessage")
 
-            controller?.onReceivedPageDidLoad()
+            controller?.onReceivedPageDidLoad(pageLoadMessage.pageViewId)
         }
 
         @JavascriptInterface

--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerController.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerController.kt
@@ -290,8 +290,8 @@ internal class StripeConnectWebViewContainerController<Listener : StripeEmbedded
         analyticsService.track(
             ConnectAnalyticsEvent.WebComponentLoaded(
                 pageViewId = pageViewId,
-                timeToLoad = timeToLoad,
-                perceivedTimeToLoad = timeToLoad,
+                timeToLoadMs = timeToLoad,
+                perceivedTimeToLoadMs = timeToLoad,
             )
         )
     }

--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerController.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerController.kt
@@ -80,9 +80,13 @@ internal class StripeConnectWebViewContainerController<Listener : StripeEmbedded
         if (url != null) {
             val pageLoadUrl = Uri.parse(url)
             val expectedUrl = Uri.parse(embeddedComponentManager.getStripeURL(embeddedComponent))
-            if (pageLoadUrl.host != expectedUrl.host || pageLoadUrl.path != expectedUrl.path) {
+            if (
+                pageLoadUrl.scheme != expectedUrl.scheme ||
+                pageLoadUrl.host != expectedUrl.host ||
+                pageLoadUrl.path != expectedUrl.path
+            ) {
                 // expected URL doesn't match what we navigated to
-                val sanitizedUrl = pageLoadUrl.buildUpon().clearQuery().build().toString()
+                val sanitizedUrl = pageLoadUrl.buildUpon().clearQuery().fragment(null).build().toString()
                 analyticsService.track(ConnectAnalyticsEvent.WebErrorUnexpectedNavigation(sanitizedUrl))
             }
         }
@@ -236,11 +240,11 @@ internal class StripeConnectWebViewContainerController<Listener : StripeEmbedded
                 analyticsService.track(
                     ConnectAnalyticsEvent.ClientError(
                         error = "Unexpected permissions request",
-                        errorMessage = "Unexpected permissions ${request.resources.joinToString()} requested"
+                        errorMessage = "Unexpected permissions '${request.resources.joinToString()}' requested"
                     )
                 )
                 logger.warning(
-                    "($loggerTag) Denying permission - ${request.resources.joinToString()} are not supported"
+                    "($loggerTag) Denying permission - '${request.resources.joinToString()}' are not supported"
                 )
             }
             return

--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerController.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerController.kt
@@ -121,11 +121,13 @@ internal class StripeConnectWebViewContainerController<Listener : StripeEmbedded
         // don't send errors for requests that aren't for the main page load
         if (isMainPageLoad) {
             listener?.onLoadError(RuntimeException(errorString)) // TODO - wrap error better
-            analyticsService.track(ConnectAnalyticsEvent.WebErrorPageLoad(
-                status = httpStatusCode,
-                error = errorMessage,
-                url = requestUrl
-            ))
+            analyticsService.track(
+                ConnectAnalyticsEvent.WebErrorPageLoad(
+                    status = httpStatusCode,
+                    error = errorMessage,
+                    url = requestUrl
+                )
+            )
         }
     }
 
@@ -134,12 +136,14 @@ internal class StripeConnectWebViewContainerController<Listener : StripeEmbedded
         error: String,
         errorMessage: String?,
     ) {
-        analyticsService.track(ConnectAnalyticsEvent.WebErrorDeserializeMessage(
-            message = webMessage,
-            error = error,
-            errorDescription = errorMessage,
-            pageViewId = stateFlow.value.pageViewId,
-        ))
+        analyticsService.track(
+            ConnectAnalyticsEvent.WebErrorDeserializeMessage(
+                message = webMessage,
+                error = error,
+                errorDescription = errorMessage,
+                pageViewId = stateFlow.value.pageViewId,
+            )
+        )
     }
 
     /**
@@ -158,10 +162,12 @@ internal class StripeConnectWebViewContainerController<Listener : StripeEmbedded
         val url = request.url
         return if (url.host?.lowercase() in ALLOWLISTED_HOSTS) {
             logger.warning("($loggerTag) Received pop-up for allow-listed host: $url")
-            analyticsService.track(ConnectAnalyticsEvent.ClientError(
-                error = "Unexpected pop-up",
-                errorMessage = "Received pop-up for allow-listed host: $url"
-            ))
+            analyticsService.track(
+                ConnectAnalyticsEvent.ClientError(
+                    error = "Unexpected pop-up",
+                    errorMessage = "Received pop-up for allow-listed host: $url"
+                )
+            )
             false // Allow the request to propagate so we open URL in WebView, but this is not an expected operation
         } else if (
             url.scheme.equals("https", ignoreCase = true) || url.scheme.equals("http", ignoreCase = true)
@@ -227,10 +233,12 @@ internal class StripeConnectWebViewContainerController<Listener : StripeEmbedded
         if (permissionsRequested.isEmpty()) { // all calls to PermissionRequest must be on the main thread
             withContext(Dispatchers.Main) {
                 request.deny() // no supported permissions were requested, so reject the request
-                analyticsService.track(ConnectAnalyticsEvent.ClientError(
-                    error = "Unexpected permissions request",
-                    errorMessage = "Unexpected permissions ${request.resources.joinToString()} requested"
-                ))
+                analyticsService.track(
+                    ConnectAnalyticsEvent.ClientError(
+                        error = "Unexpected permissions request",
+                        errorMessage = "Unexpected permissions ${request.resources.joinToString()} requested"
+                    )
+                )
                 logger.warning(
                     "($loggerTag) Denying permission - ${request.resources.joinToString()} are not supported"
                 )
@@ -272,12 +280,16 @@ internal class StripeConnectWebViewContainerController<Listener : StripeEmbedded
         view.updateConnectInstance(embeddedComponentManager.appearanceFlow.value)
         updateState { copy(pageViewId = pageViewId) }
 
+        // right now view onAttach and begin load happen at the same time,
+        // so timeToLoad and perceivedTimeToLoad are the same value
         val timeToLoad = clock.millis() - (stateFlow.value.didBeginLoadingMillis ?: 0)
-        analyticsService.track(ConnectAnalyticsEvent.WebComponentLoaded(
-            pageViewId = pageViewId,
-            timeToLoad = timeToLoad,          // right now view onAttach and begin load happen at the same time,
-            perceivedTimeToLoad = timeToLoad, // so timeToLoad and perceivedTimeToLoad are the same value
-        ))
+        analyticsService.track(
+            ConnectAnalyticsEvent.WebComponentLoaded(
+                pageViewId = pageViewId,
+                timeToLoad = timeToLoad,
+                perceivedTimeToLoad = timeToLoad,
+            )
+        )
     }
 
     /**
@@ -300,10 +312,12 @@ internal class StripeConnectWebViewContainerController<Listener : StripeEmbedded
             }
             else -> {
                 if (value is UnknownValue) {
-                    analyticsService.track(ConnectAnalyticsEvent.WebWarnUnrecognizedSetter(
-                        setter = message.setter,
-                        pageViewId = stateFlow.value.pageViewId
-                    ))
+                    analyticsService.track(
+                        ConnectAnalyticsEvent.WebWarnUnrecognizedSetter(
+                            setter = message.setter,
+                            pageViewId = stateFlow.value.pageViewId
+                        )
+                    )
                 }
                 with(listenerDelegate) {
                     listener?.delegate(message)

--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerController.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerController.kt
@@ -129,6 +129,19 @@ internal class StripeConnectWebViewContainerController<Listener : StripeEmbedded
         }
     }
 
+    fun onErrorDeserializingWebMessage(
+        webMessage: String,
+        error: String,
+        errorMessage: String?,
+    ) {
+        analyticsService.track(ConnectAnalyticsEvent.WebErrorDeserializeMessage(
+            message = webMessage,
+            error = error,
+            errorDescription = errorMessage,
+            pageViewId = stateFlow.value.pageViewId,
+        ))
+    }
+
     /**
      * Callback whenever the merchant ID changes, such as in the
      */

--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerState.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerState.kt
@@ -9,9 +9,15 @@ import com.stripe.android.connect.util.getContrastingColor
 @OptIn(PrivateBetaConnectSDK::class)
 internal data class StripeConnectWebViewContainerState(
     /**
-     * True if we received the 'pageDidLoad' message.
+     * Non-null if we received the 'pageDidLoad' message,
+     * null otherwise.
      */
-    val receivedPageDidLoad: Boolean = false,
+    val pageViewId: String? = null,
+
+    /**
+     * The time the webview began loading, in milliseconds from midnight, January 1, 1970 UTC.
+     */
+    val didBeginLoadingMillis: Long? = null,
 
     /**
      * True if we received the 'setOnLoaderStart' message.

--- a/connect/src/test/java/com/stripe/android/connect/analytics/ComponentAnalyticsServiceTest.kt
+++ b/connect/src/test/java/com/stripe/android/connect/analytics/ComponentAnalyticsServiceTest.kt
@@ -86,8 +86,8 @@ class ComponentAnalyticsServiceTest {
         componentAnalyticsService.track(
             ConnectAnalyticsEvent.WebComponentLoaded(
                 pageViewId = "pageViewId123",
-                timeToLoad = 100.0,
-                perceivedTimeToLoad = 50.0,
+                timeToLoad = 100L,
+                perceivedTimeToLoad = 50L,
             )
         )
         val mapCaptor = argumentCaptor<Map<String, Any?>>()

--- a/connect/src/test/java/com/stripe/android/connect/analytics/ComponentAnalyticsServiceTest.kt
+++ b/connect/src/test/java/com/stripe/android/connect/analytics/ComponentAnalyticsServiceTest.kt
@@ -96,14 +96,14 @@ class ComponentAnalyticsServiceTest {
 
         val expectedMetadata = mapOf(
             "page_view_id" to "pageViewId123",
-            "time_to_load" to "100.0",
-            "perceived_time_to_load" to "50.0",
+            "time_to_load" to "100",
+            "perceived_time_to_load" to "50",
         )
         assertContains(params, "event_metadata")
         assertEquals(expectedMetadata, params["event_metadata"])
         assertEquals("pageViewId123", params["page_view_id"])
-        assertEquals("100.0", params["time_to_load"])
-        assertEquals("50.0", params["perceived_time_to_load"])
+        assertEquals("100", params["time_to_load"])
+        assertEquals("50", params["perceived_time_to_load"])
     }
 
     @Test

--- a/connect/src/test/java/com/stripe/android/connect/analytics/ComponentAnalyticsServiceTest.kt
+++ b/connect/src/test/java/com/stripe/android/connect/analytics/ComponentAnalyticsServiceTest.kt
@@ -86,8 +86,8 @@ class ComponentAnalyticsServiceTest {
         componentAnalyticsService.track(
             ConnectAnalyticsEvent.WebComponentLoaded(
                 pageViewId = "pageViewId123",
-                timeToLoad = 100L,
-                perceivedTimeToLoad = 50L,
+                timeToLoadMs = 100L,
+                perceivedTimeToLoadMs = 50L,
             )
         )
         val mapCaptor = argumentCaptor<Map<String, Any?>>()
@@ -96,14 +96,14 @@ class ComponentAnalyticsServiceTest {
 
         val expectedMetadata = mapOf(
             "page_view_id" to "pageViewId123",
-            "time_to_load" to "100",
-            "perceived_time_to_load" to "50",
+            "time_to_load" to "0.1",
+            "perceived_time_to_load" to "0.05",
         )
         assertContains(params, "event_metadata")
         assertEquals(expectedMetadata, params["event_metadata"])
         assertEquals("pageViewId123", params["page_view_id"])
-        assertEquals("100", params["time_to_load"])
-        assertEquals("50", params["perceived_time_to_load"])
+        assertEquals("0.1", params["time_to_load"])
+        assertEquals("0.05", params["perceived_time_to_load"])
     }
 
     @Test

--- a/connect/src/test/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerControllerTest.kt
+++ b/connect/src/test/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerControllerTest.kt
@@ -383,8 +383,8 @@ class StripeConnectWebViewContainerControllerTest {
         verify(analyticsService).track(
             ConnectAnalyticsEvent.WebComponentLoaded(
                 pageViewId = "pageView123",
-                timeToLoad = 100L,
-                perceivedTimeToLoad = 100L,
+                timeToLoadMs = 100L,
+                perceivedTimeToLoadMs = 100L,
             )
         )
     }

--- a/connect/src/test/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerControllerTest.kt
+++ b/connect/src/test/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerControllerTest.kt
@@ -16,6 +16,7 @@ import com.stripe.android.connect.PayoutsListener
 import com.stripe.android.connect.PrivateBetaConnectSDK
 import com.stripe.android.connect.StripeEmbeddedComponent
 import com.stripe.android.connect.analytics.ComponentAnalyticsService
+import com.stripe.android.connect.analytics.ConnectAnalyticsEvent
 import com.stripe.android.connect.appearance.Appearance
 import com.stripe.android.connect.appearance.Colors
 import com.stripe.android.connect.util.Clock
@@ -77,6 +78,7 @@ class StripeConnectWebViewContainerControllerTest {
 
         whenever(embeddedComponentManager.appearanceFlow) doReturn appearanceFlow
         whenever(embeddedComponentManager.getStripeURL(any())) doReturn "https://example.com"
+        whenever(androidClock.millis()) doReturn -1L
 
         controller = StripeConnectWebViewContainerController(
             view = view,
@@ -108,14 +110,21 @@ class StripeConnectWebViewContainerControllerTest {
     }
 
     @Test
-    fun `shouldOverrideUrlLoading allows request and returns false for allowlisted hosts`() {
+    fun `shouldOverrideUrlLoading allows request and returns false for allowlisted hosts, logs unexpected pop-up`() {
         val uri = Uri.parse("https://connect-js.stripe.com/allowlisted")
         val mockRequest = mock<WebResourceRequest> {
             on { url } doReturn uri
         }
 
+        controller.onReceivedPageDidLoad("page_view_id")
         val result = controller.shouldOverrideUrlLoading(mockContext, mockRequest)
         assertFalse(result)
+        verify(analyticsService).track(
+            ConnectAnalyticsEvent.ClientError(
+                error = "Unexpected pop-up",
+                errorMessage = "Received pop-up for allow-listed host: https://connect-js.stripe.com/allowlisted",
+            )
+        )
     }
 
     @Test
@@ -263,12 +272,18 @@ class StripeConnectWebViewContainerControllerTest {
     }
 
     @Test
-    fun `onPermissionRequest denies permission when no supported permissions are requested`() = runTest {
+    fun `onPermissionRequest denies when no supported permissions requested, logs unexpected permissions`() = runTest {
         whenever(mockPermissionRequest.resources) doReturn arrayOf("unsupported_permission")
 
         controller.onPermissionRequest(mockContext, mockPermissionRequest)
 
         verify(mockPermissionRequest).deny()
+        verify(analyticsService).track(
+            ConnectAnalyticsEvent.ClientError(
+                error = "Unexpected permissions request",
+                errorMessage = "Unexpected permissions 'unsupported_permission' requested",
+            )
+        )
     }
 
     @Test
@@ -301,5 +316,111 @@ class StripeConnectWebViewContainerControllerTest {
     fun `onMerchantIdChanged updates analytics service`() {
         controller.onMerchantIdChanged("merchant_id")
         verify(analyticsService).merchantId = "merchant_id"
+    }
+
+    @Test
+    fun `emit component created analytic on init`() {
+        verify(analyticsService).track(ConnectAnalyticsEvent.ComponentCreated)
+    }
+
+    @Test
+    fun `emit component viewed analytic on view attach`() {
+        // page view id is null since we haven't received pageDidLoad yet
+        controller.onViewAttached()
+        verify(analyticsService).track(ConnectAnalyticsEvent.ComponentViewed(null))
+
+        // once we receive pageDidLoad, we should emit the page view id for subsequent analytics
+        controller.onReceivedPageDidLoad("id123")
+        controller.onViewAttached()
+        verify(analyticsService).track(ConnectAnalyticsEvent.ComponentViewed("id123"))
+    }
+
+    @Test
+    fun `emit unexpected navigation analytic if non-stripe url page started`() {
+        whenever(
+            embeddedComponentManager.getStripeURL(embeddedComponent)
+        ) doReturn "https://stripe.com/test?foo=bar#mytest"
+
+        controller.onPageStarted("https://example.com/test?foo=bar#mytest")
+
+        // when emitting the analytic, we should strip the query params
+        verify(analyticsService).track(
+            ConnectAnalyticsEvent.WebErrorUnexpectedNavigation("https://example.com/test")
+        )
+    }
+
+    @Test
+    fun `dont emit unexpected navigation analytic if expected stripe url is used on page started`() {
+        whenever(
+            embeddedComponentManager.getStripeURL(any())
+        ) doReturn "https://stripe.com/test?foo=bar#mytest"
+
+        controller.onPageStarted("https://stripe.com/test")
+
+        // when emitting the analytic, we should strip the query params
+        verify(analyticsService, never()).track(
+            ConnectAnalyticsEvent.WebErrorUnexpectedNavigation("https://stripe.com/test")
+        )
+    }
+
+    @Test
+    fun `emit web page loaded analytic on page finished`() {
+        whenever(androidClock.millis()) doReturn 100L
+        controller.onViewAttached() // register that the page was attached to capture the start of loading
+
+        whenever(androidClock.millis()) doReturn 200L // difference of 100ms to start of load
+        controller.onPageFinished()
+        verify(analyticsService).track(ConnectAnalyticsEvent.WebPageLoaded(100L))
+    }
+
+    @Test
+    fun `emit web component loaded analytic when received pageDidLoad`() {
+        whenever(androidClock.millis()) doReturn 100L
+        controller.onViewAttached() // register that the page was attached to capture the start of loading
+
+        whenever(androidClock.millis()) doReturn 200L // difference of 100ms to start of load
+        controller.onReceivedPageDidLoad("pageView123")
+        verify(analyticsService).track(
+            ConnectAnalyticsEvent.WebComponentLoaded(
+                pageViewId = "pageView123",
+                timeToLoad = 100L,
+                perceivedTimeToLoad = 100L,
+            )
+        )
+    }
+
+    @Test
+    fun `emit web page error when main page receives an error`() {
+        controller.onReceivedError(
+            requestUrl = "https://stripe.com",
+            httpStatusCode = 404,
+            errorMessage = "Not Found",
+            isMainPageLoad = true
+        )
+        verify(analyticsService).track(
+            ConnectAnalyticsEvent.WebErrorPageLoad(
+                status = 404,
+                error = "Not Found",
+                url = "https://stripe.com",
+            )
+        )
+    }
+
+    @Test
+    fun `emit deserialization error on error to deserialize web message`() {
+        controller.onReceivedPageDidLoad("page_view_id")
+        controller.onErrorDeserializingWebMessage(
+            webMessage = "{ invalid: 4 ",
+            error = "Unable to deserialize",
+            errorMessage = "Error parsing JSON"
+        )
+        verify(analyticsService).track(
+            ConnectAnalyticsEvent.WebErrorDeserializeMessage(
+                message = "{ invalid: 4 ",
+                error = "Unable to deserialize",
+                errorDescription = "Error parsing JSON",
+                pageViewId = "page_view_id",
+            )
+        )
     }
 }

--- a/connect/src/test/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerControllerTest.kt
+++ b/connect/src/test/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerControllerTest.kt
@@ -121,7 +121,7 @@ class StripeConnectWebViewContainerControllerTest {
         assertFalse(result)
         verify(analyticsService).track(
             ConnectAnalyticsEvent.ClientError(
-                error = "Unexpected pop-up",
+                errorCode = "unexpected_popup",
                 errorMessage = "Received pop-up for allow-listed host: https://connect-js.stripe.com/allowlisted",
             )
         )
@@ -280,7 +280,7 @@ class StripeConnectWebViewContainerControllerTest {
         verify(mockPermissionRequest).deny()
         verify(analyticsService).track(
             ConnectAnalyticsEvent.ClientError(
-                error = "Unexpected permissions request",
+                errorCode = "unexpected_permissions_request",
                 errorMessage = "Unexpected permissions 'unsupported_permission' requested",
             )
         )
@@ -410,15 +410,13 @@ class StripeConnectWebViewContainerControllerTest {
     fun `emit deserialization error on error to deserialize web message`() {
         controller.onReceivedPageDidLoad("page_view_id")
         controller.onErrorDeserializingWebMessage(
-            webMessage = "{ invalid: 4 ",
-            error = "Unable to deserialize",
-            errorMessage = "Error parsing JSON"
+            webFunctionName = "onSetterFunctionCalled",
+            error = IllegalArgumentException("Unable to deserialize"),
         )
         verify(analyticsService).track(
             ConnectAnalyticsEvent.WebErrorDeserializeMessage(
-                message = "{ invalid: 4 ",
-                error = "Unable to deserialize",
-                errorDescription = "Error parsing JSON",
+                message = "onSetterFunctionCalled",
+                error = "IllegalArgumentException",
                 pageViewId = "page_view_id",
             )
         )


### PR DESCRIPTION
# Summary
This emits analytic events for the Connect SDK, as described here: https://docs.google.com/document/d/1nzHGofoclzij4nP5n5qgSpYLia-93heStXvt7vOfrkQ/edit?usp=sharing

Verified through Splunk

# Motivation
#9780 set up the infrastructure for analytics, this PR emits the analytics.

# Testing
- [x] Added tests
- [x] Modified tests
- [x] Manually verified