### PR TITLE
Link Gate to determine link launch/attest behaviour

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/LinkTypeSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/LinkTypeSettingsDefinition.kt
@@ -9,7 +9,7 @@ internal object LinkTypeSettingsDefinition : PlaygroundSettingDefinition<LinkTyp
         defaultValue = LinkType.Native
     ),
     PlaygroundSettingDefinition.Displayable<LinkType> {
-    override val displayName: String = "LinkType"
+    override val displayName: String = "Link Type"
 
     override fun createOptions(configurationData: PlaygroundConfigurationData): List<PlaygroundSettingDefinition.Displayable.Option<LinkType>> {
         return listOf(

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/LinkTypeSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/LinkTypeSettingsDefinition.kt
@@ -2,7 +2,8 @@ package com.stripe.android.paymentsheet.example.playground.settings
 
 import com.stripe.android.core.utils.FeatureFlags
 
-internal object LinkTypeSettingsDefinition : PlaygroundSettingDefinition<LinkType>,
+internal object LinkTypeSettingsDefinition :
+    PlaygroundSettingDefinition<LinkType>,
     PlaygroundSettingDefinition.Saveable<LinkType> by EnumSaveable(
         key = "LinkType",
         values = LinkType.entries.toTypedArray(),
@@ -11,7 +12,9 @@ internal object LinkTypeSettingsDefinition : PlaygroundSettingDefinition<LinkTyp
     PlaygroundSettingDefinition.Displayable<LinkType> {
     override val displayName: String = "Link Type"
 
-    override fun createOptions(configurationData: PlaygroundConfigurationData): List<PlaygroundSettingDefinition.Displayable.Option<LinkType>> {
+    override fun createOptions(
+        configurationData: PlaygroundConfigurationData
+    ): List<PlaygroundSettingDefinition.Displayable.Option<LinkType>> {
         return listOf(
             option("Native", LinkType.Native),
             option("Native + Attest", LinkType.NativeAttest),

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/LinkTypeSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/LinkTypeSettingsDefinition.kt
@@ -1,0 +1,44 @@
+package com.stripe.android.paymentsheet.example.playground.settings
+
+import com.stripe.android.core.utils.FeatureFlags
+
+internal object LinkTypeSettingsDefinition : PlaygroundSettingDefinition<LinkType>,
+    PlaygroundSettingDefinition.Saveable<LinkType> by EnumSaveable(
+        key = "LinkType",
+        values = LinkType.entries.toTypedArray(),
+        defaultValue = LinkType.Native
+    ),
+    PlaygroundSettingDefinition.Displayable<LinkType> {
+    override val displayName: String = "LinkType"
+
+    override fun createOptions(configurationData: PlaygroundConfigurationData): List<PlaygroundSettingDefinition.Displayable.Option<LinkType>> {
+        return listOf(
+            option("Native", LinkType.Native),
+            option("Native + Attest", LinkType.NativeAttest),
+            option("Web", LinkType.Web),
+        )
+    }
+
+    override fun setValue(value: LinkType) {
+        when (value) {
+            LinkType.Native -> {
+                FeatureFlags.nativeLinkEnabled.setEnabled(true)
+                FeatureFlags.nativeLinkAttestationEnabled.setEnabled(false)
+            }
+            LinkType.NativeAttest -> {
+                FeatureFlags.nativeLinkEnabled.setEnabled(true)
+                FeatureFlags.nativeLinkAttestationEnabled.setEnabled(true)
+            }
+            LinkType.Web -> {
+                FeatureFlags.nativeLinkEnabled.setEnabled(false)
+                FeatureFlags.nativeLinkAttestationEnabled.setEnabled(false)
+            }
+        }
+    }
+}
+
+enum class LinkType(override val value: String) : ValueEnum {
+    Native("Native"),
+    NativeAttest("Native + Attest"),
+    Web("Web"),
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -425,7 +425,7 @@ internal class PlaygroundSettings private constructor(
             CustomerSettingsDefinition,
             CheckoutModeSettingsDefinition,
             LinkSettingsDefinition,
-            FeatureFlagSettingsDefinition(FeatureFlags.nativeLinkEnabled),
+            LinkTypeSettingsDefinition,
             CountrySettingsDefinition,
             CurrencySettingsDefinition,
             GooglePaySettingsDefinition,

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityContract.kt
@@ -3,7 +3,7 @@ package com.stripe.android.link
 import android.content.Context
 import android.content.Intent
 import androidx.activity.result.contract.ActivityResultContract
-import com.stripe.android.core.utils.FeatureFlags
+import com.stripe.android.link.gate.LinkGate
 import javax.inject.Inject
 
 /**
@@ -11,11 +11,13 @@ import javax.inject.Inject
  */
 internal class LinkActivityContract @Inject internal constructor(
     private val nativeLinkActivityContract: NativeLinkActivityContract,
-    private val webLinkActivityContract: WebLinkActivityContract
+    private val webLinkActivityContract: WebLinkActivityContract,
+    private val linkGateFactory: LinkGate.Factory
 ) : ActivityResultContract<LinkActivityContract.Args, LinkActivityResult>() {
 
     override fun createIntent(context: Context, input: Args): Intent {
-        return if (FeatureFlags.nativeLinkEnabled.isEnabled) {
+        val linkGate = linkGateFactory.create(input.configuration)
+        return if (linkGate.useNativeLink) {
             nativeLinkActivityContract.createIntent(context, input)
         } else {
             webLinkActivityContract.createIntent(context, input)

--- a/paymentsheet/src/main/java/com/stripe/android/link/gate/DefaultLinkGate.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/gate/DefaultLinkGate.kt
@@ -9,14 +9,18 @@ internal class DefaultLinkGate @Inject constructor(
 ) : LinkGate {
     override val useNativeLink: Boolean
         get() {
-            if (FeatureFlags.nativeLinkEnabled.isEnabled) return true
-            return useAttestationEndpoints
+            if (configuration.stripeIntent.isLiveMode) {
+                return useAttestationEndpoints
+            }
+            return FeatureFlags.nativeLinkEnabled.isEnabled
         }
 
     override val useAttestationEndpoints: Boolean
         get() {
-            if (FeatureFlags.nativeLinkAttestationEnabled.isEnabled) return true
-            return configuration.useAttestationEndpointsForLink
+            if (configuration.stripeIntent.isLiveMode) {
+                return configuration.useAttestationEndpointsForLink
+            }
+            return FeatureFlags.nativeLinkAttestationEnabled.isEnabled
         }
 
     class Factory @Inject constructor() : LinkGate.Factory {

--- a/paymentsheet/src/main/java/com/stripe/android/link/gate/DefaultLinkGate.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/gate/DefaultLinkGate.kt
@@ -2,8 +2,9 @@ package com.stripe.android.link.gate
 
 import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.link.LinkConfiguration
+import javax.inject.Inject
 
-internal class DefaultLinkGate(
+internal class DefaultLinkGate @Inject constructor(
     private val configuration: LinkConfiguration
 ) : LinkGate {
     override val useNativeLink: Boolean
@@ -17,4 +18,10 @@ internal class DefaultLinkGate(
             if (FeatureFlags.nativeLinkAttestationEnabled.isEnabled) return true
             return configuration.useAttestationEndpointsForLink
         }
+
+    class Factory @Inject constructor() : LinkGate.Factory {
+        override fun create(configuration: LinkConfiguration): LinkGate {
+            return DefaultLinkGate(configuration)
+        }
+    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/gate/DefaultLinkGate.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/gate/DefaultLinkGate.kt
@@ -1,0 +1,20 @@
+package com.stripe.android.link.gate
+
+import com.stripe.android.core.utils.FeatureFlags
+import com.stripe.android.link.LinkConfiguration
+
+internal class DefaultLinkGate(
+    private val configuration: LinkConfiguration
+) : LinkGate {
+    override val useNativeLink: Boolean
+        get() {
+            if (FeatureFlags.nativeLinkEnabled.isEnabled) return true
+            return useAttestationEndpoints
+        }
+
+    override val useAttestationEndpoints: Boolean
+        get() {
+            if (FeatureFlags.nativeLinkAttestationEnabled.isEnabled) return true
+            return configuration.useAttestationEndpointsForLink
+        }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/link/gate/LinkGate.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/gate/LinkGate.kt
@@ -1,6 +1,12 @@
 package com.stripe.android.link.gate
 
+import com.stripe.android.link.LinkConfiguration
+
 internal interface LinkGate {
     val useNativeLink: Boolean
     val useAttestationEndpoints: Boolean
+
+    fun interface Factory {
+        fun create(configuration: LinkConfiguration): LinkGate
+    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/gate/LinkGate.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/gate/LinkGate.kt
@@ -1,0 +1,6 @@
+package com.stripe.android.link.gate
+
+internal interface LinkGate {
+    val useNativeLink: Boolean
+    val useAttestationEndpoints: Boolean
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/SharedPaymentElementViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/SharedPaymentElementViewModel.kt
@@ -19,6 +19,8 @@ import com.stripe.android.core.utils.requireApplication
 import com.stripe.android.googlepaylauncher.injection.GooglePayLauncherModule
 import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.link.RealLinkConfigurationCoordinator
+import com.stripe.android.link.gate.DefaultLinkGate
+import com.stripe.android.link.gate.LinkGate
 import com.stripe.android.link.injection.LinkAnalyticsComponent
 import com.stripe.android.link.injection.LinkComponent
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
@@ -238,6 +240,9 @@ internal interface SharedPaymentElementViewModelModule {
 
     @Binds
     fun bindsLinkConfigurationCoordinator(impl: RealLinkConfigurationCoordinator): LinkConfigurationCoordinator
+
+    @Binds
+    fun bindLinkGateFactory(linkGateFactory: DefaultLinkGate.Factory): LinkGate.Factory
 
     companion object {
         @Provides

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
@@ -17,6 +17,8 @@ import com.stripe.android.core.utils.RealUserFacingLogger
 import com.stripe.android.core.utils.UserFacingLogger
 import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.link.RealLinkConfigurationCoordinator
+import com.stripe.android.link.gate.DefaultLinkGate
+import com.stripe.android.link.gate.LinkGate
 import com.stripe.android.link.injection.LinkAnalyticsComponent
 import com.stripe.android.link.injection.LinkComponent
 import com.stripe.android.payments.core.analytics.ErrorReporter
@@ -48,6 +50,7 @@ import javax.inject.Provider
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
+@SuppressWarnings("TooManyFunctions")
 @Module(
     subcomponents = [
         LinkAnalyticsComponent::class,
@@ -89,6 +92,9 @@ internal abstract class PaymentSheetCommonModule {
 
     @Binds
     abstract fun bindsLinkConfigurationCoordinator(impl: RealLinkConfigurationCoordinator): LinkConfigurationCoordinator
+
+    @Binds
+    abstract fun bindLinkGateFactory(linkGateFactory: DefaultLinkGate.Factory): LinkGate.Factory
 
     @Binds
     abstract fun bindsCardAccountRangeRepositoryFactory(

--- a/paymentsheet/src/test/java/com/stripe/android/link/gate/DefaultLinkGateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/gate/DefaultLinkGateTest.kt
@@ -1,0 +1,91 @@
+package com.stripe.android.link.gate
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.utils.FeatureFlags
+import com.stripe.android.link.TestFactory
+import com.stripe.android.testing.FeatureFlagTestRule
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class DefaultLinkGateTest {
+
+    @get:Rule
+    val nativeLinkFeatureFlagTestRule = FeatureFlagTestRule(
+        featureFlag = FeatureFlags.nativeLinkEnabled,
+        isEnabled = false
+    )
+
+    @get:Rule
+    val attestationFeatureFlagTestRule = FeatureFlagTestRule(
+        featureFlag = FeatureFlags.nativeLinkAttestationEnabled,
+        isEnabled = false
+    )
+
+    @Test
+    fun `useNativeLink is true when nativeLinkFeatureFlag is enabled`() {
+        nativeLinkFeatureFlagTestRule.setEnabled(true)
+        val gate = gate()
+
+        assertThat(gate.useNativeLink).isTrue()
+    }
+
+    @Test
+    fun `useNativeLink is true when nativeLinkFeatureFlag is enabled regardless of other settings`() {
+        nativeLinkFeatureFlagTestRule.setEnabled(true)
+        attestationFeatureFlagTestRule.setEnabled(false)
+
+        val gate = gate(useAttestationEndpoints = false)
+
+        assertThat(gate.useNativeLink).isTrue()
+    }
+
+    @Test
+    fun `useNativeLink reflects useAttestationEndpoints when nativeLinkFeatureFlag is disabled`() {
+        nativeLinkFeatureFlagTestRule.setEnabled(false)
+        attestationFeatureFlagTestRule.setEnabled(true)
+
+        val gate = gate()
+
+        assertThat(gate.useNativeLink).isEqualTo(gate.useAttestationEndpoints)
+    }
+
+    @Test
+    fun `useAttestationEndpoints is true when attestationFeatureFlag is enabled`() {
+        attestationFeatureFlagTestRule.setEnabled(true)
+
+        val gate = gate()
+
+        assertThat(gate.useAttestationEndpoints).isTrue()
+    }
+
+    @Test
+    fun `useAttestationEndpoints is true when attestationFeatureFlag is enabled regardless of configuration`() {
+        attestationFeatureFlagTestRule.setEnabled(true)
+
+        val gate = gate(useAttestationEndpoints = false)
+
+        assertThat(gate.useAttestationEndpoints).isTrue()
+    }
+
+    @Test
+    fun `useAttestationEndpoints reflects configuration when attestationFeatureFlag is disabled`() {
+        attestationFeatureFlagTestRule.setEnabled(false)
+
+        val gateTrue = gate(useAttestationEndpoints = true)
+        val gateFalse = gate(useAttestationEndpoints = false)
+
+        assertThat(gateTrue.useAttestationEndpoints).isTrue()
+        assertThat(gateFalse.useAttestationEndpoints).isFalse()
+    }
+
+    private fun gate(useAttestationEndpoints: Boolean = true): DefaultLinkGate {
+        return DefaultLinkGate(
+            configuration = TestFactory.LINK_CONFIGURATION.copy(
+                useAttestationEndpointsForLink = useAttestationEndpoints
+            )
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/link/gate/DefaultLinkGateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/gate/DefaultLinkGateTest.kt
@@ -3,6 +3,8 @@ package com.stripe.android.link.gate
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.link.TestFactory
+import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.SetupIntent
 import com.stripe.android.testing.FeatureFlagTestRule
 import org.junit.Rule
 import org.junit.Test
@@ -24,67 +26,106 @@ internal class DefaultLinkGateTest {
         isEnabled = false
     )
 
+    // useNativeLink tests for test mode
     @Test
-    fun `useNativeLink is true when nativeLinkFeatureFlag is enabled`() {
+    fun `useNativeLink - test mode - returns true when feature flag enabled`() {
         nativeLinkFeatureFlagTestRule.setEnabled(true)
-        val gate = gate()
+        val gate = gate(isLiveMode = false)
 
         assertThat(gate.useNativeLink).isTrue()
     }
 
     @Test
-    fun `useNativeLink is true when nativeLinkFeatureFlag is enabled regardless of other settings`() {
-        nativeLinkFeatureFlagTestRule.setEnabled(true)
-        attestationFeatureFlagTestRule.setEnabled(false)
-
-        val gate = gate(useAttestationEndpoints = false)
-
-        assertThat(gate.useNativeLink).isTrue()
-    }
-
-    @Test
-    fun `useNativeLink reflects useAttestationEndpoints when nativeLinkFeatureFlag is disabled`() {
+    fun `useNativeLink - test mode - returns false when feature flag disabled`() {
         nativeLinkFeatureFlagTestRule.setEnabled(false)
-        attestationFeatureFlagTestRule.setEnabled(true)
+        val gate = gate(isLiveMode = false)
 
-        val gate = gate()
+        assertThat(gate.useNativeLink).isFalse()
+    }
 
-        assertThat(gate.useNativeLink).isEqualTo(gate.useAttestationEndpoints)
+    // useNativeLink tests for live mode
+    @Test
+    fun `useNativeLink - live mode - returns true when attestation enabled`() {
+        val gate = gate(isLiveMode = true, useAttestationEndpoints = true)
+
+        assertThat(gate.useNativeLink).isTrue()
     }
 
     @Test
-    fun `useAttestationEndpoints is true when attestationFeatureFlag is enabled`() {
-        attestationFeatureFlagTestRule.setEnabled(true)
+    fun `useNativeLink - live mode - returns false when attestation disabled`() {
+        val gate = gate(isLiveMode = true, useAttestationEndpoints = false)
 
-        val gate = gate()
+        assertThat(gate.useNativeLink).isFalse()
+    }
+
+    // useAttestationEndpoints tests for test mode
+    @Test
+    fun `useAttestationEndpoints - test mode - returns true when feature flag enabled`() {
+        attestationFeatureFlagTestRule.setEnabled(true)
+        val gate = gate(isLiveMode = false)
 
         assertThat(gate.useAttestationEndpoints).isTrue()
     }
 
     @Test
-    fun `useAttestationEndpoints is true when attestationFeatureFlag is enabled regardless of configuration`() {
-        attestationFeatureFlagTestRule.setEnabled(true)
-
-        val gate = gate(useAttestationEndpoints = false)
-
-        assertThat(gate.useAttestationEndpoints).isTrue()
-    }
-
-    @Test
-    fun `useAttestationEndpoints reflects configuration when attestationFeatureFlag is disabled`() {
+    fun `useAttestationEndpoints - test mode - returns false when feature flag disabled`() {
         attestationFeatureFlagTestRule.setEnabled(false)
+        val gate = gate(isLiveMode = false)
 
-        val gateTrue = gate(useAttestationEndpoints = true)
-        val gateFalse = gate(useAttestationEndpoints = false)
-
-        assertThat(gateTrue.useAttestationEndpoints).isTrue()
-        assertThat(gateFalse.useAttestationEndpoints).isFalse()
+        assertThat(gate.useAttestationEndpoints).isFalse()
     }
 
-    private fun gate(useAttestationEndpoints: Boolean = true): DefaultLinkGate {
+    // useAttestationEndpoints tests for live mode
+    @Test
+    fun `useAttestationEndpoints - live mode - returns true when configuration enabled`() {
+        val gate = gate(isLiveMode = true, useAttestationEndpoints = true)
+
+        assertThat(gate.useAttestationEndpoints).isTrue()
+    }
+
+    @Test
+    fun `useAttestationEndpoints - live mode - returns false when configuration disabled`() {
+        val gate = gate(isLiveMode = true, useAttestationEndpoints = false)
+
+        assertThat(gate.useAttestationEndpoints).isFalse()
+    }
+
+    // Feature flag independence tests
+    @Test
+    fun `useNativeLink - test mode - not affected by attestation feature flag`() {
+        nativeLinkFeatureFlagTestRule.setEnabled(true)
+        attestationFeatureFlagTestRule.setEnabled(false)
+        val gate = gate(isLiveMode = false)
+
+        assertThat(gate.useNativeLink).isTrue()
+    }
+
+    @Test
+    fun `useAttestationEndpoints - test mode - not affected by native link feature flag`() {
+        attestationFeatureFlagTestRule.setEnabled(true)
+        nativeLinkFeatureFlagTestRule.setEnabled(false)
+        val gate = gate(isLiveMode = false)
+
+        assertThat(gate.useAttestationEndpoints).isTrue()
+    }
+
+    private fun gate(
+        isLiveMode: Boolean = true,
+        useAttestationEndpoints: Boolean = true
+    ): DefaultLinkGate {
+        val newIntent = when (val intent = TestFactory.LINK_CONFIGURATION.stripeIntent) {
+            is PaymentIntent -> {
+                intent.copy(isLiveMode = isLiveMode)
+            }
+            is SetupIntent -> {
+                intent.copy(isLiveMode = isLiveMode)
+            }
+            else -> intent
+        }
         return DefaultLinkGate(
             configuration = TestFactory.LINK_CONFIGURATION.copy(
-                useAttestationEndpointsForLink = useAttestationEndpoints
+                useAttestationEndpointsForLink = useAttestationEndpoints,
+                stripeIntent = newIntent
             )
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/link/gate/FakeLinkGate.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/gate/FakeLinkGate.kt
@@ -1,0 +1,19 @@
+package com.stripe.android.link.gate
+
+internal class FakeLinkGate : LinkGate {
+    private var _useNativeLink = true
+    override val useNativeLink: Boolean
+        get() = _useNativeLink
+
+    private var _useAttestationEndpoints = true
+    override val useAttestationEndpoints: Boolean
+        get() = _useAttestationEndpoints
+
+    fun setUseNativeLink(value: Boolean) {
+        _useNativeLink = value
+    }
+
+    fun setUseAttestationEndpoints(value: Boolean) {
+        _useAttestationEndpoints = value
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ExtendedPaymentElementConfirmationTestActivity.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ExtendedPaymentElementConfirmationTestActivity.kt
@@ -23,6 +23,8 @@ import com.stripe.android.core.utils.UserFacingLogger
 import com.stripe.android.core.utils.requireApplication
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayRepository
+import com.stripe.android.link.gate.DefaultLinkGate
+import com.stripe.android.link.gate.LinkGate
 import com.stripe.android.networking.StripeApiRepository
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.paymentelement.confirmation.injection.ExtendedPaymentElementConfirmationModule
@@ -113,6 +115,9 @@ internal interface ExtendedPaymentElementConfirmationTestComponent {
 internal interface ExtendedPaymentElementConfirmationTestModule {
     @Binds
     fun bindsStripeRepository(repository: StripeApiRepository): StripeRepository
+
+    @Binds
+    fun bindLinkGateFactory(linkGateFactory: DefaultLinkGate.Factory): LinkGate.Factory
 
     companion object {
         @Provides

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/PaymentElementConfirmationTestActivity.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/PaymentElementConfirmationTestActivity.kt
@@ -23,6 +23,8 @@ import com.stripe.android.core.utils.UserFacingLogger
 import com.stripe.android.core.utils.requireApplication
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayRepository
+import com.stripe.android.link.gate.DefaultLinkGate
+import com.stripe.android.link.gate.LinkGate
 import com.stripe.android.networking.StripeApiRepository
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.paymentelement.confirmation.injection.PaymentElementConfirmationModule
@@ -113,6 +115,9 @@ internal interface PaymentElementConfirmationTestComponent {
 internal interface PaymentElementConfirmationTestModule {
     @Binds
     fun bindsStripeRepository(repository: StripeApiRepository): StripeRepository
+
+    @Binds
+    fun bindLinkGateFactory(linkGateFactory: DefaultLinkGate.Factory): LinkGate.Factory
 
     companion object {
         @Provides

--- a/stripe-core/src/main/java/com/stripe/android/core/utils/FeatureFlags.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/FeatureFlags.kt
@@ -7,6 +7,7 @@ import com.stripe.android.core.BuildConfig
 object FeatureFlags {
     // Add any feature flags here
     val nativeLinkEnabled = FeatureFlag("Native Link")
+    val nativeLinkAttestationEnabled = FeatureFlag("Native Link Attestation")
     val instantDebitsIncentives = FeatureFlag("Instant Bank Payments Incentives")
     val enableDefaultPaymentMethods = FeatureFlag("Enable Default Payment Methods")
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Link Gate to determine whether to use native link and attestation endpoints. This will be used in
* LinkActivityContract - to determine how to launch link
* LinkActivityViewModel - to determine whether to prepare Play Integrity
* SignUpViewModel - to determine whether to use attest endpoints

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots

https://github.com/user-attachments/assets/28568b3e-2a50-41e2-85a3-4e1fae6dd6a4


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
