### PR TITLE
Fix `Customer Session` settings title for enabling/disabling SPM redisplay

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionRedisplaySettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionRedisplaySettingsDefinition.kt
@@ -5,7 +5,7 @@ import com.stripe.android.paymentsheet.example.playground.model.FeatureState
 
 internal object CustomerSessionRedisplaySettingsDefinition : BooleanSettingsDefinition(
     defaultValue = true,
-    displayName = "Customer Session Allow Redisplay",
+    displayName = "Customer Session Redisplay",
     key = "customer_session_payment_method_redisplay"
 ) {
     override fun applicable(configurationData: PlaygroundConfigurationData): Boolean {


### PR DESCRIPTION
# Summary
Fix `Customer Session` settings title for enabling/disabling SPM redisplay

# Motivation
Title does not reflect actual meaning of settings

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified