### PR TITLE
Fill max height for saved pm trailing content.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUI.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
@@ -164,6 +165,7 @@ private fun EditButton(onClick: () -> Unit) {
             .testTag(TEST_TAG_EDIT_SAVED_CARD)
             .clickable(onClick = onClick)
             .padding(4.dp)
+            .fillMaxHeight()
     )
 }
 
@@ -177,6 +179,7 @@ private fun ViewMoreButton(
             .testTag(TEST_TAG_VIEW_MORE)
             .clickable(onClick = onViewMorePaymentMethods)
             .padding(4.dp)
+            .fillMaxHeight()
     ) {
         Text(
             stringResource(id = R.string.stripe_view_more),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodEmbeddedLayoutUIScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodEmbeddedLayoutUIScreenshotTest.kt
@@ -1,7 +1,10 @@
 package com.stripe.android.paymentsheet.verticalmode
 
 import android.graphics.Color
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.toArgb
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentelement.ExperimentalEmbeddedPaymentElementApi
@@ -137,6 +140,7 @@ class PaymentMethodEmbeddedLayoutUIScreenshotTest {
         displayableSavedPaymentMethod: DisplayableSavedPaymentMethod? = savedPaymentMethod,
         newPaymentMethods: List<DisplayablePaymentMethod> = paymentMethods
     ) {
+        val scrollState = rememberScrollState()
         PaymentMethodEmbeddedLayoutUI(
             paymentMethods = newPaymentMethods,
             displayedSavedPaymentMethod = displayableSavedPaymentMethod,
@@ -148,7 +152,8 @@ class PaymentMethodEmbeddedLayoutUIScreenshotTest {
             onSelectSavedPaymentMethod = {},
             onManageOneSavedPaymentMethod = {},
             imageLoader = mock(),
-            rowStyle = rowStyle
+            rowStyle = rowStyle,
+            modifier = Modifier.verticalScroll(scrollState),
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUIScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUIScreenshotTest.kt
@@ -1,5 +1,8 @@
 package com.stripe.android.paymentsheet.verticalmode
 
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.ui.Modifier
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.screenshottesting.PaparazziRule
@@ -28,6 +31,7 @@ internal class PaymentMethodVerticalLayoutUIScreenshotTest {
     @Test
     fun testSavedAndNewPms() {
         paparazziRule.snapshot {
+            val scrollState = rememberScrollState()
             PaymentMethodVerticalLayoutUI(
                 paymentMethods = paymentMethods,
                 displayedSavedPaymentMethod = savedPaymentMethod,
@@ -39,6 +43,7 @@ internal class PaymentMethodVerticalLayoutUIScreenshotTest {
                 onSelectSavedPaymentMethod = {},
                 onManageOneSavedPaymentMethod = {},
                 imageLoader = mock(),
+                modifier = Modifier.verticalScroll(scrollState),
             )
         }
     }
@@ -46,6 +51,7 @@ internal class PaymentMethodVerticalLayoutUIScreenshotTest {
     @Test
     fun testDefault() {
         paparazziRule.snapshot {
+            val scrollState = rememberScrollState()
             PaymentMethodVerticalLayoutUI(
                 paymentMethods = paymentMethods,
                 displayedSavedPaymentMethod = PaymentMethodFixtures.defaultDisplayableCard(),
@@ -57,6 +63,7 @@ internal class PaymentMethodVerticalLayoutUIScreenshotTest {
                 onSelectSavedPaymentMethod = {},
                 onManageOneSavedPaymentMethod = {},
                 imageLoader = mock(),
+                modifier = Modifier.verticalScroll(scrollState),
             )
         }
     }
@@ -68,6 +75,7 @@ internal class PaymentMethodVerticalLayoutUIScreenshotTest {
         }
 
         paparazziRule.snapshot {
+            val scrollState = rememberScrollState()
             PaymentMethodVerticalLayoutUI(
                 paymentMethods = paymentMethodsWithBadge,
                 displayedSavedPaymentMethod = savedPaymentMethod,
@@ -79,6 +87,7 @@ internal class PaymentMethodVerticalLayoutUIScreenshotTest {
                 onSelectSavedPaymentMethod = {},
                 onManageOneSavedPaymentMethod = {},
                 imageLoader = mock(),
+                modifier = Modifier.verticalScroll(scrollState),
             )
         }
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Makes the buttons clickable area bigger and more predictable.

