### PR TITLE
Add customer session setting to enable the set as default feature in CustomerSheet

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
@@ -48,8 +48,6 @@ class CheckoutRequest private constructor(
     val paymentMethodOverrideRedisplay: AllowRedisplayFilter?,
     @SerialName("customer_session_payment_method_set_as_default")
     val paymentMethodSetAsDefaultFeature: FeatureState?,
-    @SerialName("customer_session_payment_method_sync_default")
-    val paymentMethodSyncDefaultFeature: FeatureState?,
 ) {
     @Serializable
     enum class CustomerKeyType {
@@ -77,7 +75,6 @@ class CheckoutRequest private constructor(
         private var paymentMethodRemoveFeature: FeatureState = FeatureState.Enabled
         private var paymentMethodRemoveLastFeature: FeatureState = FeatureState.Enabled
         private var paymentMethodSetAsDefaultFeature: FeatureState = FeatureState.Disabled
-        private var paymentMethodSyncDefaultFeature: FeatureState = FeatureState.Disabled
         private var paymentMethodRedisplayFeature: FeatureState = FeatureState.Enabled
         private var paymentMethodRedisplayFilters: List<AllowRedisplayFilter> = listOf(
             AllowRedisplayFilter.Unspecified,
@@ -146,10 +143,6 @@ class CheckoutRequest private constructor(
             this.paymentMethodSetAsDefaultFeature = state
         }
 
-        fun paymentMethodSyncDefaultFeature(state: FeatureState) {
-            this.paymentMethodSyncDefaultFeature = state
-        }
-
         fun paymentMethodRedisplayFeature(state: FeatureState) {
             this.paymentMethodRedisplayFeature = state
         }
@@ -184,7 +177,6 @@ class CheckoutRequest private constructor(
                 paymentMethodSaveFeature = paymentMethodSaveFeature,
                 paymentMethodRemoveFeature = paymentMethodRemoveFeature,
                 paymentMethodSetAsDefaultFeature = paymentMethodSetAsDefaultFeature,
-                paymentMethodSyncDefaultFeature = paymentMethodSyncDefaultFeature,
                 paymentMethodRemoveLastFeature = paymentMethodRemoveLastFeature,
                 paymentMethodRedisplayFeature = paymentMethodRedisplayFeature,
                 paymentMethodRedisplayFilters = paymentMethodRedisplayFilters,

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
@@ -48,6 +48,8 @@ class CheckoutRequest private constructor(
     val paymentMethodOverrideRedisplay: AllowRedisplayFilter?,
     @SerialName("customer_session_payment_method_set_as_default")
     val paymentMethodSetAsDefaultFeature: FeatureState?,
+    @SerialName("customer_session_payment_method_sync_default")
+    val paymentMethodSyncDefaultFeature: FeatureState?,
 ) {
     @Serializable
     enum class CustomerKeyType {
@@ -75,6 +77,7 @@ class CheckoutRequest private constructor(
         private var paymentMethodRemoveFeature: FeatureState = FeatureState.Enabled
         private var paymentMethodRemoveLastFeature: FeatureState = FeatureState.Enabled
         private var paymentMethodSetAsDefaultFeature: FeatureState = FeatureState.Disabled
+        private var paymentMethodSyncDefaultFeature: FeatureState = FeatureState.Disabled
         private var paymentMethodRedisplayFeature: FeatureState = FeatureState.Enabled
         private var paymentMethodRedisplayFilters: List<AllowRedisplayFilter> = listOf(
             AllowRedisplayFilter.Unspecified,
@@ -143,6 +146,10 @@ class CheckoutRequest private constructor(
             this.paymentMethodSetAsDefaultFeature = state
         }
 
+        fun paymentMethodSyncDefaultFeature(state: FeatureState) {
+            this.paymentMethodSyncDefaultFeature = state
+        }
+
         fun paymentMethodRedisplayFeature(state: FeatureState) {
             this.paymentMethodRedisplayFeature = state
         }
@@ -177,6 +184,7 @@ class CheckoutRequest private constructor(
                 paymentMethodSaveFeature = paymentMethodSaveFeature,
                 paymentMethodRemoveFeature = paymentMethodRemoveFeature,
                 paymentMethodSetAsDefaultFeature = paymentMethodSetAsDefaultFeature,
+                paymentMethodSyncDefaultFeature = paymentMethodSyncDefaultFeature,
                 paymentMethodRemoveLastFeature = paymentMethodRemoveLastFeature,
                 paymentMethodRedisplayFeature = paymentMethodRedisplayFeature,
                 paymentMethodRedisplayFilters = paymentMethodRedisplayFilters,

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCustomerModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCustomerModel.kt
@@ -21,7 +21,8 @@ class CustomerEphemeralKeyRequest private constructor(
     val paymentMethodRedisplayFeature: FeatureState?,
     @SerialName("customer_session_payment_method_allow_redisplay_filters")
     val paymentMethodRedisplayFilters: List<AllowRedisplayFilter>?,
-
+    @SerialName("customer_session_payment_method_sync_default")
+    val paymentMethodSyncDefaultFeature: FeatureState?,
 ) {
     @Serializable
     enum class CustomerKeyType {
@@ -38,6 +39,7 @@ class CustomerEphemeralKeyRequest private constructor(
         private var merchantCountryCode: String? = null
         private var paymentMethodRemoveFeature: FeatureState = FeatureState.Enabled
         private var paymentMethodRemoveLastFeature: FeatureState = FeatureState.Enabled
+        private var paymentMethodSyncDefaultFeature: FeatureState = FeatureState.Disabled
         private var paymentMethodRedisplayFilters: List<AllowRedisplayFilter> = listOf(
             AllowRedisplayFilter.Unspecified,
             AllowRedisplayFilter.Limited,
@@ -60,6 +62,10 @@ class CustomerEphemeralKeyRequest private constructor(
             this.paymentMethodRemoveLastFeature = state
         }
 
+        fun paymentMethodSyncDefaultFeature(state: FeatureState) {
+            this.paymentMethodSyncDefaultFeature = state
+        }
+
         fun paymentMethodRedisplayFilters(filters: List<AllowRedisplayFilter>) {
             this.paymentMethodRedisplayFilters = filters
         }
@@ -76,6 +82,7 @@ class CustomerEphemeralKeyRequest private constructor(
                 paymentMethodSaveFeature = FeatureState.Enabled,
                 paymentMethodRemoveFeature = paymentMethodRemoveFeature,
                 paymentMethodRemoveLastFeature = paymentMethodRemoveLastFeature,
+                paymentMethodSyncDefaultFeature = paymentMethodSyncDefaultFeature,
                 paymentMethodRedisplayFeature = FeatureState.Enabled,
                 paymentMethodRedisplayFilters = paymentMethodRedisplayFilters,
             )

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionSyncDefaultSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionSyncDefaultSettingsDefinition.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.paymentsheet.example.playground.settings
 
-import com.stripe.android.paymentsheet.example.playground.model.CheckoutRequest
+import com.stripe.android.paymentsheet.example.playground.model.CustomerEphemeralKeyRequest
 import com.stripe.android.paymentsheet.example.playground.model.FeatureState
 
 internal object CustomerSessionSyncDefaultSettingsDefinition : BooleanSettingsDefinition(
@@ -15,11 +15,11 @@ internal object CustomerSessionSyncDefaultSettingsDefinition : BooleanSettingsDe
         PlaygroundSettingDefinition.Displayable.Option("Disabled", false),
     )
 
-    override fun configure(value: Boolean, checkoutRequestBuilder: CheckoutRequest.Builder) {
+    override fun configure(value: Boolean, customerEphemeralKeyRequestBuilder: CustomerEphemeralKeyRequest.Builder) {
         if (value) {
-            checkoutRequestBuilder.paymentMethodSyncDefaultFeature(FeatureState.Enabled)
+            customerEphemeralKeyRequestBuilder.paymentMethodSyncDefaultFeature(FeatureState.Enabled)
         } else {
-            checkoutRequestBuilder.paymentMethodSyncDefaultFeature(FeatureState.Disabled)
+            customerEphemeralKeyRequestBuilder.paymentMethodSyncDefaultFeature(FeatureState.Disabled)
         }
     }
 

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionSyncDefaultSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionSyncDefaultSettingsDefinition.kt
@@ -3,10 +3,10 @@ package com.stripe.android.paymentsheet.example.playground.settings
 import com.stripe.android.paymentsheet.example.playground.model.CheckoutRequest
 import com.stripe.android.paymentsheet.example.playground.model.FeatureState
 
-internal object CustomerSessionSetAsDefaultSettingsDefinition : BooleanSettingsDefinition(
+internal object CustomerSessionSyncDefaultSettingsDefinition : BooleanSettingsDefinition(
     defaultValue = false,
-    displayName = "Customer Session Set As Default Feature",
-    key = "customer_session_set_as_default"
+    displayName = "Customer Session Sync Default Feature",
+    key = "customer_session_sync_default"
 ) {
     override fun createOptions(
         configurationData: PlaygroundConfigurationData
@@ -17,13 +17,13 @@ internal object CustomerSessionSetAsDefaultSettingsDefinition : BooleanSettingsD
 
     override fun configure(value: Boolean, checkoutRequestBuilder: CheckoutRequest.Builder) {
         if (value) {
-            checkoutRequestBuilder.paymentMethodSetAsDefaultFeature(FeatureState.Enabled)
+            checkoutRequestBuilder.paymentMethodSyncDefaultFeature(FeatureState.Enabled)
         } else {
-            checkoutRequestBuilder.paymentMethodSetAsDefaultFeature(FeatureState.Disabled)
+            checkoutRequestBuilder.paymentMethodSyncDefaultFeature(FeatureState.Disabled)
         }
     }
 
     override fun applicable(configurationData: PlaygroundConfigurationData): Boolean {
-        return configurationData.integrationType.isPaymentFlow()
+        return configurationData.integrationType.isCustomerFlow()
     }
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -420,6 +420,7 @@ internal class PlaygroundSettings private constructor(
             CustomerSessionRemoveSettingsDefinition,
             CustomerSessionRemoveLastSettingsDefinition,
             CustomerSessionSetAsDefaultSettingsDefinition,
+            CustomerSessionSyncDefaultSettingsDefinition,
             CustomerSessionRedisplaySettingsDefinition,
             CustomerSessionRedisplayFiltersSettingsDefinition,
             CustomerSessionOverrideRedisplaySettingsDefinition,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add customer session setting to enable the set as default feature in CustomerSheet

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-2656

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

Used the debugger.

- Set the feature to "enabled" in the playground
- Verified that the elements session response included the payment_method_sync_default feature with the value enabled