### PR TITLE
Fix consumer lookup in verified flows

### DIFF
--- a/payments-model/src/main/java/com/stripe/android/model/parsers/ConsumerSessionLookupJsonParser.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/parsers/ConsumerSessionLookupJsonParser.kt
@@ -13,12 +13,13 @@ class ConsumerSessionLookupJsonParser : ModelJsonParser<ConsumerSessionLookup> {
         val exists = optBoolean(json, FIELD_EXISTS)
         val consumerSession = ConsumerSessionJsonParser().parse(json)
         val errorMessage = optString(json, FIELD_ERROR_MESSAGE)
-
-        return ConsumerSessionLookup(exists, consumerSession, errorMessage)
+        val publishableKey = optString(json, FIELD_PUBLISHABLE_KEY)
+        return ConsumerSessionLookup(exists, consumerSession, errorMessage, publishableKey)
     }
 
     private companion object {
         private const val FIELD_EXISTS = "exists"
         private const val FIELD_ERROR_MESSAGE = "error_message"
+        private const val FIELD_PUBLISHABLE_KEY = "publishable_key"
     }
 }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestInstantDebits.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestInstantDebits.kt
@@ -21,7 +21,6 @@ import com.stripe.android.test.core.AuthorizeAction
 import com.stripe.android.test.core.DEFAULT_UI_TIMEOUT
 import com.stripe.android.test.core.TestParameters
 import com.stripe.android.test.core.ui.ComposeButton
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -43,7 +42,6 @@ internal class TestInstantDebits : BasePlaygroundTest() {
     }
 
     @Test
-    @Ignore
     fun testInstantDebitsSuccess() {
         val params = testParameters.copyPlaygroundSettings {
             it[DefaultBillingAddressSettingsDefinition] = DefaultBillingAddress.On

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestLinkCardBrand.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestLinkCardBrand.kt
@@ -20,7 +20,6 @@ import com.stripe.android.test.core.AuthorizeAction
 import com.stripe.android.test.core.DEFAULT_UI_TIMEOUT
 import com.stripe.android.test.core.TestParameters
 import com.stripe.android.test.core.ui.ComposeButton
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -39,7 +38,6 @@ internal class TestLinkCardBrand : BasePlaygroundTest() {
     }
 
     @Test
-    @Ignore
     fun testLinkCardBrandSuccess() {
         val params = testParameters.copyPlaygroundSettings {
             it[DefaultBillingAddressSettingsDefinition] = DefaultBillingAddress.On


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue in verified flows where the consumer lookup failed.

`ConsumerSessionLookup` is a shared data class used by MPE and FC, which is constructed via `ConsumerSessionLookupJsonParser` in the former and via the Kotlin serializer in the latter.
- In non-verified flows, we’ve been deserializing it with the latter, which automatically parses the `publishable_key` property.
- In verified flows, we’re now using the former, which was missing the manual parse of that property.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
