### PR TITLE
Ensure CVC recollection is not done for payment methods from wallets.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/cvcrecollection/CvcRecollectionHandlerImpl.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/cvcrecollection/CvcRecollectionHandlerImpl.kt
@@ -42,12 +42,17 @@ internal class CvcRecollectionHandlerImpl : CvcRecollectionHandler {
         val hasNotRecollectedCvcAlready = optionsParams == null || !optionsParams.hasAlreadyRecollectedCvc()
 
         return paymentMethod.isCard() &&
+            paymentMethod.hasNoWallet() &&
             cvcRecollectionEnabled(stripeIntent, initializationMode) &&
             hasNotRecollectedCvcAlready
     }
 
     private fun PaymentMethod.isCard(): Boolean {
         return type == PaymentMethod.Type.Card
+    }
+
+    private fun PaymentMethod.hasNoWallet(): Boolean {
+        return card?.wallet == null
     }
 
     private fun StripeIntent.supportsCvcRecollection(): Boolean {


### PR DESCRIPTION
# Summary
Ensure CVC recollection is not done for payment methods from wallets.

# Motivation
Wallet PMs are not supported for CVC recollection. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified