### PR TITLE
Use formatted phone number in Link

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/model/LinkAccount.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/model/LinkAccount.kt
@@ -12,7 +12,7 @@ import kotlinx.parcelize.Parcelize
 internal class LinkAccount(private val consumerSession: ConsumerSession) : Parcelable {
 
     @IgnoredOnParcel
-    val redactedPhoneNumber = consumerSession.redactedPhoneNumber
+    val redactedPhoneNumber = consumerSession.redactedFormattedPhoneNumber.replace("*", "•")
 
     @IgnoredOnParcel
     val clientSecret = consumerSession.clientSecret

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/inline/InlineSignupViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/inline/InlineSignupViewModelTest.kt
@@ -25,7 +25,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
@@ -510,16 +509,18 @@ class InlineSignupViewModelTest {
         type: ConsumerSession.VerificationSession.SessionType,
         state: ConsumerSession.VerificationSession.SessionState
     ): ConsumerSession {
-        val verificationSession = mock<ConsumerSession.VerificationSession>()
-        whenever(verificationSession.type).thenReturn(type)
-        whenever(verificationSession.state).thenReturn(state)
+        val verificationSession = ConsumerSession.VerificationSession(
+            type = type,
+            state = state,
+        )
         val verificationSessions = listOf(verificationSession)
 
-        val consumerSession = mock<ConsumerSession>()
-        whenever(consumerSession.verificationSessions).thenReturn(verificationSessions)
-        whenever(consumerSession.clientSecret).thenReturn("secret")
-        whenever(consumerSession.emailAddress).thenReturn("email")
-        return consumerSession
+        return ConsumerSession(
+            emailAddress = "email",
+            redactedFormattedPhoneNumber = "********55",
+            redactedPhoneNumber = "(***) ***-**55",
+            verificationSessions = verificationSessions,
+        )
     }
 
     private fun stripeIntent(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request updates Link to use the formatted phone number, allowing us to show `(•••) ••• ••55` instead of `+1********55`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
