### PR TITLE
Centralize top bar back behavior.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewState.kt
@@ -47,7 +47,6 @@ internal sealed class CustomerSheetViewState(
     ) {
         override fun topBarState(onEditIconPressed: () -> Unit): PaymentSheetTopBarState {
             return PaymentSheetTopBarStateFactory.create(
-                hasBackStack = canNavigateBack,
                 isLiveMode = isLiveMode,
                 editable = PaymentSheetTopBarState.Editable.Never,
             )
@@ -80,7 +79,6 @@ internal sealed class CustomerSheetViewState(
 
         override fun topBarState(onEditIconPressed: () -> Unit): PaymentSheetTopBarState {
             return PaymentSheetTopBarStateFactory.create(
-                hasBackStack = canNavigateBack,
                 isLiveMode = isLiveMode,
                 editable = PaymentSheetTopBarState.Editable.Maybe(
                     isEditing = isEditing,
@@ -119,7 +117,6 @@ internal sealed class CustomerSheetViewState(
     ) {
         override fun topBarState(onEditIconPressed: () -> Unit): PaymentSheetTopBarState {
             return PaymentSheetTopBarStateFactory.create(
-                hasBackStack = canNavigateBack,
                 isLiveMode = isLiveMode,
                 editable = PaymentSheetTopBarState.Editable.Never,
             )
@@ -136,7 +133,6 @@ internal sealed class CustomerSheetViewState(
     ) {
         override fun topBarState(onEditIconPressed: () -> Unit): PaymentSheetTopBarState {
             return PaymentSheetTopBarStateFactory.create(
-                hasBackStack = canNavigateBack,
                 isLiveMode = isLiveMode,
                 editable = PaymentSheetTopBarState.Editable.Never,
             )

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
@@ -70,6 +70,7 @@ internal fun CustomerSheetScreen(
                 state = viewState.topBarState {
                     viewActionHandler(CustomerSheetViewAction.OnEditPressed)
                 },
+                canNavigateBack = viewState.canNavigateBack,
                 isEnabled = !viewState.isProcessing,
                 handleBackPressed = {
                     viewActionHandler(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
@@ -136,7 +136,6 @@ internal sealed interface PaymentSheetScreen {
         override fun topBarState(): StateFlow<PaymentSheetTopBarState?> {
             return interactor.state.mapAsStateFlow { state ->
                 PaymentSheetTopBarStateFactory.create(
-                    hasBackStack = false,
                     isLiveMode = interactor.isLiveMode,
                     editable = PaymentSheetTopBarState.Editable.Maybe(
                         isEditing = state.isEditing,
@@ -194,7 +193,6 @@ internal sealed interface PaymentSheetScreen {
         override fun topBarState(): StateFlow<PaymentSheetTopBarState?> {
             return stateFlowOf(
                 PaymentSheetTopBarStateFactory.create(
-                    hasBackStack = true,
                     isLiveMode = interactor.isLiveMode,
                     editable = PaymentSheetTopBarState.Editable.Never,
                 )
@@ -245,7 +243,6 @@ internal sealed interface PaymentSheetScreen {
         override fun topBarState(): StateFlow<PaymentSheetTopBarState?> {
             return stateFlowOf(
                 PaymentSheetTopBarStateFactory.create(
-                    hasBackStack = false,
                     isLiveMode = interactor.isLiveMode,
                     editable = PaymentSheetTopBarState.Editable.Never,
                 )
@@ -296,7 +293,6 @@ internal sealed interface PaymentSheetScreen {
         override fun topBarState(): StateFlow<PaymentSheetTopBarState?> {
             return stateFlowOf(
                 PaymentSheetTopBarStateFactory.create(
-                    hasBackStack = false,
                     isLiveMode = interactor.isLiveMode,
                     editable = PaymentSheetTopBarState.Editable.Never,
                 )
@@ -342,7 +338,6 @@ internal sealed interface PaymentSheetScreen {
         override fun topBarState(): StateFlow<PaymentSheetTopBarState?> {
             return stateFlowOf(
                 PaymentSheetTopBarStateFactory.create(
-                    hasBackStack = interactor.canGoBack(),
                     isLiveMode = interactor.isLiveMode,
                     editable = PaymentSheetTopBarState.Editable.Never,
                 )
@@ -380,7 +375,6 @@ internal sealed interface PaymentSheetScreen {
         override fun topBarState(): StateFlow<PaymentSheetTopBarState?> {
             return interactor.state.mapAsStateFlow { state ->
                 PaymentSheetTopBarStateFactory.create(
-                    hasBackStack = true,
                     isLiveMode = interactor.isLiveMode,
                     editable = PaymentSheetTopBarState.Editable.Maybe(
                         isEditing = state.isEditing,
@@ -437,7 +431,6 @@ internal sealed interface PaymentSheetScreen {
         override fun topBarState(): StateFlow<PaymentSheetTopBarState?> {
             return interactor.cvcCompletionState.mapAsStateFlow { complete ->
                 PaymentSheetTopBarStateFactory.create(
-                    hasBackStack = false,
                     isLiveMode = interactor.viewState.value.isTestMode.not(),
                     editable = PaymentSheetTopBarState.Editable.Maybe(
                         isEditing = complete is CvcCompletionState.Incomplete,
@@ -473,7 +466,6 @@ internal sealed interface PaymentSheetScreen {
         override fun topBarState(): StateFlow<PaymentSheetTopBarState?> {
             return stateFlowOf(
                 PaymentSheetTopBarStateFactory.create(
-                    hasBackStack = true,
                     isLiveMode = interactor.isLiveMode,
                     editable = PaymentSheetTopBarState.Editable.Never,
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateConfirmationActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateConfirmationActivity.kt
@@ -11,7 +11,6 @@ import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.runtime.LaunchedEffect
 import androidx.core.view.WindowCompat
 import com.stripe.android.common.ui.ElementsBottomSheetLayout
-import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.parseAppearance
 import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateConfirmationViewAction.OnBackPressed
 import com.stripe.android.paymentsheet.ui.PaymentSheetScaffold
@@ -21,7 +20,6 @@ import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.elements.bottomsheet.rememberStripeBottomSheetState
 import com.stripe.android.uicore.utils.fadeOut
 import kotlinx.coroutines.flow.collectLatest
-import com.stripe.android.ui.core.R as StripeUiCoreR
 
 internal class BacsMandateConfirmationActivity : AppCompatActivity() {
     private val starterArgs: BacsMandateConfirmationContract.Args by lazy {
@@ -69,13 +67,12 @@ internal class BacsMandateConfirmationActivity : AppCompatActivity() {
                         topBar = {
                             PaymentSheetTopBar(
                                 state = PaymentSheetTopBarState(
-                                    icon = R.drawable.stripe_ic_paymentsheet_close,
-                                    contentDescription = StripeUiCoreR.string.stripe_back,
                                     showEditMenu = false,
                                     showTestModeLabel = false,
                                     isEditing = false,
                                     onEditIconPressed = {},
                                 ),
+                                canNavigateBack = false,
                                 isEnabled = true,
                                 handleBackPressed = {
                                     viewModel.handleViewAction(OnBackPressed)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
@@ -138,6 +138,7 @@ private fun PaymentSheetScreen(
 
             PaymentSheetTopBar(
                 state = topBarState,
+                canNavigateBack = viewModel.navigationHandler.canGoBack,
                 isEnabled = !processing,
                 handleBackPressed = viewModel::handleBackPressed,
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBar.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBar.kt
@@ -40,6 +40,7 @@ internal const val SHEET_NAVIGATION_BUTTON_TAG = "SHEET_NAVIGATION_BUTTON_TAG"
 @Composable
 internal fun PaymentSheetTopBar(
     state: PaymentSheetTopBarState?,
+    canNavigateBack: Boolean,
     isEnabled: Boolean,
     handleBackPressed: () -> Unit,
     elevation: Dp = 0.dp,
@@ -47,6 +48,7 @@ internal fun PaymentSheetTopBar(
     if (state != null) {
         PaymentSheetTopBar(
             state = state,
+            canNavigateBack = canNavigateBack,
             isEnabled = isEnabled,
             elevation = elevation,
             onNavigationIconPressed = handleBackPressed,
@@ -57,6 +59,7 @@ internal fun PaymentSheetTopBar(
 @Composable
 internal fun PaymentSheetTopBar(
     state: PaymentSheetTopBarState,
+    canNavigateBack: Boolean,
     isEnabled: Boolean,
     elevation: Dp,
     onNavigationIconPressed: () -> Unit,
@@ -80,9 +83,20 @@ internal fun PaymentSheetTopBar(
                 },
                 modifier = Modifier.testTag(SHEET_NAVIGATION_BUTTON_TAG)
             ) {
+                val icon = if (canNavigateBack) {
+                    R.drawable.stripe_ic_paymentsheet_back
+                } else {
+                    R.drawable.stripe_ic_paymentsheet_close
+                }
+
+                val contentDescription = if (canNavigateBack) {
+                    StripeUiCoreR.string.stripe_back
+                } else {
+                    R.string.stripe_paymentsheet_close
+                }
                 Icon(
-                    painter = painterResource(state.icon),
-                    contentDescription = stringResource(state.contentDescription),
+                    painter = painterResource(icon),
+                    contentDescription = stringResource(contentDescription),
                     tint = tintColor,
                 )
             }
@@ -164,8 +178,6 @@ internal fun TestModeBadge() {
 internal fun PaymentSheetTopBar_Preview() {
     StripeTheme(colors = StripeThemeDefaults.colorsLight.copy(appBarIcon = Color.Red)) {
         val state = PaymentSheetTopBarState(
-            icon = R.drawable.stripe_ic_paymentsheet_back,
-            contentDescription = StripeUiCoreR.string.stripe_back,
             showTestModeLabel = true,
             showEditMenu = true,
             isEditing = false,
@@ -174,6 +186,7 @@ internal fun PaymentSheetTopBar_Preview() {
 
         PaymentSheetTopBar(
             state = state,
+            canNavigateBack = true,
             isEnabled = true,
             elevation = 0.dp,
             onNavigationIconPressed = {},

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBarState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBarState.kt
@@ -1,14 +1,9 @@
 package com.stripe.android.paymentsheet.ui
 
-import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
-import com.stripe.android.paymentsheet.R
 import com.stripe.android.R as StripeR
-import com.stripe.android.ui.core.R as StripeUiCoreR
 
 internal data class PaymentSheetTopBarState(
-    @DrawableRes val icon: Int,
-    @StringRes val contentDescription: Int,
     val showTestModeLabel: Boolean,
     val showEditMenu: Boolean,
     val isEditing: Boolean,
@@ -35,25 +30,10 @@ internal data class PaymentSheetTopBarState(
 
 internal object PaymentSheetTopBarStateFactory {
     fun create(
-        hasBackStack: Boolean,
         isLiveMode: Boolean,
         editable: PaymentSheetTopBarState.Editable,
     ): PaymentSheetTopBarState {
-        val icon = if (hasBackStack) {
-            R.drawable.stripe_ic_paymentsheet_back
-        } else {
-            R.drawable.stripe_ic_paymentsheet_close
-        }
-
-        val contentDescription = if (hasBackStack) {
-            StripeUiCoreR.string.stripe_back
-        } else {
-            R.string.stripe_paymentsheet_close
-        }
-
         return PaymentSheetTopBarState(
-            icon = icon,
-            contentDescription = contentDescription,
             showTestModeLabel = !isLiveMode,
             showEditMenu = (editable as? PaymentSheetTopBarState.Editable.Maybe)?.canEdit == true,
             isEditing = (editable as? PaymentSheetTopBarState.Editable.Maybe)?.isEditing == true,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormInteractor.kt
@@ -25,8 +25,6 @@ internal interface VerticalModeFormInteractor {
 
     fun handleViewAction(viewAction: ViewAction)
 
-    fun canGoBack(): Boolean
-
     fun close()
 
     data class State(
@@ -52,7 +50,6 @@ internal class DefaultVerticalModeFormInteractor(
     private val usBankAccountArguments: USBankAccountFormArguments,
     private val reportFieldInteraction: (String) -> Unit,
     private val headerInformation: FormHeaderInformation?,
-    private val canGoBackDelegate: () -> Boolean,
     override val isLiveMode: Boolean,
     processing: StateFlow<Boolean>,
     paymentMethodIncentive: StateFlow<PaymentMethodIncentive?>,
@@ -83,10 +80,6 @@ internal class DefaultVerticalModeFormInteractor(
                 onFormFieldValuesChanged(viewAction.formValues, selectedPaymentMethodCode)
             }
         }
-    }
-
-    override fun canGoBack(): Boolean {
-        return canGoBackDelegate()
     }
 
     override fun close() {
@@ -125,7 +118,6 @@ internal class DefaultVerticalModeFormInteractor(
                     },
                 ),
                 isLiveMode = paymentMethodMetadata.stripeIntent.isLiveMode,
-                canGoBackDelegate = { viewModel.navigationHandler.canGoBack },
                 processing = viewModel.processing,
                 paymentMethodIncentive = bankFormInteractor.paymentMethodIncentiveInteractor.displayedIncentive,
                 reportFieldInteraction = viewModel.analyticsListener::reportFieldInteraction,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenAddAnotherPaymentMethodScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenAddAnotherPaymentMethodScreenshotTest.kt
@@ -32,7 +32,7 @@ internal class PaymentSheetScreenAddAnotherPaymentMethodScreenshotTest {
         val metadata = PaymentMethodMetadataFactory.create()
         val interactor = FakeAddPaymentMethodInteractor(initialState = createState())
         val initialScreen = AddAnotherPaymentMethod(interactor)
-        val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen)
+        val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen, canGoBack = true)
 
         paparazziRule.snapshot {
             ViewModelStoreOwnerContext {
@@ -46,7 +46,7 @@ internal class PaymentSheetScreenAddAnotherPaymentMethodScreenshotTest {
         val metadata = PaymentMethodMetadataFactory.create()
         val interactor = FakeAddPaymentMethodInteractor(initialState = createState())
         val initialScreen = AddAnotherPaymentMethod(interactor)
-        val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen)
+        val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen, canGoBack = true)
         viewModel.onError("An error occurred.".resolvableString)
 
         paparazziRule.snapshot {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenAddFirstPaymentMethodScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenAddFirstPaymentMethodScreenshotTest.kt
@@ -32,7 +32,7 @@ internal class PaymentSheetScreenAddFirstPaymentMethodScreenshotTest {
         val metadata = PaymentMethodMetadataFactory.create()
         val interactor = FakeAddPaymentMethodInteractor(initialState = createState())
         val initialScreen = AddFirstPaymentMethod(interactor)
-        val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen)
+        val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen, canGoBack = false)
 
         paparazziRule.snapshot {
             ViewModelStoreOwnerContext {
@@ -46,7 +46,7 @@ internal class PaymentSheetScreenAddFirstPaymentMethodScreenshotTest {
         val metadata = PaymentMethodMetadataFactory.create()
         val interactor = FakeAddPaymentMethodInteractor(initialState = createState())
         val initialScreen = AddFirstPaymentMethod(interactor)
-        val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen)
+        val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen, canGoBack = false)
         viewModel.onError("An error occurred.".resolvableString)
 
         paparazziRule.snapshot {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenCvcRecollectionScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenCvcRecollectionScreenshotTest.kt
@@ -28,7 +28,7 @@ internal class PaymentSheetScreenCvcRecollectionScreenshotTest {
     fun displaysCvcRecollectionScreen() {
         val metadata = PaymentMethodMetadataFactory.create()
         val initialScreen = CvcRecollection(FakeCvcRecollectionInteractor())
-        val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen)
+        val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen, canGoBack = false)
 
         paparazziRule.snapshot {
             PaymentSheetScreen(viewModel = viewModel, type = PaymentSheetFlowType.Complete)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenLoadingScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenLoadingScreenshotTest.kt
@@ -27,7 +27,7 @@ internal class PaymentSheetScreenLoadingScreenshotTest {
     fun displaysLoading() {
         val metadata = PaymentMethodMetadataFactory.create()
         val initialScreen = Loading
-        val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen)
+        val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen, canGoBack = false)
 
         paparazziRule.snapshot {
             PaymentSheetScreen(viewModel = viewModel, type = PaymentSheetFlowType.Complete)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenManageSavedPaymentMethodsScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenManageSavedPaymentMethodsScreenshotTest.kt
@@ -51,7 +51,7 @@ internal class PaymentSheetScreenManageSavedPaymentMethodsScreenshotTest {
             )
         )
         val initialScreen = ManageSavedPaymentMethods(interactor)
-        val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen)
+        val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen, canGoBack = true)
 
         paparazziRule.snapshot {
             PaymentSheetScreen(viewModel = viewModel, type = PaymentSheetFlowType.Complete)
@@ -70,7 +70,7 @@ internal class PaymentSheetScreenManageSavedPaymentMethodsScreenshotTest {
             )
         )
         val initialScreen = ManageSavedPaymentMethods(interactor)
-        val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen)
+        val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen, canGoBack = true)
 
         paparazziRule.snapshot {
             PaymentSheetScreen(viewModel = viewModel, type = PaymentSheetFlowType.Complete)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenSelectSavedPaymentMethodsScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenSelectSavedPaymentMethodsScreenshotTest.kt
@@ -129,6 +129,6 @@ internal class PaymentSheetScreenSelectSavedPaymentMethodsScreenshotTest {
             )
         )
         val initialScreen = SelectSavedPaymentMethods(interactor)
-        return FakeBaseSheetViewModel.create(metadata, initialScreen)
+        return FakeBaseSheetViewModel.create(metadata, initialScreen, canGoBack = false)
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenVerticalModeFormTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenVerticalModeFormTest.kt
@@ -2,7 +2,6 @@ package com.stripe.android.paymentsheet.navigation
 
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.verticalmode.VerticalModeFormInteractor
 import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.flow.StateFlow
@@ -20,20 +19,18 @@ internal class PaymentSheetScreenVerticalModeFormTest {
     }
 
     @Test
-    fun `topBarState reflects live mode and canGoBack`() = runTest {
-        val trueInteractor = FakeVerticalModeFormInteractor(isLiveMode = true, canGoBack = true)
+    fun `topBarState reflects live mode`() = runTest {
+        val trueInteractor = FakeVerticalModeFormInteractor(isLiveMode = true)
         PaymentSheetScreen.VerticalModeForm(trueInteractor).topBarState().test {
             awaitItem()!!.apply {
                 assertThat(showTestModeLabel).isFalse()
-                assertThat(icon).isEqualTo(R.drawable.stripe_ic_paymentsheet_back)
             }
         }
 
-        val falseInteractor = FakeVerticalModeFormInteractor(isLiveMode = false, canGoBack = false)
+        val falseInteractor = FakeVerticalModeFormInteractor(isLiveMode = false)
         PaymentSheetScreen.VerticalModeForm(falseInteractor).topBarState().test {
             awaitItem()!!.apply {
                 assertThat(showTestModeLabel).isTrue()
-                assertThat(icon).isEqualTo(R.drawable.stripe_ic_paymentsheet_close)
             }
         }
     }
@@ -49,15 +46,10 @@ internal class PaymentSheetScreenVerticalModeFormTest {
     private class FakeVerticalModeFormInteractor(
         override val state: StateFlow<VerticalModeFormInteractor.State> = stateFlowOf(mock()),
         override val isLiveMode: Boolean = false,
-        private val canGoBack: Boolean = false,
         private val onClose: () -> Unit = {},
     ) : VerticalModeFormInteractor {
         override fun handleViewAction(viewAction: VerticalModeFormInteractor.ViewAction) {
             throw AssertionError("Not implemented")
-        }
-
-        override fun canGoBack(): Boolean {
-            return canGoBack
         }
 
         override fun close() {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenVerticalModeScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenVerticalModeScreenshotTest.kt
@@ -35,7 +35,7 @@ internal class PaymentSheetScreenVerticalModeScreenshotTest {
     fun displaysVerticalModeList() {
         val metadata = PaymentMethodMetadataFactory.create()
         val initialScreen = VerticalMode(FakePaymentMethodVerticalLayoutInteractor.create(metadata))
-        val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen)
+        val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen, canGoBack = false)
 
         paparazziRule.snapshot {
             PaymentSheetScreen(viewModel = viewModel, type = PaymentSheetFlowType.Complete)
@@ -46,7 +46,7 @@ internal class PaymentSheetScreenVerticalModeScreenshotTest {
     fun displaysVerticalModeListWithError() {
         val metadata = PaymentMethodMetadataFactory.create()
         val initialScreen = VerticalMode(FakePaymentMethodVerticalLayoutInteractor.create(metadata))
-        val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen)
+        val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen, canGoBack = false)
         viewModel.onError("Example error".resolvableString)
 
         paparazziRule.snapshot {
@@ -67,7 +67,7 @@ internal class PaymentSheetScreenVerticalModeScreenshotTest {
                 selection = PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION,
             )
         )
-        val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen)
+        val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen, canGoBack = false)
         viewModel.mandateHandler.updateMandateText("Example Mandate".resolvableString, showAbove = true)
         viewModel.primaryButtonUiStateSource.update { original ->
             original?.copy(enabled = true)
@@ -91,7 +91,7 @@ internal class PaymentSheetScreenVerticalModeScreenshotTest {
                 selection = PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION,
             )
         )
-        val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen)
+        val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen, canGoBack = false)
         viewModel.onError("Example error".resolvableString)
         viewModel.mandateHandler.updateMandateText("Example Mandate".resolvableString, showAbove = true)
         viewModel.primaryButtonUiStateSource.update { original ->
@@ -111,7 +111,7 @@ internal class PaymentSheetScreenVerticalModeScreenshotTest {
             initialShowsWalletsHeader = true
         )
         val initialScreen = VerticalMode(interactor)
-        val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen)
+        val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen, canGoBack = false)
         viewModel.walletsStateSource.value = WalletsState(
             link = WalletsState.Link(
                 email = null,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreenUpdatePaymentMethodScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreenUpdatePaymentMethodScreenshotTest.kt
@@ -133,7 +133,7 @@ internal class PaymentSheetScreenUpdatePaymentMethodScreenshotTest {
         )
         val screen = com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.UpdatePaymentMethod(interactor)
         val metadata = PaymentMethodMetadataFactory.create()
-        val viewModel = FakeBaseSheetViewModel.create(metadata, screen)
+        val viewModel = FakeBaseSheetViewModel.create(metadata, screen, canGoBack = true)
 
         PaymentSheetScreen(viewModel = viewModel, type = PaymentSheetFlowType.Complete)
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBarScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBarScreenshotTest.kt
@@ -4,15 +4,12 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.stripe.android.paymentsheet.R
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance
 import org.junit.Rule
 import org.junit.Test
-import com.stripe.android.R as StripeR
-import com.stripe.android.ui.core.R as StripeUiCoreR
 
 class PaymentSheetTopBarScreenshotTest {
 
@@ -27,8 +24,6 @@ class PaymentSheetTopBarScreenshotTest {
     @Test
     fun testLoading() {
         val state = PaymentSheetTopBarState(
-            icon = R.drawable.stripe_ic_paymentsheet_close,
-            contentDescription = StripeR.string.stripe_close,
             showTestModeLabel = false,
             showEditMenu = false,
             isEditing = false,
@@ -38,6 +33,7 @@ class PaymentSheetTopBarScreenshotTest {
         paparazzi.snapshot {
             PaymentSheetTopBar(
                 state = state,
+                canNavigateBack = false,
                 isEnabled = true,
                 elevation = 0.dp,
                 onNavigationIconPressed = {},
@@ -48,8 +44,6 @@ class PaymentSheetTopBarScreenshotTest {
     @Test
     fun testPaymentMethodsScreen() {
         val state = PaymentSheetTopBarState(
-            icon = R.drawable.stripe_ic_paymentsheet_close,
-            contentDescription = StripeR.string.stripe_close,
             showTestModeLabel = true,
             showEditMenu = true,
             isEditing = false,
@@ -59,6 +53,7 @@ class PaymentSheetTopBarScreenshotTest {
         paparazzi.snapshot {
             PaymentSheetTopBar(
                 state = state,
+                canNavigateBack = false,
                 isEnabled = true,
                 elevation = 0.dp,
                 onNavigationIconPressed = {},
@@ -69,8 +64,6 @@ class PaymentSheetTopBarScreenshotTest {
     @Test
     fun testPaymentMethodsScreenEditing() {
         val state = PaymentSheetTopBarState(
-            icon = R.drawable.stripe_ic_paymentsheet_close,
-            contentDescription = StripeR.string.stripe_close,
             showTestModeLabel = true,
             showEditMenu = true,
             isEditing = true,
@@ -80,6 +73,7 @@ class PaymentSheetTopBarScreenshotTest {
         paparazzi.snapshot {
             PaymentSheetTopBar(
                 state = state,
+                canNavigateBack = false,
                 isEnabled = true,
                 elevation = 0.dp,
                 onNavigationIconPressed = {},
@@ -90,8 +84,6 @@ class PaymentSheetTopBarScreenshotTest {
     @Test
     fun testAddPaymentMethodScreen() {
         val state = PaymentSheetTopBarState(
-            icon = R.drawable.stripe_ic_paymentsheet_back,
-            contentDescription = StripeUiCoreR.string.stripe_back,
             showTestModeLabel = true,
             showEditMenu = false,
             isEditing = false,
@@ -101,6 +93,7 @@ class PaymentSheetTopBarScreenshotTest {
         paparazzi.snapshot {
             PaymentSheetTopBar(
                 state = state,
+                canNavigateBack = true,
                 isEnabled = true,
                 elevation = 0.dp,
                 onNavigationIconPressed = {},

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBarStateFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBarStateFactoryTest.kt
@@ -1,32 +1,10 @@
 package com.stripe.android.paymentsheet.ui
 
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.paymentsheet.R
 import org.junit.Test
 import com.stripe.android.R as StripeR
-import com.stripe.android.ui.core.R as StripeUiCoreR
 
 class PaymentSheetTopBarStateFactoryTest {
-
-    @Test
-    fun `navigation is close when canNavigateBack=false`() {
-        val state = buildTopBarState(
-            canNavigateBack = false,
-        )
-
-        assertThat(state.icon).isEqualTo(R.drawable.stripe_ic_paymentsheet_close)
-        assertThat(state.contentDescription).isEqualTo(R.string.stripe_paymentsheet_close)
-    }
-
-    @Test
-    fun `navigation is back when canNavigateBack=true`() {
-        val state = buildTopBarState(
-            canNavigateBack = true,
-        )
-
-        assertThat(state.icon).isEqualTo(R.drawable.stripe_ic_paymentsheet_back)
-        assertThat(state.contentDescription).isEqualTo(StripeUiCoreR.string.stripe_back)
-    }
 
     @Test
     fun `showTestModeLabel=true when isLiveMode=false`() {
@@ -119,12 +97,10 @@ class PaymentSheetTopBarStateFactoryTest {
     }
 
     private fun buildTopBarState(
-        canNavigateBack: Boolean = false,
         isLiveMode: Boolean = false,
         editable: PaymentSheetTopBarState.Editable = PaymentSheetTopBarState.Editable.Never,
     ): PaymentSheetTopBarState {
         return PaymentSheetTopBarStateFactory.create(
-            hasBackStack = canNavigateBack,
             isLiveMode = isLiveMode,
             editable,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBarTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBarTest.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.text.input.TextInputService
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.paymentsheet.R
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -19,7 +18,6 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.robolectric.annotation.Config
-import com.stripe.android.ui.core.R as StripeUiCoreR
 
 @RunWith(AndroidJUnit4::class)
 @Config(sdk = [Build.VERSION_CODES.Q])
@@ -39,6 +37,7 @@ class PaymentSheetTopBarTest {
             ) {
                 PaymentSheetTopBar(
                     state = mockState(),
+                    canNavigateBack = true,
                     isEnabled = true,
                     elevation = 0.dp,
                     onNavigationIconPressed = { didCallOnNavigationIconPressed = true },
@@ -66,6 +65,7 @@ class PaymentSheetTopBarTest {
             ) {
                 PaymentSheetTopBar(
                     state = mockState(),
+                    canNavigateBack = true,
                     isEnabled = false,
                     elevation = 0.dp,
                     onNavigationIconPressed = { didCallOnNavigationIconPressed = true },
@@ -88,6 +88,7 @@ class PaymentSheetTopBarTest {
         composeTestRule.setContent {
             PaymentSheetTopBar(
                 state = mockState(showEditMenu = true, onEditIconPressed = { didCallOnEditIconPressed = true }),
+                canNavigateBack = true,
                 isEnabled = true,
                 elevation = 0.dp,
                 onNavigationIconPressed = { throw AssertionError("Not expected") },
@@ -106,8 +107,6 @@ class PaymentSheetTopBarTest {
         onEditIconPressed: () -> Unit = { throw AssertionError("Not expected") }
     ): PaymentSheetTopBarState {
         return PaymentSheetTopBarState(
-            icon = R.drawable.stripe_ic_paymentsheet_back,
-            contentDescription = StripeUiCoreR.string.stripe_back,
             showTestModeLabel = false,
             showEditMenu = showEditMenu,
             isEditing = false,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultVerticalModeFormInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultVerticalModeFormInteractorTest.kt
@@ -59,19 +59,6 @@ internal class DefaultVerticalModeFormInteractorTest {
         }
     }
 
-    @Test
-    fun `canGoBack calls delegate`() {
-        var canGoBack = false
-        runScenario(
-            selectedPaymentMethodCode = "card",
-            canGoBackDelegate = { canGoBack },
-        ) {
-            assertThat(interactor.canGoBack()).isFalse()
-            canGoBack = true
-            assertThat(interactor.canGoBack()).isTrue()
-        }
-    }
-
     private val notImplemented: () -> Nothing = { throw AssertionError("Not implemented") }
 
     private fun runScenario(
@@ -80,7 +67,6 @@ internal class DefaultVerticalModeFormInteractorTest {
             notImplemented()
         },
         reportFieldInteraction: (String) -> Unit = { notImplemented() },
-        canGoBackDelegate: () -> Boolean = { notImplemented() },
         testBlock: suspend TestParams.() -> Unit,
     ) {
         val formArguments = mock<FormArguments>()
@@ -96,7 +82,6 @@ internal class DefaultVerticalModeFormInteractorTest {
             reportFieldInteraction = reportFieldInteraction,
             headerInformation = null,
             isLiveMode = true,
-            canGoBackDelegate = canGoBackDelegate,
             processing = processing,
             coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
             paymentMethodIncentive = stateFlowOf(null),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakeVerticalModeFormInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakeVerticalModeFormInteractor.kt
@@ -12,16 +12,11 @@ import org.mockito.Mockito.mock
 internal class FakeVerticalModeFormInteractor private constructor(
     initialState: VerticalModeFormInteractor.State,
     override val isLiveMode: Boolean = true,
-    private val canGoBack: Boolean,
 ) : VerticalModeFormInteractor {
     override val state: StateFlow<VerticalModeFormInteractor.State> = stateFlowOf(initialState)
 
     override fun handleViewAction(viewAction: VerticalModeFormInteractor.ViewAction) {
         // No op.
-    }
-
-    override fun canGoBack(): Boolean {
-        return canGoBack
     }
 
     override fun close() {
@@ -33,7 +28,6 @@ internal class FakeVerticalModeFormInteractor private constructor(
             paymentMethodCode: PaymentMethodCode,
             metadata: PaymentMethodMetadata,
             isProcessing: Boolean = false,
-            canGoBack: Boolean = true,
         ): VerticalModeFormInteractor {
             val formArguments = FormArgumentsFactory.create(
                 paymentMethodCode = paymentMethodCode,
@@ -60,7 +54,6 @@ internal class FakeVerticalModeFormInteractor private constructor(
                         customerHasSavedPaymentMethods = false,
                     ),
                 ),
-                canGoBack = canGoBack,
             )
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUIScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUIScreenshotTest.kt
@@ -98,7 +98,7 @@ internal class VerticalModeFormUIScreenshotTest {
             ),
             showsWalletHeader = true,
         )
-        val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen, canGoBack = true)
+        val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen, canGoBack = false)
         viewModel.walletsStateSource.value = WalletsState(
             link = WalletsState.Link(
                 email = null,
@@ -150,7 +150,7 @@ internal class VerticalModeFormUIScreenshotTest {
                 metadata = metadata,
             )
         )
-        val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen, canGoBack = true)
+        val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen, canGoBack = false)
         viewModel.primaryButtonUiStateSource.update { original ->
             original?.copy(enabled = true)
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUIScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUIScreenshotTest.kt
@@ -60,7 +60,7 @@ internal class VerticalModeFormUIScreenshotTest {
                 metadata = metadata,
             )
         )
-        val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen)
+        val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen, canGoBack = true)
 
         paparazziRule.snapshot {
             ViewModelStoreOwnerContext {
@@ -78,7 +78,7 @@ internal class VerticalModeFormUIScreenshotTest {
                 metadata = metadata,
             )
         )
-        val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen)
+        val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen, canGoBack = true)
         viewModel.onError("An error occurred.".resolvableString)
 
         paparazziRule.snapshot {
@@ -98,7 +98,7 @@ internal class VerticalModeFormUIScreenshotTest {
             ),
             showsWalletHeader = true,
         )
-        val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen)
+        val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen, canGoBack = true)
         viewModel.walletsStateSource.value = WalletsState(
             link = WalletsState.Link(
                 email = null,
@@ -128,7 +128,7 @@ internal class VerticalModeFormUIScreenshotTest {
                 metadata = metadata,
             )
         )
-        val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen)
+        val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen, canGoBack = true)
 
         paparazziRule.snapshot {
             ViewModelStoreOwnerContext {
@@ -150,7 +150,7 @@ internal class VerticalModeFormUIScreenshotTest {
                 metadata = metadata,
             )
         )
-        val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen)
+        val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen, canGoBack = true)
         viewModel.primaryButtonUiStateSource.update { original ->
             original?.copy(enabled = true)
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUIScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUIScreenshotTest.kt
@@ -95,7 +95,6 @@ internal class VerticalModeFormUIScreenshotTest {
             FakeVerticalModeFormInteractor.create(
                 paymentMethodCode = "card",
                 metadata = metadata,
-                canGoBack = false,
             ),
             showsWalletHeader = true,
         )
@@ -149,7 +148,6 @@ internal class VerticalModeFormUIScreenshotTest {
             FakeVerticalModeFormInteractor.create(
                 paymentMethodCode = "cashapp",
                 metadata = metadata,
-                canGoBack = false,
             )
         )
         val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUITest.kt
@@ -124,10 +124,6 @@ internal class VerticalModeFormUITest {
                 viewActionRecorder.record(viewAction)
             }
 
-            override fun canGoBack(): Boolean {
-                return true
-            }
-
             override fun close() {}
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactoryTest.kt
@@ -63,6 +63,7 @@ class VerticalModeInitialScreenFactoryTest {
         val fakeViewModel = FakeBaseSheetViewModel.create(
             paymentMethodMetadata = paymentMethodMetadata,
             initialScreen = PaymentSheetScreen.Loading,
+            canGoBack = false,
         )
 
         val customerStateHolder = CustomerStateHolder(SavedStateHandle(), fakeViewModel.selection)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/FakeBaseSheetViewModel.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/FakeBaseSheetViewModel.kt
@@ -51,13 +51,18 @@ internal class FakeBaseSheetViewModel private constructor(
         fun create(
             paymentMethodMetadata: PaymentMethodMetadata,
             initialScreen: PaymentSheetScreen,
+            canGoBack: Boolean,
         ): FakeBaseSheetViewModel {
             val savedStateHandle = SavedStateHandle()
             val linkHandler = linkHandler(savedStateHandle)
             return FakeBaseSheetViewModel(savedStateHandle, linkHandler, paymentMethodMetadata).apply {
-                navigationHandler.transitionTo(
-                    initialScreen
-                )
+                if (canGoBack) {
+                    navigationHandler.resetTo(
+                        listOf(mock(), initialScreen)
+                    )
+                } else {
+                    navigationHandler.transitionTo(initialScreen)
+                }
             }.also {
                 if (initialScreen.buyButtonState.value.visible) {
                     it.primaryButtonUiStateSource.update {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This created a lot of complexity when setting up the top bar. It's much simpler to let the source of truth handle it.
