### PR TITLE
Upgrade bitrise machine to the new generation.

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -481,4 +481,4 @@ workflows:
 meta:
   bitrise.io:
     stack: linux-docker-android-22.04
-    machine_type_id: elite
+    machine_type_id: g2.linux.large


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Update bitrise machine to the latest generation.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Upgrading to faster Pro Medium/Large/X Large

Your Medium/Large/X Large machines were automatically switched to a faster Pro Medium/Large/X Large machine type, with no extra costs. You can keep using Medium/Large/X Large machines until the 19th of January.
