### PR TITLE
Prepare play integrity and launch web on failure

### DIFF
--- a/example/dependencies/dependencies.txt
+++ b/example/dependencies/dependencies.txt
@@ -828,6 +828,13 @@
 |    |    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3 (*)
 |    |    |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.0.21 (*)
 |    |    +--- project :stripe-ui-core (*)
+|    |    +--- project :stripe-attestation
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:2.0.21 (*)
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0 (*)
+|    |    |    \--- com.google.android.play:integrity:1.4.0
+|    |    |         +--- com.google.android.gms:play-services-basement:18.4.0 (*)
+|    |    |         +--- com.google.android.gms:play-services-tasks:18.2.0 (*)
+|    |    |         \--- com.google.android.play:core-common:2.0.4
 |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0 (*)
 |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0 (*)
 |    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3 (*)
@@ -956,13 +963,7 @@
 |    +--- project :stripe-ui-core (*)
 |    +--- project :payments-model (*)
 |    +--- org.jetbrains.kotlin:kotlin-stdlib:2.0.21 (*)
-|    +--- project :stripe-attestation
-|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:2.0.21 (*)
-|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0 (*)
-|    |    \--- com.google.android.play:integrity:1.4.0
-|    |         +--- com.google.android.gms:play-services-basement:18.4.0 (*)
-|    |         +--- com.google.android.gms:play-services-tasks:18.2.0 (*)
-|    |         \--- com.google.android.play:core-common:2.0.4
+|    +--- project :stripe-attestation (*)
 |    +--- androidx.activity:activity-ktx:1.8.2 (*)
 |    +--- androidx.annotation:annotation:1.9.0 (*)
 |    +--- androidx.appcompat:appcompat:1.7.0 (*)

--- a/financial-connections-example/dependencies/dependencies.txt
+++ b/financial-connections-example/dependencies/dependencies.txt
@@ -944,6 +944,7 @@
 |    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3 (*)
 |    |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.0.21 (*)
 |    +--- project :stripe-ui-core (*)
