### PR TITLE
Add suppress2faModal flag to LinkConfiguration

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/ElementsSession.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ElementsSession.kt
@@ -42,6 +42,9 @@ data class ElementsSession(
     val useAttestationEndpointsForLink: Boolean
         get() = linkSettings?.useAttestationEndpoints ?: false
 
+    val suppressLink2faModal: Boolean
+        get() = linkSettings?.suppress2faModal ?: false
+
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Parcelize
     data class LinkSettings(
@@ -51,7 +54,8 @@ data class ElementsSession(
         val linkFlags: Map<String, Boolean>,
         val disableLinkSignup: Boolean,
         val linkConsumerIncentive: LinkConsumerIncentive?,
-        val useAttestationEndpoints: Boolean
+        val useAttestationEndpoints: Boolean,
+        val suppress2faModal: Boolean
     ) : StripeModel
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/ElementsSessionJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/ElementsSessionJsonParser.kt
@@ -143,6 +143,7 @@ internal class ElementsSessionJsonParser(
         val disableLinkSignup = json?.optBoolean(FIELD_DISABLE_LINK_SIGNUP) ?: false
         val linkPassthroughModeEnabled = json?.optBoolean(FIELD_LINK_PASSTHROUGH_MODE_ENABLED) ?: false
         val useLinkAttestationEndpoints = json?.optBoolean(FIELD_USE_LINK_ATTESTATION_ENDPOINTS) ?: false
+        val suppressLink2faModal = json?.optBoolean(FIELD_LINK_SUPPRESS_2FA_MODAL) ?: false
 
         val linkMode = json?.optString(FIELD_LINK_MODE)?.let { mode ->
             LinkMode.entries.firstOrNull { it.value == mode }
@@ -166,7 +167,8 @@ internal class ElementsSessionJsonParser(
             linkFlags = linkFlags,
             disableLinkSignup = disableLinkSignup,
             linkConsumerIncentive = linkConsumerIncentive,
-            useAttestationEndpoints = useLinkAttestationEndpoints
+            useAttestationEndpoints = useLinkAttestationEndpoints,
+            suppress2faModal = suppressLink2faModal
         )
     }
 
@@ -333,6 +335,7 @@ internal class ElementsSessionJsonParser(
         private const val FIELD_LINK_MODE = "link_mode"
         private const val FIELD_DISABLE_LINK_SIGNUP = "link_mobile_disable_signup"
         private const val FIELD_USE_LINK_ATTESTATION_ENDPOINTS = "link_mobile_use_attestation_endpoints"
+        private const val FIELD_LINK_SUPPRESS_2FA_MODAL = "link_mobile_suppress_2fa_modal"
         private const val FIELD_MERCHANT_COUNTRY = "merchant_country"
         private const val FIELD_PAYMENT_METHOD_PREFERENCE = "payment_method_preference"
         private const val FIELD_UNACTIVATED_PAYMENT_METHOD_TYPES = "unactivated_payment_method_types"

--- a/payments-core/src/test/java/com/stripe/android/model/ElementsSessionFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/ElementsSessionFixtures.kt
@@ -144,14 +144,15 @@ internal object ElementsSessionFixtures {
         """.trimIndent()
     )
 
-    val EXPANDED_PAYMENT_INTENT_WITH_LINK_ATTESTATION_ENDPOINTS_ENABLED_JSON = JSONObject(
+    val EXPANDED_PAYMENT_INTENT_WITH_NATIVE_LINK_FLAGS_ENABLED_JSON = JSONObject(
         """
         {
           "business_name": "Mybusiness",
           "link_settings": {
             "link_bank_enabled": false,
             "link_bank_onboarding_enabled": false,
-            "link_mobile_use_attestation_endpoints": true
+            "link_mobile_use_attestation_endpoints": true,
+            "link_mobile_suppress_2fa_modal": true
           },
           "merchant_country": "US",
           "payment_method_preference": {
@@ -212,14 +213,15 @@ internal object ElementsSessionFixtures {
         """.trimIndent()
     )
 
-    val EXPANDED_PAYMENT_INTENT_WITH_LINK_ATTESTATION_ENDPOINTS_DISABLED_JSON = JSONObject(
+    val EXPANDED_PAYMENT_INTENT_WITH_NATIVE_LINK_FLAGS_DISABLED_JSON = JSONObject(
         """
         {
           "business_name": "Mybusiness",
           "link_settings": {
             "link_bank_enabled": false,
             "link_bank_onboarding_enabled": false,
-            "link_mobile_use_attestation_endpoints": false
+            "link_mobile_use_attestation_endpoints": false,
+            "link_mobile_suppress_2fa_modal": false
           },
           "merchant_country": "US",
           "payment_method_preference": {

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
@@ -828,7 +828,7 @@ class ElementsSessionJsonParserTest {
     }
 
     @Test
-    fun `Parses Link useAttestationEndpoints as enabled`() {
+    fun `Parses Native Link flags as enabled`() {
         val elementsSession = ElementsSessionJsonParser(
             ElementsSessionParams.PaymentIntentType(
                 clientSecret = "secret",
@@ -836,14 +836,15 @@ class ElementsSessionJsonParserTest {
             ),
             isLiveMode = true,
         ).parse(
-            ElementsSessionFixtures.EXPANDED_PAYMENT_INTENT_WITH_LINK_ATTESTATION_ENDPOINTS_ENABLED_JSON
+            ElementsSessionFixtures.EXPANDED_PAYMENT_INTENT_WITH_NATIVE_LINK_FLAGS_ENABLED_JSON
         )
 
         assertThat(elementsSession?.linkSettings?.useAttestationEndpoints).isTrue()
+        assertThat(elementsSession?.linkSettings?.suppress2faModal).isTrue()
     }
 
     @Test
-    fun `Parses Link useAttestationEndpoints endpoints as disabled`() {
+    fun `Parses Native Link flags as disabled`() {
         val elementsSession = ElementsSessionJsonParser(
             ElementsSessionParams.PaymentIntentType(
                 clientSecret = "secret",
@@ -851,14 +852,15 @@ class ElementsSessionJsonParserTest {
             ),
             isLiveMode = true,
         ).parse(
-            ElementsSessionFixtures.EXPANDED_PAYMENT_INTENT_WITH_LINK_ATTESTATION_ENDPOINTS_DISABLED_JSON
+            ElementsSessionFixtures.EXPANDED_PAYMENT_INTENT_WITH_NATIVE_LINK_FLAGS_DISABLED_JSON
         )
 
         assertThat(elementsSession?.linkSettings?.useAttestationEndpoints).isFalse()
+        assertThat(elementsSession?.linkSettings?.suppress2faModal).isFalse()
     }
 
     @Test
-    fun `Parses Link useAttestationEndpoints endpoints as disabled when field is omitted`() {
+    fun `Parses Native Link flags as disabled when field is omitted`() {
         val elementsSession = ElementsSessionJsonParser(
             ElementsSessionParams.PaymentIntentType(
                 clientSecret = "secret",
@@ -870,6 +872,7 @@ class ElementsSessionJsonParserTest {
         )
 
         assertThat(elementsSession?.linkSettings?.useAttestationEndpoints).isFalse()
+        assertThat(elementsSession?.linkSettings?.suppress2faModal).isFalse()
     }
 
     private fun allowRedisplayTest(

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkConfiguration.kt
@@ -17,6 +17,7 @@ internal data class LinkConfiguration(
     val flags: Map<String, Boolean>,
     val cardBrandChoice: CardBrandChoice?,
     val useAttestationEndpointsForLink: Boolean,
+    val suppress2faModal: Boolean,
     val initializationMode: PaymentElementLoader.InitializationMode,
     val elementsSessionId: String,
 ) : Parcelable {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -403,6 +403,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                 passthroughModeEnabled = elementsSession.linkPassthroughModeEnabled,
                 linkSignUpDisabled = elementsSession.disableLinkSignup,
                 useAttestationEndpointsForLink = elementsSession.useAttestationEndpointsForLink,
+                suppress2faModal = elementsSession.suppressLink2faModal,
                 flags = elementsSession.linkFlags,
                 initializationMode = initializationMode
             )
@@ -420,6 +421,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         linkSignUpDisabled: Boolean,
         flags: Map<String, Boolean>,
         useAttestationEndpointsForLink: Boolean,
+        suppress2faModal: Boolean,
         initializationMode: PaymentElementLoader.InitializationMode
     ): LinkState {
         val linkConfig = createLinkConfiguration(
@@ -430,6 +432,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
             passthroughModeEnabled = passthroughModeEnabled,
             flags = flags,
             useAttestationEndpointsForLink = useAttestationEndpointsForLink,
+            suppress2faModal = suppress2faModal,
             initializationMode = initializationMode
         )
 
@@ -481,6 +484,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         passthroughModeEnabled: Boolean,
         flags: Map<String, Boolean>,
         useAttestationEndpointsForLink: Boolean,
+        suppress2faModal: Boolean,
         initializationMode: PaymentElementLoader.InitializationMode
     ): LinkConfiguration {
         val shippingDetails: AddressDetails? = configuration.shippingDetails
@@ -527,6 +531,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
             cardBrandChoice = cardBrandChoice,
             flags = flags,
             useAttestationEndpointsForLink = useAttestationEndpointsForLink,
+            suppress2faModal = suppress2faModal,
             elementsSessionId = elementsSession.elementsSessionId,
             initializationMode = initializationMode
         )

--- a/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
@@ -148,6 +148,7 @@ internal object TestFactory {
         cardBrandChoice = null,
         passthroughModeEnabled = false,
         useAttestationEndpointsForLink = false,
+        suppress2faModal = false,
         initializationMode = PaymentSheetFixtures.INITIALIZATION_MODE_PAYMENT_INTENT,
         elementsSessionId = "session_1234"
     )

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -1316,6 +1316,7 @@ internal class PaymentMethodMetadataTest {
                 ),
                 passthroughModeEnabled = false,
                 useAttestationEndpointsForLink = false,
+                suppress2faModal = false,
                 initializationMode = PaymentSheetFixtures.INITIALIZATION_MODE_PAYMENT_INTENT,
                 elementsSessionId = "session_1234"
             ),

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElementTest.kt
@@ -128,6 +128,7 @@ class LinkFormElementTest {
                 cardBrandChoice = null,
                 flags = mapOf(),
                 useAttestationEndpointsForLink = false,
+                suppress2faModal = false,
                 initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
                     clientSecret = "pi_123_secret_123",
                 ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
@@ -440,6 +440,7 @@ class ConfirmationHandlerOptionKtxTest {
             cardBrandChoice = null,
             flags = mapOf(),
             useAttestationEndpointsForLink = false,
+            suppress2faModal = false,
             initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
                 clientSecret = "pi_123_secret_123",
             ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
@@ -656,6 +656,7 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
                 flags = mapOf(),
                 cardBrandChoice = null,
                 useAttestationEndpointsForLink = false,
+                suppress2faModal = false,
                 initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
                     clientSecret = "pi_123_secret_123",
                 ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -987,6 +987,7 @@ internal class PaymentSheetViewModelTest {
                 cardBrandChoice = null,
                 shippingDetails = null,
                 useAttestationEndpointsForLink = false,
+                suppress2faModal = false,
                 initializationMode = PaymentSheetFixtures.INITIALIZATION_MODE_PAYMENT_INTENT,
                 elementsSessionId = "session_1234"
             )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -660,6 +660,7 @@ internal class DefaultPaymentElementLoaderTest {
             cardBrandChoice = null,
             flags = emptyMap(),
             useAttestationEndpointsForLink = false,
+            suppress2faModal = false,
             initializationMode = initializationMode,
             elementsSessionId = "session_1234"
         )
@@ -700,6 +701,7 @@ internal class DefaultPaymentElementLoaderTest {
                 disableLinkSignup = false,
                 linkConsumerIncentive = null,
                 useAttestationEndpoints = false,
+                suppress2faModal = false,
             )
         )
 
@@ -733,6 +735,7 @@ internal class DefaultPaymentElementLoaderTest {
                 disableLinkSignup = false,
                 linkConsumerIncentive = null,
                 useAttestationEndpoints = false,
+                suppress2faModal = false,
             )
         )
 
@@ -810,6 +813,7 @@ internal class DefaultPaymentElementLoaderTest {
                 disableLinkSignup = false,
                 linkConsumerIncentive = null,
                 useAttestationEndpoints = false,
+                suppress2faModal = false,
             ),
             linkStore = mock {
                 on { hasUsedLink() } doReturn true
@@ -838,6 +842,7 @@ internal class DefaultPaymentElementLoaderTest {
                 disableLinkSignup = true,
                 linkConsumerIncentive = null,
                 useAttestationEndpoints = false,
+                suppress2faModal = false,
             )
         )
 
@@ -2523,6 +2528,7 @@ internal class DefaultPaymentElementLoaderTest {
             disableLinkSignup = false,
             linkConsumerIncentive = null,
             useAttestationEndpoints = false,
+            suppress2faModal = false,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
@@ -62,6 +62,7 @@ internal object LinkTestUtils {
             cardBrandChoice = null,
             shippingDetails = null,
             useAttestationEndpointsForLink = false,
+            suppress2faModal = false,
             initializationMode = PaymentSheetFixtures.INITIALIZATION_MODE_PAYMENT_INTENT,
             elementsSessionId = "session_1234"
         )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This is a backend flag that can disable launching the link 2fa when paymentsheet is opened

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
[JIRA](https://jira.corp.stripe.com/browse/MOBILESDK-3076)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
