### PR TITLE
[MOBILESDK-2894] [Android] Make Default Payment Method first

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -723,20 +723,20 @@ private fun List<PaymentMethod>.withLastUsedPaymentMethodFirst(
     savedSelection: SavedSelection,
     defaultPaymentMethodId: String?
 ): List<PaymentMethod> {
-    val defaultPaymentMethodIndex = if (defaultPaymentMethodId != null) {
+    val defaultPaymentMethodIndex = defaultPaymentMethodId?.let {
         indexOfFirst { it.id == defaultPaymentMethodId }
-    } else {
-        (savedSelection as? SavedSelection.PaymentMethod)?.let {
-            indexOfFirst { it.id == savedSelection.id }.takeIf { it != -1 }
-        }
     }
 
-    return if (defaultPaymentMethodIndex != null) {
-        val primaryPaymentMethod = get(defaultPaymentMethodIndex)
-        listOf(primaryPaymentMethod) + (this - primaryPaymentMethod)
-    } else {
-        this
+    val savedSelectionIndex = (savedSelection as? SavedSelection.PaymentMethod)?.let {
+        indexOfFirst { it.id == savedSelection.id }.takeIf { it != -1 }
     }
+
+    val primaryPaymentMethodIndex = defaultPaymentMethodIndex ?: savedSelectionIndex
+
+    return primaryPaymentMethodIndex?.let {
+        val primaryPaymentMethod = get(primaryPaymentMethodIndex)
+        listOf(primaryPaymentMethod) + (this - primaryPaymentMethod)
+    } ?: this
 }
 
 private fun PaymentMethod.toPaymentSelection(): PaymentSelection.Saved {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -349,7 +349,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         return customerState?.let { state ->
             state.copy(
                 paymentMethods = state.paymentMethods
-                    .withLastUsedPaymentMethodFirst(
+                    .withDefaultPaymentMethodOrLastUsedPaymentMethodFirst(
                         savedSelection = savedSelection.await(),
                         defaultPaymentMethodId = state.defaultPaymentMethodId
                     ).filter { cardBrandFilter.isAccepted(it) }
@@ -719,7 +719,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
     }
 }
 
-private fun List<PaymentMethod>.withLastUsedPaymentMethodFirst(
+private fun List<PaymentMethod>.withDefaultPaymentMethodOrLastUsedPaymentMethodFirst(
     savedSelection: SavedSelection,
     defaultPaymentMethodId: String?
 ): List<PaymentMethod> {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -2506,7 +2506,7 @@ internal class DefaultPaymentElementLoaderTest {
         val defaultPaymentMethod = paymentMethodsForTestingOrdering[defaultPaymentMethodIndex]
         val defaultPaymentMethodId = defaultPaymentMethod.id
 
-        if (setLastUsedIndex != null && setLastUsedIndex in paymentMethodsForTestingOrdering.indices){
+        if (setLastUsedIndex != null && setLastUsedIndex in paymentMethodsForTestingOrdering.indices) {
             val lastUsed = paymentMethodsForTestingOrdering[setLastUsedIndex]
             prefsRepository.savePaymentSelection(PaymentSelection.Saved(lastUsed))
         }


### PR DESCRIPTION
# Summary
Added logic for putting the default payment method 

# Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-2894

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified


# Screenshots
|| Before  | After |
|-| ------------- | ------------- |
|Vertical Mode|![1000000061](https://github.com/user-attachments/assets/187c5072-9fbe-49ac-af5f-d17ee5641f63)| ![1000000058](https://github.com/user-attachments/assets/1fb58a12-1a56-4543-96e8-a851a1779223)|
|Horizontal Mode|![1000000062](https://github.com/user-attachments/assets/27956e40-2e0b-4406-a6df-50c0ba40853f)|![1000000059](https://github.com/user-attachments/assets/75217159-1f77-4714-866b-633ae52d7a67)|

# Changelog
N.A.