+|    +--- project :stripe-attestation (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3 (*)

--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -195,6 +195,9 @@ interface ErrorReporter : FraudDetectionErrorReporter {
         LINK_WEB_FAILED_TO_PARSE_RESULT_URI(
             partialEventName = "link.web.result.parsing_failed"
         ),
+        LINK_NATIVE_FAILED_TO_PREPARE_INTEGRITY_MANAGER(
+            partialEventName = "link.native.integrity.preparation_failed"
+        ),
         PAYMENT_SHEET_AUTHENTICATORS_NOT_FOUND(
             partialEventName = "paymentsheet.authenticators.not_found"
         ),

--- a/payments/dependencies/dependencies.txt
+++ b/payments/dependencies/dependencies.txt
@@ -823,6 +823,13 @@
 |    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3 (*)
 |    |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.0.21 (*)
 |    +--- project :stripe-ui-core (*)
+|    +--- project :stripe-attestation
+|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:2.0.21 (*)
+|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0 (*)
+|    |    \--- com.google.android.play:integrity:1.4.0
+|    |         +--- com.google.android.gms:play-services-basement:18.4.0 (*)
+|    |         +--- com.google.android.gms:play-services-tasks:18.2.0 (*)
+|    |         \--- com.google.android.play:core-common:2.0.4
 |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3 (*)

--- a/paymentsheet-example/dependencies/dependencies.txt
+++ b/paymentsheet-example/dependencies/dependencies.txt
@@ -860,6 +860,13 @@
 |    |    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3 (*)
 |    |    |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.0.21 (*)
 |    |    +--- project :stripe-ui-core (*)
+|    |    +--- project :stripe-attestation
+|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:2.0.21 (*)
+|    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0 (*)
+|    |    |    \--- com.google.android.play:integrity:1.4.0
+|    |    |         +--- com.google.android.gms:play-services-basement:18.4.0 (*)
+|    |    |         +--- com.google.android.gms:play-services-tasks:18.2.0 (*)
+|    |    |         \--- com.google.android.play:core-common:2.0.4
 |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0 (*)
 |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0 (*)
 |    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3 (*)
@@ -1100,13 +1107,7 @@
 |    +--- project :stripe-ui-core (*)
 |    +--- project :payments-model (*)
 |    +--- org.jetbrains.kotlin:kotlin-stdlib:2.0.21 (*)
-|    +--- project :stripe-attestation
-|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:2.0.21 (*)
-|    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0 (*)
-|    |    \--- com.google.android.play:integrity:1.4.0
-|    |         +--- com.google.android.gms:play-services-basement:18.4.0 (*)
-|    |         +--- com.google.android.gms:play-services-tasks:18.2.0 (*)
-|    |         \--- com.google.android.play:core-common:2.0.4
+|    +--- project :stripe-attestation (*)
 |    +--- androidx.activity:activity-ktx:1.8.2 (*)
 |    +--- androidx.annotation:annotation:1.9.0 (*)
 |    +--- androidx.appcompat:appcompat:1.7.0 (*)

--- a/paymentsheet/build.gradle
+++ b/paymentsheet/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     implementation project(':payments-ui-core')
     implementation project(':stripe-ui-core')
     compileOnly project(':financial-connections')
+    implementation project(":stripe-attestation")
 
     // Kotlin
     implementation libs.kotlin.coroutines

--- a/paymentsheet/dependencies/dependencies.txt
+++ b/paymentsheet/dependencies/dependencies.txt
@@ -821,6 +821,13 @@
 |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3 (*)
 |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.0.21 (*)
 +--- project :stripe-ui-core (*)
++--- project :stripe-attestation
+|    +--- org.jetbrains.kotlin:kotlin-stdlib:2.0.21 (*)
+|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0 (*)
+|    \--- com.google.android.play:integrity:1.4.0
+|         +--- com.google.android.gms:play-services-basement:18.4.0 (*)
+|         +--- com.google.android.gms:play-services-tasks:18.2.0 (*)
+|         \--- com.google.android.play:core-common:2.0.4
 +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0 (*)
 +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0 (*)
 +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3 (*)

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivity.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.result.ActivityResultLauncher
 import androidx.annotation.VisibleForTesting
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.ModalBottomSheetValue
@@ -40,6 +41,7 @@ internal class LinkActivity : ComponentActivity() {
 
     @VisibleForTesting
     internal lateinit var navController: NavHostController
+    private var webLauncher: ActivityResultLauncher<LinkActivityContract.Args>? = null
 
     @OptIn(ExperimentalMaterialApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -58,6 +60,10 @@ internal class LinkActivity : ComponentActivity() {
             activityResultCaller = this,
             lifecycleOwner = this,
         )
+
+        webLauncher = registerForActivityResult(vm.activityRetainedComponent.webLinkActivityContract) { result ->
+            dismissWithResult(result)
+        }
 
         setContent {
             var bottomSheetContent by remember { mutableStateOf<BottomSheetContent?>(null) }
@@ -79,6 +85,7 @@ internal class LinkActivity : ComponentActivity() {
                 viewModel?.let {
                     it.navController = navController
                     it.dismissWithResult = ::dismissWithResult
+                    it.launchWebFlow = ::launchWebFlow
                     lifecycle.addObserver(it)
                 }
             }
@@ -129,6 +136,10 @@ internal class LinkActivity : ComponentActivity() {
         ) {
             content()
         }
+    }
+
+    fun launchWebFlow(configuration: LinkConfiguration) {
+        webLauncher?.launch(LinkActivityContract.Args(configuration))
     }
 
     companion object {

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkEventException.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkEventException.kt
@@ -2,4 +2,4 @@ package com.stripe.android.link
 
 import com.stripe.android.core.exception.StripeException
 
-class LinkEventException(override val cause: Throwable): StripeException(cause = cause)
+internal class LinkEventException(override val cause: Throwable) : StripeException(cause = cause)

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkEventException.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkEventException.kt
@@ -1,0 +1,5 @@
+package com.stripe.android.link
+
+import com.stripe.android.core.exception.StripeException
+
+class LinkEventException(override val cause: Throwable): StripeException(cause = cause)

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkViewModelModule.kt
@@ -2,8 +2,10 @@ package com.stripe.android.link.injection
 
 import com.stripe.android.link.LinkActivityViewModel
 import com.stripe.android.link.account.LinkAccountManager
+import com.stripe.android.link.gate.LinkGate
 import com.stripe.android.paymentelement.confirmation.DefaultConfirmationHandler
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.attestation.IntegrityRequestManager
 import dagger.Module
 import dagger.Provides
 
@@ -15,13 +17,17 @@ internal object LinkViewModelModule {
         component: NativeLinkComponent,
         defaultConfirmationHandlerFactory: DefaultConfirmationHandler.Factory,
         linkAccountManager: LinkAccountManager,
-        eventReporter: EventReporter
+        eventReporter: EventReporter,
+        integrityRequestManager: IntegrityRequestManager,
+        linkGate: LinkGate
     ): LinkActivityViewModel {
         return LinkActivityViewModel(
             activityRetainedComponent = component,
             confirmationHandlerFactory = defaultConfirmationHandlerFactory,
             linkAccountManager = linkAccountManager,
-            eventReporter = eventReporter
+            eventReporter = eventReporter,
+            integrityRequestManager = integrityRequestManager,
+            linkGate = linkGate
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkViewModelModule.kt
@@ -4,6 +4,7 @@ import com.stripe.android.link.LinkActivityViewModel
 import com.stripe.android.link.account.LinkAccountManager
 import com.stripe.android.link.gate.LinkGate
 import com.stripe.android.paymentelement.confirmation.DefaultConfirmationHandler
+import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.attestation.IntegrityRequestManager
 import dagger.Module
@@ -19,7 +20,8 @@ internal object LinkViewModelModule {
         linkAccountManager: LinkAccountManager,
         eventReporter: EventReporter,
         integrityRequestManager: IntegrityRequestManager,
-        linkGate: LinkGate
+        linkGate: LinkGate,
+        errorReporter: ErrorReporter
     ): LinkActivityViewModel {
         return LinkActivityViewModel(
             activityRetainedComponent = component,
@@ -27,7 +29,8 @@ internal object LinkViewModelModule {
             linkAccountManager = linkAccountManager,
             eventReporter = eventReporter,
             integrityRequestManager = integrityRequestManager,
-            linkGate = linkGate
+            linkGate = linkGate,
+            errorReporter = errorReporter
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkComponent.kt
@@ -15,7 +15,6 @@ import com.stripe.android.link.analytics.LinkEventsReporter
 import com.stripe.android.link.confirmation.LinkConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.injection.DefaultConfirmationModule
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
-import com.stripe.attestation.IntegrityRequestManager
 import dagger.BindsInstance
 import dagger.Component
 import javax.inject.Named
@@ -41,7 +40,6 @@ internal interface NativeLinkComponent {
     val linkConfirmationHandlerFactory: LinkConfirmationHandler.Factory
     val webLinkActivityContract: WebLinkActivityContract
     val cardAccountRangeRepositoryFactory: CardAccountRangeRepository.Factory
-    val integrityRequestManager: IntegrityRequestManager
     val viewModel: LinkActivityViewModel
 
     @Component.Builder

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkComponent.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.link.injection
 
+import android.app.Application
 import android.content.Context
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.cards.CardAccountRangeRepository
@@ -8,11 +9,13 @@ import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.link.LinkActivityViewModel
 import com.stripe.android.link.LinkConfiguration
+import com.stripe.android.link.WebLinkActivityContract
 import com.stripe.android.link.account.LinkAccountManager
 import com.stripe.android.link.analytics.LinkEventsReporter
 import com.stripe.android.link.confirmation.LinkConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.injection.DefaultConfirmationModule
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
+import com.stripe.attestation.IntegrityRequestManager
 import dagger.BindsInstance
 import dagger.Component
 import javax.inject.Named
@@ -36,7 +39,9 @@ internal interface NativeLinkComponent {
     val linkEventsReporter: LinkEventsReporter
     val logger: Logger
     val linkConfirmationHandlerFactory: LinkConfirmationHandler.Factory
+    val webLinkActivityContract: WebLinkActivityContract
     val cardAccountRangeRepositoryFactory: CardAccountRangeRepository.Factory
+    val integrityRequestManager: IntegrityRequestManager
     val viewModel: LinkActivityViewModel
 
     @Component.Builder
@@ -58,6 +63,9 @@ internal interface NativeLinkComponent {
 
         @BindsInstance
         fun statusBarColor(@Named(STATUS_BAR_COLOR) statusBarColor: Int?): Builder
+
+        @BindsInstance
+        fun application(application: Application): Builder
 
         fun build(): NativeLinkComponent
     }

--- a/paymentsheet/src/test/java/com/stripe/android/link/FakeIntegrityRequestManager.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/FakeIntegrityRequestManager.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.link
+
+import app.cash.turbine.Turbine
+import com.stripe.attestation.IntegrityRequestManager
+
+internal class FakeIntegrityRequestManager : IntegrityRequestManager {
+    var prepareResult: Result<Unit> = Result.success(Unit)
+    var requestResult: Result<String> = Result.success(TestFactory.VERIFICATION_TOKEN)
+    private val prepareCalls = Turbine<Unit>()
+    private val requestTokenCalls = Turbine<String?>()
+
+    override suspend fun prepare(): Result<Unit> {
+        prepareCalls.add(Unit)
+        return prepareResult
+    }
+
+    override suspend fun requestToken(requestIdentifier: String?): Result<String> {
+        requestTokenCalls.add(requestIdentifier)
+        return requestResult
+    }
+
+    suspend fun awaitPrepareCall() {
+        return prepareCalls.awaitItem()
+    }
+
+    suspend fun awaitRequestTokenCall(): String? {
+        return requestTokenCalls.awaitItem()
+    }
+
+    fun ensureAllEventsConsumed() {
+        prepareCalls.ensureAllEventsConsumed()
+        requestTokenCalls.ensureAllEventsConsumed()
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
@@ -514,6 +514,5 @@ private class FakeNativeLinkComponent(
     override val webLinkActivityContract: WebLinkActivityContract = mock(),
     override val cardAccountRangeRepositoryFactory: CardAccountRangeRepository.Factory =
         NullCardAccountRangeRepositoryFactory,
-    override val integrityRequestManager: IntegrityRequestManager = FakeIntegrityRequestManager(),
     override val viewModel: LinkActivityViewModel = mock()
 ) : NativeLinkComponent

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
@@ -19,15 +19,27 @@ import androidx.navigation.PopUpToBuilder
 import androidx.savedstate.SavedStateRegistryOwner
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.cards.CardAccountRangeRepository
+import com.stripe.android.core.Logger
 import com.stripe.android.link.account.FakeLinkAccountManager
 import com.stripe.android.link.account.LinkAccountManager
+import com.stripe.android.link.analytics.FakeLinkEventsReporter
+import com.stripe.android.link.analytics.LinkEventsReporter
+import com.stripe.android.link.confirmation.FakeLinkConfirmationHandler
+import com.stripe.android.link.confirmation.LinkConfirmationHandler
+import com.stripe.android.link.gate.FakeLinkGate
+import com.stripe.android.link.gate.LinkGate
+import com.stripe.android.link.injection.NativeLinkComponent
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.testing.CoroutineTestRule
+import com.stripe.android.testing.FakeLogger
 import com.stripe.android.utils.DummyActivityResultCaller
+import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
+import com.stripe.attestation.IntegrityRequestManager
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -295,6 +307,109 @@ internal class LinkActivityViewModelTest {
         )
     }
 
+    @Test
+    fun `onCreate should launch web when attestation fails and useAttestationEndpoints is enabled`() = runTest {
+        var launchWebConfig: LinkConfiguration? = null
+        val linkAccountManager = FakeLinkAccountManager()
+        val navController = navController()
+        val linkGate = FakeLinkGate()
+        val integrityRequestManager = FakeIntegrityRequestManager()
+
+        integrityRequestManager.prepareResult = Result.failure(Throwable("oops"))
+        linkGate.setUseAttestationEndpoints(true)
+
+        val vm = createViewModel(
+            linkAccountManager = linkAccountManager,
+            linkGate = linkGate,
+            integrityRequestManager = integrityRequestManager,
+            launchWeb = { config ->
+                launchWebConfig = config
+            }
+        )
+        vm.navController = navController
+        linkAccountManager.setAccountStatus(AccountStatus.Verified)
+
+        vm.onCreate(mock())
+
+        advanceUntilIdle()
+
+        integrityRequestManager.awaitPrepareCall()
+        assertNavigation(
+            navController = navController,
+            screen = LinkScreen.Loading,
+            clearStack = true,
+            launchSingleTop = false
+        )
+        assertThat(launchWebConfig).isNotNull()
+        integrityRequestManager.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `onCreate shouldn't launch web when integrity preparation passes and useAttestationEndpoints is enabled`() =
+        runTest {
+            var launchWebConfig: LinkConfiguration? = null
+            val linkAccountManager = FakeLinkAccountManager()
+            val navController = navController()
+            val linkGate = FakeLinkGate()
+            val integrityRequestManager = FakeIntegrityRequestManager()
+
+            linkGate.setUseAttestationEndpoints(true)
+
+            val vm = createViewModel(
+                linkAccountManager = linkAccountManager,
+                linkGate = linkGate,
+                integrityRequestManager = integrityRequestManager,
+                launchWeb = { config ->
+                    launchWebConfig = config
+                }
+            )
+            vm.navController = navController
+            linkAccountManager.setAccountStatus(AccountStatus.Verified)
+
+            vm.onCreate(mock())
+
+            advanceUntilIdle()
+
+            integrityRequestManager.awaitPrepareCall()
+            assertNavigation(
+                navController = navController,
+                screen = LinkScreen.Wallet,
+                clearStack = true,
+                launchSingleTop = true
+            )
+            assertThat(launchWebConfig).isNull()
+            integrityRequestManager.ensureAllEventsConsumed()
+        }
+
+    @Test
+    fun `onCreate should not prepare integrity when useAttestationEndpoints is disabled`() = runTest {
+        var launchWebConfig: LinkConfiguration? = null
+        val linkAccountManager = FakeLinkAccountManager()
+        val navController = navController()
+        val linkGate = FakeLinkGate()
+        val integrityRequestManager = FakeIntegrityRequestManager()
+
+        linkGate.setUseAttestationEndpoints(false)
+
+        val vm = createViewModel(
+            linkAccountManager = linkAccountManager,
+            linkGate = linkGate,
+            integrityRequestManager = integrityRequestManager,
+            launchWeb = { config ->
+                launchWebConfig = config
+            }
+        )
+        vm.navController = navController
+        linkAccountManager.setAccountStatus(AccountStatus.Verified)
+
+        vm.onCreate(mock())
+
+        advanceUntilIdle()
+
+        assertThat(launchWebConfig).isNull()
+        integrityRequestManager.ensureAllEventsConsumed()
+    }
+
     private fun navController(): NavHostController {
         val navController: NavHostController = mock()
         val mockGraph: NavGraph = mock()
@@ -342,16 +457,22 @@ internal class LinkActivityViewModelTest {
         confirmationHandler: ConfirmationHandler = FakeConfirmationHandler(),
         eventReporter: EventReporter = FakeEventReporter(),
         navController: NavHostController = navController(),
-        dismissWithResult: (LinkActivityResult) -> Unit = {}
+        integrityRequestManager: IntegrityRequestManager = FakeIntegrityRequestManager(),
+        linkGate: LinkGate = FakeLinkGate(),
+        dismissWithResult: (LinkActivityResult) -> Unit = {},
+        launchWeb: (LinkConfiguration) -> Unit = {}
     ): LinkActivityViewModel {
         return LinkActivityViewModel(
             linkAccountManager = linkAccountManager,
-            activityRetainedComponent = mock(),
+            activityRetainedComponent = FakeNativeLinkComponent(),
             eventReporter = eventReporter,
-            confirmationHandlerFactory = { confirmationHandler }
+            confirmationHandlerFactory = { confirmationHandler },
+            integrityRequestManager = integrityRequestManager,
+            linkGate = linkGate
         ).apply {
             this.navController = navController
             this.dismissWithResult = dismissWithResult
+            this.launchWebFlow = launchWeb
         }
     }
 
@@ -371,3 +492,18 @@ internal class LinkActivityViewModelTest {
         private const val FAKE_GRAPH_ID = 123
     }
 }
+
+private class FakeNativeLinkComponent(
+    override val linkAccountManager: LinkAccountManager = FakeLinkAccountManager(),
+    override val configuration: LinkConfiguration = TestFactory.LINK_CONFIGURATION,
+    override val linkEventsReporter: LinkEventsReporter = FakeLinkEventsReporter(),
+    override val logger: Logger = FakeLogger(),
+    override val linkConfirmationHandlerFactory: LinkConfirmationHandler.Factory = LinkConfirmationHandler.Factory {
+        FakeLinkConfirmationHandler()
+    },
+    override val webLinkActivityContract: WebLinkActivityContract = mock(),
+    override val cardAccountRangeRepositoryFactory: CardAccountRangeRepository.Factory =
+        NullCardAccountRangeRepositoryFactory,
+    override val integrityRequestManager: IntegrityRequestManager = FakeIntegrityRequestManager(),
+    override val viewModel: LinkActivityViewModel = mock()
+) : NativeLinkComponent

--- a/stripe-test-e2e/dependencies/dependencies.txt
+++ b/stripe-test-e2e/dependencies/dependencies.txt
@@ -825,6 +825,13 @@
      |    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3 (*)
      |    |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.0.21 (*)
      |    +--- project :stripe-ui-core (*)
+     |    +--- project :stripe-attestation
+     |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:2.0.21 (*)
+     |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0 (*)
+     |    |    \--- com.google.android.play:integrity:1.4.0
+     |    |         +--- com.google.android.gms:play-services-basement:18.4.0 (*)
+     |    |         +--- com.google.android.gms:play-services-tasks:18.2.0 (*)
+     |    |         \--- com.google.android.play:core-common:2.0.4
      |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0 (*)
      |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0 (*)
      |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3 (*)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
* Prepare integrity manager when `useAttestationEndpoints` is enabled
* Short-circuit to the web flow if integrity manager fails to prepare

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
[JIRA](https://jira.corp.stripe.com/browse/MOBILESDK-3007)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots

https://github.com/user-attachments/assets/26f174c9-c808-4b8f-b0fc-3d1d7471a9ae



# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
