### PR TITLE
Disable UI while confirming and configuring.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationStateHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationStateHolder.kt
@@ -12,6 +12,7 @@ import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
@@ -28,6 +29,9 @@ internal class EmbeddedConfirmationStateHolder @Inject constructor(
         set(value) {
             savedStateHandle[CONFIRMATION_STATE_KEY] = value
         }
+
+    val stateFlow: StateFlow<State?>
+        get() = savedStateHandle.getStateFlow(CONFIRMATION_STATE_KEY, null)
 
     init {
         coroutineScope.launch {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperTest.kt
@@ -7,6 +7,7 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.paymentelement.ExperimentalEmbeddedPaymentElementApi
+import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedContentHelper.Companion.MANDATE_KEY_EMBEDDED_CONTENT
@@ -146,6 +147,7 @@ internal class DefaultEmbeddedContentHelperTest {
             cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
             embeddedSelectionHolder = selectionHolder
         )
+        val confirmationHandler = FakeConfirmationHandler()
         val embeddedContentHelper = DefaultEmbeddedContentHelper(
             coroutineScope = CoroutineScope(Dispatchers.Unconfined),
             savedStateHandle = savedStateHandle,
@@ -155,11 +157,18 @@ internal class DefaultEmbeddedContentHelperTest {
             selectionHolder = selectionHolder,
             embeddedWalletsHelper = { stateFlowOf(null) },
             customerStateHolder = CustomerStateHolder(savedStateHandle, selectionHolder.selection),
-            embeddedFormHelperFactory = embeddedFormHelperFactory
+            embeddedFormHelperFactory = embeddedFormHelperFactory,
+            confirmationHandler = confirmationHandler,
+            confirmationStateHolder = EmbeddedConfirmationStateHolder(
+                savedStateHandle = savedStateHandle,
+                selectionHolder = selectionHolder,
+                coroutineScope = CoroutineScope(Dispatchers.Unconfined),
+            ),
         )
         Scenario(
             embeddedContentHelper = embeddedContentHelper,
             savedStateHandle = savedStateHandle,
         ).block()
+        confirmationHandler.validate()
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationStateHolderTest.kt
@@ -3,6 +3,7 @@
 package com.stripe.android.paymentelement.embedded.content
 
 import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.paymentelement.ExperimentalEmbeddedPaymentElementApi
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
@@ -44,6 +45,20 @@ internal class EmbeddedConfirmationStateHolderTest {
         assertThat(confirmationStateHolder.state?.selection?.paymentMethodType).isNull()
         selectionHolder.set(PaymentSelection.GooglePay)
         assertThat(confirmationStateHolder.state?.selection?.paymentMethodType).isEqualTo("google_pay")
+    }
+
+    @Test
+    fun `updating state or selection updates stateFlow`() = testScenario {
+        confirmationStateHolder.stateFlow.test {
+            assertThat(awaitItem()).isNull()
+            confirmationStateHolder.state = EmbeddedConfirmationStateFixtures.defaultState()
+            awaitItem().let {
+                assertThat(it).isNotNull()
+                assertThat(it?.selection?.paymentMethodType).isNull()
+            }
+            selectionHolder.set(PaymentSelection.GooglePay)
+            assertThat(awaitItem()?.selection?.paymentMethodType).isEqualTo("google_pay")
+        }
     }
 
     private class Scenario(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
We don't want users to be able to launch forms, select something different, etc while configuring and confirming.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-3064

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
