### PR TITLE
Fix EPMs return `unknown` instead of `epm` on payment events

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -472,12 +472,13 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         private fun analyticsValue(
             paymentSelection: PaymentSelection?
         ) = when (paymentSelection) {
-            PaymentSelection.GooglePay -> "googlepay"
+            is PaymentSelection.GooglePay -> "googlepay"
             is PaymentSelection.Saved -> "savedpm"
-            PaymentSelection.Link,
+            is PaymentSelection.Link,
             is PaymentSelection.New.LinkInline -> "link"
             is PaymentSelection.New -> "newpm"
-            else -> "unknown"
+            is PaymentSelection.ExternalPaymentMethod -> "epm"
+            null -> "unknown"
         }
 
         private fun formatEventName(mode: EventReporter.Mode, eventName: String): String {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
@@ -707,7 +707,7 @@ class PaymentSheetEventTest {
         assertThat(
             newPMEvent.eventName
         ).isEqualTo(
-            "mc_complete_payment_unknown_success"
+            "mc_complete_payment_epm_success"
         )
         assertThat(
             newPMEvent.params
@@ -748,7 +748,7 @@ class PaymentSheetEventTest {
         assertThat(
             newPMEvent.eventName
         ).isEqualTo(
-            "mc_complete_payment_unknown_failure"
+            "mc_complete_payment_epm_failure"
         )
         assertThat(
             newPMEvent.params


### PR DESCRIPTION
# Summary
Fix EPMs return `unknown` instead of `epm` on payment events

# Motivation
Fix EPMs return `unknown` instead of `epm` on payment events

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified