### PR TITLE
Fix Link default card change ui states

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -522,9 +522,11 @@ public final class com/stripe/android/link/ui/verification/ComposableSingletons$
 
 public final class com/stripe/android/link/ui/wallet/ComposableSingletons$PaymentDetailsKt {
 	public static final field INSTANCE Lcom/stripe/android/link/ui/wallet/ComposableSingletons$PaymentDetailsKt;
-	public static field lambda-1 Lkotlin/jvm/functions/Function2;
+	public static field lambda-1 Lkotlin/jvm/functions/Function3;
+	public static field lambda-2 Lkotlin/jvm/functions/Function2;
 	public fun <init> ()V
-	public final fun getLambda-1$paymentsheet_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-1$paymentsheet_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-2$paymentsheet_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class com/stripe/android/link/ui/wallet/ComposableSingletons$WalletScreenKt {

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/PaymentDetails.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/PaymentDetails.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.link.ui.wallet
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -80,7 +81,7 @@ internal fun PaymentDetailsListItem(
             ) {
                 PaymentDetails(paymentDetails = paymentDetails)
 
-                if (paymentDetails.isDefault) {
+                AnimatedVisibility(paymentDetails.isDefault) {
                     DefaultTag()
                 }
 
@@ -118,7 +119,9 @@ private fun MenuAndLoader(
     ) {
         if (isUpdating) {
             CircularProgressIndicator(
-                modifier = Modifier.size(24.dp),
+                modifier = Modifier
+                    .testTag(WALLET_PAYMENT_DETAIL_ITEM_LOADING_INDICATOR)
+                    .size(24.dp),
                 strokeWidth = 2.dp
             )
         } else {
@@ -262,3 +265,4 @@ private fun RowScope.BankAccountInfo(
 
 internal const val WALLET_PAYMENT_DETAIL_ITEM_RADIO_BUTTON = "wallet_payment_detail_item_radio_button"
 internal const val WALLET_PAYMENT_DETAIL_ITEM_MENU_BUTTON = "wallet_payment_detail_item_menu_button"
+internal const val WALLET_PAYMENT_DETAIL_ITEM_LOADING_INDICATOR = "wallet_payment_detail_item_loading_indicator"

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
@@ -2,6 +2,7 @@ package com.stripe.android.link.ui.wallet
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -381,6 +382,7 @@ internal fun CollapsedPaymentDetails(
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun ExpandedPaymentDetails(
     uiState: WalletUiState,
@@ -453,11 +455,12 @@ private fun PaymentDetailsList(
         ) { item ->
             PaymentDetailsListItem(
                 modifier = Modifier
+                    .animateItemPlacement()
                     .testTag(WALLET_SCREEN_PAYMENT_METHODS_LIST),
                 paymentDetails = item,
                 enabled = isEnabled,
                 isSelected = uiState.selectedItem?.id == item.id,
-                isUpdating = false,
+                isUpdating = uiState.cardBeingUpdated == item.id,
                 onClick = {
                     onItemSelected(item)
                 },

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
@@ -435,6 +435,7 @@ private fun ExpandedPaymentDetails(
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun PaymentDetailsList(
     uiState: WalletUiState,

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletUiState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletUiState.kt
@@ -15,6 +15,7 @@ internal data class WalletUiState(
     val primaryButtonLabel: ResolvableString,
     val hasCompleted: Boolean,
     val canAddNewPaymentMethod: Boolean,
+    val cardBeingUpdated: String? = null,
     val errorMessage: ResolvableString? = null,
     val expiryDateInput: FormFieldEntry = FormFieldEntry(null),
     val cvcInput: FormFieldEntry = FormFieldEntry(null),
@@ -35,16 +36,21 @@ internal data class WalletUiState(
             val isMissingCvcInput = cvcInput.isComplete.not()
 
             val disableButton = (isExpired && isMissingExpiryDateInput) ||
-                (requiresCvcRecollection && isMissingCvcInput)
+                (requiresCvcRecollection && isMissingCvcInput) || (cardBeingUpdated != null)
 
-            return if (hasCompleted) {
-                PrimaryButtonState.Completed
-            } else if (isProcessing) {
-                PrimaryButtonState.Processing
-            } else if (disableButton) {
-                PrimaryButtonState.Disabled
-            } else {
-                PrimaryButtonState.Enabled
+            return when {
+                hasCompleted -> {
+                    PrimaryButtonState.Completed
+                }
+                isProcessing -> {
+                    PrimaryButtonState.Processing
+                }
+                disableButton -> {
+                    PrimaryButtonState.Disabled
+                }
+                else -> {
+                    PrimaryButtonState.Enabled
+                }
             }
         }
 
@@ -66,7 +72,8 @@ internal data class WalletUiState(
         return copy(
             paymentDetailsList = response.paymentDetails,
             selectedItem = selectedItem,
-            isProcessing = false
+            isProcessing = false,
+            cardBeingUpdated = null
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletScreenTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletScreenTest.kt
@@ -523,7 +523,9 @@ internal class WalletScreenTest {
         dispatcher.scheduler.advanceTimeBy(1.1.seconds)
 
         onWalletPaymentMethodRowLoadingIndicator().assertDoesNotExist()
-        onWalletPayButton().assertExists()
+        onWalletPayButton()
+            .assertExists()
+            .assertIsEnabled()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletScreenTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletScreenTest.kt
@@ -485,10 +485,6 @@ internal class WalletScreenTest {
 
     @Test
     fun `pay method row is loading when card is being updated`() = runTest(dispatcher) {
-        val validCard = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD.copy(
-            expiryYear = 2099,
-            cvcCheck = CvcCheck.Pass
-        )
         val linkAccountManager = object : FakeLinkAccountManager() {
             override suspend fun updatePaymentDetails(
                 updateParams: ConsumerPaymentDetailsUpdateParams
@@ -497,9 +493,12 @@ internal class WalletScreenTest {
                 return super.updatePaymentDetails(updateParams)
             }
         }
+        val card1 = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD.copy(id = "card1", isDefault = false)
+        val card2 = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD.copy(id = "card2", isDefault = true)
         linkAccountManager.listPaymentDetailsResult = Result.success(
-            ConsumerPaymentDetails(paymentDetails = listOf(validCard))
+            ConsumerPaymentDetails(paymentDetails = listOf(card1, card2))
         )
+
         val viewModel = createViewModel(linkAccountManager)
         composeTestRule.setContent {
             WalletScreen(
@@ -510,9 +509,12 @@ internal class WalletScreenTest {
         }
         composeTestRule.waitForIdle()
 
-        onWalletPayButton().assertIsEnabled()
+        onCollapsedWalletRow()
+            .performClick()
+        composeTestRule.waitForIdle()
 
-        viewModel.onSetDefaultClicked(validCard)
+        viewModel.onSetDefaultClicked(card1)
+
         composeTestRule.waitForIdle()
 
         onWalletPaymentMethodRowLoadingIndicator().assertIsDisplayed()

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletUiStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletUiStateTest.kt
@@ -147,6 +147,16 @@ class WalletUiStateTest {
         assertThat(state.primaryButtonState).isEqualTo(PrimaryButtonState.Enabled)
     }
 
+    @Test
+    fun testDisabledButtonStateWhenCardIsBeingUpdated() {
+        val state = walletUiState(
+            selectedItem = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD,
+            cardBeingUpdated = "id"
+        )
+
+        assertThat(state.primaryButtonState).isEqualTo(PrimaryButtonState.Disabled)
+    }
+
     private fun walletUiState(
         paymentDetailsList: List<ConsumerPaymentDetails.PaymentDetails> =
             TestFactory.CONSUMER_PAYMENT_DETAILS.paymentDetails,
@@ -157,6 +167,7 @@ class WalletUiStateTest {
         expiryDateInput: FormFieldEntry = FormFieldEntry(null),
         cvcInput: FormFieldEntry = FormFieldEntry(null),
         canAddNewPaymentMethod: Boolean = true,
+        cardBeingUpdated: String? = null
     ): WalletUiState {
         return WalletUiState(
             paymentDetailsList = paymentDetailsList,
@@ -167,6 +178,7 @@ class WalletUiStateTest {
             expiryDateInput = expiryDateInput,
             cvcInput = cvcInput,
             canAddNewPaymentMethod = canAddNewPaymentMethod,
+            cardBeingUpdated = cardBeingUpdated
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
@@ -16,6 +16,7 @@ import com.stripe.android.model.ConsumerPaymentDetailsUpdateParams
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FakeLogger
 import com.stripe.android.uicore.forms.FormFieldEntry
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -24,6 +25,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.Result
+import kotlin.time.Duration.Companion.seconds
 import com.stripe.android.link.confirmation.Result as LinkConfirmationResult
 
 @RunWith(RobolectricTestRunner::class)
@@ -374,7 +376,14 @@ class WalletViewModelTest {
     fun `onSetDefaultClicked updates payment method as default successfully`() = runTest(dispatcher) {
         val card1 = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD.copy(id = "card1", isDefault = false)
         val card2 = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD.copy(id = "card2", isDefault = true)
-        val linkAccountManager = WalletLinkAccountManager()
+        val linkAccountManager = object : WalletLinkAccountManager() {
+            override suspend fun updatePaymentDetails(
+                updateParams: ConsumerPaymentDetailsUpdateParams
+            ): Result<ConsumerPaymentDetails> {
+                delay(1.seconds)
+                return super.updatePaymentDetails(updateParams)
+            }
+        }
         linkAccountManager.listPaymentDetailsResult = Result.success(
             ConsumerPaymentDetails(paymentDetails = listOf(card1, card2))
         )
@@ -393,6 +402,10 @@ class WalletViewModelTest {
 
         viewModel.onSetDefaultClicked(card1)
 
+        assertThat(viewModel.uiState.value.cardBeingUpdated).isEqualTo(card1.id)
+
+        dispatcher.scheduler.advanceTimeBy(1.1.seconds)
+
         assertThat(linkAccountManager.updatePaymentDetailsCalls).containsExactly(
             ConsumerPaymentDetailsUpdateParams(
                 id = "card1",
@@ -400,10 +413,10 @@ class WalletViewModelTest {
                 cardPaymentMethodCreateParamsMap = null
             )
         )
-
         assertThat(viewModel.uiState.value.paymentDetailsList).containsExactly(updatedCard1, updatedCard2)
         assertThat(linkAccountManager.listPaymentDetailsCalls.size).isEqualTo(2)
         assertThat(viewModel.uiState.value.isProcessing).isFalse()
+        assertThat(viewModel.uiState.value.cardBeingUpdated).isNull()
         assertThat(viewModel.uiState.value.alertMessage).isNull()
     }
 
@@ -426,6 +439,7 @@ class WalletViewModelTest {
         viewModel.onSetDefaultClicked(card)
 
         assertThat(viewModel.uiState.value.isProcessing).isFalse()
+        assertThat(viewModel.uiState.value.cardBeingUpdated).isNull()
         assertThat(viewModel.uiState.value.alertMessage).isEqualTo(error.stripeErrorMessage())
         assertThat(logger.errorLogs).contains("WalletViewModel: Failed to set payment method as default" to error)
     }
@@ -500,7 +514,7 @@ class WalletViewModelTest {
     }
 }
 
-private class WalletLinkAccountManager : FakeLinkAccountManager() {
+private open class WalletLinkAccountManager : FakeLinkAccountManager() {
     val listPaymentDetailsCalls = arrayListOf<Set<String>>()
     val updatePaymentDetailsCalls = arrayListOf<ConsumerPaymentDetailsUpdateParams>()
     val deletePaymentDetailsCalls = arrayListOf<String>()

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
@@ -380,7 +380,7 @@ class WalletViewModelTest {
             override suspend fun updatePaymentDetails(
                 updateParams: ConsumerPaymentDetailsUpdateParams
             ): Result<ConsumerPaymentDetails> {
-                delay(1.seconds)
+                delay(CARD_PROCESSING_DELAY)
                 return super.updatePaymentDetails(updateParams)
             }
         }
@@ -400,7 +400,7 @@ class WalletViewModelTest {
 
         assertThat(viewModel.uiState.value.cardBeingUpdated).isEqualTo(card1.id)
 
-        advanceUntilIdle()
+        dispatcher.scheduler.advanceTimeBy(CARD_PROCESSING_COMPLETION_TIME)
 
         assertThat(linkAccountManager.updatePaymentDetailsCalls).containsExactly(
             ConsumerPaymentDetailsUpdateParams(
@@ -507,6 +507,11 @@ class WalletViewModelTest {
             navigateAndClearStack = navigateAndClearStack,
             dismissWithResult = dismissWithResult
         )
+    }
+
+    companion object {
+        private val CARD_PROCESSING_DELAY = 1.seconds
+        private val CARD_PROCESSING_COMPLETION_TIME = 1.1.seconds
     }
 }
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
@@ -396,10 +396,6 @@ class WalletViewModelTest {
 
         val viewModel = createViewModel(linkAccountManager = linkAccountManager)
 
-        linkAccountManager.listPaymentDetailsResult = Result.success(
-            ConsumerPaymentDetails(paymentDetails = listOf(updatedCard1, updatedCard2))
-        )
-
         viewModel.onSetDefaultClicked(card1)
 
         assertThat(viewModel.uiState.value.cardBeingUpdated).isEqualTo(card1.id)
@@ -414,7 +410,7 @@ class WalletViewModelTest {
             )
         )
         assertThat(viewModel.uiState.value.paymentDetailsList).containsExactly(updatedCard1, updatedCard2)
-        assertThat(linkAccountManager.listPaymentDetailsCalls.size).isEqualTo(2)
+        assertThat(linkAccountManager.listPaymentDetailsCalls.size).isEqualTo(1)
         assertThat(viewModel.uiState.value.isProcessing).isFalse()
         assertThat(viewModel.uiState.value.cardBeingUpdated).isNull()
         assertThat(viewModel.uiState.value.alertMessage).isNull()

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
@@ -400,7 +400,7 @@ class WalletViewModelTest {
 
         assertThat(viewModel.uiState.value.cardBeingUpdated).isEqualTo(card1.id)
 
-        dispatcher.scheduler.advanceTimeBy(1.1.seconds)
+        advanceUntilIdle()
 
         assertThat(linkAccountManager.updatePaymentDetailsCalls).containsExactly(
             ConsumerPaymentDetailsUpdateParams(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
* Fix selected button flicker when default card is changed
* Loading bar should be on payment method row, not primary button

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
[Payment Method Update Loading State](https://docs.google.com/document/d/1_dgqF_FYmvgNFjn_yf1yoj4O34MZRim64DaCa81McOA/edit?tab=t.0#heading=h.ucbxz9yr2auv)

[Default Card Radio Button Flicker](https://docs.google.com/document/d/1_dgqF_FYmvgNFjn_yf1yoj4O34MZRim64DaCa81McOA/edit?tab=t.0#heading=h.p5e0eloylykn)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots

https://github.com/user-attachments/assets/7880bae3-daa1-46cd-a264-3fdea8138283



# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
