### PR TITLE
Update DefaultEmbeddedSelectionChooser to keep the previousConfiguration.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/SharedPaymentElementViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/SharedPaymentElementViewModel.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
 import com.stripe.android.cards.CardAccountRangeRepository
 import com.stripe.android.cards.DefaultCardAccountRangeRepositoryFactory
+import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.utils.RealUserFacingLogger
 import com.stripe.android.core.utils.UserFacingLogger
@@ -126,7 +127,6 @@ internal class SharedPaymentElementViewModel @Inject constructor(
         intentConfiguration: PaymentSheet.IntentConfiguration,
         configuration: EmbeddedPaymentElement.Configuration,
     ) {
-        val previousConfiguration = confirmationStateHolder.state?.configuration
         confirmationStateHolder.state = EmbeddedConfirmationStateHolder.State(
             paymentMethodMetadata = state.paymentMethodMetadata,
             selection = state.paymentSelection,
@@ -142,8 +142,7 @@ internal class SharedPaymentElementViewModel @Inject constructor(
                 paymentMethods = state.customer?.paymentMethods,
                 previousSelection = selectionHolder.selection.value,
                 newSelection = state.paymentSelection,
-                previousConfiguration = previousConfiguration,
-                newConfiguration = configuration,
+                newConfiguration = configuration.asCommonConfiguration(),
             )
         )
         embeddedContentHelper.dataLoaded(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/SharedPaymentElementViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/SharedPaymentElementViewModelTest.kt
@@ -382,7 +382,7 @@ internal class SharedPaymentElementViewModelTest {
             configurationHandler = configurationHandler,
             paymentOptionDisplayDataFactory = paymentOptionDisplayDataFactory,
             selectionHolder = selectionHolder,
-            selectionChooser = { _, _, _, newSelection, _, _ ->
+            selectionChooser = { _, _, _, newSelection, _ ->
                 newSelection
             },
             customerStateHolder = customerStateHolder,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This has no behavior changes.

I want to make a follow up refactor to block confirmation when configuration is happening, and keeping this state internal (not having to pass it in) simplifies things.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-2986

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
