### PR TITLE
Pass composition to TextFieldUi.value to prevent render loop (#9871)

### DIFF
--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldUI.kt
@@ -165,10 +165,15 @@ fun TextField(
         mutableStateOf<TextRange?>(null)
     }
 
+    var composition by remember {
+        mutableStateOf<TextRange?>(null)
+    }
+
     TextFieldUi(
         value = TextFieldValue(
             text = value,
             selection = selection ?: TextRange(value.length),
+            composition = composition
         ),
         loading = loading,
         onValueChange = { newValue ->
@@ -177,6 +182,7 @@ fun TextField(
 
             if (newTextValue == value || acceptInput) {
                 selection = newValue.selection
+                composition = newValue.composition
             }
 
             if (acceptInput) {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Cherry pick https://github.com/stripe/stripe-android/pull/9871

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
ir-wary-component


