### PR TITLE
Fix a bug where configuring embedded with the same configuration values but different instances caused extraneous network calls.

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -1428,10 +1428,13 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$IntentConfigurat
 	public fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$Mode;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Z)V
 	public synthetic fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$Mode;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
 	public final fun getMode ()Lcom/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$Mode;
 	public final fun getOnBehalfOf ()Ljava/lang/String;
 	public final fun getPaymentMethodConfigurationId ()Ljava/lang/String;
 	public final fun getPaymentMethodTypes ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 	public final fun writeToParcel (Landroid/os/Parcel;I)V
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -322,6 +322,7 @@ class PaymentSheet internal constructor(
      * @param onBehalfOf The account (if any) for which the funds of the intent are intended. See
      * [our docs](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-on_behalf_of) for more info.
      */
+    @Poko
     @Parcelize
     class IntentConfiguration @JvmOverloads constructor(
         val mode: Mode,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/DefaultEmbeddedConfigurationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/DefaultEmbeddedConfigurationHandlerTest.kt
@@ -130,19 +130,20 @@ internal class DefaultEmbeddedConfigurationHandlerTest {
 
     @Test
     fun `result is used from saved state handle when configurations are the same`() = runScenario {
-        val intentConfiguration = PaymentSheet.IntentConfiguration(
-            mode = PaymentSheet.IntentConfiguration.Mode.Setup(currency = "USD"),
-        )
         val configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build()
         savedStateHandle[ConfigurationCache.KEY] = ConfigurationCache(
             arguments = DefaultEmbeddedConfigurationHandler.Arguments(
-                intentConfiguration = intentConfiguration,
+                intentConfiguration = PaymentSheet.IntentConfiguration(
+                    mode = PaymentSheet.IntentConfiguration.Mode.Setup(currency = "USD"),
+                ),
                 configuration = configuration.asCommonConfiguration(),
             ),
             resultState = loader.createSuccess(configuration.asCommonConfiguration()).getOrThrow(),
         )
         val result = handler.configure(
-            intentConfiguration = intentConfiguration,
+            intentConfiguration = PaymentSheet.IntentConfiguration(
+                mode = PaymentSheet.IntentConfiguration.Mode.Setup(currency = "USD"),
+            ),
             configuration = configuration,
         )
         assertThat(result.getOrThrow())


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This was happening because we didn't implement equals on what of the objects we were comparing.
