### PR TITLE
Add additionalHorizontalInsetsDp to FlatWithRadio and FlatWithCheckmark

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/AppearanceBottomSheetDialogFragment.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/AppearanceBottomSheetDialogFragment.kt
@@ -716,10 +716,19 @@ private fun EmbeddedPicker(
     }
     Divider()
 
-    IncrementDecrementItem("additionalInsetsDp", embeddedAppearance.additionalInsetsDp) {
+    IncrementDecrementItem("additionalInsetsDp", embeddedAppearance.additionalVerticalInsetsDp) {
         updateEmbedded(
             embeddedAppearance.copy(
-                additionalInsetsDp = it
+                additionalVerticalInsetsDp = it
+            )
+        )
+    }
+    Divider()
+
+    IncrementDecrementItem("additionalHorizontalInsetsDp", embeddedAppearance.additionalHorizontalInsets) {
+        updateEmbedded(
+            embeddedAppearance.copy(
+                additionalHorizontalInsets = it
             )
         )
     }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/EmbeddedAppearanceSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/EmbeddedAppearanceSettingsDefinition.kt
@@ -51,7 +51,8 @@ internal data class EmbeddedAppearance(
     val separatorThicknessDp: Float = 1.0f,
     val startSeparatorInset: Float = 0.0f,
     val endSeparatorInset: Float = 0.0f,
-    val additionalInsetsDp: Float = 4.0f,
+    val additionalVerticalInsetsDp: Float = 4.0f,
+    val additionalHorizontalInsets: Float = 0.0f,
     val checkmarkInsetsDp: Float = 12.0f,
     val floatingButtonSpacingDp: Float = 12.0f,
     val topSeparatorEnabled: Boolean = true,
@@ -72,7 +73,8 @@ internal data class EmbeddedAppearance(
                 bottomSeparatorEnabled = bottomSeparatorEnabled,
                 selectedColor = selectedColor,
                 unselectedColor = unselectedColor,
-                additionalInsetsDp = additionalInsetsDp
+                additionalVerticalInsetsDp = additionalVerticalInsetsDp,
+                additionalHorizontalInsetsDp = additionalHorizontalInsets
             )
             EmbeddedRow.FlatWithCheckmark -> PaymentSheet.Appearance.Embedded.RowStyle.FlatWithCheckmark(
                 separatorThicknessDp = separatorThicknessDp,
@@ -83,11 +85,12 @@ internal data class EmbeddedAppearance(
                 bottomSeparatorEnabled = bottomSeparatorEnabled,
                 checkmarkColor = checkmarkColor,
                 checkmarkInsetDp = checkmarkInsetsDp,
-                additionalInsetsDp = additionalInsetsDp
+                additionalVerticalInsetsDp = additionalVerticalInsetsDp,
+                additionalHorizontalInsetsDp = additionalHorizontalInsets
             )
             EmbeddedRow.FloatingButton -> PaymentSheet.Appearance.Embedded.RowStyle.FloatingButton(
                 spacingDp = floatingButtonSpacingDp,
-                additionalInsetsDp = additionalInsetsDp
+                additionalInsetsDp = additionalVerticalInsetsDp
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContent.kt
@@ -27,7 +27,7 @@ internal data class EmbeddedContent(
         StripeTheme {
             Column(
                 modifier = Modifier
-                    .background(MaterialTheme.colors.surface)
+                    .background(MaterialTheme.colors.background)
                     .padding(top = 8.dp)
                     .animateContentSize()
             ) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -1014,7 +1014,11 @@ class PaymentSheet internal constructor(
                      * Additional vertical insets applied to a payment method row.
                      * - Note: Increasing this value increases the height of each row.
                      */
-                    internal val additionalInsetsDp: Float,
+                    internal val additionalVerticalInsetsDp: Float,
+                    /**
+                     * Additional horizontal insets applied to a payment method row.
+                     */
+                    internal val additionalHorizontalInsetsDp: Float,
                 ) : RowStyle() {
                     constructor(
                         context: Context,
@@ -1026,7 +1030,8 @@ class PaymentSheet internal constructor(
                         bottomSeparatorEnabled: Boolean,
                         selectedColor: Color,
                         unselectedColor: Color,
-                        additionalInsetsDp: Int
+                        additionalVerticalInsetsDp: Int,
+                        additionalHorizontalInsetsDp: Int
                     ) : this(
                         separatorThicknessDp = context.getRawValueFromDimenResource(separatorThicknessDp),
                         separatorColor = separatorColor.toArgb(),
@@ -1036,7 +1041,10 @@ class PaymentSheet internal constructor(
                         bottomSeparatorEnabled = bottomSeparatorEnabled,
                         selectedColor = selectedColor.toArgb(),
                         unselectedColor = unselectedColor.toArgb(),
-                        additionalInsetsDp = context.getRawValueFromDimenResource(additionalInsetsDp)
+                        additionalVerticalInsetsDp = context.getRawValueFromDimenResource(additionalVerticalInsetsDp),
+                        additionalHorizontalInsetsDp = context.getRawValueFromDimenResource(
+                            additionalHorizontalInsetsDp
+                        )
                     )
 
                     override fun hasSeparators() = true
@@ -1052,7 +1060,8 @@ class PaymentSheet internal constructor(
                             bottomSeparatorEnabled = StripeThemeDefaults.flat.bottomSeparatorEnabled,
                             selectedColor = StripeThemeDefaults.colorsLight.materialColors.primary.toArgb(),
                             unselectedColor = StripeThemeDefaults.colorsLight.componentBorder.toArgb(),
-                            additionalInsetsDp = StripeThemeDefaults.embeddedCommon.additionalInsetsDp
+                            additionalVerticalInsetsDp = StripeThemeDefaults.embeddedCommon.additionalInsetsDp,
+                            additionalHorizontalInsetsDp = StripeThemeDefaults.embeddedCommon.additionalInsetsDp
                         )
 
                         val defaultDark = FlatWithRadio(
@@ -1064,7 +1073,8 @@ class PaymentSheet internal constructor(
                             bottomSeparatorEnabled = StripeThemeDefaults.flat.bottomSeparatorEnabled,
                             selectedColor = StripeThemeDefaults.colorsDark.materialColors.primary.toArgb(),
                             unselectedColor = StripeThemeDefaults.colorsDark.componentBorder.toArgb(),
-                            additionalInsetsDp = StripeThemeDefaults.embeddedCommon.additionalInsetsDp
+                            additionalVerticalInsetsDp = StripeThemeDefaults.embeddedCommon.additionalInsetsDp,
+                            additionalHorizontalInsetsDp = StripeThemeDefaults.embeddedCommon.additionalInsetsDp
                         )
                     }
                 }
@@ -1117,7 +1127,11 @@ class PaymentSheet internal constructor(
                      * Additional vertical insets applied to a payment method row.
                      * - Note: Increasing this value increases the height of each row.
                      */
-                    internal val additionalInsetsDp: Float,
+                    internal val additionalVerticalInsetsDp: Float,
+                    /**
+                     * Additional horizontal insets applied to a payment method row.
+                     */
+                    internal val additionalHorizontalInsetsDp: Float,
                 ) : RowStyle() {
                     constructor(
                         context: Context,
@@ -1129,7 +1143,8 @@ class PaymentSheet internal constructor(
                         bottomSeparatorEnabled: Boolean,
                         checkmarkColor: Color,
                         checkmarkInsetDp: Int,
-                        additionalInsetsDp: Int
+                        additionalVerticalInsetsDp: Int,
+                        additionalHorizontalInsetsDp: Int
                     ) : this(
                         separatorThicknessDp = context.getRawValueFromDimenResource(separatorThicknessDp),
                         separatorColor = separatorColor.toArgb(),
@@ -1139,7 +1154,10 @@ class PaymentSheet internal constructor(
                         bottomSeparatorEnabled = bottomSeparatorEnabled,
                         checkmarkColor = checkmarkColor.toArgb(),
                         checkmarkInsetDp = context.getRawValueFromDimenResource(checkmarkInsetDp),
-                        additionalInsetsDp = context.getRawValueFromDimenResource(additionalInsetsDp)
+                        additionalVerticalInsetsDp = context.getRawValueFromDimenResource(additionalVerticalInsetsDp),
+                        additionalHorizontalInsetsDp = context.getRawValueFromDimenResource(
+                            additionalHorizontalInsetsDp
+                        )
                     )
 
                     override fun hasSeparators() = true
@@ -1155,7 +1173,8 @@ class PaymentSheet internal constructor(
                             bottomSeparatorEnabled = StripeThemeDefaults.flat.bottomSeparatorEnabled,
                             checkmarkColor = StripeThemeDefaults.colorsLight.materialColors.primary.toArgb(),
                             checkmarkInsetDp = StripeThemeDefaults.embeddedCommon.checkmarkInsetDp,
-                            additionalInsetsDp = StripeThemeDefaults.embeddedCommon.additionalInsetsDp
+                            additionalVerticalInsetsDp = StripeThemeDefaults.embeddedCommon.additionalInsetsDp,
+                            additionalHorizontalInsetsDp = StripeThemeDefaults.embeddedCommon.additionalInsetsDp,
                         )
 
                         val defaultDark = FlatWithCheckmark(
@@ -1167,7 +1186,8 @@ class PaymentSheet internal constructor(
                             bottomSeparatorEnabled = StripeThemeDefaults.flat.bottomSeparatorEnabled,
                             checkmarkColor = StripeThemeDefaults.colorsDark.materialColors.primary.toArgb(),
                             checkmarkInsetDp = StripeThemeDefaults.embeddedCommon.checkmarkInsetDp,
-                            additionalInsetsDp = StripeThemeDefaults.embeddedCommon.additionalInsetsDp
+                            additionalVerticalInsetsDp = StripeThemeDefaults.embeddedCommon.additionalInsetsDp,
+                            additionalHorizontalInsetsDp = StripeThemeDefaults.embeddedCommon.additionalInsetsDp
                         )
                     }
                 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodRowButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodRowButton.kt
@@ -140,7 +140,7 @@ private fun RowButtonOuterContent(
                 isSelected = isSelected,
                 contentPaddingValues = PaddingValues(
                     horizontal = 0.dp,
-                    vertical = contentPaddingValues + style.additionalInsetsDp.dp
+                    vertical = contentPaddingValues + style.additionalVerticalInsetsDp.dp
                 ),
                 verticalArrangement = Arrangement.Center,
                 trailingContent = trailingContent,
@@ -156,7 +156,7 @@ private fun RowButtonOuterContent(
                 isSelected = isSelected,
                 contentPaddingValues = PaddingValues(
                     horizontal = 0.dp,
-                    vertical = contentPaddingValues + style.additionalInsetsDp.dp
+                    vertical = contentPaddingValues + style.additionalVerticalInsetsDp.dp
                 ),
                 verticalArrangement = Arrangement.Center,
                 onClick = onClick,
@@ -210,6 +210,7 @@ private fun RowButtonRadioOuterContent(
     Row(
         modifier = modifier
             .background(MaterialTheme.stripeColors.component)
+            .padding(horizontal = style.additionalHorizontalInsetsDp.dp)
     ) {
         RadioButton(
             selected = isSelected,
@@ -246,7 +247,8 @@ private fun RowButtonCheckmarkOuterContent(
 ) {
     Row(
         modifier = modifier
-            .background(MaterialTheme.stripeColors.component),
+            .background(MaterialTheme.stripeColors.component)
+            .padding(horizontal = style.additionalHorizontalInsetsDp.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Column(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Adds additionalHorizontalInsetsDp as an EmbeddedAppearance param for RowStyles FlatWithRadio and FlatWithCheckmark

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Allow integrators to control internal padding of rows

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified


https://github.com/user-attachments/assets/0d8863dc-1e0b-4089-8dc2-1d2e347b59af
