### PR TITLE
Integrate attestation with LinkActivityViewModel

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -198,6 +198,9 @@ interface ErrorReporter : FraudDetectionErrorReporter {
         LINK_NATIVE_FAILED_TO_PREPARE_INTEGRITY_MANAGER(
             partialEventName = "link.native.integrity.preparation_failed"
         ),
+        LINK_NATIVE_FAILED_TO_ATTEST_REQUEST(
+            partialEventName = "link.native.failed_to_attest_request"
+        ),
         PAYMENT_SHEET_AUTHENTICATORS_NOT_FOUND(
             partialEventName = "paymentsheet.authenticators.not_found"
         ),

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkViewModelModule.kt
@@ -1,7 +1,9 @@
 package com.stripe.android.link.injection
 
 import com.stripe.android.link.LinkActivityViewModel
+import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.account.LinkAccountManager
+import com.stripe.android.link.account.LinkAuth
 import com.stripe.android.link.gate.LinkGate
 import com.stripe.android.paymentelement.confirmation.DefaultConfirmationHandler
 import com.stripe.android.payments.core.analytics.ErrorReporter
@@ -21,7 +23,9 @@ internal object LinkViewModelModule {
         eventReporter: EventReporter,
         integrityRequestManager: IntegrityRequestManager,
         linkGate: LinkGate,
-        errorReporter: ErrorReporter
+        errorReporter: ErrorReporter,
+        linkAuth: LinkAuth,
+        linkConfiguration: LinkConfiguration
     ): LinkActivityViewModel {
         return LinkActivityViewModel(
             activityRetainedComponent = component,
@@ -30,7 +34,9 @@ internal object LinkViewModelModule {
             eventReporter = eventReporter,
             integrityRequestManager = integrityRequestManager,
             linkGate = linkGate,
-            errorReporter = errorReporter
+            errorReporter = errorReporter,
+            linkAuth = linkAuth,
+            linkConfiguration = linkConfiguration
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/FakeLinkAuth.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/FakeLinkAuth.kt
@@ -1,0 +1,75 @@
+package com.stripe.android.link.account
+
+import app.cash.turbine.Turbine
+import com.stripe.android.link.TestFactory
+import com.stripe.android.link.ui.inline.SignUpConsentAction
+import com.stripe.android.model.EmailSource
+
+internal class FakeLinkAuth : LinkAuth {
+    var signupResult: LinkAuthResult = LinkAuthResult.Success(TestFactory.LINK_ACCOUNT)
+    var lookupResult: LinkAuthResult = LinkAuthResult.Success(TestFactory.LINK_ACCOUNT)
+
+    private val signupTurbine = Turbine<SignUpCall>()
+    private val lookupTurbine = Turbine<LookupCall>()
+
+    override suspend fun signUp(
+        email: String,
+        phoneNumber: String,
+        country: String,
+        name: String?,
+        consentAction: SignUpConsentAction
+    ): LinkAuthResult {
+        signupTurbine.add(
+            item = SignUpCall(
+                email = email,
+                phone = phoneNumber,
+                country = country,
+                name = name,
+                consentAction = consentAction
+            )
+        )
+        return signupResult
+    }
+
+    override suspend fun lookUp(
+        email: String,
+        emailSource: EmailSource,
+        startSession: Boolean
+    ): LinkAuthResult {
+        lookupTurbine.add(
+            item = LookupCall(
+                email = email,
+                emailSource = emailSource,
+                startSession = startSession
+            )
+        )
+        return lookupResult
+    }
+
+    suspend fun awaitSignUpCall(): SignUpCall {
+        return signupTurbine.awaitItem()
+    }
+
+    suspend fun awaitLookupCall(): LookupCall {
+        return lookupTurbine.awaitItem()
+    }
+
+    fun ensureAllItemsConsumed() {
+        lookupTurbine.ensureAllEventsConsumed()
+        signupTurbine.ensureAllEventsConsumed()
+    }
+
+    data class SignUpCall(
+        val email: String,
+        val phone: String,
+        val country: String,
+        val name: String?,
+        val consentAction: SignUpConsentAction
+    )
+
+    data class LookupCall(
+        val email: String,
+        val emailSource: EmailSource,
+        val startSession: Boolean
+    )
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Integrate attestation with LinkActivityViewModel

LinkActivityViewModel will
* Prepare the integrity manager if attestation is enabled
* It will then perform a lookup

It will short-circuit to web if play integrity attestation fails or lookup fails due to an attestation error

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
