### PR TITLE
Fix 3DS2 Cancel / Rotation Issue

### DIFF
--- a/3ds2sdk/src/main/AndroidManifest.xml
+++ b/3ds2sdk/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 
     <application>
         <activity android:name="com.stripe.android.stripe3ds2.views.ChallengeActivity"
+            android:configChanges="orientation|screenSize"
             android:theme="@style/Stripe3DS2Theme"
             android:exported="false" />
     </application>

--- a/3ds2sdk/src/main/kotlin/com/stripe/android/stripe3ds2/views/ChallengeFragment.kt
+++ b/3ds2sdk/src/main/kotlin/com/stripe/android/stripe3ds2/views/ChallengeFragment.kt
@@ -367,7 +367,13 @@ internal class ChallengeFragment(
 
             viewModel.onFinish(challengeResult)
         } else {
-            viewModel.onNextScreen(cresData)
+            if (creqData.cancelReason != null) {
+                viewModel.stopTimer()
+
+                viewModel.onFinish(ChallengeResult.Canceled(uiTypeCode, initialUiType, intentData))
+            } else {
+                viewModel.onNextScreen(cresData)
+            }
         }
 
         analyticsDelegate?.didReceiveChallengeResponseWithTransactionId(cresData.serverTransId, uiTypeCode)


### PR DESCRIPTION
# Summary
Fixes an issue with cancelling where the `cresData.isChallengeCompleted` would be false when a user's last action was to tap cancel. This resulted in trying to continue in the process despite cancellation occurring.

Fixes an issue where the ChallengeActivity would be re-created on rotation, causing the OOB flow to auto-submit more often than it should've.  

# Motivation
Got a report of the cancel button not functioning properly, tracked it down to this section. The existing playground does not show this issue, as the response assumes the challenge is completed when cancel is tapped.

# Testing
This was tested under the playground / self test environment. Please pay extra attention to testing in a production environment, as I know the presentation flow is handled outside the SDK on Android.

<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
