### PR TITLE
[MOBILESDK-2660][Android] Don’t read from the local default payment method when opted into the “set as default” feature

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -9,7 +9,6 @@ import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.IOContext
-import com.stripe.android.core.utils.FeatureFlag
 import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.core.utils.UserFacingLogger
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -25,7 +25,6 @@ import com.stripe.android.lpmfoundations.paymentmethod.link.LinkInlineConfigurat
 import com.stripe.android.lpmfoundations.paymentmethod.toPaymentSheetSaveConsentBehavior
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PaymentMethod
-import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.PaymentSheet

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -1985,7 +1985,7 @@ internal class DefaultPaymentElementLoaderTest {
         }
 
     @Test
-    fun `When DefaultPaymentMethod not null, no saved selection, paymentMethod order correct`() = runTest {
+    fun `When DefaultPaymentMethod not null, no saved selection, defaultPaymentMethod first`() = runTest {
         val result = getPaymentElementLoaderStateForTestingOfPaymentMethodsWithDefaultPaymentMethodId(
             lastUsedPaymentMethod = null,
             defaultPaymentMethod = paymentMethodsForTestingOrdering[2],
@@ -1997,19 +1997,21 @@ internal class DefaultPaymentElementLoaderTest {
     }
 
     @Test
-    fun `When DefaultPaymentMethod not null, no saved selection, selection correct`() = runTest {
+    fun `When DefaultPaymentMethod not null, no saved selection, defaultPaymentMethod selected`() = runTest {
+        val defaultPaymentMethod = paymentMethodsForTestingOrdering[2]
+
         val result = getPaymentElementLoaderStateForTestingOfPaymentMethodsWithDefaultPaymentMethodId(
             lastUsedPaymentMethod = null,
-            defaultPaymentMethod = paymentMethodsForTestingOrdering[2],
+            defaultPaymentMethod = defaultPaymentMethod,
         )
 
         assertThat((result.paymentSelection as? PaymentSelection.Saved)?.paymentMethod).isEqualTo(
-            PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "c3", customerId = "carol")
+            defaultPaymentMethod
         )
     }
 
     @Test
-    fun `When DefaultPaymentMethod not null, saved selection, paymentMethod order correct`() = runTest {
+    fun `When DefaultPaymentMethod not null, saved selection, defaultPaymentMethod first`() = runTest {
         val result = getPaymentElementLoaderStateForTestingOfPaymentMethodsWithDefaultPaymentMethodId(
             lastUsedPaymentMethod = paymentMethodsForTestingOrdering[1],
             defaultPaymentMethod = paymentMethodsForTestingOrdering[2],
@@ -2021,19 +2023,21 @@ internal class DefaultPaymentElementLoaderTest {
     }
 
     @Test
-    fun `When DefaultPaymentMethod not null, saved selection, selection correct`() = runTest {
+    fun `When DefaultPaymentMethod not null, saved selection, defaultPaymentMethod selected`() = runTest {
+        val defaultPaymentMethod = paymentMethodsForTestingOrdering[2]
+
         val result = getPaymentElementLoaderStateForTestingOfPaymentMethodsWithDefaultPaymentMethodId(
             lastUsedPaymentMethod = paymentMethodsForTestingOrdering[1],
-            defaultPaymentMethod = paymentMethodsForTestingOrdering[2],
+            defaultPaymentMethod = defaultPaymentMethod,
         )
 
         assertThat((result.paymentSelection as? PaymentSelection.Saved)?.paymentMethod).isEqualTo(
-            PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "c3", customerId = "carol")
+            defaultPaymentMethod
         )
     }
 
     @Test
-    fun `When DefaultPaymentMethod not null, saved selection is same as defaultPaymentMethod, paymentMethod order correct`() = runTest {
+    fun `When DefaultPaymentMethod not null, saved selection is defaultPaymentMethod, defaultPaymentMethod first`() = runTest {
         val result = getPaymentElementLoaderStateForTestingOfPaymentMethodsWithDefaultPaymentMethodId(
             lastUsedPaymentMethod = paymentMethodsForTestingOrdering[2],
             defaultPaymentMethod = paymentMethodsForTestingOrdering[2],
@@ -2045,19 +2049,21 @@ internal class DefaultPaymentElementLoaderTest {
     }
 
     @Test
-    fun `When DefaultPaymentMethod not null, saved selection is same as defaultPaymentMethod, selection correct`() = runTest {
+    fun `When DefaultPaymentMethod not null, saved selection is same as defaultPaymentMethod, defaultPaymentMethod selected`() = runTest {
+        val defaultPaymentMethod = paymentMethodsForTestingOrdering[2]
+
         val result = getPaymentElementLoaderStateForTestingOfPaymentMethodsWithDefaultPaymentMethodId(
             lastUsedPaymentMethod = paymentMethodsForTestingOrdering[2],
-            defaultPaymentMethod = paymentMethodsForTestingOrdering[2],
+            defaultPaymentMethod = defaultPaymentMethod,
         )
 
         assertThat((result.paymentSelection as? PaymentSelection.Saved)?.paymentMethod).isEqualTo(
-            PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "c3", customerId = "carol")
+            defaultPaymentMethod
         )
     }
 
     @Test
-    fun `When DefaultPaymentMethod null, no saved selection, paymentMethod order correct`() = runTest {
+    fun `When DefaultPaymentMethod null, no saved selection, order unchanged`() = runTest {
         val result = getPaymentElementLoaderStateForTestingOfPaymentMethodsWithDefaultPaymentMethodId(
             lastUsedPaymentMethod = null,
             defaultPaymentMethod = null,
@@ -2069,19 +2075,21 @@ internal class DefaultPaymentElementLoaderTest {
     }
 
     @Test
-    fun `When DefaultPaymentMethod null, no saved selection, selection correct`() = runTest {
+    fun `When DefaultPaymentMethod null, no saved selection, first payment method selected`() = runTest {
+        val firstPaymentMethod = paymentMethodsForTestingOrdering[0]
+
         val result = getPaymentElementLoaderStateForTestingOfPaymentMethodsWithDefaultPaymentMethodId(
             lastUsedPaymentMethod = null,
             defaultPaymentMethod = null,
         )
 
         assertThat((result.paymentSelection as? PaymentSelection.Saved)?.paymentMethod).isEqualTo(
-            PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "a1", customerId = "alice")
+            firstPaymentMethod
         )
     }
 
     @Test
-    fun `When DefaultPaymentMethod null, saved selection first, paymentMethod order correct`() = runTest {
+    fun `When DefaultPaymentMethod null, saved selection first, order unchanged`() = runTest {
         val result = getPaymentElementLoaderStateForTestingOfPaymentMethodsWithDefaultPaymentMethodId(
             lastUsedPaymentMethod = paymentMethodsForTestingOrdering[0],
             defaultPaymentMethod = null,
@@ -2093,19 +2101,21 @@ internal class DefaultPaymentElementLoaderTest {
     }
 
     @Test
-    fun `When DefaultPaymentMethod null, saved selection first, selection correct`() = runTest {
+    fun `When DefaultPaymentMethod null, saved selection first, first payment method selected`() = runTest {
+        val firstPaymentMethod = paymentMethodsForTestingOrdering[0]
+
         val result = getPaymentElementLoaderStateForTestingOfPaymentMethodsWithDefaultPaymentMethodId(
             lastUsedPaymentMethod = paymentMethodsForTestingOrdering[0],
             defaultPaymentMethod = null,
         )
 
         assertThat((result.paymentSelection as? PaymentSelection.Saved)?.paymentMethod).isEqualTo(
-            PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "a1", customerId = "alice")
+            firstPaymentMethod
         )
     }
 
     @Test
-    fun `When DefaultPaymentMethod null, saved selection not first, paymentMethod order correct`() = runTest {
+    fun `When DefaultPaymentMethod null, saved selection not first, order unchanged`() = runTest {
         val result = getPaymentElementLoaderStateForTestingOfPaymentMethodsWithDefaultPaymentMethodId(
             lastUsedPaymentMethod = paymentMethodsForTestingOrdering[1],
             defaultPaymentMethod = null,
@@ -2117,14 +2127,16 @@ internal class DefaultPaymentElementLoaderTest {
     }
 
     @Test
-    fun `When DefaultPaymentMethod null, saved selection not first, selection correct`() = runTest {
+    fun `When DefaultPaymentMethod null, saved selection not first, first payment method selected`() = runTest {
+        val firstPaymentMethod = paymentMethodsForTestingOrdering[0]
+
         val result = getPaymentElementLoaderStateForTestingOfPaymentMethodsWithDefaultPaymentMethodId(
             lastUsedPaymentMethod = paymentMethodsForTestingOrdering[1],
             defaultPaymentMethod = null,
         )
 
         assertThat((result.paymentSelection as? PaymentSelection.Saved)?.paymentMethod).isEqualTo(
-            PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "a1", customerId = "alice")
+            firstPaymentMethod
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -1985,7 +1985,7 @@ internal class DefaultPaymentElementLoaderTest {
         }
 
     @Test
-    fun `When DefaultPaymentMethod not null, no saved selection, paymentMethod order correct`() = runTest {
+    fun `When DefaultPaymentMethod not null, paymentMethod order correct`() = runTest {
         val result = getPaymentElementLoaderStateForTestingOfPaymentMethodsWithDefaultPaymentMethodId()
 
         val observedElements = result.customer?.paymentMethods
@@ -1994,30 +1994,8 @@ internal class DefaultPaymentElementLoaderTest {
     }
 
     @Test
-    fun `When DefaultPaymentMethod not null, and saved selection, paymentMethod order correct`() = runTest {
-        val result = getPaymentElementLoaderStateForTestingOfPaymentMethodsWithDefaultPaymentMethodId(
-            setLastUsedIndex = 1
-        )
-
-        val observedElements = result.customer?.paymentMethods
-        val expectedElements = expectedPaymentMethodsWithDefaultPaymentMethod
-        assertThat(observedElements).containsExactlyElementsIn(expectedElements).inOrder()
-    }
-
-    @Test
-    fun `When DefaultPaymentMethod not null, and no savedSelection, selection correct`() = runTest {
+    fun `When DefaultPaymentMethod not null, selection correct`() = runTest {
         val result = getPaymentElementLoaderStateForTestingOfPaymentMethodsWithDefaultPaymentMethodId()
-
-        assertThat((result.paymentSelection as? PaymentSelection.Saved)?.paymentMethod).isEqualTo(
-            PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "c3", customerId = "carol")
-        )
-    }
-
-    @Test
-    fun `When DefaultPaymentMethod not null, and savedSelection, selection correct`() = runTest {
-        val result = getPaymentElementLoaderStateForTestingOfPaymentMethodsWithDefaultPaymentMethodId(
-            setLastUsedIndex = 1
-        )
 
         assertThat((result.paymentSelection as? PaymentSelection.Saved)?.paymentMethod).isEqualTo(
             PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "c3", customerId = "carol")
@@ -2563,19 +2541,12 @@ internal class DefaultPaymentElementLoaderTest {
     )
 
     @OptIn(ExperimentalCustomerSessionApi::class)
-    private suspend fun getPaymentElementLoaderStateForTestingOfPaymentMethodsWithDefaultPaymentMethodId(
-        setLastUsedIndex: Int? = null
-    ): PaymentElementLoader.State {
+    private suspend fun getPaymentElementLoaderStateForTestingOfPaymentMethodsWithDefaultPaymentMethodId(): PaymentElementLoader.State {
         enableDefaultPaymentMethods.setEnabled(true)
 
         val defaultPaymentMethodIndex = 2
         val defaultPaymentMethod = paymentMethodsForTestingOrdering[defaultPaymentMethodIndex]
         val defaultPaymentMethodId = defaultPaymentMethod.id
-
-        if (setLastUsedIndex != null && setLastUsedIndex in paymentMethodsForTestingOrdering.indices) {
-            val lastUsed = paymentMethodsForTestingOrdering[setLastUsedIndex]
-            prefsRepository.savePaymentSelection(PaymentSelection.Saved(lastUsed))
-        }
 
         val loader = createPaymentElementLoader(
             customer = ElementsSession.Customer(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -1985,8 +1985,11 @@ internal class DefaultPaymentElementLoaderTest {
         }
 
     @Test
-    fun `When DefaultPaymentMethod not null, paymentMethod order correct`() = runTest {
-        val result = getPaymentElementLoaderStateForTestingOfPaymentMethodsWithDefaultPaymentMethodId()
+    fun `When DefaultPaymentMethod not null, no saved selection, paymentMethod order correct`() = runTest {
+        val result = getPaymentElementLoaderStateForTestingOfPaymentMethodsWithDefaultPaymentMethodId(
+            lastUsedPaymentMethod = null,
+            defaultPaymentMethod = paymentMethodsForTestingOrdering[2],
+        )
 
         val observedElements = result.customer?.paymentMethods
         val expectedElements = expectedPaymentMethodsWithDefaultPaymentMethod
@@ -1994,11 +1997,134 @@ internal class DefaultPaymentElementLoaderTest {
     }
 
     @Test
-    fun `When DefaultPaymentMethod not null, selection correct`() = runTest {
-        val result = getPaymentElementLoaderStateForTestingOfPaymentMethodsWithDefaultPaymentMethodId()
+    fun `When DefaultPaymentMethod not null, no saved selection, selection correct`() = runTest {
+        val result = getPaymentElementLoaderStateForTestingOfPaymentMethodsWithDefaultPaymentMethodId(
+            lastUsedPaymentMethod = null,
+            defaultPaymentMethod = paymentMethodsForTestingOrdering[2],
+        )
 
         assertThat((result.paymentSelection as? PaymentSelection.Saved)?.paymentMethod).isEqualTo(
             PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "c3", customerId = "carol")
+        )
+    }
+
+    @Test
+    fun `When DefaultPaymentMethod not null, saved selection, paymentMethod order correct`() = runTest {
+        val result = getPaymentElementLoaderStateForTestingOfPaymentMethodsWithDefaultPaymentMethodId(
+            lastUsedPaymentMethod = paymentMethodsForTestingOrdering[1],
+            defaultPaymentMethod = paymentMethodsForTestingOrdering[2],
+        )
+
+        val observedElements = result.customer?.paymentMethods
+        val expectedElements = expectedPaymentMethodsWithDefaultPaymentMethod
+        assertThat(observedElements).containsExactlyElementsIn(expectedElements).inOrder()
+    }
+
+    @Test
+    fun `When DefaultPaymentMethod not null, saved selection, selection correct`() = runTest {
+        val result = getPaymentElementLoaderStateForTestingOfPaymentMethodsWithDefaultPaymentMethodId(
+            lastUsedPaymentMethod = paymentMethodsForTestingOrdering[1],
+            defaultPaymentMethod = paymentMethodsForTestingOrdering[2],
+        )
+
+        assertThat((result.paymentSelection as? PaymentSelection.Saved)?.paymentMethod).isEqualTo(
+            PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "c3", customerId = "carol")
+        )
+    }
+
+    @Test
+    fun `When DefaultPaymentMethod not null, saved selection is same as defaultPaymentMethod, paymentMethod order correct`() = runTest {
+        val result = getPaymentElementLoaderStateForTestingOfPaymentMethodsWithDefaultPaymentMethodId(
+            lastUsedPaymentMethod = paymentMethodsForTestingOrdering[2],
+            defaultPaymentMethod = paymentMethodsForTestingOrdering[2],
+        )
+
+        val observedElements = result.customer?.paymentMethods
+        val expectedElements = expectedPaymentMethodsWithDefaultPaymentMethod
+        assertThat(observedElements).containsExactlyElementsIn(expectedElements).inOrder()
+    }
+
+    @Test
+    fun `When DefaultPaymentMethod not null, saved selection is same as defaultPaymentMethod, selection correct`() = runTest {
+        val result = getPaymentElementLoaderStateForTestingOfPaymentMethodsWithDefaultPaymentMethodId(
+            lastUsedPaymentMethod = paymentMethodsForTestingOrdering[2],
+            defaultPaymentMethod = paymentMethodsForTestingOrdering[2],
+        )
+
+        assertThat((result.paymentSelection as? PaymentSelection.Saved)?.paymentMethod).isEqualTo(
+            PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "c3", customerId = "carol")
+        )
+    }
+
+    @Test
+    fun `When DefaultPaymentMethod null, no saved selection, paymentMethod order correct`() = runTest {
+        val result = getPaymentElementLoaderStateForTestingOfPaymentMethodsWithDefaultPaymentMethodId(
+            lastUsedPaymentMethod = null,
+            defaultPaymentMethod = null,
+        )
+
+        val observedElements = result.customer?.paymentMethods
+        val expectedElements = paymentMethodsForTestingOrdering
+        assertThat(observedElements).containsExactlyElementsIn(expectedElements).inOrder()
+    }
+
+    @Test
+    fun `When DefaultPaymentMethod null, no saved selection, selection correct`() = runTest {
+        val result = getPaymentElementLoaderStateForTestingOfPaymentMethodsWithDefaultPaymentMethodId(
+            lastUsedPaymentMethod = null,
+            defaultPaymentMethod = null,
+        )
+
+        assertThat((result.paymentSelection as? PaymentSelection.Saved)?.paymentMethod).isEqualTo(
+            PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "a1", customerId = "alice")
+        )
+    }
+
+    @Test
+    fun `When DefaultPaymentMethod null, saved selection first, paymentMethod order correct`() = runTest {
+        val result = getPaymentElementLoaderStateForTestingOfPaymentMethodsWithDefaultPaymentMethodId(
+            lastUsedPaymentMethod = paymentMethodsForTestingOrdering[0],
+            defaultPaymentMethod = null,
+        )
+
+        val observedElements = result.customer?.paymentMethods
+        val expectedElements = paymentMethodsForTestingOrdering
+        assertThat(observedElements).containsExactlyElementsIn(expectedElements).inOrder()
+    }
+
+    @Test
+    fun `When DefaultPaymentMethod null, saved selection first, selection correct`() = runTest {
+        val result = getPaymentElementLoaderStateForTestingOfPaymentMethodsWithDefaultPaymentMethodId(
+            lastUsedPaymentMethod = paymentMethodsForTestingOrdering[0],
+            defaultPaymentMethod = null,
+        )
+
+        assertThat((result.paymentSelection as? PaymentSelection.Saved)?.paymentMethod).isEqualTo(
+            PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "a1", customerId = "alice")
+        )
+    }
+
+    @Test
+    fun `When DefaultPaymentMethod null, saved selection not first, paymentMethod order correct`() = runTest {
+        val result = getPaymentElementLoaderStateForTestingOfPaymentMethodsWithDefaultPaymentMethodId(
+            lastUsedPaymentMethod = paymentMethodsForTestingOrdering[1],
+            defaultPaymentMethod = null,
+        )
+
+        val observedElements = result.customer?.paymentMethods
+        val expectedElements = paymentMethodsForTestingOrdering
+        assertThat(observedElements).containsExactlyElementsIn(expectedElements).inOrder()
+    }
+
+    @Test
+    fun `When DefaultPaymentMethod null, saved selection not first, selection correct`() = runTest {
+        val result = getPaymentElementLoaderStateForTestingOfPaymentMethodsWithDefaultPaymentMethodId(
+            lastUsedPaymentMethod = paymentMethodsForTestingOrdering[1],
+            defaultPaymentMethod = null,
+        )
+
+        assertThat((result.paymentSelection as? PaymentSelection.Saved)?.paymentMethod).isEqualTo(
+            PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "a1", customerId = "alice")
         )
     }
 
@@ -2541,12 +2667,17 @@ internal class DefaultPaymentElementLoaderTest {
     )
 
     @OptIn(ExperimentalCustomerSessionApi::class)
-    private suspend fun getPaymentElementLoaderStateForTestingOfPaymentMethodsWithDefaultPaymentMethodId(): PaymentElementLoader.State {
+    private suspend fun getPaymentElementLoaderStateForTestingOfPaymentMethodsWithDefaultPaymentMethodId(
+        lastUsedPaymentMethod: PaymentMethod?,
+        defaultPaymentMethod: PaymentMethod?,
+    ): PaymentElementLoader.State {
         enableDefaultPaymentMethods.setEnabled(true)
 
-        val defaultPaymentMethodIndex = 2
-        val defaultPaymentMethod = paymentMethodsForTestingOrdering[defaultPaymentMethodIndex]
-        val defaultPaymentMethodId = defaultPaymentMethod.id
+        val defaultPaymentMethodId = defaultPaymentMethod?.id
+
+        lastUsedPaymentMethod?.let {
+            prefsRepository.savePaymentSelection(PaymentSelection.Saved(lastUsedPaymentMethod))
+        }
 
         val loader = createPaymentElementLoader(
             customer = ElementsSession.Customer(


### PR DESCRIPTION
# Summary
Added a feature flag to correct logic error

Was previously reading dpm, then last used Saved Payment Method, regardless of if DPM was enabled or not.

Am now reading DPM if DPM enabled, and last used Saved Payment Method if DPM is disabled

# Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-2660

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified
