### PR TITLE
[FC] Reduce cache_level for FC builds. 

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -103,7 +103,6 @@ workflows:
             - module: financial-connections-example
             - variant: $BUILD_VARIANT
             - build_type: apk
-            - cache_level: all
       - deploy-to-bitrise-io@2:
           inputs:
             - pipeline_intermediate_files: "$BITRISE_APK_PATH:BITRISE_APK_PATH"


### PR DESCRIPTION
# Summary
Attempts to build dex duplication failures on CI by bringing cache level to parity with other example apps.

More details about caching: https://github.com/bitrise-steplib/bitrise-step-android-build?tab=readme-ov-file#%EF%B8%8F-configuration

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
