### PR TITLE
Update `CompatTextField` with Jetpack Compose 1.7 changes.

### DIFF
--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/compat/CompatTextField.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/compat/CompatTextField.kt
@@ -33,7 +33,6 @@ import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.defaultMinSize
-import androidx.compose.foundation.shape.ZeroCornerSize
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -42,7 +41,6 @@ import androidx.compose.material.LocalContentAlpha
 import androidx.compose.material.LocalContentColor
 import androidx.compose.material.LocalTextStyle
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.ProvideTextStyle
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
@@ -148,8 +146,7 @@ internal fun CompatTextField(
     maxLines: Int = if (singleLine) 1 else Int.MAX_VALUE,
     minLines: Int = 1,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-    shape: Shape =
-        MaterialTheme.shapes.small.copy(bottomEnd = ZeroCornerSize, bottomStart = ZeroCornerSize),
+    shape: Shape = TextFieldDefaults.TextFieldShape,
     colors: TextFieldColors = TextFieldDefaults.textFieldColors()
 ) {
     // If color is not provided via the text style, use content color as a default
@@ -162,7 +159,6 @@ internal fun CompatTextField(
     BasicTextField(
         value = value,
         modifier = modifier
-            .background(colors.backgroundColor(enabled).value, shape)
             .indicatorLine(enabled, isError, interactionSource, colors)
             .defaultErrorSemantics(isError, stringResource(ComposeUiR.string.default_error_message))
             .defaultMinSize(
@@ -196,6 +192,7 @@ internal fun CompatTextField(
                 isError = isError,
                 interactionSource = interactionSource,
                 colors = colors,
+                shape = shape,
                 contentPadding = if (label == null) {
                     TextFieldDefaults.textFieldWithoutLabelPadding()
                 } else {
@@ -207,7 +204,7 @@ internal fun CompatTextField(
 }
 
 /**
- * Implementation of the [TextField] and [OutlinedTextField]
+ * Implementation of the [CompatTextField]
  */
 @Composable
 @Suppress("CyclomaticComplexMethod", "LongMethod")
@@ -216,14 +213,15 @@ internal fun CommonDecorationBox(
     innerTextField: @Composable () -> Unit,
     visualTransformation: VisualTransformation,
     label: @Composable (() -> Unit)?,
-    placeholder: @Composable (() -> Unit)? = null,
-    leadingIcon: @Composable (() -> Unit)? = null,
-    trailingIcon: @Composable (() -> Unit)? = null,
-    singleLine: Boolean = false,
-    enabled: Boolean = true,
-    isError: Boolean = false,
+    placeholder: @Composable (() -> Unit)?,
+    leadingIcon: @Composable (() -> Unit)?,
+    trailingIcon: @Composable (() -> Unit)?,
+    singleLine: Boolean,
+    enabled: Boolean,
+    isError: Boolean,
     interactionSource: InteractionSource,
     contentPadding: PaddingValues,
+    shape: Shape,
     colors: TextFieldColors,
 ) {
     val transformedText = remember(value, visualTransformation) {
@@ -296,22 +294,25 @@ internal fun CommonDecorationBox(
                 null
             }
 
-        val leadingIconColor = colors.leadingIconColor(enabled, isError).value
+        val leadingIconColor = colors.leadingIconColor(enabled, isError, interactionSource).value
         val decoratedLeading: @Composable (() -> Unit)? = leadingIcon?.let {
             @Composable {
                 Decoration(contentColor = leadingIconColor, content = it)
             }
         }
 
-        val trailingIconColor = colors.trailingIconColor(enabled, isError).value
+        val trailingIconColor = colors.trailingIconColor(enabled, isError, interactionSource).value
         val decoratedTrailing: @Composable (() -> Unit)? = trailingIcon?.let {
             @Composable {
                 Decoration(contentColor = trailingIconColor, content = it)
             }
         }
 
+        val backgroundModifier =
+            Modifier.background(colors.backgroundColor(enabled).value, shape)
+
         TextFieldLayout(
-            modifier = Modifier,
+            modifier = backgroundModifier,
             textField = innerTextField,
             placeholder = decoratedPlaceholder,
             label = decoratedLabel,

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/compat/TextFieldLayout.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/compat/TextFieldLayout.kt
@@ -43,8 +43,8 @@ import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.coerceAtLeast
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.offset
-import kotlin.contracts.ExperimentalContracts
-import kotlin.contracts.contract
+import androidx.compose.ui.util.fastFirst
+import androidx.compose.ui.util.fastFirstOrNull
 import kotlin.math.max
 import kotlin.math.roundToInt
 
@@ -315,11 +315,15 @@ private class TextFieldMeasurePolicy(
     ): Int {
         var remainingWidth = width
         val leadingHeight = measurables.fastFirstOrNull { it.layoutId == LeadingId }?.let {
-            remainingWidth -= it.maxIntrinsicWidth(Constraints.Infinity)
+            remainingWidth = remainingWidth.substractConstraintSafely(
+                it.maxIntrinsicWidth(Constraints.Infinity)
+            )
             intrinsicMeasurer(it, width)
         } ?: 0
         val trailingHeight = measurables.fastFirstOrNull { it.layoutId == TrailingId }?.let {
-            remainingWidth -= it.maxIntrinsicWidth(Constraints.Infinity)
+            remainingWidth = remainingWidth.substractConstraintSafely(
+                it.maxIntrinsicWidth(Constraints.Infinity)
+            )
             intrinsicMeasurer(it, width)
         } ?: 0
 
@@ -345,6 +349,13 @@ private class TextFieldMeasurePolicy(
             paddingValues = paddingValues
         )
     }
+}
+
+private fun Int.substractConstraintSafely(from: Int): Int {
+    if (this == Constraints.Infinity) {
+        return this
+    }
+    return this - from
 }
 
 private fun calculateWidth(
@@ -487,29 +498,6 @@ private fun Placeable.PlacementScope.placeWithoutLabel(
             widthOrZero(leadingPlaceable),
             placeholderVerticalPosition
         )
-    }
-}
-
-@OptIn(ExperimentalContracts::class)
-internal inline fun <T> List<T>.fastFirst(predicate: (T) -> Boolean): T {
-    contract { callsInPlace(predicate) }
-    fastForEach { if (predicate(it)) return it }
-    throw NoSuchElementException("Collection contains no element matching the predicate.")
-}
-
-@OptIn(ExperimentalContracts::class)
-internal inline fun <T> List<T>.fastFirstOrNull(predicate: (T) -> Boolean): T? {
-    contract { callsInPlace(predicate) }
-    fastForEach { if (predicate(it)) return it }
-    return null
-}
-
-@OptIn(ExperimentalContracts::class)
-internal inline fun <T> List<T>.fastForEach(action: (T) -> Unit) {
-    contract { callsInPlace(action) }
-    for (index in indices) {
-        val item = get(index)
-        action(item)
     }
 }
 


### PR DESCRIPTION
# Summary
Update `CompatTextField` with Jetpack Compose 1.7 changes.

# Motivation
Ensures our compat text field works with Jetpack Compose 1.7

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified