### PR TITLE
Add a FormActivityTest for the happy path case.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButtonNew.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButtonNew.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.BiasAlignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -59,6 +60,7 @@ import com.stripe.android.paymentsheet.R
 import com.stripe.android.uicore.StripeTheme
 import kotlinx.coroutines.delay
 
+internal const val PRIMARY_BUTTON_TEST_TAG = "PRIMARY_BUTTON_TEST_TAG"
 private const val FADE_ANIMATION_DURATION = 100
 private const val FADE_OUT_ANIMATION_DELAY = 90
 
@@ -122,6 +124,7 @@ internal fun PrimaryButton(
             TextButton(
                 onClick = onClick,
                 modifier = Modifier
+                    .testTag(PRIMARY_BUTTON_TEST_TAG)
                     .fillMaxWidth()
                     .defaultMinSize(
                         minHeight = dimensionResource(id = R.dimen.stripe_paymentsheet_primary_button_height)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityTest.kt
@@ -1,15 +1,52 @@
 package com.stripe.android.paymentelement.embedded.form
 
+import android.app.Application
 import android.os.Bundle
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.hasParent
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.PaymentMethodCode
+import com.stripe.android.networktesting.NetworkRule
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentelement.ExperimentalEmbeddedPaymentElementApi
+import com.stripe.android.paymentelement.embedded.manage.ManageActivity
+import com.stripe.android.paymentsheet.FormPage
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.state.PaymentElementLoader
+import com.stripe.android.paymentsheet.ui.PRIMARY_BUTTON_TEST_TAG
+import com.stripe.android.testing.PaymentConfigurationTestRule
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
+@OptIn(ExperimentalEmbeddedPaymentElementApi::class)
 internal class FormActivityTest {
+    private val applicationContext = ApplicationProvider.getApplicationContext<Application>()
+    private val composeTestRule = createAndroidComposeRule<ManageActivity>()
+    private val networkRule = NetworkRule()
+
+    private val formPage = FormPage(composeTestRule)
+    private val primaryButton = composeTestRule.onNode(
+        hasTestTag(PRIMARY_BUTTON_TEST_TAG)
+            .and(hasParent(hasTestTag(EMBEDDED_FORM_ACTIVITY_PRIMARY_BUTTON)))
+    )
+
+    @get:Rule
+    val ruleChain: RuleChain = RuleChain
+        .outerRule(composeTestRule)
+        .around(networkRule)
+        .around(PaymentConfigurationTestRule(applicationContext))
 
     @Test
     fun `when launched without args should finish with cancelled result`() {
@@ -20,6 +57,44 @@ internal class FormActivityTest {
             assertThat(activityScenario.state).isEqualTo(Lifecycle.State.DESTROYED)
             val result = FormContract.parseResult(0, activityScenario.result.resultData)
             assertThat(result).isInstanceOf(FormResult.Cancelled::class.java)
+        }
+    }
+
+    @Test
+    fun `primary button is enabled when form is filled out`() = launch {
+        primaryButton.assertIsNotEnabled()
+        formPage.fillOutCardDetails()
+        primaryButton.assertIsEnabled()
+    }
+
+    private fun launch(
+        selectedPaymentMethodCode: PaymentMethodCode = "card",
+        paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+        hasSavedPaymentMethods: Boolean = false,
+        configuration: EmbeddedPaymentElement.Configuration =
+            EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
+        intentConfiguration: PaymentSheet.IntentConfiguration = PaymentSheet.IntentConfiguration(
+            mode = PaymentSheet.IntentConfiguration.Mode.Payment(
+                amount = 5000,
+                currency = "USD",
+            ),
+        ),
+        block: () -> Unit,
+    ) {
+        ActivityScenario.launchActivityForResult<FormActivity>(
+            FormContract.createIntent(
+                context = applicationContext,
+                input = FormContract.Args(
+                    selectedPaymentMethodCode = selectedPaymentMethodCode,
+                    paymentMethodMetadata = paymentMethodMetadata,
+                    hasSavedPaymentMethods = hasSavedPaymentMethods,
+                    configuration = configuration,
+                    initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(intentConfiguration),
+                    statusBarColor = null,
+                ),
+            )
+        ).use { scenario ->
+            block()
         }
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Starts the form activity and runs through filling out the form.

It's hard to write a test for confirmation right now. I think we have that covered with our end to end tests, but we should probably add more tests once we add the continue functionality. 