### PR TITLE
Hide GooglePay in CustomerSheet when set as default feature is enabled

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -193,7 +193,7 @@ internal class CustomerSheetViewModel(
             isLiveMode = isLiveModeProvider(),
             canRemovePaymentMethods = customerState.canRemove,
             primaryButtonVisible = primaryButtonVisible,
-            isGooglePayEnabled = paymentMethodMetadata?.isGooglePayReady == true,
+            showGooglePay = shouldShowGooglePay(paymentMethodMetadata),
             isEditing = userCanEditAndIsEditing,
             isProcessing = selectionConfirmationState.isConfirming,
             errorMessage = selectionConfirmationState.error,
@@ -1220,7 +1220,7 @@ internal class CustomerSheetViewModel(
             isModifiable(method, cbcEligibility)
         }
 
-        val canShowSavedPaymentMethods = paymentMethods.isNotEmpty() || metadata?.isGooglePayReady == true
+        val canShowSavedPaymentMethods = paymentMethods.isNotEmpty() || shouldShowGooglePay(metadata)
     }
 
     private data class SelectionConfirmationState(
@@ -1228,8 +1228,13 @@ internal class CustomerSheetViewModel(
         val error: String?,
     )
 
-    private companion object {
+    internal companion object {
         const val REMOVAL_TRANSITION_DELAY = 50L
+
+        fun shouldShowGooglePay(paymentMethodMetadata: PaymentMethodMetadata?): Boolean {
+            return paymentMethodMetadata?.isGooglePayReady == true &&
+                paymentMethodMetadata.customerMetadata?.isPaymentMethodSetAsDefaultEnabled != true
+        }
     }
 
     class Factory(

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewState.kt
@@ -60,7 +60,7 @@ internal sealed class CustomerSheetViewState(
         override val isLiveMode: Boolean,
         override val isProcessing: Boolean,
         val isEditing: Boolean,
-        val isGooglePayEnabled: Boolean,
+        val showGooglePay: Boolean,
         val primaryButtonVisible: Boolean,
         val canEdit: Boolean,
         val canRemovePaymentMethods: Boolean,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
@@ -137,7 +137,7 @@ internal fun SelectPaymentMethod(
 
         val paymentOptionsState = PaymentOptionsStateFactory.create(
             paymentMethods = viewState.savedPaymentMethods,
-            showGooglePay = viewState.isGooglePayEnabled,
+            showGooglePay = viewState.showGooglePay,
             showLink = false,
             currentSelection = viewState.paymentSelection,
             nameProvider = paymentMethodNameProvider,

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -84,7 +84,7 @@ internal class CustomerSheetScreenshotTest {
         isLiveMode = false,
         isProcessing = false,
         isEditing = false,
-        isGooglePayEnabled = false,
+        showGooglePay = false,
         primaryButtonVisible = false,
         canEdit = true,
         canRemovePaymentMethods = true,
@@ -200,7 +200,7 @@ internal class CustomerSheetScreenshotTest {
                         savedPaymentMethods.first()
                     ),
                     isEditing = true,
-                    isGooglePayEnabled = true,
+                    showGooglePay = true,
                     errorMessage = "This is an error message.",
                 ),
                 paymentMethodNameProvider = {
@@ -218,7 +218,7 @@ internal class CustomerSheetScreenshotTest {
                 viewState = selectPaymentMethodViewState.copy(
                     title = "Screenshot testing",
                     paymentSelection = PaymentSelection.GooglePay,
-                    isGooglePayEnabled = true,
+                    showGooglePay = true,
                     errorMessage = "This is an error message.",
                 ),
                 paymentMethodNameProvider = { it!!.resolvableString },
@@ -239,7 +239,7 @@ internal class CustomerSheetScreenshotTest {
                     paymentSelection = PaymentSelection.Saved(
                         PaymentMethodFixtures.US_BANK_ACCOUNT
                     ),
-                    isGooglePayEnabled = false,
+                    showGooglePay = false,
                     primaryButtonVisible = true,
                     mandateText = "Some mandate text.".resolvableString
                 ),

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -1268,7 +1268,7 @@ class CustomerSheetViewModelTest {
         )
 
         viewModel.viewState.test {
-            assertThat(awaitViewState<SelectPaymentMethod>().isGooglePayEnabled).isFalse()
+            assertThat(awaitViewState<SelectPaymentMethod>().showGooglePay).isFalse()
         }
     }
 
@@ -1286,7 +1286,47 @@ class CustomerSheetViewModelTest {
         )
 
         viewModel.viewState.test {
-            assertThat(awaitViewState<SelectPaymentMethod>().isGooglePayEnabled).isTrue()
+            assertThat(awaitViewState<SelectPaymentMethod>().showGooglePay).isTrue()
+        }
+    }
+
+    @Test
+    fun `When default PM feature enabled, then Google Pay should not be shown`() = runTest(testDispatcher) {
+        val viewModel = createViewModel(
+            workContext = testDispatcher,
+            configuration = CustomerSheet.Configuration(
+                merchantDisplayName = "Example",
+                googlePayEnabled = true,
+            ),
+            customerSheetLoader = FakeCustomerSheetLoader(
+                customerPaymentMethods = listOf(CARD_PAYMENT_METHOD),
+                isGooglePayAvailable = true,
+                isPaymentMethodSyncDefaultEnabled = true,
+            ),
+        )
+
+        viewModel.viewState.test {
+            assertThat(awaitViewState<SelectPaymentMethod>().showGooglePay).isFalse()
+        }
+    }
+
+    @Test
+    fun `When default PM feature enabled and no saved PMs, then initial screen is add payment method`() = runTest(testDispatcher) {
+        val viewModel = createViewModel(
+            workContext = testDispatcher,
+            configuration = CustomerSheet.Configuration(
+                merchantDisplayName = "Example",
+                googlePayEnabled = true,
+            ),
+            customerSheetLoader = FakeCustomerSheetLoader(
+                customerPaymentMethods = emptyList(),
+                isGooglePayAvailable = true,
+                isPaymentMethodSyncDefaultEnabled = true,
+            ),
+        )
+
+        viewModel.viewState.test {
+            assertThat(awaitItem()).isInstanceOf(AddPaymentMethod::class.java)
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/FakeCustomerSheetLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/FakeCustomerSheetLoader.kt
@@ -32,6 +32,7 @@ internal class FakeCustomerSheetLoader(
         canRemovePaymentMethods = true,
         canRemoveLastPaymentMethod = true,
     ),
+    private val isPaymentMethodSyncDefaultEnabled: Boolean = false,
 ) : CustomerSheetLoader {
 
     override suspend fun load(configuration: CustomerSheet.Configuration): Result<CustomerSheetState.Full> {
@@ -48,6 +49,7 @@ internal class FakeCustomerSheetLoader(
                         financialConnectionsAvailable = financialConnectionsAvailable,
                         paymentMethodOrder = configuration.paymentMethodOrder,
                         isGooglePayReady = isGooglePayAvailable,
+                        isPaymentMethodSetAsDefaultEnabled = isPaymentMethodSyncDefaultEnabled,
                     ),
                     supportedPaymentMethods = supportedPaymentMethods,
                     customerPaymentMethods = customerPaymentMethods,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Hide GooglePay in CustomerSheet when set as default feature is enabled

This only hides GooglePay within CustomerSheet, it doesn't prevent us from returning GooglePay as the initial user selection. I'll follow up with that change.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-2687

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified