### PR TITLE
Fix Connect behavior in FC playground

### DIFF
--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundActivity.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundActivity.kt
@@ -170,7 +170,7 @@ class FinancialConnectionsPlaygroundActivity : AppCompatActivity() {
         when (experience) {
             FinancialConnections -> collectBankAccountForAchLauncher.presentWithPaymentIntent(
                 publishableKey = publishableKey,
-                stripeAccountId = null,
+                stripeAccountId = stripeAccountId,
                 clientSecret = paymentIntentSecret,
                 configuration = CollectBankAccountConfiguration.USBankAccount(
                     name = "Sample name",
@@ -180,7 +180,7 @@ class FinancialConnectionsPlaygroundActivity : AppCompatActivity() {
             InstantDebits,
             LinkCardBrand -> collectBankAccountForInstantDebitsLauncher.presentWithPaymentIntent(
                 publishableKey = publishableKey,
-                stripeAccountId = null,
+                stripeAccountId = stripeAccountId,
                 clientSecret = paymentIntentSecret,
                 configuration = CollectBankAccountConfiguration.InstantDebits(
                     email = email,
@@ -196,7 +196,8 @@ class FinancialConnectionsPlaygroundActivity : AppCompatActivity() {
     ) {
         PaymentConfiguration.init(
             context = this@FinancialConnectionsPlaygroundActivity,
-            publishableKey = publishableKey
+            publishableKey = publishableKey,
+            stripeAccountId = stripeAccountId,
         )
 
         val config = PaymentSheet.Configuration(

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
@@ -143,10 +143,14 @@ internal class FinancialConnectionsPlaygroundViewModel(
                             }
                         )
                     }
+
+                    val stripeAccount = settings.get<StripeAccountIdSetting>().selectedOption
+
                     _viewEffect.emit(
                         FinancialConnectionsPlaygroundViewEffect.OpenForPaymentIntent(
                             paymentIntentSecret = it.intentSecret,
                             publishableKey = it.publishableKey,
+                            stripeAccountId = stripeAccount.takeIf(String::isNotBlank),
                             ephemeralKey = it.ephemeralKey,
                             customerId = it.customerId,
                             elementsSessionContext = ElementsSessionContext(
@@ -182,13 +186,16 @@ internal class FinancialConnectionsPlaygroundViewModel(
                 // Success creating session: open the financial connections sheet with received secret
                 .onSuccess {
                     showLoadingWithMessage("Session created, opening FinancialConnectionsSheet.")
+
+                    val stripeAccount = settings.get<StripeAccountIdSetting>().selectedOption
+
                     _state.update { current -> current.copy(publishableKey = it.publishableKey) }
                     _viewEffect.emit(
                         FinancialConnectionsPlaygroundViewEffect.OpenForData(
                             configuration = FinancialConnectionsSheet.Configuration(
                                 financialConnectionsSessionClientSecret = it.clientSecret,
                                 publishableKey = it.publishableKey,
-                                stripeAccountId = _state.value.stripeAccountId
+                                stripeAccountId = stripeAccount.takeIf(String::isNotBlank),
                             )
                         )
                     )
@@ -207,6 +214,7 @@ internal class FinancialConnectionsPlaygroundViewModel(
                 // Success creating session: open the financial connections sheet with received secret
                 .onSuccess {
                     showLoadingWithMessage("Session created, opening FinancialConnectionsSheet.")
+
                     _state.update { current -> current.copy(publishableKey = it.publishableKey) }
                     _viewEffect.emit(
                         FinancialConnectionsPlaygroundViewEffect.OpenForToken(
@@ -502,6 +510,7 @@ sealed class FinancialConnectionsPlaygroundViewEffect {
         val ephemeralKey: String?,
         val customerId: String?,
         val publishableKey: String,
+        val stripeAccountId: String?,
         val experience: Experience,
         val integrationType: IntegrationType,
         val elementsSessionContext: ElementsSessionContext,

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/StripeAccountIdSetting.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/StripeAccountIdSetting.kt
@@ -23,7 +23,7 @@ internal data class StripeAccountIdSetting(
     )
 
     override fun shouldDisplay(merchant: Merchant, flow: Flow, experience: Experience): Boolean {
-        return experience == Experience.FinancialConnections && flow == Flow.Data
+        return experience == Experience.FinancialConnections
     }
 
     override fun valueUpdated(

--- a/maestro/financial-connections/Testmode-Token-NME.yaml
+++ b/maestro/financial-connections/Testmode-Token-NME.yaml
@@ -17,6 +17,9 @@ tags:
     id: "Customer email setting"
 - inputRandomEmail
 - hideKeyboard
+- scrollUntilVisible:
+    element:
+      id: "connect_accounts"
 - tapOn:
     id: "connect_accounts"
 # Wait until the consent button is visible


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes a Connect-related issue in the Financial Connections playground, which caused the flow to not display the connect account logo in the consent pane.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
