### PR TITLE
Make sonatype deploy step agnostic to local gpg location

### DIFF
--- a/scripts/deploy/common.rb
+++ b/scripts/deploy/common.rb
@@ -43,6 +43,12 @@ def replace_in_file(filename, pattern, replacement)
   File.write(filename, new_content)
 end
 
+def append_to_file(filename, new_content)
+    puts "> Updating #{filename}"
+    content = File.read(filename)
+    File.write(filename, "#{content}\n#{new_content}\n")
+end
+
 def switch_to_release_branch()
     switch_to_new_branch(release_branch, @deploy_branch)
 end

--- a/scripts/deploy/publish_to_sonatype.rb
+++ b/scripts/deploy/publish_to_sonatype.rb
@@ -11,58 +11,77 @@ def publish_to_sonatype
     execute_or_fail("git checkout #{@deploy_branch}")
     execute_or_fail("git pull")
 
-    m2_settings = Nokogiri::XML(fetch_password("bindings/java-maven-api-token"))
+    set_gpg_location()
 
-    # Required in order to use xpath sanely (the commands below would
-    # otherwise come up with no results because the top level `<settings>`
-    # has an `xmlns`.
-    m2_settings.remove_namespaces!
+    begin
+        m2_settings = Nokogiri::XML(fetch_password("bindings/java-maven-api-token"))
 
-    # Note that we're looking for the "sonatype-nexus-staging" server here.
-    # Currently hard-coded to the second <server> element in the array but
-    # there's got to be a better way (I tried a few clever xpath tricks, but
-    # Nokogiri didn't like them one bit)..
-    server_element = m2_settings.xpath("//settings/servers/server")[1]
+        # Required in order to use xpath sanely (the commands below would
+        # otherwise come up with no results because the top level `<settings>`
+        # has an `xmlns`.
+        m2_settings.remove_namespaces!
 
-    nexus_user = server_element.xpath("//username").first.content
-    nexus_pass = server_element.xpath("//password").first.content
-    gnupg_key_id = fetch_password("bindings/gnupg/fingerprint").strip
+        # Note that we're looking for the "sonatype-nexus-staging" server here.
+        # Currently hard-coded to the second <server> element in the array but
+        # there's got to be a better way (I tried a few clever xpath tricks, but
+        # Nokogiri didn't like them one bit)..
+        server_element = m2_settings.xpath("//settings/servers/server")[1]
 
-    gradle_opts = \
-    "-Dorg.gradle.project.NEXUS_USERNAME=#{nexus_user} " \
-    "-Dorg.gradle.project.NEXUS_PASSWORD=#{nexus_pass} " \
-    "-Dorg.gradle.project.signing.gnupg.keyName=#{gnupg_key_id}"
+        nexus_user = server_element.xpath("//username").first.content
+        nexus_pass = server_element.xpath("//password").first.content
+        gnupg_key_id = fetch_password("bindings/gnupg/fingerprint").strip
 
-    gnupg_env do |env|
-        env.update(
-            "GRADLE_OPTS" => gradle_opts,
+        gradle_opts = \
+        "-Dorg.gradle.project.NEXUS_USERNAME=#{nexus_user} " \
+        "-Dorg.gradle.project.NEXUS_PASSWORD=#{nexus_pass} " \
+        "-Dorg.gradle.project.signing.gnupg.keyName=#{gnupg_key_id}"
 
-            # Ensure that /usr/bin is in the PATH. This is
-            # where the Java executable is located on a Mac
-            # OS machine.
-            "PATH" => path_with("/usr/bin"),
-        )
+        gnupg_env do |env|
+            env.update(
+                "GRADLE_OPTS" => gradle_opts,
 
-        # See https://github.com/gradle-nexus/publish-plugin for info on these gradle commands.
-        if (@is_dry_run)
-            publish_to_sonatype_commands = ['./gradlew', 'publishToSonatype', 'closeSonatypeStagingRepository', '--stacktrace']
-        else
-            publish_to_sonatype_commands = ['./gradlew', 'publishToSonatype', 'closeAndReleaseSonatypeStagingRepository', '--stacktrace']
-        end
+                # Ensure that /usr/bin is in the PATH. This is
+                # where the Java executable is located on a Mac
+                # OS machine.
+                "PATH" => path_with("/usr/bin"),
+            )
 
-        Subprocess.check_call(
-            publish_to_sonatype_commands,
-            env: env
-        )
+            # See https://github.com/gradle-nexus/publish-plugin for info on these gradle commands.
+            if (@is_dry_run)
+                publish_to_sonatype_commands = ['./gradlew', 'publishToSonatype', 'closeSonatypeStagingRepository', '--stacktrace']
+            else
+                publish_to_sonatype_commands = ['./gradlew', 'publishToSonatype', 'closeAndReleaseSonatypeStagingRepository', '--stacktrace']
+            end
 
-        puts "Release succeeded!"
+            Subprocess.check_call(
+                publish_to_sonatype_commands,
+                env: env
+            )
 
-        if (@is_dry_run)
-            rputs "At the open link, verify that a new release was added to the staging repo. You can log in to sonatype using your credentials found at `fetch-password bindings/java-maven-api-token`"
-            open_url("https://oss.sonatype.org/#stagingRepositories")
-            wait_for_user
+            puts "Release succeeded!"
+
+            if (@is_dry_run)
+                rputs "At the open link, verify that a new release was added to the staging repo. You can log in to sonatype using your credentials found at `fetch-password bindings/java-maven-api-token`"
+                open_url("https://oss.sonatype.org/#stagingRepositories")
+                wait_for_user
+            end
+        ensure
+            reset_gradle_properties()
         end
     end
+end
+
+private def set_gpg_location
+    begin
+        gpg_location = `which gpg`
+    rescue
+        rputs "Could not find gpg location via `which gpg`, do you have gpg installed?"
+    end
+    append_to_file("gradle.properties", "signing.gnupg.executable=#{gpg_location}")
+end
+
+private def reset_gradle_properties
+    execute_or_fail("git checkout origin/master gradle.properties")
 end
 
 # Gets the contents of the PATH environment variable, but before it does


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Make sonatype deploy step agnostic to local gpg location

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
The sonatype step fails for me because my gpg install isn't in the location it expects. I believe this issue will affect anyone who has installed gpg via homebrew. Setting the gpg location explicitly in gradle.properties fixed it for me.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

Verified via running a deploy dry run.