### PR TITLE
Disable Link if Card Brand Filtering is used

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -1,6 +1,9 @@
+@file:OptIn(ExperimentalCardBrandFilteringApi::class)
+
 package com.stripe.android.paymentsheet.state
 
 import android.os.Parcelable
+import com.stripe.android.ExperimentalCardBrandFilteringApi
 import com.stripe.android.common.coroutines.runCatching
 import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.core.Logger
@@ -388,7 +391,8 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         initializationMode: PaymentElementLoader.InitializationMode
     ): LinkState? {
         return if (elementsSession.isLinkEnabled &&
-            !configuration.billingDetailsCollectionConfiguration.collectsAnything
+            !configuration.billingDetailsCollectionConfiguration.collectsAnything &&
+            configuration.cardBrandAcceptance == PaymentSheet.CardBrandAcceptance.all()
         ) {
             loadLinkState(
                 configuration = configuration,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -1350,6 +1350,26 @@ internal class DefaultPaymentElementLoaderTest {
         assertThat(result.paymentMethodMetadata.linkInlineConfiguration).isNull()
     }
 
+    @OptIn(ExperimentalCardBrandFilteringApi::class)
+    @Test
+    fun `Disables Link if card brand filtering is used`() = runTest {
+        val loader = createPaymentElementLoader()
+
+        val result = loader.load(
+            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
+                clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
+            ),
+            paymentSheetConfiguration = PaymentSheet.Configuration(
+                merchantDisplayName = "Some Name",
+                cardBrandAcceptance = PaymentSheet.CardBrandAcceptance.disallowed(listOf(PaymentSheet.CardBrandAcceptance.BrandCategory.Amex))
+            ),
+            initializedViaCompose = false,
+        ).getOrThrow()
+
+        assertThat(result.paymentMethodMetadata.linkState).isNull()
+        assertThat(result.paymentMethodMetadata.linkInlineConfiguration).isNull()
+    }
+
     @Test
     fun `When EPMs are requested but not returned by elements session, no EPMs are used`() = runTest {
         testExternalPaymentMethods(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -1361,7 +1361,11 @@ internal class DefaultPaymentElementLoaderTest {
             ),
             paymentSheetConfiguration = PaymentSheet.Configuration(
                 merchantDisplayName = "Some Name",
-                cardBrandAcceptance = PaymentSheet.CardBrandAcceptance.disallowed(listOf(PaymentSheet.CardBrandAcceptance.BrandCategory.Amex))
+                cardBrandAcceptance = PaymentSheet.CardBrandAcceptance.disallowed(
+                    listOf(
+                        PaymentSheet.CardBrandAcceptance.BrandCategory.Amex
+                    )
+                )
             ),
             initializedViaCompose = false,
         ).getOrThrow()


### PR DESCRIPTION
# Summary
- Disables Link if card brand filtering is used
- Context [here](https://stripe.slack.com/archives/C07P1VD52UA/p1737482498269689?thread_ts=1737482412.166249&cid=C07P1VD52UA)

# Motivation
- https://jira.corp.stripe.com/browse/MOBILESDK-3033

# Testing
- Manual
- New unit test

# Changelog
N/A (private beta)