### PR TITLE
Fix SavedPaymentMethod accessibility issue

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTab.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTab.kt
@@ -59,13 +59,13 @@ internal val SavedPaymentMethodsTopContentPadding = 12.dp
 
 @Composable
 internal fun SavedPaymentMethodTab(
+    modifier: Modifier = Modifier,
     viewWidth: Dp,
     isSelected: Boolean,
     shouldShowModifyBadge: Boolean,
     isEnabled: Boolean,
     isClickable: Boolean = isEnabled,
     iconRes: Int,
-    modifier: Modifier = Modifier,
     iconTint: Color? = null,
     @DrawableRes labelIcon: Int? = null,
     labelText: String = "",
@@ -84,14 +84,19 @@ internal fun SavedPaymentMethodTab(
             )
         },
         content = {
-            Column {
+            Column(
+                modifier = Modifier
+                    .testTag("${SAVED_PAYMENT_METHOD_CARD_TEST_TAG}_$labelText")
+                    .selectable(
+                        selected = isSelected,
+                        enabled = isClickable,
+                        onClick = onItemSelectedListener,
+                    ),
+            ) {
                 SavedPaymentMethodCard(
                     isSelected = isSelected,
-                    isClickable = isClickable,
-                    labelText = labelText,
                     iconRes = iconRes,
                     iconTint = iconTint,
-                    onItemSelectedListener = onItemSelectedListener,
                 )
 
                 LpmSelectorText(
@@ -137,11 +142,8 @@ private fun SavedPaymentMethodBadge(
 @Composable
 private fun SavedPaymentMethodCard(
     isSelected: Boolean,
-    isClickable: Boolean,
     iconRes: Int,
     iconTint: Color?,
-    labelText: String,
-    onItemSelectedListener: (() -> Unit),
     modifier: Modifier = Modifier,
 ) {
     SectionCard(
@@ -156,12 +158,6 @@ private fun SavedPaymentMethodCard(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier
                 .fillMaxSize()
-                .testTag("${SAVED_PAYMENT_METHOD_CARD_TEST_TAG}_$labelText")
-                .selectable(
-                    selected = isSelected,
-                    enabled = isClickable,
-                    onClick = onItemSelectedListener,
-                ),
         ) {
             Image(
                 painter = painterResource(iconRes),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentOptionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentOptionTest.kt
@@ -4,7 +4,6 @@ import android.os.Build
 import androidx.compose.ui.test.assertContentDescriptionEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.onParent
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.paymentsheet.R
@@ -39,7 +38,6 @@ class PaymentOptionTest {
 
         composeTestRule
             .onNodeWithText(label)
-            .onParent()
             .assertContentDescriptionEquals("Card ending in 4 2 4 2 ")
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Modify SavedPaymentMethodTab click group to match the accessibility requirements

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-2678
This pull request aims to improve accessibility for VoiceOver users on the payment method selection screen. It ensures that when the "Add" tab is selected, VoiceOver reads out "Button, double tap to select, Add new card," and provides clear identification of saved payment methods by announcing the card name or number when selected. These enhancements will facilitate better navigation and understanding for users relying on screen readers.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| https://github.com/user-attachments/assets/0f732223-08a2-40a4-a273-1390d4c43db8 | https://github.com/user-attachments/assets/000e91d2-d3a8-47b9-8253-b00c0a077063 |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
