### PR TITLE
Add PaymentSheet.InitializationMode to LinkConfiguration

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkConfiguration.kt
@@ -3,6 +3,7 @@ package com.stripe.android.link
 import android.os.Parcelable
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
+import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -16,6 +17,7 @@ internal data class LinkConfiguration(
     val flags: Map<String, Boolean>,
     val cardBrandChoice: CardBrandChoice?,
     val useAttestationEndpointsForLink: Boolean,
+    val initializationMode: PaymentElementLoader.InitializationMode
 ) : Parcelable {
     @Parcelize
     data class CustomerInfo(

--- a/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
@@ -5,14 +5,11 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.model.ConsumerPaymentDetails
-import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethodCreateParams
-import com.stripe.android.model.SetupIntent
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import javax.inject.Inject
 
 internal class DefaultLinkConfirmationHandler @Inject constructor(
@@ -74,21 +71,9 @@ internal class DefaultLinkConfirmationHandler @Inject constructor(
                 shouldSave = false
             ),
             appearance = PaymentSheet.Appearance(),
-            initializationMode = initializationMode(),
+            initializationMode = configuration.initializationMode,
             shippingDetails = configuration.shippingDetails
         )
-    }
-
-    private fun initializationMode(): PaymentElementLoader.InitializationMode {
-        val clientSecret = configuration.stripeIntent.clientSecret ?: throw NO_CLIENT_SECRET_FOUND
-        return when (configuration.stripeIntent) {
-            is PaymentIntent -> {
-                PaymentElementLoader.InitializationMode.PaymentIntent(clientSecret)
-            }
-            is SetupIntent -> {
-                PaymentElementLoader.InitializationMode.SetupIntent(clientSecret)
-            }
-        }
     }
 
     private fun createPaymentMethodCreateParams(
@@ -114,9 +99,5 @@ internal class DefaultLinkConfirmationHandler @Inject constructor(
                 configuration = configuration
             )
         }
-    }
-
-    companion object {
-        val NO_CLIENT_SECRET_FOUND = IllegalStateException("No client secret found.")
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -170,6 +170,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                 configuration = configuration,
                 elementsSession = elementsSession,
                 customer = customerInfo,
+                initializationMode = initializationMode
             )
         }
 
@@ -384,6 +385,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         elementsSession: ElementsSession,
         configuration: CommonConfiguration,
         customer: CustomerInfo?,
