### PR TITLE
Add loading and retry to embedded playground.

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/embedded/EmbeddedPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/embedded/EmbeddedPlaygroundActivity.kt
@@ -7,14 +7,24 @@ import android.util.Log
 import android.widget.Toast
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.Button
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.ExperimentalEmbeddedPaymentElementApi
@@ -29,6 +39,7 @@ import com.stripe.android.paymentsheet.example.playground.settings.PlaygroundCon
 import com.stripe.android.paymentsheet.example.samples.ui.shared.BuyButton
 import com.stripe.android.paymentsheet.example.samples.ui.shared.PaymentMethodSelector
 import com.stripe.android.uicore.utils.collectAsState
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalEmbeddedPaymentElementApi::class)
 internal class EmbeddedPlaygroundActivity : AppCompatActivity(), ExternalPaymentMethodConfirmHandler {
@@ -62,16 +73,31 @@ internal class EmbeddedPlaygroundActivity : AppCompatActivity(), ExternalPayment
         setContent {
             val embeddedPaymentElement = rememberEmbeddedPaymentElement(embeddedBuilder)
 
-            LaunchedEffect(embeddedPaymentElement) {
-                embeddedPaymentElement.configure(
+            var loadingState by remember {
+                mutableStateOf(LoadingState.Loading)
+            }
+
+            val coroutineScope = rememberCoroutineScope()
+
+            fun configure() = coroutineScope.launch {
+                loadingState = LoadingState.Loading
+                val result = embeddedPaymentElement.configure(
                     intentConfiguration = playgroundState.intentConfiguration(),
                     configuration = playgroundState.embeddedConfiguration(),
                 )
+                loadingState = when (result) {
+                    is EmbeddedPaymentElement.ConfigureResult.Failed -> LoadingState.Failed
+                    is EmbeddedPaymentElement.ConfigureResult.Succeeded -> LoadingState.Complete
+                }
+            }
+
+            LaunchedEffect(embeddedPaymentElement) {
+                configure()
             }
 
             PlaygroundTheme(
                 content = {
-                    embeddedPaymentElement.Content()
+                    loadingState.Content(embeddedPaymentElement = embeddedPaymentElement, retry = ::configure)
                 },
                 bottomBarContent = {
                     val selectedPaymentOption by embeddedPaymentElement.paymentOption.collectAsState()
@@ -150,5 +176,38 @@ internal class EmbeddedPlaygroundActivity : AppCompatActivity(), ExternalPayment
                 Toast.makeText(this, "Payment Failed.", Toast.LENGTH_LONG).show()
             }
         }
+    }
+
+    private enum class LoadingState {
+        Loading {
+            @Composable
+            override fun Content(embeddedPaymentElement: EmbeddedPaymentElement, retry: () -> Unit) {
+                Box(modifier = Modifier.fillMaxWidth()) {
+                    CircularProgressIndicator(
+                        modifier = Modifier
+                            .padding(20.dp)
+                            .width(64.dp)
+                            .align(Alignment.Center),
+                    )
+                }
+            }
+        },
+        Complete {
+            @Composable
+            override fun Content(embeddedPaymentElement: EmbeddedPaymentElement, retry: () -> Unit) {
+                embeddedPaymentElement.Content()
+            }
+        },
+        Failed {
+            @Composable
+            override fun Content(embeddedPaymentElement: EmbeddedPaymentElement, retry: () -> Unit) {
+                Button(onClick = retry, Modifier.fillMaxWidth()) {
+                    Text("Retry")
+                }
+            }
+        };
+
+        @Composable
+        abstract fun Content(embeddedPaymentElement: EmbeddedPaymentElement, retry: () -> Unit)
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Adds retry and loading to our playground. This will match more similarly to what merchants will do.
