### PR TITLE
Do not auto-share payment details in passthrough mode for native link

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkConfigurationCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkConfigurationCoordinator.kt
@@ -86,7 +86,10 @@ internal class RealLinkConfigurationCoordinator @Inject internal constructor(
     ): Result<LinkPaymentDetails> =
         getLinkPaymentLauncherComponent(configuration)
             .linkAccountManager
-            .createCardPaymentDetails(paymentMethodCreateParams)
+            .createCardPaymentDetails(
+                paymentMethodCreateParams = paymentMethodCreateParams,
+                shouldShareCardPaymentDetails = configuration.passthroughModeEnabled
+            )
 
     override suspend fun logOut(
         configuration: LinkConfiguration,

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
@@ -167,7 +167,8 @@ internal class DefaultLinkAccountManager @Inject constructor(
             }
 
     override suspend fun createCardPaymentDetails(
-        paymentMethodCreateParams: PaymentMethodCreateParams
+        paymentMethodCreateParams: PaymentMethodCreateParams,
+        shouldShareCardPaymentDetails: Boolean
     ): Result<LinkPaymentDetails> {
         val linkAccountValue = linkAccount.value
         return if (linkAccountValue != null) {
@@ -180,7 +181,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
                     consumerPublishableKey = if (config.passthroughModeEnabled) null else consumerPublishableKey,
                     active = config.passthroughModeEnabled,
                 ).mapCatching {
-                    if (config.passthroughModeEnabled) {
+                    if (shouldShareCardPaymentDetails) {
                         linkRepository.shareCardPaymentDetails(
                             id = it.paymentDetails.id,
                             last4 = paymentMethodCreateParams.cardLast4().orEmpty(),

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
@@ -55,7 +55,8 @@ internal interface LinkAccountManager {
     suspend fun logOut(): Result<ConsumerSession>
 
     suspend fun createCardPaymentDetails(
-        paymentMethodCreateParams: PaymentMethodCreateParams
+        paymentMethodCreateParams: PaymentMethodCreateParams,
+        shouldShareCardPaymentDetails: Boolean = false
     ): Result<LinkPaymentDetails>
 
     fun setLinkAccountFromLookupResult(

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAccountManagerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAccountManagerTest.kt
@@ -509,7 +509,7 @@ class DefaultLinkAccountManagerTest {
     }
 
     @Test
-    fun `createCardPaymentDetails makes correct calls in passthrough mode`() = runSuspendTest {
+    fun `createCardPaymentDetails should call shareCardPaymentDetails when enabled`() = runSuspendTest {
         val linkRepository = object : FakeLinkRepository() {
             var createCardPaymentDetailsCallCount = 0
             var shareCardPaymentDetailsCallCount = 0
@@ -552,7 +552,10 @@ class DefaultLinkAccountManagerTest {
             startSession = true,
         )
 
-        val result = accountManager.createCardPaymentDetails(TestFactory.PAYMENT_METHOD_CREATE_PARAMS)
+        val result = accountManager.createCardPaymentDetails(
+            paymentMethodCreateParams = TestFactory.PAYMENT_METHOD_CREATE_PARAMS,
+            shouldShareCardPaymentDetails = true
+        )
 
         assertThat(result.isSuccess).isTrue()
         val linkPaymentDetails = result.getOrThrow()
@@ -561,6 +564,60 @@ class DefaultLinkAccountManagerTest {
 
         assertThat(linkRepository.createCardPaymentDetailsCallCount).isEqualTo(1)
         assertThat(linkRepository.shareCardPaymentDetailsCallCount).isEqualTo(1)
+        assertThat(accountManager.linkAccount.value).isNotNull()
+    }
+
+    @Test
+    fun `createCardPaymentDetails should not call shareCardPaymentDetails when disabled`() = runSuspendTest {
+        val linkRepository = object : FakeLinkRepository() {
+            var createCardPaymentDetailsCallCount = 0
+            var shareCardPaymentDetailsCallCount = 0
+            override suspend fun createCardPaymentDetails(
+                paymentMethodCreateParams: PaymentMethodCreateParams,
+                userEmail: String,
+                stripeIntent: StripeIntent,
+                consumerSessionClientSecret: String,
+                consumerPublishableKey: String?,
+                active: Boolean
+            ): Result<LinkPaymentDetails.New> {
+                createCardPaymentDetailsCallCount += 1
+                return Result.success(TestFactory.LINK_NEW_PAYMENT_DETAILS)
+            }
+
+            override suspend fun shareCardPaymentDetails(
+                paymentMethodCreateParams: PaymentMethodCreateParams,
+                id: String,
+                last4: String,
+                consumerSessionClientSecret: String
+            ): Result<LinkPaymentDetails.New> {
+                shareCardPaymentDetailsCallCount += 1
+                return super.shareCardPaymentDetails(
+                    paymentMethodCreateParams,
+                    id,
+                    last4,
+                    consumerSessionClientSecret
+                )
+            }
+        }
+        val accountManager = accountManager(passthroughModeEnabled = true, linkRepository = linkRepository)
+
+        accountManager.setLinkAccountFromLookupResult(
+            TestFactory.CONSUMER_SESSION_LOOKUP,
+            startSession = true,
+        )
+
+        val result = accountManager.createCardPaymentDetails(
+            paymentMethodCreateParams = TestFactory.PAYMENT_METHOD_CREATE_PARAMS,
+            shouldShareCardPaymentDetails = false
+        )
+
+        assertThat(result.isSuccess).isTrue()
+        val linkPaymentDetails = result.getOrThrow()
+        assertThat(linkPaymentDetails.paymentDetails.id)
+            .isEqualTo(TestFactory.LINK_NEW_PAYMENT_DETAILS.paymentDetails.id)
+
+        assertThat(linkRepository.createCardPaymentDetailsCallCount).isEqualTo(1)
+        assertThat(linkRepository.shareCardPaymentDetailsCallCount).isEqualTo(0)
         assertThat(accountManager.linkAccount.value).isNotNull()
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/FakeLinkAccountManager.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/FakeLinkAccountManager.kt
@@ -68,7 +68,8 @@ internal open class FakeLinkAccountManager : LinkAccountManager {
     }
 
     override suspend fun createCardPaymentDetails(
-        paymentMethodCreateParams: PaymentMethodCreateParams
+        paymentMethodCreateParams: PaymentMethodCreateParams,
+        shouldShareCardPaymentDetails: Boolean
     ): Result<LinkPaymentDetails> {
         return createCardPaymentDetailsResult
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Remove auto-sharing of payment details for passthrough mode in `LinkAccountManager`. Native link does not need this behaviour and it is causing payment confirmation to fail after card creation.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
