### PR TITLE
Enable `Customer Session` by default in playground

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/TestParameters.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/TestParameters.kt
@@ -7,6 +7,7 @@ import com.stripe.android.paymentsheet.example.playground.settings.Country
 import com.stripe.android.paymentsheet.example.playground.settings.CountrySettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.Currency
 import com.stripe.android.paymentsheet.example.playground.settings.CurrencySettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.CustomerSessionSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.CustomerSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.CustomerType
 import com.stripe.android.paymentsheet.example.playground.settings.DefaultShippingAddressSettingsDefinition
@@ -61,6 +62,7 @@ internal data class TestParameters(
         private fun playgroundSettings(block: (PlaygroundSettings) -> Unit = {}): PlaygroundSettings {
             val settings = PlaygroundSettings.createFromDefaults()
             settings[CustomerSettingsDefinition] = CustomerType.NEW
+            settings[CustomerSessionSettingsDefinition] = false
             settings[LinkSettingsDefinition] = false
             settings[CountrySettingsDefinition] = Country.GB
             settings[CurrencySettingsDefinition] = Currency.EUR

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionSettingsDefinition.kt
@@ -4,7 +4,7 @@ import com.stripe.android.paymentsheet.example.playground.model.CheckoutRequest
 import com.stripe.android.paymentsheet.example.playground.model.CustomerEphemeralKeyRequest
 
 internal object CustomerSessionSettingsDefinition : BooleanSettingsDefinition(
-    defaultValue = false,
+    defaultValue = true,
     displayName = "Use Customer Session",
     key = "customer_session_enabled"
 ) {


### PR DESCRIPTION
# Summary
Enable `Customer Session` by default in playground

# Motivation
We want to test our our features with `CustomerSession` more often as we begin to ramp up merchants onto it and make it our default integration eventually.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified