### PR TITLE
[MOBILESDK-2679] Focus edit badge on edit mode entry

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetPage.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetPage.kt
@@ -75,6 +75,16 @@ internal class PaymentSheetPage(
         clickViewWithText("Save your info for secure 1-click checkout with Link")
     }
 
+    fun clickEditButton() {
+        Espresso.onIdle()
+        composeTestRule.waitForIdle()
+
+        waitForText("EDIT")
+        composeTestRule
+            .onNodeWithText("EDIT")
+            .performClick()
+    }
+
     fun clickOnSaveForFutureUsage() {
         Espresso.onIdle()
         composeTestRule.waitForIdle()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTab.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTab.kt
@@ -8,6 +8,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -130,7 +131,7 @@ private fun SavedPaymentMethodBadge(
         ModifyBadge(
             onModifyAccessibilityDescription = onModifyAccessibilityDescription,
             onPressed = { onModifyListener?.invoke() },
-            modifier = Modifier.offset(x = (-14).dp, y = 1.dp),
+            modifier = Modifier.offset(x = (-14).dp, y = 1.dp).focusable(),
         )
     } else if (isSelected) {
         SelectedBadge(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
@@ -129,7 +129,19 @@ internal fun SavedPaymentMethodTabLayoutUI(
     modifier: Modifier = Modifier,
     scrollState: LazyListState = rememberLazyListState(),
 ) {
-    BoxWithConstraints(modifier = modifier.fillMaxWidth().testTag(SAVED_PAYMENT_OPTION_TAB_LAYOUT_TEST_TAG)) {
+    val focusRequester = remember { FocusRequester() }
+    LaunchedEffect(isEditing) {
+        if (isEditing) {
+            focusRequester.requestFocus()
+        }
+    }
+
+    BoxWithConstraints(
+        modifier = modifier
+            .fillMaxWidth()
+            .testTag(SAVED_PAYMENT_OPTION_TAB_LAYOUT_TEST_TAG)
+            .focusRequester(focusRequester)
+    ) {
         val width = rememberItemWidth(maxWidth)
 
         LazyRow(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Request focus from SavedPaymentMethodTabLayoutUI to correctly handle focus change when entering editing

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-2679
Accessibility: after you click the edit button on the saved payment method screen, focus isn't moved anywhere

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| ![before](https://github.com/user-attachments/assets/54720898-66a4-4034-bed1-b186a81087d6) | ![after](https://github.com/user-attachments/assets/d8b9025f-9364-4dd1-b58c-f3ea3d731399) |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
