### PR TITLE
Transport LinkAccount between PaymentSheet & Native Link

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -268,6 +268,22 @@ public abstract interface class com/stripe/android/customersheet/SetupIntentClie
 	public abstract fun provideSetupIntentClientSecret (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public final class com/stripe/android/link/LinkAccountUpdate$None$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/link/LinkAccountUpdate$None;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/link/LinkAccountUpdate$None;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/link/LinkAccountUpdate$Value$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/link/LinkAccountUpdate$Value;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/link/LinkAccountUpdate$Value;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/link/LinkActivityResult$Canceled$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/link/LinkActivityResult$Canceled;

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivity.kt
@@ -84,7 +84,8 @@ internal class LinkActivity : ComponentActivity() {
         webLauncher?.launch(
             LinkActivityContract.Args(
                 configuration = configuration,
-                startWithVerificationDialog = false
+                startWithVerificationDialog = false,
+                linkAccount = null
             )
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityContract.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import androidx.activity.result.contract.ActivityResultContract
 import com.stripe.android.link.gate.LinkGate
+import com.stripe.android.link.model.LinkAccount
 import javax.inject.Inject
 
 /**
@@ -37,7 +38,8 @@ internal class LinkActivityContract @Inject internal constructor(
 
     data class Args internal constructor(
         internal val configuration: LinkConfiguration,
-        internal val startWithVerificationDialog: Boolean
+        internal val startWithVerificationDialog: Boolean,
+        internal val linkAccount: LinkAccount?
     )
 
     data class Result(

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityResult.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityResult.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.link
 
 import android.os.Parcelable
+import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.model.PaymentMethod
 import kotlinx.parcelize.Parcelize
 
@@ -9,7 +10,9 @@ internal sealed class LinkActivityResult : Parcelable {
      * Indicates that the flow was completed successfully.
      */
     @Parcelize
-    data object Completed : LinkActivityResult()
+    data class Completed(
+        val linkAccountUpdate: LinkAccountUpdate
+    ) : LinkActivityResult()
 
     /**
      * Indicates that the user selected a payment method. This payment method has not yet been confirmed.
@@ -25,6 +28,7 @@ internal sealed class LinkActivityResult : Parcelable {
     @Parcelize
     data class Canceled(
         val reason: Reason = Reason.BackPressed,
+        val linkAccountUpdate: LinkAccountUpdate
     ) : LinkActivityResult() {
         enum class Reason {
             BackPressed,
@@ -38,6 +42,16 @@ internal sealed class LinkActivityResult : Parcelable {
      */
     @Parcelize
     data class Failed(
-        val error: Throwable
+        val error: Throwable,
+        val linkAccountUpdate: LinkAccountUpdate
     ) : LinkActivityResult()
+}
+
+@Parcelize
+internal sealed interface LinkAccountUpdate : Parcelable {
+    @Parcelize
+    data class Value(val linkAccount: LinkAccount?) : LinkAccountUpdate
+
+    @Parcelize
+    data object None : LinkAccountUpdate
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
@@ -6,6 +6,7 @@ import androidx.activity.result.ActivityResultRegistry
 import com.stripe.android.link.LinkActivityResult.PaymentMethodObtained
 import com.stripe.android.link.account.LinkStore
 import com.stripe.android.link.injection.LinkAnalyticsComponent
+import com.stripe.android.link.model.LinkAccount
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -52,7 +53,7 @@ internal class LinkPaymentLauncher @Inject internal constructor(
     ) {
         analyticsHelper.onLinkResult(linkActivityResult)
         when (linkActivityResult) {
-            is PaymentMethodObtained, LinkActivityResult.Completed -> {
+            is PaymentMethodObtained, is LinkActivityResult.Completed -> {
                 linkStore.markLinkAsUsed()
             }
             is LinkActivityResult.Canceled, is LinkActivityResult.Failed -> Unit
@@ -71,11 +72,13 @@ internal class LinkPaymentLauncher @Inject internal constructor(
      * @param configuration The payment and customer settings
      */
     fun present(
-        configuration: LinkConfiguration
+        configuration: LinkConfiguration,
+        linkAccount: LinkAccount?
     ) {
         val args = LinkActivityContract.Args(
             configuration = configuration,
-            startWithVerificationDialog = false
+            startWithVerificationDialog = false,
+            linkAccount = linkAccount
         )
         linkActivityResultLauncher?.launch(args)
         analyticsHelper.onLinkLaunched()

--- a/paymentsheet/src/main/java/com/stripe/android/link/NativeLinkActivityContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/NativeLinkActivityContract.kt
@@ -21,7 +21,8 @@ internal class NativeLinkActivityContract @Inject constructor() :
                 configuration = input.configuration,
                 stripeAccountId = paymentConfiguration.stripeAccountId,
                 publishableKey = paymentConfiguration.publishableKey,
-                startWithVerificationDialog = input.startWithVerificationDialog
+                startWithVerificationDialog = input.startWithVerificationDialog,
+                linkAccount = input.linkAccount
             )
         )
     }
@@ -29,18 +30,24 @@ internal class NativeLinkActivityContract @Inject constructor() :
     override fun parseResult(resultCode: Int, intent: Intent?): LinkActivityResult {
         return when (resultCode) {
             Activity.RESULT_CANCELED -> {
-                LinkActivityResult.Canceled()
+                LinkActivityResult.Canceled(
+                    linkAccountUpdate = LinkAccountUpdate.None
+                )
             }
 
             LinkActivity.RESULT_COMPLETE -> {
                 val result = intent?.extras?.let {
                     BundleCompat.getParcelable(it, LinkActivityContract.EXTRA_RESULT, LinkActivityResult::class.java)
                 }
-                return result ?: LinkActivityResult.Canceled()
+                return result ?: LinkActivityResult.Canceled(
+                    linkAccountUpdate = LinkAccountUpdate.None
+                )
             }
 
             else -> {
-                LinkActivityResult.Canceled()
+                LinkActivityResult.Canceled(
+                    linkAccountUpdate = LinkAccountUpdate.None
+                )
             }
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/link/NativeLinkArgs.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/NativeLinkArgs.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.link
 
 import android.os.Parcelable
+import com.stripe.android.link.model.LinkAccount
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -8,5 +9,6 @@ internal data class NativeLinkArgs(
     val configuration: LinkConfiguration,
     val publishableKey: String,
     val stripeAccountId: String?,
-    val startWithVerificationDialog: Boolean
+    val startWithVerificationDialog: Boolean,
+    val linkAccount: LinkAccount?
 ) : Parcelable

--- a/paymentsheet/src/main/java/com/stripe/android/link/WebLinkActivityContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/WebLinkActivityContract.kt
@@ -47,40 +47,63 @@ internal class WebLinkActivityContract @Inject internal constructor(
                     )
                 }
                 if (exception != null) {
-                    LinkActivityResult.Failed(exception)
+                    LinkActivityResult.Failed(
+                        error = exception,
+                        linkAccountUpdate = LinkAccountUpdate.None
+
+                    )
                 } else {
-                    LinkActivityResult.Canceled()
+                    LinkActivityResult.Canceled(
+                        linkAccountUpdate = LinkAccountUpdate.None
+                    )
                 }
             }
 
             LinkForegroundActivity.RESULT_COMPLETE -> {
-                val redirectUri = intent?.data ?: return LinkActivityResult.Canceled()
-                when (redirectUri.getQueryParameter("link_status")) {
-                    "complete" -> {
-                        val paymentMethod = redirectUri.getQueryParameter("pm")
-                            ?.parsePaymentMethod()
-                        if (paymentMethod == null) {
-                            LinkActivityResult.Canceled()
-                        } else {
-                            LinkActivityResult.PaymentMethodObtained(paymentMethod)
-                        }
-                    }
-
-                    "logout" -> {
-                        LinkActivityResult.Canceled(LinkActivityResult.Canceled.Reason.LoggedOut)
-                    }
-
-                    else -> {
-                        LinkActivityResult.Canceled()
-                    }
-                }
+                handleCompleteResult(intent)
             }
 
             Activity.RESULT_CANCELED -> {
-                LinkActivityResult.Canceled()
+                LinkActivityResult.Canceled(
+                    linkAccountUpdate = LinkAccountUpdate.None
+                )
             }
             else -> {
-                LinkActivityResult.Canceled()
+                LinkActivityResult.Canceled(
+                    linkAccountUpdate = LinkAccountUpdate.None
+                )
+            }
+        }
+    }
+
+    private fun handleCompleteResult(intent: Intent?): LinkActivityResult {
+        val redirectUri = intent?.data ?: return LinkActivityResult.Canceled(
+            linkAccountUpdate = LinkAccountUpdate.None
+        )
+        return when (redirectUri.getQueryParameter("link_status")) {
+            "complete" -> {
+                val paymentMethod = redirectUri.getQueryParameter("pm")
+                    ?.parsePaymentMethod()
+                if (paymentMethod == null) {
+                    LinkActivityResult.Canceled(
+                        linkAccountUpdate = LinkAccountUpdate.None
+                    )
+                } else {
+                    LinkActivityResult.PaymentMethodObtained(paymentMethod)
+                }
+            }
+
+            "logout" -> {
+                LinkActivityResult.Canceled(
+                    reason = LinkActivityResult.Canceled.Reason.LoggedOut,
+                    linkAccountUpdate = LinkAccountUpdate.None
+                )
+            }
+
+            else -> {
+                LinkActivityResult.Canceled(
+                    linkAccountUpdate = LinkAccountUpdate.None
+                )
             }
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAccountUtil.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAccountUtil.kt
@@ -1,0 +1,6 @@
+package com.stripe.android.link.account
+
+import com.stripe.android.link.LinkAccountUpdate
+
+internal val LinkAccountManager.linkAccountUpdate: LinkAccountUpdate
+    get() = LinkAccountUpdate.Value(linkAccount.value)

--- a/paymentsheet/src/main/java/com/stripe/android/link/analytics/DefaultLinkAnalyticsHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/analytics/DefaultLinkAnalyticsHelper.kt
@@ -25,7 +25,8 @@ internal class DefaultLinkAnalyticsHelper @Inject internal constructor(
                 }
             }
 
-            is LinkActivityResult.PaymentMethodObtained, LinkActivityResult.Completed -> {
+            is LinkActivityResult.PaymentMethodObtained,
+            is LinkActivityResult.Completed -> {
                 linkEventsReporter.onPopupSuccess()
             }
 

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkViewModelModule.kt
@@ -2,7 +2,6 @@ package com.stripe.android.link.injection
 
 import com.stripe.android.link.LinkActivityViewModel
 import com.stripe.android.link.LinkConfiguration
-import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.link.account.LinkAccountManager
 import com.stripe.android.link.account.LinkAuth
 import com.stripe.android.link.gate.LinkGate
@@ -22,7 +21,6 @@ internal object LinkViewModelModule {
         component: NativeLinkComponent,
         defaultConfirmationHandlerFactory: DefaultConfirmationHandler.Factory,
         linkAccountManager: LinkAccountManager,
-        linkAccountHolder: LinkAccountHolder,
         eventReporter: EventReporter,
         integrityRequestManager: IntegrityRequestManager,
         linkGate: LinkGate,
@@ -35,7 +33,6 @@ internal object LinkViewModelModule {
             activityRetainedComponent = component,
             confirmationHandlerFactory = defaultConfirmationHandlerFactory,
             linkAccountManager = linkAccountManager,
-            linkAccountHolder = linkAccountHolder,
             eventReporter = eventReporter,
             integrityRequestManager = integrityRequestManager,
             linkGate = linkGate,

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkComponent.kt
@@ -14,6 +14,7 @@ import com.stripe.android.link.account.LinkAccountManager
 import com.stripe.android.link.account.LinkAuth
 import com.stripe.android.link.analytics.LinkEventsReporter
 import com.stripe.android.link.confirmation.LinkConfirmationHandler
+import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.paymentelement.confirmation.injection.DefaultConfirmationModule
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
@@ -73,6 +74,9 @@ internal interface NativeLinkComponent {
         fun startWithVerificationDialog(
             @Named(START_WITH_VERIFICATION_DIALOG) startWithVerificationDialog: Boolean
         ): Builder
+
+        @BindsInstance
+        fun linkAccount(linkAccount: LinkAccount?): Builder
 
         fun build(): NativeLinkComponent
     }

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkModule.kt
@@ -33,6 +33,7 @@ import com.stripe.android.link.confirmation.DefaultLinkConfirmationHandler
 import com.stripe.android.link.confirmation.LinkConfirmationHandler
 import com.stripe.android.link.gate.DefaultLinkGate
 import com.stripe.android.link.gate.LinkGate
+import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.link.repositories.LinkApiRepository
 import com.stripe.android.link.repositories.LinkRepository
 import com.stripe.android.networking.StripeApiRepository
@@ -99,8 +100,13 @@ internal interface NativeLinkModule {
     companion object {
         @Provides
         @NativeLinkScope
-        fun providesLinkAccountHolder(savedStateHandle: SavedStateHandle): LinkAccountHolder {
-            return LinkAccountHolder(savedStateHandle)
+        fun providesLinkAccountHolder(
+            savedStateHandle: SavedStateHandle,
+            linkAccount: LinkAccount?
+        ): LinkAccountHolder {
+            return LinkAccountHolder(savedStateHandle).apply {
+                set(linkAccount)
+            }
         }
 
         @Provides

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/LinkContent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/LinkContent.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.LinkAction
 import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkActivityViewModel
@@ -150,7 +151,7 @@ private fun Screens(
 
         composable(LinkScreen.Verification.route) {
             val linkAccount = getLinkAccount()
-                ?: return@composable dismissWithResult(LinkActivityResult.Failed(NoLinkAccountFoundException()))
+                ?: return@composable dismissWithResult(noLinkAccountResult())
             val viewModel: VerificationViewModel = linkViewModel { parentComponent ->
                 VerificationViewModel.factory(
                     parentComponent = parentComponent,
@@ -164,7 +165,7 @@ private fun Screens(
 
         composable(LinkScreen.Wallet.route) {
             val linkAccount = getLinkAccount()
-                ?: return@composable dismissWithResult(LinkActivityResult.Failed(NoLinkAccountFoundException()))
+                ?: return@composable dismissWithResult(noLinkAccountResult())
             val viewModel: WalletViewModel = linkViewModel { parentComponent ->
                 WalletViewModel.factory(
                     parentComponent = parentComponent,
@@ -187,7 +188,7 @@ private fun Screens(
 
         composable(LinkScreen.PaymentMethod.route) {
             val linkAccount = getLinkAccount()
-                ?: return@composable dismissWithResult(LinkActivityResult.Failed(NoLinkAccountFoundException()))
+                ?: return@composable dismissWithResult(noLinkAccountResult())
             PaymentMethodRoute(linkAccount = linkAccount, dismissWithResult = dismissWithResult)
         }
     }
@@ -236,4 +237,11 @@ private fun Loader() {
     ) {
         CircularProgressIndicator()
     }
+}
+
+private fun noLinkAccountResult(): LinkActivityResult {
+    return LinkActivityResult.Failed(
+        error = NoLinkAccountFoundException(),
+        linkAccountUpdate = LinkAccountUpdate.None
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
@@ -11,6 +11,7 @@ import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkPaymentDetails
 import com.stripe.android.link.account.LinkAccountManager
+import com.stripe.android.link.account.linkAccountUpdate
 import com.stripe.android.link.confirmation.LinkConfirmationHandler
 import com.stripe.android.link.confirmation.Result
 import com.stripe.android.link.injection.NativeLinkComponent
@@ -114,7 +115,11 @@ internal class PaymentMethodViewModel @Inject constructor(
                 _state.update { it.copy(errorMessage = result.message) }
             }
             Result.Succeeded -> {
-                dismissWithResult(LinkActivityResult.Completed)
+                dismissWithResult(
+                    LinkActivityResult.Completed(
+                        linkAccountUpdate = linkAccountManager.linkAccountUpdate
+                    )
+                )
             }
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
@@ -11,6 +11,7 @@ import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkScreen
 import com.stripe.android.link.account.LinkAccountManager
+import com.stripe.android.link.account.linkAccountUpdate
 import com.stripe.android.link.confirmation.LinkConfirmationHandler
 import com.stripe.android.link.injection.NativeLinkComponent
 import com.stripe.android.link.model.LinkAccount
@@ -120,7 +121,12 @@ internal class WalletViewModel @Inject constructor(
 
     private fun onFatal(fatalError: Throwable) {
         logger.error("WalletViewModel Fatal error: ", fatalError)
-        dismissWithResult(LinkActivityResult.Failed(fatalError))
+        dismissWithResult(
+            LinkActivityResult.Failed(
+                error = fatalError,
+                linkAccountUpdate = linkAccountManager.linkAccountUpdate
+            )
+        )
     }
 
     fun onItemSelected(item: ConsumerPaymentDetails.PaymentDetails) {
@@ -197,7 +203,11 @@ internal class WalletViewModel @Inject constructor(
                 }
             }
             LinkConfirmationResult.Succeeded -> {
-                dismissWithResult(LinkActivityResult.Completed)
+                dismissWithResult(
+                    LinkActivityResult.Completed(
+                        linkAccountUpdate = linkAccountManager.linkAccountUpdate
+                    )
+                )
             }
         }
     }
@@ -217,7 +227,12 @@ internal class WalletViewModel @Inject constructor(
     }
 
     fun onPayAnotherWayClicked() {
-        dismissWithResult(LinkActivityResult.Canceled(LinkActivityResult.Canceled.Reason.PayAnotherWay))
+        dismissWithResult(
+            LinkActivityResult.Canceled(
+                reason = LinkActivityResult.Canceled.Reason.PayAnotherWay,
+                linkAccountUpdate = linkAccountManager.linkAccountUpdate
+            )
+        )
     }
 
     fun onRemoveClicked(item: ConsumerPaymentDetails.PaymentDetails) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinition.kt
@@ -2,8 +2,10 @@ package com.stripe.android.paymentelement.confirmation.link
 
 import androidx.activity.result.ActivityResultCaller
 import com.stripe.android.common.exception.stripeErrorMessage
+import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkPaymentLauncher
+import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.link.account.LinkStore
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
@@ -14,6 +16,7 @@ import javax.inject.Inject
 internal class LinkConfirmationDefinition @Inject constructor(
     private val linkPaymentLauncher: LinkPaymentLauncher,
     private val linkStore: LinkStore,
+    private val linkAccountHolder: LinkAccountHolder
 ) : ConfirmationDefinition<LinkConfirmationOption, LinkPaymentLauncher, Unit, LinkActivityResult> {
     override val key: String = "Link"
 
@@ -51,7 +54,10 @@ internal class LinkConfirmationDefinition @Inject constructor(
         confirmationOption: LinkConfirmationOption,
         confirmationParameters: ConfirmationDefinition.Parameters,
     ) {
-        launcher.present(confirmationOption.configuration)
+        launcher.present(
+            configuration = confirmationOption.configuration,
+            linkAccount = linkAccountHolder.linkAccount.value
+        )
     }
 
     override fun toResult(
@@ -68,27 +74,45 @@ internal class LinkConfirmationDefinition @Inject constructor(
         }
 
         return when (result) {
-            is LinkActivityResult.PaymentMethodObtained -> ConfirmationDefinition.Result.NextStep(
-                confirmationOption = PaymentMethodConfirmationOption.Saved(
-                    paymentMethod = result.paymentMethod,
-                    optionsParams = null,
-                ),
-                parameters = confirmationParameters,
-            )
-            is LinkActivityResult.Failed -> ConfirmationDefinition.Result.Failed(
-                cause = result.error,
-                message = result.error.stripeErrorMessage(),
-                type = ConfirmationHandler.Result.Failed.ErrorType.Payment,
-            )
-            is LinkActivityResult.Canceled -> ConfirmationDefinition.Result.Canceled(
-                action = ConfirmationHandler.Result.Canceled.Action.InformCancellation,
-            )
-            LinkActivityResult.Completed -> {
+            is LinkActivityResult.PaymentMethodObtained -> {
+                ConfirmationDefinition.Result.NextStep(
+                    confirmationOption = PaymentMethodConfirmationOption.Saved(
+                        paymentMethod = result.paymentMethod,
+                        optionsParams = null,
+                    ),
+                    parameters = confirmationParameters,
+                )
+            }
+            is LinkActivityResult.Failed -> {
+                result.linkAccountUpdate.updateLinkAccount()
+                ConfirmationDefinition.Result.Failed(
+                    cause = result.error,
+                    message = result.error.stripeErrorMessage(),
+                    type = ConfirmationHandler.Result.Failed.ErrorType.Payment,
+                )
+            }
+            is LinkActivityResult.Canceled -> {
+                result.linkAccountUpdate.updateLinkAccount()
+                ConfirmationDefinition.Result.Canceled(
+                    action = ConfirmationHandler.Result.Canceled.Action.InformCancellation,
+                )
+            }
+            is LinkActivityResult.Completed -> {
+                result.linkAccountUpdate.updateLinkAccount()
                 ConfirmationDefinition.Result.Succeeded(
                     intent = confirmationParameters.intent,
                     deferredIntentConfirmationType = deferredIntentConfirmationType
                 )
             }
+        }
+    }
+
+    private fun LinkAccountUpdate.updateLinkAccount() {
+        when (this) {
+            is LinkAccountUpdate.Value -> {
+                linkAccountHolder.set(linkAccount)
+            }
+            LinkAccountUpdate.None -> Unit
         }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityContractTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityContractTest.kt
@@ -21,7 +21,8 @@ class LinkActivityContractTest {
     private val context: Context = ApplicationProvider.getApplicationContext()
     private val args = LinkActivityContract.Args(
         configuration = TestFactory.LINK_CONFIGURATION,
-        startWithVerificationDialog = false
+        startWithVerificationDialog = false,
+        linkAccount = null
     )
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkPaymentLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkPaymentLauncherTest.kt
@@ -87,7 +87,10 @@ internal class LinkPaymentLauncherTest {
             val registerCall = awaitRegisterCall()
             assertThat(registerCall).isNotNull()
 
-            linkPaymentLauncher.present(TestFactory.LINK_CONFIGURATION)
+            linkPaymentLauncher.present(
+                configuration = TestFactory.LINK_CONFIGURATION,
+                linkAccount = TestFactory.LINK_ACCOUNT
+            )
 
             val launchCall = awaitLaunchCall()
 
@@ -95,7 +98,8 @@ internal class LinkPaymentLauncherTest {
                 .isEqualTo(
                     LinkActivityContract.Args(
                         configuration = TestFactory.LINK_CONFIGURATION,
-                        startWithVerificationDialog = false
+                        startWithVerificationDialog = false,
+                        linkAccount = TestFactory.LINK_ACCOUNT
                     )
                 )
 
@@ -106,7 +110,9 @@ internal class LinkPaymentLauncherTest {
     @Test
     fun `ActivityResultRegistry callback should handle Completed result correctly`() {
         testActivityResultCallbackWithActivityResultRegistry(
-            linkActivityResult = LinkActivityResult.Completed,
+            linkActivityResult = LinkActivityResult.Completed(
+                linkAccountUpdate = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT)
+            ),
             expectedMarkAsUsedCalls = 1,
         )
     }
@@ -122,7 +128,9 @@ internal class LinkPaymentLauncherTest {
     @Test
     fun `ActivityResultRegistry callback should handle Canceled result correctly`() {
         testActivityResultCallbackWithActivityResultRegistry(
-            linkActivityResult = LinkActivityResult.Canceled(),
+            linkActivityResult = LinkActivityResult.Canceled(
+                linkAccountUpdate = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT)
+            ),
             expectedMarkAsUsedCalls = 0,
         )
     }
@@ -130,7 +138,10 @@ internal class LinkPaymentLauncherTest {
     @Test
     fun `ActivityResultRegistry callback should handle Failed result correctly`() {
         testActivityResultCallbackWithActivityResultRegistry(
-            linkActivityResult = LinkActivityResult.Failed(Exception("oops")),
+            linkActivityResult = LinkActivityResult.Failed(
+                error = Exception("oops"),
+                linkAccountUpdate = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT)
+            ),
             expectedMarkAsUsedCalls = 0,
         )
     }
@@ -138,7 +149,9 @@ internal class LinkPaymentLauncherTest {
     @Test
     fun `ActivityResultCaller callback should handle Completed result correctly`() {
         testActivityResultCallbackWithResultCaller(
-            linkActivityResult = LinkActivityResult.Completed,
+            linkActivityResult = LinkActivityResult.Completed(
+                linkAccountUpdate = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT)
+            ),
             expectedMarkAsUsedCalls = 1,
         )
     }
@@ -154,7 +167,9 @@ internal class LinkPaymentLauncherTest {
     @Test
     fun `ActivityResultCaller callback should handle Canceled result correctly`() {
         testActivityResultCallbackWithResultCaller(
-            linkActivityResult = LinkActivityResult.Canceled(),
+            linkActivityResult = LinkActivityResult.Canceled(
+                linkAccountUpdate = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT)
+            ),
             expectedMarkAsUsedCalls = 0,
         )
     }
@@ -162,7 +177,10 @@ internal class LinkPaymentLauncherTest {
     @Test
     fun `ActivityResultCaller callback should handle Failed result correctly`() {
         testActivityResultCallbackWithResultCaller(
-            linkActivityResult = LinkActivityResult.Failed(Exception("oops")),
+            linkActivityResult = LinkActivityResult.Failed(
+                error = Exception("oops"),
+                linkAccountUpdate = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT)
+            ),
             expectedMarkAsUsedCalls = 0,
         )
     }
@@ -183,7 +201,10 @@ internal class LinkPaymentLauncherTest {
             var callbackParam: LinkActivityResult? = null
             linkPaymentLauncher.register(activityResultRegistry) { callbackParam = it }
 
-            linkPaymentLauncher.present(TestFactory.LINK_CONFIGURATION)
+            linkPaymentLauncher.present(
+                configuration = TestFactory.LINK_CONFIGURATION,
+                linkAccount = TestFactory.LINK_ACCOUNT
+            )
 
             verifyActivityResultCallback(
                 linkActivityResult = linkActivityResult,
@@ -210,7 +231,10 @@ internal class LinkPaymentLauncherTest {
                 var callbackParam: LinkActivityResult? = null
                 linkPaymentLauncher.register(activityResultCaller) { callbackParam = it }
 
-                linkPaymentLauncher.present(TestFactory.LINK_CONFIGURATION)
+                linkPaymentLauncher.present(
+                    configuration = TestFactory.LINK_CONFIGURATION,
+                    linkAccount = TestFactory.LINK_ACCOUNT
+                )
 
                 val registerCall = awaitRegisterCall()
                 registerCall.callback.asCallbackFor<LinkActivityResult>().onActivityResult(linkActivityResult)

--- a/paymentsheet/src/test/java/com/stripe/android/link/NativeLinkActivityContractTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/NativeLinkActivityContractTest.kt
@@ -35,7 +35,8 @@ class NativeLinkActivityContractTest {
         val contract = NativeLinkActivityContract()
         val args = LinkActivityContract.Args(
             configuration = TestFactory.LINK_CONFIGURATION,
-            startWithVerificationDialog = false
+            startWithVerificationDialog = false,
+            linkAccount = TestFactory.LINK_ACCOUNT
         )
 
         val intent = contract.createIntent(ApplicationProvider.getApplicationContext(), args)
@@ -50,7 +51,8 @@ class NativeLinkActivityContractTest {
                 configuration = TestFactory.LINK_CONFIGURATION,
                 publishableKey = "pk_test_abcdefg",
                 stripeAccountId = null,
-                startWithVerificationDialog = false
+                startWithVerificationDialog = false,
+                linkAccount = TestFactory.LINK_ACCOUNT
             )
         )
     }
@@ -80,7 +82,12 @@ class NativeLinkActivityContractTest {
             intent = Intent()
         )
 
-        assertThat(result).isEqualTo(LinkActivityResult.Canceled())
+        assertThat(result)
+            .isEqualTo(
+                LinkActivityResult.Canceled(
+                    linkAccountUpdate = LinkAccountUpdate.None
+                )
+            )
     }
 
     @Test
@@ -89,7 +96,12 @@ class NativeLinkActivityContractTest {
 
         val result = contract.parseResult(42, Intent())
 
-        assertThat(result).isEqualTo(LinkActivityResult.Canceled())
+        assertThat(result)
+            .isEqualTo(
+                LinkActivityResult.Canceled(
+                    linkAccountUpdate = LinkAccountUpdate.None
+                )
+            )
     }
 
     @Test
@@ -98,7 +110,12 @@ class NativeLinkActivityContractTest {
 
         val result = contract.parseResult(Activity.RESULT_CANCELED, Intent())
 
-        assertThat(result).isEqualTo(LinkActivityResult.Canceled())
+        assertThat(result)
+            .isEqualTo(
+                LinkActivityResult.Canceled(
+                    linkAccountUpdate = LinkAccountUpdate.None
+                )
+            )
     }
 
     private fun intent(result: LinkActivityResult): Intent {

--- a/paymentsheet/src/test/java/com/stripe/android/link/WebLinkActivityContractTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/WebLinkActivityContractTest.kt
@@ -41,7 +41,8 @@ class WebLinkActivityContractTest {
         val contract = contract(stripeRepository)
         val args = LinkActivityContract.Args(
             configuration = TestFactory.LINK_CONFIGURATION,
-            startWithVerificationDialog = false
+            startWithVerificationDialog = false,
+            linkAccount = TestFactory.LINK_ACCOUNT
         )
 
         val intent = contract.createIntent(ApplicationProvider.getApplicationContext(), args)

--- a/paymentsheet/src/test/java/com/stripe/android/link/analytics/DefaultLinkAnalyticsHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/analytics/DefaultLinkAnalyticsHelperTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.link.analytics
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.model.PaymentMethod
 import org.junit.Test
@@ -48,7 +49,7 @@ internal class DefaultLinkAnalyticsHelperTest {
             }
         }
         val analyticsHelper = DefaultLinkAnalyticsHelper(eventReporter)
-        analyticsHelper.onLinkResult(LinkActivityResult.Completed)
+        analyticsHelper.onLinkResult(LinkActivityResult.Completed(LinkAccountUpdate.None))
         assertThat(eventReporter.calledCount).isEqualTo(1)
     }
 
@@ -60,7 +61,12 @@ internal class DefaultLinkAnalyticsHelperTest {
             }
         }
         val analyticsHelper = DefaultLinkAnalyticsHelper(eventReporter)
-        analyticsHelper.onLinkResult(LinkActivityResult.Failed(IllegalStateException()))
+        analyticsHelper.onLinkResult(
+            linkActivityResult = LinkActivityResult.Failed(
+                error = IllegalStateException(),
+                linkAccountUpdate = LinkAccountUpdate.None
+            )
+        )
         assertThat(eventReporter.calledCount).isEqualTo(1)
     }
 
@@ -72,7 +78,12 @@ internal class DefaultLinkAnalyticsHelperTest {
             }
         }
         val analyticsHelper = DefaultLinkAnalyticsHelper(eventReporter)
-        analyticsHelper.onLinkResult(LinkActivityResult.Canceled(LinkActivityResult.Canceled.Reason.BackPressed))
+        analyticsHelper.onLinkResult(
+            linkActivityResult = LinkActivityResult.Canceled(
+                reason = LinkActivityResult.Canceled.Reason.BackPressed,
+                linkAccountUpdate = LinkAccountUpdate.None
+            )
+        )
         assertThat(eventReporter.calledCount).isEqualTo(1)
     }
 
@@ -84,7 +95,12 @@ internal class DefaultLinkAnalyticsHelperTest {
             }
         }
         val analyticsHelper = DefaultLinkAnalyticsHelper(eventReporter)
-        analyticsHelper.onLinkResult(LinkActivityResult.Canceled(LinkActivityResult.Canceled.Reason.LoggedOut))
+        analyticsHelper.onLinkResult(
+            linkActivityResult = LinkActivityResult.Canceled(
+                reason = LinkActivityResult.Canceled.Reason.LoggedOut,
+                linkAccountUpdate = LinkAccountUpdate.None
+            )
+        )
         assertThat(eventReporter.calledCount).isEqualTo(1)
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModelTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.link.ui.paymentmethod
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.Logger
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.TestFactory
 import com.stripe.android.link.account.FakeLinkAccountManager
@@ -96,6 +97,8 @@ class PaymentMethodViewModelTest {
     fun `onPayClicked confirms payment successfully`() = runTest {
         val linkConfirmationHandler = FakeLinkConfirmationHandler()
         val linkAccountManager = FakeLinkAccountManager()
+        linkAccountManager.setLinkAccount(TestFactory.LINK_ACCOUNT)
+
         var result: LinkActivityResult? = null
         val viewModel = createViewModel(
             linkConfirmationHandler = linkConfirmationHandler,
@@ -117,7 +120,12 @@ class PaymentMethodViewModelTest {
         assertThat(call.paymentDetails)
             .isEqualTo(TestFactory.LINK_NEW_PAYMENT_DETAILS)
         assertThat(call.cvc).isEqualTo("111")
-        assertThat(result).isEqualTo(LinkActivityResult.Completed)
+        assertThat(result)
+            .isEqualTo(
+                LinkActivityResult.Completed(
+                    linkAccountUpdate = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT)
+                )
+            )
         assertThat(viewModel.state.value.primaryButtonState).isEqualTo(PrimaryButtonState.Enabled)
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
@@ -4,6 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.core.Logger
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkScreen
 import com.stripe.android.link.TestFactory
@@ -60,6 +61,7 @@ class WalletViewModelTest {
     fun `viewmodel should dismiss with failure on load payment method failure`() = runTest(dispatcher) {
         val error = Throwable("oops")
         val linkAccountManager = WalletLinkAccountManager()
+        linkAccountManager.setLinkAccount(TestFactory.LINK_ACCOUNT)
         linkAccountManager.listPaymentDetailsResult = Result.failure(error)
 
         var linkActivityResult: LinkActivityResult? = null
@@ -75,7 +77,13 @@ class WalletViewModelTest {
             dismissWithResult = ::dismissWithResult
         )
 
-        assertThat(linkActivityResult).isEqualTo(LinkActivityResult.Failed(error))
+        assertThat(linkActivityResult)
+            .isEqualTo(
+                LinkActivityResult.Failed(
+                    error = error,
+                    linkAccountUpdate = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT)
+                )
+            )
         assertThat(logger.errorLogs).isEqualTo(listOf("WalletViewModel Fatal error: " to error))
     }
 
@@ -271,6 +279,7 @@ class WalletViewModelTest {
     fun `performPaymentConfirmation dismisses with Completed result on success`() = runTest(dispatcher) {
         val validCard = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD.copy(expiryYear = 2099)
         val linkAccountManager = WalletLinkAccountManager()
+        linkAccountManager.setLinkAccount(TestFactory.LINK_ACCOUNT)
         linkAccountManager.listPaymentDetailsResult = Result.success(
             value = ConsumerPaymentDetails(paymentDetails = listOf(validCard))
         )
@@ -299,7 +308,8 @@ class WalletViewModelTest {
             )
         )
 
-        assertThat(result).isEqualTo(LinkActivityResult.Completed)
+        assertThat(result)
+            .isEqualTo(LinkActivityResult.Completed(LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT)))
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationUtils.kt
@@ -5,6 +5,7 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLauncherFactory
 import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.link.LinkPaymentLauncher
+import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.link.analytics.FakeLinkAnalyticsHelper
 import com.stripe.android.paymentelement.confirmation.bacs.BacsConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.cvc.CvcRecollectionConfirmationDefinition
@@ -68,6 +69,7 @@ internal fun createTestConfirmationHandlerFactory(
                 LinkConfirmationDefinition(
                     linkPaymentLauncher = linkLauncher,
                     linkStore = RecordingLinkStore.noOp(),
+                    linkAccountHolder = LinkAccountHolder(SavedStateHandle())
                 ),
                 LinkInlineSignupConfirmationDefinition(
                     linkConfigurationCoordinator = linkConfigurationCoordinator,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ExtendedPaymentElementConfirmationTestActivity.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ExtendedPaymentElementConfirmationTestActivity.kt
@@ -24,6 +24,7 @@ import com.stripe.android.core.utils.requireApplication
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayRepository
 import com.stripe.android.link.LinkConfigurationCoordinator
+import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.link.gate.DefaultLinkGate
 import com.stripe.android.link.gate.LinkGate
 import com.stripe.android.networking.StripeApiRepository
@@ -171,5 +172,11 @@ internal interface ExtendedPaymentElementConfirmationTestModule {
         @Singleton
         fun providesFakeLinkConfigurationCoordinator(): LinkConfigurationCoordinator =
             FakeLinkConfigurationCoordinator()
+
+        @Provides
+        @Singleton
+        fun providesLinkAccountHolder(savedStateHandle: SavedStateHandle): LinkAccountHolder {
+            return LinkAccountHolder(savedStateHandle)
+        }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/PaymentElementConfirmationTestActivity.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/PaymentElementConfirmationTestActivity.kt
@@ -24,6 +24,7 @@ import com.stripe.android.core.utils.requireApplication
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayRepository
 import com.stripe.android.link.LinkConfigurationCoordinator
+import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.link.gate.DefaultLinkGate
 import com.stripe.android.link.gate.LinkGate
 import com.stripe.android.networking.StripeApiRepository
@@ -171,5 +172,11 @@ internal interface PaymentElementConfirmationTestModule {
         @Singleton
         fun providesFakeLinkConfigurationCoordinator(): LinkConfigurationCoordinator =
             FakeLinkConfigurationCoordinator()
+
+        @Provides
+        @Singleton
+        fun providesLinkAccountHolder(savedStateHandle: SavedStateHandle): LinkAccountHolder {
+            return LinkAccountHolder(savedStateHandle)
+        }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinitionTest.kt
@@ -116,6 +116,29 @@ internal class LinkConfirmationDefinitionTest {
         val presentCall = launcherScenario.presentCalls.awaitItem()
 
         assertThat(presentCall.configuration).isEqualTo(LINK_CONFIRMATION_OPTION.configuration)
+        assertThat(presentCall.linkAccount).isNull()
+    }
+
+    @Test
+    fun `'launch', when linkAccount is provided, should launch properly with provided parameters`() = test {
+        val linkAccountHolder = LinkAccountHolder(SavedStateHandle())
+        linkAccountHolder.set(TestFactory.LINK_ACCOUNT)
+
+        val definition = createLinkConfirmationDefinition(
+            linkAccountHolder = linkAccountHolder
+        )
+
+        definition.launch(
+            confirmationOption = LINK_CONFIRMATION_OPTION,
+            confirmationParameters = CONFIRMATION_PARAMETERS,
+            launcher = launcherScenario.launcher,
+            arguments = Unit,
+        )
+
+        val presentCall = launcherScenario.presentCalls.awaitItem()
+
+        assertThat(presentCall.configuration).isEqualTo(LINK_CONFIRMATION_OPTION.configuration)
+        assertThat(presentCall.linkAccount).isEqualTo(TestFactory.LINK_ACCOUNT)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationFlowTest.kt
@@ -5,6 +5,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.isInstanceOf
 import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.TestFactory
+import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationMediator
 import com.stripe.android.paymentelement.confirmation.ConfirmationMediator.Parameters
@@ -31,6 +32,7 @@ class LinkConfirmationFlowTest {
             LinkConfirmationDefinition(
                 linkPaymentLauncher = launcher,
                 linkStore = RecordingLinkStore.noOp(),
+                linkAccountHolder = LinkAccountHolder(SavedStateHandle())
             )
         )
 
@@ -87,6 +89,7 @@ class LinkConfirmationFlowTest {
             LinkConfirmationDefinition(
                 linkPaymentLauncher = launcher,
                 linkStore = RecordingLinkStore.noOp(),
+                linkAccountHolder = LinkAccountHolder(SavedStateHandle())
             )
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -827,7 +827,7 @@ internal class DefaultFlowControllerTest {
 
         flowController.confirm()
 
-        verify(linkPaymentLauncher).present(any())
+        verify(linkPaymentLauncher).present(any(), anyOrNull())
     }
 
     @Test
@@ -1217,7 +1217,7 @@ internal class DefaultFlowControllerTest {
         )
         flowController.confirm()
 
-        verify(linkPaymentLauncher).present(any())
+        verify(linkPaymentLauncher).present(any(), anyOrNull())
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/utils/RecordingLinkPaymentLauncher.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/RecordingLinkPaymentLauncher.kt
@@ -7,6 +7,7 @@ import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkPaymentLauncher
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.mock
 
@@ -37,7 +38,7 @@ internal object RecordingLinkPaymentLauncher {
                 unregisterCalls.add(Unit)
             }
 
-            on { present(any()) } doAnswer { invocation ->
+            on { present(any(), anyOrNull()) } doAnswer { invocation ->
                 val arguments = invocation.arguments
 
                 presentCalls.add(

--- a/paymentsheet/src/test/java/com/stripe/android/utils/RecordingLinkPaymentLauncher.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/RecordingLinkPaymentLauncher.kt
@@ -6,6 +6,7 @@ import app.cash.turbine.Turbine
 import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkPaymentLauncher
+import com.stripe.android.link.model.LinkAccount
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doAnswer
@@ -44,6 +45,7 @@ internal object RecordingLinkPaymentLauncher {
                 presentCalls.add(
                     PresentCall(
                         configuration = arguments[0] as LinkConfiguration,
+                        linkAccount = arguments[1] as? LinkAccount
                     )
                 )
             }
@@ -77,5 +79,6 @@ internal object RecordingLinkPaymentLauncher {
 
     data class PresentCall(
         val configuration: LinkConfiguration,
+        val linkAccount: LinkAccount?
     )
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Transport LinkAccount between PaymentSheet & Native Link

Follow up to [this PR](https://github.com/stripe/stripe-android/pull/10057)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
This will ensure the link auth has a consistent state across PaymentSheet and Link. It specifically solves the problem where a user needs to complete 2fa every time Native Link closed and reopened

# Screen Recordings
## Before

https://github.com/user-attachments/assets/ce45bca6-6abc-4745-8bcd-14a671fcb3f7

## After

https://github.com/user-attachments/assets/c31f3b29-ae7c-4275-bb7e-f8c4ebf6d0b8

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
