### PR TITLE
Fix event name for EPMs.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -476,8 +476,8 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
             is PaymentSelection.Saved -> "savedpm"
             is PaymentSelection.Link,
             is PaymentSelection.New.LinkInline -> "link"
+            is PaymentSelection.ExternalPaymentMethod,
             is PaymentSelection.New -> "newpm"
-            is PaymentSelection.ExternalPaymentMethod -> "epm"
             null -> "unknown"
         }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
@@ -707,7 +707,7 @@ class PaymentSheetEventTest {
         assertThat(
             newPMEvent.eventName
         ).isEqualTo(
-            "mc_complete_payment_epm_success"
+            "mc_complete_payment_newpm_success"
         )
         assertThat(
             newPMEvent.params
@@ -748,7 +748,7 @@ class PaymentSheetEventTest {
         assertThat(
             newPMEvent.eventName
         ).isEqualTo(
-            "mc_complete_payment_epm_failure"
+            "mc_complete_payment_newpm_failure"
         )
         assertThat(
             newPMEvent.params


### PR DESCRIPTION
# Summary
Fix event names for external payment methods to send `newpm` instead of `epm`.

# Motivation
External payment methods don't have their own subnames for payment events. Instead we label them as new PM events like the other non-savable LPMs

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified