### PR TITLE
Filter SEPA payment methods out of CustomerSheet when sync default feature enabled

### DIFF
--- a/payments-core-testing/src/main/java/com/stripe/android/testing/PaymentMethodFactory.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/PaymentMethodFactory.kt
@@ -227,6 +227,23 @@ object PaymentMethodFactory {
         return paymentMethodJson
     }
 
+    fun convertSepaPaymentMethodToJson(paymentMethod: PaymentMethod): JSONObject {
+        val paymentMethodJson = convertGenericPaymentMethodToJson(paymentMethod)
+
+        val sepaDebitJson = JSONObject()
+        // Test values from the SEPA account with the test IBAN we use for e2e tests: DE89370400440532013000
+        sepaDebitJson.put("bank_code", "37040044")
+        sepaDebitJson.put("branch_code", "")
+        sepaDebitJson.put("country", "DE")
+        sepaDebitJson.put("fingerprint", "vifs0Ho7vwRn1Miu")
+        sepaDebitJson.put("last4", "3000")
+
+        paymentMethodJson.put("type", "sepa_debit")
+        paymentMethodJson.put("sepa_debit", sepaDebitJson)
+
+        return paymentMethodJson
+    }
+
     private fun convertGenericPaymentMethodToJson(paymentMethod: PaymentMethod): JSONObject {
         val paymentMethodJson = JSONObject()
 

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSessionCustomerSheetTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSessionCustomerSheetTest.kt
@@ -1,5 +1,8 @@
 package com.stripe.android.paymentsheet
 
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.onAllNodesWithTag
 import com.google.common.truth.Truth.assertThat
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
@@ -13,6 +16,7 @@ import com.stripe.android.networktesting.RequestMatchers.method
 import com.stripe.android.networktesting.RequestMatchers.path
 import com.stripe.android.networktesting.ResponseReplacement
 import com.stripe.android.networktesting.testBodyFromFile
+import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_OPTION_TEST_TAG
 import com.stripe.android.paymentsheet.utils.CustomerSheetTestType
 import com.stripe.android.paymentsheet.utils.IntegrationType
 import com.stripe.android.paymentsheet.utils.IntegrationTypeProvider
@@ -124,14 +128,81 @@ internal class CustomerSessionCustomerSheetTest {
         page.clickConfirmButton()
     }
 
+    @Test
+    fun testSepaSuccessfullyHiddenWhenDefaultPMsFeatureEnabled() = runCustomerSheetTest(
+        networkRule = networkRule,
+        integrationType = integrationType,
+        customerSheetTestType = CustomerSheetTestType.CustomerSession,
+        resultCallback = { result ->
+            verifySelected(
+                expectedLast4 = "4242",
+                expectedBrand = CardBrand.Visa,
+                result = result,
+            )
+        }
+    ) { context ->
+        enqueueElementsSession(
+            cards = listOf(),
+            sepaPaymentMethod = PaymentMethodFactory.sepaDebit(),
+            isPaymentMethodSyncDefaultEnabled = true,
+        )
+
+        context.presentCustomerSheet()
+
+        page.fillOutCardDetails()
+
+        enqueuePaymentMethodCreation()
+        enqueueSetupIntentRetrieval()
+        enqueueSetupIntentConfirmation()
+
+        enqueueElementsSession(
+            cards = listOf(
+                PaymentMethodFactory.card(id = "pm_12345").update(
+                    last4 = "4242",
+                    addCbcNetworks = false,
+                    brand = CardBrand.Visa,
+                )
+            ),
+            sepaPaymentMethod = PaymentMethodFactory.sepaDebit(),
+            isPaymentMethodSyncDefaultEnabled = true,
+        )
+
+        page.clickSaveButton()
+        assertOnlySavedCardIsDisplayed()
+
+        page.clickConfirmButton()
+    }
+
+    private fun assertOnlySavedCardIsDisplayed() {
+        val savedPaymentMethodMatcher = hasTestTag(SAVED_PAYMENT_OPTION_TEST_TAG)
+            .and(hasText("4242", substring = true))
+
+        page.waitUntil(savedPaymentMethodMatcher)
+        assertThat(
+            composeTestRule.onAllNodesWithTag(SAVED_PAYMENT_OPTION_TEST_TAG).fetchSemanticsNodes().size
+        ).isEqualTo(1)
+    }
+
     private fun enqueueElementsSession(
         cards: List<PaymentMethod>,
+        sepaPaymentMethod: PaymentMethod? = null,
+        isPaymentMethodSyncDefaultEnabled: Boolean = false,
         isCbcEligible: Boolean = false,
     ) {
-        val cardsArray = JSONArray()
+        val paymentMethodsArray = JSONArray()
 
         cards.forEach { card ->
-            cardsArray.put(PaymentMethodFactory.convertCardToJson(card))
+            paymentMethodsArray.put(PaymentMethodFactory.convertCardToJson(card))
+        }
+
+        sepaPaymentMethod?.let {
+            paymentMethodsArray.put(PaymentMethodFactory.convertSepaPaymentMethodToJson(sepaPaymentMethod))
+        }
+
+        val syncDefaultFeature = if (isPaymentMethodSyncDefaultEnabled) {
+            "enabled"
+        } else {
+            "disabled"
         }
 
         networkRule.enqueue(
@@ -144,11 +215,15 @@ internal class CustomerSessionCustomerSheetTest {
                 replacements = listOf(
                     ResponseReplacement(
                         original = "[PAYMENT_METHODS_HERE]",
-                        new = cardsArray.toString(2),
+                        new = paymentMethodsArray.toString(2),
                     ),
                     ResponseReplacement(
                         original = "CARD_BRAND_CHOICE_ELIGIBILITY",
                         new = isCbcEligible.toString(),
+                    ),
+                    ResponseReplacement(
+                        original = "PAYMENT_METHOD_SYNC_DEFAULT_FEATURE",
+                        new = syncDefaultFeature,
                     ),
                 ),
             )

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetPage.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetPage.kt
@@ -130,7 +130,7 @@ internal class CustomerSheetPage(
         composeTestRule.waitForIdle()
     }
 
-    private fun waitUntil(matcher: SemanticsMatcher) {
+    fun waitUntil(matcher: SemanticsMatcher) {
         waitForIdle()
 
         composeTestRule.waitUntil(5_000) {

--- a/paymentsheet/src/androidTest/resources/elements-sessions-requires_pm_with_cs.json
+++ b/paymentsheet/src/androidTest/resources/elements-sessions-requires_pm_with_cs.json
@@ -29,7 +29,8 @@
         "customer_sheet": {
           "enabled": true,
           "features": {
-            "payment_method_remove": "PAYMENT_METHOD_REMOVE_FEATURE"
+            "payment_method_remove": "PAYMENT_METHOD_REMOVE_FEATURE",
+            "payment_method_sync_default": "PAYMENT_METHOD_SYNC_DEFAULT_FEATURE"
           }
         }
       }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -74,7 +74,7 @@ internal class DefaultCustomerSheetLoader(
 
         val filteredPaymentMethods = customerSheetSession.paymentMethods.filter { paymentMethod ->
             PaymentSheetCardBrandFilter(configuration.cardBrandAcceptance).isAccepted(paymentMethod) &&
-                !shouldBeFilteredOutForSyncDefaultFeature(isPaymentMethodSyncDefaultEnabled, paymentMethod)
+                (!isPaymentMethodSyncDefaultEnabled || isSupportedBySyncDefaultFeature(paymentMethod))
         }
         customerSheetSession = customerSheetSession.copy(
             paymentMethods = filteredPaymentMethods
@@ -93,16 +93,14 @@ internal class DefaultCustomerSheetLoader(
         )
     }
 
-    private fun shouldBeFilteredOutForSyncDefaultFeature(
-        isPaymentMethodSyncDefaultEnabled: Boolean,
+    private fun isSupportedBySyncDefaultFeature(
         paymentMethod: PaymentMethod,
     ): Boolean {
         val paymentMethodTypesSupportedWithSyncDefaultFeature = listOf(
             PaymentMethod.Type.Card,
             PaymentMethod.Type.USBankAccount,
         )
-        return isPaymentMethodSyncDefaultEnabled &&
-            paymentMethodTypesSupportedWithSyncDefaultFeature.contains(paymentMethod.type).not()
+        return paymentMethodTypesSupportedWithSyncDefaultFeature.contains(paymentMethod.type)
     }
 
     private suspend fun retrieveInitializationDataSource(): Result<CustomerSheetInitializationDataSource> {

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSource.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.customersheet.data
 
 import com.stripe.android.core.injection.IOContext
+import com.stripe.android.customersheet.util.filterToSupportedPaymentMethods
+import com.stripe.android.customersheet.util.getDefaultPaymentMethodsEnabledForCustomerSheet
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodUpdateParams
 import com.stripe.android.payments.core.analytics.ErrorReporter
@@ -18,7 +20,13 @@ internal class CustomerSessionPaymentMethodDataSource @Inject constructor(
     override suspend fun retrievePaymentMethods(): CustomerSheetDataResult<List<PaymentMethod>> {
         return withContext(workContext) {
             elementsSessionManager.fetchElementsSession().mapCatching { elementsSessionWithCustomer ->
-                elementsSessionWithCustomer.customer.paymentMethods
+                val isSyncDefaultPaymentMethodFeatureEnabled = getDefaultPaymentMethodsEnabledForCustomerSheet(
+                    elementsSessionWithCustomer.elementsSession
+                )
+
+                elementsSessionWithCustomer.customer.paymentMethods.filterToSupportedPaymentMethods(
+                    isSyncDefaultPaymentMethodFeatureEnabled
+                )
             }.toCustomerSheetDataResult()
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/util/SyncDefaultPaymentMethodUtils.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/util/SyncDefaultPaymentMethodUtils.kt
@@ -12,7 +12,8 @@ internal fun List<PaymentMethod>.filterToSupportedPaymentMethods(
     )
 
     return this.filter { paymentMethod ->
-        !isSyncDefaultPaymentMethodFeatureEnabled || paymentMethodTypesSupportedWithSyncDefaultFeature.contains(paymentMethod.type)
+        !isSyncDefaultPaymentMethodFeatureEnabled ||
+            paymentMethodTypesSupportedWithSyncDefaultFeature.contains(paymentMethod.type)
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/util/SyncDefaultPaymentMethodUtils.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/util/SyncDefaultPaymentMethodUtils.kt
@@ -1,0 +1,26 @@
+package com.stripe.android.customersheet.util
+
+import com.stripe.android.model.ElementsSession
+import com.stripe.android.model.PaymentMethod
+
+internal fun List<PaymentMethod>.filterToSupportedPaymentMethods(
+    isSyncDefaultPaymentMethodFeatureEnabled: Boolean,
+): List<PaymentMethod> {
+    val paymentMethodTypesSupportedWithSyncDefaultFeature = listOf(
+        PaymentMethod.Type.Card,
+        PaymentMethod.Type.USBankAccount,
+    )
+
+    return this.filter { paymentMethod ->
+        !isSyncDefaultPaymentMethodFeatureEnabled || paymentMethodTypesSupportedWithSyncDefaultFeature.contains(paymentMethod.type)
+    }
+}
+
+internal fun getDefaultPaymentMethodsEnabledForCustomerSheet(elementsSession: ElementsSession): Boolean {
+    return when (val customerSheetComponent = elementsSession.customer?.session?.components?.customerSheet) {
+        is ElementsSession.Customer.Components.CustomerSheet.Enabled ->
+            customerSheetComponent.isPaymentMethodSyncDefaultEnabled
+        ElementsSession.Customer.Components.CustomerSheet.Disabled,
+        null -> false
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -284,6 +284,7 @@ internal data class PaymentMethodMetadata(
             sharedDataSpecs: List<SharedDataSpec>,
             isGooglePayReady: Boolean,
             isFinancialConnectionsAvailable: IsFinancialConnectionsAvailable,
+            isPaymentMethodSyncDefaultEnabled: Boolean,
         ): PaymentMethodMetadata {
             return PaymentMethodMetadata(
                 stripeIntent = elementsSession.stripeIntent,
@@ -300,8 +301,7 @@ internal data class PaymentMethodMetadata(
                 shippingDetails = null,
                 customerMetadata = CustomerMetadata(
                     hasCustomerConfiguration = true,
-                    isPaymentMethodSetAsDefaultEnabled =
-                    getDefaultPaymentMethodsEnabledForCustomerSheet(elementsSession),
+                    isPaymentMethodSetAsDefaultEnabled = isPaymentMethodSyncDefaultEnabled,
                 ),
                 sharedDataSpecs = sharedDataSpecs,
                 isGooglePayReady = isGooglePayReady,
@@ -354,16 +354,6 @@ internal data class PaymentMethodMetadata(
                 as? ElementsSession.Customer.Components.MobilePaymentElement.Enabled
             return mobilePaymentElement?.isPaymentMethodSetAsDefaultEnabled
                 ?: false
-        }
-
-        private fun getDefaultPaymentMethodsEnabledForCustomerSheet(elementsSession: ElementsSession): Boolean {
-            val customerSheetComponent = elementsSession.customer?.session?.components?.customerSheet
-            return when (customerSheetComponent) {
-                is ElementsSession.Customer.Components.CustomerSheet.Enabled ->
-                    customerSheetComponent.isPaymentMethodSyncDefaultEnabled
-                ElementsSession.Customer.Components.CustomerSheet.Disabled,
-                null -> false
-            }
         }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -234,7 +234,6 @@ class DefaultCustomerSheetLoaderTest {
         )
         val loader = createCustomerSheetLoader(
             paymentMethods = expectedPaymentMethods.plus(sepaPaymentMethod),
-            // Setting a saved selection here so we can validate that it is not used.
             isPaymentMethodSyncDefaultEnabled = true,
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -226,6 +226,25 @@ class DefaultCustomerSheetLoaderTest {
     }
 
     @Test
+    fun `when default payment method feature is enabled, sepa PMs are filtered out`() = runTest {
+        val sepaPaymentMethod = PaymentMethodFixtures.SEPA_DEBIT_PAYMENT_METHOD
+        val expectedPaymentMethods = listOf(
+            PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+            PaymentMethodFixtures.US_BANK_ACCOUNT
+        )
+        val loader = createCustomerSheetLoader(
+            paymentMethods = expectedPaymentMethods.plus(sepaPaymentMethod),
+            // Setting a saved selection here so we can validate that it is not used.
+            isPaymentMethodSyncDefaultEnabled = true,
+        )
+
+        val config = CustomerSheet.Configuration(merchantDisplayName = "Example")
+
+        val state = loader.load(config).getOrThrow()
+        assertThat(state.customerPaymentMethods).containsExactlyElementsIn(expectedPaymentMethods).inOrder()
+    }
+
+    @Test
     fun `When the FC unavailable, flag disabled, us bank not in intent, then us bank account is not available`() = runTest {
         val loader = createCustomerSheetLoader(
             isFinancialConnectionsAvailable = { false },

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -837,7 +837,8 @@ internal class PaymentMethodMetadataTest {
             paymentMethodSaveConsentBehavior = paymentMethodSaveConsentBehavior,
             sharedDataSpecs = listOf(SharedDataSpec("card")),
             isGooglePayReady = true,
-            isFinancialConnectionsAvailable = { false }
+            isFinancialConnectionsAvailable = { false },
+            isPaymentMethodSyncDefaultEnabled = false,
         )
 
         val expectedMetadata = PaymentMethodMetadata(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Filter SEPA payment methods out of CustomerSheet when sync default feature enabled

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
We don't support setting SEPA payment methods as a default payment method in CustomerSheet. We need to hide these PMs in CustomerSheet so that users don't try to set it as their default.

https://jira.corp.stripe.com/browse/MOBILESDK-2687

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified