### PR TITLE
Pass funding sources along to Link popup

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/serialization/PopupPayload.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/serialization/PopupPayload.kt
@@ -52,6 +52,9 @@ internal data class PopupPayload(
 
     @SerialName("flags")
     val flags: Map<String, Boolean>,
+
+    @SerialName("linkFundingSources")
+    val linkFundingSources: List<String>,
 ) {
     @SerialName("path")
     val path: String = "mobile_pay"
@@ -167,6 +170,7 @@ internal data class PopupPayload(
                 intentMode = stripeIntent.toIntentMode().type,
                 setupFutureUsage = stripeIntent.isSetupForFutureUsage(),
                 flags = flags,
+                linkFundingSources = stripeIntent.linkFundingSources.map { it.uppercase() },
             )
         }
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/serialization/PopupPayloadTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/serialization/PopupPayloadTest.kt
@@ -27,14 +27,14 @@ internal class PopupPayloadTest {
             value = createPayload(),
         )
 
-        assertThat(json).isEqualTo("""{"publishableKey":"pk_test_abc","stripeAccount":"123","merchantInfo":{"businessName":"Jay's Taco Stand","country":"US"},"customerInfo":{"email":"jaystacostandfake@gmail.com","country":"US"},"paymentInfo":{"currency":"USD","amount":5555},"appId":"example.stripe.unittest","locale":"US","paymentUserAgent":"test","paymentObject":"link_payment_method","intentMode":"payment","setupFutureUsage":true,"cardBrandChoice":{"isMerchantEligibleForCBC":true,"stripePreferredNetworks":["cartes_bancaires"]},"flags":{"link_authenticated_change_event_enabled":false,"link_bank_incentives_enabled":false,"link_bank_onboarding_enabled":false,"link_email_verification_login_enabled":false,"link_financial_incentives_experiment_enabled":false,"link_local_storage_login_enabled":true,"link_only_for_payment_method_types_enabled":false,"link_passthrough_mode_enabled":true},"path":"mobile_pay","integrationType":"mobile","loggerMetadata":{"mobile_session_id":"$currentSessionId"},"experiments":{}}""")
+        assertThat(json).isEqualTo("""{"publishableKey":"pk_test_abc","stripeAccount":"123","merchantInfo":{"businessName":"Jay's Taco Stand","country":"US"},"customerInfo":{"email":"jaystacostandfake@gmail.com","country":"US"},"paymentInfo":{"currency":"USD","amount":5555},"appId":"example.stripe.unittest","locale":"US","paymentUserAgent":"test","paymentObject":"link_payment_method","intentMode":"payment","setupFutureUsage":true,"cardBrandChoice":{"isMerchantEligibleForCBC":true,"stripePreferredNetworks":["cartes_bancaires"]},"flags":{"link_authenticated_change_event_enabled":false,"link_bank_incentives_enabled":false,"link_bank_onboarding_enabled":false,"link_email_verification_login_enabled":false,"link_financial_incentives_experiment_enabled":false,"link_local_storage_login_enabled":true,"link_only_for_payment_method_types_enabled":false,"link_passthrough_mode_enabled":true},"linkFundingSources":["CARD"],"path":"mobile_pay","integrationType":"mobile","loggerMetadata":{"mobile_session_id":"$currentSessionId"},"experiments":{}}""")
     }
 
     @Test
     fun testToUrl() {
         AnalyticsRequestFactory.setSessionId(UUID.fromString("537a88ff-a54f-42cc-ba52-c7c5623730b6"))
 
-        assertThat(createPayload().toUrl()).isEqualTo("https://checkout.link.com/#eyJwdWJsaXNoYWJsZUtleSI6InBrX3Rlc3RfYWJjIiwic3RyaXBlQWNjb3VudCI6IjEyMyIsIm1lcmNoYW50SW5mbyI6eyJidXNpbmVzc05hbWUiOiJKYXkncyBUYWNvIFN0YW5kIiwiY291bnRyeSI6IlVTIn0sImN1c3RvbWVySW5mbyI6eyJlbWFpbCI6ImpheXN0YWNvc3RhbmRmYWtlQGdtYWlsLmNvbSIsImNvdW50cnkiOiJVUyJ9LCJwYXltZW50SW5mbyI6eyJjdXJyZW5jeSI6IlVTRCIsImFtb3VudCI6NTU1NX0sImFwcElkIjoiZXhhbXBsZS5zdHJpcGUudW5pdHRlc3QiLCJsb2NhbGUiOiJVUyIsInBheW1lbnRVc2VyQWdlbnQiOiJ0ZXN0IiwicGF5bWVudE9iamVjdCI6ImxpbmtfcGF5bWVudF9tZXRob2QiLCJpbnRlbnRNb2RlIjoicGF5bWVudCIsInNldHVwRnV0dXJlVXNhZ2UiOnRydWUsImNhcmRCcmFuZENob2ljZSI6eyJpc01lcmNoYW50RWxpZ2libGVGb3JDQkMiOnRydWUsInN0cmlwZVByZWZlcnJlZE5ldHdvcmtzIjpbImNhcnRlc19iYW5jYWlyZXMiXX0sImZsYWdzIjp7ImxpbmtfYXV0aGVudGljYXRlZF9jaGFuZ2VfZXZlbnRfZW5hYmxlZCI6ZmFsc2UsImxpbmtfYmFua19pbmNlbnRpdmVzX2VuYWJsZWQiOmZhbHNlLCJsaW5rX2Jhbmtfb25ib2FyZGluZ19lbmFibGVkIjpmYWxzZSwibGlua19lbWFpbF92ZXJpZmljYXRpb25fbG9naW5fZW5hYmxlZCI6ZmFsc2UsImxpbmtfZmluYW5jaWFsX2luY2VudGl2ZXNfZXhwZXJpbWVudF9lbmFibGVkIjpmYWxzZSwibGlua19sb2NhbF9zdG9yYWdlX2xvZ2luX2VuYWJsZWQiOnRydWUsImxpbmtfb25seV9mb3JfcGF5bWVudF9tZXRob2RfdHlwZXNfZW5hYmxlZCI6ZmFsc2UsImxpbmtfcGFzc3Rocm91Z2hfbW9kZV9lbmFibGVkIjp0cnVlfSwicGF0aCI6Im1vYmlsZV9wYXkiLCJpbnRlZ3JhdGlvblR5cGUiOiJtb2JpbGUiLCJsb2dnZXJNZXRhZGF0YSI6eyJtb2JpbGVfc2Vzc2lvbl9pZCI6IjUzN2E4OGZmLWE1NGYtNDJjYy1iYTUyLWM3YzU2MjM3MzBiNiJ9LCJleHBlcmltZW50cyI6e319")
+        assertThat(createPayload().toUrl()).isEqualTo("https://checkout.link.com/#eyJwdWJsaXNoYWJsZUtleSI6InBrX3Rlc3RfYWJjIiwic3RyaXBlQWNjb3VudCI6IjEyMyIsIm1lcmNoYW50SW5mbyI6eyJidXNpbmVzc05hbWUiOiJKYXkncyBUYWNvIFN0YW5kIiwiY291bnRyeSI6IlVTIn0sImN1c3RvbWVySW5mbyI6eyJlbWFpbCI6ImpheXN0YWNvc3RhbmRmYWtlQGdtYWlsLmNvbSIsImNvdW50cnkiOiJVUyJ9LCJwYXltZW50SW5mbyI6eyJjdXJyZW5jeSI6IlVTRCIsImFtb3VudCI6NTU1NX0sImFwcElkIjoiZXhhbXBsZS5zdHJpcGUudW5pdHRlc3QiLCJsb2NhbGUiOiJVUyIsInBheW1lbnRVc2VyQWdlbnQiOiJ0ZXN0IiwicGF5bWVudE9iamVjdCI6ImxpbmtfcGF5bWVudF9tZXRob2QiLCJpbnRlbnRNb2RlIjoicGF5bWVudCIsInNldHVwRnV0dXJlVXNhZ2UiOnRydWUsImNhcmRCcmFuZENob2ljZSI6eyJpc01lcmNoYW50RWxpZ2libGVGb3JDQkMiOnRydWUsInN0cmlwZVByZWZlcnJlZE5ldHdvcmtzIjpbImNhcnRlc19iYW5jYWlyZXMiXX0sImZsYWdzIjp7ImxpbmtfYXV0aGVudGljYXRlZF9jaGFuZ2VfZXZlbnRfZW5hYmxlZCI6ZmFsc2UsImxpbmtfYmFua19pbmNlbnRpdmVzX2VuYWJsZWQiOmZhbHNlLCJsaW5rX2Jhbmtfb25ib2FyZGluZ19lbmFibGVkIjpmYWxzZSwibGlua19lbWFpbF92ZXJpZmljYXRpb25fbG9naW5fZW5hYmxlZCI6ZmFsc2UsImxpbmtfZmluYW5jaWFsX2luY2VudGl2ZXNfZXhwZXJpbWVudF9lbmFibGVkIjpmYWxzZSwibGlua19sb2NhbF9zdG9yYWdlX2xvZ2luX2VuYWJsZWQiOnRydWUsImxpbmtfb25seV9mb3JfcGF5bWVudF9tZXRob2RfdHlwZXNfZW5hYmxlZCI6ZmFsc2UsImxpbmtfcGFzc3Rocm91Z2hfbW9kZV9lbmFibGVkIjp0cnVlfSwibGlua0Z1bmRpbmdTb3VyY2VzIjpbIkNBUkQiXSwicGF0aCI6Im1vYmlsZV9wYXkiLCJpbnRlZ3JhdGlvblR5cGUiOiJtb2JpbGUiLCJsb2dnZXJNZXRhZGF0YSI6eyJtb2JpbGVfc2Vzc2lvbl9pZCI6IjUzN2E4OGZmLWE1NGYtNDJjYy1iYTUyLWM3YzU2MjM3MzBiNiJ9LCJleHBlcmltZW50cyI6e319")
     }
 
     @Test
