### PR TITLE
Change the way we bind confirmation definitions.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationDefinition.kt
@@ -11,8 +11,9 @@ import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateCon
 import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateConfirmationLauncherFactory
 import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateConfirmationResult
 import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateData
+import javax.inject.Inject
 
-internal class BacsConfirmationDefinition(
+internal class BacsConfirmationDefinition @Inject constructor(
     private val bacsMandateConfirmationLauncherFactory: BacsMandateConfirmationLauncherFactory,
 ) : ConfirmationDefinition<
     BacsConfirmationOption,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationModule.kt
@@ -3,22 +3,23 @@ package com.stripe.android.paymentelement.confirmation.bacs
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateConfirmationLauncherFactory
 import com.stripe.android.paymentsheet.paymentdatacollection.bacs.DefaultBacsMandateConfirmationLauncherFactory
+import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoSet
 
 @Module
-internal class BacsConfirmationModule {
-    @Provides
-    fun providesBacsMandateConfirmationLauncherFactory(): BacsMandateConfirmationLauncherFactory =
-        DefaultBacsMandateConfirmationLauncherFactory
-
+internal interface BacsConfirmationModule {
     @JvmSuppressWildcards
-    @Provides
+    @Binds
     @IntoSet
-    fun providesBacsConfirmationDefinition(
-        bacsMandateConfirmationLauncherFactory: BacsMandateConfirmationLauncherFactory,
-    ): ConfirmationDefinition<*, *, *, *> {
-        return BacsConfirmationDefinition(bacsMandateConfirmationLauncherFactory)
+    fun bindsBacsConfirmationDefinition(
+        definition: BacsConfirmationDefinition,
+    ): ConfirmationDefinition<*, *, *, *>
+
+    companion object {
+        @Provides
+        fun providesBacsMandateConfirmationLauncherFactory(): BacsMandateConfirmationLauncherFactory =
+            DefaultBacsMandateConfirmationLauncherFactory
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationDefinition.kt
@@ -11,8 +11,9 @@ import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.Cvc
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcRecollectionLauncher
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcRecollectionLauncherFactory
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcRecollectionResult
+import javax.inject.Inject
 
-internal class CvcRecollectionConfirmationDefinition(
+internal class CvcRecollectionConfirmationDefinition @Inject constructor(
     private val handler: CvcRecollectionHandler,
     private val factory: CvcRecollectionLauncherFactory,
 ) : ConfirmationDefinition<

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationModule.kt
@@ -15,7 +15,7 @@ internal interface CvcRecollectionConfirmationModule {
     @JvmSuppressWildcards
     @Binds
     @IntoSet
-    fun providesCvcConfirmationDefinition(
+    fun bindsCvcConfirmationDefinition(
         cvcReConfirmationDefinition: CvcRecollectionConfirmationDefinition,
     ): ConfirmationDefinition<*, *, *, *>
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationModule.kt
@@ -5,29 +5,29 @@ import com.stripe.android.paymentsheet.cvcrecollection.CvcRecollectionHandler
 import com.stripe.android.paymentsheet.cvcrecollection.CvcRecollectionHandlerImpl
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcRecollectionLauncherFactory
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.DefaultCvcRecollectionLauncherFactory
+import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoSet
 
 @Module
-internal class CvcRecollectionConfirmationModule {
-    @Provides
-    fun provideCvcRecollectionLauncherFactory(): CvcRecollectionLauncherFactory {
-        return DefaultCvcRecollectionLauncherFactory
-    }
-
-    @Provides
-    fun provideCvcRecollectionHandler(): CvcRecollectionHandler {
-        return CvcRecollectionHandlerImpl()
-    }
-
+internal interface CvcRecollectionConfirmationModule {
     @JvmSuppressWildcards
-    @Provides
+    @Binds
     @IntoSet
     fun providesCvcConfirmationDefinition(
-        cvcRecollectionLauncherFactory: CvcRecollectionLauncherFactory,
-        cvcRecollectionHandler: CvcRecollectionHandler,
-    ): ConfirmationDefinition<*, *, *, *> {
-        return CvcRecollectionConfirmationDefinition(cvcRecollectionHandler, cvcRecollectionLauncherFactory)
+        cvcReConfirmationDefinition: CvcRecollectionConfirmationDefinition,
+    ): ConfirmationDefinition<*, *, *, *>
+
+    companion object {
+        @Provides
+        fun provideCvcRecollectionLauncherFactory(): CvcRecollectionLauncherFactory {
+            return DefaultCvcRecollectionLauncherFactory
+        }
+
+        @Provides
+        fun provideCvcRecollectionHandler(): CvcRecollectionHandler {
+            return CvcRecollectionHandlerImpl()
+        }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationDefinition.kt
@@ -12,9 +12,10 @@ import com.stripe.android.paymentsheet.ExternalPaymentMethodConfirmHandler
 import com.stripe.android.paymentsheet.ExternalPaymentMethodContract
 import com.stripe.android.paymentsheet.ExternalPaymentMethodInput
 import java.lang.IllegalStateException
+import javax.inject.Inject
 import javax.inject.Provider
 
-internal class ExternalPaymentMethodConfirmationDefinition(
+internal class ExternalPaymentMethodConfirmationDefinition @Inject constructor(
     private val externalPaymentMethodConfirmHandlerProvider: Provider<ExternalPaymentMethodConfirmHandler?>,
     private val errorReporter: ErrorReporter,
 ) : ConfirmationDefinition<

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationModule.kt
@@ -1,25 +1,26 @@
 package com.stripe.android.paymentelement.confirmation.epms
 
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
-import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.paymentsheet.ExternalPaymentMethodConfirmHandler
 import com.stripe.android.paymentsheet.ExternalPaymentMethodInterceptor
+import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoSet
 
 @Module
-internal class ExternalPaymentMethodConfirmationModule {
+internal interface ExternalPaymentMethodConfirmationModule {
     @JvmSuppressWildcards
-    @Provides
+    @Binds
     @IntoSet
-    fun providesExternalPaymentMethodConfirmationDefinition(
-        errorReporter: ErrorReporter
-    ): ConfirmationDefinition<*, *, *, *> {
-        return ExternalPaymentMethodConfirmationDefinition(
-            externalPaymentMethodConfirmHandlerProvider = {
-                ExternalPaymentMethodInterceptor.externalPaymentMethodConfirmHandler
-            },
-            errorReporter = errorReporter
-        )
+    fun bindsExternalPaymentMethodConfirmationDefinition(
+        definition: ExternalPaymentMethodConfirmationDefinition
+    ): ConfirmationDefinition<*, *, *, *>
+
+    companion object {
+        @Provides
+        fun provideExternalPaymentMethodConfirmHandler(): ExternalPaymentMethodConfirmHandler? {
+            return ExternalPaymentMethodInterceptor.externalPaymentMethodConfirmHandler
+        }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinition.kt
@@ -20,9 +20,10 @@ import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import javax.inject.Inject
 import com.stripe.android.R as PaymentsCoreR
 
-internal class GooglePayConfirmationDefinition(
+internal class GooglePayConfirmationDefinition @Inject constructor(
     private val googlePayPaymentMethodLauncherFactory: GooglePayPaymentMethodLauncherFactory,
     private val userFacingLogger: UserFacingLogger?,
 ) : ConfirmationDefinition<

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationModule.kt
@@ -1,24 +1,16 @@
 package com.stripe.android.paymentelement.confirmation.gpay
 
-import com.stripe.android.core.utils.UserFacingLogger
-import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLauncherFactory
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
+import dagger.Binds
 import dagger.Module
-import dagger.Provides
 import dagger.multibindings.IntoSet
 
 @Module
-internal class GooglePayConfirmationModule {
+internal interface GooglePayConfirmationModule {
     @JvmSuppressWildcards
-    @Provides
+    @Binds
     @IntoSet
-    fun providesGooglePayConfirmationDefinition(
-        googlePayPaymentMethodLauncherFactory: GooglePayPaymentMethodLauncherFactory,
-        userFacingLogger: UserFacingLogger?,
-    ): ConfirmationDefinition<*, *, *, *> {
-        return GooglePayConfirmationDefinition(
-            googlePayPaymentMethodLauncherFactory = googlePayPaymentMethodLauncherFactory,
-            userFacingLogger = userFacingLogger,
-        )
-    }
+    fun bindsGooglePayConfirmationDefinition(
+        definition: GooglePayConfirmationDefinition
+    ): ConfirmationDefinition<*, *, *, *>
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinition.kt
@@ -9,8 +9,9 @@ import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
+import javax.inject.Inject
 
-internal class LinkConfirmationDefinition(
+internal class LinkConfirmationDefinition @Inject constructor(
     private val linkPaymentLauncher: LinkPaymentLauncher,
     private val linkStore: LinkStore,
 ) : ConfirmationDefinition<LinkConfirmationOption, LinkPaymentLauncher, Unit, LinkActivityResult> {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationModule.kt
@@ -1,11 +1,9 @@
 package com.stripe.android.paymentelement.confirmation.link
 
-import com.stripe.android.link.LinkPaymentLauncher
-import com.stripe.android.link.account.LinkStore
 import com.stripe.android.link.injection.LinkAnalyticsComponent
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
+import dagger.Binds
 import dagger.Module
-import dagger.Provides
 import dagger.multibindings.IntoSet
 
 @Module(
@@ -13,17 +11,11 @@ import dagger.multibindings.IntoSet
         LinkAnalyticsComponent::class,
     ]
 )
-internal object LinkConfirmationModule {
+internal interface LinkConfirmationModule {
     @JvmSuppressWildcards
-    @Provides
+    @Binds
     @IntoSet
-    fun providesLinkConfirmationDefinition(
-        linkStore: LinkStore,
-        linkPaymentLauncher: LinkPaymentLauncher,
-    ): ConfirmationDefinition<*, *, *, *> {
-        return LinkConfirmationDefinition(
-            linkStore = linkStore,
-            linkPaymentLauncher = linkPaymentLauncher,
-        )
-    }
+    fun bindsLinkConfirmationDefinition(
+        definition: LinkConfirmationDefinition
+    ): ConfirmationDefinition<*, *, *, *>
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Uses binds rather than provides for confirmation definition dependency injection. The only real point of this is to make adding new params to the definitions only require one file to change, rather than 2.
