### PR TITLE
Perform attestation check before launching Link 2FA dialog

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkConfigurationCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkConfigurationCoordinator.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.link
 
+import com.stripe.android.link.attestation.LinkAttestationCheck
 import com.stripe.android.link.gate.LinkGate
 import com.stripe.android.link.injection.LinkComponent
 import com.stripe.android.link.model.AccountStatus
@@ -24,6 +25,8 @@ internal interface LinkConfigurationCoordinator {
     fun getAccountStatusFlow(configuration: LinkConfiguration): Flow<AccountStatus>
 
     fun linkGate(configuration: LinkConfiguration): LinkGate
+
+    fun linkAttestationCheck(configuration: LinkConfiguration): LinkAttestationCheck
 
     suspend fun signInWithUserInput(
         configuration: LinkConfiguration,
@@ -67,6 +70,10 @@ internal class RealLinkConfigurationCoordinator @Inject internal constructor(
 
     override fun linkGate(configuration: LinkConfiguration): LinkGate {
         return getLinkPaymentLauncherComponent(configuration).linkGate
+    }
+
+    override fun linkAttestationCheck(configuration: LinkConfiguration): LinkAttestationCheck {
+        return getLinkPaymentLauncherComponent(configuration).linkAttestationCheck
     }
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/link/attestation/DefaultLinkAttestationCheck.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/attestation/DefaultLinkAttestationCheck.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.link.attestation
 
 import com.stripe.android.core.exception.StripeException
+import com.stripe.android.core.injection.IOContext
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.account.LinkAccountManager
 import com.stripe.android.link.account.LinkAuth
@@ -9,7 +10,9 @@ import com.stripe.android.link.gate.LinkGate
 import com.stripe.android.model.EmailSource
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.attestation.IntegrityRequestManager
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
+import kotlin.coroutines.CoroutineContext
 
 internal class DefaultLinkAttestationCheck @Inject constructor(
     private val linkGate: LinkGate,
@@ -17,45 +20,51 @@ internal class DefaultLinkAttestationCheck @Inject constructor(
     private val integrityRequestManager: IntegrityRequestManager,
     private val linkAccountManager: LinkAccountManager,
     private val linkConfiguration: LinkConfiguration,
-    private val errorReporter: ErrorReporter
+    private val errorReporter: ErrorReporter,
+    @IOContext private val workContext: CoroutineContext
 ) : LinkAttestationCheck {
     override suspend fun invoke(): LinkAttestationCheck.Result {
         if (linkGate.useAttestationEndpoints.not()) return LinkAttestationCheck.Result.Successful
-        val result = integrityRequestManager.prepare()
-
-        return result.fold(
-            onSuccess = {
-                val email = linkAccountManager.linkAccount.value?.email
-                    ?: linkConfiguration.customerInfo.email
-                if (email == null) return@fold LinkAttestationCheck.Result.Successful
-                val lookupResult = linkAuth.lookUp(
-                    email = email,
-                    emailSource = EmailSource.CUSTOMER_OBJECT,
-                    startSession = false
-                )
-                when (lookupResult) {
-                    is LinkAuthResult.AttestationFailed -> {
-                        LinkAttestationCheck.Result.AttestationFailed(lookupResult.error)
-                    }
-                    is LinkAuthResult.Error -> {
-                        LinkAttestationCheck.Result.Error(lookupResult.error)
-                    }
-                    is LinkAuthResult.AccountError -> {
-                        LinkAttestationCheck.Result.AccountError(lookupResult.error)
-                    }
-                    LinkAuthResult.NoLinkAccountFound,
-                    is LinkAuthResult.Success -> {
-                        LinkAttestationCheck.Result.Successful
-                    }
+        return withContext(workContext) {
+            val result = integrityRequestManager.prepare()
+            result.fold(
+                onSuccess = {
+                    val email = linkAccountManager.linkAccount.value?.email
+                        ?: linkConfiguration.customerInfo.email
+                    if (email == null) return@fold LinkAttestationCheck.Result.Successful
+                    val lookupResult = linkAuth.lookUp(
+                        email = email,
+                        emailSource = EmailSource.CUSTOMER_OBJECT,
+                        startSession = false
+                    )
+                    handleLookupResult(lookupResult)
+                },
+                onFailure = { error ->
+                    errorReporter.report(
+                        errorEvent = ErrorReporter.ExpectedErrorEvent.LINK_NATIVE_FAILED_TO_PREPARE_INTEGRITY_MANAGER,
+                        stripeException = StripeException.create(error)
+                    )
+                    LinkAttestationCheck.Result.AttestationFailed(error)
                 }
-            },
-            onFailure = { error ->
-                errorReporter.report(
-                    errorEvent = ErrorReporter.ExpectedErrorEvent.LINK_NATIVE_FAILED_TO_PREPARE_INTEGRITY_MANAGER,
-                    stripeException = StripeException.create(error)
-                )
-                LinkAttestationCheck.Result.AttestationFailed(error)
+            )
+        }
+    }
+
+    private fun handleLookupResult(lookupResult: LinkAuthResult): LinkAttestationCheck.Result {
+        return when (lookupResult) {
+            is LinkAuthResult.AttestationFailed -> {
+                LinkAttestationCheck.Result.AttestationFailed(lookupResult.error)
             }
-        )
+            is LinkAuthResult.Error -> {
+                LinkAttestationCheck.Result.Error(lookupResult.error)
+            }
+            is LinkAuthResult.AccountError -> {
+                LinkAttestationCheck.Result.AccountError(lookupResult.error)
+            }
+            LinkAuthResult.NoLinkAccountFound,
+            is LinkAuthResult.Success -> {
+                LinkAttestationCheck.Result.Successful
+            }
+        }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/IntegrityRequestManagerModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/IntegrityRequestManagerModule.kt
@@ -6,19 +6,13 @@ import com.stripe.android.core.Logger
 import com.stripe.attestation.IntegrityRequestManager
 import com.stripe.attestation.IntegrityStandardRequestManager
 import com.stripe.attestation.RealStandardIntegrityManagerFactory
-import dagger.Module
-import dagger.Provides
 
-@Module
-internal object IntegrityRequestManagerModule {
-    @Provides
-    fun providesIntegrityStandardRequestManager(
-        context: Application
-    ): IntegrityRequestManager = IntegrityStandardRequestManager(
-        cloudProjectNumber = 577365562050, // stripe-payments-sdk-prod
-        logError = { message, error ->
-            Logger.getInstance(BuildConfig.DEBUG).error(message, error)
-        },
-        factory = RealStandardIntegrityManagerFactory(context)
-    )
-}
+internal fun createIntegrityStandardRequestManager(
+    context: Application
+): IntegrityRequestManager = IntegrityStandardRequestManager(
+    cloudProjectNumber = 577365562050, // stripe-payments-sdk-prod
+    logError = { message, error ->
+        Logger.getInstance(BuildConfig.DEBUG).error(message, error)
+    },
+    factory = RealStandardIntegrityManagerFactory(context)
+)

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkComponent.kt
@@ -3,7 +3,9 @@ package com.stripe.android.link.injection
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.account.LinkAccountManager
+import com.stripe.android.link.attestation.LinkAttestationCheck
 import com.stripe.android.link.gate.LinkGate
+import com.stripe.android.link.injection.NativeLinkComponent.Builder
 import dagger.BindsInstance
 import dagger.Subcomponent
 import javax.inject.Scope
@@ -20,12 +22,14 @@ internal annotation class LinkScope
 @Subcomponent(
     modules = [
         LinkModule::class,
+        ApplicationIdModule::class,
     ]
 )
 internal abstract class LinkComponent {
     internal abstract val linkAccountManager: LinkAccountManager
     internal abstract val configuration: LinkConfiguration
     internal abstract val linkGate: LinkGate
+    internal abstract val linkAttestationCheck: LinkAttestationCheck
     internal abstract val inlineSignupViewModelFactory: LinkInlineSignupAssistedViewModelFactory
 
     @Subcomponent.Builder

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkModule.kt
@@ -1,20 +1,26 @@
 package com.stripe.android.link.injection
 
+import android.app.Application
 import com.stripe.android.Stripe
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.networking.DefaultStripeNetworkClient
 import com.stripe.android.core.version.StripeSdkVersion
 import com.stripe.android.link.account.DefaultLinkAccountManager
+import com.stripe.android.link.account.DefaultLinkAuth
 import com.stripe.android.link.account.LinkAccountManager
+import com.stripe.android.link.account.LinkAuth
 import com.stripe.android.link.analytics.DefaultLinkEventsReporter
 import com.stripe.android.link.analytics.LinkEventsReporter
+import com.stripe.android.link.attestation.DefaultLinkAttestationCheck
+import com.stripe.android.link.attestation.LinkAttestationCheck
 import com.stripe.android.link.gate.DefaultLinkGate
 import com.stripe.android.link.gate.LinkGate
 import com.stripe.android.link.repositories.LinkApiRepository
 import com.stripe.android.link.repositories.LinkRepository
 import com.stripe.android.repository.ConsumersApiService
 import com.stripe.android.repository.ConsumersApiServiceImpl
+import com.stripe.attestation.IntegrityRequestManager
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
@@ -38,6 +44,14 @@ internal interface LinkModule {
     @LinkScope
     fun bindsLinkGate(linkGate: DefaultLinkGate): LinkGate
 
+    @Binds
+    @LinkScope
+    fun bindsLinkAuth(linkGate: DefaultLinkAuth): LinkAuth
+
+    @Binds
+    @LinkScope
+    fun bindsLinkAttestationCheck(linkAttestationCheck: DefaultLinkAttestationCheck): LinkAttestationCheck
+
     companion object {
         @Provides
         @LinkScope
@@ -53,5 +67,11 @@ internal interface LinkModule {
                 workContext = workContext
             )
         )
+
+        @Provides
+        @LinkScope
+        fun provideIntegrityStandardRequestManager(
+            context: Application
+        ): IntegrityRequestManager = createIntegrityStandardRequestManager(context)
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkComponent.kt
@@ -32,7 +32,6 @@ internal annotation class NativeLinkScope
     modules = [
         NativeLinkModule::class,
         LinkViewModelModule::class,
-        IntegrityRequestManagerModule::class,
         ApplicationIdModule::class,
         DefaultConfirmationModule::class,
     ]

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkModule.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.link.injection
 
+import android.app.Application
 import android.content.Context
 import androidx.core.os.LocaleListCompat
 import androidx.lifecycle.SavedStateHandle
@@ -47,6 +48,7 @@ import com.stripe.android.paymentsheet.analytics.DefaultEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.repository.ConsumersApiService
 import com.stripe.android.repository.ConsumersApiServiceImpl
+import com.stripe.attestation.IntegrityRequestManager
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
@@ -196,5 +198,11 @@ internal interface NativeLinkModule {
         @Provides
         @NativeLinkScope
         fun provideEventReporterMode(): EventReporter.Mode = EventReporter.Mode.Custom
+
+        @Provides
+        @NativeLinkScope
+        fun provideIntegrityStandardRequestManager(
+            context: Application
+        ): IntegrityRequestManager = createIntegrityStandardRequestManager(context)
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModelComponent.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentelement.embedded.content
 
+import android.app.Application
 import android.content.Context
 import android.content.res.Resources
 import androidx.lifecycle.SavedStateHandle
@@ -63,6 +64,9 @@ internal interface EmbeddedPaymentElementViewModelComponent {
 
         @BindsInstance
         fun context(context: Context): Builder
+
+        @BindsInstance
+        fun application(application: Application): Builder
 
         @BindsInstance
         fun statusBarColor(@Named(STATUS_BAR_COLOR) statusBarColor: Int?): Builder

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityViewModelComponent.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentelement.embedded.form
 
+import android.app.Application
 import android.content.Context
 import androidx.activity.result.ActivityResultCaller
 import androidx.lifecycle.LifecycleOwner
@@ -76,6 +77,9 @@ internal interface FormActivityViewModelComponent {
 
         @BindsInstance
         fun context(context: Context): Builder
+
+        @BindsInstance
+        fun application(application: Application): Builder
 
         @BindsInstance
         fun savedStateHandle(savedStateHandle: SavedStateHandle): Builder

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/LinkHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/LinkHandler.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet
 
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkConfigurationCoordinator
+import com.stripe.android.link.attestation.LinkAttestationCheck
 import com.stripe.android.paymentsheet.state.LinkState
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
@@ -30,15 +31,28 @@ internal class LinkHandler @Inject constructor(
         _linkConfiguration.value = state.configuration
     }
 
-    fun setupLinkWithEagerLaunch(state: LinkState?): Boolean {
+    suspend fun setupLinkWithEagerLaunch(state: LinkState?): Boolean {
         setupLink(state)
 
         val configuration = state?.configuration ?: return false
         val linkGate = linkConfigurationCoordinator.linkGate(configuration)
-
         if (linkGate.suppress2faModal) return false
 
-        return when (state.loginState) {
+        val linkAttestationCheck = linkConfigurationCoordinator.linkAttestationCheck(configuration).invoke()
+        return when (linkAttestationCheck) {
+            is LinkAttestationCheck.Result.AccountError,
+            is LinkAttestationCheck.Result.AttestationFailed,
+            is LinkAttestationCheck.Result.Error -> {
+                false
+            }
+            LinkAttestationCheck.Result.Successful -> {
+                shouldLaunchLinkEagerly(state.loginState)
+            }
+        }
+    }
+
+    private fun shouldLaunchLinkEagerly(loginState: LinkState.LoginState): Boolean {
+        return when (loginState) {
             LinkState.LoginState.LoggedIn,
             LinkState.LoginState.NeedsVerification -> true
             LinkState.LoginState.LoggedOut -> false

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -287,6 +287,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
             val starterArgs = starterArgsSupplier()
 
             val component = DaggerPaymentOptionsViewModelFactoryComponent.builder()
+                .application(application)
                 .context(application)
                 .productUsage(starterArgs.productUsage)
                 .savedStateHandle(savedStateHandle)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelFactoryComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelFactoryComponent.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.injection
 
+import android.app.Application
 import android.content.Context
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.core.injection.CoreCommonModule
@@ -30,6 +31,9 @@ internal interface PaymentOptionsViewModelFactoryComponent {
     interface Builder {
         @BindsInstance
         fun context(context: Context): Builder
+
+        @BindsInstance
+        fun application(application: Application): Builder
 
         @BindsInstance
         fun savedStateHandle(handle: SavedStateHandle): Builder

--- a/paymentsheet/src/test/java/com/stripe/android/link/attestation/DefaultLinkAttestationCheckTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/attestation/DefaultLinkAttestationCheckTest.kt
@@ -15,13 +15,16 @@ import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.attestation.IntegrityRequestManager
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 
 internal class DefaultLinkAttestationCheckTest {
+    private val dispatcher = UnconfinedTestDispatcher()
+
     @get:Rule
-    val testRule = CoroutineTestRule()
+    val testRule = CoroutineTestRule(dispatcher)
 
     @Test
     fun `attestation check should be successful when useAttestationEndpoints is false`() = runTest {
@@ -148,7 +151,7 @@ internal class DefaultLinkAttestationCheckTest {
         integrityRequestManager: IntegrityRequestManager = FakeIntegrityRequestManager(),
         linkAccountManager: LinkAccountManager = FakeLinkAccountManager(),
         errorReporter: ErrorReporter = FakeErrorReporter(),
-        linkConfiguration: LinkConfiguration = TestFactory.LINK_CONFIGURATION
+        linkConfiguration: LinkConfiguration = TestFactory.LINK_CONFIGURATION,
     ): DefaultLinkAttestationCheck {
         return DefaultLinkAttestationCheck(
             linkGate = linkGate,
@@ -156,7 +159,8 @@ internal class DefaultLinkAttestationCheckTest {
             integrityRequestManager = integrityRequestManager,
             linkAccountManager = linkAccountManager,
             linkConfiguration = linkConfiguration,
-            errorReporter = errorReporter
+            errorReporter = errorReporter,
+            workContext = dispatcher.scheduler
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElementTest.kt
@@ -13,6 +13,8 @@ import com.stripe.android.link.LinkPaymentDetails
 import com.stripe.android.link.account.FakeLinkAccountManager
 import com.stripe.android.link.account.LinkAccountManager
 import com.stripe.android.link.analytics.FakeLinkEventsReporter
+import com.stripe.android.link.attestation.FakeLinkAttestationCheck
+import com.stripe.android.link.attestation.LinkAttestationCheck
 import com.stripe.android.link.gate.FakeLinkGate
 import com.stripe.android.link.gate.LinkGate
 import com.stripe.android.link.injection.LinkComponent
@@ -158,7 +160,11 @@ class LinkFormElementTest {
         }
 
         override fun linkGate(configuration: LinkConfiguration): LinkGate {
-            TODO("Not yet implemented")
+            error("Not implemented!")
+        }
+
+        override fun linkAttestationCheck(configuration: LinkConfiguration): LinkAttestationCheck {
+            error("Not implemented!")
         }
 
         override suspend fun signInWithUserInput(
@@ -185,6 +191,7 @@ class LinkFormElementTest {
     ) : LinkComponent() {
         override val linkAccountManager: LinkAccountManager = FakeLinkAccountManager()
         override val linkGate: LinkGate = FakeLinkGate()
+        override val linkAttestationCheck = FakeLinkAttestationCheck()
 
         override val inlineSignupViewModelFactory: LinkInlineSignupAssistedViewModelFactory =
             FakeLinkInlineSignupAssistedViewModelFactory(linkAccountManager, configuration)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
@@ -11,6 +11,7 @@ import com.stripe.android.link.LinkPaymentDetails
 import com.stripe.android.link.account.LinkStore
 import com.stripe.android.link.analytics.FakeLinkAnalyticsHelper
 import com.stripe.android.link.analytics.LinkAnalyticsHelper
+import com.stripe.android.link.attestation.LinkAttestationCheck
 import com.stripe.android.link.gate.LinkGate
 import com.stripe.android.link.injection.LinkComponent
 import com.stripe.android.link.model.AccountStatus
@@ -763,6 +764,10 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
         }
 
         override fun linkGate(configuration: LinkConfiguration): LinkGate {
+            throw NotImplementedError()
+        }
+
+        override fun linkAttestationCheck(configuration: LinkConfiguration): LinkAttestationCheck {
             throw NotImplementedError()
         }
 

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeLinkConfigurationCoordinator.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeLinkConfigurationCoordinator.kt
@@ -4,6 +4,8 @@ import com.stripe.android.core.model.CountryCode
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.link.LinkPaymentDetails
+import com.stripe.android.link.attestation.FakeLinkAttestationCheck
+import com.stripe.android.link.attestation.LinkAttestationCheck
 import com.stripe.android.link.gate.FakeLinkGate
 import com.stripe.android.link.gate.LinkGate
 import com.stripe.android.link.injection.LinkComponent
@@ -42,6 +44,7 @@ internal class FakeLinkConfigurationCoordinator(
     ),
     private val accountStatus: AccountStatus = AccountStatus.SignedOut,
     private val linkGate: LinkGate = FakeLinkGate(),
+    private val linkAttestationCheck: LinkAttestationCheck = FakeLinkAttestationCheck(),
     private val email: String? = null
 ) : LinkConfigurationCoordinator {
 
@@ -58,6 +61,10 @@ internal class FakeLinkConfigurationCoordinator(
 
     override fun linkGate(configuration: LinkConfiguration): LinkGate {
         return linkGate
+    }
+
+    override fun linkAttestationCheck(configuration: LinkConfiguration): LinkAttestationCheck {
+        return linkAttestationCheck
     }
 
     override suspend fun signInWithUserInput(configuration: LinkConfiguration, userInput: UserInput): Result<Boolean> {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
We don't want to show the 2fa loader and then redirect the users to web. This change will perform an attestation check before showing the 2fa dialog with the help of `LinkAttestationCheck`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
