### PR TITLE
LinkAuth abstraction for lookup and signup

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAuth.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAuth.kt
@@ -1,8 +1,8 @@
 package com.stripe.android.link.account
 
 import com.stripe.android.core.exception.APIException
-import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.NoLinkAccountFoundException
+import com.stripe.android.link.gate.LinkGate
 import com.stripe.android.link.injection.APPLICATION_ID
 import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.link.ui.inline.SignUpConsentAction
@@ -13,7 +13,7 @@ import javax.inject.Inject
 import javax.inject.Named
 
 internal class DefaultLinkAuth @Inject constructor(
-    private val linkConfiguration: LinkConfiguration,
+    private val linkGate: LinkGate,
     private val linkAccountManager: LinkAccountManager,
     private val integrityRequestManager: IntegrityRequestManager,
     @Named(APPLICATION_ID) private val applicationId: String
@@ -25,7 +25,7 @@ internal class DefaultLinkAuth @Inject constructor(
         name: String?,
         consentAction: SignUpConsentAction
     ): LinkAuthResult {
-        val signupResult = if (linkConfiguration.useAttestationEndpointsForLink) {
+        val signupResult = if (linkGate.useAttestationEndpoints) {
             mobileSignUp(
                 email = email,
                 phoneNumber = phoneNumber,
@@ -46,7 +46,7 @@ internal class DefaultLinkAuth @Inject constructor(
     }
 
     override suspend fun lookUp(email: String, emailSource: EmailSource): LinkAuthResult {
-        val lookupResult = if (linkConfiguration.useAttestationEndpointsForLink) {
+        val lookupResult = if (linkGate.useAttestationEndpoints) {
             mobileLookUp(
                 email = email,
                 emailSource = emailSource

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAuth.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAuth.kt
@@ -1,0 +1,129 @@
+package com.stripe.android.link.account
+
+import com.stripe.android.core.exception.APIException
+import com.stripe.android.link.LinkConfiguration
+import com.stripe.android.link.NoLinkAccountFoundException
+import com.stripe.android.link.injection.APPLICATION_ID
+import com.stripe.android.link.model.LinkAccount
+import com.stripe.android.link.ui.inline.SignUpConsentAction
+import com.stripe.android.model.EmailSource
+import com.stripe.attestation.AttestationError
+import com.stripe.attestation.IntegrityRequestManager
+import javax.inject.Inject
+import javax.inject.Named
+
+internal class DefaultLinkAuth @Inject constructor(
+    private val linkConfiguration: LinkConfiguration,
+    private val linkAccountManager: LinkAccountManager,
+    private val integrityRequestManager: IntegrityRequestManager,
+    @Named(APPLICATION_ID) private val applicationId: String
+) : LinkAuth {
+    override suspend fun signUp(
+        email: String,
+        phoneNumber: String,
+        country: String,
+        name: String?,
+        consentAction: SignUpConsentAction
+    ): LinkAuthResult {
+        val signupResult = if (linkConfiguration.useAttestationEndpointsForLink) {
+            mobileSignUp(
+                email = email,
+                phoneNumber = phoneNumber,
+                country = country,
+                name = name,
+                consentAction = consentAction
+            )
+        } else {
+            linkAccountManager.signUp(
+                email = email,
+                phone = phoneNumber,
+                country = country,
+                name = name,
+                consentAction = consentAction
+            )
+        }
+        return signupResult.toLinkAuthResult()
+    }
+
+    override suspend fun lookUp(email: String, emailSource: EmailSource): LinkAuthResult {
+        val lookupResult = if (linkConfiguration.useAttestationEndpointsForLink) {
+            mobileLookUp(
+                email = email,
+                emailSource = emailSource
+            )
+        } else {
+            linkAccountManager.lookupConsumer(
+                email = email,
+                startSession = true
+            )
+        }
+        return lookupResult.toLinkAuthResult()
+    }
+
+    private suspend fun mobileSignUp(
+        email: String,
+        phoneNumber: String,
+        country: String,
+        name: String?,
+        consentAction: SignUpConsentAction
+    ): Result<LinkAccount> {
+        return runCatching {
+            val verificationToken = integrityRequestManager.requestToken().getOrThrow()
+            linkAccountManager.mobileSignUp(
+                email = email,
+                phone = phoneNumber,
+                country = country,
+                name = name,
+                consentAction = consentAction,
+                verificationToken = verificationToken,
+                appId = applicationId
+            ).getOrThrow()
+        }
+    }
+
+    private suspend fun mobileLookUp(
+        email: String,
+        emailSource: EmailSource
+    ): Result<LinkAccount?> {
+        return runCatching {
+            val verificationToken = integrityRequestManager.requestToken().getOrThrow()
+            linkAccountManager.mobileLookupConsumer(
+                email = email,
+                emailSource = emailSource,
+                verificationToken = verificationToken,
+                appId = applicationId,
+                startSession = true
+            ).getOrThrow()
+        }
+    }
+
+    private fun Result<LinkAccount?>.toLinkAuthResult(): LinkAuthResult {
+        return runCatching {
+            val linkAccount = getOrThrow()
+            return if (linkAccount != null) {
+                LinkAuthResult.Success(linkAccount)
+            } else {
+                LinkAuthResult.Error(NoLinkAccountFoundException())
+            }
+        }.getOrElse { error ->
+            error.toLinkAuthResult()
+        }
+    }
+
+    private fun Throwable.toLinkAuthResult(): LinkAuthResult {
+        return if (isAttestationError) {
+            LinkAuthResult.AttestationFailed(this)
+        } else {
+            LinkAuthResult.Error(this)
+        }
+    }
+
+    private val Throwable.isAttestationError: Boolean
+        get() = when (this) {
+            // Stripe backend could not verify the intregrity of the request
+            is APIException -> stripeError?.code == "link_failed_to_attest_request"
+            // Interaction with Integrity API to generate tokens resulted in a failure
+            is AttestationError -> true
+            else -> false
+        }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAuth.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAuth.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.link.account
 
 import com.stripe.android.core.exception.APIException
-import com.stripe.android.link.NoLinkAccountFoundException
 import com.stripe.android.link.gate.LinkGate
 import com.stripe.android.link.injection.APPLICATION_ID
 import com.stripe.android.link.model.LinkAccount
@@ -103,7 +102,7 @@ internal class DefaultLinkAuth @Inject constructor(
             return if (linkAccount != null) {
                 LinkAuthResult.Success(linkAccount)
             } else {
-                LinkAuthResult.Error(NoLinkAccountFoundException())
+                LinkAuthResult.NoLinkAccountFound
             }
         }.getOrElse { error ->
             error.toLinkAuthResult()

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAuth.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAuth.kt
@@ -44,16 +44,21 @@ internal class DefaultLinkAuth @Inject constructor(
         return signupResult.toLinkAuthResult()
     }
 
-    override suspend fun lookUp(email: String, emailSource: EmailSource): LinkAuthResult {
+    override suspend fun lookUp(
+        email: String,
+        emailSource: EmailSource,
+        startSession: Boolean
+    ): LinkAuthResult {
         val lookupResult = if (linkGate.useAttestationEndpoints) {
             mobileLookUp(
                 email = email,
-                emailSource = emailSource
+                emailSource = emailSource,
+                startSession = startSession
             )
         } else {
             linkAccountManager.lookupConsumer(
                 email = email,
-                startSession = true
+                startSession = startSession
             )
         }
         return lookupResult.toLinkAuthResult()
@@ -82,7 +87,8 @@ internal class DefaultLinkAuth @Inject constructor(
 
     private suspend fun mobileLookUp(
         email: String,
-        emailSource: EmailSource
+        emailSource: EmailSource,
+        startSession: Boolean
     ): Result<LinkAccount?> {
         return runCatching {
             val verificationToken = integrityRequestManager.requestToken().getOrThrow()
@@ -91,7 +97,7 @@ internal class DefaultLinkAuth @Inject constructor(
                 emailSource = emailSource,
                 verificationToken = verificationToken,
                 appId = applicationId,
-                startSession = true
+                startSession = startSession
             ).getOrThrow()
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAuth.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAuth.kt
@@ -1,0 +1,19 @@
+package com.stripe.android.link.account
+
+import com.stripe.android.link.ui.inline.SignUpConsentAction
+import com.stripe.android.model.EmailSource
+
+internal interface LinkAuth {
+    suspend fun signUp(
+        email: String,
+        phoneNumber: String,
+        country: String,
+        name: String?,
+        consentAction: SignUpConsentAction
+    ): LinkAuthResult
+
+    suspend fun lookUp(
+        email: String,
+        emailSource: EmailSource,
+    ): LinkAuthResult
+}

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAuth.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAuth.kt
@@ -15,5 +15,6 @@ internal interface LinkAuth {
     suspend fun lookUp(
         email: String,
         emailSource: EmailSource,
+        startSession: Boolean
     ): LinkAuthResult
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAuthResult.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAuthResult.kt
@@ -4,6 +4,7 @@ import com.stripe.android.link.model.LinkAccount
 
 internal sealed interface LinkAuthResult {
     data class Success(val account: LinkAccount) : LinkAuthResult
+    data object NoLinkAccountFound : LinkAuthResult
     data class AttestationFailed(val throwable: Throwable) : LinkAuthResult
     data class Error(val throwable: Throwable) : LinkAuthResult
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAuthResult.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAuthResult.kt
@@ -1,0 +1,9 @@
+package com.stripe.android.link.account
+
+import com.stripe.android.link.model.LinkAccount
+
+internal sealed interface LinkAuthResult {
+    data class Success(val account: LinkAccount) : LinkAuthResult
+    data class AttestationFailed(val throwable: Throwable) : LinkAuthResult
+    data class Error(val throwable: Throwable) : LinkAuthResult
+}

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkModule.kt
@@ -22,7 +22,9 @@ import com.stripe.android.core.utils.DefaultDurationProvider
 import com.stripe.android.core.utils.DurationProvider
 import com.stripe.android.core.version.StripeSdkVersion
 import com.stripe.android.link.account.DefaultLinkAccountManager
+import com.stripe.android.link.account.DefaultLinkAuth
 import com.stripe.android.link.account.LinkAccountManager
+import com.stripe.android.link.account.LinkAuth
 import com.stripe.android.link.analytics.DefaultLinkEventsReporter
 import com.stripe.android.link.analytics.LinkEventsReporter
 import com.stripe.android.link.confirmation.DefaultLinkConfirmationHandler
@@ -86,6 +88,10 @@ internal interface NativeLinkModule {
     @Binds
     @NativeLinkScope
     fun bindsLinkGate(linkGate: DefaultLinkGate): LinkGate
+
+    @Binds
+    @NativeLinkScope
+    fun bindsLinkAuth(linkGate: DefaultLinkAuth): LinkAuth
 
     @SuppressWarnings("TooManyFunctions")
     companion object {
@@ -186,5 +192,16 @@ internal interface NativeLinkModule {
         @Provides
         @NativeLinkScope
         fun provideEventReporterMode(): EventReporter.Mode = EventReporter.Mode.Custom
+
+        @Provides
+        @NativeLinkScope
+        @Named(APPLICATION_ID)
+        fun provideApplicationId(
+            application: Application
+        ): String {
+            return application.packageName
+        }
     }
 }
+
+internal const val APPLICATION_ID = "application_id"

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAuthTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAuthTest.kt
@@ -5,6 +5,7 @@ import com.stripe.android.core.StripeError
 import com.stripe.android.core.exception.APIException
 import com.stripe.android.link.FakeIntegrityRequestManager
 import com.stripe.android.link.TestFactory
+import com.stripe.android.link.gate.FakeLinkGate
 import com.stripe.android.link.ui.inline.SignUpConsentAction
 import com.stripe.attestation.AttestationError
 import com.stripe.attestation.IntegrityRequestManager
@@ -407,9 +408,9 @@ internal class DefaultLinkAuthTest {
         integrityRequestManager: IntegrityRequestManager = FakeIntegrityRequestManager()
     ): DefaultLinkAuth {
         return DefaultLinkAuth(
-            linkConfiguration = TestFactory.LINK_CONFIGURATION.copy(
-                useAttestationEndpointsForLink = useAttestationEndpoints
-            ),
+            linkGate = FakeLinkGate().apply {
+                setUseAttestationEndpoints(useAttestationEndpoints)
+            },
             linkAccountManager = linkAccountManager,
             integrityRequestManager = integrityRequestManager,
             applicationId = TestFactory.APP_ID

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAuthTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAuthTest.kt
@@ -1,0 +1,418 @@
+package com.stripe.android.link.account
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.StripeError
+import com.stripe.android.core.exception.APIException
+import com.stripe.android.link.FakeIntegrityRequestManager
+import com.stripe.android.link.TestFactory
+import com.stripe.android.link.ui.inline.SignUpConsentAction
+import com.stripe.attestation.AttestationError
+import com.stripe.attestation.IntegrityRequestManager
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+internal class DefaultLinkAuthTest {
+
+    private val dispatcher = UnconfinedTestDispatcher()
+
+    @Before
+    fun before() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    fun cleanup() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `config with attestation enabled successfully signs in`() = runTest {
+        val linkAccountManager = FakeLinkAccountManager()
+        val integrityRequestManager = FakeIntegrityRequestManager()
+
+        val linkAuth = linkAuth(
+            linkAccountManager = linkAccountManager,
+            integrityRequestManager = integrityRequestManager
+        )
+
+        val result = linkAuth.signUp(
+            email = TestFactory.CUSTOMER_EMAIL,
+            phoneNumber = TestFactory.CUSTOMER_PHONE,
+            country = TestFactory.COUNTRY,
+            name = TestFactory.CUSTOMER_NAME,
+            consentAction = SignUpConsentAction.Implied
+        )
+
+        val accountManagerCall = linkAccountManager.awaitMobileSignUpCall()
+        integrityRequestManager.awaitRequestTokenCall()
+
+        assertThat(accountManagerCall.name).isEqualTo(TestFactory.CUSTOMER_NAME)
+        assertThat(accountManagerCall.email).isEqualTo(TestFactory.CUSTOMER_EMAIL)
+        assertThat(accountManagerCall.country).isEqualTo(TestFactory.COUNTRY)
+        assertThat(accountManagerCall.phone).isEqualTo(TestFactory.CUSTOMER_PHONE)
+        assertThat(accountManagerCall.consentAction).isEqualTo(SignUpConsentAction.Implied)
+        assertThat(accountManagerCall.verificationToken).isEqualTo(TestFactory.VERIFICATION_TOKEN)
+        assertThat(accountManagerCall.appId).isEqualTo(TestFactory.APP_ID)
+
+        assertThat(result).isEqualTo(LinkAuthResult.Success(TestFactory.LINK_ACCOUNT))
+
+        linkAccountManager.ensureAllEventsConsumed()
+        integrityRequestManager.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `sign in attempt with attestation failure returns AttestationFailed`() = runTest {
+        val error = APIException(
+            stripeError = StripeError(
+                code = "link_failed_to_attest_request"
+            )
+        )
+        val linkAccountManager = FakeLinkAccountManager()
+        val integrityRequestManager = FakeIntegrityRequestManager()
+
+        integrityRequestManager.requestResult = Result.failure(error)
+
+        val linkAuth = linkAuth(
+            linkAccountManager = linkAccountManager,
+            integrityRequestManager = integrityRequestManager
+        )
+
+        val result = linkAuth.signUp(
+            email = TestFactory.CUSTOMER_EMAIL,
+            phoneNumber = TestFactory.CUSTOMER_PHONE,
+            country = TestFactory.COUNTRY,
+            name = TestFactory.CUSTOMER_NAME,
+            consentAction = SignUpConsentAction.Implied
+        )
+
+        integrityRequestManager.awaitRequestTokenCall()
+
+        assertThat(result).isEqualTo(LinkAuthResult.AttestationFailed(error))
+
+        linkAccountManager.ensureAllEventsConsumed()
+        integrityRequestManager.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `sign in attempt with token fetch failure returns AttestationFailed`() = runTest {
+        val error = AttestationError(
+            errorType = AttestationError.ErrorType.INTERNAL_ERROR,
+            message = "oops"
+        )
+        val linkAccountManager = FakeLinkAccountManager()
+        val integrityRequestManager = FakeIntegrityRequestManager()
+
+        integrityRequestManager.requestResult = Result.failure(error)
+
+        val linkAuth = linkAuth(
+            linkAccountManager = linkAccountManager,
+            integrityRequestManager = integrityRequestManager
+        )
+
+        val result = linkAuth.signUp(
+            email = TestFactory.CUSTOMER_EMAIL,
+            phoneNumber = TestFactory.CUSTOMER_PHONE,
+            country = TestFactory.COUNTRY,
+            name = TestFactory.CUSTOMER_NAME,
+            consentAction = SignUpConsentAction.Implied
+        )
+
+        integrityRequestManager.awaitRequestTokenCall()
+
+        assertThat(result).isEqualTo(LinkAuthResult.AttestationFailed(error))
+
+        linkAccountManager.ensureAllEventsConsumed()
+        integrityRequestManager.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `sign in attempt with generic failure returns Error`() = runTest {
+        val error = Throwable("oops")
+        val linkAccountManager = FakeLinkAccountManager()
+        val integrityRequestManager = FakeIntegrityRequestManager()
+
+        integrityRequestManager.requestResult = Result.failure(error)
+
+        val linkAuth = linkAuth(
+            linkAccountManager = linkAccountManager,
+            integrityRequestManager = integrityRequestManager
+        )
+
+        val result = linkAuth.signUp(
+            email = TestFactory.CUSTOMER_EMAIL,
+            phoneNumber = TestFactory.CUSTOMER_PHONE,
+            country = TestFactory.COUNTRY,
+            name = TestFactory.CUSTOMER_NAME,
+            consentAction = SignUpConsentAction.Implied
+        )
+
+        integrityRequestManager.awaitRequestTokenCall()
+
+        assertThat(result).isEqualTo(LinkAuthResult.Error(error))
+
+        linkAccountManager.ensureAllEventsConsumed()
+        integrityRequestManager.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `config with attestation disabled successfully signs in`() = runTest {
+        val linkAccountManager = FakeLinkAccountManager()
+        val integrityRequestManager = FakeIntegrityRequestManager()
+
+        val linkAuth = linkAuth(
+            useAttestationEndpoints = false,
+            linkAccountManager = linkAccountManager,
+            integrityRequestManager = integrityRequestManager
+        )
+
+        val result = linkAuth.signUp(
+            email = TestFactory.CUSTOMER_EMAIL,
+            phoneNumber = TestFactory.CUSTOMER_PHONE,
+            country = TestFactory.COUNTRY,
+            name = TestFactory.CUSTOMER_NAME,
+            consentAction = SignUpConsentAction.Implied
+        )
+
+        val accountManagerCall = linkAccountManager.awaitSignUpCall()
+
+        assertThat(accountManagerCall.name).isEqualTo(TestFactory.CUSTOMER_NAME)
+        assertThat(accountManagerCall.email).isEqualTo(TestFactory.CUSTOMER_EMAIL)
+        assertThat(accountManagerCall.country).isEqualTo(TestFactory.COUNTRY)
+        assertThat(accountManagerCall.phone).isEqualTo(TestFactory.CUSTOMER_PHONE)
+        assertThat(accountManagerCall.consentAction).isEqualTo(SignUpConsentAction.Implied)
+
+        assertThat(result).isEqualTo(LinkAuthResult.Success(TestFactory.LINK_ACCOUNT))
+
+        linkAccountManager.ensureAllEventsConsumed()
+        integrityRequestManager.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `config with attestation disabled returns error on sign up failure`() = runTest {
+        val error = Throwable("oops")
+        val linkAccountManager = FakeLinkAccountManager()
+        val integrityRequestManager = FakeIntegrityRequestManager()
+
+        linkAccountManager.signUpResult = Result.failure(error)
+
+        val linkAuth = linkAuth(
+            useAttestationEndpoints = false,
+            linkAccountManager = linkAccountManager,
+            integrityRequestManager = integrityRequestManager
+        )
+
+        val result = linkAuth.signUp(
+            email = TestFactory.CUSTOMER_EMAIL,
+            phoneNumber = TestFactory.CUSTOMER_PHONE,
+            country = TestFactory.COUNTRY,
+            name = TestFactory.CUSTOMER_NAME,
+            consentAction = SignUpConsentAction.Implied
+        )
+
+        val accountManagerCall = linkAccountManager.awaitSignUpCall()
+
+        assertThat(accountManagerCall.name).isEqualTo(TestFactory.CUSTOMER_NAME)
+        assertThat(accountManagerCall.email).isEqualTo(TestFactory.CUSTOMER_EMAIL)
+        assertThat(accountManagerCall.country).isEqualTo(TestFactory.COUNTRY)
+        assertThat(accountManagerCall.phone).isEqualTo(TestFactory.CUSTOMER_PHONE)
+        assertThat(accountManagerCall.consentAction).isEqualTo(SignUpConsentAction.Implied)
+
+        assertThat(result).isEqualTo(LinkAuthResult.Error(error))
+
+        linkAccountManager.ensureAllEventsConsumed()
+        integrityRequestManager.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `config with attestation enabled performs lookup successfully`() = runTest {
+        val linkAccountManager = FakeLinkAccountManager()
+        val integrityRequestManager = FakeIntegrityRequestManager()
+
+        val linkAuth = linkAuth(
+            linkAccountManager = linkAccountManager,
+            integrityRequestManager = integrityRequestManager
+        )
+
+        val result = linkAuth.lookUp(
+            email = TestFactory.CUSTOMER_EMAIL,
+            emailSource = TestFactory.EMAIL_SOURCE
+        )
+
+        val accountManagerCall = linkAccountManager.awaitMobileLookupCall()
+        integrityRequestManager.awaitRequestTokenCall()
+
+        assertThat(accountManagerCall.email).isEqualTo(TestFactory.CUSTOMER_EMAIL)
+        assertThat(accountManagerCall.emailSource).isEqualTo(TestFactory.EMAIL_SOURCE)
+        assertThat(accountManagerCall.verificationToken).isEqualTo(TestFactory.VERIFICATION_TOKEN)
+        assertThat(accountManagerCall.appId).isEqualTo(TestFactory.APP_ID)
+        assertThat(accountManagerCall.startSession).isTrue()
+
+        assertThat(result).isEqualTo(LinkAuthResult.Success(TestFactory.LINK_ACCOUNT))
+
+        linkAccountManager.ensureAllEventsConsumed()
+        integrityRequestManager.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `lookup attempt with attestation failure returns AttestationFailed`() = runTest {
+        val error = APIException(
+            stripeError = StripeError(
+                code = "link_failed_to_attest_request"
+            )
+        )
+        val linkAccountManager = FakeLinkAccountManager()
+        val integrityRequestManager = FakeIntegrityRequestManager()
+
+        integrityRequestManager.requestResult = Result.failure(error)
+
+        val linkAuth = linkAuth(
+            linkAccountManager = linkAccountManager,
+            integrityRequestManager = integrityRequestManager
+        )
+
+        val result = linkAuth.lookUp(
+            email = TestFactory.CUSTOMER_EMAIL,
+            emailSource = TestFactory.EMAIL_SOURCE
+        )
+
+        integrityRequestManager.awaitRequestTokenCall()
+
+        assertThat(result).isEqualTo(LinkAuthResult.AttestationFailed(error))
+
+        linkAccountManager.ensureAllEventsConsumed()
+        integrityRequestManager.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `lookup attempt with token fetch failure returns AttestationFailed`() = runTest {
+        val error = AttestationError(
+            errorType = AttestationError.ErrorType.INTERNAL_ERROR,
+            message = "oops"
+        )
+        val linkAccountManager = FakeLinkAccountManager()
+        val integrityRequestManager = FakeIntegrityRequestManager()
+
+        integrityRequestManager.requestResult = Result.failure(error)
+
+        val linkAuth = linkAuth(
+            linkAccountManager = linkAccountManager,
+            integrityRequestManager = integrityRequestManager
+        )
+
+        val result = linkAuth.lookUp(
+            email = TestFactory.CUSTOMER_EMAIL,
+            emailSource = TestFactory.EMAIL_SOURCE
+        )
+
+        integrityRequestManager.awaitRequestTokenCall()
+
+        assertThat(result).isEqualTo(LinkAuthResult.AttestationFailed(error))
+
+        linkAccountManager.ensureAllEventsConsumed()
+        integrityRequestManager.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `lookup attempt with generic failure returns Error`() = runTest {
+        val error = Throwable("oops")
+        val linkAccountManager = FakeLinkAccountManager()
+        val integrityRequestManager = FakeIntegrityRequestManager()
+
+        integrityRequestManager.requestResult = Result.failure(error)
+
+        val linkAuth = linkAuth(
+            linkAccountManager = linkAccountManager,
+            integrityRequestManager = integrityRequestManager
+        )
+
+        val result = linkAuth.lookUp(
+            email = TestFactory.CUSTOMER_EMAIL,
+            emailSource = TestFactory.EMAIL_SOURCE
+        )
+
+        integrityRequestManager.awaitRequestTokenCall()
+
+        assertThat(result).isEqualTo(LinkAuthResult.Error(error))
+
+        linkAccountManager.ensureAllEventsConsumed()
+        integrityRequestManager.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `config with attestation disabled performs lookup successfully`() = runTest {
+        val linkAccountManager = FakeLinkAccountManager()
+        val integrityRequestManager = FakeIntegrityRequestManager()
+
+        val linkAuth = linkAuth(
+            useAttestationEndpoints = false,
+            linkAccountManager = linkAccountManager,
+            integrityRequestManager = integrityRequestManager
+        )
+
+        val result = linkAuth.lookUp(
+            email = TestFactory.CUSTOMER_EMAIL,
+            emailSource = TestFactory.EMAIL_SOURCE
+        )
+
+        val accountManagerCall = linkAccountManager.awaitLookupCall()
+
+        assertThat(accountManagerCall.email).isEqualTo(TestFactory.CUSTOMER_EMAIL)
+        assertThat(accountManagerCall.startSession).isTrue()
+
+        assertThat(result).isEqualTo(LinkAuthResult.Success(TestFactory.LINK_ACCOUNT))
+
+        linkAccountManager.ensureAllEventsConsumed()
+        integrityRequestManager.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `config with attestation disabled returns error on lookup failure`() = runTest {
+        val error = Throwable("oops")
+        val linkAccountManager = FakeLinkAccountManager()
+        val integrityRequestManager = FakeIntegrityRequestManager()
+
+        linkAccountManager.lookupConsumerResult = Result.failure(error)
+
+        val linkAuth = linkAuth(
+            useAttestationEndpoints = false,
+            linkAccountManager = linkAccountManager,
+            integrityRequestManager = integrityRequestManager
+        )
+
+        val result = linkAuth.lookUp(
+            email = TestFactory.CUSTOMER_EMAIL,
+            emailSource = TestFactory.EMAIL_SOURCE
+        )
+
+        val accountManagerCall = linkAccountManager.awaitLookupCall()
+
+        assertThat(accountManagerCall.email).isEqualTo(TestFactory.CUSTOMER_EMAIL)
+        assertThat(accountManagerCall.startSession).isTrue()
+
+        assertThat(result).isEqualTo(LinkAuthResult.Error(error))
+
+        linkAccountManager.ensureAllEventsConsumed()
+        integrityRequestManager.ensureAllEventsConsumed()
+    }
+
+    private fun linkAuth(
+        useAttestationEndpoints: Boolean = true,
+        linkAccountManager: FakeLinkAccountManager = FakeLinkAccountManager(),
+        integrityRequestManager: IntegrityRequestManager = FakeIntegrityRequestManager()
+    ): DefaultLinkAuth {
+        return DefaultLinkAuth(
+            linkConfiguration = TestFactory.LINK_CONFIGURATION.copy(
+                useAttestationEndpointsForLink = useAttestationEndpoints
+            ),
+            linkAccountManager = linkAccountManager,
+            integrityRequestManager = integrityRequestManager,
+            applicationId = TestFactory.APP_ID
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAuthTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAuthTest.kt
@@ -354,6 +354,8 @@ internal class DefaultLinkAuthTest {
         val linkAccountManager = FakeLinkAccountManager()
         val integrityRequestManager = FakeIntegrityRequestManager()
 
+        linkAccountManager.lookupConsumerResult = Result.success(TestFactory.LINK_ACCOUNT)
+
         val linkAuth = linkAuth(
             useAttestationEndpoints = false,
             linkAccountManager = linkAccountManager,

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAuthTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAuthTest.kt
@@ -242,7 +242,8 @@ internal class DefaultLinkAuthTest {
 
         val result = linkAuth.lookUp(
             email = TestFactory.CUSTOMER_EMAIL,
-            emailSource = TestFactory.EMAIL_SOURCE
+            emailSource = TestFactory.EMAIL_SOURCE,
+            startSession = true
         )
 
         val accountManagerCall = linkAccountManager.awaitMobileLookupCall()
@@ -279,7 +280,8 @@ internal class DefaultLinkAuthTest {
 
         val result = linkAuth.lookUp(
             email = TestFactory.CUSTOMER_EMAIL,
-            emailSource = TestFactory.EMAIL_SOURCE
+            emailSource = TestFactory.EMAIL_SOURCE,
+            startSession = false
         )
 
         integrityRequestManager.awaitRequestTokenCall()
@@ -308,7 +310,8 @@ internal class DefaultLinkAuthTest {
 
         val result = linkAuth.lookUp(
             email = TestFactory.CUSTOMER_EMAIL,
-            emailSource = TestFactory.EMAIL_SOURCE
+            emailSource = TestFactory.EMAIL_SOURCE,
+            startSession = false
         )
 
         integrityRequestManager.awaitRequestTokenCall()
@@ -334,7 +337,8 @@ internal class DefaultLinkAuthTest {
 
         val result = linkAuth.lookUp(
             email = TestFactory.CUSTOMER_EMAIL,
-            emailSource = TestFactory.EMAIL_SOURCE
+            emailSource = TestFactory.EMAIL_SOURCE,
+            startSession = false
         )
 
         integrityRequestManager.awaitRequestTokenCall()
@@ -358,13 +362,14 @@ internal class DefaultLinkAuthTest {
 
         val result = linkAuth.lookUp(
             email = TestFactory.CUSTOMER_EMAIL,
-            emailSource = TestFactory.EMAIL_SOURCE
+            emailSource = TestFactory.EMAIL_SOURCE,
+            startSession = false
         )
 
         val accountManagerCall = linkAccountManager.awaitLookupCall()
 
         assertThat(accountManagerCall.email).isEqualTo(TestFactory.CUSTOMER_EMAIL)
-        assertThat(accountManagerCall.startSession).isTrue()
+        assertThat(accountManagerCall.startSession).isFalse()
 
         assertThat(result).isEqualTo(LinkAuthResult.Success(TestFactory.LINK_ACCOUNT))
 
@@ -388,7 +393,8 @@ internal class DefaultLinkAuthTest {
 
         val result = linkAuth.lookUp(
             email = TestFactory.CUSTOMER_EMAIL,
-            emailSource = TestFactory.EMAIL_SOURCE
+            emailSource = TestFactory.EMAIL_SOURCE,
+            startSession = true
         )
 
         val accountManagerCall = linkAccountManager.awaitLookupCall()
@@ -416,12 +422,14 @@ internal class DefaultLinkAuthTest {
 
         val result = linkAuth.lookUp(
             email = TestFactory.CUSTOMER_EMAIL,
-            emailSource = TestFactory.EMAIL_SOURCE
+            emailSource = TestFactory.EMAIL_SOURCE,
+            startSession = false
         )
 
-        linkAccountManager.awaitMobileLookupCall()
+        val accountManagerCall = linkAccountManager.awaitMobileLookupCall()
         integrityRequestManager.awaitRequestTokenCall()
 
+        assertThat(accountManagerCall.startSession).isFalse()
         assertThat(result).isEqualTo(LinkAuthResult.NoLinkAccountFound)
 
         linkAccountManager.ensureAllEventsConsumed()

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAuthTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAuthTest.kt
@@ -402,6 +402,32 @@ internal class DefaultLinkAuthTest {
         integrityRequestManager.ensureAllEventsConsumed()
     }
 
+    @Test
+    fun `null link account yields NoLinkAccountFound result`() = runTest {
+        val linkAccountManager = FakeLinkAccountManager()
+        val integrityRequestManager = FakeIntegrityRequestManager()
+
+        linkAccountManager.mobileLookupConsumerResult = Result.success(null)
+
+        val linkAuth = linkAuth(
+            linkAccountManager = linkAccountManager,
+            integrityRequestManager = integrityRequestManager
+        )
+
+        val result = linkAuth.lookUp(
+            email = TestFactory.CUSTOMER_EMAIL,
+            emailSource = TestFactory.EMAIL_SOURCE
+        )
+
+        linkAccountManager.awaitMobileLookupCall()
+        integrityRequestManager.awaitRequestTokenCall()
+
+        assertThat(result).isEqualTo(LinkAuthResult.NoLinkAccountFound)
+
+        linkAccountManager.ensureAllEventsConsumed()
+        integrityRequestManager.ensureAllEventsConsumed()
+    }
+
     private fun linkAuth(
         useAttestationEndpoints: Boolean = true,
         linkAccountManager: FakeLinkAccountManager = FakeLinkAccountManager(),

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/FakeLinkAccountManager.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/FakeLinkAccountManager.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.link.account
 
+import app.cash.turbine.Turbine
 import com.stripe.android.link.LinkPaymentDetails
 import com.stripe.android.link.TestFactory
 import com.stripe.android.link.model.AccountStatus
@@ -23,10 +24,12 @@ internal open class FakeLinkAccountManager : LinkAccountManager {
     private val _accountStatus = MutableStateFlow(AccountStatus.SignedOut)
     override val accountStatus: Flow<AccountStatus> = _accountStatus
 
-    var lookupConsumerResult: Result<LinkAccount?> = Result.success(null)
+    var lookupConsumerResult: Result<LinkAccount?> = Result.success(TestFactory.LINK_ACCOUNT)
+    var mobileLookupConsumerResult: Result<LinkAccount?> = Result.success(TestFactory.LINK_ACCOUNT)
     var startVerificationResult: Result<LinkAccount> = Result.success(LinkAccount(ConsumerSession("", "", "", "")))
     var confirmVerificationResult: Result<LinkAccount> = Result.success(LinkAccount(ConsumerSession("", "", "", "")))
-    var signUpResult: Result<LinkAccount> = Result.success(LinkAccount(ConsumerSession("", "", "", "")))
+    var signUpResult: Result<LinkAccount> = Result.success(TestFactory.LINK_ACCOUNT)
+    var mobileSignUpResult: Result<LinkAccount> = Result.success(TestFactory.LINK_ACCOUNT)
     var signInWithUserInputResult: Result<LinkAccount> = Result.success(LinkAccount(ConsumerSession("", "", "", "")))
     var logOutResult: Result<ConsumerSession> = Result.success(ConsumerSession("", "", "", ""))
     var createCardPaymentDetailsResult: Result<LinkPaymentDetails> = Result.success(
@@ -36,6 +39,13 @@ internal open class FakeLinkAccountManager : LinkAccountManager {
     var updatePaymentDetailsResult = Result.success(TestFactory.CONSUMER_PAYMENT_DETAILS)
     var deletePaymentDetailsResult: Result<Unit> = Result.success(Unit)
     var linkAccountFromLookupResult: LinkAccount? = null
+
+    private val lookupTurbine = Turbine<LookupCall>()
+    private val mobileLookupTurbine = Turbine<MobileLookupCall>()
+
+    private val signupTurbine = Turbine<SignUpCall>()
+    private val mobileSignUpTurbine = Turbine<MobileSignUpCall>()
+
     override var consumerPublishableKey: String? = null
 
     fun setLinkAccount(account: LinkAccount?) {
@@ -47,6 +57,12 @@ internal open class FakeLinkAccountManager : LinkAccountManager {
     }
 
     override suspend fun lookupConsumer(email: String, startSession: Boolean): Result<LinkAccount?> {
+        lookupTurbine.add(
+            item = LookupCall(
+                email = email,
+                startSession = startSession
+            )
+        )
         return lookupConsumerResult
     }
 
@@ -57,7 +73,16 @@ internal open class FakeLinkAccountManager : LinkAccountManager {
         appId: String,
         startSession: Boolean
     ): Result<LinkAccount?> {
-        TODO("Not yet implemented")
+        mobileLookupTurbine.add(
+            item = MobileLookupCall(
+                email = email,
+                emailSource = emailSource,
+                verificationToken = verificationToken,
+                appId = appId,
+                startSession = startSession
+            )
+        )
+        return mobileLookupConsumerResult
     }
 
     override suspend fun signUp(
@@ -67,6 +92,15 @@ internal open class FakeLinkAccountManager : LinkAccountManager {
         name: String?,
         consentAction: SignUpConsentAction
     ): Result<LinkAccount> {
+        signupTurbine.add(
+            item = SignUpCall(
+                email = email,
+                phone = phone,
+                country = country,
+                name = name,
+                consentAction = consentAction
+            )
+        )
         return signUpResult
     }
 
@@ -79,7 +113,18 @@ internal open class FakeLinkAccountManager : LinkAccountManager {
         appId: String,
         consentAction: SignUpConsentAction
     ): Result<LinkAccount> {
-        TODO("Not yet implemented")
+        mobileSignUpTurbine.add(
+            item = MobileSignUpCall(
+                email = email,
+                phone = phone,
+                country = country,
+                name = name,
+                verificationToken = verificationToken,
+                appId = appId,
+                consentAction = consentAction
+            )
+        )
+        return mobileSignUpResult
     }
 
     override suspend fun signInWithUserInput(userInput: UserInput): Result<LinkAccount> {
@@ -118,4 +163,58 @@ internal open class FakeLinkAccountManager : LinkAccountManager {
     ): Result<ConsumerPaymentDetails> {
         return updatePaymentDetailsResult
     }
+
+    suspend fun awaitMobileSignUpCall(): MobileSignUpCall {
+        return mobileSignUpTurbine.awaitItem()
+    }
+
+    suspend fun awaitSignUpCall(): SignUpCall {
+        return signupTurbine.awaitItem()
+    }
+
+    suspend fun awaitMobileLookupCall(): MobileLookupCall {
+        return mobileLookupTurbine.awaitItem()
+    }
+
+    suspend fun awaitLookupCall(): LookupCall {
+        return lookupTurbine.awaitItem()
+    }
+
+    fun ensureAllEventsConsumed() {
+        lookupTurbine.ensureAllEventsConsumed()
+        mobileLookupTurbine.ensureAllEventsConsumed()
+        signupTurbine.ensureAllEventsConsumed()
+        mobileSignUpTurbine.ensureAllEventsConsumed()
+    }
+
+    data class LookupCall(
+        val email: String,
+        val startSession: Boolean
+    )
+
+    data class MobileLookupCall(
+        val email: String,
+        val emailSource: EmailSource,
+        val verificationToken: String,
+        val appId: String,
+        val startSession: Boolean
+    )
+
+    data class SignUpCall(
+        val email: String,
+        val phone: String,
+        val country: String,
+        val name: String?,
+        val consentAction: SignUpConsentAction
+    )
+
+    data class MobileSignUpCall(
+        val email: String,
+        val phone: String,
+        val country: String,
+        val name: String?,
+        val verificationToken: String,
+        val appId: String,
+        val consentAction: SignUpConsentAction
+    )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/FakeLinkAccountManager.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/FakeLinkAccountManager.kt
@@ -24,7 +24,7 @@ internal open class FakeLinkAccountManager : LinkAccountManager {
     private val _accountStatus = MutableStateFlow(AccountStatus.SignedOut)
     override val accountStatus: Flow<AccountStatus> = _accountStatus
 
-    var lookupConsumerResult: Result<LinkAccount?> = Result.success(TestFactory.LINK_ACCOUNT)
+    var lookupConsumerResult: Result<LinkAccount?> = Result.success(null)
     var mobileLookupConsumerResult: Result<LinkAccount?> = Result.success(TestFactory.LINK_ACCOUNT)
     var startVerificationResult: Result<LinkAccount> = Result.success(LinkAccount(ConsumerSession("", "", "", "")))
     var confirmVerificationResult: Result<LinkAccount> = Result.success(LinkAccount(ConsumerSession("", "", "", "")))


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
`LinkAuth` will be used as an abstraction to call lookup and signup. It will use attestation endpoints when the attestation flag is enabled. It will use the old endpoints otherwise. `LinkAuth` will replace `LinkAccountManager` in 
* `SignUpVieModel` (for look up and signup)
* `LinkActivityViewModel` (for look up)

`LinkAuth` uses `LinkAccountManager` and `IntegrityRequestManager` underneath.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
[JIRA](https://jira.corp.stripe.com/browse/MOBILESDK-3060)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified
