### PR TITLE
Sends app id regardless of app verification support

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
@@ -123,7 +123,7 @@ internal class FinancialConnectionsSheetViewModel @Inject constructor(
                 val attestationInitResult = prepareStandardRequestManager()
                 val syncResponse = getOrFetchSync(
                     refetchCondition = Always,
-                    supportsAppVerification = attestationInitResult.initialized
+                    supportsAppVerification = attestationInitResult.supportsAppVerification
                 )
                 val pane = syncResponse.manifest.nextPane
                 when (attestationInitResult) {
@@ -587,10 +587,10 @@ internal class FinancialConnectionsSheetViewModel @Inject constructor(
         }
     }
 
-    private sealed class AttestationInitResult(val initialized: Boolean) {
-        data object Success : AttestationInitResult(initialized = true)
-        data object Skipped : AttestationInitResult(initialized = false)
-        data class Failure(val error: Throwable) : AttestationInitResult(initialized = false)
+    private sealed class AttestationInitResult(val supportsAppVerification: Boolean) {
+        data object Success : AttestationInitResult(supportsAppVerification = true)
+        data object Skipped : AttestationInitResult(supportsAppVerification = false)
+        data class Failure(val error: Throwable) : AttestationInitResult(supportsAppVerification = false)
     }
 
     companion object {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
@@ -123,7 +123,7 @@ internal class FinancialConnectionsSheetViewModel @Inject constructor(
                 val attestationInitResult = prepareStandardRequestManager()
                 val syncResponse = getOrFetchSync(
                     refetchCondition = Always,
-                    attestationInitialized = attestationInitResult.initialized
+                    supportsAppVerification = attestationInitResult.initialized
                 )
                 val pane = syncResponse.manifest.nextPane
                 when (attestationInitResult) {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/GetOrFetchSync.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/GetOrFetchSync.kt
@@ -19,13 +19,13 @@ internal class GetOrFetchSync @Inject constructor(
 
     suspend operator fun invoke(
         refetchCondition: RefetchCondition = RefetchCondition.None,
-        attestationInitialized: Boolean = false
+        supportsAppVerification: Boolean = false
     ): SynchronizeSessionResponse {
         return repository.getOrSynchronizeFinancialConnectionsSession(
             clientSecret = configuration.financialConnectionsSessionClientSecret,
             applicationId = applicationId,
             reFetchCondition = refetchCondition::shouldReFetch,
-            attestationInitialized = attestationInitialized
+            supportsAppVerification = supportsAppVerification
         )
     }
 

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModelTest.kt
@@ -101,7 +101,7 @@ class FinancialConnectionsSheetViewModelTest {
                 )
             )
 
-            verify(getOrFetchSync).invoke(refetchCondition = Always, attestationInitialized = true)
+            verify(getOrFetchSync).invoke(refetchCondition = Always, supportsAppVerification = true)
         }
 
     @Test
@@ -115,7 +115,7 @@ class FinancialConnectionsSheetViewModelTest {
                 )
             )
 
-            verify(getOrFetchSync).invoke(refetchCondition = Always, attestationInitialized = false)
+            verify(getOrFetchSync).invoke(refetchCondition = Always, supportsAppVerification = false)
         }
 
     @Test

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/networking/AbsFinancialConnectionsManifestRepository.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/networking/AbsFinancialConnectionsManifestRepository.kt
@@ -94,7 +94,7 @@ internal abstract class AbsFinancialConnectionsManifestRepository : FinancialCon
     override suspend fun getOrSynchronizeFinancialConnectionsSession(
         clientSecret: String,
         applicationId: String,
-        attestationInitialized: Boolean,
+        supportsAppVerification: Boolean,
         reFetchCondition: (SynchronizeSessionResponse) -> Boolean
     ): SynchronizeSessionResponse {
         TODO("Not yet implemented")

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/networking/FakeFinancialConnectionsManifestRepository.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/networking/FakeFinancialConnectionsManifestRepository.kt
@@ -27,7 +27,7 @@ internal class FakeFinancialConnectionsManifestRepository : FinancialConnections
     override suspend fun getOrSynchronizeFinancialConnectionsSession(
         clientSecret: String,
         applicationId: String,
-        attestationInitialized: Boolean,
+        supportsAppVerification: Boolean,
         reFetchCondition: (SynchronizeSessionResponse) -> Boolean
     ): SynchronizeSessionResponse = getSynchronizeSessionResponseProvider()
 

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/FinancialConnectionsManifestRepositoryImplTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/FinancialConnectionsManifestRepositoryImplTest.kt
@@ -59,7 +59,7 @@ internal class FinancialConnectionsManifestRepositoryImplTest {
                     repository.getOrSynchronizeFinancialConnectionsSession(
                         clientSecret = "",
                         applicationId = "",
-                        attestationInitialized = false,
+                        supportsAppVerification = false,
                         reFetchCondition = None::shouldReFetch
                     )
                 },
@@ -67,7 +67,7 @@ internal class FinancialConnectionsManifestRepositoryImplTest {
                     repository.getOrSynchronizeFinancialConnectionsSession(
                         clientSecret = "",
                         applicationId = "",
-                        attestationInitialized = false,
+                        supportsAppVerification = false,
                         reFetchCondition = None::shouldReFetch
                     )
                 }
@@ -86,7 +86,7 @@ internal class FinancialConnectionsManifestRepositoryImplTest {
                 repository.getOrSynchronizeFinancialConnectionsSession(
                     clientSecret = "",
                     applicationId = "",
-                    attestationInitialized = false,
+                    supportsAppVerification = false,
                     reFetchCondition = None::shouldReFetch
                 )
 


### PR DESCRIPTION
# Summary

The application id is used backend side to check if the current merchant is trusted ([see code](https://git.corp.stripe.com/stripe-internal/pay-server/blob/master/lib/bank_connections/auth_session/command/set_or_update_link_account_session_mobile_app_verification_enabled.rb#L122-L123)).

Currently, if the client does not support verified apps, we're not sending the app id. That incorrectly catalogs the current session as `merchant_not_trusted`, where in reality the reason to disable app verification is `client_attestation_unsupported`. 


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
