### PR TITLE
Update copy/paste error in embedded docs.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
@@ -404,7 +404,7 @@ class EmbeddedPaymentElement private constructor(
          * - If this is an external payment method, see
          *      https://stripe.com/docs/payments/external-payment-methods?platform=ios#available-external-payment-methods
          *      for possible values.
-         * - If this is Apple Pay, the value is "apple_pay".
+         * - If this is Google Pay, the value is "google_pay".
          */
         val paymentMethodType: String,
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This was an issue with copy/paste from iOS docs.