### PR TITLE
Use single instance of LinkAccountManager across sdk

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/LinkTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/LinkTest.kt
@@ -6,6 +6,7 @@ import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import com.stripe.android.core.utils.urlEncode
 import com.stripe.android.link.account.LinkStore
+import com.stripe.android.link.injection.LinkAccountManagerModule
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatcher
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
@@ -21,6 +22,7 @@ import com.stripe.android.paymentsheet.utils.ProductIntegrationTypeProvider
 import com.stripe.android.paymentsheet.utils.TestRules
 import com.stripe.android.paymentsheet.utils.assertCompleted
 import com.stripe.android.paymentsheet.utils.runProductIntegrationTest
+import org.junit.After
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -42,6 +44,11 @@ internal class LinkTest {
 
     @TestParameter(valuesProvider = ProductIntegrationTypeProvider::class)
     lateinit var integrationType: ProductIntegrationType
+
+    @After
+    fun clearLinkAccountManagerModule() {
+        LinkAccountManagerModule.clear()
+    }
 
     @Test
     fun testSuccessfulCardPaymentWithLinkSignUp() = runProductIntegrationTest(

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkAccountManagerModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkAccountManagerModule.kt
@@ -1,0 +1,36 @@
+package com.stripe.android.link.injection
+
+import com.stripe.android.link.LinkConfiguration
+import com.stripe.android.link.account.DefaultLinkAccountManager
+import com.stripe.android.link.account.LinkAccountManager
+import com.stripe.android.link.analytics.LinkEventsReporter
+import com.stripe.android.link.repositories.LinkRepository
+import com.stripe.android.payments.core.analytics.ErrorReporter
+import dagger.Module
+import dagger.Provides
+
+@Module
+internal object LinkAccountManagerModule {
+
+    @Volatile
+    private var linkAccountManager: LinkAccountManager? = null
+
+    @Provides
+    fun provideLinkAccountManager(
+        config: LinkConfiguration,
+        linkRepository: LinkRepository,
+        linkEventsReporter: LinkEventsReporter,
+        errorReporter: ErrorReporter,
+    ): LinkAccountManager {
+        return linkAccountManager ?: synchronized(this) {
+            linkAccountManager ?: DefaultLinkAccountManager(
+                config = config,
+                linkRepository = linkRepository,
+                linkEventsReporter = linkEventsReporter,
+                errorReporter = errorReporter
+            ).also {
+                this.linkAccountManager = it
+            }
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkAccountManagerModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkAccountManagerModule.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.link.injection
 
+import androidx.annotation.VisibleForTesting
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.account.DefaultLinkAccountManager
 import com.stripe.android.link.account.LinkAccountManager
@@ -32,5 +33,10 @@ internal object LinkAccountManagerModule {
                 this.linkAccountManager = it
             }
         }
+    }
+
+    @VisibleForTesting
+    fun clear() {
+        linkAccountManager = null
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkComponent.kt
@@ -19,6 +19,7 @@ internal annotation class LinkScope
 @Subcomponent(
     modules = [
         LinkModule::class,
+        LinkAccountManagerModule::class
     ]
 )
 internal abstract class LinkComponent {

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkModule.kt
@@ -5,8 +5,6 @@ import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.networking.DefaultStripeNetworkClient
 import com.stripe.android.core.version.StripeSdkVersion
-import com.stripe.android.link.account.DefaultLinkAccountManager
-import com.stripe.android.link.account.LinkAccountManager
 import com.stripe.android.link.analytics.DefaultLinkEventsReporter
 import com.stripe.android.link.analytics.LinkEventsReporter
 import com.stripe.android.link.repositories.LinkApiRepository
@@ -27,10 +25,6 @@ internal interface LinkModule {
     @Binds
     @LinkScope
     fun bindLinkEventsReporter(linkEventsReporter: DefaultLinkEventsReporter): LinkEventsReporter
-
-    @Binds
-    @LinkScope
-    fun bindLinkAccountManager(linkAccountManager: DefaultLinkAccountManager): LinkAccountManager
 
     companion object {
         @Provides

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkComponent.kt
@@ -29,6 +29,7 @@ internal annotation class NativeLinkScope
     modules = [
         NativeLinkModule::class,
         LinkViewModelModule::class,
+        LinkAccountManagerModule::class,
         DefaultConfirmationModule::class,
     ]
 )

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkModule.kt
@@ -21,9 +21,7 @@ import com.stripe.android.core.utils.ContextUtils.packageInfo
 import com.stripe.android.core.utils.DefaultDurationProvider
 import com.stripe.android.core.utils.DurationProvider
 import com.stripe.android.core.version.StripeSdkVersion
-import com.stripe.android.link.account.DefaultLinkAccountManager
 import com.stripe.android.link.account.DefaultLinkAuth
-import com.stripe.android.link.account.LinkAccountManager
 import com.stripe.android.link.account.LinkAuth
 import com.stripe.android.link.analytics.DefaultLinkEventsReporter
 import com.stripe.android.link.analytics.LinkEventsReporter
@@ -62,10 +60,6 @@ internal interface NativeLinkModule {
     @Binds
     @NativeLinkScope
     fun bindLinkEventsReporter(linkEventsReporter: DefaultLinkEventsReporter): LinkEventsReporter
-
-    @Binds
-    @NativeLinkScope
-    fun bindLinkAccountManager(linkAccountManager: DefaultLinkAccountManager): LinkAccountManager
 
     @Binds
     @NativeLinkScope


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Use single instance of LinkAccountManager across sdk

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
This fixes the issue where closing and re-opening link requires 2fa login
[JIRA](https://jira.corp.stripe.com/browse/MOBILESDK-3069)


# Screen Recordings
## Before

https://github.com/user-attachments/assets/ce45bca6-6abc-4745-8bcd-14a671fcb3f7

## After

https://github.com/user-attachments/assets/c31f3b29-ae7c-4275-bb7e-f8c4ebf6d0b8


