### PR TITLE
Add customer session setting to enable the set as default feature

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
@@ -46,6 +46,8 @@ class CheckoutRequest private constructor(
     val paymentMethodRedisplayFilters: List<AllowRedisplayFilter>?,
     @SerialName("customer_session_payment_method_save_allow_redisplay_override")
     val paymentMethodOverrideRedisplay: AllowRedisplayFilter?,
+    @SerialName("customer_session_payment_method_set_as_default")
+    val paymentMethodSetAsDefaultFeature: FeatureState?,
 ) {
     @Serializable
     enum class CustomerKeyType {
@@ -72,6 +74,7 @@ class CheckoutRequest private constructor(
         private var paymentMethodSaveFeature: FeatureState = FeatureState.Enabled
         private var paymentMethodRemoveFeature: FeatureState = FeatureState.Enabled
         private var paymentMethodRemoveLastFeature: FeatureState = FeatureState.Enabled
+        private var paymentMethodSetAsDefaultFeature: FeatureState = FeatureState.Disabled
         private var paymentMethodRedisplayFeature: FeatureState = FeatureState.Enabled
         private var paymentMethodRedisplayFilters: List<AllowRedisplayFilter> = listOf(
             AllowRedisplayFilter.Unspecified,
@@ -136,6 +139,10 @@ class CheckoutRequest private constructor(
             this.paymentMethodRemoveLastFeature = state
         }
 
+        fun paymentMethodSetAsDefaultFeature(state: FeatureState) {
+            this.paymentMethodSetAsDefaultFeature = state
+        }
+
         fun paymentMethodRedisplayFeature(state: FeatureState) {
             this.paymentMethodRedisplayFeature = state
         }
@@ -169,6 +176,7 @@ class CheckoutRequest private constructor(
                 customerSessionComponentName = "mobile_payment_element",
                 paymentMethodSaveFeature = paymentMethodSaveFeature,
                 paymentMethodRemoveFeature = paymentMethodRemoveFeature,
+                paymentMethodSetAsDefaultFeature = paymentMethodSetAsDefaultFeature,
                 paymentMethodRemoveLastFeature = paymentMethodRemoveLastFeature,
                 paymentMethodRedisplayFeature = paymentMethodRedisplayFeature,
                 paymentMethodRedisplayFilters = paymentMethodRedisplayFilters,

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCustomerModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCustomerModel.kt
@@ -21,7 +21,6 @@ class CustomerEphemeralKeyRequest private constructor(
     val paymentMethodRedisplayFeature: FeatureState?,
     @SerialName("customer_session_payment_method_allow_redisplay_filters")
     val paymentMethodRedisplayFilters: List<AllowRedisplayFilter>?,
-
 ) {
     @Serializable
     enum class CustomerKeyType {

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCustomerModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCustomerModel.kt
@@ -21,6 +21,7 @@ class CustomerEphemeralKeyRequest private constructor(
     val paymentMethodRedisplayFeature: FeatureState?,
     @SerialName("customer_session_payment_method_allow_redisplay_filters")
     val paymentMethodRedisplayFilters: List<AllowRedisplayFilter>?,
+
 ) {
     @Serializable
     enum class CustomerKeyType {

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionSetAsDefaultSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionSetAsDefaultSettingsDefinition.kt
@@ -1,0 +1,25 @@
+package com.stripe.android.paymentsheet.example.playground.settings
+
+import com.stripe.android.paymentsheet.example.playground.model.CheckoutRequest
+import com.stripe.android.paymentsheet.example.playground.model.FeatureState
+
+internal object CustomerSessionSetAsDefaultSettingsDefinition : BooleanSettingsDefinition(
+    defaultValue = false,
+    displayName = "Customer Session Set As Default Feature",
+    key = "customer_session_set_as_default"
+) {
+    override fun createOptions(
+        configurationData: PlaygroundConfigurationData
+    ) = listOf(
+        PlaygroundSettingDefinition.Displayable.Option("Enabled", true),
+        PlaygroundSettingDefinition.Displayable.Option("Disabled", false),
+    )
+
+    override fun configure(value: Boolean, checkoutRequestBuilder: CheckoutRequest.Builder) {
+        if (value) {
+            checkoutRequestBuilder.paymentMethodSetAsDefaultFeature(FeatureState.Enabled)
+        } else {
+            checkoutRequestBuilder.paymentMethodSetAsDefaultFeature(FeatureState.Disabled)
+        }
+    }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -419,6 +419,7 @@ internal class PlaygroundSettings private constructor(
             CustomerSessionSaveSettingsDefinition,
             CustomerSessionRemoveSettingsDefinition,
             CustomerSessionRemoveLastSettingsDefinition,
+            CustomerSessionSetAsDefaultSettingsDefinition,
             CustomerSessionRedisplaySettingsDefinition,
             CustomerSessionRedisplayFiltersSettingsDefinition,
             CustomerSessionOverrideRedisplaySettingsDefinition,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add customer session setting to enable the set as default feature

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-2656

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

Used the debugger.

1. Set the feature to "enabled" in the playground
2. Verified that the elements session response included the `payment_method_set_as_default` feature with the value `enabled`