### PR TITLE
Retrieve default PM from backend when default PMs behavior enabled

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
@@ -134,7 +134,7 @@ class CustomerSheet internal constructor(
         return coroutineScope {
             val savedSelectionDeferred = async {
                 CustomerSheetHacks.savedSelectionDataSource.await().retrieveSavedSelection(
-                    null
+                    customerSessionElementsSession = null
                 ).toResult()
             }
             val paymentMethodsDeferred = async {

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
@@ -133,7 +133,9 @@ class CustomerSheet internal constructor(
 
         return coroutineScope {
             val savedSelectionDeferred = async {
-                CustomerSheetHacks.savedSelectionDataSource.await().retrieveSavedSelection().toResult()
+                CustomerSheetHacks.savedSelectionDataSource.await().retrieveSavedSelection(
+                    null
+                ).toResult()
             }
             val paymentMethodsDeferred = async {
                 CustomerSheetHacks.paymentMethodDataSource.await().retrievePaymentMethods().toResult()

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -11,7 +11,7 @@ import com.stripe.android.customersheet.util.CustomerSheetHacks
 import com.stripe.android.customersheet.util.filterToSupportedPaymentMethods
 import com.stripe.android.customersheet.util.getDefaultPaymentMethodsEnabledForCustomerSheet
 import com.stripe.android.customersheet.util.sortPaymentMethods
-import com.stripe.android.customersheet.util.getDefaultPaymentMethod
+import com.stripe.android.customersheet.util.getDefaultPaymentMethodAsPaymentSelection
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayRepository
 import com.stripe.android.lpmfoundations.luxe.LpmRepository
@@ -171,7 +171,7 @@ internal class DefaultCustomerSheetLoader(
         paymentMethods: List<PaymentMethod>
     ): PaymentSelection? {
         return if (metadata.customerMetadata?.isPaymentMethodSetAsDefaultEnabled == true) {
-            getDefaultPaymentMethod(paymentMethods, customerSheetSession.defaultPaymentMethodId)
+            getDefaultPaymentMethodAsPaymentSelection(paymentMethods, customerSheetSession.defaultPaymentMethodId)
         } else {
             useLocalSelectionAsPaymentSelection(customerSheetSession, paymentMethods)
         }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -11,6 +11,7 @@ import com.stripe.android.customersheet.util.CustomerSheetHacks
 import com.stripe.android.customersheet.util.filterToSupportedPaymentMethods
 import com.stripe.android.customersheet.util.getDefaultPaymentMethodsEnabledForCustomerSheet
 import com.stripe.android.customersheet.util.sortPaymentMethods
+import com.stripe.android.customersheet.util.getDefaultPaymentMethod
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayRepository
 import com.stripe.android.lpmfoundations.luxe.LpmRepository
@@ -170,19 +171,10 @@ internal class DefaultCustomerSheetLoader(
         paymentMethods: List<PaymentMethod>
     ): PaymentSelection? {
         return if (metadata.customerMetadata?.isPaymentMethodSetAsDefaultEnabled == true) {
-            useDefaultPaymentMethodAsPaymentSelection(paymentMethods, customerSheetSession.defaultPaymentMethodId)
+            getDefaultPaymentMethod(paymentMethods, customerSheetSession.defaultPaymentMethodId)
         } else {
             useLocalSelectionAsPaymentSelection(customerSheetSession, paymentMethods)
         }
-    }
-
-    private fun useDefaultPaymentMethodAsPaymentSelection(
-        paymentMethods: List<PaymentMethod>,
-        defaultPaymentMethodId: String?,
-    ): PaymentSelection? {
-        return paymentMethods.find { paymentMethod ->
-            paymentMethod.id == defaultPaymentMethodId
-        }?.let { PaymentSelection.Saved(it) }
     }
 
     private fun useLocalSelectionAsPaymentSelection(

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -9,9 +9,9 @@ import com.stripe.android.customersheet.data.CustomerSheetInitializationDataSour
 import com.stripe.android.customersheet.data.CustomerSheetSession
 import com.stripe.android.customersheet.util.CustomerSheetHacks
 import com.stripe.android.customersheet.util.filterToSupportedPaymentMethods
+import com.stripe.android.customersheet.util.getDefaultPaymentMethodAsPaymentSelection
 import com.stripe.android.customersheet.util.getDefaultPaymentMethodsEnabledForCustomerSheet
 import com.stripe.android.customersheet.util.sortPaymentMethods
-import com.stripe.android.customersheet.util.getDefaultPaymentMethodAsPaymentSelection
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayRepository
 import com.stripe.android.lpmfoundations.luxe.LpmRepository

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerAdapterDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerAdapterDataSource.kt
@@ -48,7 +48,8 @@ internal class CustomerAdapterDataSource @Inject constructor(
             }
 
             val savedSelectionResult = async {
-                retrieveSavedSelection().toResult()
+                // TODO: add comment.
+                retrieveSavedSelection(elementsSession = null).toResult()
             }
 
             val elementsSession = elementsSessionResult.await().getOrThrow()
@@ -91,7 +92,7 @@ internal class CustomerAdapterDataSource @Inject constructor(
         customerAdapter.detachPaymentMethod(paymentMethodId)
     }
 
-    override suspend fun retrieveSavedSelection() = runCatchingAdapterTask {
+    override suspend fun retrieveSavedSelection(elementsSession: CustomerSessionElementsSession?) = runCatchingAdapterTask {
         customerAdapter.retrieveSelectedPaymentOption().map { result ->
             result?.toSavedSelection()
         }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerAdapterDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerAdapterDataSource.kt
@@ -48,8 +48,7 @@ internal class CustomerAdapterDataSource @Inject constructor(
             }
 
             val savedSelectionResult = async {
-                // TODO: add comment.
-                retrieveSavedSelection(elementsSession = null).toResult()
+                retrieveSavedSelection(customerSessionElementsSession = null).toResult()
             }
 
             val elementsSession = elementsSessionResult.await().getOrThrow()
@@ -92,7 +91,9 @@ internal class CustomerAdapterDataSource @Inject constructor(
         customerAdapter.detachPaymentMethod(paymentMethodId)
     }
 
-    override suspend fun retrieveSavedSelection(elementsSession: CustomerSessionElementsSession?) = runCatchingAdapterTask {
+    override suspend fun retrieveSavedSelection(
+        customerSessionElementsSession: CustomerSessionElementsSession?
+    ) = runCatchingAdapterTask {
         customerAdapter.retrieveSelectedPaymentOption().map { result ->
             result?.toSavedSelection()
         }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionInitializationDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionInitializationDataSource.kt
@@ -22,7 +22,7 @@ internal class CustomerSessionInitializationDataSource @Inject constructor(
             elementsSessionManager.fetchElementsSession().mapCatching { customerSessionElementsSession ->
                 val savedSelection = savedSelectionDataSource
                     .retrieveSavedSelection(
-                        elementsSession = customerSessionElementsSession
+                        customerSessionElementsSession = customerSessionElementsSession
                     )
                     .toResult()
                     .getOrThrow()

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionInitializationDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionInitializationDataSource.kt
@@ -21,7 +21,9 @@ internal class CustomerSessionInitializationDataSource @Inject constructor(
         return withContext(workContext) {
             elementsSessionManager.fetchElementsSession().mapCatching { customerSessionElementsSession ->
                 val savedSelection = savedSelectionDataSource
-                    .retrieveSavedSelection()
+                    .retrieveSavedSelection(
+                        elementsSession = customerSessionElementsSession
+                    )
                     .toResult()
                     .getOrThrow()
 

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSource.kt
@@ -1,8 +1,8 @@
 package com.stripe.android.customersheet.data
 
 import com.stripe.android.core.injection.IOContext
-import com.stripe.android.customersheet.util.getDefaultPaymentMethodsEnabledForCustomerSheet
 import com.stripe.android.customersheet.util.getDefaultPaymentMethodAsPaymentSelection
+import com.stripe.android.customersheet.util.getDefaultPaymentMethodsEnabledForCustomerSheet
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.model.SavedSelection
@@ -22,8 +22,8 @@ internal class CustomerSessionSavedSelectionDataSource @Inject constructor(
     ): CustomerSheetDataResult<SavedSelection?> {
         return withContext(workContext) {
             val loadedElementsSession = customerSessionElementsSession?.let {
-                    Result.success(it)
-                } ?: elementsSessionManager.fetchElementsSession()
+                Result.success(it)
+            } ?: elementsSessionManager.fetchElementsSession()
             return@withContext loadedElementsSession.fold(
                 onSuccess = {
                     if (getDefaultPaymentMethodsEnabledForCustomerSheet(it.elementsSession)) {

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSource.kt
@@ -2,7 +2,7 @@ package com.stripe.android.customersheet.data
 
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.customersheet.util.getDefaultPaymentMethodsEnabledForCustomerSheet
-import com.stripe.android.customersheet.util.getDefaultPaymentMethod
+import com.stripe.android.customersheet.util.getDefaultPaymentMethodAsPaymentSelection
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.model.SavedSelection
@@ -18,11 +18,12 @@ internal class CustomerSessionSavedSelectionDataSource @Inject constructor(
     @IOContext private val workContext: CoroutineContext,
 ) : CustomerSheetSavedSelectionDataSource {
     override suspend fun retrieveSavedSelection(
-        elementsSession: CustomerSessionElementsSession?,
+        customerSessionElementsSession: CustomerSessionElementsSession?,
     ): CustomerSheetDataResult<SavedSelection?> {
         return withContext(workContext) {
-            val loadedElementsSession =
-                elementsSession?.let { Result.success(it) } ?: elementsSessionManager.fetchElementsSession()
+            val loadedElementsSession = customerSessionElementsSession?.let {
+                    Result.success(it)
+                } ?: elementsSessionManager.fetchElementsSession()
             return@withContext loadedElementsSession.fold(
                 onSuccess = {
                     if (getDefaultPaymentMethodsEnabledForCustomerSheet(it.elementsSession)) {
@@ -41,7 +42,7 @@ internal class CustomerSessionSavedSelectionDataSource @Inject constructor(
     private fun useDefaultPaymentMethodFromBackend(
         customer: ElementsSession.Customer,
     ): CustomerSheetDataResult<SavedSelection?> {
-        val savedSelection = getDefaultPaymentMethod(
+        val savedSelection = getDefaultPaymentMethodAsPaymentSelection(
             paymentMethods = customer.paymentMethods,
             defaultPaymentMethodId = customer.defaultPaymentMethod
         )?.toSavedSelection()

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSource.kt
@@ -1,8 +1,12 @@
 package com.stripe.android.customersheet.data
 
 import com.stripe.android.core.injection.IOContext
+import com.stripe.android.customersheet.util.getDefaultPaymentMethodsEnabledForCustomerSheet
+import com.stripe.android.customersheet.util.getDefaultPaymentMethod
+import com.stripe.android.model.ElementsSession
 import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.model.SavedSelection
+import com.stripe.android.paymentsheet.model.toSavedSelection
 import kotlinx.coroutines.withContext
 import java.io.IOException
 import javax.inject.Inject
@@ -13,19 +17,48 @@ internal class CustomerSessionSavedSelectionDataSource @Inject constructor(
     private val prefsRepositoryFactory: @JvmSuppressWildcards (String) -> PrefsRepository,
     @IOContext private val workContext: CoroutineContext,
 ) : CustomerSheetSavedSelectionDataSource {
-    override suspend fun retrieveSavedSelection(): CustomerSheetDataResult<SavedSelection?> {
+    override suspend fun retrieveSavedSelection(
+        elementsSession: CustomerSessionElementsSession?,
+    ): CustomerSheetDataResult<SavedSelection?> {
         return withContext(workContext) {
-            createPrefsRepository().mapCatching { prefsRepository ->
-                prefsRepository.getSavedSelection(
-                    /*
-                     * We don't calculate on `Google Pay` availability in this function. Instead, we check
-                     * within `CustomerSheet` similar to how we check if a saved payment option is still exists
-                     * within the user's payment methods from `retrievePaymentMethods`
-                     */
-                    isGooglePayAvailable = true,
-                    isLinkAvailable = false,
-                )
-            }
+            val loadedElementsSession =
+                elementsSession?.let { Result.success(it) } ?: elementsSessionManager.fetchElementsSession()
+            return@withContext loadedElementsSession.fold(
+                onSuccess = {
+                    if (getDefaultPaymentMethodsEnabledForCustomerSheet(it.elementsSession)) {
+                        useDefaultPaymentMethodFromBackend(it.customer)
+                    } else {
+                        useLocallySavedSelection()
+                    }
+                },
+                onFailure = {
+                    CustomerSheetDataResult.failure(it, displayMessage = null)
+                }
+            )
+        }
+    }
+
+    private fun useDefaultPaymentMethodFromBackend(
+        customer: ElementsSession.Customer,
+    ): CustomerSheetDataResult<SavedSelection?> {
+        val savedSelection = getDefaultPaymentMethod(
+            paymentMethods = customer.paymentMethods,
+            defaultPaymentMethodId = customer.defaultPaymentMethod
+        )?.toSavedSelection()
+        return CustomerSheetDataResult.success(savedSelection)
+    }
+
+    private suspend fun useLocallySavedSelection(): CustomerSheetDataResult<SavedSelection?> {
+        return createPrefsRepository().mapCatching { prefsRepository ->
+            prefsRepository.getSavedSelection(
+                /*
+                 * We don't calculate on `Google Pay` availability in this function. Instead, we check
+                 * within `CustomerSheet` similar to how we check if a saved payment option is still exists
+                 * within the user's payment methods from `retrievePaymentMethods`
+                 */
+                isGooglePayAvailable = true,
+                isLinkAvailable = false,
+            )
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSheetSavedSelectionDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSheetSavedSelectionDataSource.kt
@@ -12,7 +12,7 @@ internal interface CustomerSheetSavedSelectionDataSource {
      *
      * @return a result containing the saved selection if operation was successful
      */
-    suspend fun retrieveSavedSelection(): CustomerSheetDataResult<SavedSelection?>
+    suspend fun retrieveSavedSelection(elementsSession: CustomerSessionElementsSession?): CustomerSheetDataResult<SavedSelection?>
 
     suspend fun setSavedSelection(selection: SavedSelection?): CustomerSheetDataResult<Unit>
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSheetSavedSelectionDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSheetSavedSelectionDataSource.kt
@@ -12,7 +12,9 @@ internal interface CustomerSheetSavedSelectionDataSource {
      *
      * @return a result containing the saved selection if operation was successful
      */
-    suspend fun retrieveSavedSelection(elementsSession: CustomerSessionElementsSession?): CustomerSheetDataResult<SavedSelection?>
+    suspend fun retrieveSavedSelection(
+        customerSessionElementsSession: CustomerSessionElementsSession?
+    ): CustomerSheetDataResult<SavedSelection?>
 
     suspend fun setSavedSelection(selection: SavedSelection?): CustomerSheetDataResult<Unit>
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/util/SyncDefaultPaymentMethodUtils.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/util/SyncDefaultPaymentMethodUtils.kt
@@ -27,7 +27,7 @@ internal fun getDefaultPaymentMethodsEnabledForCustomerSheet(elementsSession: El
     }
 }
 
-internal fun getDefaultPaymentMethod(
+internal fun getDefaultPaymentMethodAsPaymentSelection(
     paymentMethods: List<PaymentMethod>,
     defaultPaymentMethodId: String?,
 ): PaymentSelection? {

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/util/SyncDefaultPaymentMethodUtils.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/util/SyncDefaultPaymentMethodUtils.kt
@@ -2,6 +2,7 @@ package com.stripe.android.customersheet.util
 
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentsheet.model.PaymentSelection
 
 internal fun List<PaymentMethod>.filterToSupportedPaymentMethods(
     isSyncDefaultPaymentMethodFeatureEnabled: Boolean,
@@ -24,4 +25,13 @@ internal fun getDefaultPaymentMethodsEnabledForCustomerSheet(elementsSession: El
         ElementsSession.Customer.Components.CustomerSheet.Disabled,
         null -> false
     }
+}
+
+internal fun getDefaultPaymentMethod(
+    paymentMethods: List<PaymentMethod>,
+    defaultPaymentMethodId: String?,
+): PaymentSelection? {
+    return paymentMethods.find { paymentMethod ->
+        paymentMethod.id == defaultPaymentMethodId
+    }?.let { PaymentSelection.Saved(it) }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerAdapterDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerAdapterDataSourceTest.kt
@@ -96,7 +96,7 @@ class CustomerAdapterDataSourceTest {
             ),
         )
 
-        val result = dataSource.retrieveSavedSelection()
+        val result = dataSource.retrieveSavedSelection(null)
 
         assertThat(result).isInstanceOf<CustomerSheetDataResult.Success<SavedSelection?>>()
 
@@ -116,7 +116,7 @@ class CustomerAdapterDataSourceTest {
             )
         )
 
-        val result = dataSource.retrieveSavedSelection()
+        val result = dataSource.retrieveSavedSelection(null)
 
         assertThat(result).isInstanceOf<CustomerSheetDataResult.Failure<SavedSelection?>>()
 
@@ -139,7 +139,7 @@ class CustomerAdapterDataSourceTest {
             )
         )
 
-        val result = dataSource.retrieveSavedSelection()
+        val result = dataSource.retrieveSavedSelection(null)
 
         assertThat(result).isInstanceOf<CustomerSheetDataResult.Failure<SavedSelection?>>()
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSourceTest.kt
@@ -157,7 +157,7 @@ class CustomerSessionSavedSelectionDataSourceTest {
 
     @Test
     fun `When elements session passed to retrieveSavedSelection, should not re-query elements session`() = runTest {
-        val existingElementsSession = FakeCustomerSessionElementsSessionManager().fetchElementsSession()
+        val existingElementsSession = FakeCustomerSessionElementsSessionManager().fetchElementsSession().getOrThrow()
         val failingElementsSessionManager = FakeCustomerSessionElementsSessionManager(
             elementsSession = Result.failure(
                 IllegalAccessError("Should not re-query elements session in this test!")
@@ -168,7 +168,7 @@ class CustomerSessionSavedSelectionDataSourceTest {
             elementsSessionManager = failingElementsSessionManager
         )
 
-        val result = dataSource.retrieveSavedSelection(customerSessionElementsSession = existingElementsSession.getOrThrow())
+        val result = dataSource.retrieveSavedSelection(customerSessionElementsSession = existingElementsSession)
 
         assertThat(result).isInstanceOf<CustomerSheetDataResult.Success<SavedSelection?>>()
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSourceTest.kt
@@ -100,7 +100,7 @@ class CustomerSessionSavedSelectionDataSourceTest {
             elementsSessionManager = elementsSessionManager,
         )
 
-        val result = dataSource.retrieveSavedSelection(elementsSession = null)
+        val result = dataSource.retrieveSavedSelection(customerSessionElementsSession = null)
 
         assertThat(result).isInstanceOf<CustomerSheetDataResult.Failure<Unit>>()
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSourceTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.customersheet.data
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.isInstanceOf
+import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.FakePrefsRepository
 import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.model.SavedSelection
@@ -110,18 +111,69 @@ class CustomerSessionSavedSelectionDataSourceTest {
     }
 
     @Test
-    fun `When default payment methods enabled, should get selection from backend`() {
-        // TODO: implement test.
+    fun `When default payment methods enabled, should get selection from backend`() = runTest {
+        val expectedSavedSelectionId = "pm_1"
+        val elementsSessionManager = FakeCustomerSessionElementsSessionManager(
+            isPaymentMethodSyncDefaultEnabled = true,
+            defaultPaymentMethodId = expectedSavedSelectionId,
+            paymentMethods = listOf(
+                PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = "pm_2"),
+                PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = expectedSavedSelectionId),
+            )
+        )
+
+        val dataSource = createDataSource(
+            elementsSessionManager = elementsSessionManager,
+        )
+
+        val result = dataSource.retrieveSavedSelection(customerSessionElementsSession = null)
+
+        assertThat(result).isInstanceOf<CustomerSheetDataResult.Success<SavedSelection?>>()
+
+        val successResult = result.asSuccess()
+
+        assertThat(successResult.value).isEqualTo(SavedSelection.PaymentMethod(id = expectedSavedSelectionId))
     }
 
     @Test
-    fun `When default payment methods enabled and no default PM, should return null selection`() {
-        // TODO: implement test.
+    fun `When default payment methods enabled and no default PM, should return null selection`() = runTest {
+        val elementsSessionManager = FakeCustomerSessionElementsSessionManager(
+            isPaymentMethodSyncDefaultEnabled = true,
+            defaultPaymentMethodId = null,
+        )
+
+        val dataSource = createDataSource(
+            elementsSessionManager = elementsSessionManager,
+        )
+
+        val result = dataSource.retrieveSavedSelection(customerSessionElementsSession = null)
+
+        assertThat(result).isInstanceOf<CustomerSheetDataResult.Success<SavedSelection?>>()
+
+        val successResult = result.asSuccess()
+
+        assertThat(successResult.value).isEqualTo(null)
     }
 
     @Test
-    fun `When elements session passed to retrieveSavedSelection, should not re-query elements session`() {
-        // TODO: implement test.
+    fun `When elements session passed to retrieveSavedSelection, should not re-query elements session`() = runTest {
+        val existingElementsSession = FakeCustomerSessionElementsSessionManager().fetchElementsSession()
+        val failingElementsSessionManager = FakeCustomerSessionElementsSessionManager(
+            elementsSession = Result.failure(
+                IllegalAccessError("Should not re-query elements session in this test!")
+            )
+        )
+
+        val dataSource = createDataSource(
+            elementsSessionManager = failingElementsSessionManager
+        )
+
+        val result = dataSource.retrieveSavedSelection(customerSessionElementsSession = existingElementsSession.getOrThrow())
+
+        assertThat(result).isInstanceOf<CustomerSheetDataResult.Success<SavedSelection?>>()
+
+        // No exception being thrown indicates we did not try to re-query elements session from the
+        // "failingElementsSessionManager".
     }
 
     private suspend fun createDataSource(

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSourceTest.kt
@@ -20,7 +20,7 @@ class CustomerSessionSavedSelectionDataSourceTest {
             prefsRepository = prefsRepository
         )
 
-        val result = dataSource.retrieveSavedSelection()
+        val result = dataSource.retrieveSavedSelection(null)
 
         assertThat(result).isInstanceOf<CustomerSheetDataResult.Success<SavedSelection?>>()
 
@@ -40,7 +40,7 @@ class CustomerSessionSavedSelectionDataSourceTest {
             elementsSessionManager = elementsSessionManager,
         )
 
-        val result = dataSource.retrieveSavedSelection()
+        val result = dataSource.retrieveSavedSelection(null)
 
         assertThat(result).isInstanceOf<CustomerSheetDataResult.Failure<SavedSelection?>>()
 
@@ -87,6 +87,41 @@ class CustomerSessionSavedSelectionDataSourceTest {
         val failedResult = result.asFailure()
 
         assertThat(failedResult.cause).isEqualTo(exception)
+    }
+
+    @Test
+    fun `On failed to get elements session, should fail to get selection`() = runTest {
+        val exception = IllegalStateException("Failed to load!")
+
+        val elementsSessionManager = FakeCustomerSessionElementsSessionManager(
+            elementsSession = Result.failure(exception),
+        )
+        val dataSource = createDataSource(
+            elementsSessionManager = elementsSessionManager,
+        )
+
+        val result = dataSource.retrieveSavedSelection(elementsSession = null)
+
+        assertThat(result).isInstanceOf<CustomerSheetDataResult.Failure<Unit>>()
+
+        val failedResult = result.asFailure()
+
+        assertThat(failedResult.cause).isEqualTo(exception)
+    }
+
+    @Test
+    fun `When default payment methods enabled, should get selection from backend`() {
+        // TODO: implement test.
+    }
+
+    @Test
+    fun `When default payment methods enabled and no default PM, should return null selection`() {
+        // TODO: implement test.
+    }
+
+    @Test
+    fun `When elements session passed to retrieveSavedSelection, should not re-query elements session`() {
+        // TODO: implement test.
     }
 
     private suspend fun createDataSource(

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/FakeCustomerSessionElementsSessionManager.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/FakeCustomerSessionElementsSessionManager.kt
@@ -17,11 +17,12 @@ internal class FakeCustomerSessionElementsSessionManager(
     private val intent: StripeIntent = SetupIntentFactory.create(),
     private val paymentMethods: List<PaymentMethod> = listOf(),
     private val defaultPaymentMethodId: String? = null,
+    private val isPaymentMethodSyncDefaultEnabled: Boolean = false,
     private val customerSheetComponent: ElementsSession.Customer.Components.CustomerSheet =
         ElementsSession.Customer.Components.CustomerSheet.Enabled(
             isPaymentMethodRemoveEnabled = true,
             canRemoveLastPaymentMethod = true,
-            isPaymentMethodSyncDefaultEnabled = false,
+            isPaymentMethodSyncDefaultEnabled = isPaymentMethodSyncDefaultEnabled,
         ),
     private val customer: ElementsSession.Customer = ElementsSession.Customer(
         session = ElementsSession.Customer.Session(

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/FakeCustomerSheetSavedSelectionDataSource.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/FakeCustomerSheetSavedSelectionDataSource.kt
@@ -9,7 +9,7 @@ internal class FakeCustomerSheetSavedSelectionDataSource(
         CustomerSheetDataResult.success(null),
     private val onSetSavedSelection: SetSavedSelectionOperation? = null
 ) : CustomerSheetSavedSelectionDataSource {
-    override suspend fun retrieveSavedSelection(): CustomerSheetDataResult<SavedSelection?> {
+    override suspend fun retrieveSavedSelection(elementsSession: CustomerSessionElementsSession?): CustomerSheetDataResult<SavedSelection?> {
         return savedSelection
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/FakeCustomerSheetSavedSelectionDataSource.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/FakeCustomerSheetSavedSelectionDataSource.kt
@@ -9,7 +9,9 @@ internal class FakeCustomerSheetSavedSelectionDataSource(
         CustomerSheetDataResult.success(null),
     private val onSetSavedSelection: SetSavedSelectionOperation? = null
 ) : CustomerSheetSavedSelectionDataSource {
-    override suspend fun retrieveSavedSelection(elementsSession: CustomerSessionElementsSession?): CustomerSheetDataResult<SavedSelection?> {
+    override suspend fun retrieveSavedSelection(
+        customerSessionElementsSession: CustomerSessionElementsSession?
+    ): CustomerSheetDataResult<SavedSelection?> {
         return savedSelection
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Use default payment method from elements/session instead of local selection as customer's saved selection when default PMs feature enabled

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
We need to always use the default PM when default PMs feature is enabled. This is the last place where we would have read the local selection. 

https://jira.corp.stripe.com/browse/MOBILESDK-2687