### PR TITLE
Fix out of order events.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
@@ -44,14 +44,16 @@ internal class DefaultEmbeddedUpdateScreenInteractorFactory @Inject constructor(
                 result
             },
             updateExecutor = { method, brand ->
-                val result = savedPaymentMethodMutatorProvider.get().modifyCardPaymentMethod(method, brand)
-                result.onSuccess { paymentMethod ->
-                    val currentSelection = selectionHolder.selection.value
-                    if (paymentMethod.id == (currentSelection as? PaymentSelection.Saved)?.paymentMethod?.id) {
-                        selectionHolder.set(PaymentSelection.Saved(paymentMethod))
-                    }
-                }
-                result
+                savedPaymentMethodMutatorProvider.get().modifyCardPaymentMethod(
+                    paymentMethod = method,
+                    brand = brand,
+                    onSuccess = { paymentMethod ->
+                        val currentSelection = selectionHolder.selection.value
+                        if (paymentMethod.id == (currentSelection as? PaymentSelection.Saved)?.paymentMethod?.id) {
+                            selectionHolder.set(PaymentSelection.Saved(paymentMethod))
+                        }
+                    },
+                )
             },
             onBrandChoiceOptionsShown = {
                 eventReporter.onShowPaymentOptionBrands(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -223,6 +223,7 @@ internal class SavedPaymentMethodMutator(
     suspend fun modifyCardPaymentMethod(
         paymentMethod: PaymentMethod,
         brand: CardBrand,
+        onSuccess: (PaymentMethod) -> Unit = {},
     ): Result<PaymentMethod> {
         // TODO(samer-stripe): Send 'unexpected_error' here
         val currentCustomer = customerStateHolder.customer.value ?: return Result.failure(
@@ -262,6 +263,8 @@ internal class SavedPaymentMethodMutator(
                         }
                     )
                 )
+
+                onSuccess(updatedMethod)
 
                 navigationPop()
             }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
We would run the pop before updating the selection. This caused some test flakes.