### PR TITLE
Show details cannot be changed copy for CBF/CBC

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
@@ -26,6 +26,7 @@ internal interface UpdatePaymentMethodInteractor {
     val cardBrandFilter: CardBrandFilter
     val isExpiredCard: Boolean
     val isModifiablePaymentMethod: Boolean
+    val hasValidBrandChoices: Boolean
 
     val state: StateFlow<State>
 
@@ -89,7 +90,7 @@ internal class DefaultUpdatePaymentMethodInteractor(
     private val cardBrandChoice = MutableStateFlow(getInitialCardBrandChoice())
     private val cardBrandHasBeenChanged = MutableStateFlow(false)
     private val savedCardBrand = MutableStateFlow(getInitialCardBrandChoice())
-
+    override val hasValidBrandChoices = hasValidBrandChoices()
     override val isExpiredCard = paymentMethodIsExpiredCard()
     override val screenTitle: ResolvableString? = UpdatePaymentMethodInteractor.screenTitle(
         displayableSavedPaymentMethod
@@ -188,6 +189,13 @@ internal class DefaultUpdatePaymentMethodInteractor(
         } else {
             null
         }
+    }
+
+    private fun hasValidBrandChoices(): Boolean {
+        val filteredCardBrands = displayableSavedPaymentMethod.paymentMethod.card?.networks?.available?.map {
+            CardBrand.fromCode(it)
+        }?.filter { cardBrandFilter.isAccepted(it) }
+        return (filteredCardBrands?.size ?: 0) > 1
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
@@ -89,7 +89,7 @@ internal fun UpdatePaymentMethodUI(interactor: UpdatePaymentMethodInteractor, mo
 
         if (!interactor.isExpiredCard) {
             interactor.displayableSavedPaymentMethod.getDetailsCannotBeChangedText(
-                shouldShowCardBrandDropdown = shouldShowCardBrandDropdown,
+                canUpdateCardBrand = shouldShowCardBrandDropdown && interactor.hasValidBrandChoices,
             )?.let {
                 Text(
                     text = it.resolve(context),
@@ -498,12 +498,12 @@ private fun PreviewUpdatePaymentMethodUI() {
 }
 
 private fun DisplayableSavedPaymentMethod.getDetailsCannotBeChangedText(
-    shouldShowCardBrandDropdown: Boolean,
+    canUpdateCardBrand: Boolean,
 ): ResolvableString? {
     return (
         when (savedPaymentMethod) {
             is SavedPaymentMethod.Card ->
-                if (shouldShowCardBrandDropdown) {
+                if (canUpdateCardBrand) {
                     PaymentSheetR.string.stripe_paymentsheet_only_card_brand_can_be_changed
                 } else {
                     PaymentSheetR.string.stripe_paymentsheet_card_details_cannot_be_changed

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeUpdatePaymentMethodInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeUpdatePaymentMethodInteractor.kt
@@ -13,6 +13,8 @@ internal class FakeUpdatePaymentMethodInteractor(
     override val canRemove: Boolean,
     override val isExpiredCard: Boolean,
     override val isModifiablePaymentMethod: Boolean,
+    override val hasValidBrandChoices: Boolean = false,
+    override val cardBrandFilter: CardBrandFilter = DefaultCardBrandFilter,
     val viewActionRecorder: ViewActionRecorder<UpdatePaymentMethodInteractor.ViewAction>?,
     initialState: UpdatePaymentMethodInteractor.State,
 ) : UpdatePaymentMethodInteractor {
@@ -20,7 +22,6 @@ internal class FakeUpdatePaymentMethodInteractor(
     override val screenTitle: ResolvableString? = UpdatePaymentMethodInteractor.screenTitle(
         displayableSavedPaymentMethod
     )
-    override val cardBrandFilter: CardBrandFilter = DefaultCardBrandFilter
     override val topBarState: PaymentSheetTopBarState = PaymentSheetTopBarStateFactory.create(
         isLiveMode = false,
         editable = PaymentSheetTopBarState.Editable.Never,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeUpdatePaymentMethodInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeUpdatePaymentMethodInteractor.kt
@@ -13,7 +13,7 @@ internal class FakeUpdatePaymentMethodInteractor(
     override val canRemove: Boolean,
     override val isExpiredCard: Boolean,
     override val isModifiablePaymentMethod: Boolean,
-    override val hasValidBrandChoices: Boolean = false,
+    override val hasValidBrandChoices: Boolean = true,
     override val cardBrandFilter: CardBrandFilter = DefaultCardBrandFilter,
     val viewActionRecorder: ViewActionRecorder<UpdatePaymentMethodInteractor.ViewAction>?,
     initialState: UpdatePaymentMethodInteractor.State,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreenUpdatePaymentMethodScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreenUpdatePaymentMethodScreenshotTest.kt
@@ -38,6 +38,7 @@ internal class PaymentSheetScreenUpdatePaymentMethodScreenshotTest {
                 canRemove = true,
                 initialCardBrand = CardBrand.CartesBancaires,
                 isModifiablePaymentMethod = true,
+                hasValidBrandChoices = true
             )
         }
     }
@@ -52,6 +53,7 @@ internal class PaymentSheetScreenUpdatePaymentMethodScreenshotTest {
                 canRemove = false,
                 initialCardBrand = CardBrand.CartesBancaires,
                 isModifiablePaymentMethod = true,
+                hasValidBrandChoices = true
             )
         }
     }
@@ -117,6 +119,7 @@ internal class PaymentSheetScreenUpdatePaymentMethodScreenshotTest {
         initialCardBrand: CardBrand = CardBrand.Unknown,
         isExpiredCard: Boolean = false,
         error: String? = null,
+        hasValidBrandChoices: Boolean = false
     ) {
         val interactor = FakeUpdatePaymentMethodInteractor(
             displayableSavedPaymentMethod = paymentMethod,
@@ -124,6 +127,7 @@ internal class PaymentSheetScreenUpdatePaymentMethodScreenshotTest {
             isExpiredCard = isExpiredCard,
             isModifiablePaymentMethod = isModifiablePaymentMethod,
             viewActionRecorder = null,
+            hasValidBrandChoices = hasValidBrandChoices,
             initialState = UpdatePaymentMethodInteractor.State(
                 error = error?.resolvableString,
                 status = UpdatePaymentMethodInteractor.Status.Idle,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreenUpdatePaymentMethodScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreenUpdatePaymentMethodScreenshotTest.kt
@@ -38,7 +38,6 @@ internal class PaymentSheetScreenUpdatePaymentMethodScreenshotTest {
                 canRemove = true,
                 initialCardBrand = CardBrand.CartesBancaires,
                 isModifiablePaymentMethod = true,
-                hasValidBrandChoices = true
             )
         }
     }
@@ -53,7 +52,6 @@ internal class PaymentSheetScreenUpdatePaymentMethodScreenshotTest {
                 canRemove = false,
                 initialCardBrand = CardBrand.CartesBancaires,
                 isModifiablePaymentMethod = true,
-                hasValidBrandChoices = true
             )
         }
     }
@@ -119,7 +117,6 @@ internal class PaymentSheetScreenUpdatePaymentMethodScreenshotTest {
         initialCardBrand: CardBrand = CardBrand.Unknown,
         isExpiredCard: Boolean = false,
         error: String? = null,
-        hasValidBrandChoices: Boolean = false
     ) {
         val interactor = FakeUpdatePaymentMethodInteractor(
             displayableSavedPaymentMethod = paymentMethod,
@@ -127,7 +124,6 @@ internal class PaymentSheetScreenUpdatePaymentMethodScreenshotTest {
             isExpiredCard = isExpiredCard,
             isModifiablePaymentMethod = isModifiablePaymentMethod,
             viewActionRecorder = null,
-            hasValidBrandChoices = hasValidBrandChoices,
             initialState = UpdatePaymentMethodInteractor.State(
                 error = error?.resolvableString,
                 status = UpdatePaymentMethodInteractor.Status.Idle,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUITest.kt
@@ -304,7 +304,8 @@ class UpdatePaymentMethodUITest {
             displayableSavedPaymentMethod = PaymentMethodFixtures
                 .CARD_WITH_NETWORKS_PAYMENT_METHOD
                 .toDisplayableSavedPaymentMethod(),
-            cardBrandFilter = cardBrandFilter
+            cardBrandFilter = cardBrandFilter,
+            hasValidBrandChoices = false
         ) {
             composeRule.onNodeWithTag(UPDATE_PM_DETAILS_SUBTITLE_TEST_TAG).assertTextEquals(
                 "Card details cannot be changed."
@@ -483,6 +484,7 @@ class UpdatePaymentMethodUITest {
         cardBrandHasBeenChanged: Boolean = false,
         canRemove: Boolean = true,
         isModifiablePaymentMethod: Boolean = true,
+        hasValidBrandChoices: Boolean = true,
         cardBrandFilter: CardBrandFilter = DefaultCardBrandFilter,
         testBlock: Scenario.() -> Unit,
     ) {
@@ -494,6 +496,7 @@ class UpdatePaymentMethodUITest {
             isModifiablePaymentMethod = isModifiablePaymentMethod,
             cardBrandFilter = cardBrandFilter,
             viewActionRecorder = viewActionRecorder,
+            hasValidBrandChoices = hasValidBrandChoices,
             initialState = UpdatePaymentMethodInteractor.State(
                 error = errorMessage,
                 status = UpdatePaymentMethodInteractor.Status.Idle,


### PR DESCRIPTION
# Summary
- We just made some changes that modify the behavior with card brand filtering and card brand choice.
- Previously, blocked card brands were filtered out of the CBC drop down, but now they are shown in the dropdown as disabled.
- We need the copy on the form in the update view to know whether there are blocked brands in the drop down and if the user can update their card brand.

# Motivation
- Card Brand Filtering <> Default PMs

# Testing
- Manual
- New unit test

# Changelog
N/A (CBF is private beta)