### PR TITLE
defaultPaymentMethodId to savedPaymentMethodSelectionId

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/ElementsSessionParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ElementsSessionParams.kt
@@ -14,7 +14,7 @@ sealed interface ElementsSessionParams : Parcelable {
     val customerSessionClientSecret: String?
     val locale: String?
     val expandFields: List<String>
-    val defaultPaymentMethodId: String?
+    val savedPaymentMethodSelectionId: String?
     val externalPaymentMethods: List<String>
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -23,7 +23,7 @@ sealed interface ElementsSessionParams : Parcelable {
         override val clientSecret: String,
         override val locale: String? = Locale.getDefault().toLanguageTag(),
         override val customerSessionClientSecret: String? = null,
-        override val defaultPaymentMethodId: String? = null,
+        override val savedPaymentMethodSelectionId: String? = null,
         override val externalPaymentMethods: List<String>,
     ) : ElementsSessionParams {
 
@@ -40,7 +40,7 @@ sealed interface ElementsSessionParams : Parcelable {
         override val clientSecret: String,
         override val locale: String? = Locale.getDefault().toLanguageTag(),
         override val customerSessionClientSecret: String? = null,
-        override val defaultPaymentMethodId: String? = null,
+        override val savedPaymentMethodSelectionId: String? = null,
         override val externalPaymentMethods: List<String>,
     ) : ElementsSessionParams {
 
@@ -57,7 +57,7 @@ sealed interface ElementsSessionParams : Parcelable {
         override val locale: String? = Locale.getDefault().toLanguageTag(),
         val deferredIntentParams: DeferredIntentParams,
         override val externalPaymentMethods: List<String>,
-        override val defaultPaymentMethodId: String? = null,
+        override val savedPaymentMethodSelectionId: String? = null,
         override val customerSessionClientSecret: String? = null,
     ) : ElementsSessionParams {
 

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -1564,7 +1564,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
             params.locale.let { this["locale"] = it }
             params.customerSessionClientSecret?.let { this["customer_session_client_secret"] = it }
             params.externalPaymentMethods.takeIf { it.isNotEmpty() }?.let { this["external_payment_methods"] = it }
-            params.defaultPaymentMethodId?.let { this["client_default_payment_method"] = it }
+            params.savedPaymentMethodSelectionId?.let { this["client_default_payment_method"] = it }
             (params as? ElementsSessionParams.DeferredIntentType)?.let { type ->
                 this.putAll(type.deferredIntentParams.toQueryParams())
             }

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -2569,7 +2569,7 @@ internal class StripeApiRepositoryTest {
             params = ElementsSessionParams.PaymentIntentType(
                 clientSecret = "client_secret",
                 externalPaymentMethods = emptyList(),
-                defaultPaymentMethodId = "pm_123",
+                savedPaymentMethodSelectionId = "pm_123",
             ),
             options = DEFAULT_OPTIONS,
         )
@@ -2601,7 +2601,7 @@ internal class StripeApiRepositoryTest {
         create().retrieveElementsSession(
             params = ElementsSessionParams.PaymentIntentType(
                 clientSecret = "client_secret",
-                defaultPaymentMethodId = null,
+                savedPaymentMethodSelectionId = null,
                 externalPaymentMethods = emptyList(),
             ),
             options = DEFAULT_OPTIONS,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerAdapterDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerAdapterDataSource.kt
@@ -116,7 +116,7 @@ internal class CustomerAdapterDataSource @Inject constructor(
             initializationMode,
             customer = null,
             externalPaymentMethods = emptyList(),
-            defaultPaymentMethodId = null,
+            savedPaymentMethodSelectionId = null,
         ).onSuccess {
             errorReporter.report(
                 errorEvent = ErrorReporter.SuccessEvent.CUSTOMER_SHEET_ELEMENTS_SESSION_LOAD_SUCCESS,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionElementsSessionManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionElementsSessionManager.kt
@@ -84,7 +84,7 @@ internal class DefaultCustomerSessionElementsSessionManager @Inject constructor(
                             paymentMethodTypes = intentConfiguration.paymentMethodTypes,
                         )
                     ),
-                    defaultPaymentMethodId = savedSelection?.id,
+                    savedPaymentMethodSelectionId = savedSelection?.id,
                     customer = PaymentSheet.CustomerConfiguration.createWithCustomerSession(
                         id = customerSessionClientSecret.customerId,
                         clientSecret = customerSessionClientSecret.clientSecret,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
@@ -25,7 +25,7 @@ internal interface ElementsSessionRepository {
         initializationMode: PaymentElementLoader.InitializationMode,
         customer: PaymentSheet.CustomerConfiguration?,
         externalPaymentMethods: List<String>,
-        defaultPaymentMethodId: String?,
+        savedPaymentMethodSelectionId: String?,
     ): Result<ElementsSession>
 }
 
@@ -50,12 +50,12 @@ internal class RealElementsSessionRepository @Inject constructor(
         initializationMode: PaymentElementLoader.InitializationMode,
         customer: PaymentSheet.CustomerConfiguration?,
         externalPaymentMethods: List<String>,
-        defaultPaymentMethodId: String?,
+        savedPaymentMethodSelectionId: String?,
     ): Result<ElementsSession> {
         val params = initializationMode.toElementsSessionParams(
             customer = customer,
             externalPaymentMethods = externalPaymentMethods,
-            defaultPaymentMethodId = defaultPaymentMethodId,
+            savedPaymentMethodSelectionId = savedPaymentMethodSelectionId,
         )
 
         val elementsSession = stripeRepository.retrieveElementsSession(
@@ -113,7 +113,7 @@ private fun StripeIntent.withoutWeChatPay(): StripeIntent {
 internal fun PaymentElementLoader.InitializationMode.toElementsSessionParams(
     customer: PaymentSheet.CustomerConfiguration?,
     externalPaymentMethods: List<String>,
-    defaultPaymentMethodId: String?,
+    savedPaymentMethodSelectionId: String?,
 ): ElementsSessionParams {
     val customerSessionClientSecret = customer?.toElementSessionParam()
 
@@ -123,7 +123,7 @@ internal fun PaymentElementLoader.InitializationMode.toElementsSessionParams(
                 clientSecret = clientSecret,
                 customerSessionClientSecret = customerSessionClientSecret,
                 externalPaymentMethods = externalPaymentMethods,
-                defaultPaymentMethodId = defaultPaymentMethodId,
+                savedPaymentMethodSelectionId = savedPaymentMethodSelectionId,
             )
         }
 
@@ -132,7 +132,7 @@ internal fun PaymentElementLoader.InitializationMode.toElementsSessionParams(
                 clientSecret = clientSecret,
                 customerSessionClientSecret = customerSessionClientSecret,
                 externalPaymentMethods = externalPaymentMethods,
-                defaultPaymentMethodId = defaultPaymentMethodId,
+                savedPaymentMethodSelectionId = savedPaymentMethodSelectionId,
             )
         }
 
@@ -141,7 +141,7 @@ internal fun PaymentElementLoader.InitializationMode.toElementsSessionParams(
                 deferredIntentParams = intentConfiguration.toDeferredIntentParams(),
                 externalPaymentMethods = externalPaymentMethods,
                 customerSessionClientSecret = customerSessionClientSecret,
-                defaultPaymentMethodId = defaultPaymentMethodId,
+                savedPaymentMethodSelectionId = savedPaymentMethodSelectionId,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -147,7 +147,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
             initializationMode = initializationMode,
             customer = configuration.customer,
             externalPaymentMethods = configuration.externalPaymentMethods,
-            defaultPaymentMethodId = savedPaymentMethodSelection?.id,
+            savedPaymentMethodSelectionId = savedPaymentMethodSelection?.id,
         ).getOrThrow()
 
         val customerInfo = createCustomerInfo(
@@ -233,13 +233,13 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         initializationMode: PaymentElementLoader.InitializationMode,
         customer: PaymentSheet.CustomerConfiguration?,
         externalPaymentMethods: List<String>,
-        defaultPaymentMethodId: String?,
+        savedPaymentMethodSelectionId: String?,
     ): Result<ElementsSession> {
         return elementsSessionRepository.get(
             initializationMode = initializationMode,
             customer = customer,
             externalPaymentMethods = externalPaymentMethods,
-            defaultPaymentMethodId = defaultPaymentMethodId
+            savedPaymentMethodSelectionId = savedPaymentMethodSelectionId
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/DefaultCustomerSessionElementsSessionManagerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/DefaultCustomerSessionElementsSessionManagerTest.kt
@@ -53,7 +53,7 @@ class DefaultCustomerSessionElementsSessionManagerTest {
 
         val lastParams = elementsSessionRepository.lastParams
 
-        assertThat(lastParams?.defaultPaymentMethodId).isEqualTo("pm_123")
+        assertThat(lastParams?.savedPaymentMethodSelectionId).isEqualTo("pm_123")
         assertThat(lastParams?.externalPaymentMethods).isEmpty()
 
         val initializationMode = lastParams?.initializationMode

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepositoryTest.kt
@@ -53,7 +53,7 @@ internal class ElementsSessionRepositoryTest {
                 ),
                 customer = null,
                 externalPaymentMethods = emptyList(),
-                defaultPaymentMethodId = null,
+                savedPaymentMethodSelectionId = null,
             ).getOrThrow()
         }
 
@@ -82,7 +82,7 @@ internal class ElementsSessionRepositoryTest {
                     ),
                     customer = null,
                     externalPaymentMethods = emptyList(),
-                    defaultPaymentMethodId = null,
+                    savedPaymentMethodSelectionId = null,
                 ).getOrThrow()
             }
 
@@ -108,7 +108,7 @@ internal class ElementsSessionRepositoryTest {
                     ),
                     customer = null,
                     externalPaymentMethods = emptyList(),
-                    defaultPaymentMethodId = null,
+                    savedPaymentMethodSelectionId = null,
                 ).getOrThrow()
             }
 
@@ -140,7 +140,7 @@ internal class ElementsSessionRepositoryTest {
             ),
             customer = null,
             externalPaymentMethods = emptyList(),
-            defaultPaymentMethodId = null,
+            savedPaymentMethodSelectionId = null,
         ).getOrThrow()
 
         val argumentCaptor: KArgumentCaptor<ElementsSessionParams> = argumentCaptor()
@@ -177,7 +177,7 @@ internal class ElementsSessionRepositoryTest {
             ),
             customer = null,
             externalPaymentMethods = emptyList(),
-            defaultPaymentMethodId = null,
+            savedPaymentMethodSelectionId = null,
         )
 
         assertThat(session.isSuccess).isTrue()
@@ -210,7 +210,7 @@ internal class ElementsSessionRepositoryTest {
             ),
             customer = null,
             externalPaymentMethods = emptyList(),
-            defaultPaymentMethodId = null,
+            savedPaymentMethodSelectionId = null,
         )
 
         assertThat(session.isSuccess).isTrue()
@@ -246,7 +246,7 @@ internal class ElementsSessionRepositoryTest {
                 clientSecret = "customer_session_client_secret"
             ),
             externalPaymentMethods = emptyList(),
-            defaultPaymentMethodId = null,
+            savedPaymentMethodSelectionId = null,
         )
 
         verify(stripeRepository).retrieveElementsSession(
@@ -255,7 +255,7 @@ internal class ElementsSessionRepositoryTest {
                     clientSecret = "client_secret",
                     customerSessionClientSecret = "customer_session_client_secret",
                     externalPaymentMethods = emptyList(),
-                    defaultPaymentMethodId = null,
+                    savedPaymentMethodSelectionId = null,
                 )
             ),
             options = any()
@@ -287,7 +287,7 @@ internal class ElementsSessionRepositoryTest {
             ),
             customer = null,
             externalPaymentMethods = emptyList(),
-            defaultPaymentMethodId = "pm_123",
+            savedPaymentMethodSelectionId = "pm_123",
         )
 
         verify(stripeRepository).retrieveElementsSession(
@@ -295,7 +295,7 @@ internal class ElementsSessionRepositoryTest {
                 ElementsSessionParams.PaymentIntentType(
                     clientSecret = "client_secret",
                     externalPaymentMethods = emptyList(),
-                    defaultPaymentMethodId = "pm_123",
+                    savedPaymentMethodSelectionId = "pm_123",
                 )
             ),
             options = any()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -1910,7 +1910,7 @@ internal class DefaultPaymentElementLoaderTest {
                 initializedViaCompose = false,
             )
 
-            assertThat(repository.lastParams?.defaultPaymentMethodId)
+            assertThat(repository.lastParams?.savedPaymentMethodSelectionId)
                 .isEqualTo("pm_1234321")
         }
 
@@ -1941,7 +1941,7 @@ internal class DefaultPaymentElementLoaderTest {
                 initializedViaCompose = false,
             )
 
-            assertThat(repository.lastParams?.defaultPaymentMethodId).isNull()
+            assertThat(repository.lastParams?.savedPaymentMethodSelectionId).isNull()
         }
 
     @Test
