### PR TITLE
Take IBP incentive eligibility from return URL

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
@@ -494,8 +494,7 @@ internal class FinancialConnectionsSheetViewModel @Inject constructor(
                                 encodedPaymentMethod = paymentMethod,
                                 last4 = url.getQueryParameter(QUERY_PARAM_LAST4),
                                 bankName = url.getQueryParameter(QUERY_BANK_NAME),
-                                // TODO(tillh-stripe): Pull this from the URL
-                                eligibleForIncentive = false,
+                                eligibleForIncentive = url.getQueryParameter(QUERY_INCENTIVE_ELIGIBLE).toBoolean(),
                             ),
                             financialConnectionsSession = null,
                             token = null
@@ -608,6 +607,7 @@ internal class FinancialConnectionsSheetViewModel @Inject constructor(
         internal const val QUERY_PARAM_PAYMENT_METHOD = "payment_method"
         internal const val QUERY_PARAM_LAST4 = "last4"
         internal const val QUERY_BANK_NAME = "bank_name"
+        internal const val QUERY_INCENTIVE_ELIGIBLE = "incentive_eligible"
     }
 
     override fun updateTopAppBar(state: FinancialConnectionsSheetState): TopAppBarStateUpdate? {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request takes the incentive eligibility from the redirect `incentive_eligible` query parameter (added [here](https://git.corp.stripe.com/stripe-internal/pay-server/pull/951356)).

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
