### PR TITLE
Speed up CI.

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -224,6 +224,9 @@ workflows:
           inputs:
             - content: ./gradlew paymentsheet-example:executeScreenshotTests -Precord -Pandroid.testInstrumentationRunnerArguments.package=com.stripe.android.screenshot -Dorg.gradle.jvmargs="--add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/java.nio.channels=ALL-UNNAMED --add-exports java.base/sun.nio.ch=ALL-UNNAMED"
       - script@1:
+          inputs:
+            - content: asdf install ruby 3.2.4
+      - script@1:
           title: Check updated screenshots
           inputs:
             - content: ruby scripts/check_for_changed_paymentsheet_screenshots.rb
@@ -327,6 +330,9 @@ workflows:
     steps:
       - script@1:
           inputs:
+            - content: asdf install ruby 3.2.4
+      - script@1:
+          inputs:
             - content: ruby scripts/dependencies/update_transitive_dependencies.rb
       - script@1:
           inputs:
@@ -386,9 +392,6 @@ workflows:
                 -no-boot-anim
   prepare_all:
     steps:
-      - script@1:
-          inputs:
-            - content: asdf install ruby 3.2.4
       - activate-ssh-key@4:
           run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
       - git-clone@8: { }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Installing ruby takes ~2 minutes, and we were doing it for every type of check, but we only needed it for a few. So only installing it when needed.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
CI go brrrr
