### PR TITLE
Handle suspended Link Account scenario

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
@@ -223,11 +223,12 @@ internal class LinkActivityViewModel @Inject constructor(
                     is LinkAuthResult.AttestationFailed -> {
                         errorReporter.report(
                             errorEvent = ErrorReporter.UnexpectedErrorEvent.LINK_NATIVE_FAILED_TO_ATTEST_REQUEST,
-                            stripeException = LinkEventException(lookupResult.throwable)
+                            stripeException = LinkEventException(lookupResult.error)
                         )
-                        throw lookupResult.throwable
+                        throw lookupResult.error
                     }
                     is LinkAuthResult.Error,
+                    is LinkAuthResult.AccountError,
                     LinkAuthResult.NoLinkAccountFound,
                     is LinkAuthResult.Success,
                     null -> Unit

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAuthResult.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAuthResult.kt
@@ -5,6 +5,7 @@ import com.stripe.android.link.model.LinkAccount
 internal sealed interface LinkAuthResult {
     data class Success(val account: LinkAccount) : LinkAuthResult
     data object NoLinkAccountFound : LinkAuthResult
-    data class AttestationFailed(val throwable: Throwable) : LinkAuthResult
-    data class Error(val throwable: Throwable) : LinkAuthResult
+    data class AttestationFailed(val error: Throwable) : LinkAuthResult
+    data class AccountError(val error: Throwable) : LinkAuthResult
+    data class Error(val error: Throwable) : LinkAuthResult
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/signup/SignUpScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/signup/SignUpScreen.kt
@@ -108,6 +108,7 @@ internal fun SignUpBody(
                 text = signUpScreenState.errorMessage?.resolve(LocalContext.current).orEmpty(),
                 modifier = Modifier
                     .fillMaxWidth()
+                    .testTag(SIGN_UP_ERROR_TAG)
             )
         }
         AnimatedVisibility(visible = signUpScreenState.signUpState == SignUpState.InputtingRemainingFields) {

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/signup/SignUpViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/signup/SignUpViewModel.kt
@@ -103,17 +103,16 @@ internal class SignUpViewModel @Inject constructor(
         emailController.formFieldValue.mapLatest { entry ->
             entry.takeIf { it.isComplete }?.value
         }.collectLatest { email ->
+            onError(null)
             delay(LOOKUP_DEBOUNCE)
             if (email != null) {
                 if (email != configuration.customerInfo.email || emailHasChanged) {
                     lookupEmail(email)
                 } else {
                     updateSignUpState(SignUpState.InputtingRemainingFields)
-                    onError(null)
                 }
             } else {
                 updateSignUpState(SignUpState.InputtingPrimaryField)
-                onError(null)
             }
 
             if (email != configuration.customerInfo.email) {

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/signup/SignUpViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/signup/SignUpViewModel.kt
@@ -133,7 +133,7 @@ internal class SignUpViewModel @Inject constructor(
             }
             is LinkAuthResult.Error -> {
                 updateSignUpState(SignUpState.InputtingRemainingFields)
-                onError(lookupResult.throwable)
+                onError(lookupResult.error)
             }
             is LinkAuthResult.Success -> {
                 onAccountFetched(lookupResult.account)
@@ -141,6 +141,10 @@ internal class SignUpViewModel @Inject constructor(
             }
             LinkAuthResult.NoLinkAccountFound -> {
                 updateSignUpState(SignUpState.InputtingRemainingFields)
+            }
+            is LinkAuthResult.AccountError -> {
+                updateSignUpState(SignUpState.InputtingPrimaryField)
+                onError(lookupResult.error)
             }
         }
     }
@@ -161,8 +165,8 @@ internal class SignUpViewModel @Inject constructor(
                     moveToWeb()
                 }
                 is LinkAuthResult.Error -> {
-                    onError(signupResult.throwable)
-                    linkEventsReporter.onSignupFailure(error = signupResult.throwable)
+                    onError(signupResult.error)
+                    linkEventsReporter.onSignupFailure(error = signupResult.error)
                 }
                 is LinkAuthResult.Success -> {
                     onAccountFetched(signupResult.account)
@@ -171,6 +175,10 @@ internal class SignUpViewModel @Inject constructor(
                 LinkAuthResult.NoLinkAccountFound -> {
                     onError(NoLinkAccountFoundException())
                     linkEventsReporter.onSignupFailure(error = NoLinkAccountFoundException())
+                }
+                is LinkAuthResult.AccountError -> {
+                    updateSignUpState(SignUpState.InputtingPrimaryField)
+                    onError(signupResult.error)
                 }
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/signup/SignUpViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/signup/SignUpViewModel.kt
@@ -109,9 +109,11 @@ internal class SignUpViewModel @Inject constructor(
                     lookupEmail(email)
                 } else {
                     updateSignUpState(SignUpState.InputtingRemainingFields)
+                    onError(null)
                 }
             } else {
                 updateSignUpState(SignUpState.InputtingPrimaryField)
+                onError(null)
             }
 
             if (email != configuration.customerInfo.email) {
@@ -141,6 +143,7 @@ internal class SignUpViewModel @Inject constructor(
             }
             LinkAuthResult.NoLinkAccountFound -> {
                 updateSignUpState(SignUpState.InputtingRemainingFields)
+                onError(null)
             }
             is LinkAuthResult.AccountError -> {
                 updateSignUpState(SignUpState.InputtingPrimaryField)
@@ -195,11 +198,13 @@ internal class SignUpViewModel @Inject constructor(
         }
     }
 
-    private fun onError(error: Throwable) {
-        logger.error("SignUpViewModel Error: ", error)
+    private fun onError(error: Throwable?) {
+        if (error != null) {
+            logger.error("SignUpViewModel Error: ", error)
+        }
         updateState {
             it.copy(
-                errorMessage = error.stripeErrorMessage()
+                errorMessage = error?.stripeErrorMessage()
             )
         }
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Handle suspended Link Account scenario
* Check for suspended or banned account in `LinkAuth`
* Hide `Join Link` button after lookup/signup failure due to account error

[Sample response for this scenario](https://admin.corp.stripe.com/request-log/req_lQ9V97T2vDLaR9)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots

https://github.com/user-attachments/assets/28aaa360-7acd-49c7-a9c2-b816848edea2



# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