@@ -1974,7 +1974,7 @@ internal class DefaultPaymentElementLoaderTest {
                 initializedViaCompose = false,
             )
 
-            assertThat(repository.lastParams?.defaultPaymentMethodId).isNull()
+            assertThat(repository.lastParams?.savedPaymentMethodSelectionId).isNull()
         }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeElementsSessionRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeElementsSessionRepository.kt
@@ -20,7 +20,7 @@ internal class FakeElementsSessionRepository(
         val initializationMode: PaymentElementLoader.InitializationMode,
         val customer: PaymentSheet.CustomerConfiguration?,
         val externalPaymentMethods: List<String>,
-        val defaultPaymentMethodId: String?
+        val savedPaymentMethodSelectionId: String?
     )
 
     var lastParams: Params? = null
@@ -35,7 +35,7 @@ internal class FakeElementsSessionRepository(
             initializationMode = initializationMode,
             customer = customer,
             externalPaymentMethods = externalPaymentMethods,
-            defaultPaymentMethodId = savedPaymentMethodSelectionId,
+            savedPaymentMethodSelectionId = savedPaymentMethodSelectionId,
         )
         return if (error != null) {
             Result.failure(error)

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeElementsSessionRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeElementsSessionRepository.kt
@@ -29,13 +29,13 @@ internal class FakeElementsSessionRepository(
         initializationMode: PaymentElementLoader.InitializationMode,
         customer: PaymentSheet.CustomerConfiguration?,
         externalPaymentMethods: List<String>,
-        defaultPaymentMethodId: String?,
+        savedPaymentMethodSelectionId: String?,
     ): Result<ElementsSession> {
         lastParams = Params(
             initializationMode = initializationMode,
             customer = customer,
             externalPaymentMethods = externalPaymentMethods,
-            defaultPaymentMethodId = defaultPaymentMethodId,
+            defaultPaymentMethodId = savedPaymentMethodSelectionId,
         )
         return if (error != null) {
             Result.failure(error)


### PR DESCRIPTION
# Summary
Renamed defaultPaymentMethodId to savedPaymentMethodSelectionid for elementSessionParams and elementsSessionRepository

# Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-2894
It doesn't make sense to call it defaultPaymentMethodId when we are reading the defaultPaymentMethodId from the backend and this is for the savedPaymentMethodSelection