### PR TITLE
Restore `UserInput` when `PaymentSelection` is Link Inline Signup

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkInlineSignupAssistedViewModelFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkInlineSignupAssistedViewModelFactory.kt
@@ -2,9 +2,10 @@ package com.stripe.android.link.injection
 
 import com.stripe.android.link.ui.inline.InlineSignupViewModel
 import com.stripe.android.link.ui.inline.LinkSignupMode
+import com.stripe.android.link.ui.inline.UserInput
 import dagger.assisted.AssistedFactory
 
 @AssistedFactory
 internal interface LinkInlineSignupAssistedViewModelFactory {
-    fun create(signupMode: LinkSignupMode): InlineSignupViewModel
+    fun create(signupMode: LinkSignupMode, initialUserInput: UserInput?): InlineSignupViewModel
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/inline/InlineSignupViewState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/inline/InlineSignupViewState.kt
@@ -47,7 +47,8 @@ constructor(
 
         fun create(
             signupMode: LinkSignupMode,
-            config: LinkConfiguration
+            config: LinkConfiguration,
+            isExpanded: Boolean = false,
         ): InlineSignupViewState {
             val isAlternativeFlow = signupMode == LinkSignupMode.AlongsideSaveForFutureUse
             val customer = config.customerInfo
@@ -89,6 +90,7 @@ constructor(
                 signupMode = signupMode,
                 fields = fields,
                 prefillEligibleFields = prefillEligibleFields,
+                isExpanded = isExpanded,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/inline/LinkElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/inline/LinkElement.kt
@@ -17,6 +17,7 @@ import java.util.UUID
 
 @Composable
 internal fun LinkElement(
+    initialUserInput: UserInput?,
     linkConfigurationCoordinator: LinkConfigurationCoordinator,
     configuration: LinkConfiguration,
     linkSignupMode: LinkSignupMode,
@@ -34,6 +35,7 @@ internal fun LinkElement(
     val viewModel: InlineSignupViewModel = viewModel(
         key = uuid,
         factory = InlineSignupViewModel.Factory(
+            initialUserInput = initialUserInput,
             signupMode = linkSignupMode,
             linkComponent = component,
         )

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignupFields.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignupFields.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
@@ -93,7 +94,7 @@ internal fun LinkInlineSignupFields(
                 onShowingAllFields()
             }
 
-            Column(modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.fillMaxWidth().testTag(LINK_INLINE_SIGNUP_REMAINING_FIELDS_TEST_TAG)) {
                 Divider(
                     color = MaterialTheme.stripeColors.componentDivider,
                     thickness = MaterialTheme.stripeShapes.borderStrokeWidth.dp,
@@ -158,3 +159,5 @@ internal fun LinkInlineSignupFields(
         }
     }
 }
+
+internal const val LINK_INLINE_SIGNUP_REMAINING_FIELDS_TEST_TAG = "LinkInlineSignupRemainingFields"

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionFactory.kt
@@ -4,6 +4,7 @@ import com.stripe.android.CardBrandFilter
 import com.stripe.android.cards.CardAccountRangeRepository
 import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.link.ui.inline.InlineSignupViewState
+import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.lpmfoundations.FormHeaderInformation
 import com.stripe.android.lpmfoundations.luxe.InitialValuesFactory
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
@@ -23,6 +24,7 @@ internal sealed interface UiDefinitionFactory {
         val cardAccountRangeRepositoryFactory: CardAccountRangeRepository.Factory,
         val linkConfigurationCoordinator: LinkConfigurationCoordinator?,
         val initialValues: Map<IdentifierSpec, String?>,
+        val initialLinkUserInput: UserInput?,
         val shippingValues: Map<IdentifierSpec, String?>?,
         val saveForFutureUseInitialValue: Boolean,
         val merchantName: String,
@@ -44,6 +46,7 @@ internal sealed interface UiDefinitionFactory {
                 private val onLinkInlineSignupStateChanged: (InlineSignupViewState) -> Unit,
                 private val paymentMethodCreateParams: PaymentMethodCreateParams? = null,
                 private val paymentMethodExtraParams: PaymentMethodExtraParams? = null,
+                private val initialLinkUserInput: UserInput? = null,
             ) : Factory {
                 override fun create(
                     metadata: PaymentMethodMetadata,
@@ -65,6 +68,7 @@ internal sealed interface UiDefinitionFactory {
                         requiresMandate = requiresMandate,
                         onLinkInlineSignupStateChanged = onLinkInlineSignupStateChanged,
                         cardBrandFilter = metadata.cardBrandFilter,
+                        initialLinkUserInput = initialLinkUserInput,
                     )
                 }
             }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -120,6 +120,7 @@ private object CardUiDefinitionFactory : UiDefinitionFactory.Simple {
                     LinkFormElement(
                         configuration = metadata.linkInlineConfiguration,
                         linkConfigurationCoordinator = arguments.linkConfigurationCoordinator,
+                        initialLinkUserInput = arguments.initialLinkUserInput,
                         onLinkInlineSignupStateChanged = arguments.onLinkInlineSignupStateChanged,
                     )
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElement.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.link.ui.inline.InlineSignupViewState
 import com.stripe.android.link.ui.inline.LinkElement
+import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.ui.core.elements.RenderableFormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.forms.FormFieldEntry
@@ -13,6 +14,7 @@ import kotlinx.coroutines.flow.StateFlow
 internal class LinkFormElement(
     private val configuration: LinkInlineConfiguration,
     private val linkConfigurationCoordinator: LinkConfigurationCoordinator,
+    private val initialLinkUserInput: UserInput?,
     private val onLinkInlineSignupStateChanged: (InlineSignupViewState) -> Unit,
 ) : RenderableFormElement(
     allowsUserInteraction = true,
@@ -25,6 +27,7 @@ internal class LinkFormElement(
     @Composable
     override fun ComposeUI(enabled: Boolean) {
         LinkElement(
+            initialUserInput = initialLinkUserInput,
             linkConfigurationCoordinator = linkConfigurationCoordinator,
             linkSignupMode = configuration.signupMode,
             configuration = configuration.linkConfiguration,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultFormHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultFormHelper.kt
@@ -124,6 +124,10 @@ internal class DefaultFormHelper(
                 onLinkInlineSignupStateChanged = linkInlineHandler::onStateUpdated,
                 paymentMethodCreateParams = currentSelection?.getPaymentMethodCreateParams(),
                 paymentMethodExtraParams = currentSelection?.getPaymentMethodExtraParams(),
+                initialLinkUserInput = when (val selection = currentSelection?.paymentSelection) {
+                    is PaymentSelection.New.LinkInline -> selection.input
+                    else -> null
+                }
             ),
         ) ?: emptyList()
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/FormControllerModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/FormControllerModule.kt
@@ -34,8 +34,10 @@ internal object FormControllerModule {
             requiresMandate = false,
             /*
              * `FormController` is only used by `AddressElement` now so it does not require a
-             * `LinkConfigurationCoordinator` instance or a callback for reacting to `InlineSignUpViewState` changes.
+             * `LinkConfigurationCoordinator` instance, a callback for reacting to `InlineSignUpViewState` changes, or
+             * initial user input for Link signup.
              */
+            initialLinkUserInput = null,
             linkConfigurationCoordinator = null,
             onLinkInlineSignupStateChanged = {
                 throw IllegalStateException(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/FormElementsBuilderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/FormElementsBuilderTest.kt
@@ -101,6 +101,7 @@ class FormElementsBuilderTest {
         val context = ApplicationProvider.getApplicationContext<Application>()
         return UiDefinitionFactory.Arguments(
             initialValues = emptyMap(),
+            initialLinkUserInput = null,
             shippingValues = emptyMap(),
             saveForFutureUseInitialValue = false,
             merchantName = "Example Inc.",

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElementsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElementsTest.kt
@@ -380,6 +380,7 @@ private object TransformSpecToElementsFactory {
         return TransformSpecToElements(
             UiDefinitionFactory.Arguments(
                 initialValues = mapOf(),
+                initialLinkUserInput = null,
                 saveForFutureUseInitialValue = true,
                 merchantName = "Merchant, Inc.",
                 cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/TestUiDefinitionFactoryArgumentsFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/TestUiDefinitionFactoryArgumentsFactory.kt
@@ -6,6 +6,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.stripe.android.cards.CardAccountRangeRepository
 import com.stripe.android.cards.DefaultCardAccountRangeRepositoryFactory
 import com.stripe.android.link.LinkConfigurationCoordinator
+import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
@@ -15,6 +16,7 @@ internal object TestUiDefinitionFactoryArgumentsFactory {
         paymentMethodCreateParams: PaymentMethodCreateParams? = null,
         paymentMethodExtraParams: PaymentMethodExtraParams? = null,
         linkConfigurationCoordinator: LinkConfigurationCoordinator? = null,
+        initialLinkUserInput: UserInput? = null,
     ): UiDefinitionFactory.Arguments.Factory {
         val context: Context? = try {
             ApplicationProvider.getApplicationContext<Application>()
@@ -26,6 +28,7 @@ internal object TestUiDefinitionFactoryArgumentsFactory {
             paymentMethodCreateParams = paymentMethodCreateParams,
             paymentMethodExtraParams = paymentMethodExtraParams,
             linkConfigurationCoordinator = linkConfigurationCoordinator,
+            initialLinkUserInput = initialLinkUserInput,
             onLinkInlineSignupStateChanged = { throw AssertionError("Not implemented") },
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionTestHelper.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.lpmfoundations.paymentmethod
 
 import com.stripe.android.link.LinkConfigurationCoordinator
+import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.uicore.elements.FormElement
@@ -9,6 +10,7 @@ internal fun PaymentMethodDefinition.formElements(
     metadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
     paymentMethodCreateParams: PaymentMethodCreateParams? = null,
     paymentMethodExtraParams: PaymentMethodExtraParams? = null,
+    initialLinkUserInput: UserInput? = null,
     linkConfigurationCoordinator: LinkConfigurationCoordinator? = null,
 ): List<FormElement> {
     return requireNotNull(
@@ -18,6 +20,7 @@ internal fun PaymentMethodDefinition.formElements(
                 paymentMethodCreateParams = paymentMethodCreateParams,
                 paymentMethodExtraParams = paymentMethodExtraParams,
                 linkConfigurationCoordinator = linkConfigurationCoordinator,
+                initialLinkUserInput = initialLinkUserInput,
             )
         )
     )

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/UiDefinitionTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/UiDefinitionTestHelper.kt
@@ -2,6 +2,7 @@ package com.stripe.android.lpmfoundations.paymentmethod.definitions
 
 import androidx.compose.runtime.Composable
 import com.stripe.android.link.LinkConfigurationCoordinator
+import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.formElements
@@ -14,12 +15,14 @@ internal fun PaymentMethodDefinition.CreateFormUi(
     metadata: PaymentMethodMetadata,
     paymentMethodCreateParams: PaymentMethodCreateParams? = null,
     paymentMethodExtraParams: PaymentMethodExtraParams? = null,
+    initialLinkUserInput: UserInput? = null,
     linkConfigurationCoordinator: LinkConfigurationCoordinator? = null,
 ) {
     val formElements = formElements(
         metadata = metadata,
         paymentMethodCreateParams = paymentMethodCreateParams,
         paymentMethodExtraParams = paymentMethodExtraParams,
+        initialLinkUserInput = initialLinkUserInput,
         linkConfigurationCoordinator = linkConfigurationCoordinator,
     )
     FormUI(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElementTest.kt
@@ -1,0 +1,210 @@
+package com.stripe.android.lpmfoundations.paymentmethod.link
+
+import android.util.Log
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.stripe.android.core.Logger
+import com.stripe.android.link.LinkConfiguration
+import com.stripe.android.link.LinkConfigurationCoordinator
+import com.stripe.android.link.LinkPaymentDetails
+import com.stripe.android.link.account.FakeLinkAccountManager
+import com.stripe.android.link.account.LinkAccountManager
+import com.stripe.android.link.analytics.FakeLinkEventsReporter
+import com.stripe.android.link.injection.LinkComponent
+import com.stripe.android.link.injection.LinkInlineSignupAssistedViewModelFactory
+import com.stripe.android.link.model.AccountStatus
+import com.stripe.android.link.ui.inline.InlineSignupViewModel
+import com.stripe.android.link.ui.inline.LINK_INLINE_SIGNUP_REMAINING_FIELDS_TEST_TAG
+import com.stripe.android.link.ui.inline.LinkSignupMode
+import com.stripe.android.link.ui.inline.SignUpConsentAction
+import com.stripe.android.link.ui.inline.UserInput
+import com.stripe.android.model.ConsumerSession
+import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.paymentsheet.state.PaymentElementLoader
+import com.stripe.android.testing.PaymentIntentFactory
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
+import org.junit.Rule
+import org.junit.runner.RunWith
+import kotlin.test.Test
+
+@RunWith(AndroidJUnit4::class)
+class LinkFormElementTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `If initial user input is provided, should be displayed to the user when alongside SFU`() {
+        val element = createLinkFormElement(
+            signupMode = LinkSignupMode.AlongsideSaveForFutureUse,
+            initialLinkUserInput = UserInput.SignUp(
+                name = "John Doe",
+                email = "email@email.com",
+                phone = "+11234567890",
+                country = "CA",
+                consentAction = SignUpConsentAction.Checkbox,
+            ),
+        )
+
+        composeTestRule.setContent {
+            element.ComposeUI(enabled = true)
+        }
+
+        composeTestRule.waitForRemainingLinkFields()
+
+        composeTestRule.hasLinkFieldWith(text = "John Doe")
+        composeTestRule.hasLinkFieldWith(text = "email@email.com")
+        composeTestRule.hasLinkFieldWith(text = "(123) 456-7890")
+    }
+
+    @Test
+    fun `If initial user input is provided, should be expanded and displayed to the user when instead of SFU`() {
+        val element = createLinkFormElement(
+            signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
+            initialLinkUserInput = UserInput.SignUp(
+                name = "John Doe",
+                email = "email@email.com",
+                phone = "+11234567890",
+                country = "CA",
+                consentAction = SignUpConsentAction.Checkbox,
+            ),
+        )
+
+        composeTestRule.setContent {
+            element.ComposeUI(enabled = true)
+        }
+
+        composeTestRule.waitForRemainingLinkFields()
+
+        composeTestRule.hasLinkFieldWith(text = "John Doe")
+        composeTestRule.hasLinkFieldWith(text = "email@email.com")
+        composeTestRule.hasLinkFieldWith(text = "(123) 456-7890")
+    }
+
+    private fun ComposeTestRule.hasLinkFieldWith(text: String) {
+        onNodeWithText(text).assertExists()
+    }
+
+    private fun ComposeTestRule.waitForRemainingLinkFields() {
+        waitUntil(timeoutMillis = 5000L) {
+            onAllNodesWithTag(testTag = LINK_INLINE_SIGNUP_REMAINING_FIELDS_TEST_TAG)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+    }
+
+    private fun createLinkFormElement(
+        signupMode: LinkSignupMode,
+        initialLinkUserInput: UserInput?,
+    ): LinkFormElement {
+        return LinkFormElement(
+            configuration = createLinkInlineConfiguration(signupMode),
+            initialLinkUserInput = initialLinkUserInput,
+            linkConfigurationCoordinator = createLinkConfigurationCoordinator(),
+            onLinkInlineSignupStateChanged = {},
+        )
+    }
+
+    private fun createLinkInlineConfiguration(
+        signupMode: LinkSignupMode,
+    ): LinkInlineConfiguration {
+        return LinkInlineConfiguration(
+            signupMode = signupMode,
+            linkConfiguration = LinkConfiguration(
+                stripeIntent = PaymentIntentFactory.create(),
+                merchantName = "Merchant, Inc.",
+                merchantCountryCode = "CA",
+                customerInfo = LinkConfiguration.CustomerInfo(
+                    name = "John Doe",
+                    email = null,
+                    phone = null,
+                    billingCountryCode = "CA",
+                ),
+                shippingDetails = null,
+                passthroughModeEnabled = false,
+                cardBrandChoice = null,
+                flags = mapOf(),
+                useAttestationEndpointsForLink = false,
+                initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
+                    clientSecret = "pi_123_secret_123",
+                ),
+            ),
+        )
+    }
+
+    private fun createLinkConfigurationCoordinator(): LinkConfigurationCoordinator {
+        return FakeLinkConfigurationCoordinator
+    }
+
+    private object FakeLinkConfigurationCoordinator : LinkConfigurationCoordinator {
+        override val emailFlow: StateFlow<String?>
+            get() {
+                error("Not implemented!")
+            }
+
+        override fun getComponent(configuration: LinkConfiguration): LinkComponent {
+            return FakeLinkComponent(configuration)
+        }
+
+        override fun getAccountStatusFlow(configuration: LinkConfiguration): Flow<AccountStatus> {
+            error("Not implemented!")
+        }
+
+        override suspend fun signInWithUserInput(
+            configuration: LinkConfiguration,
+            userInput: UserInput
+        ): Result<Boolean> {
+            error("Not implemented!")
+        }
+
+        override suspend fun attachNewCardToAccount(
+            configuration: LinkConfiguration,
+            paymentMethodCreateParams: PaymentMethodCreateParams
+        ): Result<LinkPaymentDetails> {
+            error("Not implemented!")
+        }
+
+        override suspend fun logOut(configuration: LinkConfiguration): Result<ConsumerSession> {
+            error("Not implemented!")
+        }
+    }
+
+    private class FakeLinkComponent(
+        override val configuration: LinkConfiguration,
+    ) : LinkComponent() {
+        override val linkAccountManager: LinkAccountManager = FakeLinkAccountManager()
+
+        override val inlineSignupViewModelFactory: LinkInlineSignupAssistedViewModelFactory =
+            FakeLinkInlineSignupAssistedViewModelFactory(linkAccountManager, configuration)
+    }
+
+    private class FakeLinkInlineSignupAssistedViewModelFactory(
+        private val linkAccountManager: LinkAccountManager,
+        private val configuration: LinkConfiguration,
+    ) : LinkInlineSignupAssistedViewModelFactory {
+        override fun create(signupMode: LinkSignupMode, initialUserInput: UserInput?): InlineSignupViewModel {
+            return InlineSignupViewModel(
+                signupMode = signupMode,
+                config = configuration,
+                initialUserInput = initialUserInput,
+                linkAccountManager = linkAccountManager,
+                linkEventsReporter = FakeLinkInlineSignupEventsReporter,
+                logger = Logger.noop(),
+                lookupDelay = 0L,
+            )
+        }
+    }
+
+    private object FakeLinkInlineSignupEventsReporter : FakeLinkEventsReporter() {
+        override fun onSignupStarted(isInline: Boolean) {
+            Log.d("LINK_FORM_ELEMENT_TEST", "onSignupStarted")
+        }
+
+        override fun onInlineSignupCheckboxChecked() {
+            Log.d("LINK_FORM_ELEMENT_TEST", "onInlineSignupCheckboxChecked")
+        }
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/FormControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/FormControllerTest.kt
@@ -37,6 +37,7 @@ class FormControllerTest {
     private val transformSpecToElements = TransformSpecToElements(
         UiDefinitionFactory.Arguments(
             initialValues = emptyMap(),
+            initialLinkUserInput = null,
             saveForFutureUseInitialValue = false,
             merchantName = "Merchant",
             cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),


### PR DESCRIPTION
# Summary
Restore `UserInput` when `PaymentSelection` is Link Inline Signup.

# Motivation
When we restore `FlowController`, we want to see any Link user input also restored just like the other LPM fields are when the user opens the sheet before confirming a Stripe transaction.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

# Video
[FastFollow.webm](https://github.com/user-attachments/assets/1b8da089-51c9-4e09-8c65-ccec2b9f3632)