@@ -206,6 +206,42 @@ internal class PopupPayloadTest {
         assertThat(payload.cardBrandChoice?.preferredNetworks).isEqualTo(listOf("cartes_bancaires"))
     }
 
+    @Test
+    fun `on 'create' without bank funding source, should contain expected funding sources`() {
+        val payload = PopupPayload.create(
+            configuration = createLinkConfiguration(
+                customerCountryCode = null,
+                intent = PaymentIntentFactory.create(
+                    linkFundingSources = listOf("card"),
+                ),
+            ),
+            context = getContext(Locale.CANADA),
+            paymentUserAgent = "Android",
+            publishableKey = "pk_123",
+            stripeAccount = "str_123"
+        )
+
+        assertThat(payload.linkFundingSources).containsExactly("CARD").inOrder()
+    }
+
+    @Test
+    fun `on 'create' with bank funding source, should contain expected funding sources`() {
+        val payload = PopupPayload.create(
+            configuration = createLinkConfiguration(
+                customerCountryCode = null,
+                intent = PaymentIntentFactory.create(
+                    linkFundingSources = listOf("card", "bank_account"),
+                ),
+            ),
+            context = getContext(Locale.CANADA),
+            paymentUserAgent = "Android",
+            publishableKey = "pk_123",
+            stripeAccount = "str_123"
+        )
+
+        assertThat(payload.linkFundingSources).containsExactly("CARD", "BANK_ACCOUNT").inOrder()
+    }
+
     private fun createLinkConfiguration(
         customerCountryCode: String?,
         cardBrandChoice: LinkConfiguration.CardBrandChoice? = null,
@@ -255,6 +291,7 @@ internal class PopupPayloadTest {
             "link_only_for_payment_method_types_enabled" to false,
             "link_passthrough_mode_enabled" to true,
         ),
+        linkFundingSources = listOf("CARD"),
     )
 
     private fun getContext(locale: Locale): Context {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request passes `linkFundingSources` along to the Link popup to ensure that the correct payment methods are displayed.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
