### PR TITLE
Attempt to wait for intent callback to be available before attempting deferred intent confirmation.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -268,6 +268,9 @@ interface ErrorReporter : FraudDetectionErrorReporter {
         EXTERNAL_PAYMENT_METHODS_LAUNCH_SUCCESS(
             eventName = "paymentsheet.external_payment_method.launch_success"
         ),
+        FOUND_CREATE_INTENT_CALLBACK_WHILE_POLLING(
+            eventName = "paymentsheet.polling_for_create_intent_callback.found"
+        ),
     }
 }
 


### PR DESCRIPTION
# Summary
Attempt to wait for intent callback to be available before attempting deferred intent confirmation.

# Motivation
We have a few merchant complaining when using deferred intents that they receive a `CreateIntentCallback must be implemented when using IntentConfiguration with PaymentSheet` exception even though they implemented the callback properly when initializing `PaymentSheet`. It hasn't been reproducible locally though by these merchants or us. 

I suspect the reason is that this issue happening between activity destruction & activity re-creation. The scenario would be:

- The user starts the deferred intent confirmation process
- A config change is triggered (either by the user directly or an automatic system change such as battery save mode)
- The activity is destroyed
- The callback is de-initialized
- The deferred intent process reaches the create intent stage.
- Crash occurs

The activity is not re-initialized in time meaning the callback was also not re-initialized.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified