### PR TITLE
Move LinkState into PaymentMethodMetadata.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -25,6 +25,7 @@ import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.model.PaymentMethodIncentive
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.toPaymentMethodIncentive
+import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.ui.core.elements.ExternalPaymentMethodSpec
@@ -54,6 +55,7 @@ internal data class PaymentMethodMetadata(
     val linkInlineConfiguration: LinkInlineConfiguration?,
     val paymentMethodSaveConsentBehavior: PaymentMethodSaveConsentBehavior,
     val linkMode: LinkMode?,
+    val linkState: LinkState?,
     val paymentMethodIncentive: PaymentMethodIncentive?,
     val financialConnectionsAvailable: Boolean = DefaultIsFinancialConnectionsAvailable(),
     val cardBrandFilter: CardBrandFilter,
@@ -237,6 +239,7 @@ internal data class PaymentMethodMetadata(
             externalPaymentMethodSpecs: List<ExternalPaymentMethodSpec>,
             isGooglePayReady: Boolean,
             linkInlineConfiguration: LinkInlineConfiguration?,
+            linkState: LinkState?,
         ): PaymentMethodMetadata {
             val linkSettings = elementsSession.linkSettings
             return PaymentMethodMetadata(
@@ -259,6 +262,7 @@ internal data class PaymentMethodMetadata(
                 paymentMethodSaveConsentBehavior = elementsSession.toPaymentSheetSaveConsentBehavior(),
                 linkInlineConfiguration = linkInlineConfiguration,
                 linkMode = linkSettings?.linkMode,
+                linkState = linkState,
                 paymentMethodIncentive = linkSettings?.linkConsumerIncentive?.toPaymentMethodIncentive(),
                 isGooglePayReady = isGooglePayReady,
                 cardBrandFilter = PaymentSheetCardBrandFilter(configuration.cardBrandAcceptance)
@@ -293,6 +297,7 @@ internal data class PaymentMethodMetadata(
                 financialConnectionsAvailable = isFinancialConnectionsAvailable(),
                 paymentMethodSaveConsentBehavior = paymentMethodSaveConsentBehavior,
                 linkMode = elementsSession.linkSettings?.linkMode,
+                linkState = null,
                 paymentMethodIncentive = null,
                 externalPaymentMethodSpecs = emptyList(),
                 cardBrandFilter = PaymentSheetCardBrandFilter(configuration.cardBrandAcceptance)
@@ -322,6 +327,7 @@ internal data class PaymentMethodMetadata(
                 paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Disabled(null),
                 linkInlineConfiguration = null,
                 linkMode = null,
+                linkState = null,
                 paymentMethodIncentive = null,
                 isGooglePayReady = false,
                 cardBrandFilter = PaymentSheetCardBrandFilter(PaymentSheet.CardBrandAcceptance.all())

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -139,7 +139,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
         // This is bad, but I don't think there's a better option
         PaymentSheet.FlowController.linkHandler = linkHandler
 
-        linkHandler.setupLink(args.state.linkState)
+        linkHandler.setupLink(args.state.paymentMethodMetadata.linkState)
 
         // After recovering from don't keep activities the paymentMethodMetadata will be saved,
         // calling setPaymentMethodMetadata would require the repository be initialized, which

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -306,7 +306,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
 
         setPaymentMethodMetadata(state.paymentMethodMetadata)
 
-        linkHandler.setupLink(state.linkState)
+        linkHandler.setupLink(state.paymentMethodMetadata.linkState)
 
         val pendingFailedPaymentResult = confirmationHandler.awaitResult()
             as? ConfirmationHandler.Result.Failed

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -323,7 +323,7 @@ internal class DefaultFlowController @Inject internal constructor(
         viewModelScope.launch {
             val confirmationOption = paymentSelection?.toConfirmationOption(
                 configuration = state.config,
-                linkConfiguration = state.linkState?.configuration,
+                linkConfiguration = state.paymentMethodMetadata.linkState?.configuration,
             )
 
             confirmationOption?.let { option ->

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdater.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdater.kt
@@ -56,7 +56,7 @@ internal class DefaultPaymentSelectionUpdater @Inject constructor() : PaymentSel
                 state.paymentMethodMetadata.isGooglePayReady
             }
             is PaymentSelection.Link -> {
-                state.linkState != null
+                state.paymentMethodMetadata.linkState != null
             }
             is PaymentSelection.ExternalPaymentMethod -> {
                 state.paymentMethodMetadata.isExternalPaymentMethod(selection.type)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -98,7 +98,6 @@ internal interface PaymentElementLoader {
     data class State(
         val config: CommonConfiguration,
         val customer: CustomerState?,
-        val linkState: LinkState?,
         val paymentSelection: PaymentSelection?,
         val validationError: PaymentSheetLoadingException?,
         val paymentMethodMetadata: PaymentMethodMetadata,
@@ -214,7 +213,6 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         val state = PaymentElementLoader.State(
             config = configuration,
             customer = customer.await(),
-            linkState = linkState.await(),
             paymentSelection = initialPaymentSelection.await(),
             validationError = stripeIntent.validate(),
             paymentMethodMetadata = paymentMethodMetadata,
@@ -276,6 +274,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
             externalPaymentMethodSpecs = externalPaymentMethodSpecs,
             isGooglePayReady = isGooglePayReady,
             linkInlineConfiguration = createLinkInlineConfiguration(linkState),
+            linkState = linkState,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetState.kt
@@ -16,7 +16,6 @@ internal sealed interface PaymentSheetState : Parcelable {
     data class Full(
         val config: CommonConfiguration,
         val customer: CustomerState?,
-        val linkState: LinkState?,
         val paymentSelection: PaymentSelection?,
         val validationError: PaymentSheetLoadingException?,
         val paymentMethodMetadata: PaymentMethodMetadata,
@@ -24,7 +23,6 @@ internal sealed interface PaymentSheetState : Parcelable {
         constructor(state: PaymentElementLoader.State) : this(
             config = state.config,
             customer = state.customer,
-            linkState = state.linkState,
             paymentSelection = state.paymentSelection,
             validationError = state.validationError,
             paymentMethodMetadata = state.paymentMethodMetadata,

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
@@ -10,6 +10,7 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.model.PaymentMethodIncentive
+import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.ui.core.elements.ExternalPaymentMethodSpec
 import com.stripe.android.ui.core.elements.LpmSerializer
@@ -33,6 +34,7 @@ internal object PaymentMethodMetadataFactory {
         paymentMethodSaveConsentBehavior: PaymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
         linkInlineConfiguration: LinkInlineConfiguration? = null,
         linkMode: LinkMode? = LinkMode.LinkPaymentMethod,
+        linkState: LinkState? = null,
         cardBrandFilter: CardBrandFilter = DefaultCardBrandFilter,
         defaultBillingDetails: PaymentSheet.BillingDetails = PaymentSheet.BillingDetails(),
         paymentMethodIncentive: PaymentMethodIncentive? = null,
@@ -55,6 +57,7 @@ internal object PaymentMethodMetadataFactory {
             isGooglePayReady = isGooglePayReady,
             linkInlineConfiguration = linkInlineConfiguration,
             linkMode = linkMode,
+            linkState = linkState,
             cardBrandFilter = cardBrandFilter,
             paymentMethodIncentive = paymentMethodIncentive,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -765,6 +765,7 @@ internal class PaymentMethodMetadataTest {
             externalPaymentMethodSpecs = externalPaymentMethodSpecs,
             isGooglePayReady = false,
             linkInlineConfiguration = linkInlineConfiguration,
+            linkState = null,
         )
 
         val expectedMetadata = PaymentMethodMetadata(
@@ -789,6 +790,7 @@ internal class PaymentMethodMetadataTest {
             isGooglePayReady = false,
             linkInlineConfiguration = linkInlineConfiguration,
             linkMode = null,
+            linkState = null,
             cardBrandFilter = PaymentSheetCardBrandFilter(cardBrandAcceptance),
             paymentMethodIncentive = null,
         )
@@ -854,6 +856,7 @@ internal class PaymentMethodMetadataTest {
             financialConnectionsAvailable = false,
             linkInlineConfiguration = null,
             linkMode = null,
+            linkState = null,
             cardBrandFilter = PaymentSheetCardBrandFilter(cardBrandAcceptance),
             paymentMethodIncentive = null,
         )
@@ -924,6 +927,7 @@ internal class PaymentMethodMetadataTest {
             externalPaymentMethodSpecs = listOf(),
             isGooglePayReady = false,
             linkInlineConfiguration = null,
+            linkState = null,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/DefaultEmbeddedConfigurationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/DefaultEmbeddedConfigurationHandlerTest.kt
@@ -269,7 +269,6 @@ internal class DefaultEmbeddedConfigurationHandlerTest {
                 PaymentElementLoader.State(
                     config = configuration,
                     customer = null,
-                    linkState = null,
                     paymentSelection = null,
                     validationError = null,
                     paymentMethodMetadata = PaymentMethodMetadataFactory.create(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/SharedPaymentElementViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/SharedPaymentElementViewModelTest.kt
@@ -38,7 +38,6 @@ internal class SharedPaymentElementViewModelTest {
                 PaymentElementLoader.State(
                     config = configuration.asCommonConfiguration(),
                     customer = null,
-                    linkState = null,
                     paymentSelection = null,
                     validationError = null,
                     paymentMethodMetadata = PaymentMethodMetadataFactory.create(
@@ -78,7 +77,6 @@ internal class SharedPaymentElementViewModelTest {
                 PaymentElementLoader.State(
                     config = configuration.asCommonConfiguration(),
                     customer = null,
-                    linkState = null,
                     paymentSelection = PaymentSelection.GooglePay,
                     validationError = null,
                     paymentMethodMetadata = PaymentMethodMetadataFactory.create(
@@ -120,7 +118,6 @@ internal class SharedPaymentElementViewModelTest {
                 PaymentElementLoader.State(
                     config = configuration.asCommonConfiguration(),
                     customer = null,
-                    linkState = null,
                     paymentSelection = null,
                     validationError = null,
                     paymentMethodMetadata = PaymentMethodMetadataFactory.create(
@@ -159,7 +156,6 @@ internal class SharedPaymentElementViewModelTest {
                 PaymentElementLoader.State(
                     config = configuration.asCommonConfiguration(),
                     customer = null,
-                    linkState = null,
                     paymentSelection = PaymentSelection.GooglePay,
                     validationError = null,
                     paymentMethodMetadata = PaymentMethodMetadataFactory.create(
@@ -211,7 +207,6 @@ internal class SharedPaymentElementViewModelTest {
                 PaymentElementLoader.State(
                     config = configuration.asCommonConfiguration(),
                     customer = null,
-                    linkState = null,
                     paymentSelection = PaymentSelection.GooglePay,
                     validationError = null,
                     paymentMethodMetadata = PaymentMethodMetadataFactory.create(
@@ -264,7 +259,6 @@ internal class SharedPaymentElementViewModelTest {
                 PaymentElementLoader.State(
                     config = configuration.asCommonConfiguration(),
                     customer = null,
-                    linkState = null,
                     paymentSelection = PaymentSelection.GooglePay,
                     validationError = null,
                     paymentMethodMetadata = PaymentMethodMetadataFactory.create(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -777,11 +777,17 @@ internal class PaymentOptionsViewModelTest {
 
     private fun createViewModel(
         args: PaymentOptionContract.Args = PAYMENT_OPTION_CONTRACT_ARGS,
-        linkState: LinkState? = args.state.linkState,
+        linkState: LinkState? = args.state.paymentMethodMetadata.linkState,
         linkConfigurationCoordinator: LinkConfigurationCoordinator = FakeLinkConfigurationCoordinator()
     ) = TestViewModelFactory.create(linkConfigurationCoordinator) { linkHandler, savedStateHandle ->
         PaymentOptionsViewModel(
-            args = args.copy(state = args.state.copy(linkState = linkState)),
+            args = args.copy(
+                state = args.state.copy(
+                    paymentMethodMetadata = args.state.paymentMethodMetadata.copy(
+                        linkState = linkState
+                    )
+                )
+            ),
             eventReporter = eventReporter,
             customerRepository = customerRepository,
             workContext = testDispatcher,
@@ -832,7 +838,6 @@ internal class PaymentOptionsViewModelTest {
                 customer = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE,
                 config = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY.asCommonConfiguration(),
                 paymentSelection = null,
-                linkState = null,
                 validationError = null,
                 paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                     stripeIntent = PAYMENT_INTENT,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
@@ -137,7 +137,6 @@ internal object PaymentSheetFixtures {
             customer = EMPTY_CUSTOMER_STATE,
             config = CONFIG_GOOGLEPAY.asCommonConfiguration(),
             paymentSelection = null,
-            linkState = null,
             validationError = null,
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
         ),
@@ -152,7 +151,7 @@ internal object PaymentSheetFixtures {
         stripeIntent: StripeIntent = state.stripeIntent,
         config: PaymentSheet.Configuration = configuration,
         paymentSelection: PaymentSelection? = state.paymentSelection,
-        linkState: LinkState? = state.linkState,
+        linkState: LinkState? = state.paymentMethodMetadata.linkState,
     ): PaymentOptionContract.Args {
         return copy(
             state = state.copy(
@@ -170,10 +169,10 @@ internal object PaymentSheetFixtures {
                 ),
                 config = config.asCommonConfiguration(),
                 paymentSelection = paymentSelection,
-                linkState = linkState,
                 paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                     stripeIntent = stripeIntent,
                     isGooglePayReady = isGooglePayReady,
+                    linkState = linkState,
                 ),
             ),
             configuration = config,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -451,7 +451,6 @@ internal class DefaultFlowControllerTest {
                 customer = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE,
                 config = PaymentSheet.Configuration("com.stripe.android.paymentsheet.test").asCommonConfiguration(),
                 paymentSelection = null,
-                linkState = null,
                 validationError = null,
                 paymentMethodMetadata = PaymentMethodMetadataFactory.create(allowsDelayedPaymentMethods = false),
             ),
@@ -665,7 +664,6 @@ internal class DefaultFlowControllerTest {
                 customer = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE.copy(
                     paymentMethods = PAYMENT_METHODS
                 ),
-                linkState = null,
                 paymentSelection = initialSelection,
                 validationError = null,
                 paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
@@ -706,7 +704,6 @@ internal class DefaultFlowControllerTest {
                 customer = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE.copy(
                     paymentMethods = PAYMENT_METHODS
                 ),
-                linkState = null,
                 paymentSelection = initialSelection,
                 validationError = null,
                 paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
@@ -750,7 +747,6 @@ internal class DefaultFlowControllerTest {
                 customer = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE.copy(
                     paymentMethods = PAYMENT_METHODS
                 ),
-                linkState = null,
                 paymentSelection = initialSelection,
                 validationError = null,
                 paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
@@ -2400,7 +2396,6 @@ internal class DefaultFlowControllerTest {
             customer = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE.copy(
                 paymentMethods = PAYMENT_METHODS
             ),
-            linkState = null,
             paymentSelection = null,
             validationError = null,
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdaterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdaterTest.kt
@@ -361,7 +361,6 @@ class PaymentSelectionUpdaterTest {
             customer = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE.copy(
                 paymentMethods = customerPaymentMethods
             ),
-            linkState = null,
             paymentSelection = paymentSelection,
             validationError = null,
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(
@@ -392,7 +391,6 @@ class PaymentSelectionUpdaterTest {
             customer = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE.copy(
                 paymentMethods = customerPaymentMethods
             ),
-            linkState = null,
             paymentSelection = paymentSelection,
             validationError = null,
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -136,7 +136,6 @@ internal class DefaultPaymentElementLoaderTest {
                 paymentSelection = PaymentSelection.Saved(
                     paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
                 ),
-                linkState = null,
                 validationError = null,
                 paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                     stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_WITHOUT_LINK,
@@ -577,7 +576,7 @@ internal class DefaultPaymentElementLoaderTest {
             initializedViaCompose = false,
         ).getOrThrow()
 
-        assertThat(result.linkState?.loginState).isEqualTo(LinkState.LoginState.LoggedIn)
+        assertThat(result.paymentMethodMetadata.linkState?.loginState).isEqualTo(LinkState.LoginState.LoggedIn)
     }
 
     @Test
@@ -590,7 +589,7 @@ internal class DefaultPaymentElementLoaderTest {
             initializedViaCompose = false,
         ).getOrThrow()
 
-        assertThat(result.linkState?.loginState).isEqualTo(LinkState.LoginState.NeedsVerification)
+        assertThat(result.paymentMethodMetadata.linkState?.loginState).isEqualTo(LinkState.LoginState.NeedsVerification)
     }
 
     @Test
@@ -603,7 +602,7 @@ internal class DefaultPaymentElementLoaderTest {
             initializedViaCompose = false,
         ).getOrThrow()
 
-        assertThat(result.linkState?.loginState).isEqualTo(LinkState.LoginState.NeedsVerification)
+        assertThat(result.paymentMethodMetadata.linkState?.loginState).isEqualTo(LinkState.LoginState.NeedsVerification)
     }
 
     @Test
@@ -616,7 +615,7 @@ internal class DefaultPaymentElementLoaderTest {
             initializedViaCompose = false,
         ).getOrThrow()
 
-        assertThat(result.linkState?.loginState).isEqualTo(LinkState.LoginState.LoggedOut)
+        assertThat(result.paymentMethodMetadata.linkState?.loginState).isEqualTo(LinkState.LoginState.LoggedOut)
     }
 
     @Test
@@ -652,7 +651,7 @@ internal class DefaultPaymentElementLoaderTest {
             flags = emptyMap(),
         )
 
-        assertThat(result.linkState?.configuration).isEqualTo(expectedLinkConfig)
+        assertThat(result.paymentMethodMetadata.linkState?.configuration).isEqualTo(expectedLinkConfig)
     }
 
     @Test
@@ -673,7 +672,7 @@ internal class DefaultPaymentElementLoaderTest {
             initializedViaCompose = false,
         ).getOrThrow()
 
-        assertThat(result.linkState?.configuration?.shippingDetails).isNotNull()
+        assertThat(result.paymentMethodMetadata.linkState?.configuration?.shippingDetails).isNotNull()
     }
 
     @Test
@@ -696,7 +695,7 @@ internal class DefaultPaymentElementLoaderTest {
             initializedViaCompose = false,
         ).getOrThrow()
 
-        assertThat(result.linkState?.configuration?.passthroughModeEnabled).isTrue()
+        assertThat(result.paymentMethodMetadata.linkState?.configuration?.passthroughModeEnabled).isTrue()
     }
 
     @Test
@@ -739,7 +738,7 @@ internal class DefaultPaymentElementLoaderTest {
             "link_passthrough_mode_enabled" to true,
         )
 
-        assertThat(result.linkState?.configuration?.flags).containsExactlyEntriesIn(expectedFlags)
+        assertThat(result.paymentMethodMetadata.linkState?.configuration?.flags).containsExactlyEntriesIn(expectedFlags)
     }
 
     @Test
@@ -757,7 +756,7 @@ internal class DefaultPaymentElementLoaderTest {
             initializedViaCompose = false,
         ).getOrThrow()
 
-        val cardBrandChoice = result.linkState?.configuration?.cardBrandChoice
+        val cardBrandChoice = result.paymentMethodMetadata.linkState?.configuration?.cardBrandChoice
 
         assertThat(cardBrandChoice?.eligible).isTrue()
         assertThat(cardBrandChoice?.preferredNetworks).isEqualTo(listOf("cartes_bancaires"))
@@ -778,7 +777,7 @@ internal class DefaultPaymentElementLoaderTest {
             initializedViaCompose = false,
         ).getOrThrow()
 
-        val cardBrandChoice = result.linkState?.configuration?.cardBrandChoice
+        val cardBrandChoice = result.paymentMethodMetadata.linkState?.configuration?.cardBrandChoice
 
         assertThat(cardBrandChoice?.eligible).isFalse()
         assertThat(cardBrandChoice?.preferredNetworks).isEqualTo(listOf("cartes_bancaires"))
@@ -807,7 +806,7 @@ internal class DefaultPaymentElementLoaderTest {
             initializedViaCompose = false,
         ).getOrThrow()
 
-        assertThat(result.linkState?.signupMode).isNull()
+        assertThat(result.paymentMethodMetadata.linkState?.signupMode).isNull()
         assertThat(result.paymentMethodMetadata.linkInlineConfiguration?.signupMode).isNull()
     }
 
@@ -831,7 +830,7 @@ internal class DefaultPaymentElementLoaderTest {
             initializedViaCompose = false,
         ).getOrThrow()
 
-        assertThat(result.linkState?.signupMode).isNull()
+        assertThat(result.paymentMethodMetadata.linkState?.signupMode).isNull()
         assertThat(result.paymentMethodMetadata.linkInlineConfiguration?.signupMode).isNull()
     }
 
@@ -850,7 +849,7 @@ internal class DefaultPaymentElementLoaderTest {
             initializedViaCompose = false,
         ).getOrThrow()
 
-        assertThat(result.linkState?.signupMode).isNull()
+        assertThat(result.paymentMethodMetadata.linkState?.signupMode).isNull()
         assertThat(result.paymentMethodMetadata.linkInlineConfiguration?.signupMode).isNull()
     }
 
@@ -866,7 +865,7 @@ internal class DefaultPaymentElementLoaderTest {
             initializedViaCompose = false,
         ).getOrThrow()
 
-        assertThat(result.linkState?.signupMode).isNull()
+        assertThat(result.paymentMethodMetadata.linkState?.signupMode).isNull()
         assertThat(result.paymentMethodMetadata.linkInlineConfiguration?.signupMode).isNull()
     }
 
@@ -882,7 +881,7 @@ internal class DefaultPaymentElementLoaderTest {
             initializedViaCompose = false,
         ).getOrThrow()
 
-        assertThat(result.linkState?.signupMode).isNull()
+        assertThat(result.paymentMethodMetadata.linkState?.signupMode).isNull()
         assertThat(result.paymentMethodMetadata.linkInlineConfiguration?.signupMode).isNull()
     }
 
@@ -898,7 +897,7 @@ internal class DefaultPaymentElementLoaderTest {
             initializedViaCompose = false,
         ).getOrThrow()
 
-        assertThat(result.linkState?.signupMode).isNull()
+        assertThat(result.paymentMethodMetadata.linkState?.signupMode).isNull()
         assertThat(result.paymentMethodMetadata.linkInlineConfiguration?.signupMode).isNull()
     }
 
@@ -917,7 +916,7 @@ internal class DefaultPaymentElementLoaderTest {
             initializedViaCompose = false,
         ).getOrThrow()
 
-        assertThat(result.linkState?.signupMode).isEqualTo(InsteadOfSaveForFutureUse)
+        assertThat(result.paymentMethodMetadata.linkState?.signupMode).isEqualTo(InsteadOfSaveForFutureUse)
         assertThat(result.paymentMethodMetadata.linkInlineConfiguration?.signupMode)
             .isEqualTo(InsteadOfSaveForFutureUse)
     }
@@ -934,7 +933,7 @@ internal class DefaultPaymentElementLoaderTest {
             initializedViaCompose = false,
         ).getOrThrow()
 
-        assertThat(result.linkState?.signupMode).isEqualTo(InsteadOfSaveForFutureUse)
+        assertThat(result.paymentMethodMetadata.linkState?.signupMode).isEqualTo(InsteadOfSaveForFutureUse)
         assertThat(result.paymentMethodMetadata.linkInlineConfiguration?.signupMode)
             .isEqualTo(InsteadOfSaveForFutureUse)
     }
@@ -960,7 +959,8 @@ internal class DefaultPaymentElementLoaderTest {
             initializedViaCompose = false,
         ).getOrThrow()
 
-        assertThat(result.linkState?.configuration?.customerInfo?.phone).isEqualTo(shippingDetails.phoneNumber)
+        assertThat(result.paymentMethodMetadata.linkState?.configuration?.customerInfo?.phone)
+            .isEqualTo(shippingDetails.phoneNumber)
     }
 
     @Test
@@ -987,7 +987,8 @@ internal class DefaultPaymentElementLoaderTest {
             initializedViaCompose = false,
         ).getOrThrow()
 
-        assertThat(result.linkState?.configuration?.customerInfo?.email).isEqualTo("email@stripe.com")
+        assertThat(result.paymentMethodMetadata.linkState?.configuration?.customerInfo?.email)
+            .isEqualTo("email@stripe.com")
     }
 
     @Test
@@ -1242,7 +1243,7 @@ internal class DefaultPaymentElementLoaderTest {
             initializedViaCompose = false,
         ).getOrThrow()
 
-        assertThat(result.linkState?.signupMode).isEqualTo(InsteadOfSaveForFutureUse)
+        assertThat(result.paymentMethodMetadata.linkState?.signupMode).isEqualTo(InsteadOfSaveForFutureUse)
         assertThat(result.paymentMethodMetadata.linkInlineConfiguration?.signupMode)
             .isEqualTo(InsteadOfSaveForFutureUse)
     }
@@ -1267,7 +1268,7 @@ internal class DefaultPaymentElementLoaderTest {
             initializedViaCompose = false,
         ).getOrThrow()
 
-        assertThat(result.linkState?.signupMode).isEqualTo(AlongsideSaveForFutureUse)
+        assertThat(result.paymentMethodMetadata.linkState?.signupMode).isEqualTo(AlongsideSaveForFutureUse)
         assertThat(result.paymentMethodMetadata.linkInlineConfiguration?.signupMode)
             .isEqualTo(AlongsideSaveForFutureUse)
     }
@@ -1287,7 +1288,7 @@ internal class DefaultPaymentElementLoaderTest {
             initializedViaCompose = false,
         ).getOrThrow()
 
-        assertThat(result.linkState?.signupMode).isEqualTo(InsteadOfSaveForFutureUse)
+        assertThat(result.paymentMethodMetadata.linkState?.signupMode).isEqualTo(InsteadOfSaveForFutureUse)
         assertThat(result.paymentMethodMetadata.linkInlineConfiguration?.signupMode)
             .isEqualTo(InsteadOfSaveForFutureUse)
     }
@@ -1307,7 +1308,7 @@ internal class DefaultPaymentElementLoaderTest {
             initializedViaCompose = false,
         ).getOrThrow()
 
-        assertThat(result.linkState?.signupMode).isEqualTo(AlongsideSaveForFutureUse)
+        assertThat(result.paymentMethodMetadata.linkState?.signupMode).isEqualTo(AlongsideSaveForFutureUse)
         assertThat(result.paymentMethodMetadata.linkInlineConfiguration?.signupMode)
             .isEqualTo(AlongsideSaveForFutureUse)
     }
@@ -1329,7 +1330,7 @@ internal class DefaultPaymentElementLoaderTest {
             initializedViaCompose = false,
         ).getOrThrow()
 
-        assertThat(result.linkState).isNull()
+        assertThat(result.paymentMethodMetadata.linkState).isNull()
         assertThat(result.paymentMethodMetadata.linkInlineConfiguration).isNull()
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentElementLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentElementLoader.kt
@@ -49,7 +49,6 @@ internal class FakePaymentElementLoader(
                 PaymentElementLoader.State(
                     config = configuration,
                     customer = customer,
-                    linkState = linkState,
                     paymentSelection = paymentSelection,
                     validationError = validationError,
                     paymentMethodMetadata = PaymentMethodMetadataFactory.create(
@@ -61,6 +60,7 @@ internal class FakePaymentElementLoader(
                             .allowsPaymentMethodsRequiringShippingAddress,
                         isGooglePayReady = isGooglePayAvailable,
                         cbcEligibility = cbcEligibility,
+                        linkState = linkState,
                     ),
                 )
             )

--- a/paymentsheet/src/test/java/com/stripe/android/utils/RelayingPaymentElementLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/RelayingPaymentElementLoader.kt
@@ -24,7 +24,6 @@ internal class RelayingPaymentElementLoader : PaymentElementLoader {
                     customer = null,
                     config = PaymentSheet.Configuration("Example").asCommonConfiguration(),
                     paymentSelection = null,
-                    linkState = null,
                     validationError = validationError,
                     paymentMethodMetadata = PaymentMethodMetadataFactory.create(stripeIntent = stripeIntent),
                 ),


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This is a pure refactor (no behavior changes) to allow me to wire up link in embedded.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
I'm trying to wire link up to embedded, and we always need it in tandem with PaymentMethodMetadata, and it's an immutable type that's parcelable, so it makes sense inside of PaymentMethodMetadata.