+        initializationMode: PaymentElementLoader.InitializationMode
     ): LinkState? {
         return if (elementsSession.isLinkEnabled &&
             !configuration.billingDetailsCollectionConfiguration.collectsAnything
@@ -397,6 +399,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                 linkSignUpDisabled = elementsSession.disableLinkSignup,
                 useAttestationEndpointsForLink = elementsSession.useAttestationEndpointsForLink,
                 flags = elementsSession.linkFlags,
+                initializationMode = initializationMode
             )
         } else {
             null
@@ -412,6 +415,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         linkSignUpDisabled: Boolean,
         flags: Map<String, Boolean>,
         useAttestationEndpointsForLink: Boolean,
+        initializationMode: PaymentElementLoader.InitializationMode
     ): LinkState {
         val linkConfig = createLinkConfiguration(
             configuration = configuration,
@@ -421,6 +425,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
             passthroughModeEnabled = passthroughModeEnabled,
             flags = flags,
             useAttestationEndpointsForLink = useAttestationEndpointsForLink,
+            initializationMode = initializationMode
         )
 
         val accountStatus = accountStatusProvider(linkConfig)
@@ -471,6 +476,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         passthroughModeEnabled: Boolean,
         flags: Map<String, Boolean>,
         useAttestationEndpointsForLink: Boolean,
+        initializationMode: PaymentElementLoader.InitializationMode
     ): LinkConfiguration {
         val shippingDetails: AddressDetails? = configuration.shippingDetails
 
@@ -516,6 +522,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
             cardBrandChoice = cardBrandChoice,
             flags = flags,
             useAttestationEndpointsForLink = useAttestationEndpointsForLink,
+            initializationMode = initializationMode
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
@@ -16,6 +16,7 @@ import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.ui.core.Amount
@@ -135,7 +136,7 @@ internal object TestFactory {
         cardBrandChoice = null,
         passthroughModeEnabled = false,
         useAttestationEndpointsForLink = false,
-        initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent("gg")
+        initializationMode = PaymentSheetFixtures.INITIALIZATION_MODE_PAYMENT_INTENT
     )
 
     val LINK_WALLET_PRIMARY_BUTTON_LABEL = Amount(

--- a/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
@@ -17,6 +17,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
+import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import org.mockito.kotlin.mock
@@ -134,6 +135,7 @@ internal object TestFactory {
         cardBrandChoice = null,
         passthroughModeEnabled = false,
         useAttestationEndpointsForLink = false,
+        initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent("gg")
     )
 
     val LINK_WALLET_PRIMARY_BUTTON_LABEL = Amount(

--- a/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
@@ -18,7 +18,6 @@ import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import org.mockito.kotlin.mock

--- a/paymentsheet/src/test/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandlerTest.kt
@@ -7,21 +7,34 @@ import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.TestFactory
 import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.model.ConsumerPaymentDetails
-import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentsheet.R
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.FakeLogger
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
 
 internal class DefaultLinkConfirmationHandlerTest {
     private val dispatcher = UnconfinedTestDispatcher()
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    fun cleanup() {
+        Dispatchers.resetMain()
+    }
 
     @Test
     fun `successful confirmation yields success result`() = runTest(dispatcher) {
@@ -50,10 +63,7 @@ internal class DefaultLinkConfirmationHandlerTest {
             configuration = configuration,
             linkAccount = TestFactory.LINK_ACCOUNT,
             paymentDetails = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD,
-            cvc = CVC,
-            initMode = PaymentElementLoader.InitializationMode.PaymentIntent(
-                clientSecret = configuration.stripeIntent.clientSecret.orEmpty()
-            )
+            cvc = CVC
         )
     }
 
@@ -85,10 +95,7 @@ internal class DefaultLinkConfirmationHandlerTest {
             configuration = configuration,
             linkAccount = TestFactory.LINK_ACCOUNT,
             paymentDetails = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD,
-            cvc = null,
-            initMode = PaymentElementLoader.InitializationMode.SetupIntent(
-                clientSecret = configuration.stripeIntent.clientSecret.orEmpty()
-            )
+            cvc = null
         )
     }
 
@@ -162,41 +169,11 @@ internal class DefaultLinkConfirmationHandlerTest {
             .containsExactly("DefaultLinkConfirmationHandler: Payment confirmation returned null" to null)
     }
 
-    @Test
-    fun `invalid client secret yields error result`() = runTest(dispatcher) {
-        val confirmationHandler = FakeConfirmationHandler()
-        val logger = FakeLogger()
-        val handler = createHandler(
-            confirmationHandler = confirmationHandler,
-            logger = logger,
-            configuration = TestFactory.LINK_CONFIGURATION.copy(
-                stripeIntent = PaymentIntentFixtures.PI_SUCCEEDED.copy(
-                    clientSecret = null
-                )
-            )
-        )
-
-        confirmationHandler.awaitResultTurbine.add(null)
-
-        val result = handler.confirm(
-            paymentDetails = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD,
-            linkAccount = TestFactory.LINK_ACCOUNT
-        )
-
-        assertThat(result).isEqualTo(Result.Failed(R.string.stripe_something_went_wrong.resolvableString))
-        assertThat(logger.errorLogs)
-            .containsExactly(
-                "DefaultLinkConfirmationHandler: Failed to confirm payment"
-                    to DefaultLinkConfirmationHandler.NO_CLIENT_SECRET_FOUND
-            )
-    }
-
     private fun ConfirmationHandler.Args.assertConfirmationArgs(
         configuration: LinkConfiguration,
         paymentDetails: ConsumerPaymentDetails.PaymentDetails,
         linkAccount: LinkAccount,
         cvc: String?,
-        initMode: PaymentElementLoader.InitializationMode
     ) {
         assertThat(intent).isEqualTo(configuration.stripeIntent)
         val option = confirmationOption as PaymentMethodConfirmationOption.New
@@ -208,7 +185,7 @@ internal class DefaultLinkConfirmationHandlerTest {
             )
         )
         assertThat(shippingDetails).isEqualTo(configuration.shippingDetails)
-        assertThat(initializationMode).isEqualTo(initMode)
+        assertThat(initializationMode).isEqualTo(configuration.initializationMode)
     }
 
     private fun createHandler(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -22,6 +22,7 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.R
@@ -1315,6 +1316,9 @@ internal class PaymentMethodMetadataTest {
                 ),
                 passthroughModeEnabled = false,
                 useAttestationEndpointsForLink = false,
+                initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
+                    clientSecret = "secret"
+                )
             ),
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -22,7 +22,6 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.R
@@ -1316,9 +1315,7 @@ internal class PaymentMethodMetadataTest {
                 ),
                 passthroughModeEnabled = false,
                 useAttestationEndpointsForLink = false,
-                initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
-                    clientSecret = "secret"
-                )
+                initializationMode = PaymentSheetFixtures.INITIALIZATION_MODE_PAYMENT_INTENT
             ),
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
@@ -30,6 +30,10 @@ internal object PaymentSheetFixtures {
     internal val PAYMENT_INTENT_CLIENT_SECRET = PaymentIntentClientSecret(CLIENT_SECRET)
     internal val SETUP_INTENT_CLIENT_SECRET = PaymentIntentClientSecret(SETUP_CLIENT_SECRET)
 
+    internal val INITIALIZATION_MODE_PAYMENT_INTENT = PaymentElementLoader.InitializationMode.PaymentIntent(
+        clientSecret = CLIENT_SECRET
+    )
+
     internal val CONFIG_MINIMUM = PaymentSheet.Configuration(
         merchantDisplayName = MERCHANT_DISPLAY_NAME,
         paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -952,6 +952,9 @@ internal class PaymentSheetViewModelTest {
                 cardBrandChoice = null,
                 shippingDetails = null,
                 useAttestationEndpointsForLink = false,
+                initializationMode = InitializationMode.PaymentIntent(
+                    clientSecret = "secret"
+                )
             )
 
             val viewModel = createViewModel(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -952,9 +952,7 @@ internal class PaymentSheetViewModelTest {
                 cardBrandChoice = null,
                 shippingDetails = null,
                 useAttestationEndpointsForLink = false,
-                initializationMode = InitializationMode.PaymentIntent(
-                    clientSecret = "secret"
-                )
+                initializationMode = PaymentSheetFixtures.INITIALIZATION_MODE_PAYMENT_INTENT
             )
 
             val viewModel = createViewModel(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -659,7 +659,8 @@ internal class DefaultPaymentElementLoaderTest {
             passthroughModeEnabled = false,
             cardBrandChoice = null,
             flags = emptyMap(),
-            useAttestationEndpointsForLink = false
+            useAttestationEndpointsForLink = false,
+            initializationMode = initializationMode,
         )
 
         assertThat(result.paymentMethodMetadata.linkState?.configuration).isEqualTo(expectedLinkConfig)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
@@ -7,6 +7,7 @@ import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.CvcCheck
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 
@@ -61,6 +62,9 @@ internal object LinkTestUtils {
             cardBrandChoice = null,
             shippingDetails = null,
             useAttestationEndpointsForLink = false,
+            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
+                clientSecret = "secret"
+            )
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
@@ -7,7 +7,7 @@ import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.CvcCheck
 import com.stripe.android.model.PaymentMethod
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
+import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 
@@ -62,9 +62,7 @@ internal object LinkTestUtils {
             cardBrandChoice = null,
             shippingDetails = null,
             useAttestationEndpointsForLink = false,
-            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
-                clientSecret = "secret"
-            )
+            initializationMode = PaymentSheetFixtures.INITIALIZATION_MODE_PAYMENT_INTENT
         )
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
`PaymentSheet.InitializationMode` is provided during PaymentSheet initialization. This value is reconstructed in `LinkConfirmationHandler`, but some values are omitted, causing deferred intent confirmation to fail. This PR passes `PaymentSheet.InitializationMode` as part of `LinkConfiguration`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
