### PR TITLE
Add Device ID to shared analytics

### DIFF
--- a/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsFields.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsFields.kt
@@ -15,6 +15,7 @@ object AnalyticsFields {
     const val BINDINGS_VERSION = "bindings_version"
     const val IS_DEVELOPMENT = "is_development"
     const val DEVICE_TYPE = "device_type"
+    const val DEVICE_ID = "device_id"
     const val EVENT = "event"
     const val PLUGIN_TYPE = "plugin_type"
     const val OS_NAME = "os_name"

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestV2Factory.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestV2Factory.kt
@@ -1,7 +1,5 @@
 package com.stripe.android.core.networking
 
-import android.adservices.appsetid.AppSetId
-import android.adservices.appsetid.AppSetIdManager
 import android.annotation.SuppressLint
 import android.content.Context
 import android.os.Build

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestV2Factory.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestV2Factory.kt
@@ -1,7 +1,11 @@
 package com.stripe.android.core.networking
 
+import android.adservices.appsetid.AppSetId
+import android.adservices.appsetid.AppSetIdManager
+import android.annotation.SuppressLint
 import android.content.Context
 import android.os.Build
+import android.provider.Settings
 import androidx.annotation.RestrictTo
 import com.stripe.android.core.utils.ContextUtils.packageInfo
 import com.stripe.android.core.utils.PluginDetector
@@ -49,6 +53,7 @@ class AnalyticsRequestV2Factory(
     )
 
     // Common SDK related parameters, need dedicated ingestion logic on server side.
+    @SuppressLint("HardwareIds")
     private fun sdkParams() = mapOf(
         AnalyticsFields.OS_VERSION to Build.VERSION.SDK_INT,
         PARAM_SDK_PLATFORM to "android",
@@ -56,6 +61,7 @@ class AnalyticsRequestV2Factory(
         AnalyticsFields.DEVICE_TYPE to "${Build.MANUFACTURER}_${Build.BRAND}_${Build.MODEL}",
         AnalyticsFields.APP_NAME to getAppName(),
         AnalyticsFields.APP_VERSION to appContext.packageInfo?.versionCode,
+        AnalyticsFields.DEVICE_ID to Settings.Secure.getString(appContext.contentResolver, Settings.Secure.ANDROID_ID),
         PARAM_PLUGIN_TYPE to pluginType,
         PARAM_PLATFORM_INFO to mapOf(
             PARAM_PACKAGE_NAME to appContext.packageName

--- a/stripe-core/src/test/java/com/stripe/android/core/networking/AnalyticsRequestV2FactoryTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/networking/AnalyticsRequestV2FactoryTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.core.networking
 
 import android.content.Context
+import android.provider.Settings
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.networking.AnalyticsRequestV2.Companion.PARAM_CLIENT_ID
@@ -8,9 +9,11 @@ import com.stripe.android.core.networking.AnalyticsRequestV2Factory.Companion.PA
 import com.stripe.android.core.networking.AnalyticsRequestV2Factory.Companion.PARAM_PLUGIN_TYPE
 import com.stripe.android.core.networking.AnalyticsRequestV2Factory.Companion.PARAM_SDK_PLATFORM
 import com.stripe.android.core.networking.AnalyticsRequestV2Factory.Companion.PARAM_SDK_VERSION
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.shadows.ShadowSettings
 import java.net.URLEncoder
 
 @RunWith(RobolectricTestRunner::class)
@@ -34,6 +37,12 @@ class AnalyticsRequestV2FactoryTest {
         PARAM_PLUGIN_TYPE,
         PARAM_PLATFORM_INFO
     )
+
+    @Before
+    fun setup() {
+        // set the android_id to a known value for testing
+        Settings.Secure.putString(context.contentResolver, Settings.Secure.ANDROID_ID, "android_id")
+    }
 
     @Test
     fun `verify clientId and origin`() {

--- a/stripe-core/src/test/java/com/stripe/android/core/networking/AnalyticsRequestV2FactoryTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/networking/AnalyticsRequestV2FactoryTest.kt
@@ -30,6 +30,7 @@ class AnalyticsRequestV2FactoryTest {
         AnalyticsFields.DEVICE_TYPE,
         AnalyticsFields.APP_NAME,
         AnalyticsFields.APP_VERSION,
+        AnalyticsFields.DEVICE_ID,
         PARAM_PLUGIN_TYPE,
         PARAM_PLATFORM_INFO
     )

--- a/stripe-core/src/test/java/com/stripe/android/core/networking/AnalyticsRequestV2FactoryTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/networking/AnalyticsRequestV2FactoryTest.kt
@@ -13,7 +13,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.shadows.ShadowSettings
 import java.net.URLEncoder
 
 @RunWith(RobolectricTestRunner::class)


### PR DESCRIPTION
# Summary
Adds Android_ID to our analytics events. The Android_ID is a device-specific ID that is robust to app uninstalls - see more here: https://developer.android.com/reference/android/provider/Settings.Secure#ANDROID_ID.

Google is recommending against using Android_ID, but reading through their developer post it's unclear that any of the alternatives they outline are reasonable for our use case (they have a page on unique ids here: https://developer.android.com/identity/user-data-ids). The alternatives they recommend like Firebase ID or App set ID all appear to either:
1. not be robust to app uninstalls (meaning it's not a true device ID) - this is the case for Firebase ID
2. require ads libraries and/or high Android API versions - this is the case for App set ID, which requires either API 34+ or the Ad Services Extensions SDK, which itself requires API 33+.

Given that the alternatives require introducing new libraries and/or bumping the API version, I recommend sticking with the Android_ID hardware identifier for the time being.

# Motivation
For the Connect SDK, we want to have a device-specific ID logged with our analytics events. 

# Testing
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified
