### PR TITLE
Add app bar insets to PaymentSheet Playground

### DIFF
--- a/paymentsheet-example/src/main/AndroidManifest.xml
+++ b/paymentsheet-example/src/main/AndroidManifest.xml
@@ -48,6 +48,7 @@
         <activity android:name="com.stripe.android.paymentsheet.example.playground.embedded.EmbeddedPlaygroundActivity" />
         <activity
             android:name="com.stripe.android.paymentsheet.example.playground.PaymentSheetPlaygroundActivity"
+            android:theme="@style/AppTheme.NoActionBar"
             android:exported="true"
             >
             <intent-filter>

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
@@ -12,12 +12,12 @@ import androidx.compose.animation.AnimatedContent
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.material.Button
 import androidx.compose.material.Text
-import androidx.compose.material.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -148,38 +148,35 @@ internal class PaymentSheetPlaygroundActivity : AppCompatActivity(), ExternalPay
             }
 
             PlaygroundTheme(
-                topBarContent = {
-                    TopAppBar(
-                        windowInsets = WindowInsets.statusBars,
-                        title = {
-                            Text("PaymentSheet Playground")
-                        }
-                    )
-                },
                 content = {
-                    playgroundState?.asPaymentState()?.endpoint?.let { customEndpoint ->
-                        Text(
-                            text = "Using $customEndpoint",
-                            modifier = Modifier
-                                .clickable { showCustomEndpointDialog = true }
-                                .padding(bottom = 16.dp),
-                        )
+                    Column(
+                        modifier = Modifier
+                            .padding(WindowInsets.statusBars.asPaddingValues())
+                    ) {
+                        playgroundState?.asPaymentState()?.endpoint?.let { customEndpoint ->
+                            Text(
+                                text = "Using $customEndpoint",
+                                modifier = Modifier
+                                    .clickable { showCustomEndpointDialog = true }
+                                    .padding(bottom = 16.dp),
+                            )
+                        }
+
+                        playgroundState?.asPaymentState()?.stripeIntentId?.let { stripeIntentId ->
+                            Text(
+                                text = stripeIntentId,
+                                modifier = Modifier.padding(bottom = 16.dp)
+                            )
+                        }
+
+                        SettingsUi(playgroundSettings = localPlaygroundSettings)
+
+                        AppearanceButton()
+
+                        QrCodeButton(playgroundSettings = localPlaygroundSettings)
+
+                        ClearLinkDataButton()
                     }
-
-                    playgroundState?.asPaymentState()?.stripeIntentId?.let { stripeIntentId ->
-                        Text(
-                            text = stripeIntentId,
-                            modifier = Modifier.padding(bottom = 16.dp)
-                        )
-                    }
-
-                    SettingsUi(playgroundSettings = localPlaygroundSettings)
-
-                    AppearanceButton()
-
-                    QrCodeButton(playgroundSettings = localPlaygroundSettings)
-
-                    ClearLinkDataButton()
                 },
                 bottomBarContent = {
                     ReloadButton(playgroundSettings = localPlaygroundSettings)

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
@@ -11,10 +11,13 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.material.Button
 import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -145,6 +148,14 @@ internal class PaymentSheetPlaygroundActivity : AppCompatActivity(), ExternalPay
             }
 
             PlaygroundTheme(
+                topBarContent = {
+                    TopAppBar(
+                        windowInsets = WindowInsets.statusBars,
+                        title = {
+                            Text("PaymentSheet Playground")
+                        }
+                    )
+                },
                 content = {
                     playgroundState?.asPaymentState()?.endpoint?.let { customEndpoint ->
                         Text(

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PlaygroundTheme.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PlaygroundTheme.kt
@@ -32,6 +32,7 @@ import com.stripe.android.paymentsheet.example.playground.activity.AppearanceSto
 internal fun PlaygroundTheme(
     content: @Composable ColumnScope.() -> Unit,
     bottomBarContent: @Composable ColumnScope.() -> Unit,
+    topBarContent: @Composable (() -> Unit)? = null
 ) {
     val colors = if (isSystemInDarkTheme() || AppearanceStore.forceDarkMode) {
         darkColors()
@@ -48,6 +49,9 @@ internal fun PlaygroundTheme(
             color = MaterialTheme.colors.background,
         ) {
             Scaffold(
+                topBar = {
+                    topBarContent?.invoke()
+                },
                 bottomBar = {
                     Column(
                         modifier = Modifier


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Compose content not respecting supportActionBar insets (sometimes). This change switches the playground to a compose top bar and uses WindowInsets

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
<img width="331" alt="Screenshot 2025-02-05 at 11 25 38 AM" src="https://github.com/user-attachments/assets/ec891a86-30c4-4a78-92ba-1f57fbe6cb63" />


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
