### PR TITLE
Extract LinkAccountHolder.

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -348,6 +348,14 @@ public final class com/stripe/android/link/NativeLinkArgs$Creator : android/os/P
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/link/model/LinkAccount$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/link/model/LinkAccount;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/link/model/LinkAccount;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/link/ui/ComposableSingletons$LinkAppBarKt {
 	public static final field INSTANCE Lcom/stripe/android/link/ui/ComposableSingletons$LinkAppBarKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function3;

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
@@ -14,6 +14,7 @@ import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import androidx.navigation.NavHostController
 import com.stripe.android.link.LinkActivity.Companion.getArgs
+import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.link.account.LinkAccountManager
 import com.stripe.android.link.account.LinkAuth
 import com.stripe.android.link.account.LinkAuthResult
@@ -39,6 +40,7 @@ internal class LinkActivityViewModel @Inject constructor(
     val activityRetainedComponent: NativeLinkComponent,
     confirmationHandlerFactory: ConfirmationHandler.Factory,
     private val linkAccountManager: LinkAccountManager,
+    private val linkAccountHolder: LinkAccountHolder,
     val eventReporter: EventReporter,
     private val integrityRequestManager: IntegrityRequestManager,
     private val linkGate: LinkGate,
@@ -62,7 +64,7 @@ internal class LinkActivityViewModel @Inject constructor(
     val linkScreenState: StateFlow<ScreenState> = _linkScreenState
 
     val linkAccount: LinkAccount?
-        get() = linkAccountManager.linkAccount.value
+        get() = linkAccountHolder.linkAccount.value
 
     var navController: NavHostController? = null
     var dismissWithResult: ((LinkActivityResult) -> Unit)? = null
@@ -179,7 +181,7 @@ internal class LinkActivityViewModel @Inject constructor(
     }
 
     private suspend fun updateScreenState() {
-        val linkAccount = linkAccountManager.linkAccount.value
+        val linkAccount = linkAccountHolder.linkAccount.value
         val accountStatus = linkAccountManager.accountStatus.first()
         when (accountStatus) {
             AccountStatus.Verified,
@@ -215,7 +217,7 @@ internal class LinkActivityViewModel @Inject constructor(
     }
 
     private suspend fun lookupUser(): LinkAuthResult? {
-        val customerEmail = linkAccountManager.linkAccount.value?.email
+        val customerEmail = linkAccountHolder.linkAccount.value?.email
             ?: linkConfiguration.customerInfo.email
             ?: return null
 

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
@@ -282,7 +282,8 @@ internal class DefaultLinkAccountManager @Inject constructor(
     }
 
     override suspend fun startVerification(): Result<LinkAccount> {
-        val clientSecret = linkAccountHolder.linkAccount.value?.clientSecret ?: return Result.failure(Throwable("no link account found"))
+        val clientSecret = linkAccountHolder.linkAccount.value?.clientSecret
+            ?: return Result.failure(Throwable("no link account found"))
         linkEventsReporter.on2FAStart()
         return linkRepository.startVerification(clientSecret, consumerPublishableKey)
             .onFailure {
@@ -293,7 +294,8 @@ internal class DefaultLinkAccountManager @Inject constructor(
     }
 
     override suspend fun confirmVerification(code: String): Result<LinkAccount> {
-        val clientSecret = linkAccountHolder.linkAccount.value?.clientSecret ?: return Result.failure(Throwable("no link account found"))
+        val clientSecret = linkAccountHolder.linkAccount.value?.clientSecret
+            ?: return Result.failure(Throwable("no link account found"))
         return linkRepository.confirmVerification(code, clientSecret, consumerPublishableKey)
             .onSuccess {
                 linkEventsReporter.on2FAComplete()
@@ -305,7 +307,8 @@ internal class DefaultLinkAccountManager @Inject constructor(
     }
 
     override suspend fun listPaymentDetails(paymentMethodTypes: Set<String>): Result<ConsumerPaymentDetails> {
-        val clientSecret = linkAccountHolder.linkAccount.value?.clientSecret ?: return Result.failure(NoLinkAccountFoundException())
+        val clientSecret = linkAccountHolder.linkAccount.value?.clientSecret
+            ?: return Result.failure(NoLinkAccountFoundException())
         return linkRepository.listPaymentDetails(
             paymentMethodTypes = paymentMethodTypes,
             consumerSessionClientSecret = clientSecret,
@@ -314,7 +317,8 @@ internal class DefaultLinkAccountManager @Inject constructor(
     }
 
     override suspend fun deletePaymentDetails(paymentDetailsId: String): Result<Unit> {
-        val clientSecret = linkAccountHolder.linkAccount.value?.clientSecret ?: return Result.failure(NoLinkAccountFoundException())
+        val clientSecret = linkAccountHolder.linkAccount.value?.clientSecret
+            ?: return Result.failure(NoLinkAccountFoundException())
         return linkRepository.deletePaymentDetails(
             paymentDetailsId = paymentDetailsId,
             consumerSessionClientSecret = clientSecret,
@@ -325,7 +329,8 @@ internal class DefaultLinkAccountManager @Inject constructor(
     override suspend fun updatePaymentDetails(
         updateParams: ConsumerPaymentDetailsUpdateParams
     ): Result<ConsumerPaymentDetails> {
-        val clientSecret = linkAccountHolder.linkAccount.value?.clientSecret ?: return Result.failure(NoLinkAccountFoundException())
+        val clientSecret = linkAccountHolder.linkAccount.value?.clientSecret
+            ?: return Result.failure(NoLinkAccountFoundException())
         return linkRepository.updatePaymentDetails(
             updateParams = updateParams,
             consumerSessionClientSecret = clientSecret,

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAccountHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAccountHolder.kt
@@ -1,0 +1,19 @@
+package com.stripe.android.link.account
+
+import androidx.lifecycle.SavedStateHandle
+import com.stripe.android.link.model.LinkAccount
+import kotlinx.coroutines.flow.StateFlow
+
+internal class LinkAccountHolder(
+    private val savedStateHandle: SavedStateHandle
+) {
+    val linkAccount: StateFlow<LinkAccount?> = savedStateHandle.getStateFlow(LINK_ACCOUNT_HOLDER_STATE, null)
+
+    fun set(account: LinkAccount?) {
+        savedStateHandle[LINK_ACCOUNT_HOLDER_STATE] = account
+    }
+
+    companion object {
+        private const val LINK_ACCOUNT_HOLDER_STATE = "LINK_ACCOUNT_HOLDER_STATE"
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkViewModelModule.kt
@@ -2,6 +2,7 @@ package com.stripe.android.link.injection
 
 import com.stripe.android.link.LinkActivityViewModel
 import com.stripe.android.link.LinkConfiguration
+import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.link.account.LinkAccountManager
 import com.stripe.android.link.account.LinkAuth
 import com.stripe.android.link.gate.LinkGate
@@ -21,6 +22,7 @@ internal object LinkViewModelModule {
         component: NativeLinkComponent,
         defaultConfirmationHandlerFactory: DefaultConfirmationHandler.Factory,
         linkAccountManager: LinkAccountManager,
+        linkAccountHolder: LinkAccountHolder,
         eventReporter: EventReporter,
         integrityRequestManager: IntegrityRequestManager,
         linkGate: LinkGate,
@@ -33,6 +35,7 @@ internal object LinkViewModelModule {
             activityRetainedComponent = component,
             confirmationHandlerFactory = defaultConfirmationHandlerFactory,
             linkAccountManager = linkAccountManager,
+            linkAccountHolder = linkAccountHolder,
             eventReporter = eventReporter,
             integrityRequestManager = integrityRequestManager,
             linkGate = linkGate,

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkModule.kt
@@ -3,6 +3,7 @@ package com.stripe.android.link.injection
 import android.app.Application
 import android.content.Context
 import androidx.core.os.LocaleListCompat
+import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.BuildConfig
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.Stripe
@@ -23,6 +24,7 @@ import com.stripe.android.core.utils.DurationProvider
 import com.stripe.android.core.version.StripeSdkVersion
 import com.stripe.android.link.account.DefaultLinkAccountManager
 import com.stripe.android.link.account.DefaultLinkAuth
+import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.link.account.LinkAccountManager
 import com.stripe.android.link.account.LinkAuth
 import com.stripe.android.link.analytics.DefaultLinkEventsReporter
@@ -95,6 +97,12 @@ internal interface NativeLinkModule {
 
     @SuppressWarnings("TooManyFunctions")
     companion object {
+        @Provides
+        @NativeLinkScope
+        fun providesLinkAccountHolder(savedStateHandle: SavedStateHandle): LinkAccountHolder {
+            return LinkAccountHolder(savedStateHandle)
+        }
+
         @Provides
         @NativeLinkScope
         fun provideConsumersApiService(

--- a/paymentsheet/src/main/java/com/stripe/android/link/model/LinkAccount.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/model/LinkAccount.kt
@@ -1,21 +1,30 @@
 package com.stripe.android.link.model
 
+import android.os.Parcelable
 import com.stripe.android.model.ConsumerSession
+import kotlinx.parcelize.IgnoredOnParcel
+import kotlinx.parcelize.Parcelize
 
 /**
  * Immutable object representing a Link account.
  */
-internal class LinkAccount(private val consumerSession: ConsumerSession) {
+@Parcelize
+internal class LinkAccount(private val consumerSession: ConsumerSession) : Parcelable {
 
+    @IgnoredOnParcel
     val redactedPhoneNumber = consumerSession.redactedPhoneNumber
 
+    @IgnoredOnParcel
     val clientSecret = consumerSession.clientSecret
 
+    @IgnoredOnParcel
     val email = consumerSession.emailAddress
 
+    @IgnoredOnParcel
     val isVerified: Boolean = consumerSession.containsVerifiedSMSSession() ||
         consumerSession.isVerifiedForSignup()
 
+    @IgnoredOnParcel
     val accountStatus = when {
         isVerified -> {
             AccountStatus.Verified

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModelComponent.kt
@@ -12,6 +12,7 @@ import com.stripe.android.core.utils.UserFacingLogger
 import com.stripe.android.googlepaylauncher.injection.GooglePayLauncherModule
 import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.link.RealLinkConfigurationCoordinator
+import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.link.gate.DefaultLinkGate
 import com.stripe.android.link.gate.LinkGate
 import com.stripe.android.link.injection.LinkAnalyticsComponent
@@ -129,6 +130,12 @@ internal interface EmbeddedPaymentElementViewModelModule {
     fun bindsEmbeddedContentHelper(helper: DefaultEmbeddedContentHelper): EmbeddedContentHelper
 
     companion object {
+        @Provides
+        @Singleton
+        fun providesLinkAccountHolder(savedStateHandle: SavedStateHandle): LinkAccountHolder {
+            return LinkAccountHolder(savedStateHandle)
+        }
+
         @Provides
         fun providePrefsRepositoryFactory(
             appContext: Context,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityComponent.kt
@@ -8,6 +8,7 @@ import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.link.RealLinkConfigurationCoordinator
+import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.link.injection.LinkAnalyticsComponent
 import com.stripe.android.link.injection.LinkComponent
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
@@ -73,6 +74,12 @@ internal interface FormActivityModule {
     fun bindsLinkConfigurationCoordinator(impl: RealLinkConfigurationCoordinator): LinkConfigurationCoordinator
 
     companion object {
+        @Provides
+        @Singleton
+        fun providesLinkAccountHolder(savedStateHandle: SavedStateHandle): LinkAccountHolder {
+            return LinkAccountHolder(savedStateHandle)
+        }
+
         @Provides
         @Singleton
         @ViewModelScope

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -289,11 +289,11 @@ internal class PaymentOptionsViewModel @Inject constructor(
             val component = DaggerPaymentOptionsViewModelFactoryComponent.builder()
                 .context(application)
                 .productUsage(starterArgs.productUsage)
+                .savedStateHandle(savedStateHandle)
                 .build()
                 .paymentOptionsViewModelSubcomponentBuilder
                 .application(application)
                 .args(starterArgs)
-                .savedStateHandle(savedStateHandle)
                 .build()
 
             return component.viewModel as T

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -681,10 +681,10 @@ internal class PaymentSheetViewModel @Inject internal constructor(
             val component = DaggerPaymentSheetLauncherComponent
                 .builder()
                 .application(application)
+                .savedStateHandle(savedStateHandle)
                 .build()
                 .paymentSheetViewModelSubcomponentBuilder
                 .paymentSheetViewModelModule(PaymentSheetViewModelModule(starterArgsSupplier()))
-                .savedStateHandle(savedStateHandle)
                 .build()
 
             return component.viewModel as T

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelFactoryComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelFactoryComponent.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.injection
 
 import android.content.Context
+import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
@@ -29,6 +30,9 @@ internal interface PaymentOptionsViewModelFactoryComponent {
     interface Builder {
         @BindsInstance
         fun context(context: Context): Builder
+
+        @BindsInstance
+        fun savedStateHandle(handle: SavedStateHandle): Builder
 
         @BindsInstance
         fun productUsage(@Named(PRODUCT_USAGE) productUsage: Set<String>): Builder

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelSubcomponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelSubcomponent.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentsheet.injection
 
 import android.app.Application
-import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.paymentsheet.PaymentOptionContract
 import com.stripe.android.paymentsheet.PaymentOptionsViewModel
 import dagger.BindsInstance
@@ -15,9 +14,6 @@ internal interface PaymentOptionsViewModelSubcomponent {
     interface Builder {
         @BindsInstance
         fun application(application: Application): Builder
-
-        @BindsInstance
-        fun savedStateHandle(handle: SavedStateHandle): Builder
 
         @BindsInstance
         fun args(args: PaymentOptionContract.Args): Builder

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.injection
 
 import android.content.Context
+import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.cards.CardAccountRangeRepository
 import com.stripe.android.cards.DefaultCardAccountRangeRepositoryFactory
@@ -17,6 +18,7 @@ import com.stripe.android.core.utils.RealUserFacingLogger
 import com.stripe.android.core.utils.UserFacingLogger
 import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.link.RealLinkConfigurationCoordinator
+import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.link.gate.DefaultLinkGate
 import com.stripe.android.link.gate.LinkGate
 import com.stripe.android.link.injection.LinkAnalyticsComponent
@@ -103,6 +105,12 @@ internal abstract class PaymentSheetCommonModule {
 
     @Suppress("TooManyFunctions")
     companion object {
+        @Provides
+        @Singleton
+        fun providesLinkAccountHolder(savedStateHandle: SavedStateHandle): LinkAccountHolder {
+            return LinkAccountHolder(savedStateHandle)
+        }
+
         /**
          * Provides a non-singleton PaymentConfiguration.
          *

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherComponent.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.injection
 
 import android.app.Application
+import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.googlepaylauncher.injection.GooglePayLauncherModule
@@ -29,6 +30,9 @@ internal interface PaymentSheetLauncherComponent {
     interface Builder {
         @BindsInstance
         fun application(application: Application): Builder
+
+        @BindsInstance
+        fun savedStateHandle(handle: SavedStateHandle): Builder
 
         fun build(): PaymentSheetLauncherComponent
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelSubcomponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelSubcomponent.kt
@@ -1,9 +1,7 @@
 package com.stripe.android.paymentsheet.injection
 
-import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.paymentelement.confirmation.injection.PaymentElementConfirmationModule
 import com.stripe.android.paymentsheet.PaymentSheetViewModel
-import dagger.BindsInstance
 import dagger.Subcomponent
 
 @Subcomponent(
@@ -17,9 +15,6 @@ internal interface PaymentSheetViewModelSubcomponent {
         fun paymentSheetViewModelModule(
             paymentSheetViewModelModule: PaymentSheetViewModelModule
         ): Builder
-
-        @BindsInstance
-        fun savedStateHandle(handle: SavedStateHandle): Builder
 
         fun build(): PaymentSheetViewModelSubcomponent
     }

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
@@ -674,7 +674,7 @@ internal class LinkActivityViewModelTest {
     }
 
     private fun createViewModel(
-        linkAccountManager: LinkAccountManager = FakeLinkAccountManager(),
+        linkAccountManager: FakeLinkAccountManager = FakeLinkAccountManager(),
         confirmationHandler: ConfirmationHandler = FakeConfirmationHandler(),
         eventReporter: EventReporter = FakeEventReporter(),
         navController: NavHostController = navController(),
@@ -688,6 +688,7 @@ internal class LinkActivityViewModelTest {
     ): LinkActivityViewModel {
         return LinkActivityViewModel(
             linkAccountManager = linkAccountManager,
+            linkAccountHolder = linkAccountManager.linkAccountHolder,
             activityRetainedComponent = FakeNativeLinkComponent(),
             eventReporter = eventReporter,
             confirmationHandlerFactory = { confirmationHandler },

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAccountManagerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAccountManagerTest.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.link.account
 
+import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.StripeError
@@ -982,6 +983,7 @@ class DefaultLinkAccountManagerTest {
             email = customerEmail,
         )
         return DefaultLinkAccountManager(
+            linkAccountHolder = LinkAccountHolder(SavedStateHandle()),
             config = TestFactory.LINK_CONFIGURATION.copy(
                 stripeIntent = stripeIntent,
                 passthroughModeEnabled = passthroughModeEnabled,

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/FakeLinkAccountManager.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/FakeLinkAccountManager.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.link.account
 
+import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.Turbine
 import com.stripe.android.link.LinkPaymentDetails
 import com.stripe.android.link.TestFactory
@@ -17,9 +18,10 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
-internal open class FakeLinkAccountManager : LinkAccountManager {
-    private val _linkAccount = MutableStateFlow<LinkAccount?>(null)
-    override val linkAccount: StateFlow<LinkAccount?> = _linkAccount
+internal open class FakeLinkAccountManager(
+    val linkAccountHolder: LinkAccountHolder = LinkAccountHolder(SavedStateHandle()),
+) : LinkAccountManager {
+    override val linkAccount: StateFlow<LinkAccount?> = linkAccountHolder.linkAccount
 
     private val _accountStatus = MutableStateFlow(AccountStatus.SignedOut)
     override val accountStatus: Flow<AccountStatus> = _accountStatus
@@ -49,7 +51,7 @@ internal open class FakeLinkAccountManager : LinkAccountManager {
     override var consumerPublishableKey: String? = null
 
     fun setLinkAccount(account: LinkAccount?) {
-        _linkAccount.value = account
+        linkAccountHolder.set(account)
     }
 
     fun setAccountStatus(status: AccountStatus) {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
@toluo-stripe is trying to keep the link account between screens, which means we need a way to set it as a result of an action in the LinkConfirmationDefinition.

Right now the dependency graphs are too gnarly to change how `LinkAccountManager` is injected. So I pulled the state out we need into a `LinkAccountHolder`. This allows us to inject `LinkAccountHolder` into the `LinkConfirmationDefinition`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://github.com/stripe/stripe-android/compare/master...tolu/link/link_account_transport

