### PR TITLE
[FC][Attestation] Prefill email on verification when switching to web

### DIFF
--- a/financial-connections/detekt-baseline.xml
+++ b/financial-connections/detekt-baseline.xml
@@ -5,6 +5,7 @@
     <ID>ConstructorParameterNaming:FinancialConnectionsAuthorizationSession.kt$FinancialConnectionsAuthorizationSession$@SerialName(value = "is_oauth") private val _isOAuth: Boolean? = false</ID>
     <ID>ConstructorParameterNaming:PartnerAccountsList.kt$PartnerAccount$@SerialName(value = "allow_selection") private val _allowSelection: Boolean? = null</ID>
     <ID>LargeClass:FinancialConnectionsSheetViewModelTest.kt$FinancialConnectionsSheetViewModelTest</ID>
+    <ID>LargeClass:NetworkingLinkSignupViewModelTest.kt$NetworkingLinkSignupViewModelTest</ID>
     <ID>LongMethod:AccountItem.kt$@Composable @Preview internal fun AccountItemPreview()</ID>
     <ID>LongMethod:Button.kt$@Composable internal fun FinancialConnectionsButton( onClick: () -> Unit, modifier: Modifier = Modifier, type: Type = Primary, size: FinancialConnectionsButton.Size = FinancialConnectionsButton.Size.Regular, enabled: Boolean = true, loading: Boolean = false, content: @Composable (RowScope.() -> Unit) )</ID>
     <ID>LongMethod:FinancialConnectionsSheetNativeActivity.kt$FinancialConnectionsSheetNativeActivity$@Composable fun NavHost( initialPane: Pane, testMode: Boolean, )</ID>
@@ -20,13 +21,11 @@
     <ID>MagicNumber:InstitutionPickerScreen.kt$0.5f</ID>
     <ID>MagicNumber:InstitutionPickerScreen.kt$0.75f</ID>
     <ID>MagicNumber:InstitutionPickerScreen.kt$10</ID>
-    <ID>MagicNumber:Layout.kt$4</ID>
     <ID>MagicNumber:LinkAccountPickerScreen.kt$3</ID>
     <ID>MagicNumber:ManualEntryViewModel.kt$ManualEntryViewModel$4</ID>
     <ID>MagicNumber:SharedPartnerAuth.kt$.50f</ID>
     <ID>MatchingDeclarationName:ServerDrivenUi.kt$BulletUI</ID>
     <ID>MatchingDeclarationName:Type.kt$FinancialConnectionsTypography</ID>
-    <ID>MaxLineLength:NetworkingLinkSignupViewModelTest.kt$NetworkingLinkSignupViewModelTest$fun</ID>
     <ID>NestedBlockDepth:InstitutionPickerScreen.kt$private fun LazyListScope.searchResults( isInputEmpty: Boolean, payload: Payload, selectedInstitutionId: String?, onInstitutionSelected: (FinancialConnectionsInstitution, Boolean) -> Unit, institutions: Async&lt;InstitutionResponse>, onManualEntryClick: () -> Unit, onSearchMoreClick: () -> Unit )</ID>
     <ID>SwallowedException:PollAttachPaymentAccount.kt$PollAttachPaymentAccount$e: StripeException</ID>
     <ID>SwallowedException:PollAuthorizationSessionAccounts.kt$PollAuthorizationSessionAccounts$e: StripeException</ID>

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheet.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheet.kt
@@ -10,6 +10,7 @@ import com.stripe.android.financialconnections.launcher.FinancialConnectionsShee
 import com.stripe.android.model.IncentiveEligibilitySession
 import com.stripe.android.model.LinkMode
 import kotlinx.parcelize.Parcelize
+import java.io.Serializable
 
 /**
  * A drop in class to present the Financial Connections Auth Flow.
@@ -78,7 +79,7 @@ class FinancialConnectionsSheet internal constructor(
             val email: String?,
             val phone: String?,
             val phoneCountryCode: String?,
-        ) : Parcelable
+        ) : Parcelable, Serializable
     }
 
     /**

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheet.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheet.kt
@@ -79,7 +79,12 @@ class FinancialConnectionsSheet internal constructor(
             val email: String?,
             val phone: String?,
             val phoneCountryCode: String?,
-        ) : Parcelable, Serializable
+        ) : Parcelable, Serializable {
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            companion object {
+                private const val serialVersionUID: Long = 626669472462415908L
+            }
+        }
     }
 
     /**

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
@@ -541,7 +541,7 @@ internal class FinancialConnectionsSheetViewModel @Inject constructor(
         if (result is Failed && result.error is FinancialConnectionsAttestationError) {
             val error = result.error
             integrityVerdictManager.setVerdictFailed()
-            switchToWebFlow(error.prefilledEmail)
+            switchToWebFlow(error.prefillDetails)
             return
         }
         eventReporter.onResult(state.initialArgs.configuration, result)
@@ -562,19 +562,13 @@ internal class FinancialConnectionsSheetViewModel @Inject constructor(
     /**
      * On scenarios where native failed mid flow due to attestation errors, switch back to web flow.
      */
