### PR TITLE
Configuration is allowed to use the cached variant when sheetIsOpen.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfigurationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfigurationHandler.kt
@@ -45,10 +45,6 @@ internal class DefaultEmbeddedConfigurationHandler @Inject constructor(
         intentConfiguration: PaymentSheet.IntentConfiguration,
         configuration: EmbeddedPaymentElement.Configuration,
     ): Result<PaymentElementLoader.State> {
-        if (sheetStateHolder.sheetIsOpen) {
-            return Result.failure(IllegalStateException("Configuring while a sheet is open is not supported."))
-        }
-
         val targetConfiguration = configuration.asCommonConfiguration()
 
         val initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(intentConfiguration)
@@ -80,6 +76,10 @@ internal class DefaultEmbeddedConfigurationHandler @Inject constructor(
             }
         }
         inFlightRequest = null
+
+        if (sheetStateHolder.sheetIsOpen) {
+            return Result.failure(IllegalStateException("Configuring while a sheet is open is not supported."))
+        }
 
         val supervisorJob = SupervisorJob()
         val coroutineScope = CoroutineScope(supervisorJob)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfigurationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfigurationHandlerTest.kt
@@ -55,6 +55,29 @@ internal class DefaultEmbeddedConfigurationHandlerTest {
     }
 
     @Test
+    fun `result is used from saved state handle when configurations are the same and sheetIsOpen`() = runScenario {
+        sheetStateHolder.sheetIsOpen = true
+        val configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build()
+        savedStateHandle[ConfigurationCache.KEY] = ConfigurationCache(
+            arguments = DefaultEmbeddedConfigurationHandler.Arguments(
+                intentConfiguration = PaymentSheet.IntentConfiguration(
+                    mode = PaymentSheet.IntentConfiguration.Mode.Setup(currency = "USD"),
+                ),
+                configuration = configuration.asCommonConfiguration(),
+            ),
+            resultState = loader.createSuccess(configuration.asCommonConfiguration()).getOrThrow(),
+        )
+        val result = handler.configure(
+            intentConfiguration = PaymentSheet.IntentConfiguration(
+                mode = PaymentSheet.IntentConfiguration.Mode.Setup(currency = "USD"),
+            ),
+            configuration = configuration,
+        )
+        assertThat(result.getOrThrow())
+            .isInstanceOf<PaymentElementLoader.State>()
+    }
+
+    @Test
     fun paymentElementLoaderIsCalledWithCorrectArguments() = runScenario {
         val configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build()
         loader.emit(loader.createSuccess(configuration.asCommonConfiguration()))


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
There was a bug where on rotation (any configuration change), when the sheet was open, configuration was denied. Now we allow the same configuration to return the cached result while the sheet is open, just not for a new configuration to occur.