### PR TITLE
[MOBILESDK-2894] [Android] Make Default Payment Method selected

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -543,14 +543,13 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         customer: Deferred<CustomerState?>,
         isGooglePayReady: Boolean,
     ): PaymentSelection? {
-        val customerArrived = customer.await()
-        val selection = savedSelection.await()
+        val defaultPaymentMethodPaymentSelection = customer.await()?.defaultPaymentMethodId?.let {
+            customer.await()?.paymentMethods?.firstOrNull {
+                it.id == customer.await()?.defaultPaymentMethodId
+            }?.toPaymentSelection()
+        }
 
-        val defaultPaymentMethodPaymentSelection = customerArrived?.paymentMethods?.firstOrNull {
-            it.id == customerArrived.defaultPaymentMethodId && customerArrived.defaultPaymentMethodId != null
-        }?.toPaymentSelection()
-
-        val savedSelectionPaymentMethodPaymentSelection = when (selection) {
+        val savedSelectionPaymentMethodPaymentSelection = when (val selection = savedSelection.await()) {
             is SavedSelection.GooglePay -> PaymentSelection.GooglePay
             is SavedSelection.Link -> PaymentSelection.Link
             is SavedSelection.PaymentMethod -> {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -1955,8 +1955,6 @@ internal class DefaultPaymentElementLoaderTest {
 
     @Test
     fun `When DefaultPaymentMethod not null, no saved selection, paymentMethod order correct`() = runTest {
-        enableDefaultPaymentMethods.setEnabled(true)
-
         val result = getPaymentElementLoaderStateForTestingOfPaymentMethodsWithDefaultPaymentMethodId()
 
         val observedElements = result.customer?.paymentMethods
@@ -1966,8 +1964,6 @@ internal class DefaultPaymentElementLoaderTest {
 
     @Test
     fun `When DefaultPaymentMethod not null, and saved selection, paymentMethod order correct`() = runTest {
-        enableDefaultPaymentMethods.setEnabled(true)
-
         val result = getPaymentElementLoaderStateForTestingOfPaymentMethodsWithDefaultPaymentMethodId(
             setLastUsedIndex = 1
         )
@@ -1979,8 +1975,6 @@ internal class DefaultPaymentElementLoaderTest {
 
     @Test
     fun `When DefaultPaymentMethod not null, and no savedSelection, selection correct`() = runTest {
-        enableDefaultPaymentMethods.setEnabled(true)
-
         val result = getPaymentElementLoaderStateForTestingOfPaymentMethodsWithDefaultPaymentMethodId()
 
         assertThat((result.paymentSelection as? PaymentSelection.Saved)?.paymentMethod).isEqualTo(
@@ -1990,8 +1984,6 @@ internal class DefaultPaymentElementLoaderTest {
 
     @Test
     fun `When DefaultPaymentMethod not null, and savedSelection, selection correct`() = runTest {
-        enableDefaultPaymentMethods.setEnabled(true)
-
         val result = getPaymentElementLoaderStateForTestingOfPaymentMethodsWithDefaultPaymentMethodId(
             setLastUsedIndex = 1
         )
@@ -2542,6 +2534,8 @@ internal class DefaultPaymentElementLoaderTest {
     private suspend fun getPaymentElementLoaderStateForTestingOfPaymentMethodsWithDefaultPaymentMethodId(
         setLastUsedIndex: Int? = null
     ): PaymentElementLoader.State {
+        enableDefaultPaymentMethods.setEnabled(true)
+
         val defaultPaymentMethodIndex = 2
         val defaultPaymentMethod = paymentMethodsForTestingOrdering[defaultPaymentMethodIndex]
         val defaultPaymentMethodId = defaultPaymentMethod.id


### PR DESCRIPTION
# Summary
Added Logic for retrieving the initial payment selection
did some refactoring in DefaultPaymentElementLoaderTest to accomodate testing for selection

# Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-2894

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified

# Screenshots
|| Before  | After |
|-| ------------- | ------------- |
|Vertical Mode|![1000000061](https://github.com/user-attachments/assets/9a3c2d87-9bda-4373-8b93-16fba517548e)|![1000000063](https://github.com/user-attachments/assets/2bae86f0-d068-4e82-bd0f-6f2ade9a987f)|
|Horizontal Mode|![1000000062](https://github.com/user-attachments/assets/52c9f7d5-3790-4518-b89e-da3127f41501)| ![1000000065](https://github.com/user-attachments/assets/11c6202e-940a-4013-8e63-3ca625af0883)|

# Changelog
N.A.