### PR TITLE
Add PaymentDetails ID to incentives call

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/CreateInstantDebitsResult.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/CreateInstantDebitsResult.kt
@@ -63,6 +63,7 @@ internal class RealCreateInstantDebitsResult @Inject constructor(
         val eligibleForIncentive = if (incentiveEligibilitySessionId != null) {
             consumerRepository.updateAvailableIncentives(
                 sessionId = incentiveEligibilitySessionId,
+                paymentDetailsId = paymentDetails.id,
                 consumerSessionClientSecret = clientSecret,
             ).map {
                 it.data.isNotEmpty()

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepository.kt
@@ -72,6 +72,7 @@ internal interface FinancialConnectionsConsumerSessionRepository {
 
     suspend fun updateAvailableIncentives(
         sessionId: String,
+        paymentDetailsId: String,
         consumerSessionClientSecret: String,
     ): Result<UpdateAvailableIncentives>
 
@@ -246,10 +247,12 @@ private class FinancialConnectionsConsumerSessionRepositoryImpl(
 
     override suspend fun updateAvailableIncentives(
         sessionId: String,
+        paymentDetailsId: String,
         consumerSessionClientSecret: String,
     ): Result<UpdateAvailableIncentives> {
         return consumersApiService.updateAvailableIncentives(
             sessionId = sessionId,
+            paymentDetailsId = paymentDetailsId,
             consumerSessionClientSecret = consumerSessionClientSecret,
             requestSurface = requestSurface,
             requestOptions = provideApiRequestOptions(useConsumerPublishableKey = true),

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/RealCreateInstantDebitsResultTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/RealCreateInstantDebitsResultTest.kt
@@ -193,6 +193,7 @@ class RealCreateInstantDebitsResultTest {
 
         verify(consumerRepository, never()).updateAvailableIncentives(
             sessionId = any(),
+            paymentDetailsId = any(),
             consumerSessionClientSecret = any(),
         )
 
@@ -218,6 +219,7 @@ class RealCreateInstantDebitsResultTest {
         whenever(
             consumerRepository.updateAvailableIncentives(
                 sessionId = eq("pi_123"),
+                paymentDetailsId = eq("ba_1234"),
                 consumerSessionClientSecret = eq("clientSecret"),
             )
         ).thenReturn(

--- a/payments-model/src/main/java/com/stripe/android/repository/ConsumersApiService.kt
+++ b/payments-model/src/main/java/com/stripe/android/repository/ConsumersApiService.kt
@@ -96,6 +96,7 @@ interface ConsumersApiService {
 
     suspend fun updateAvailableIncentives(
         sessionId: String,
+        paymentDetailsId: String,
         consumerSessionClientSecret: String,
         requestSurface: String,
         requestOptions: ApiRequest.Options,
@@ -325,6 +326,7 @@ class ConsumersApiServiceImpl(
 
     override suspend fun updateAvailableIncentives(
         sessionId: String,
+        paymentDetailsId: String,
         consumerSessionClientSecret: String,
         requestSurface: String,
         requestOptions: ApiRequest.Options,
@@ -338,6 +340,7 @@ class ConsumersApiServiceImpl(
                 params = mapOf(
                     "request_surface" to requestSurface,
                     "session_id" to sessionId,
+                    "payment_details_id" to paymentDetailsId,
                     "credentials" to mapOf(
                         "consumer_session_client_secret" to consumerSessionClientSecret
                     ),


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds the `payment_details_id` to the call to `incentives/update_available`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

[Web pull request](https://git.corp.stripe.com/stripe-internal/pay-server/pull/968445)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
