### PR TITLE
Sort the list of country name in Chinese by Pinyin alphabet romanization.

### DIFF
--- a/stripe-core/src/main/java/com/stripe/android/core/model/CountryUtils.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/model/CountryUtils.kt
@@ -1,9 +1,7 @@
 package com.stripe.android.core.model
 
 import androidx.annotation.RestrictTo
-import androidx.annotation.VisibleForTesting
 import java.text.Collator
-import java.text.Normalizer
 import java.util.Locale
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) // For paymentsheet -- this still auto-completes

--- a/stripe-core/src/main/java/com/stripe/android/core/model/CountryUtils.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/model/CountryUtils.kt
@@ -2,6 +2,7 @@ package com.stripe.android.core.model
 
 import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
+import java.text.Collator
 import java.text.Normalizer
 import java.util.Locale
 
@@ -111,6 +112,7 @@ object CountryUtils {
             cachedOrderedLocalizedCountries
         } else {
             val localizedCountries = localizedCountries(currentLocale)
+            val collator = Collator.getInstance(currentLocale)
             cachedOrderedLocalizedCountries = listOfNotNull(
                 localizedCountries.firstOrNull {
                     it.code == currentLocale.getCountryCode()
@@ -118,7 +120,7 @@ object CountryUtils {
             ).plus(
                 localizedCountries
                     .filterNot { it.code == currentLocale.getCountryCode() }
-                    .sortedBy { formatNameForSorting(it.name) }
+                    .sortedWith { c1, c2 -> collator.compare(c1.name, c2.name) }
             )
 
             cachedCountriesLocale = currentLocale

--- a/stripe-core/src/main/java/com/stripe/android/core/model/CountryUtils.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/model/CountryUtils.kt
@@ -69,17 +69,6 @@ object CountryUtils {
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     fun getOrderedCountries(currentLocale: Locale) = getSortedLocalizedCountries(currentLocale)
 
-    @VisibleForTesting
-    internal fun formatNameForSorting(name: String): String {
-        // Before normalization: åland islands
-        // After normalization: aºland islands
-        // After regex: aland islands
-        return Normalizer.normalize(name.lowercase(), Normalizer.Form.NFD)
-            .replace("\\p{Mn}+".toRegex(), "")
-            .replace("[^A-Za-z ]".toRegex(), "")
-            .replace("[^\\p{ASCII}]".toRegex(), "")
-    }
-
     @Deprecated(
         message = "Use with parameter CountryCode",
         replaceWith = ReplaceWith(

--- a/stripe-core/src/test/java/com/stripe/android/core/model/CountryUtilsTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/model/CountryUtilsTest.kt
@@ -156,36 +156,4 @@ class CountryUtilsTest {
         assertThat(germany?.name)
             .isEqualTo("Deutschland")
     }
-
-    @Test
-    fun `formatNameForSorting does nothing to already formatted strings`() {
-        val input = "aland"
-        val expectedOutput = "aland"
-
-        assertThat(CountryUtils.formatNameForSorting(input)).isEqualTo(expectedOutput)
-    }
-
-    @Test
-    fun `formatNameForSorting removes accents and diacritics`() {
-        val input = "Dziękuję Åland"
-        val expectedOutput = "dziekuje aland"
-
-        assertThat(CountryUtils.formatNameForSorting(input)).isEqualTo(expectedOutput)
-    }
-
-    @Test
-    fun `formatNameForSorting removes capitalization`() {
-        val input = "Aland"
-        val expectedOutput = "aland"
-
-        assertThat(CountryUtils.formatNameForSorting(input)).isEqualTo(expectedOutput)
-    }
-
-    @Test
-    fun `formatNameForSorting removes non alphanumeric characters`() {
-        val input = "aºland1!!!"
-        val expectedOutput = "aland"
-
-        assertThat(CountryUtils.formatNameForSorting(input)).isEqualTo(expectedOutput)
-    }
 }

--- a/stripe-core/src/test/java/com/stripe/android/core/model/CountryUtilsTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/model/CountryUtilsTest.kt
@@ -74,9 +74,9 @@ class CountryUtilsTest {
         val  orderedCountries =  CountryUtils.getOrderedCountries(Locale("fr", "FR"))
         // Check the first 20 countries in the list.
         assertThat(orderedCountries.subList(0,20).map { it.name }.toList()).isEqualTo(
-            listOf("France", "Afrique du Sud", "Albanie", "Algérie", "Allemagne", "Andorre",
-                "Antarctique", "Antigua-et-Barbuda", "Arabie saoudite", "Argentine", "Arménie",
-                "Australie", "Autriche", "Azerbaïdjan", "Bahreïn")
+            listOf("France", "Afghanistan", "Afrique du Sud", "Albanie", "Algérie", "Allemagne", "Andorre",
+                "Angola", "Anguilla", "Antarctique", "Antigua-et-Barbuda", "Arabie saoudite", "Argentine",
+                "Arménie", "Aruba", "Australie", "Autriche", "Azerbaïdjan", "Bahamas", "Bahreïn")
         )
     }
 

--- a/stripe-core/src/test/java/com/stripe/android/core/model/CountryUtilsTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/model/CountryUtilsTest.kt
@@ -46,6 +46,76 @@ class CountryUtilsTest {
     }
 
     @Test
+    fun getOrderedCountriesIn_en_US() {
+        val  orderedCountries =  CountryUtils.getOrderedCountries(Locale("en", "US"))
+        // Check the first 20 countries in the list.
+        assertThat(orderedCountries.subList(0,20).map { it.name }.toList()).isEqualTo(
+            listOf("United States", "Afghanistan", "Åland Islands", "Albania", "Algeria",
+                "Andorra", "Angola", "Anguilla", "Antarctica", "Antigua & Barbuda",
+                "Argentina", "Armenia", "Aruba", "Australia", "Austria", "Azerbaijan",
+                "Bahamas", "Bahrain", "Bangladesh", "Barbados")
+        )
+    }
+
+    @Test
+    fun getOrderedCountriesIn_en_SG() {
+        val  orderedCountries =  CountryUtils.getOrderedCountries(Locale("en", "SG"))
+        // Check the first 20 countries in the list.
+        assertThat(orderedCountries.subList(0,20).map { it.name }.toList()).isEqualTo(
+            listOf("Singapore", "Afghanistan", "Åland Islands", "Albania", "Algeria",
+                "Andorra", "Angola", "Anguilla", "Antarctica", "Antigua & Barbuda",
+                "Argentina", "Armenia", "Aruba", "Australia", "Austria", "Azerbaijan",
+                "Bahamas", "Bahrain", "Bangladesh", "Barbados")
+        )
+    }
+
+    @Test
+    fun getOrderedCountriesIn_fr_FR() {
+        val  orderedCountries =  CountryUtils.getOrderedCountries(Locale("fr", "FR"))
+        // Check the first 20 countries in the list.
+        assertThat(orderedCountries.subList(0,20).map { it.name }.toList()).isEqualTo(
+            listOf("France", "Afrique du Sud", "Albanie", "Algérie", "Allemagne", "Andorre",
+                "Antarctique", "Antigua-et-Barbuda", "Arabie saoudite", "Argentine", "Arménie",
+                "Australie", "Autriche", "Azerbaïdjan", "Bahreïn")
+        )
+    }
+
+    @Test
+    fun getOrderedCountriesIn_de_DE() {
+        val  orderedCountries =  CountryUtils.getOrderedCountries(Locale("de", "De"))
+        // Check the first 20 countries in the list.
+        assertThat(orderedCountries.subList(0,20).map { it.name }.toList()).isEqualTo(
+            listOf("Deutschland", "Afghanistan", "Ägypten", "Ålandinseln", "Albanien",
+                "Algerien", "Andorra", "Angola", "Anguilla", "Antarktis", "Antigua und Barbuda",
+                "Äquatorialguinea", "Argentinien", "Armenien", "Aruba", "Aserbaidschan", "Äthiopien",
+                "Australien", "Bahamas", "Bahrain")
+        )
+    }
+
+    @Test
+    fun getOrderedCountriesIn_zh_CN() {
+        val  orderedCountries =  CountryUtils.getOrderedCountries(Locale("zh", "CN"))
+        // Check the first 20 countries in the list.
+        assertThat(orderedCountries.subList(0,20).map { it.name }.toList()).isEqualTo(
+            listOf("中国", "阿尔巴尼亚", "阿尔及利亚", "阿富汗",
+                "阿根廷", "阿拉伯联合酋长国", "阿鲁巴", "阿曼", "阿塞拜疆", "埃及", "埃塞俄比亚",
+                "爱尔兰", "爱沙尼亚", "安道尔", "安哥拉", "安圭拉", "安提瓜和巴布达", "奥地利", "奥兰群岛",
+                "澳大利亚")
+        )
+    }
+
+    @Test
+    fun getOrderedCountriesIn_ja_JP() {
+        val  orderedCountries =  CountryUtils.getOrderedCountries(Locale("ja", "JP"))
+        // Check the first 20 countries in the list.
+        assertThat(orderedCountries.subList(0,20).map { it.name }.toList()).isEqualTo(
+            listOf("日本", "アイスランド", "アイルランド", "アゼルバイジャン", "アフガニスタン", "アメリカ合衆国",
+                "アラブ首長国連邦", "アルジェリア", "アルゼンチン", "アルバ", "アルバニア", "アルメニア", "アンギラ",
+                "アンゴラ", "アンティグア・バーブーダ", "アンドラ", "イエメン", "イギリス", "イスラエル", "イタリア")
+        )
+    }
+
+    @Test
     fun `getDisplayCountry() should return expected result`() {
         var currentLocale = Locale.US
         assertThat(CountryUtils.getDisplayCountry(CountryCode.US, currentLocale))

--- a/stripe-core/src/test/java/com/stripe/android/core/model/CountryUtilsTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/model/CountryUtilsTest.kt
@@ -47,71 +47,83 @@ class CountryUtilsTest {
 
     @Test
     fun getOrderedCountriesIn_en_US() {
-        val  orderedCountries =  CountryUtils.getOrderedCountries(Locale("en", "US"))
+        val orderedCountries = CountryUtils.getOrderedCountries(Locale("en", "US"))
         // Check the first 20 countries in the list.
-        assertThat(orderedCountries.subList(0,20).map { it.name }.toList()).isEqualTo(
-            listOf("United States", "Afghanistan", "Åland Islands", "Albania", "Algeria",
+        assertThat(orderedCountries.subList(0, 20).map { it.name }.toList()).isEqualTo(
+            listOf(
+                "United States", "Afghanistan", "Åland Islands", "Albania", "Algeria",
                 "Andorra", "Angola", "Anguilla", "Antarctica", "Antigua & Barbuda",
                 "Argentina", "Armenia", "Aruba", "Australia", "Austria", "Azerbaijan",
-                "Bahamas", "Bahrain", "Bangladesh", "Barbados")
+                "Bahamas", "Bahrain", "Bangladesh", "Barbados"
+            )
         )
     }
 
     @Test
     fun getOrderedCountriesIn_en_SG() {
-        val  orderedCountries =  CountryUtils.getOrderedCountries(Locale("en", "SG"))
+        val orderedCountries = CountryUtils.getOrderedCountries(Locale("en", "SG"))
         // Check the first 20 countries in the list.
-        assertThat(orderedCountries.subList(0,20).map { it.name }.toList()).isEqualTo(
-            listOf("Singapore", "Afghanistan", "Åland Islands", "Albania", "Algeria",
+        assertThat(orderedCountries.subList(0, 20).map { it.name }.toList()).isEqualTo(
+            listOf(
+                "Singapore", "Afghanistan", "Åland Islands", "Albania", "Algeria",
                 "Andorra", "Angola", "Anguilla", "Antarctica", "Antigua & Barbuda",
                 "Argentina", "Armenia", "Aruba", "Australia", "Austria", "Azerbaijan",
-                "Bahamas", "Bahrain", "Bangladesh", "Barbados")
+                "Bahamas", "Bahrain", "Bangladesh", "Barbados"
+            )
         )
     }
 
     @Test
     fun getOrderedCountriesIn_fr_FR() {
-        val  orderedCountries =  CountryUtils.getOrderedCountries(Locale("fr", "FR"))
+        val orderedCountries = CountryUtils.getOrderedCountries(Locale("fr", "FR"))
         // Check the first 20 countries in the list.
-        assertThat(orderedCountries.subList(0,20).map { it.name }.toList()).isEqualTo(
-            listOf("France", "Afghanistan", "Afrique du Sud", "Albanie", "Algérie", "Allemagne", "Andorre",
+        assertThat(orderedCountries.subList(0, 20).map { it.name }.toList()).isEqualTo(
+            listOf(
+                "France", "Afghanistan", "Afrique du Sud", "Albanie", "Algérie", "Allemagne", "Andorre",
                 "Angola", "Anguilla", "Antarctique", "Antigua-et-Barbuda", "Arabie saoudite", "Argentine",
-                "Arménie", "Aruba", "Australie", "Autriche", "Azerbaïdjan", "Bahamas", "Bahreïn")
+                "Arménie", "Aruba", "Australie", "Autriche", "Azerbaïdjan", "Bahamas", "Bahreïn"
+            )
         )
     }
 
     @Test
     fun getOrderedCountriesIn_de_DE() {
-        val  orderedCountries =  CountryUtils.getOrderedCountries(Locale("de", "De"))
+        val orderedCountries = CountryUtils.getOrderedCountries(Locale("de", "De"))
         // Check the first 20 countries in the list.
-        assertThat(orderedCountries.subList(0,20).map { it.name }.toList()).isEqualTo(
-            listOf("Deutschland", "Afghanistan", "Ägypten", "Ålandinseln", "Albanien",
+        assertThat(orderedCountries.subList(0, 20).map { it.name }.toList()).isEqualTo(
+            listOf(
+                "Deutschland", "Afghanistan", "Ägypten", "Ålandinseln", "Albanien",
                 "Algerien", "Andorra", "Angola", "Anguilla", "Antarktis", "Antigua und Barbuda",
                 "Äquatorialguinea", "Argentinien", "Armenien", "Aruba", "Aserbaidschan", "Äthiopien",
-                "Australien", "Bahamas", "Bahrain")
+                "Australien", "Bahamas", "Bahrain"
+            )
         )
     }
 
     @Test
     fun getOrderedCountriesIn_zh_CN() {
-        val  orderedCountries =  CountryUtils.getOrderedCountries(Locale("zh", "CN"))
+        val orderedCountries = CountryUtils.getOrderedCountries(Locale("zh", "CN"))
         // Check the first 20 countries in the list.
-        assertThat(orderedCountries.subList(0,20).map { it.name }.toList()).isEqualTo(
-            listOf("中国", "阿尔巴尼亚", "阿尔及利亚", "阿富汗",
+        assertThat(orderedCountries.subList(0, 20).map { it.name }.toList()).isEqualTo(
+            listOf(
+                "中国", "阿尔巴尼亚", "阿尔及利亚", "阿富汗",
                 "阿根廷", "阿拉伯联合酋长国", "阿鲁巴", "阿曼", "阿塞拜疆", "埃及", "埃塞俄比亚",
                 "爱尔兰", "爱沙尼亚", "安道尔", "安哥拉", "安圭拉", "安提瓜和巴布达", "奥地利", "奥兰群岛",
-                "澳大利亚")
+                "澳大利亚"
+            )
         )
     }
 
     @Test
     fun getOrderedCountriesIn_ja_JP() {
-        val  orderedCountries =  CountryUtils.getOrderedCountries(Locale("ja", "JP"))
+        val orderedCountries = CountryUtils.getOrderedCountries(Locale("ja", "JP"))
         // Check the first 20 countries in the list.
-        assertThat(orderedCountries.subList(0,20).map { it.name }.toList()).isEqualTo(
-            listOf("日本", "アイスランド", "アイルランド", "アゼルバイジャン", "アフガニスタン", "アメリカ合衆国",
+        assertThat(orderedCountries.subList(0, 20).map { it.name }.toList()).isEqualTo(
+            listOf(
+                "日本", "アイスランド", "アイルランド", "アゼルバイジャン", "アフガニスタン", "アメリカ合衆国",
                 "アラブ首長国連邦", "アルジェリア", "アルゼンチン", "アルバ", "アルバニア", "アルメニア", "アンギラ",
-                "アンゴラ", "アンティグア・バーブーダ", "アンドラ", "イエメン", "イギリス", "イスラエル", "イタリア")
+                "アンゴラ", "アンティグア・バーブーダ", "アンドラ", "イエメン", "イギリス", "イスラエル", "イタリア"
+            )
         )
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Sort the list of country name in Chinese by Pinyin alphabet romanization, so it's easier for Chinese speaking users to locate the country that they want to choose.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

MOBILESDK-1173

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
|  <img width="377" alt="Screenshot 2023-04-12 at 10 27 59 AM" src="https://github.com/user-attachments/assets/4dac28c0-997a-4655-85f9-8fbb8c62275f" /> |  <img width="298" alt="Screenshot 2025-01-18 at 9 11 30 PM" src="https://github.com/user-attachments/assets/e4f27e96-a6b2-4173-9b7f-a802eb82b6fa" /> |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
