### PR TITLE
Fix flakey US Bank tests.

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestEmbedded.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestEmbedded.kt
@@ -11,7 +11,6 @@ import com.stripe.android.paymentsheet.example.playground.settings.DefaultBillin
 import com.stripe.android.paymentsheet.example.playground.settings.DelayedPaymentMethodsSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.SupportedPaymentMethodsSettingsDefinition
 import com.stripe.android.test.core.TestParameters
-import org.junit.Ignore
 import org.junit.Test
 
 internal class TestEmbedded : BasePlaygroundTest() {
@@ -49,13 +48,11 @@ internal class TestEmbedded : BasePlaygroundTest() {
         )
     }
 
-    @Ignore("Ignore until we can investigate why US Bank Account does not progress when clicking the primary button")
     @Test
     fun testUsBankAccount() {
         testDriver.confirmEmbeddedUsBankAccount(
             testParameters = TestParameters.create(
                 paymentMethodCode = "us_bank_account",
-                authorizationAction = null,
                 executeInNightlyRun = true,
             ) { settings ->
                 settings[CountrySettingsDefinition] = Country.US

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -1531,6 +1531,13 @@ internal class PlaygroundTestDriver(
             TimeUnit.MILLISECONDS.sleep(250)
         }
 
+        composeTestRule.waitUntil(timeoutMillis = DEFAULT_UI_TIMEOUT.inWholeMilliseconds) {
+            composeTestRule
+                .onAllNodesWithText("Agree and continue")
+                .fetchSemanticsNodes(atLeastOneRootRequired = false)
+                .size == 1
+        }
+
         clickButton("Agree and continue")
         clickButton("Test Institution")
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
I ran these on CI with `ShampooRule` and didn't see any more flakes after my changes.
