### PR TITLE
Refactor buyButtonLabel and continueButtonLabel out of PrimaryButtonUiStateMapper

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/utils/PrimaryButtonUtils.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/utils/PrimaryButtonUtils.kt
@@ -1,0 +1,26 @@
+package com.stripe.android.paymentsheet.utils
+
+import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.paymentsheet.R
+import com.stripe.android.ui.core.Amount
+
+internal fun buyButtonLabel(
+    amount: Amount?,
+    primaryButtonLabel: String?,
+    isProcessingPayment: Boolean
+): ResolvableString {
+    return primaryButtonLabel?.resolvableString ?: run {
+        if (isProcessingPayment) {
+            val fallback = R.string.stripe_paymentsheet_pay_button_label.resolvableString
+            amount?.buildPayButtonLabel() ?: fallback
+        } else {
+            com.stripe.android.ui.core.R.string.stripe_setup_button_label.resolvableString
+        }
+    }
+}
+
+internal fun continueButtonLabel(primaryButtonLabel: String?): ResolvableString {
+    return primaryButtonLabel?.resolvableString
+        ?: com.stripe.android.ui.core.R.string.stripe_continue_button_label.resolvableString
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/utils/PrimaryButtonUtils.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/utils/PrimaryButtonUtils.kt
@@ -4,23 +4,24 @@ import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.ui.core.Amount
+import com.stripe.android.ui.core.R as StripeUiCoreR
 
 internal fun buyButtonLabel(
     amount: Amount?,
     primaryButtonLabel: String?,
-    isProcessingPayment: Boolean
+    isForPaymentIntent: Boolean
 ): ResolvableString {
     return primaryButtonLabel?.resolvableString ?: run {
-        if (isProcessingPayment) {
+        if (isForPaymentIntent) {
             val fallback = R.string.stripe_paymentsheet_pay_button_label.resolvableString
             amount?.buildPayButtonLabel() ?: fallback
         } else {
-            com.stripe.android.ui.core.R.string.stripe_setup_button_label.resolvableString
+            StripeUiCoreR.string.stripe_setup_button_label.resolvableString
         }
     }
 }
 
 internal fun continueButtonLabel(primaryButtonLabel: String?): ResolvableString {
     return primaryButtonLabel?.resolvableString
-        ?: com.stripe.android.ui.core.R.string.stripe_continue_button_label.resolvableString
+        ?: StripeUiCoreR.string.stripe_continue_button_label.resolvableString
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/PrimaryButtonUtilsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/PrimaryButtonUtilsTest.kt
@@ -1,0 +1,78 @@
+package com.stripe.android.paymentsheet.utils
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.paymentsheet.R
+import com.stripe.android.ui.core.Amount
+import org.junit.Test
+import com.stripe.android.ui.core.R as StripeUiCoreR
+
+class PrimaryButtonUtilsTest {
+    @Test
+    fun `buyButtonLabel returns primaryButtonLabel if provided`() {
+        val label = buyButtonLabel(
+            amount = null,
+            primaryButtonLabel = "Test Label",
+            isForPaymentIntent = true
+        )
+
+        assertThat(label).isEqualTo("Test Label".resolvableString)
+    }
+
+    @Test
+    fun `buyButtonLabel returns resolvableString with correct args`() {
+        val label = buyButtonLabel(
+            amount = Amount(
+                value = 1099,
+                currencyCode = "usd"
+            ),
+            primaryButtonLabel = null,
+            isForPaymentIntent = true
+        )
+
+        assertThat(label).isEqualTo(
+            resolvableString(
+                id = StripeUiCoreR.string.stripe_pay_button_amount,
+                formatArgs = arrayOf("$10.99")
+            )
+        )
+    }
+
+    @Test
+    fun `buyButtonLabel returns Set up if isForPaymentIntent is false`() {
+        val label = buyButtonLabel(
+            amount = null,
+            primaryButtonLabel = null,
+            isForPaymentIntent = false
+        )
+
+        assertThat(label).isEqualTo(StripeUiCoreR.string.stripe_setup_button_label.resolvableString)
+    }
+
+    @Test
+    fun `buyButtonLabel returns fallback if amount is null`() {
+        val label = buyButtonLabel(
+            amount = null,
+            primaryButtonLabel = null,
+            isForPaymentIntent = true
+        )
+
+        assertThat(label).isEqualTo(R.string.stripe_paymentsheet_pay_button_label.resolvableString)
+    }
+
+    @Test
+    fun `continueButtonLabel returns primaryButtonLabel if not null`() {
+        val label = continueButtonLabel(
+            primaryButtonLabel = "Test Label",
+        )
+
+        assertThat(label).isEqualTo("Test Label".resolvableString)
+    }
+
+    @Test
+    fun `continueButtonLabel returns Continue if primaryButtonLabel is null`() {
+        val label = continueButtonLabel(null)
+
+        assertThat(label).isEqualTo(StripeUiCoreR.string.stripe_continue_button_label.resolvableString)
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Move `buyButtonLabel` and `continueButtonLabel` to `PrimaryButtonUtils.kt`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Re-use label logic for embedded

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

No behavior change, label logic is verified by `PrimaryButtonUiStateMapperTest`
