### PR TITLE
Fix an issue where sheets were launched twice when double clicked.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
@@ -94,6 +94,7 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
             )
             return
         }
+        if (sheetStateHolder.sheetIsOpen) return
         sheetStateHolder.sheetIsOpen = true
         selectionHolder.setTemporary(code)
         val args = FormContract.Args(
@@ -112,6 +113,7 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
         customerState: CustomerState,
         selection: PaymentSelection?,
     ) {
+        if (sheetStateHolder.sheetIsOpen) return
         sheetStateHolder.sheetIsOpen = true
         val args = ManageContract.Args(
             paymentMethodMetadata = paymentMethodMetadata,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
@@ -70,6 +70,15 @@ internal class DefaultEmbeddedSheetLauncherTest {
     }
 
     @Test
+    fun `launchForm is not launched again when the sheet is already open`() = testScenario {
+        val code = "test_code"
+        val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
+        val state = EmbeddedConfirmationStateFixtures.defaultState()
+        sheetStateHolder.sheetIsOpen = true
+        sheetLauncher.launchForm(code, paymentMethodMetadata, false, state)
+    }
+
+    @Test
     fun `formActivityLauncher clears selection holder and invokes callback on complete result`() = testScenario {
         sheetStateHolder.sheetIsOpen = true
         selectionHolder.setTemporary("test_code")
@@ -111,6 +120,14 @@ internal class DefaultEmbeddedSheetLauncherTest {
 
         assertThat(launchCall).isEqualTo(expectedArgs)
         assertThat(sheetStateHolder.sheetIsOpen).isTrue()
+    }
+
+    @Test
+    fun `launchManage is not launched again when the sheet is already open`() = testScenario {
+        val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
+        val customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
+        sheetStateHolder.sheetIsOpen = true
+        sheetLauncher.launchManage(paymentMethodMetadata, customerState, PaymentSelection.GooglePay)
     }
 
     @Test


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
We weren't debouncing clicks, so the activities would get launched twice if double tapped.
