### PR TITLE
Only conditionally attach LAS to Intent

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/CollectBankAccountForACHLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/CollectBankAccountForACHLauncher.kt
@@ -8,6 +8,12 @@ internal class CollectBankAccountForACHLauncher(
     private val hostedSurface: String?
 ) : CollectBankAccountLauncher {
 
+    private val attachToIntent: Boolean
+        // We only attach the intent if we're not hosted within another
+        // Stripe surface. If we're in one, then the surface will take care of
+        // attaching the LinkAccountSession.
+        get() = hostedSurface == null
+
     override fun presentWithPaymentIntent(
         publishableKey: String,
         stripeAccountId: String?,
@@ -21,7 +27,7 @@ internal class CollectBankAccountForACHLauncher(
                 clientSecret = clientSecret,
                 configuration = configuration,
                 hostedSurface = hostedSurface,
-                attachToIntent = true
+                attachToIntent = attachToIntent,
             )
         )
     }
@@ -39,7 +45,7 @@ internal class CollectBankAccountForACHLauncher(
                 clientSecret = clientSecret,
                 configuration = configuration,
                 hostedSurface = hostedSurface,
-                attachToIntent = true
+                attachToIntent = attachToIntent,
             )
         )
     }

--- a/payments-core/src/test/java/com/stripe/android/payments/bankaccount/CollectBankAccountForACHLauncherTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/bankaccount/CollectBankAccountForACHLauncherTest.kt
@@ -14,13 +14,10 @@ class CollectBankAccountForACHLauncherTest {
     private val mockHostActivityLauncher =
         mock<ActivityResultLauncher<CollectBankAccountContract.Args>>()
 
-    private val launcher = CollectBankAccountForACHLauncher(
-        mockHostActivityLauncher,
-        hostedSurface = null
-    )
-
     @Test
     fun `presentWithPaymentIntent - launches CollectBankAccountActivity with correct arguments`() {
+        val launcher = makeLauncher()
+
         launcher.presentWithPaymentIntent(
             publishableKey = PUBLISHABLE_KEY,
             clientSecret = CLIENT_SECRET,
@@ -41,7 +38,32 @@ class CollectBankAccountForACHLauncherTest {
     }
 
     @Test
+    fun `presentWithPaymentIntent - launches with correct attachToIntent if hostedSurface not null`() {
+        val launcher = makeLauncher(hostedSurface = "payment_element")
+
+        launcher.presentWithPaymentIntent(
+            publishableKey = PUBLISHABLE_KEY,
+            clientSecret = CLIENT_SECRET,
+            stripeAccountId = STRIPE_ACCOUNT_ID,
+            configuration = CONFIGURATION
+        )
+
+        verify(mockHostActivityLauncher).launch(
+            CollectBankAccountContract.Args.ForPaymentIntent(
+                publishableKey = PUBLISHABLE_KEY,
+                stripeAccountId = STRIPE_ACCOUNT_ID,
+                clientSecret = CLIENT_SECRET,
+                configuration = CONFIGURATION,
+                attachToIntent = false,
+                hostedSurface = "payment_element",
+            )
+        )
+    }
+
+    @Test
     fun `presentWithSetupIntent - launches CollectBankAccountActivity with correct arguments`() {
+        val launcher = makeLauncher()
+
         launcher.presentWithSetupIntent(
             publishableKey = PUBLISHABLE_KEY,
             stripeAccountId = STRIPE_ACCOUNT_ID,
@@ -62,7 +84,32 @@ class CollectBankAccountForACHLauncherTest {
     }
 
     @Test
+    fun `presentWithSetupIntent - launches with correct attachToIntent if hostedSurface not null`() {
+        val launcher = makeLauncher(hostedSurface = "payment_element")
+
+        launcher.presentWithSetupIntent(
+            publishableKey = PUBLISHABLE_KEY,
+            stripeAccountId = STRIPE_ACCOUNT_ID,
+            clientSecret = CLIENT_SECRET,
+            configuration = CONFIGURATION,
+        )
+
+        verify(mockHostActivityLauncher).launch(
+            CollectBankAccountContract.Args.ForSetupIntent(
+                publishableKey = PUBLISHABLE_KEY,
+                stripeAccountId = STRIPE_ACCOUNT_ID,
+                clientSecret = CLIENT_SECRET,
+                configuration = CONFIGURATION,
+                attachToIntent = false,
+                hostedSurface = "payment_element",
+            )
+        )
+    }
+
+    @Test
     fun `presentWithDeferredPayment - launches CollectBankAccountActivity with correct arguments`() {
+        val launcher = makeLauncher()
+
         launcher.presentWithDeferredPayment(
             publishableKey = PUBLISHABLE_KEY,
             stripeAccountId = STRIPE_ACCOUNT_ID,
@@ -91,6 +138,8 @@ class CollectBankAccountForACHLauncherTest {
 
     @Test
     fun `presentWithDeferredSetup - launches CollectBankAccountActivity with correct arguments`() {
+        val launcher = makeLauncher()
+
         launcher.presentWithDeferredSetup(
             publishableKey = PUBLISHABLE_KEY,
             stripeAccountId = STRIPE_ACCOUNT_ID,
@@ -110,6 +159,15 @@ class CollectBankAccountForACHLauncherTest {
                 onBehalfOf = "on_behalf_of_id",
                 hostedSurface = null
             )
+        )
+    }
+
+    private fun makeLauncher(
+        hostedSurface: String? = null,
+    ): CollectBankAccountForACHLauncher {
+        return CollectBankAccountForACHLauncher(
+            mockHostActivityLauncher,
+            hostedSurface = hostedSurface,
         )
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where we attached the LAS to the intent, causing two `PaymentMethod` objects to be created in the backend.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
