### PR TITLE
Fix Link Sign Up navigation

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/LinkContent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/LinkContent.kt
@@ -138,12 +138,9 @@ private fun Screens(
         }
 
         composable(LinkScreen.SignUp.route) {
-            val viewModel: SignUpViewModel = linkViewModel {
-                SignUpViewModel.factory(it)
-            }
-            SignUpScreen(
-                viewModel = viewModel,
-                navController = navController
+            SignUpRoute(
+                navigate = navigate,
+                navigateAndClearStack = navigateAndClearStack
             )
         }
 
@@ -190,6 +187,23 @@ private fun Screens(
             PaymentMethodRoute(linkAccount = linkAccount, dismissWithResult = dismissWithResult)
         }
     }
+}
+
+@Composable
+private fun SignUpRoute(
+    navigate: (route: LinkScreen) -> Unit,
+    navigateAndClearStack: (route: LinkScreen) -> Unit,
+) {
+    val viewModel: SignUpViewModel = linkViewModel { parentComponent ->
+        SignUpViewModel.factory(
+            parentComponent = parentComponent,
+            navigate = navigate,
+            navigateAndClearStack = navigateAndClearStack
+        )
+    }
+    SignUpScreen(
+        viewModel = viewModel,
+    )
 }
 
 @Composable

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/signup/SignUpScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/signup/SignUpScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -28,7 +27,6 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavHostController
 import com.stripe.android.link.theme.DefaultLinkTheme
 import com.stripe.android.link.theme.StripeThemeForLink
 import com.stripe.android.link.theme.linkColors
@@ -50,15 +48,7 @@ import com.stripe.android.uicore.utils.collectAsState
 @Composable
 internal fun SignUpScreen(
     viewModel: SignUpViewModel,
-    navController: NavHostController
 ) {
-    DisposableEffect(Unit) {
-        viewModel.navController = navController
-
-        onDispose {
-            viewModel.navController = null
-        }
-    }
     val signUpScreenState by viewModel.state.collectAsState()
 
     SignUpBody(

--- a/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
@@ -120,16 +120,18 @@ internal object TestFactory {
         )
     )
 
+    val LINK_CUSTOMER_INFO = LinkConfiguration.CustomerInfo(
+        name = CUSTOMER_NAME,
+        email = CUSTOMER_EMAIL,
+        phone = CUSTOMER_PHONE,
+        billingCountryCode = CUSTOMER_BILLING_COUNTRY_CODE
+    )
+
     val LINK_CONFIGURATION = LinkConfiguration(
         stripeIntent = PaymentIntentFixtures.PI_SUCCEEDED,
         merchantName = MERCHANT_NAME,
         merchantCountryCode = "",
-        customerInfo = LinkConfiguration.CustomerInfo(
-            name = CUSTOMER_NAME,
-            email = CUSTOMER_EMAIL,
-            phone = CUSTOMER_PHONE,
-            billingCountryCode = CUSTOMER_BILLING_COUNTRY_CODE
-        ),
+        customerInfo = LINK_CUSTOMER_INFO,
         shippingDetails = null,
         flags = emptyMap(),
         cardBrandChoice = null,

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenTest.kt
@@ -37,14 +37,12 @@ internal class SignUpScreenTest {
     }
     private val logger = FakeLogger()
 
-    private lateinit var viewModel: SignUpViewModel
-
     @get:Rule
     val coroutineTestRule = CoroutineTestRule(dispatcher)
 
     @Test
     fun `only email field displayed when controllers are empty`() = runTest(dispatcher) {
-        viewModel = viewModel()
+        val viewModel = viewModel()
 
         composeTestRule.setContent {
             SignUpScreen(viewModel = viewModel)
@@ -59,7 +57,7 @@ internal class SignUpScreenTest {
 
     @Test
     fun `all fields displayed and sign up enabled when all controllers are filled`() = runTest(dispatcher) {
-        viewModel = viewModel()
+        val viewModel = viewModel()
 
         composeTestRule.setContent {
             SignUpScreen(viewModel = viewModel)
@@ -75,7 +73,7 @@ internal class SignUpScreenTest {
 
     @Test
     fun `all fields displayed when email controller is filled`() = runTest(dispatcher) {
-        viewModel(
+        val viewModel = viewModel(
             customerInfo = TestFactory.LINK_CUSTOMER_INFO.copy(
                 name = null,
                 email = "test@test.com",
@@ -100,7 +98,7 @@ internal class SignUpScreenTest {
     fun `field displayed, sign up enabled and error displayed when controllers are filled and sign up fails`() =
         runTest(dispatcher) {
             val linkAccountManager = FakeLinkAccountManager()
-            viewModel = viewModel(linkAccountManager = linkAccountManager)
+            val viewModel = viewModel(linkAccountManager = linkAccountManager)
 
             composeTestRule.setContent {
                 SignUpScreen(viewModel)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
The `SignUpScreen` pops back to non-existent `VerificationScreen` after sign up succeeds. As a result of this, the  user is stuck on the `SignUpScreen` screen after a successful sign up. This PR fixes that.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
[JIRA](https://jira.corp.stripe.com/browse/MOBILESDK-3043)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots

https://github.com/user-attachments/assets/9d674908-aeb4-4081-84f3-09d79b85e320



# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
