### PR TITLE
[Connect] Remove duplicate annotation

### DIFF
--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerController.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerController.kt
@@ -33,7 +33,6 @@ import kotlinx.coroutines.withContext
 
 @Suppress("TooManyFunctions")
 @OptIn(PrivateBetaConnectSDK::class)
-@Suppress("TooManyFunctions")
 internal class StripeConnectWebViewContainerController<Listener : StripeEmbeddedComponentListener>(
     private val view: StripeConnectWebViewContainerInternal,
     private val analyticsService: ComponentAnalyticsService,


### PR DESCRIPTION
# Summary
When merging #9780 and #9879 the merge unintentionally added the same annotation to `StripeConnectWebViewContainerController` twice (once for each PR), which fails the build on master. This PR removes the duplicate annotation and unblocks the build

# Motivation
Unblock master and fix the build

# Testing
I ran `./gradlew :connect:compileReleaseKotlin` and confirmed it compiles
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified