### PR TITLE
Use attestation on sign up screen

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -201,6 +201,9 @@ interface ErrorReporter : FraudDetectionErrorReporter {
         LINK_NATIVE_FAILED_TO_ATTEST_REQUEST(
             partialEventName = "link.native.failed_to_attest_request"
         ),
+        LINK_NATIVE_FAILED_TO_ATTEST_SIGNUP_REQUEST(
+            partialEventName = "link.native.signup.failed_to_attest_request"
+        ),
         PAYMENT_SHEET_AUTHENTICATORS_NOT_FOUND(
             partialEventName = "paymentsheet.authenticators.not_found"
         ),

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivity.kt
@@ -97,7 +97,8 @@ internal class LinkActivity : ComponentActivity() {
                     onUpdateSheetContent = {
                         bottomSheetContent = it
                     },
-                    onBackPressed = onBackPressedDispatcher::onBackPressed
+                    onBackPressed = onBackPressedDispatcher::onBackPressed,
+                    moveToWeb = vm::moveToWeb
                 )
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
@@ -70,7 +70,7 @@ internal class LinkActivityViewModel @Inject constructor(
         }
     }
 
-    private fun moveToWeb() {
+    fun moveToWeb() {
         launchWebFlow?.let { launcher ->
             navigate(LinkScreen.Loading, clearStack = true)
             launcher.invoke(linkConfiguration)

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkComponent.kt
@@ -11,9 +11,11 @@ import com.stripe.android.link.LinkActivityViewModel
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.WebLinkActivityContract
 import com.stripe.android.link.account.LinkAccountManager
+import com.stripe.android.link.account.LinkAuth
 import com.stripe.android.link.analytics.LinkEventsReporter
 import com.stripe.android.link.confirmation.LinkConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.injection.DefaultConfirmationModule
+import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import dagger.BindsInstance
 import dagger.Component
@@ -36,10 +38,12 @@ internal interface NativeLinkComponent {
     val linkAccountManager: LinkAccountManager
     val configuration: LinkConfiguration
     val linkEventsReporter: LinkEventsReporter
+    val errorReporter: ErrorReporter
     val logger: Logger
     val linkConfirmationHandlerFactory: LinkConfirmationHandler.Factory
     val webLinkActivityContract: WebLinkActivityContract
     val cardAccountRangeRepositoryFactory: CardAccountRangeRepository.Factory
+    val linkAuth: LinkAuth
     val viewModel: LinkActivityViewModel
 
     @Component.Builder

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/LinkContent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/LinkContent.kt
@@ -52,7 +52,8 @@ internal fun LinkContent(
     sheetState: ModalBottomSheetState,
     bottomSheetContent: BottomSheetContent?,
     onUpdateSheetContent: (BottomSheetContent?) -> Unit,
-    onBackPressed: () -> Unit
+    onBackPressed: () -> Unit,
+    moveToWeb: () -> Unit
 ) {
     val coroutineScope = rememberCoroutineScope()
     DefaultLinkTheme {
@@ -96,6 +97,7 @@ internal fun LinkContent(
                 Screens(
                     navController = navController,
                     goBack = viewModel::goBack,
+                    moveToWeb = moveToWeb,
                     navigate = { screen ->
                         viewModel.navigate(screen, clearStack = false)
                     },
@@ -127,7 +129,8 @@ private fun Screens(
     navigateAndClearStack: (route: LinkScreen) -> Unit,
     dismissWithResult: (LinkActivityResult) -> Unit,
     showBottomSheetContent: (BottomSheetContent?) -> Unit,
-    hideBottomSheetContent: () -> Unit
+    hideBottomSheetContent: () -> Unit,
+    moveToWeb: () -> Unit
 ) {
     NavHost(
         navController = navController,
@@ -140,7 +143,8 @@ private fun Screens(
         composable(LinkScreen.SignUp.route) {
             SignUpRoute(
                 navigate = navigate,
-                navigateAndClearStack = navigateAndClearStack
+                navigateAndClearStack = navigateAndClearStack,
+                moveToWeb = moveToWeb
             )
         }
 
@@ -193,12 +197,14 @@ private fun Screens(
 private fun SignUpRoute(
     navigate: (route: LinkScreen) -> Unit,
     navigateAndClearStack: (route: LinkScreen) -> Unit,
+    moveToWeb: () -> Unit
 ) {
     val viewModel: SignUpViewModel = linkViewModel { parentComponent ->
         SignUpViewModel.factory(
             parentComponent = parentComponent,
             navigate = navigate,
-            navigateAndClearStack = navigateAndClearStack
+            navigateAndClearStack = navigateAndClearStack,
+            moveToWeb = moveToWeb
         )
     }
     SignUpScreen(

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/signup/SignUpViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/signup/SignUpViewModel.kt
@@ -9,7 +9,6 @@ import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.core.Logger
 import com.stripe.android.core.model.CountryCode
 import com.stripe.android.link.LinkConfiguration
-import com.stripe.android.link.LinkEventException
 import com.stripe.android.link.LinkScreen
 import com.stripe.android.link.NoLinkAccountFoundException
 import com.stripe.android.link.account.LinkAuth
@@ -21,7 +20,6 @@ import com.stripe.android.link.ui.inline.SignUpConsentAction
 import com.stripe.android.model.EmailSource
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.SetupIntent
-import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.uicore.elements.EmailConfig
 import com.stripe.android.uicore.elements.NameConfig
 import com.stripe.android.uicore.elements.PhoneNumberController
@@ -42,7 +40,6 @@ internal class SignUpViewModel @Inject constructor(
     private val linkEventsReporter: LinkEventsReporter,
     private val logger: Logger,
     private val linkAuth: LinkAuth,
-    private val errorReporter: ErrorReporter,
     private val navigate: (LinkScreen) -> Unit,
     private val navigateAndClearStack: (LinkScreen) -> Unit,
     private val moveToWeb: () -> Unit
@@ -132,10 +129,6 @@ internal class SignUpViewModel @Inject constructor(
 
         when (lookupResult) {
             is LinkAuthResult.AttestationFailed -> {
-                errorReporter.report(
-                    errorEvent = ErrorReporter.UnexpectedErrorEvent.LINK_NATIVE_FAILED_TO_ATTEST_SIGNUP_REQUEST,
-                    stripeException = LinkEventException(lookupResult.throwable)
-                )
                 moveToWeb()
             }
             is LinkAuthResult.Error -> {
@@ -234,7 +227,6 @@ internal class SignUpViewModel @Inject constructor(
                         linkEventsReporter = parentComponent.linkEventsReporter,
                         logger = parentComponent.logger,
                         linkAuth = parentComponent.linkAuth,
-                        errorReporter = parentComponent.errorReporter,
                         navigate = navigate,
                         navigateAndClearStack = navigateAndClearStack,
                         moveToWeb = moveToWeb

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/signup/SignUpViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/signup/SignUpViewModel.kt
@@ -5,9 +5,9 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
+import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.core.Logger
 import com.stripe.android.core.model.CountryCode
-import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkEventException
 import com.stripe.android.link.LinkScreen
@@ -17,8 +17,6 @@ import com.stripe.android.link.account.LinkAuthResult
 import com.stripe.android.link.analytics.LinkEventsReporter
 import com.stripe.android.link.injection.NativeLinkComponent
 import com.stripe.android.link.model.LinkAccount
-import com.stripe.android.link.ui.ErrorMessage
-import com.stripe.android.link.ui.getErrorMessage
 import com.stripe.android.link.ui.inline.SignUpConsentAction
 import com.stripe.android.model.EmailSource
 import com.stripe.android.model.PaymentIntent
@@ -142,6 +140,7 @@ internal class SignUpViewModel @Inject constructor(
             }
             is LinkAuthResult.Error -> {
                 updateSignUpState(SignUpState.InputtingRemainingFields)
+                onError(lookupResult.throwable)
             }
             is LinkAuthResult.Success -> {
                 onAccountFetched(lookupResult.account)
@@ -199,14 +198,7 @@ internal class SignUpViewModel @Inject constructor(
         logger.error("SignUpViewModel Error: ", error)
         updateState {
             it.copy(
-                errorMessage = when (val errorMessage = error.getErrorMessage()) {
-                    is ErrorMessage.FromResources -> {
-                        errorMessage.stringResId.resolvableString
-                    }
-                    is ErrorMessage.Raw -> {
-                        errorMessage.errorMessage.resolvableString
-                    }
-                }
+                errorMessage = error.stripeErrorMessage()
             )
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
@@ -653,5 +653,7 @@ private class FakeNativeLinkComponent(
     override val webLinkActivityContract: WebLinkActivityContract = mock(),
     override val cardAccountRangeRepositoryFactory: CardAccountRangeRepository.Factory =
         NullCardAccountRangeRepositoryFactory,
-    override val viewModel: LinkActivityViewModel = mock()
+    override val viewModel: LinkActivityViewModel = mock(),
+    override val errorReporter: ErrorReporter = FakeErrorReporter(),
+    override val linkAuth: LinkAuth = FakeLinkAuth()
 ) : NativeLinkComponent

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenTest.kt
@@ -131,7 +131,7 @@ internal class SignUpScreenTest {
             composeTestRule.waitForIdle()
 
             dispatcher.scheduler.advanceTimeBy(1001)
-            onErrorSection().assertExists() // .assert(hasAnyChild(hasText("Something went wrong")))
+            onErrorSection().assertExists()
         }
 
     private fun viewModel(

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenTest.kt
@@ -19,7 +19,6 @@ import com.stripe.android.link.account.LinkAuth
 import com.stripe.android.link.account.LinkAuthResult
 import com.stripe.android.link.analytics.FakeLinkEventsReporter
 import com.stripe.android.testing.CoroutineTestRule
-import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.FakeLogger
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -147,7 +146,6 @@ internal class SignUpScreenTest {
             linkAuth = linkAuth,
             linkEventsReporter = linkEventsReporter,
             logger = logger,
-            errorReporter = FakeErrorReporter(),
             navigate = {},
             navigateAndClearStack = {},
             moveToWeb = moveToWeb

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenTest.kt
@@ -14,7 +14,9 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.TestFactory
-import com.stripe.android.link.account.FakeLinkAccountManager
+import com.stripe.android.link.account.FakeLinkAuth
+import com.stripe.android.link.account.LinkAuth
+import com.stripe.android.link.account.LinkAuthResult
 import com.stripe.android.link.analytics.FakeLinkEventsReporter
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FakeLogger
@@ -97,14 +99,14 @@ internal class SignUpScreenTest {
     @Test
     fun `field displayed, sign up enabled and error displayed when controllers are filled and sign up fails`() =
         runTest(dispatcher) {
-            val linkAccountManager = FakeLinkAccountManager()
-            val viewModel = viewModel(linkAccountManager = linkAccountManager)
+            val linkAuth = FakeLinkAuth()
+            val viewModel = viewModel(linkAuth = linkAuth)
 
             composeTestRule.setContent {
                 SignUpScreen(viewModel)
             }
 
-            linkAccountManager.signUpResult = Result.failure(Throwable("oops"))
+            linkAuth.signupResult = LinkAuthResult.Error(Throwable("oops"))
             viewModel.onSignUpClick()
 
             dispatcher.scheduler.advanceTimeBy(1001)
@@ -112,18 +114,20 @@ internal class SignUpScreenTest {
         }
 
     private fun viewModel(
-        linkAccountManager: FakeLinkAccountManager = FakeLinkAccountManager(),
-        customerInfo: LinkConfiguration.CustomerInfo = TestFactory.LINK_CUSTOMER_INFO
+        linkAuth: LinkAuth = FakeLinkAuth(),
+        customerInfo: LinkConfiguration.CustomerInfo = TestFactory.LINK_CUSTOMER_INFO,
+        moveToWeb: () -> Unit = {}
     ): SignUpViewModel {
         return SignUpViewModel(
             configuration = TestFactory.LINK_CONFIGURATION.copy(
                 customerInfo = customerInfo
             ),
-            linkAccountManager = linkAccountManager,
+            linkAuth = linkAuth,
             linkEventsReporter = linkEventsReporter,
             logger = logger,
             navigate = {},
-            navigateAndClearStack = {}
+            navigateAndClearStack = {},
+            moveToWeb = moveToWeb
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenTest.kt
@@ -19,6 +19,7 @@ import com.stripe.android.link.account.LinkAuth
 import com.stripe.android.link.account.LinkAuthResult
 import com.stripe.android.link.analytics.FakeLinkEventsReporter
 import com.stripe.android.testing.CoroutineTestRule
+import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.FakeLogger
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -125,6 +126,7 @@ internal class SignUpScreenTest {
             linkAuth = linkAuth,
             linkEventsReporter = linkEventsReporter,
             logger = logger,
+            errorReporter = FakeErrorReporter(),
             navigate = {},
             navigateAndClearStack = {},
             moveToWeb = moveToWeb

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenTest.kt
@@ -100,6 +100,7 @@ internal class SignUpScreenTest {
     @Test
     fun `field displayed, sign up enabled and error displayed when controllers are filled and sign up fails`() =
         runTest(dispatcher) {
+            val error = Throwable("oops")
             val linkAuth = FakeLinkAuth()
             val viewModel = viewModel(linkAuth = linkAuth)
 
@@ -107,11 +108,31 @@ internal class SignUpScreenTest {
                 SignUpScreen(viewModel)
             }
 
-            linkAuth.signupResult = LinkAuthResult.Error(Throwable("oops"))
+            linkAuth.signupResult = LinkAuthResult.Error(error)
             viewModel.onSignUpClick()
 
             dispatcher.scheduler.advanceTimeBy(1001)
-            onErrorSection().assertExists().assert(hasAnyChild(hasText("oops")))
+            onErrorSection().assertExists().assert(hasAnyChild(hasText("Something went wrong")))
+        }
+
+    @Test
+    fun `error is displayed on lookup failure after email entry`() =
+        runTest(dispatcher) {
+            val error = Throwable("oops")
+            val linkAuth = FakeLinkAuth()
+            val viewModel = viewModel(linkAuth = linkAuth)
+
+            composeTestRule.setContent {
+                SignUpScreen(viewModel)
+            }
+
+            linkAuth.lookupResult = LinkAuthResult.Error(error)
+
+            viewModel.emailController.onRawValueChange("a@b.com")
+            composeTestRule.waitForIdle()
+
+            dispatcher.scheduler.advanceTimeBy(1001)
+            onErrorSection().assertExists() // .assert(hasAnyChild(hasText("Something went wrong")))
         }
 
     private fun viewModel(

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpViewModelTest.kt
@@ -19,9 +19,7 @@ import com.stripe.android.link.ui.inline.SignUpConsentAction
 import com.stripe.android.model.ConsumerSession
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.SetupIntent
-import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.testing.CoroutineTestRule
-import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.FakeLogger
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
@@ -458,7 +456,6 @@ internal class SignUpViewModelTest {
             lookupResult = LinkAuthResult.NoLinkAccountFound
         },
         logger: Logger = FakeLogger(),
-        errorReporter: ErrorReporter = FakeErrorReporter(),
         navigate: (LinkScreen) -> Unit = {},
         navigateAndClearStack: (LinkScreen) -> Unit = {},
         moveToWeb: () -> Unit = {}
@@ -479,7 +476,6 @@ internal class SignUpViewModelTest {
             navigate = navigate,
             navigateAndClearStack = navigateAndClearStack,
             moveToWeb = moveToWeb,
-            errorReporter = errorReporter
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpViewModelTest.kt
@@ -1,9 +1,9 @@
 package com.stripe.android.link.ui.signup
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.core.Logger
 import com.stripe.android.core.model.CountryCode
-import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkScreen
 import com.stripe.android.link.TestFactory
@@ -146,6 +146,7 @@ internal class SignUpViewModelTest {
         advanceTimeBy(SignUpViewModel.LOOKUP_DEBOUNCE + 1.milliseconds)
 
         assertThat(viewModel.state.value.signUpState).isEqualTo(SignUpState.InputtingRemainingFields)
+        assertThat(viewModel.state.value.errorMessage).isEqualTo(error.stripeErrorMessage())
     }
 
     @Test
@@ -208,7 +209,7 @@ internal class SignUpViewModelTest {
 
         viewModel.performValidSignup()
 
-        assertThat(viewModel.contentState.errorMessage).isEqualTo(errorMessage.resolvableString)
+        assertThat(viewModel.contentState.errorMessage).isEqualTo(exception.stripeErrorMessage())
         assertThat(logger.errorLogs).isEqualTo(listOf("SignUpViewModel Error: " to exception))
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Use hardware attestation for sign up and lookup on the SignUpScreen. This PR also reintroduces email lookup.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
Simulates an attestation error on lookup
https://github.com/user-attachments/assets/6cc9167c-a121-44e8-875f-e9d6f34adfa4


Simulates attestation error on signup
https://github.com/user-attachments/assets/362983be-9da6-4f1b-8a15-ddfd0e05d3ab



# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
