### PR TITLE
Fail rather than crash when `CreateIntentCallback` is not available in deferred intent mode.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -152,6 +152,9 @@ interface ErrorReporter : FraudDetectionErrorReporter {
         EXTERNAL_PAYMENT_METHOD_LAUNCHER_NULL(
             eventName = "paymentsheet.external_payment_method.launcher_is_null"
         ),
+        CREATE_INTENT_CALLBACK_NULL(
+            eventName = "paymentsheet.create_intent_callback.is_null"
+        ),
     }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptor.kt
@@ -25,6 +25,7 @@ import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import javax.inject.Inject
 import javax.inject.Named
+import com.stripe.android.R as PaymentsCoreR
 
 internal interface IntentConfirmationInterceptor {
 
@@ -251,9 +252,16 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
             }
 
             else -> {
-                error(
-                    "${CreateIntentCallback::class.java.simpleName} must be implemented " +
-                        "when using IntentConfiguration with PaymentSheet"
+                val error = "${CreateIntentCallback::class.java.simpleName} must be implemented " +
+                    "when using IntentConfiguration with PaymentSheet"
+
+                NextStep.Fail(
+                    cause = IllegalStateException(error),
+                    message = if (requestOptions.apiKeyIsLiveMode) {
+                        PaymentsCoreR.string.stripe_internal_error.resolvableString
+                    } else {
+                        error.resolvableString
+                    }
                 )
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptor.kt
@@ -17,6 +17,7 @@ import com.stripe.android.model.setupFutureUsage
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.paymentelement.confirmation.ALLOWS_MANUAL_CONFIRMATION
 import com.stripe.android.paymentelement.confirmation.intent.IntentConfirmationInterceptor.NextStep
+import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.CreateIntentCallback
 import com.stripe.android.paymentsheet.CreateIntentResult
 import com.stripe.android.paymentsheet.DeferredIntentValidator
@@ -107,6 +108,7 @@ internal class InvalidDeferredIntentUsageException : StripeException() {
 
 internal class DefaultIntentConfirmationInterceptor @Inject constructor(
     private val stripeRepository: StripeRepository,
+    private val errorReporter: ErrorReporter,
     @Named(ALLOWS_MANUAL_CONFIRMATION) private val allowsManualConfirmation: Boolean,
     @Named(PUBLISHABLE_KEY) private val publishableKeyProvider: () -> String,
     @Named(STRIPE_ACCOUNT_ID) private val stripeAccountIdProvider: () -> String?,
@@ -254,6 +256,8 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
             else -> {
                 val error = "${CreateIntentCallback::class.java.simpleName} must be implemented " +
                     "when using IntentConfiguration with PaymentSheet"
+
+                errorReporter.report(ErrorReporter.ExpectedErrorEvent.CREATE_INTENT_CALLBACK_NULL)
 
                 NextStep.Fail(
                     cause = IllegalStateException(error),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultIntentConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultIntentConfirmationInterceptorTest.kt
@@ -18,12 +18,14 @@ import com.stripe.android.paymentelement.confirmation.intent.DefaultIntentConfir
 import com.stripe.android.paymentelement.confirmation.intent.IntentConfirmationInterceptor
 import com.stripe.android.paymentelement.confirmation.intent.InvalidDeferredIntentUsageException
 import com.stripe.android.paymentelement.confirmation.intent.intercept
+import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.CreateIntentCallback
 import com.stripe.android.paymentsheet.CreateIntentResult
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.state.PaymentElementLoader.InitializationMode
 import com.stripe.android.testing.AbsFakeStripeRepository
+import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.utils.IntentConfirmationInterceptorTestRule
 import kotlinx.coroutines.test.runTest
@@ -50,6 +52,7 @@ class DefaultIntentConfirmationInterceptorTest {
             stripeRepository = object : AbsFakeStripeRepository() {},
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
+            errorReporter = FakeErrorReporter(),
             allowsManualConfirmation = false,
         )
 
@@ -75,6 +78,7 @@ class DefaultIntentConfirmationInterceptorTest {
             stripeRepository = object : AbsFakeStripeRepository() {},
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
+            errorReporter = FakeErrorReporter(),
             allowsManualConfirmation = false,
         )
 
@@ -124,10 +128,12 @@ class DefaultIntentConfirmationInterceptorTest {
 
     @Test
     fun `Fails if invoked without a confirm callback for existing payment method`() = runTest {
+        val errorReporter = FakeErrorReporter()
         val interceptor = DefaultIntentConfirmationInterceptor(
             stripeRepository = object : AbsFakeStripeRepository() {},
             publishableKeyProvider = { "pk_test_123" },
             stripeAccountIdProvider = { null },
+            errorReporter = errorReporter,
             allowsManualConfirmation = false,
         )
 
@@ -152,10 +158,15 @@ class DefaultIntentConfirmationInterceptorTest {
         assertThat(failedStep.cause).isInstanceOf<IllegalStateException>()
         assertThat(failedStep.cause.message).isEqualTo(CREATE_INTENT_CALLBACK_MESSAGE)
         assertThat(failedStep.message).isEqualTo(CREATE_INTENT_CALLBACK_MESSAGE.resolvableString)
+
+        assertThat(errorReporter.getLoggedErrors()).containsExactly(
+            ErrorReporter.ExpectedErrorEvent.CREATE_INTENT_CALLBACK_NULL.eventName,
+        )
     }
 
     @Test
     fun `Fails if invoked without a confirm callback for new payment method`() = runTest {
+        val errorReporter = FakeErrorReporter()
         val interceptor = DefaultIntentConfirmationInterceptor(
             stripeRepository = object : AbsFakeStripeRepository() {
                 override suspend fun createPaymentMethod(
@@ -167,6 +178,7 @@ class DefaultIntentConfirmationInterceptorTest {
             },
             publishableKeyProvider = { "pk_test_123" },
             stripeAccountIdProvider = { null },
+            errorReporter = errorReporter,
             allowsManualConfirmation = false,
         )
 
@@ -184,14 +196,20 @@ class DefaultIntentConfirmationInterceptorTest {
         assertThat(failedStep.cause).isInstanceOf<IllegalStateException>()
         assertThat(failedStep.cause.message).isEqualTo(CREATE_INTENT_CALLBACK_MESSAGE)
         assertThat(failedStep.message).isEqualTo(CREATE_INTENT_CALLBACK_MESSAGE.resolvableString)
+
+        assertThat(errorReporter.getLoggedErrors()).containsExactly(
+            ErrorReporter.ExpectedErrorEvent.CREATE_INTENT_CALLBACK_NULL.eventName,
+        )
     }
 
     @Test
     fun `Message for live key when error without confirm callback is user friendly`() = runTest {
+        val errorReporter = FakeErrorReporter()
         val interceptor = DefaultIntentConfirmationInterceptor(
             stripeRepository = object : AbsFakeStripeRepository() {},
             publishableKeyProvider = { "pk_live_123" },
             stripeAccountIdProvider = { null },
+            errorReporter = errorReporter,
             allowsManualConfirmation = false,
         )
 
@@ -216,6 +234,10 @@ class DefaultIntentConfirmationInterceptorTest {
         assertThat(failedStep.cause).isInstanceOf<IllegalStateException>()
         assertThat(failedStep.cause.message).isEqualTo(CREATE_INTENT_CALLBACK_MESSAGE)
         assertThat(failedStep.message).isEqualTo(PaymentsCoreR.string.stripe_internal_error.resolvableString)
+
+        assertThat(errorReporter.getLoggedErrors()).containsExactly(
+            ErrorReporter.ExpectedErrorEvent.CREATE_INTENT_CALLBACK_NULL.eventName,
+        )
     }
 
     @Test
@@ -237,6 +259,7 @@ class DefaultIntentConfirmationInterceptorTest {
             },
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
+            errorReporter = FakeErrorReporter(),
             allowsManualConfirmation = false,
         )
 
@@ -277,6 +300,7 @@ class DefaultIntentConfirmationInterceptorTest {
             },
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
+            errorReporter = FakeErrorReporter(),
             allowsManualConfirmation = false,
         )
 
@@ -303,6 +327,7 @@ class DefaultIntentConfirmationInterceptorTest {
             stripeRepository = mock(),
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
+            errorReporter = FakeErrorReporter(),
             allowsManualConfirmation = false,
         )
 
@@ -331,6 +356,7 @@ class DefaultIntentConfirmationInterceptorTest {
             stripeRepository = mock(),
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
+            errorReporter = FakeErrorReporter(),
             allowsManualConfirmation = false,
         )
 
@@ -371,6 +397,7 @@ class DefaultIntentConfirmationInterceptorTest {
             },
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
+            errorReporter = FakeErrorReporter(),
             allowsManualConfirmation = false,
         )
 
@@ -409,6 +436,7 @@ class DefaultIntentConfirmationInterceptorTest {
             },
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
+            errorReporter = FakeErrorReporter(),
             allowsManualConfirmation = false,
         )
 
@@ -454,6 +482,7 @@ class DefaultIntentConfirmationInterceptorTest {
             },
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
+            errorReporter = FakeErrorReporter(),
             allowsManualConfirmation = false,
         )
 
@@ -495,6 +524,7 @@ class DefaultIntentConfirmationInterceptorTest {
             },
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
+            errorReporter = FakeErrorReporter(),
             allowsManualConfirmation = false,
         )
 
@@ -536,6 +566,7 @@ class DefaultIntentConfirmationInterceptorTest {
             stripeRepository = stripeRepository,
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
+            errorReporter = FakeErrorReporter(),
             allowsManualConfirmation = false,
         )
 
@@ -576,6 +607,7 @@ class DefaultIntentConfirmationInterceptorTest {
                 ),
                 publishableKeyProvider = { "pk" },
                 stripeAccountIdProvider = { null },
+                errorReporter = FakeErrorReporter(),
                 allowsManualConfirmation = false,
             )
 
@@ -630,6 +662,7 @@ class DefaultIntentConfirmationInterceptorTest {
             stripeRepository = object : AbsFakeStripeRepository() {},
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
+            errorReporter = FakeErrorReporter(),
             allowsManualConfirmation = false,
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationFlowTest.kt
@@ -23,6 +23,7 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
+import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.FakePaymentLauncher
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -228,6 +229,7 @@ internal class IntentConfirmationFlowTest {
                     createPaymentMethodResult = createPaymentMethodResult,
                     retrieveIntent = intentResult,
                 ),
+                errorReporter = FakeErrorReporter(),
             ),
             paymentLauncherFactory = {
                 FakePaymentLauncher()


### PR DESCRIPTION
# Summary
Fail rather than crash when `CreateIntentCallback` is not available in deferred intent mode.

# Motivation
Merchants are reporting app crashes when the callback is not available. We should fail rather than crash.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified