### PR TITLE
Refactor `PaymentSelection` & nullability out of `CvcRecollectionHandler`.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -359,11 +359,13 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     }
 
     fun checkout() {
-        if (shouldLaunchCvcRecollectionScreen()) {
-            launchCvcRecollection()
+        val currentSelection = selection.value
+
+        if (currentSelection is PaymentSelection.Saved && shouldLaunchCvcRecollectionScreen(currentSelection)) {
+            launchCvcRecollection(currentSelection)
             return
         }
-        checkout(selection.value, CheckoutIdentifier.SheetBottomBuy)
+        checkout(currentSelection, CheckoutIdentifier.SheetBottomBuy)
     }
 
     fun checkoutWithGooglePay() {
@@ -395,10 +397,8 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         }
     }
 
-    private fun launchCvcRecollection() {
-        cvcRecollectionHandler.launch(
-            paymentSelection = selection.value
-        ) { cvcRecollectionData ->
+    private fun launchCvcRecollection(selection: PaymentSelection.Saved) {
+        cvcRecollectionHandler.launch(selection.paymentMethod) { cvcRecollectionData ->
             val interactor = cvcRecollectionInteractorFactory.create(
                 args = Args(
                     lastFour = cvcRecollectionData.lastFour ?: "",
@@ -454,7 +454,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     @Suppress("ComplexCondition")
     private fun paymentSelectionWithCvcIfEnabled(paymentSelection: PaymentSelection?): PaymentSelection? {
         if (paymentSelection !is PaymentSelection.Saved) return paymentSelection
-        return if (shouldAttachCvc()) {
+        return if (shouldAttachCvc(paymentSelection)) {
             val paymentMethodOptionsParams =
                 (paymentSelection.paymentMethodOptionsParams as? PaymentMethodOptionsParams.Card)
                     ?: PaymentMethodOptionsParams.Card()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModelCvcHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModelCvcHelper.kt
@@ -1,32 +1,42 @@
 package com.stripe.android.paymentsheet
 
+import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 
-internal fun PaymentSheetViewModel.shouldLaunchCvcRecollectionScreen(): Boolean {
-    return requiresCvcRecollection {
+internal fun PaymentSheetViewModel.shouldLaunchCvcRecollectionScreen(selection: PaymentSelection.Saved): Boolean {
+    return requiresCvcRecollection(selection) {
         config.paymentMethodLayout != PaymentSheet.PaymentMethodLayout.Horizontal &&
             navigationHandler.currentScreen.value !is PaymentSheetScreen.CvcRecollection
     }
 }
 
-internal fun PaymentSheetViewModel.shouldAttachCvc(): Boolean {
-    return requiresCvcRecollection {
+internal fun PaymentSheetViewModel.shouldAttachCvc(selection: PaymentSelection.Saved): Boolean {
+    return requiresCvcRecollection(selection) {
         config.paymentMethodLayout == PaymentSheet.PaymentMethodLayout.Horizontal
     }
 }
 
 internal fun PaymentSheetViewModel.isCvcRecollectionEnabled(): Boolean {
-    return cvcRecollectionHandler.cvcRecollectionEnabled(
-        stripeIntent = paymentMethodMetadata.value?.stripeIntent,
-        initializationMode = args.initializationMode
-    )
+    return paymentMethodMetadata.value?.run {
+        cvcRecollectionHandler.cvcRecollectionEnabled(
+            stripeIntent = stripeIntent,
+            initializationMode = args.initializationMode
+        )
+    } ?: false
 }
 
-private fun PaymentSheetViewModel.requiresCvcRecollection(extraRequirements: () -> Boolean): Boolean {
-    return cvcRecollectionHandler.requiresCVCRecollection(
-        stripeIntent = paymentMethodMetadata.value?.stripeIntent,
-        paymentSelection = selection.value,
-        initializationMode = args.initializationMode,
-        extraRequirements = extraRequirements
-    )
+private fun PaymentSheetViewModel.requiresCvcRecollection(
+    selection: PaymentSelection.Saved,
+    extraRequirements: () -> Boolean
+): Boolean {
+    return paymentMethodMetadata.value?.run {
+        val requiresCvcRecollection = cvcRecollectionHandler.requiresCVCRecollection(
+            stripeIntent = stripeIntent,
+            paymentMethod = selection.paymentMethod,
+            optionsParams = selection.paymentMethodOptionsParams,
+            initializationMode = args.initializationMode,
+        )
+
+        requiresCvcRecollection && extraRequirements()
+    } ?: false
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/cvcrecollection/CvcRecollectionHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/cvcrecollection/CvcRecollectionHandler.kt
@@ -1,22 +1,26 @@
 package com.stripe.android.paymentsheet.cvcrecollection
 
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.model.StripeIntent
-import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcRecollectionData
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 
 internal interface CvcRecollectionHandler {
-    fun launch(paymentSelection: PaymentSelection?, launch: (CvcRecollectionData) -> Unit)
+    fun launch(
+        paymentMethod: PaymentMethod,
+        launch: (CvcRecollectionData) -> Unit
+    )
 
     fun cvcRecollectionEnabled(
-        stripeIntent: StripeIntent?,
-        initializationMode: PaymentElementLoader.InitializationMode?,
+        stripeIntent: StripeIntent,
+        initializationMode: PaymentElementLoader.InitializationMode,
     ): Boolean
 
     fun requiresCVCRecollection(
-        stripeIntent: StripeIntent?,
-        paymentSelection: PaymentSelection?,
-        initializationMode: PaymentElementLoader.InitializationMode?,
-        extraRequirements: () -> Boolean = { true }
+        stripeIntent: StripeIntent,
+        paymentMethod: PaymentMethod,
+        optionsParams: PaymentMethodOptionsParams?,
+        initializationMode: PaymentElementLoader.InitializationMode,
     ): Boolean
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/cvcrecollection/CvcRecollectionHandlerImpl.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/cvcrecollection/CvcRecollectionHandlerImpl.kt
@@ -2,56 +2,65 @@ package com.stripe.android.paymentsheet.cvcrecollection
 
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodOptionsParams
+import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcRecollectionData
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 
 internal class CvcRecollectionHandlerImpl : CvcRecollectionHandler {
 
-    override fun launch(paymentSelection: PaymentSelection?, launch: (CvcRecollectionData) -> Unit) {
-        val card = (paymentSelection as? PaymentSelection.Saved)?.paymentMethod?.card
-        CvcRecollectionData.fromPaymentSelection(card)?.let(launch)
+    override fun launch(
+        paymentMethod: PaymentMethod,
+        launch: (CvcRecollectionData) -> Unit
+    ) {
+        CvcRecollectionData.fromPaymentSelection(paymentMethod.card)?.let(launch)
             ?: throw IllegalStateException("unable to create CvcRecollectionData")
     }
 
     override fun cvcRecollectionEnabled(
-        stripeIntent: StripeIntent?,
-        initializationMode: PaymentElementLoader.InitializationMode?
+        stripeIntent: StripeIntent,
+        initializationMode: PaymentElementLoader.InitializationMode,
     ): Boolean {
-        return deferredIntentRequiresCVCRecollection(initializationMode) ||
-            paymentIntentRequiresCVCRecollection(stripeIntent, initializationMode)
+        return when (initializationMode) {
+            is PaymentElementLoader.InitializationMode.DeferredIntent -> {
+                initializationMode.intentConfiguration.requireCvcRecollection &&
+                    initializationMode.intentConfiguration.mode is PaymentSheet.IntentConfiguration.Mode.Payment
+            }
+            is PaymentElementLoader.InitializationMode.PaymentIntent -> stripeIntent.supportsCvcRecollection()
+            is PaymentElementLoader.InitializationMode.SetupIntent -> false
+        }
     }
 
     override fun requiresCVCRecollection(
-        stripeIntent: StripeIntent?,
-        paymentSelection: PaymentSelection?,
-        initializationMode: PaymentElementLoader.InitializationMode?,
-        extraRequirements: () -> Boolean
+        stripeIntent: StripeIntent,
+        paymentMethod: PaymentMethod,
+        optionsParams: PaymentMethodOptionsParams?,
+        initializationMode: PaymentElementLoader.InitializationMode,
     ): Boolean {
-        return paymentSelectionIsSavedCard(paymentSelection) &&
-            cvcRecollectionEnabled(stripeIntent, initializationMode) && extraRequirements()
+        val hasNotRecollectedCvcAlready = optionsParams == null || !optionsParams.hasAlreadyRecollectedCvc()
+
+        return paymentMethod.isCard() &&
+            cvcRecollectionEnabled(stripeIntent, initializationMode) &&
+            hasNotRecollectedCvcAlready
     }
 
-    private fun deferredIntentRequiresCVCRecollection(
-        initializationMode: PaymentElementLoader.InitializationMode?
-    ): Boolean {
-        return (initializationMode as? PaymentElementLoader.InitializationMode.DeferredIntent)
-            ?.intentConfiguration?.requireCvcRecollection == true &&
-            initializationMode.intentConfiguration.mode is PaymentSheet.IntentConfiguration.Mode.Payment
+    private fun PaymentMethod.isCard(): Boolean {
+        return type == PaymentMethod.Type.Card
     }
 
-    private fun paymentIntentRequiresCVCRecollection(
-        stripeIntent: StripeIntent?,
-        initializationMode: PaymentElementLoader.InitializationMode?
-    ): Boolean {
-        return (stripeIntent as? PaymentIntent)?.requireCvcRecollection == true &&
-            initializationMode is PaymentElementLoader.InitializationMode.PaymentIntent
+    private fun StripeIntent.supportsCvcRecollection(): Boolean {
+        return when (this) {
+            is PaymentIntent -> requireCvcRecollection
+            is SetupIntent -> false
+        }
     }
 
-    private fun paymentSelectionIsSavedCard(paymentSelection: PaymentSelection?): Boolean {
-        return paymentSelection is PaymentSelection.Saved &&
-            paymentSelection.paymentMethod.type == PaymentMethod.Type.Card
+    private fun PaymentMethodOptionsParams.hasAlreadyRecollectedCvc(): Boolean {
+        return when (this) {
+            is PaymentMethodOptionsParams.Card -> cvc != null
+            else -> false
+        }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -2771,27 +2771,29 @@ internal class PaymentSheetViewModelTest {
             )
         )
 
+        val savedSelection = PaymentSelection.Saved(CARD_PAYMENT_METHOD)
+
         cvcRecollectionHandler.requiresCVCRecollection = true
-        assertThat(viewModel.shouldLaunchCvcRecollectionScreen()).isTrue()
-        assertThat(viewModel.shouldAttachCvc()).isFalse()
+        assertThat(viewModel.shouldLaunchCvcRecollectionScreen(savedSelection)).isTrue()
+        assertThat(viewModel.shouldAttachCvc(savedSelection)).isFalse()
 
         viewModel.checkout()
-        assertThat(viewModel.shouldLaunchCvcRecollectionScreen()).isFalse()
-        assertThat(viewModel.shouldAttachCvc()).isFalse()
+        assertThat(viewModel.shouldLaunchCvcRecollectionScreen(savedSelection)).isFalse()
+        assertThat(viewModel.shouldAttachCvc(savedSelection)).isFalse()
 
         cvcRecollectionHandler.requiresCVCRecollection = false
-        assertThat(viewModel.shouldAttachCvc()).isFalse()
-        assertThat(viewModel.shouldLaunchCvcRecollectionScreen()).isFalse()
+        assertThat(viewModel.shouldAttachCvc(savedSelection)).isFalse()
+        assertThat(viewModel.shouldLaunchCvcRecollectionScreen(savedSelection)).isFalse()
 
         viewModel = createViewModel()
 
         cvcRecollectionHandler.requiresCVCRecollection = true
-        assertThat(viewModel.shouldLaunchCvcRecollectionScreen()).isFalse()
-        assertThat(viewModel.shouldAttachCvc()).isTrue()
+        assertThat(viewModel.shouldLaunchCvcRecollectionScreen(savedSelection)).isFalse()
+        assertThat(viewModel.shouldAttachCvc(savedSelection)).isTrue()
 
         cvcRecollectionHandler.requiresCVCRecollection = false
-        assertThat(viewModel.shouldAttachCvc()).isFalse()
-        assertThat(viewModel.shouldLaunchCvcRecollectionScreen()).isFalse()
+        assertThat(viewModel.shouldAttachCvc(savedSelection)).isFalse()
+        assertThat(viewModel.shouldLaunchCvcRecollectionScreen(savedSelection)).isFalse()
     }
 
     @Test
@@ -2804,27 +2806,29 @@ internal class PaymentSheetViewModelTest {
             )
         )
 
+        val savedSelection = PaymentSelection.Saved(CARD_PAYMENT_METHOD)
+
         cvcRecollectionHandler.requiresCVCRecollection = true
-        assertThat(viewModel.shouldLaunchCvcRecollectionScreen()).isTrue()
-        assertThat(viewModel.shouldAttachCvc()).isFalse()
+        assertThat(viewModel.shouldLaunchCvcRecollectionScreen(savedSelection)).isTrue()
+        assertThat(viewModel.shouldAttachCvc(savedSelection)).isFalse()
 
         viewModel.checkout()
-        assertThat(viewModel.shouldLaunchCvcRecollectionScreen()).isFalse()
-        assertThat(viewModel.shouldAttachCvc()).isFalse()
+        assertThat(viewModel.shouldLaunchCvcRecollectionScreen(savedSelection)).isFalse()
+        assertThat(viewModel.shouldAttachCvc(savedSelection)).isFalse()
 
         cvcRecollectionHandler.requiresCVCRecollection = false
-        assertThat(viewModel.shouldAttachCvc()).isFalse()
-        assertThat(viewModel.shouldLaunchCvcRecollectionScreen()).isFalse()
+        assertThat(viewModel.shouldAttachCvc(savedSelection)).isFalse()
+        assertThat(viewModel.shouldLaunchCvcRecollectionScreen(savedSelection)).isFalse()
 
         viewModel = createViewModel()
 
         cvcRecollectionHandler.requiresCVCRecollection = true
-        assertThat(viewModel.shouldLaunchCvcRecollectionScreen()).isFalse()
-        assertThat(viewModel.shouldAttachCvc()).isTrue()
+        assertThat(viewModel.shouldLaunchCvcRecollectionScreen(savedSelection)).isFalse()
+        assertThat(viewModel.shouldAttachCvc(savedSelection)).isTrue()
 
         cvcRecollectionHandler.requiresCVCRecollection = false
-        assertThat(viewModel.shouldAttachCvc()).isFalse()
-        assertThat(viewModel.shouldLaunchCvcRecollectionScreen()).isFalse()
+        assertThat(viewModel.shouldAttachCvc(savedSelection)).isFalse()
+        assertThat(viewModel.shouldLaunchCvcRecollectionScreen(savedSelection)).isFalse()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/cvcrecollection/FakeCvcRecollectionHandler.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/cvcrecollection/FakeCvcRecollectionHandler.kt
@@ -1,7 +1,8 @@
 package com.stripe.android.paymentsheet.cvcrecollection
 
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.model.StripeIntent
-import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcRecollectionData
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 
@@ -9,20 +10,19 @@ internal class FakeCvcRecollectionHandler : CvcRecollectionHandler {
     var cvcRecollectionEnabled = false
     var requiresCVCRecollection = false
 
-    override fun launch(paymentSelection: PaymentSelection?, launch: (CvcRecollectionData) -> Unit) {
-        val card = (paymentSelection as? PaymentSelection.Saved)?.paymentMethod?.card
-        CvcRecollectionData.fromPaymentSelection(card)?.let(launch)
+    override fun launch(paymentMethod: PaymentMethod, launch: (CvcRecollectionData) -> Unit) {
+        CvcRecollectionData.fromPaymentSelection(paymentMethod.card)?.let(launch)
     }
 
     override fun cvcRecollectionEnabled(
-        stripeIntent: StripeIntent?,
-        initializationMode: PaymentElementLoader.InitializationMode?
+        stripeIntent: StripeIntent,
+        initializationMode: PaymentElementLoader.InitializationMode
     ) = requiresCVCRecollection || cvcRecollectionEnabled
 
     override fun requiresCVCRecollection(
-        stripeIntent: StripeIntent?,
-        paymentSelection: PaymentSelection?,
-        initializationMode: PaymentElementLoader.InitializationMode?,
-        extraRequirements: () -> Boolean
-    ) = requiresCVCRecollection && extraRequirements()
+        stripeIntent: StripeIntent,
+        paymentMethod: PaymentMethod,
+        optionsParams: PaymentMethodOptionsParams?,
+        initializationMode: PaymentElementLoader.InitializationMode,
+    ) = requiresCVCRecollection
 }


### PR DESCRIPTION
# Summary
Refactor `PaymentSelection` & nullability out of `CvcRecollectionHandler`.

# Motivation
I want to use `CvcRecollectionHandler` with confirmation definitions. Unfortunately, it is tied down to `PaymentSelection` which I don't want the confirmation definition to be aware of.  This refactor allows for code reuse between the `PaymentSheet` implementation and the confirmation definition that will be used by embedded and flow controller.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified