### PR TITLE
Increase timeouts for native Link tests

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -796,20 +797,28 @@ internal class PlaygroundTestDriver(
         composeTestRule.waitForIdle()
 
         // Expect the OTP dialog
-        composeTestRule.waitUntilExactlyOneExists(hasTestTag("OTP-0"))
+        composeTestRule.waitUntilExactlyOneExists(
+            matcher = hasTestTag("OTP-0"),
+            timeoutMillis = DEFAULT_UI_TIMEOUT.inWholeMilliseconds,
+        )
 
         composeTestRule
             .onNodeWithTag("OTP-0")
             .performTextInput("000000")
 
-        composeTestRule.waitUntilExactlyOneExists(hasTestTag("collapsed_wallet_row_tag"))
+        composeTestRule.waitUntilExactlyOneExists(
+            matcher = hasTestTag("collapsed_wallet_row_tag"),
+            timeoutMillis = DEFAULT_UI_TIMEOUT.inWholeMilliseconds,
+        )
 
         composeTestRule
             .onNodeWithTag("collapsed_wallet_row_tag")
             .performClick()
 
+        // We might have more than one bank account
         composeTestRule
-            .onNodeWithText("Test Institution")
+            .onAllNodesWithText("Test Institution")
+            .onFirst()
             .performClick()
 
         composeTestRule


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request increases the timeouts in the native Link UI tests. The default of only one second is a tad too aggressive.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
