### PR TITLE
PaymentSelection support in LinkConfirmationHandler

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/confirmation/LinkConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/confirmation/LinkConfirmationHandler.kt
@@ -4,12 +4,18 @@ import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentsheet.model.PaymentSelection
 
 internal interface LinkConfirmationHandler {
     suspend fun confirm(
         paymentDetails: ConsumerPaymentDetails.PaymentDetails,
         linkAccount: LinkAccount,
         cvc: String? = null
+    ): Result
+
+    suspend fun confirm(
+        paymentSelection: PaymentSelection,
+        linkAccount: LinkAccount,
     ): Result
 
     fun interface Factory {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationOptionKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationOptionKtx.kt
@@ -11,7 +11,7 @@ import com.stripe.android.paymentelement.confirmation.link.LinkConfirmationOptio
 import com.stripe.android.paymentsheet.model.PaymentSelection
 
 internal fun PaymentSelection.toConfirmationOption(
-    configuration: CommonConfiguration,
+    configuration: CommonConfiguration?,
     linkConfiguration: LinkConfiguration?,
 ): ConfirmationHandler.Option? {
     return when (this) {
@@ -53,7 +53,7 @@ internal fun PaymentSelection.toConfirmationOption(
                 )
             }
         }
-        is PaymentSelection.GooglePay -> configuration.googlePay?.let { googlePay ->
+        is PaymentSelection.GooglePay -> configuration?.googlePay?.let { googlePay ->
             GooglePayConfirmationOption(
                 config = GooglePayConfirmationOption.Config(
                     environment = googlePay.environment,

--- a/paymentsheet/src/test/java/com/stripe/android/link/confirmation/FakeLinkConfirmationHandler.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/confirmation/FakeLinkConfirmationHandler.kt
@@ -2,6 +2,7 @@ package com.stripe.android.link.confirmation
 
 import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.model.ConsumerPaymentDetails
+import com.stripe.android.paymentsheet.model.PaymentSelection
 
 internal class FakeLinkConfirmationHandler : LinkConfirmationHandler {
     var confirmResult: Result = Result.Succeeded
@@ -13,7 +14,7 @@ internal class FakeLinkConfirmationHandler : LinkConfirmationHandler {
         cvc: String?
     ): Result {
         calls.add(
-            element = Call(
+            element = Call.WithPaymentDetails(
                 paymentDetails = paymentDetails,
                 linkAccount = linkAccount,
                 cvc = cvc
@@ -22,9 +23,29 @@ internal class FakeLinkConfirmationHandler : LinkConfirmationHandler {
         return confirmResult
     }
 
-    data class Call(
-        val paymentDetails: ConsumerPaymentDetails.PaymentDetails,
-        val linkAccount: LinkAccount,
-        val cvc: String?
-    )
+    override suspend fun confirm(
+        paymentSelection: PaymentSelection,
+        linkAccount: LinkAccount
+    ): Result {
+        calls.add(
+            element = Call.WithPaymentSelection(
+                paymentSelection = paymentSelection,
+                linkAccount = linkAccount
+            )
+        )
+        return confirmResult
+    }
+
+    sealed interface Call {
+        data class WithPaymentDetails(
+            val paymentDetails: ConsumerPaymentDetails.PaymentDetails,
+            val linkAccount: LinkAccount,
+            val cvc: String?
+        ) : Call
+
+        data class WithPaymentSelection(
+            val paymentSelection: PaymentSelection,
+            val linkAccount: LinkAccount,
+        ) : Call
+    }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
@@ -205,7 +205,7 @@ class WalletViewModelTest {
         )
 
         assertThat(linkConfirmationHandler.calls).containsExactly(
-            FakeLinkConfirmationHandler.Call(
+            FakeLinkConfirmationHandler.Call.WithPaymentDetails(
                 paymentDetails = updatedCard,
                 linkAccount = TestFactory.LINK_ACCOUNT,
                 cvc = "123"
@@ -259,7 +259,7 @@ class WalletViewModelTest {
         assertThat(linkAccountManager.updatePaymentDetailsCalls).isEmpty()
 
         assertThat(linkConfirmationHandler.calls).containsExactly(
-            FakeLinkConfirmationHandler.Call(
+            FakeLinkConfirmationHandler.Call.WithPaymentDetails(
                 paymentDetails = validCard,
                 linkAccount = TestFactory.LINK_ACCOUNT,
                 cvc = null
@@ -292,7 +292,7 @@ class WalletViewModelTest {
         assertThat(linkAccountManager.updatePaymentDetailsCalls).isEmpty()
 
         assertThat(linkConfirmationHandler.calls).containsExactly(
-            FakeLinkConfirmationHandler.Call(
+            FakeLinkConfirmationHandler.Call.WithPaymentDetails(
                 paymentDetails = validCard,
                 cvc = null,
                 linkAccount = TestFactory.LINK_ACCOUNT


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Confirm payment with `PaymentSelection`. We get a `PaymentSelection` object after creating a new card payment method.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
[JIRA](https://jira.corp.stripe.com/browse/MOBILESDK-2756)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
