### PR TITLE
Navigate back to AddFirstPaymentMethod immediately after removing last PM

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
@@ -217,8 +217,8 @@ internal class DefaultEmbeddedContentHelper @Inject constructor(
                 setSelection(null)
             },
             customerStateHolder = customerStateHolder,
-            onPaymentMethodRemoved = {
-            },
+            prePaymentMethodRemoveActions = {},
+            postPaymentMethodRemoveActions = {},
             onUpdatePaymentMethod = { _, _, _, _ ->
                 sheetLauncher?.launchManage(
                     paymentMethodMetadata = paymentMethodMetadata,
@@ -230,7 +230,6 @@ internal class DefaultEmbeddedContentHelper @Inject constructor(
             },
             isLinkEnabled = stateFlowOf(paymentMethodMetadata.linkState != null),
             isNotPaymentFlow = false,
-            isEmbedded = true,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/ManageSavedPaymentMethodMutatorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/ManageSavedPaymentMethodMutatorFactory.kt
@@ -39,7 +39,8 @@ internal class ManageSavedPaymentMethodMutatorFactory @Inject constructor(
                 selectionHolder.set(null)
             },
             customerStateHolder = customerStateHolder,
-            onPaymentMethodRemoved = ::onPaymentMethodRemoved,
+            prePaymentMethodRemoveActions = {},
+            postPaymentMethodRemoveActions = ::onPaymentMethodRemoved,
             onUpdatePaymentMethod = { displayableSavedPaymentMethod, _, _, _ ->
                 onUpdatePaymentMethod(displayableSavedPaymentMethod)
             },
@@ -48,7 +49,6 @@ internal class ManageSavedPaymentMethodMutatorFactory @Inject constructor(
             },
             isLinkEnabled = stateFlowOf(false), // Link is never enabled in the manage screen.
             isNotPaymentFlow = false,
-            isEmbedded = true,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/NavigationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/NavigationHandler.kt
@@ -26,6 +26,15 @@ internal class NavigationHandler<T : Any>(
     val currentScreen: StateFlow<T> = backStack
         .mapAsStateFlow { it.last() }
 
+    val previousScreen: StateFlow<T?> = backStack.mapAsStateFlow {
+        if (it.isEmpty() || it.size == 1) {
+            // In these cases, there is no "previous screen".
+            null
+        } else {
+            it[it.size - 2]
+        }
+    }
+
     val canGoBack: Boolean
         get() = backStack.value.size > 1
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/NavigationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/NavigationHandlerTest.kt
@@ -342,4 +342,22 @@ internal class NavigationHandlerTest {
             verify(screenTwo as Closeable).close()
         }
     }
+
+    @Test
+    fun `previousScreen value is correct`() = runTest {
+        val navigationHandler = NavigationHandler<PaymentSheetScreen>(this, PaymentSheetScreen.Loading) {}
+        navigationHandler.previousScreen.test {
+            // Initially, there is no previous screen.
+            assertThat(awaitItem()).isNull()
+
+            val screenOne = mock<PaymentSheetScreen>()
+            navigationHandler.transitionTo(screenOne)
+            // The previous screen doesn't get updated here -- Loading is removed from the backstack as part of the
+            // initial loading. The previous screen is still null.
+
+            val screenTwo = mock<PaymentSheetScreen>()
+            navigationHandler.transitionTo(screenTwo)
+            assertThat(awaitItem()).isEqualTo(screenOne)
+        }
+    }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Navigate back to AddFirstPaymentMethod immediately after removing last PM

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Walk the store PQ bug: https://docs.google.com/document/d/1jAte_o-0Ifl6242HB-okkpeoOn_te-dmepN3VGgn9ls/edit?tab=t.0#bookmark=id.dj6xrfb3vqpr

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [X] Manually verified

We already have a test that verifies that we navigate back to the AddFirstPaymentMethod screen: [here](https://github.com/stripe/stripe-android/blob/f4931d4ed99c7655f93fb35d55f6aa21cbc28552/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt#L455). It didn't previously account for the fact that we were on SelectSavedPaymentMethods for a short time before navigating back to that screen, so there's no test updating to do for that logic.

# Screenshots
Before: 


https://github.com/user-attachments/assets/cdbc28e9-3168-4c09-8e7d-fc80769423b2



After:

https://github.com/user-attachments/assets/241363b8-a2d6-4baf-ab2c-ad3572193521


