### PR TITLE
Explicit feature flags for Link

### DIFF
--- a/payments-core-testing/src/main/java/com/stripe/android/testing/FeatureFlagTestRule.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/FeatureFlagTestRule.kt
@@ -23,7 +23,11 @@ class FeatureFlagTestRule(
         }
     }
 
-    fun setEnabled(isEnabled: Boolean) {
-        featureFlag.setEnabled(isEnabled)
+    fun setEnabled(isEnabled: Boolean?) {
+        if (isEnabled != null) {
+            featureFlag.setEnabled(isEnabled)
+            return
+        }
+        featureFlag.reset()
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/gate/DefaultLinkGate.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/gate/DefaultLinkGate.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.link.gate
 
+import com.stripe.android.core.utils.FeatureFlag
 import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.link.LinkConfiguration
 import javax.inject.Inject
@@ -12,7 +13,11 @@ internal class DefaultLinkGate @Inject constructor(
             if (configuration.stripeIntent.isLiveMode) {
                 return useAttestationEndpoints
             }
-            return FeatureFlags.nativeLinkEnabled.isEnabled
+            return when (FeatureFlags.nativeLinkEnabled.value) {
+                FeatureFlag.Flag.Disabled -> false
+                FeatureFlag.Flag.Enabled -> true
+                FeatureFlag.Flag.NotSet -> useAttestationEndpoints
+            }
         }
 
     override val useAttestationEndpoints: Boolean
@@ -20,7 +25,11 @@ internal class DefaultLinkGate @Inject constructor(
             if (configuration.stripeIntent.isLiveMode) {
                 return configuration.useAttestationEndpointsForLink
             }
-            return FeatureFlags.nativeLinkAttestationEnabled.isEnabled
+            return when (FeatureFlags.nativeLinkAttestationEnabled.value) {
+                FeatureFlag.Flag.Disabled -> false
+                FeatureFlag.Flag.Enabled -> true
+                FeatureFlag.Flag.NotSet -> configuration.useAttestationEndpointsForLink
+            }
         }
 
     override val suppress2faModal: Boolean

--- a/paymentsheet/src/test/java/com/stripe/android/link/gate/DefaultLinkGateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/gate/DefaultLinkGateTest.kt
@@ -43,6 +43,18 @@ internal class DefaultLinkGateTest {
         assertThat(gate.useNativeLink).isFalse()
     }
 
+    @Test
+    fun `useNativeLink - test mode - returns attestation value when feature flag not set`() {
+        nativeLinkFeatureFlagTestRule.setEnabled(null)
+        attestationFeatureFlagTestRule.setEnabled(true)
+        val gate = gate(isLiveMode = false, useAttestationEndpoints = true)
+        assertThat(gate.useNativeLink).isTrue()
+
+        attestationFeatureFlagTestRule.setEnabled(false)
+        val gateWithoutAttestation = gate(isLiveMode = false, useAttestationEndpoints = false)
+        assertThat(gateWithoutAttestation.useNativeLink).isFalse()
+    }
+
     // useNativeLink tests for live mode
     @Test
     fun `useNativeLink - live mode - returns true when attestation enabled`() {
@@ -56,6 +68,18 @@ internal class DefaultLinkGateTest {
         val gate = gate(isLiveMode = true, useAttestationEndpoints = false)
 
         assertThat(gate.useNativeLink).isFalse()
+    }
+
+    @Test
+    fun `useNativeLink - live mode - returns attestation value when feature flag not set`() {
+        nativeLinkFeatureFlagTestRule.setEnabled(null)
+        attestationFeatureFlagTestRule.setEnabled(true)
+        val gate = gate(isLiveMode = true, useAttestationEndpoints = true)
+        assertThat(gate.useNativeLink).isTrue()
+
+        attestationFeatureFlagTestRule.setEnabled(false)
+        val gateWithoutAttestation = gate(isLiveMode = true, useAttestationEndpoints = false)
+        assertThat(gateWithoutAttestation.useNativeLink).isFalse()
     }
 
     // useAttestationEndpoints tests for test mode
@@ -75,6 +99,16 @@ internal class DefaultLinkGateTest {
         assertThat(gate.useAttestationEndpoints).isFalse()
     }
 
+    @Test
+    fun `useAttestationEndpoints - test mode - returns configuration value when feature flag not set`() {
+        attestationFeatureFlagTestRule.setEnabled(null)
+        val gate = gate(isLiveMode = false, useAttestationEndpoints = true)
+        assertThat(gate.useAttestationEndpoints).isTrue()
+
+        val gateWithoutAttestation = gate(isLiveMode = false, useAttestationEndpoints = false)
+        assertThat(gateWithoutAttestation.useAttestationEndpoints).isFalse()
+    }
+
     // useAttestationEndpoints tests for live mode
     @Test
     fun `useAttestationEndpoints - live mode - returns true when configuration enabled`() {
@@ -88,6 +122,16 @@ internal class DefaultLinkGateTest {
         val gate = gate(isLiveMode = true, useAttestationEndpoints = false)
 
         assertThat(gate.useAttestationEndpoints).isFalse()
+    }
+
+    @Test
+    fun `useAttestationEndpoints - live mode - returns configuration value when feature flag not set`() {
+        attestationFeatureFlagTestRule.setEnabled(null)
+        val gate = gate(isLiveMode = true, useAttestationEndpoints = true)
+        assertThat(gate.useAttestationEndpoints).isTrue()
+
+        val gateWithoutAttestation = gate(isLiveMode = true, useAttestationEndpoints = false)
+        assertThat(gateWithoutAttestation.useAttestationEndpoints).isFalse()
     }
 
     // Feature flag independence tests

--- a/stripe-core/api/stripe-core.api
+++ b/stripe-core/api/stripe-core.api
@@ -341,6 +341,27 @@ public final class com/stripe/android/core/strings/transformations/Replace$Creat
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/core/utils/FeatureFlag$Flag$Disabled : com/stripe/android/core/utils/FeatureFlag$Flag {
+	public static final field INSTANCE Lcom/stripe/android/core/utils/FeatureFlag$Flag$Disabled;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/core/utils/FeatureFlag$Flag$Enabled : com/stripe/android/core/utils/FeatureFlag$Flag {
+	public static final field INSTANCE Lcom/stripe/android/core/utils/FeatureFlag$Flag$Enabled;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/core/utils/FeatureFlag$Flag$NotSet : com/stripe/android/core/utils/FeatureFlag$Flag {
+	public static final field INSTANCE Lcom/stripe/android/core/utils/FeatureFlag$Flag$NotSet;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/stripe/android/core/version/StripeSdkVersion {
 	public static final field INSTANCE Lcom/stripe/android/core/version/StripeSdkVersion;
 	public static final field VERSION Ljava/lang/String;

--- a/stripe-core/src/main/java/com/stripe/android/core/utils/FeatureFlags.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/FeatureFlags.kt
@@ -46,6 +46,7 @@ class FeatureFlag(
         overrideEnabledValue = null
     }
 
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     sealed interface Flag {
         data object Enabled : Flag
         data object Disabled : Flag

--- a/stripe-core/src/main/java/com/stripe/android/core/utils/FeatureFlags.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/FeatureFlags.kt
@@ -26,11 +26,29 @@ class FeatureFlag(
             false
         }
 
+    val value: Flag
+        get() {
+            if (BuildConfig.DEBUG.not()) {
+                return Flag.NotSet
+            }
+            return when (overrideEnabledValue) {
+                true -> Flag.Enabled
+                false -> Flag.Disabled
+                null -> Flag.NotSet
+            }
+        }
+
     fun setEnabled(isEnabled: Boolean) {
         overrideEnabledValue = isEnabled
     }
 
     fun reset() {
         overrideEnabledValue = null
+    }
+
+    sealed interface Flag {
+        data object Enabled : Flag
+        data object Disabled : Flag
+        data object NotSet : Flag
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Explicit feature flags for Link. This will allow us to keep link settings in the playground while relying on backend flags outside paymentsheet

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Currently, feature flags default to `false` in release mode, which disables Link functionality. This works for development but not for merchants using our SDK. By changing the default to `NotSet` in release mode, we can fall back to backend flags, ensuring Link remains available for merchants.

For merchant apps in debug mode, we also want to use backend flags. Setting the default to `NotSet` allows us to handle both scenarios consistently.
# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
