### PR TITLE
Add link mode to playground checkout request

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
@@ -24,6 +24,8 @@ class CheckoutRequest private constructor(
     val automaticPaymentMethods: Boolean?,
     @SerialName("use_link")
     val useLink: Boolean?,
+    @SerialName("link_mode")
+    val linkMode: String?,
     @SerialName("merchant_country_code")
     val merchantCountryCode: String?,
     @SerialName("supported_payment_methods")
@@ -67,6 +69,7 @@ class CheckoutRequest private constructor(
         private var setShippingAddress: Boolean? = null
         private var automaticPaymentMethods: Boolean? = null
         private var useLink: Boolean? = null
+        private var linkMode: String? = null
         private var merchantCountryCode: String? = null
         private var supportedPaymentMethods: List<String>? = null
         private var paymentMethodConfigurationId: String? = null
@@ -113,6 +116,10 @@ class CheckoutRequest private constructor(
 
         fun useLink(useLink: Boolean?) = apply {
             this.useLink = useLink
+        }
+
+        fun linkMode(linkMode: String?) = apply {
+            this.linkMode = linkMode
         }
 
         fun merchantCountryCode(merchantCountryCode: String?) = apply {
@@ -169,6 +176,7 @@ class CheckoutRequest private constructor(
                 setShippingAddress = setShippingAddress,
                 automaticPaymentMethods = automaticPaymentMethods,
                 useLink = useLink,
+                linkMode = linkMode,
                 merchantCountryCode = merchantCountryCode,
                 supportedPaymentMethods = supportedPaymentMethods,
                 paymentMethodConfigurationId = paymentMethodConfigurationId,

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/LinkTypeSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/LinkTypeSettingsDefinition.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.example.playground.settings
 
 import com.stripe.android.core.utils.FeatureFlags
+import com.stripe.android.paymentsheet.example.playground.model.CheckoutRequest
 
 internal object LinkTypeSettingsDefinition :
     PlaygroundSettingDefinition<LinkType>,
@@ -35,6 +36,23 @@ internal object LinkTypeSettingsDefinition :
             LinkType.Web -> {
                 FeatureFlags.nativeLinkEnabled.setEnabled(false)
                 FeatureFlags.nativeLinkAttestationEnabled.setEnabled(false)
+            }
+        }
+    }
+
+    override fun configure(
+        value: LinkType,
+        checkoutRequestBuilder: CheckoutRequest.Builder,
+    ) {
+        when (value) {
+            LinkType.Native -> {
+                checkoutRequestBuilder.linkMode("native")
+            }
+            LinkType.NativeAttest -> {
+                checkoutRequestBuilder.linkMode("attest")
+            }
+            LinkType.Web -> {
+                checkoutRequestBuilder.linkMode("web")
             }
         }
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Setting the link mode to will cause the backend to switch the appropriate merchant. `link_mode="attest"` will use a merchant registered as trusted.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
This will allow us to test hardware attestation on the playground app

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
