### PR TITLE
[FC] Ensures bottomsheet NavBackStackEntry is ready before rendering.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,7 @@
 ## XX.XX.XX - 20XX-XX-XX
 
 ### Financial Connections
-
-- [Fixed] Addresses a known issue where NavBackStackEntry's ViewModels in bottom sheets become inaccessible after the associated NavBackStackEntry is destroyed.
+- [FIXED] Fixes a rare crash that could occur when presenting a bottom sheet.
 
 ## 21.3.1 - 2025-01-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## XX.XX.XX - 20XX-XX-XX
 
+### Financial Connections
+
+- [Fixed] Addresses a known issue where NavBackStackEntry's ViewModels in bottom sheets become inaccessible after the associated NavBackStackEntry is destroyed.
+
 ## 21.3.1 - 2025-01-06
 
 ### PaymentSheet

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/navigation/Destination.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/navigation/Destination.kt
@@ -36,6 +36,7 @@ import com.stripe.android.financialconnections.features.partnerauth.PartnerAuthS
 import com.stripe.android.financialconnections.features.reset.ResetScreen
 import com.stripe.android.financialconnections.features.success.SuccessScreen
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
+import com.stripe.android.financialconnections.navigation.bottomsheet.LifecycleAwareContent
 import com.stripe.android.financialconnections.navigation.bottomsheet.bottomSheet
 import com.stripe.android.financialconnections.presentation.parentViewModel
 
@@ -283,6 +284,10 @@ internal fun NavGraphBuilder.bottomSheet(
         route = destination.fullRoute,
         arguments = destination.arguments,
         deepLinks = deepLinks,
-        content = { destination.Composable(navBackStackEntry = it) }
+        content = { navBackStackEntry ->
+            LifecycleAwareContent(navBackStackEntry) {
+                destination.Composable(navBackStackEntry = navBackStackEntry)
+            }
+        }
     )
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/navigation/bottomsheet/BackstackSafeContent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/navigation/bottomsheet/BackstackSafeContent.kt
@@ -1,0 +1,53 @@
+package com.stripe.android.financialconnections.navigation.bottomsheet
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+
+/**
+ * Prevents the content from being rendered until the lifecycle is ready.
+ *
+ * Addresses: You cannot access the NavBackStackEntry's ViewModels after the NavBackStackEntry is destroyed.
+ * https://github.com/google/accompanist/issues/1487#top
+ */
+@Composable
+internal fun LifecycleAwareContent(
+    lifecycleOwner: LifecycleOwner,
+    content: @Composable () -> Unit
+) {
+    val isReady = remember { mutableStateOf(false) }
+
+    // Track the lifecycle to update the readiness state
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_CREATE -> isReady.value = true
+                Lifecycle.Event.ON_DESTROY -> isReady.value = false
+                else -> Unit
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
+
+    // Render content only when ready
+    AnimatedVisibility(
+        visible = isReady.value,
+        enter = fadeIn(),
+        exit = fadeOut()
+    ) {
+        content()
+    }
+}

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/navigation/bottomsheet/BackstackSafeContent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/navigation/bottomsheet/BackstackSafeContent.kt
@@ -1,12 +1,14 @@
 package com.stripe.android.financialconnections.navigation.bottomsheet
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
@@ -24,7 +26,6 @@ internal fun LifecycleAwareContent(
 ) {
     val isReady = remember { mutableStateOf(false) }
 
-    // Track the lifecycle to update the readiness state
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
             when (event) {
@@ -40,12 +41,13 @@ internal fun LifecycleAwareContent(
         }
     }
 
-    // Render content only when ready
-    AnimatedVisibility(
-        visible = isReady.value,
-        enter = fadeIn(),
-        exit = fadeOut()
+    // This will typically be used on bottom sheets, where we see the NavBackStackEntry issue.
+    // animating the content height will ensure we respect the bottom sheet open animation.
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .animateContentSize(animationSpec = tween())
     ) {
-        content()
+        if (isReady.value) { content() }
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/navigation/bottomsheet/BackstackSafeContent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/navigation/bottomsheet/BackstackSafeContent.kt
@@ -1,12 +1,10 @@
 package com.stripe.android.financialconnections.navigation.bottomsheet
 
-import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.lifecycle.Lifecycle


### PR DESCRIPTION
# Summary




- Adds `LifecycleAwareContent` composable to ensure that its content is only rendered when the lifecycle is ready, thus preventing issues with accessing `NavBackStackEntry's` ViewModels after the NavBackStackEntry has been destroyed. This composable also includes smooth height animations to respect the bottom sheet's opening animations.
- Integrates the above into the `NavGraphBuilder.bottomSheet` helper function to manage lifecycle-aware rendering of bottom sheet destinations.

# Motivation

This change addresses a known issue where NavBackStackEntry's ViewModels become inaccessible after the associated NavBackStackEntry is destroyed.

Reference: [Google Accompanist Issue #1487](https://github.com/google/accompanist/issues/1487#top).

The additional height animation ensures a smoother user experience in bottom sheet transitions while respecting lifecycle readiness.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots

| Behavior Type          | Video Link                                                                                |
|------------------------|-------------------------------------------------------------------------------------------|
| Forcing Delay (to show behavior) | [Watch Video](https://github.com/user-attachments/assets/b9619681-577d-4119-8795-308cc3f9046a) |
| Regular Behavior       | [Watch Video](https://github.com/user-attachments/assets/46aea9f6-89c2-455a-b2d4-5c0178667c9f) |


# Changelog

- [Fixed] Addresses a known issue where NavBackStackEntry's ViewModels in bottom sheets become inaccessible after the associated NavBackStackEntry is destroyed.
