### PR TITLE
Validate if CVC is recollected only in confirmation definition.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationDefinition.kt
@@ -31,7 +31,7 @@ internal class CvcRecollectionConfirmationDefinition(
         confirmationOption: PaymentMethodConfirmationOption.Saved,
         confirmationParameters: ConfirmationDefinition.Parameters,
     ): Boolean {
-        return handler.requiresCVCRecollection(
+        return !confirmationOption.optionsParams.hasAlreadyRecollectedCvc() && handler.requiresCVCRecollection(
             stripeIntent = confirmationParameters.intent,
             initializationMode = confirmationParameters.initializationMode,
             paymentMethod = confirmationOption.paymentMethod,
@@ -96,6 +96,13 @@ internal class CvcRecollectionConfirmationDefinition(
             is CvcRecollectionResult.Cancelled -> ConfirmationDefinition.Result.Canceled(
                 action = ConfirmationHandler.Result.Canceled.Action.None,
             )
+        }
+    }
+
+    private fun PaymentMethodOptionsParams?.hasAlreadyRecollectedCvc(): Boolean {
+        return when (this) {
+            is PaymentMethodOptionsParams.Card -> cvc != null
+            else -> false
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/cvcrecollection/CvcRecollectionHandlerImpl.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/cvcrecollection/CvcRecollectionHandlerImpl.kt
@@ -39,12 +39,9 @@ internal class CvcRecollectionHandlerImpl : CvcRecollectionHandler {
         optionsParams: PaymentMethodOptionsParams?,
         initializationMode: PaymentElementLoader.InitializationMode,
     ): Boolean {
-        val hasNotRecollectedCvcAlready = optionsParams == null || !optionsParams.hasAlreadyRecollectedCvc()
-
         return paymentMethod.isCard() &&
             paymentMethod.hasNoWallet() &&
-            cvcRecollectionEnabled(stripeIntent, initializationMode) &&
-            hasNotRecollectedCvcAlready
+            cvcRecollectionEnabled(stripeIntent, initializationMode)
     }
 
     private fun PaymentMethod.isCard(): Boolean {
@@ -59,13 +56,6 @@ internal class CvcRecollectionHandlerImpl : CvcRecollectionHandler {
         return when (this) {
             is PaymentIntent -> requireCvcRecollection
             is SetupIntent -> false
-        }
-    }
-
-    private fun PaymentMethodOptionsParams.hasAlreadyRecollectedCvc(): Boolean {
-        return when (this) {
-            is PaymentMethodOptionsParams.Card -> cvc != null
-            else -> false
         }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationDefinitionTest.kt
@@ -75,6 +75,22 @@ class CvcRecollectionConfirmationDefinitionTest {
     }
 
     @Test
+    fun `'canConfirm' returns 'false' if CVC is already recollected`() = test(
+        handler = FakeCvcRecollectionHandler().apply {
+            requiresCVCRecollection = true
+        }
+    ) {
+        assertThat(
+            definition.canConfirm(
+                confirmationOption = createSavedConfirmationOption(
+                    optionsParams = PaymentMethodOptionsParams.Card(cvc = "444")
+                ),
+                confirmationParameters = CONFIRMATION_PARAMETERS,
+            )
+        ).isFalse()
+    }
+
+    @Test
     fun `'createLauncher' should register launcher properly for activity result`() = test {
         var onResultCalled = false
         val onResult: (CvcRecollectionResult) -> Unit = { onResultCalled = true }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/cvcrecollection/CvcRecollectionHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/cvcrecollection/CvcRecollectionHandlerTest.kt
@@ -3,7 +3,6 @@ package com.stripe.android.paymentsheet.cvcrecollection
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethodFixtures
-import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.model.wallets.Wallet
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcRecollectionData
@@ -56,19 +55,6 @@ class CvcRecollectionHandlerTest {
             stripeIntent = paymentIntent,
             paymentMethod = PaymentMethodFixtures.PAYPAL_PAYMENT_METHOD,
             optionsParams = null,
-            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent("")
-        )
-        assertThat(response).isFalse()
-    }
-
-    @Test
-    fun `card & intent requiring cvc recollection should return false if CVC is in options params`() {
-        val paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_CVC_RECOLLECTION
-        val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
-        val response = handler.requiresCVCRecollection(
-            stripeIntent = paymentIntent,
-            paymentMethod = paymentMethod,
-            optionsParams = PaymentMethodOptionsParams.Card(cvc = "444"),
             initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent("")
         )
         assertThat(response).isFalse()
@@ -128,26 +114,6 @@ class CvcRecollectionHandlerTest {
             stripeIntent = paymentIntent,
             paymentMethod = PaymentMethodFixtures.SEPA_DEBIT_PAYMENT_METHOD,
             optionsParams = null,
-            initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
-                intentConfiguration = PaymentSheet.IntentConfiguration(
-                    mode = PaymentSheet.IntentConfiguration.Mode.Payment(
-                        amount = 1234,
-                        currency = "cad",
-                    ),
-                    requireCvcRecollection = true
-                )
-            )
-        )
-        assertThat(response).isFalse()
-    }
-
-    @Test
-    fun `card & valid deferred intent should return false if CVC is in options params`() {
-        val paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD
-        val response = handler.requiresCVCRecollection(
-            stripeIntent = paymentIntent,
-            paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
-            optionsParams = PaymentMethodOptionsParams.Card(cvc = "444"),
             initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
                 intentConfiguration = PaymentSheet.IntentConfiguration(
                     mode = PaymentSheet.IntentConfiguration.Mode.Payment(


### PR DESCRIPTION
# Summary
Validate if CVC is recollected only in confirmation definition.

# Motivation
When testing & validating some CVC logic for this release, I noticed that there's the potential for infinite CVC recollection error loop.

Scenario:
- Merchant requires CVC recollection
- User uses a saved payment method for a purchase
- User is shown the CVC recollection screen (in the PS variant)
- User enters their CVC
- CVC is saved directly into the selection per our logic
- User hits the pay button
- Payment fails and user is shown an error that the CVC they entered was incorrect
- User attempts to pay again with the same payment method
- User is NOT shown the CVC recollection screen
- Payment fails and user is shown an error that the CVC they entered was incorrect

Because of the way we update `PaymentSelection` in our products, this can result in bad assumptions when checking if CVC recollection is required. The long-term fix for this is to change the way we use `PaymentSelection` but for now I think it's fair to make this assumption in just the confirmation definition until we can make those changes.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified