### PR TITLE
Add FormActivityStateHelper

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivity.kt
@@ -32,7 +32,7 @@ internal class FormActivity : AppCompatActivity() {
     lateinit var eventReporter: EventReporter
 
     @Inject
-    lateinit var primaryButtonStateHolder: PrimaryButtonStateHolder
+    lateinit var formActivityStateHelper: FormActivityStateHelper
 
     @OptIn(ExperimentalMaterialApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -56,7 +56,7 @@ internal class FormActivity : AppCompatActivity() {
                         interactor = formInteractor,
                         eventReporter = eventReporter,
                         onDismissed = ::setCancelAndFinish,
-                        primaryButtonStateHolder = primaryButtonStateHolder
+                        stateHelper = formActivityStateHelper
                     )
                 }
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityComponent.kt
@@ -79,6 +79,9 @@ internal interface FormActivityModule {
     @Binds
     fun bindsLinkConfigurationCoordinator(impl: RealLinkConfigurationCoordinator): LinkConfigurationCoordinator
 
+    @Binds
+    fun bindsFormActivityStateHelper(helper: DefaultFormActivityStateHelper): FormActivityStateHelper
+
     companion object {
         @Provides
         @Singleton

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityUI.kt
@@ -11,7 +11,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -24,6 +23,7 @@ import com.stripe.android.paymentsheet.utils.EventReporterProvider
 import com.stripe.android.paymentsheet.utils.PaymentSheetContentPadding
 import com.stripe.android.paymentsheet.verticalmode.DefaultVerticalModeFormInteractor
 import com.stripe.android.paymentsheet.verticalmode.VerticalModeFormUI
+import com.stripe.android.uicore.strings.resolve
 import com.stripe.android.uicore.stripeColors
 import com.stripe.android.uicore.utils.collectAsState
 
@@ -77,7 +77,7 @@ internal fun FormActivityPrimaryButton(
             )
     ) {
         PrimaryButton(
-            label = state.primaryButtonLabel.resolve(LocalContext.current),
+            label = state.primaryButtonLabel.resolve(),
             locked = true,
             enabled = state.isEnabled && !isProcessing,
             onClick = onClick,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityUI.kt
@@ -31,12 +31,12 @@ import com.stripe.android.uicore.utils.collectAsState
 internal fun FormActivityUI(
     interactor: DefaultVerticalModeFormInteractor,
     eventReporter: EventReporter,
-    primaryButtonStateHolder: PrimaryButtonStateHolder,
+    stateHelper: FormActivityStateHelper,
     onDismissed: () -> Unit,
 ) {
     val scrollState = rememberScrollState()
     val interactorState by interactor.state.collectAsState()
-    val primaryButtonState by primaryButtonStateHolder.state.collectAsState()
+    val state by stateHelper.state.collectAsState()
     EventReporterProvider(eventReporter) {
         BottomSheetScaffold(
             topBar = {
@@ -52,7 +52,7 @@ internal fun FormActivityUI(
                 )
                 PaymentSheetContentPadding()
                 FormActivityPrimaryButton(
-                    state = primaryButtonState,
+                    state = state,
                     isProcessing = interactorState.isProcessing,
                     onClick = {},
                 )
@@ -65,7 +65,7 @@ internal fun FormActivityUI(
 
 @Composable
 internal fun FormActivityPrimaryButton(
-    state: PrimaryButtonStateHolder.State,
+    state: FormActivityStateHelper.State,
     isProcessing: Boolean,
     onProcessingCompleted: () -> Unit = {},
     onClick: () -> Unit,
@@ -77,7 +77,7 @@ internal fun FormActivityPrimaryButton(
             )
     ) {
         PrimaryButton(
-            label = state.label.resolve(LocalContext.current),
+            label = state.primaryButtonLabel.resolve(LocalContext.current),
             locked = true,
             enabled = state.isEnabled && !isProcessing,
             onClick = onClick,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/DefaultFormActivityStateHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/DefaultFormActivityStateHelperTest.kt
@@ -15,20 +15,18 @@ import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.content.EmbeddedConfirmationStateFixtures
 import com.stripe.android.paymentsheet.ui.PrimaryButtonProcessingState
 import com.stripe.android.ui.core.R
-import kotlinx.coroutines.test.TestScope
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
 @OptIn(ExperimentalEmbeddedPaymentElementApi::class)
-class PrimaryButtonStateHolderTest {
+class DefaultFormActivityStateHelperTest {
     @Test
     fun `state initializes correctly`() = testScenario {
         stateHolder.state.test {
             val state = awaitItem()
             assertThat(state.processingState).isEqualTo(PrimaryButtonProcessingState.Idle(null))
             assertThat(state.isEnabled).isFalse()
-            assertThat(state.label).isEqualTo(
+            assertThat(state.primaryButtonLabel).isEqualTo(
                 resolvableString(
                     id = R.string.stripe_pay_button_amount,
                     formatArgs = arrayOf("$10.99")
@@ -45,7 +43,7 @@ class PrimaryButtonStateHolderTest {
                 .build()
         ) {
             stateHolder.state.test {
-                assertThat(awaitItem().label).isEqualTo("Test Label".resolvableString)
+                assertThat(awaitItem().primaryButtonLabel).isEqualTo("Test Label".resolvableString)
             }
         }
     }
@@ -54,7 +52,8 @@ class PrimaryButtonStateHolderTest {
     fun `state returns correct label for setup intent`() {
         testScenario(stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD) {
             stateHolder.state.test {
-                assertThat(awaitItem().label).isEqualTo(R.string.stripe_setup_button_label.resolvableString)
+                assertThat(awaitItem().primaryButtonLabel)
+                    .isEqualTo(R.string.stripe_setup_button_label.resolvableString)
             }
         }
     }
@@ -70,7 +69,7 @@ class PrimaryButtonStateHolderTest {
 
     private class Scenario(
         val selectionHolder: EmbeddedSelectionHolder,
-        val stateHolder: PrimaryButtonStateHolder
+        val stateHolder: FormActivityStateHelper
     )
 
     private fun testScenario(
@@ -80,10 +79,9 @@ class PrimaryButtonStateHolderTest {
     ) = runTest {
         val paymentMethodMetadata = PaymentMethodMetadataFactory.create(stripeIntent = stripeIntent)
         val selectionHolder = EmbeddedSelectionHolder(SavedStateHandle())
-        val stateHolder = PrimaryButtonStateHolder(
+        val stateHolder = DefaultFormActivityStateHelper(
             paymentMethodMetadata = paymentMethodMetadata,
             selectionHolder = selectionHolder,
-            coroutineScope = TestScope(UnconfinedTestDispatcher()),
             configuration = config
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityUiTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityUiTest.kt
@@ -61,18 +61,17 @@ class FormActivityUiTest {
             viewModelScope = testScope
         ).create()
 
-        val primaryButtonStateHolder = PrimaryButtonStateHolder(
+        val stateHelper = DefaultFormActivityStateHelper(
             paymentMethodMetadata = paymentMethodMetadata,
             selectionHolder = embeddedSelectionHolder,
             configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
-            coroutineScope = testScope
         )
 
         composeRule.setContent {
             FormActivityUI(
                 interactor = interactor,
                 eventReporter = mock(),
-                primaryButtonStateHolder = primaryButtonStateHolder,
+                stateHelper = stateHelper,
                 onDismissed = {}
             )
         }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Adds FormActivityStateHelper interface
Refactors PrimaryButtonStateHolder into DefaultFormActivityStateHelper
Makes individual state flows for each state param

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Will be used to control UI updates for FormActivity, including errors and mandates
Changed to use individual state flows for state params so they can be updated individually and combined into a state flow
Adds interface to make testing easier 
An `update` method will be added to the interface in future PRs to allow updates from ConfirmationHandler

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [X] Manually verified
