### PR TITLE
Remove CameraCore asserts

### DIFF
--- a/camera-core/src/main/java/com/stripe/android/camera/framework/image/Image.kt
+++ b/camera-core/src/main/java/com/stripe/android/camera/framework/image/Image.kt
@@ -88,13 +88,6 @@ fun cropCameraPreviewToSquare(
     previewBounds: Rect,
     viewFinder: Rect
 ): Bitmap {
-    require(
-        viewFinder.left >= previewBounds.left &&
-            viewFinder.right <= previewBounds.right &&
-            viewFinder.top >= previewBounds.top &&
-            viewFinder.bottom <= previewBounds.bottom
-    ) { "Card finder is outside preview image bounds" }
-
     val visiblePreview = getVisiblePreview(previewBounds)
     val squareViewFinder = maxAspectRatioInSize(visiblePreview, 1F).centerOn(viewFinder)
 

--- a/camera-core/src/main/java/com/stripe/android/camera/framework/image/Image.kt
+++ b/camera-core/src/main/java/com/stripe/android/camera/framework/image/Image.kt
@@ -42,13 +42,6 @@ fun determineViewFinderCrop(
     previewBounds: Rect,
     viewFinder: Rect
 ): Rect {
-    require(
-        viewFinder.left >= previewBounds.left &&
-            viewFinder.right <= previewBounds.right &&
-            viewFinder.top >= previewBounds.top &&
-            viewFinder.bottom <= previewBounds.bottom
-    ) { "View finder $viewFinder is outside preview image bounds $previewBounds" }
-
     // Scale the cardFinder to match the full image
     return previewBounds
         .projectRegionOfInterest(
@@ -74,13 +67,6 @@ fun cropCameraPreviewToViewFinder(
     previewBounds: Rect,
     viewFinder: Rect
 ): Bitmap {
-    require(
-        viewFinder.left >= previewBounds.left &&
-            viewFinder.right <= previewBounds.right &&
-            viewFinder.top >= previewBounds.top &&
-            viewFinder.bottom <= previewBounds.bottom
-    ) { "View finder $viewFinder is outside preview image bounds $previewBounds" }
-
     return cameraPreviewImage.crop(
         determineViewFinderCrop(cameraPreviewImage.size(), previewBounds, viewFinder)
     )


### PR DESCRIPTION
# Summary
Remove non-fatal asserts from CardScan.

# Motivation
These asserts were causing crashes in CardScan, which is disruptive to the checkout process. We should treat these as non-fatal for now, as it's possible the scanner will still work. Ideally we'd display an error, but we have plans to move away from this card scanner soon.

# Testing
- [] Added tests
- [ ] Modified tests
- [x] Manually verified

# Changelog
Added