### PR TITLE
Clear confirmation state while configuring to prevent confirming while configuring.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/SharedPaymentElementViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/SharedPaymentElementViewModel.kt
@@ -103,6 +103,7 @@ internal class SharedPaymentElementViewModel @Inject constructor(
         configuration: EmbeddedPaymentElement.Configuration,
     ): ConfigureResult {
         return viewModelScope.async {
+            confirmationStateHolder.state = null
             configurationHandler.configure(
                 intentConfiguration = intentConfiguration,
                 configuration = configuration,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This makes embeddedPaymentElement.confirm() fail if a configure is in flight.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-2986

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