-    private fun switchToWebFlow(prefilledEmail: String?) {
+    private fun switchToWebFlow(prefillDetails: PrefillDetails?) {
         viewModelScope.launch {
             val sync = getOrFetchSync()
             val hostedAuthUrl = HostedAuthUrlBuilder.create(
                 args = initialState.initialArgs,
                 manifest = sync.manifest,
-                sdkPrefillDetails = prefilledEmail?.let {
-                    PrefillDetails(
-                        email = it,
-                        phone = null,
-                        phoneCountryCode = null
-                    )
-                }
+                sdkPrefillDetails = prefillDetails
             )
 
             if (hostedAuthUrl != null) {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
@@ -568,7 +568,7 @@ internal class FinancialConnectionsSheetViewModel @Inject constructor(
             val hostedAuthUrl = HostedAuthUrlBuilder.create(
                 args = initialState.initialArgs,
                 manifest = sync.manifest,
-                sdkPrefillDetails = prefillDetails
+                prefillDetails = prefillDetails
             )
 
             if (hostedAuthUrl != null) {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/HostedAuthUrlBuilder.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/HostedAuthUrlBuilder.kt
@@ -56,6 +56,9 @@ internal object HostedAuthUrlBuilder {
             phoneCountryCode?.let { queryParams.add("linkMobilePhoneCountry=$it") }
         }
 
+        // hint for frontend to understand the surface launching the web flow.
+        queryParams.add("launched_by=android_sdk")
+
         return queryParams.joinToString("&")
     }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/HostedAuthUrlBuilder.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/HostedAuthUrlBuilder.kt
@@ -14,13 +14,14 @@ internal object HostedAuthUrlBuilder {
     fun create(
         args: FinancialConnectionsSheetActivityArgs,
         manifest: FinancialConnectionsSessionManifest,
+        sdkPrefillDetails: PrefillDetails? = null,
     ): String? {
         return create(
             hostedAuthUrl = manifest.hostedAuthUrl,
             isInstantDebits = args is FinancialConnectionsSheetActivityArgs.ForInstantDebits,
             linkMode = args.elementsSessionContext?.linkMode,
             billingDetails = args.elementsSessionContext?.billingDetails,
-            prefillDetails = args.elementsSessionContext?.prefillDetails,
+            prefillDetails = sdkPrefillDetails ?: args.elementsSessionContext?.prefillDetails,
             incentiveEligibilitySession = args.elementsSessionContext?.incentiveEligibilitySession,
         )
     }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/HostedAuthUrlBuilder.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/HostedAuthUrlBuilder.kt
@@ -14,14 +14,14 @@ internal object HostedAuthUrlBuilder {
     fun create(
         args: FinancialConnectionsSheetActivityArgs,
         manifest: FinancialConnectionsSessionManifest,
-        sdkPrefillDetails: PrefillDetails? = null,
+        prefillDetails: PrefillDetails? = args.elementsSessionContext?.prefillDetails,
     ): String? {
         return create(
             hostedAuthUrl = manifest.hostedAuthUrl,
             isInstantDebits = args is FinancialConnectionsSheetActivityArgs.ForInstantDebits,
             linkMode = args.elementsSessionContext?.linkMode,
             billingDetails = args.elementsSessionContext?.billingDetails,
-            prefillDetails = sdkPrefillDetails ?: args.elementsSessionContext?.prefillDetails,
+            prefillDetails = prefillDetails,
             incentiveEligibilitySession = args.elementsSessionContext?.incentiveEligibilitySession,
         )
     }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/HandleError.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/HandleError.kt
@@ -4,7 +4,7 @@ import com.stripe.android.core.Logger
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsTracker
 import com.stripe.android.financialconnections.analytics.logError
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.Message.CloseWithError
-import com.stripe.android.financialconnections.features.error.isAttestationError
+import com.stripe.android.financialconnections.features.error.FinancialConnectionsAttestationError
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
 import com.stripe.android.financialconnections.navigation.Destination
 import com.stripe.android.financialconnections.navigation.NavigationManager
@@ -56,7 +56,7 @@ internal class RealHandleError @Inject constructor(
             pane = pane
         )
 
-        if (error.isAttestationError) {
+        if (error is FinancialConnectionsAttestationError) {
             /*
             An attestation error (verification token generation error, unsatisfactory attestation verdict, etc)
             Happened mid flow -> Close the native flow with the error (right after we'll open a web browser to finish

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/LookupAccount.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/LookupAccount.kt
@@ -2,6 +2,7 @@ package com.stripe.android.financialconnections.domain
 
 import android.app.Application
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
+import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsSessionContext.PrefillDetails
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.AttestationEndpoint
 import com.stripe.android.financialconnections.features.error.toAttestationErrorIfApplicable
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
@@ -48,7 +49,7 @@ internal class LookupAccount @Inject constructor(
             }
         }.getOrElse { throwable ->
             throw throwable.toAttestationErrorIfApplicable(
-                FinancialConnectionsSheet.ElementsSessionContext.PrefillDetails(
+                PrefillDetails(
                     email = email,
                     phone = phone,
                     phoneCountryCode = phoneCountryCode

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/LookupAccount.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/LookupAccount.kt
@@ -3,6 +3,7 @@ package com.stripe.android.financialconnections.domain
 import android.app.Application
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.AttestationEndpoint
+import com.stripe.android.financialconnections.features.error.toAttestationErrorIfApplicable
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
 import com.stripe.android.financialconnections.repository.FinancialConnectionsConsumerSessionRepository
 import com.stripe.android.model.ConsumerSessionLookup
@@ -23,24 +24,28 @@ internal class LookupAccount @Inject constructor(
         sessionId: String,
         pane: Pane
     ): ConsumerSessionLookup {
-        return if (verifiedFlow) {
-            val token = requestIntegrityToken(pane = pane, endpoint = AttestationEndpoint.LOOKUP)
-            requireNotNull(
-                consumerSessionRepository.mobileLookupConsumerSession(
-                    email = email.lowercase().trim(),
-                    emailSource = emailSource,
-                    verificationToken = token,
-                    appId = application.packageName,
-                    sessionId = sessionId
+        return runCatching {
+            if (verifiedFlow) {
+                val token = requestIntegrityToken(pane = pane, endpoint = AttestationEndpoint.LOOKUP)
+                requireNotNull(
+                    consumerSessionRepository.mobileLookupConsumerSession(
+                        email = email.lowercase().trim(),
+                        emailSource = emailSource,
+                        verificationToken = token,
+                        appId = application.packageName,
+                        sessionId = sessionId
+                    )
                 )
-            )
-        } else {
-            requireNotNull(
-                consumerSessionRepository.postConsumerSession(
-                    email = email.lowercase().trim(),
-                    clientSecret = configuration.financialConnectionsSessionClientSecret
+            } else {
+                requireNotNull(
+                    consumerSessionRepository.postConsumerSession(
+                        email = email.lowercase().trim(),
+                        clientSecret = configuration.financialConnectionsSessionClientSecret
+                    )
                 )
-            )
+            }
+        }.getOrElse { throwable ->
+            throw throwable.toAttestationErrorIfApplicable(prefilledEmail = email)
         }
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/LookupAccount.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/LookupAccount.kt
@@ -19,6 +19,8 @@ internal class LookupAccount @Inject constructor(
 
     suspend operator fun invoke(
         email: String,
+        phone: String?,
+        phoneCountryCode: String?,
         emailSource: EmailSource,
         verifiedFlow: Boolean,
         sessionId: String,
@@ -45,7 +47,13 @@ internal class LookupAccount @Inject constructor(
                 )
             }
         }.getOrElse { throwable ->
-            throw throwable.toAttestationErrorIfApplicable(prefilledEmail = email)
+            throw throwable.toAttestationErrorIfApplicable(
+                FinancialConnectionsSheet.ElementsSessionContext.PrefillDetails(
+                    email = email,
+                    phone = phone,
+                    phoneCountryCode = phoneCountryCode
+                )
+            )
         }
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/error/ErrorExt.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/error/ErrorExt.kt
@@ -4,6 +4,14 @@ import com.stripe.android.core.exception.APIException
 import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsSessionContext.PrefillDetails
 import com.stripe.attestation.AttestationError
 
+/**
+ * Maps attestation related exceptions from the data layer (Integrity SDK, Stripe API) to a Financial Connections
+ * specific domain exception type, when applicable.
+ *
+ * @param sdkPrefillDetails the prefill details to be used when the attestation error triggers a switch from
+ * native to web flow. If the user entered email / phone on the native side before the exception occurred,
+ * we'll pass this information to the web flow so the user doesn't have to re-enter it.
+ */
 internal fun Throwable.toAttestationErrorIfApplicable(sdkPrefillDetails: PrefillDetails?): Throwable {
     return when {
         this is APIException && stripeError?.code == "link_failed_to_attest_request" -> FinancialConnectionsAttestationError(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/error/ErrorExt.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/error/ErrorExt.kt
@@ -12,22 +12,24 @@ import com.stripe.attestation.AttestationError
  * native to web flow. If the user entered email / phone on the native side before the exception occurred,
  * we'll pass this information to the web flow so the user doesn't have to re-enter it.
  */
-internal fun Throwable.toAttestationErrorIfApplicable(sdkPrefillDetails: PrefillDetails?): Throwable {
-    return when {
-        this is APIException && stripeError?.code == "link_failed_to_attest_request" -> FinancialConnectionsAttestationError(
+internal fun Throwable.toAttestationErrorIfApplicable(sdkPrefillDetails: PrefillDetails?): Throwable = when {
+    this is APIException && stripeError?.code == "link_failed_to_attest_request" -> {
+        FinancialConnectionsAttestationError(
             errorType = AttestationError.ErrorType.BACKEND_VERDICT_FAILED,
             message = stripeError?.message ?: "An unknown error occurred",
             prefillDetails = sdkPrefillDetails,
             cause = this
         )
-        this is AttestationError -> FinancialConnectionsAttestationError(
+    }
+    this is AttestationError -> {
+        FinancialConnectionsAttestationError(
             errorType = this.errorType,
             message = this.message ?: "An unknown error occurred",
             prefillDetails = sdkPrefillDetails,
             cause = this
         )
-        else -> this
     }
+    else -> this
 }
 
 internal class FinancialConnectionsAttestationError(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/error/ErrorExt.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/error/ErrorExt.kt
@@ -3,11 +3,28 @@ package com.stripe.android.financialconnections.features.error
 import com.stripe.android.core.exception.APIException
 import com.stripe.attestation.AttestationError
 
-internal val Throwable.isAttestationError: Boolean
-    get() = when (this) {
-        // Stripe backend could not verify the intregrity of the request
-        is APIException -> stripeError?.code == "link_failed_to_attest_request"
-        // Interaction with Integrity API to generate tokens resulted in a failure
-        is AttestationError -> true
-        else -> false
+internal fun Throwable.toAttestationErrorIfApplicable(prefilledEmail: String?): Throwable {
+    return when {
+        this is APIException && stripeError?.code == "link_failed_to_attest_request" -> FinancialConnectionsAttestationError(
+            errorType = AttestationError.ErrorType.BACKEND_VERDICT_FAILED,
+            message = stripeError?.message ?: "An unknown error occurred",
+            prefilledEmail = prefilledEmail,
+            cause = this
+        )
+        this is AttestationError -> FinancialConnectionsAttestationError(
+            errorType = this.errorType,
+            message = this.message ?: "An unknown error occurred",
+            prefilledEmail = prefilledEmail,
+            cause = this
+        )
+        else -> this
     }
+}
+
+internal class FinancialConnectionsAttestationError(
+    val errorType: AttestationError.ErrorType,
+    val prefilledEmail: String?,
+    message: String,
+    cause: Throwable? = null
+) : Exception(message, cause)
+

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/error/ErrorExt.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/error/ErrorExt.kt
@@ -1,20 +1,21 @@
 package com.stripe.android.financialconnections.features.error
 
 import com.stripe.android.core.exception.APIException
+import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsSessionContext.PrefillDetails
 import com.stripe.attestation.AttestationError
 
-internal fun Throwable.toAttestationErrorIfApplicable(prefilledEmail: String?): Throwable {
+internal fun Throwable.toAttestationErrorIfApplicable(sdkPrefillDetails: PrefillDetails?): Throwable {
     return when {
         this is APIException && stripeError?.code == "link_failed_to_attest_request" -> FinancialConnectionsAttestationError(
             errorType = AttestationError.ErrorType.BACKEND_VERDICT_FAILED,
             message = stripeError?.message ?: "An unknown error occurred",
-            prefilledEmail = prefilledEmail,
+            prefillDetails = sdkPrefillDetails,
             cause = this
         )
         this is AttestationError -> FinancialConnectionsAttestationError(
             errorType = this.errorType,
             message = this.message ?: "An unknown error occurred",
-            prefilledEmail = prefilledEmail,
+            prefillDetails = sdkPrefillDetails,
             cause = this
         )
         else -> this
@@ -23,7 +24,7 @@ internal fun Throwable.toAttestationErrorIfApplicable(prefilledEmail: String?): 
 
 internal class FinancialConnectionsAttestationError(
     val errorType: AttestationError.ErrorType,
-    val prefilledEmail: String?,
+    val prefillDetails: PrefillDetails?,
     message: String,
     cause: Throwable? = null
 ) : Exception(message, cause)

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/error/ErrorExt.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/error/ErrorExt.kt
@@ -27,4 +27,3 @@ internal class FinancialConnectionsAttestationError(
     message: String,
     cause: Throwable? = null
 ) : Exception(message, cause)
-

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkloginwarmup/NetworkingLinkLoginWarmupViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkloginwarmup/NetworkingLinkLoginWarmupViewModel.kt
@@ -97,6 +97,8 @@ internal class NetworkingLinkLoginWarmupViewModel @AssistedInject constructor(
             lookupAccount(
                 pane = PANE,
                 email = payload.email,
+                phone = null,
+                phoneCountryCode = null,
                 emailSource = EmailSource.CUSTOMER_OBJECT,
                 sessionId = payload.sessionId,
                 verifiedFlow = payload.verifiedFlow

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/LinkSignupHandler.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/LinkSignupHandler.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.financialconnections.features.networkinglinksignup
 
 import com.stripe.android.core.Logger
+import com.stripe.android.financialconnections.FinancialConnectionsSheet.ElementsSessionContext.PrefillDetails
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.AttestationEndpoint.SIGNUP
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.Click
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsTracker
@@ -94,7 +95,13 @@ internal class LinkSignupHandlerForInstantDebits @Inject constructor(
     ) {
         handleError(
             extraMessage = "Error creating a Link account",
-            error = error.toAttestationErrorIfApplicable(state.validEmail!!),
+            error = error.toAttestationErrorIfApplicable(
+                PrefillDetails(
+                    state.validEmail!!,
+                    state.validPhone,
+                    state.payload()!!.phoneController.getCountryCode()
+                )
+            ),
             pane = LINK_LOGIN,
             displayErrorScreen = true,
         )
@@ -167,7 +174,13 @@ internal class LinkSignupHandlerForNetworking @Inject constructor(
     ) {
         eventTracker.logError(
             extraMessage = "Error saving account to Link",
-            error = error.toAttestationErrorIfApplicable(state.validEmail!!),
+            error = error.toAttestationErrorIfApplicable(
+                PrefillDetails(
+                    state.validEmail!!,
+                    state.validPhone,
+                    state.payload()!!.phoneController.getCountryCode()
+                )
+            ),
             logger = logger,
             pane = NETWORKING_LINK_SIGNUP_PANE,
         )

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/LinkSignupHandler.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/LinkSignupHandler.kt
@@ -14,6 +14,7 @@ import com.stripe.android.financialconnections.domain.HandleError
 import com.stripe.android.financialconnections.domain.RequestIntegrityToken
 import com.stripe.android.financialconnections.domain.SaveAccountToLink
 import com.stripe.android.financialconnections.features.common.isDataFlow
+import com.stripe.android.financialconnections.features.error.toAttestationErrorIfApplicable
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane.LINK_LOGIN
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane.NETWORKING_LINK_SIGNUP_PANE
@@ -32,7 +33,8 @@ internal interface LinkSignupHandler {
     ): Pane
 
     fun handleSignupFailure(
-        error: Throwable,
+        state: NetworkingLinkSignupState,
+        error: Throwable
     )
 
     fun navigateToVerification()
@@ -86,10 +88,13 @@ internal class LinkSignupHandlerForInstantDebits @Inject constructor(
         navigationManager.tryNavigateTo(NetworkingLinkVerification(referrer = LINK_LOGIN))
     }
 
-    override fun handleSignupFailure(error: Throwable) {
+    override fun handleSignupFailure(
+        state: NetworkingLinkSignupState,
+        error: Throwable
+    ) {
         handleError(
             extraMessage = "Error creating a Link account",
-            error = error,
+            error = error.toAttestationErrorIfApplicable(state.validEmail!!),
             pane = LINK_LOGIN,
             displayErrorScreen = true,
         )
@@ -156,10 +161,13 @@ internal class LinkSignupHandlerForNetworking @Inject constructor(
         navigationManager.tryNavigateTo(NetworkingSaveToLinkVerification(referrer = NETWORKING_LINK_SIGNUP_PANE))
     }
 
-    override fun handleSignupFailure(error: Throwable) {
+    override fun handleSignupFailure(
+        state: NetworkingLinkSignupState,
+        error: Throwable
+    ) {
         eventTracker.logError(
             extraMessage = "Error saving account to Link",
-            error = error,
+            error = error.toAttestationErrorIfApplicable(state.validEmail!!),
             logger = logger,
             pane = NETWORKING_LINK_SIGNUP_PANE,
         )

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModel.kt
@@ -215,6 +215,8 @@ internal class NetworkingLinkSignupViewModel @AssistedInject constructor(
                 lookupAccount(
                     pane = pane,
                     email = validEmail,
+                    phone = payload?.phoneController?.getLocalNumber(),
+                    phoneCountryCode = payload?.phoneController?.getCountryCode(),
                     emailSource = if (payload?.prefilledEmail == validEmail) CUSTOMER_OBJECT else USER_ACTION,
                     sessionId = payload?.sessionId ?: "",
                     verifiedFlow = payload?.appVerificationEnabled == true

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModel.kt
@@ -169,7 +169,7 @@ internal class NetworkingLinkSignupViewModel @AssistedInject constructor(
                 val destination = nextPane.destination(referrer = pane)
                 navigationManager.tryNavigateTo(destination)
             },
-            onFail = linkSignupHandler::handleSignupFailure,
+            onFail = { linkSignupHandler.handleSignupFailure(stateFlow.value, it) },
         )
     }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
@@ -38,7 +38,7 @@ import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.
 import com.stripe.android.financialconnections.exception.CustomManualEntryRequiredError
 import com.stripe.android.financialconnections.exception.FinancialConnectionsError
 import com.stripe.android.financialconnections.exception.UnclassifiedError
-import com.stripe.android.financialconnections.features.error.isAttestationError
+import com.stripe.android.financialconnections.features.error.FinancialConnectionsAttestationError
 import com.stripe.android.financialconnections.features.manualentry.isCustomManualEntryError
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetActivityResult
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetActivityResult.Canceled
@@ -310,7 +310,7 @@ internal class FinancialConnectionsSheetNativeViewModel @Inject constructor(
             }
             setState { copy(completed = true) }
 
-            if (closeAuthFlowError?.isAttestationError == true) {
+            if (closeAuthFlowError is FinancialConnectionsAttestationError) {
                 // Attestation error is a special case where we need to close the native flow
                 // and continue with the AuthFlow on a web browser.
                 finishWithResult(Failed(error = closeAuthFlowError))

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModelTest.kt
@@ -443,7 +443,7 @@ class FinancialConnectionsSheetViewModelTest {
         // Then
         withState(viewModel) {
             val viewEffect = it.viewEffect as OpenAuthFlowWithUrl
-            assertThat(viewEffect.url).isEqualTo("${syncResponse.manifest.hostedAuthUrl}")
+            assertThat(viewEffect.url).isEqualTo("${syncResponse.manifest.hostedAuthUrl}?launched_by=android_sdk")
         }
     }
 

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModelTest.kt
@@ -443,7 +443,7 @@ class FinancialConnectionsSheetViewModelTest {
         // Then
         withState(viewModel) {
             val viewEffect = it.viewEffect as OpenAuthFlowWithUrl
-            assertThat(viewEffect.url).isEqualTo("${syncResponse.manifest.hostedAuthUrl}?launched_by=android_sdk")
+            assertThat(viewEffect.url).isEqualTo("${syncResponse.manifest.hostedAuthUrl}&launched_by=android_sdk")
         }
     }
 

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinkloginwarmup/NetworkingLinkLoginWarmupViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinkloginwarmup/NetworkingLinkLoginWarmupViewModelTest.kt
@@ -80,10 +80,12 @@ class NetworkingLinkLoginWarmupViewModelTest {
         whenever(
             lookupAccount(
                 email = anyOrNull(),
+                phone = anyOrNull(),
+                phoneCountryCode = anyOrNull(),
                 emailSource = anyOrNull(),
                 verifiedFlow = anyOrNull(),
                 sessionId = anyOrNull(),
-                pane = any()
+                pane = anyOrNull()
             )
         ).thenReturn(
             ConsumerSessionLookup(
@@ -96,7 +98,15 @@ class NetworkingLinkLoginWarmupViewModelTest {
         val viewModel = buildViewModel(NetworkingLinkLoginWarmupState())
         viewModel.onContinueClick()
 
-        verify(lookupAccount).invoke(any(), any(), any(), any(), any())
+        verify(lookupAccount).invoke(
+            email = anyOrNull(),
+            phone = anyOrNull(),
+            phoneCountryCode = anyOrNull(),
+            emailSource = anyOrNull(),
+            verifiedFlow = anyOrNull(),
+            sessionId = anyOrNull(),
+            pane = anyOrNull()
+        )
         navigationManager.assertNavigatedTo(
             destination = Destination.NetworkingLinkVerification,
             pane = Pane.NETWORKING_LINK_LOGIN_WARMUP

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinksignup/LinkSignupHandlerForInstantDebitsTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinksignup/LinkSignupHandlerForInstantDebitsTest.kt
@@ -97,8 +97,15 @@ class LinkSignupHandlerForInstantDebitsTest {
 
     @Test
     fun `handleSignupFailure should call handleError with correct parameters`() = runTest {
+        val testState = NetworkingLinkSignupState(
+            validEmail = "test@instantdebits.com",
+            validPhone = "+1234567890",
+            isInstantDebits = true,
+            payload = Async.Success(validPayload)
+        )
         val error = RuntimeException("Test Error")
-        handler.handleSignupFailure(error)
+
+        handler.handleSignupFailure(testState, error)
 
         verify(handleError).invoke(
             extraMessage = "Error creating a Link account",

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinksignup/LinkSignupHandlerForNetworkingTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinksignup/LinkSignupHandlerForNetworkingTest.kt
@@ -111,8 +111,14 @@ class LinkSignupHandlerForNetworkingTest {
     @Test
     fun `handleSignupFailure should log error and navigate to Success pane`() = runTest {
         val error = RuntimeException("Test Error")
+        val testState = NetworkingLinkSignupState(
+            validEmail = "test@instantdebits.com",
+            validPhone = "+1234567890",
+            isInstantDebits = true,
+            payload = Async.Success(validPayload)
+        )
 
-        handler.handleSignupFailure(error)
+        handler.handleSignupFailure(testState, error)
 
         verify(eventTracker).logError(
             extraMessage = "Error saving account to Link",

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModelTest.kt
@@ -96,7 +96,17 @@ class NetworkingLinkSignupViewModelTest {
                 )
             )
         )
-        whenever(lookupAccount(any(), any(), any(), any(), any())).thenReturn(ConsumerSessionLookup(exists = false))
+        whenever(
+            lookupAccount(
+                email = any(),
+                phone = any(),
+                phoneCountryCode = any(),
+                emailSource = any(),
+                verifiedFlow = any(),
+                sessionId = any(),
+                pane = any()
+            )
+        ).thenReturn(ConsumerSessionLookup(exists = false))
 
         val viewModel = buildViewModel(NetworkingLinkSignupState())
         val state = viewModel.stateFlow.value
@@ -117,7 +127,17 @@ class NetworkingLinkSignupViewModelTest {
                 )
             )
         )
-        whenever(lookupAccount(any(), any(), any(), any(), any())).thenReturn(ConsumerSessionLookup(exists = false))
+        whenever(
+            lookupAccount(
+                email = any(),
+                phone = any(),
+                phoneCountryCode = any(),
+                emailSource = any(),
+                verifiedFlow = any(),
+                sessionId = any(),
+                pane = any()
+            )
+        ).thenReturn(ConsumerSessionLookup(exists = false))
 
         val viewModel = buildViewModel(
             state = NetworkingLinkSignupState(),
@@ -201,7 +221,17 @@ class NetworkingLinkSignupViewModelTest {
             )
         )
         whenever(getOrFetchSync().manifest).thenReturn(manifest)
-        whenever(lookupAccount(any(), any(), any(), any(), any())).thenReturn(ConsumerSessionLookup(exists = true))
+        whenever(
+            lookupAccount(
+                email = any(),
+                phone = any(),
+                phoneCountryCode = any(),
+                emailSource = any(),
+                verifiedFlow = any(),
+                sessionId = any(),
+                pane = any()
+            )
+        ).thenReturn(ConsumerSessionLookup(exists = true))
 
         val viewModel = buildViewModel(NetworkingLinkSignupState())
 
@@ -236,7 +266,17 @@ class NetworkingLinkSignupViewModelTest {
             )
         )
 
-        whenever(lookupAccount(any(), any(), any(), any(), any())).thenReturn(ConsumerSessionLookup(exists = true))
+        whenever(
+            lookupAccount(
+                email = any(),
+                phone = any(),
+                phoneCountryCode = any(),
+                emailSource = any(),
+                verifiedFlow = any(),
+                sessionId = any(),
+                pane = any()
+            )
+        ).thenReturn(ConsumerSessionLookup(exists = true))
 
         val viewModel = buildViewModel(
             state = NetworkingLinkSignupState(isInstantDebits = true),
@@ -274,7 +314,17 @@ class NetworkingLinkSignupViewModelTest {
             )
         )
         whenever(getOrFetchSync().manifest).thenReturn(manifest)
-        whenever(lookupAccount(any(), any(), any(), any(), any())).thenReturn(ConsumerSessionLookup(exists = true))
+        whenever(
+            lookupAccount(
+                email = any(),
+                phone = any(),
+                phoneCountryCode = any(),
+                emailSource = any(),
+                verifiedFlow = any(),
+                sessionId = any(),
+                pane = any()
+            )
+        ).thenReturn(ConsumerSessionLookup(exists = true))
 
         val viewModel = buildViewModel(
             state = NetworkingLinkSignupState(),
@@ -368,7 +418,17 @@ class NetworkingLinkSignupViewModelTest {
         )
 
         whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(syncResponse)
-        whenever(lookupAccount(any(), any(), any(), any(), any())).thenReturn(ConsumerSessionLookup(exists = false))
+        whenever(
+            lookupAccount(
+                email = any(),
+                phone = any(),
+                phoneCountryCode = any(),
+                emailSource = any(),
+                verifiedFlow = any(),
+                sessionId = any(),
+                pane = any()
+            )
+        ).thenReturn(ConsumerSessionLookup(exists = false))
 
         val viewModel = buildViewModel(
             state = NetworkingLinkSignupState(isInstantDebits = false),
@@ -402,7 +462,17 @@ class NetworkingLinkSignupViewModelTest {
         )
 
         whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(initialSyncResponse)
-        whenever(lookupAccount(any(), any(), any(), any(), any())).thenReturn(ConsumerSessionLookup(exists = false))
+        whenever(
+            lookupAccount(
+                email = any(),
+                phone = any(),
+                phoneCountryCode = any(),
+                emailSource = any(),
+                verifiedFlow = any(),
+                sessionId = any(),
+                pane = any()
+            )
+        ).thenReturn(ConsumerSessionLookup(exists = false))
 
         val viewModel = buildViewModel(
             state = NetworkingLinkSignupState(isInstantDebits = true),
@@ -436,7 +506,17 @@ class NetworkingLinkSignupViewModelTest {
         )
 
         whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(syncResponse)
-        whenever(lookupAccount(any(), any(), any(), any(), any())).thenReturn(ConsumerSessionLookup(exists = false))
+        whenever(
+            lookupAccount(
+                email = any(),
+                phone = any(),
+                phoneCountryCode = any(),
+                emailSource = any(),
+                verifiedFlow = any(),
+                sessionId = any(),
+                pane = any()
+            )
+        ).thenReturn(ConsumerSessionLookup(exists = false))
 
         val viewModel = buildViewModel(
             state = NetworkingLinkSignupState(isInstantDebits = false),
@@ -470,7 +550,17 @@ class NetworkingLinkSignupViewModelTest {
         )
 
         whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(initialSyncResponse)
-        whenever(lookupAccount(any(), any(), any(), any(), any())).thenReturn(ConsumerSessionLookup(exists = false))
+        whenever(
+            lookupAccount(
+                email = any(),
+                phone = any(),
+                phoneCountryCode = any(),
+                emailSource = any(),
+                verifiedFlow = any(),
+                sessionId = any(),
+                pane = any()
+            )
+        ).thenReturn(ConsumerSessionLookup(exists = false))
 
         val viewModel = buildViewModel(
             state = NetworkingLinkSignupState(isInstantDebits = true),
@@ -502,7 +592,17 @@ class NetworkingLinkSignupViewModelTest {
         val permissionException = PermissionException(stripeError = StripeError())
 
         whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(initialSyncResponse)
-        whenever(lookupAccount(any(), any(), any(), any(), any())).then {
+        whenever(
+            lookupAccount(
+                email = any(),
+                phone = any(),
+                phoneCountryCode = any(),
+                emailSource = any(),
+                verifiedFlow = any(),
+                sessionId = any(),
+                pane = any()
+            )
+        ).then {
             throw permissionException
         }
 
@@ -522,36 +622,47 @@ class NetworkingLinkSignupViewModelTest {
     }
 
     @Test
-    fun `Does not navigate to error pane if encountering non-permission exception in lookup in Instant Debits`() = runTest {
-        val initialSyncResponse = syncResponse().copy(
-            manifest = sessionManifest().copy(
-                accountholderCustomerEmailAddress = "known_user@email.com",
-                isLinkWithStripe = true,
-            ),
-            text = TextUpdate(linkLoginPane = linkLoginPane()),
-        )
+    fun `Does not navigate to error pane if encountering non-permission exception in lookup in Instant Debits`() =
+        runTest {
+            val initialSyncResponse = syncResponse().copy(
+                manifest = sessionManifest().copy(
+                    accountholderCustomerEmailAddress = "known_user@email.com",
+                    isLinkWithStripe = true,
+                ),
+                text = TextUpdate(linkLoginPane = linkLoginPane()),
+            )
 
-        val apiException = APIConnectionException()
+            val apiException = APIConnectionException()
 
-        whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(initialSyncResponse)
-        whenever(lookupAccount(any(), any(), any(), any(), any())).then {
-            throw apiException
+            whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(initialSyncResponse)
+            whenever(
+                lookupAccount(
+                    email = any(),
+                    phone = any(),
+                    phoneCountryCode = any(),
+                    emailSource = any(),
+                    verifiedFlow = any(),
+                    sessionId = any(),
+                    pane = any()
+                )
+            ).then {
+                throw apiException
+            }
+
+            buildViewModel(
+                state = NetworkingLinkSignupState(isInstantDebits = true),
+                signupHandler = mockLinkSignupHandlerForInstantDebits(failOnSignup = true),
+            )
+
+            delay(300)
+
+            handleError.assertError(
+                extraMessage = "Error looking up account",
+                error = apiException,
+                pane = LINK_LOGIN,
+                displayErrorScreen = false,
+            )
         }
-
-        buildViewModel(
-            state = NetworkingLinkSignupState(isInstantDebits = true),
-            signupHandler = mockLinkSignupHandlerForInstantDebits(failOnSignup = true),
-        )
-
-        delay(300)
-
-        handleError.assertError(
-            extraMessage = "Error looking up account",
-            error = apiException,
-            pane = LINK_LOGIN,
-            displayErrorScreen = false,
-        )
-    }
 
     @Test
     fun `Does not navigate to error pane if encountering any exception in lookup in Financial Connections`() = runTest {
@@ -566,7 +677,17 @@ class NetworkingLinkSignupViewModelTest {
         val permissionException = PermissionException(stripeError = StripeError())
 
         whenever(getOrFetchSync(anyOrNull(), anyOrNull())).thenReturn(initialSyncResponse)
-        whenever(lookupAccount(any(), any(), any(), any(), any())).then {
+        whenever(
+            lookupAccount(
+                email = any(),
+                phone = any(),
+                phoneCountryCode = any(),
+                emailSource = any(),
+                verifiedFlow = any(),
+                sessionId = any(),
+                pane = any()
+            )
+        ).then {
             throw permissionException
         }
 

--- a/stripe-attestation/src/main/java/com/stripe/attestation/AttestationError.kt
+++ b/stripe-attestation/src/main/java/com/stripe/attestation/AttestationError.kt
@@ -15,6 +15,7 @@ class AttestationError(
     enum class ErrorType(
         val isRetriable: Boolean
     ) {
+        // Play Store related errors
         API_NOT_AVAILABLE(isRetriable = false),
         APP_NOT_INSTALLED(isRetriable = false),
         APP_UID_MISMATCH(isRetriable = false),
@@ -32,7 +33,8 @@ class AttestationError(
         PLAY_STORE_VERSION_OUTDATED(isRetriable = false),
         REQUEST_HASH_TOO_LONG(isRetriable = false),
         TOO_MANY_REQUESTS(isRetriable = true),
-        MAX_RETRIES_EXCEEDED(isRetriable = false),
+        // Stripe backend related errors
+        BACKEND_VERDICT_FAILED(isRetriable = false),
         UNKNOWN(isRetriable = false)
     }
 

--- a/stripe-attestation/src/main/java/com/stripe/attestation/AttestationError.kt
+++ b/stripe-attestation/src/main/java/com/stripe/attestation/AttestationError.kt
@@ -15,7 +15,7 @@ class AttestationError(
     enum class ErrorType(
         val isRetriable: Boolean
     ) {
-        // Play Store related errors
+        // Play Integrity SDK related errors
         API_NOT_AVAILABLE(isRetriable = false),
         APP_NOT_INSTALLED(isRetriable = false),
         APP_UID_MISMATCH(isRetriable = false),

--- a/stripe-attestation/src/main/java/com/stripe/attestation/AttestationError.kt
+++ b/stripe-attestation/src/main/java/com/stripe/attestation/AttestationError.kt
@@ -33,6 +33,7 @@ class AttestationError(
         PLAY_STORE_VERSION_OUTDATED(isRetriable = false),
         REQUEST_HASH_TOO_LONG(isRetriable = false),
         TOO_MANY_REQUESTS(isRetriable = true),
+
         // Stripe backend related errors
         BACKEND_VERDICT_FAILED(isRetriable = false),
         UNKNOWN(isRetriable = false)


### PR DESCRIPTION
# Summary
If attestation fails on lookup / signup and we switch to the web flow, pass entered email info as prefill details to `hostedAuthUrl` using the existing framework.

Also adds `FinancialConnectionsAttestationError` and removes `isAttestationError`. This allows bundling data along with the exception passed from native to web, and merges token generation and verdict failure errors.

https://github.com/user-attachments/assets/b1a64d2f-fb1e-448f-b0dc-3bfcb19e1241

# Motivation

https://jira.corp.stripe.com/browse/CONSUMERBANK-674

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
