### PR TITLE
Link Dark Mode Fix

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
@@ -200,7 +200,7 @@ internal class LinkActivityViewModel @Inject constructor(
         }
     }
 
-    fun linkScreenScreenCreated() {
+    fun linkScreenCreated() {
         viewModelScope.launch {
             val currentRoute = navController?.currentBackStackEntry?.destination?.route
             if (currentRoute == null || currentRoute == LinkScreen.Loading.route) {

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
@@ -202,7 +202,10 @@ internal class LinkActivityViewModel @Inject constructor(
 
     fun linkScreenScreenCreated() {
         viewModelScope.launch {
-            navigateToLinkScreen()
+            val currentRoute = navController?.currentBackStackEntry?.destination?.route
+            if (currentRoute == null || currentRoute == LinkScreen.Loading.route) {
+                navigateToLinkScreen()
+            }
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkScreenContent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkScreenContent.kt
@@ -28,7 +28,7 @@ internal fun LinkScreenContent(
         onDismissClicked = viewModel::onDismissVerificationClicked,
         onBackPressed = onBackPressed,
         onLinkScreenScreenCreated = {
-            viewModel.linkScreenScreenCreated()
+            viewModel.linkScreenCreated()
         },
         onNavControllerCreated = { navController ->
             viewModel.navController = navController

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
@@ -219,7 +219,7 @@ internal class LinkActivityViewModelTest {
         linkAccountManager.setAccountStatus(AccountStatus.Verified)
 
         vm.onCreate(mock())
-        vm.linkScreenScreenCreated()
+        vm.linkScreenCreated()
 
         advanceUntilIdle()
 
@@ -241,7 +241,7 @@ internal class LinkActivityViewModelTest {
         linkAccountManager.setAccountStatus(AccountStatus.NeedsVerification)
 
         vm.onCreate(mock())
-        vm.linkScreenScreenCreated()
+        vm.linkScreenCreated()
 
         advanceUntilIdle()
 
@@ -263,7 +263,7 @@ internal class LinkActivityViewModelTest {
         linkAccountManager.setAccountStatus(AccountStatus.VerificationStarted)
 
         vm.onCreate(mock())
-        vm.linkScreenScreenCreated()
+        vm.linkScreenCreated()
 
         advanceUntilIdle()
 
@@ -285,7 +285,7 @@ internal class LinkActivityViewModelTest {
         linkAccountManager.setAccountStatus(AccountStatus.SignedOut)
 
         vm.onCreate(mock())
-        vm.linkScreenScreenCreated()
+        vm.linkScreenCreated()
 
         advanceUntilIdle()
 
@@ -307,7 +307,7 @@ internal class LinkActivityViewModelTest {
         linkAccountManager.setAccountStatus(AccountStatus.Error)
 
         vm.onCreate(mock())
-        vm.linkScreenScreenCreated()
+        vm.linkScreenCreated()
 
         advanceUntilIdle()
 
@@ -562,7 +562,7 @@ internal class LinkActivityViewModelTest {
         linkAccountManager.setAccountStatus(AccountStatus.Verified)
 
         vm.onCreate(mock())
-        vm.linkScreenScreenCreated()
+        vm.linkScreenCreated()
 
         advanceUntilIdle()
 
@@ -582,7 +582,7 @@ internal class LinkActivityViewModelTest {
         linkAccountManager.setAccountStatus(AccountStatus.Verified)
 
         vm.onCreate(mock())
-        vm.linkScreenScreenCreated()
+        vm.linkScreenCreated()
 
         advanceUntilIdle()
 
@@ -604,7 +604,7 @@ internal class LinkActivityViewModelTest {
         linkAccountManager.setAccountStatus(AccountStatus.Verified)
 
         vm.onCreate(mock())
-        vm.linkScreenScreenCreated()
+        vm.linkScreenCreated()
 
         advanceUntilIdle()
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Switching between Light/Dark mode causes activity to be recreated which in turn triggers `LinkActivityViewModel.linkScreenCreated`. This function navigates to the correct destination (SignUp or Wallet). This change will only navigate when the `navController` is on the Loading screen - this is the default screen when native link is launched. 

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| https://github.com/user-attachments/assets/bb465a30-6972-4acb-a15c-4a888f82b2c5 | https://github.com/user-attachments/assets/17fa8b87-dc59-45e3-802e-b6a1f0b3bd52 |


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
