### PR TITLE
Fix customer state holder reset.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/CustomerStateHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/CustomerStateHolder.kt
@@ -44,6 +44,11 @@ internal class CustomerStateHolder(
 
     fun setCustomerState(customerState: CustomerState?) {
         savedStateHandle[SAVED_CUSTOMER] = customerState
+
+        val currentSelection = mostRecentlySelectedSavedPaymentMethod.value
+        if (currentSelection != null && customerState?.paymentMethods?.contains(currentSelection) == false) {
+            updateMostRecentlySelectedSavedPaymentMethod(null)
+        }
     }
 
     fun updateMostRecentlySelectedSavedPaymentMethod(paymentMethod: PaymentMethod?) {
@@ -52,7 +57,7 @@ internal class CustomerStateHolder(
 
     companion object {
         const val SAVED_CUSTOMER = "customer_info"
-        private const val SAVED_PM_SELECTION = "saved_selection"
+        const val SAVED_PM_SELECTION = "saved_selection"
 
         fun create(viewModel: BaseSheetViewModel): CustomerStateHolder {
             return CustomerStateHolder(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -162,10 +162,6 @@ internal class SavedPaymentMethodMutator(
             )
         )
 
-        if (customerStateHolder.mostRecentlySelectedSavedPaymentMethod.value?.id == paymentMethodId) {
-            customerStateHolder.updateMostRecentlySelectedSavedPaymentMethod(null)
-        }
-
         if ((selection.value as? PaymentSelection.Saved)?.paymentMethod?.id == paymentMethodId) {
             clearSelection()
         }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This worked fine for PaymentSheet. But the CustomerStateHolder doesn't have a current state for the `mostRecentlySelectedSavedPaymentMethod` to easily restore.