### PR TITLE
[MOBILESDK-3084] Create customerMetadata type

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/CustomerMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/CustomerMetadata.kt
@@ -1,0 +1,86 @@
+package com.stripe.android.lpmfoundations.paymentmethod
+
+import com.stripe.android.common.model.CommonConfiguration
+import com.stripe.android.core.utils.FeatureFlags
+import com.stripe.android.model.ElementsSession
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.state.CustomerState.Permissions
+
+internal data class CustomerMetadata(
+    val id: String,
+    val ephemeralKeySecret: String,
+    val customerSessionClientSecret: String?,
+    val permissions: Permissions,
+    val isDefaultPaymentMethodEnabled: Boolean
+) {
+    internal companion object {
+        internal fun createForCustomerSession(
+            configuration: CommonConfiguration,
+            customer: ElementsSession.Customer,
+            customerSessionClientSecret: String,
+        ): CustomerMetadata {
+            val mobilePaymentElementComponent = customer.session.components.mobilePaymentElement
+
+            val canRemovePaymentMethods = when (mobilePaymentElementComponent) {
+                is ElementsSession.Customer.Components.MobilePaymentElement.Enabled -> {
+                    mobilePaymentElementComponent.isPaymentMethodRemoveEnabled
+                }
+                is ElementsSession.Customer.Components.MobilePaymentElement.Disabled -> false
+            }
+
+            val canRemoveLastPaymentMethod = when {
+                !configuration.allowsRemovalOfLastSavedPaymentMethod -> false
+                mobilePaymentElementComponent is ElementsSession.Customer.Components.MobilePaymentElement.Enabled ->
+                    mobilePaymentElementComponent.canRemoveLastPaymentMethod
+                else -> false
+            }
+
+            val isDefaultPaymentMethodEnabled = FeatureFlags.enableDefaultPaymentMethods.isEnabled
+
+            return CustomerMetadata(
+                id = customer.session.customerId,
+                ephemeralKeySecret = customer.session.apiKey,
+                customerSessionClientSecret = customerSessionClientSecret,
+                permissions = Permissions(
+                    canRemovePaymentMethods = canRemovePaymentMethods,
+                    canRemoveLastPaymentMethod = canRemoveLastPaymentMethod,
+                    // Should always remove duplicates when using `customer_session`
+                    canRemoveDuplicates = true,
+                ),
+                isDefaultPaymentMethodEnabled = isDefaultPaymentMethodEnabled,
+            )
+        }
+
+        internal fun createForLegacyEphemeralKey(
+            configuration: CommonConfiguration,
+            customerId: String,
+            accessType: PaymentSheet.CustomerAccessType.LegacyCustomerEphemeralKey,
+        ): CustomerMetadata {
+            return CustomerMetadata(
+                id = customerId,
+                ephemeralKeySecret = accessType.ephemeralKeySecret,
+                customerSessionClientSecret = null,
+                permissions = Permissions(
+                    /*
+                     * Un-scoped legacy ephemeral keys have full permissions to remove/save/modify. This should
+                     * always be set to true.
+                     */
+                    canRemovePaymentMethods = true,
+                    /*
+                     * Un-scoped legacy ephemeral keys normally have full permissions to remove the last payment
+                     * method, however we do have client-side configuration option to configure this ability. This
+                     * should eventually be removed in favor of the server-side option available with customer
+                     * sessions.
+                     */
+                    canRemoveLastPaymentMethod = configuration.allowsRemovalOfLastSavedPaymentMethod,
+                    /*
+                     * Removing duplicates is not applicable here since we don't filter out duplicates for for
+                     * un-scoped ephemeral keys.
+                     */
+                    canRemoveDuplicates = false,
+                ),
+                isDefaultPaymentMethodEnabled = false,
+            )
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -50,7 +50,7 @@ internal data class PaymentMethodMetadata(
     val shippingDetails: AddressDetails?,
     val sharedDataSpecs: List<SharedDataSpec>,
     val externalPaymentMethodSpecs: List<ExternalPaymentMethodSpec>,
-    val hasCustomerConfiguration: Boolean,
+    val hasCustomerConfiguration: Boolean, // will be replaced with CustomerMetadata
     val isGooglePayReady: Boolean,
     val linkInlineConfiguration: LinkInlineConfiguration?,
     val paymentMethodSaveConsentBehavior: PaymentMethodSaveConsentBehavior,


### PR DESCRIPTION
# Summary
Creating customerMetadata data class to enable moving of immutable fields of CustomerState to PaymentMethodMetadata

Logic is directly lifted from customerState

# Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-3084

Breaking this task into multiple PRs

- **_We are here ->_** Creating customerMetadata 
- Adding customerMetadata to PaymentMethodMetadata and updating tests
- Moving logic from reading **Permissions** in customerState to CustomerMetadata, removing Permissions from customerState
- Moving logic from reading **id** in customerState, to CustomerMetadata, removing from customerState
- Moving logic from reading **ephemeralKeySecret** in customerState, to CustomerMetadata, removing from customerState
- Moving logic from reading **customerSessionClientSecret** in customerState, to CustomerMetadata, removing from customerState
- Moving logic from reading **isDefaultPaymentenabled** in customerState, to CustomerMetadata, removing from customerState

# Testing
N.A.

# Screenshots
N.A.

# Changelog
N.A.
