### PR TITLE
Fix mandate during confirmation.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/ConfirmStripeIntentParamsFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/ConfirmStripeIntentParamsFactory.kt
@@ -123,7 +123,7 @@ internal class ConfirmSetupIntentParamsFactory(
 private fun mandateData(intent: StripeIntent, paymentMethodType: PaymentMethod.Type?): MandateDataParams? {
     return paymentMethodType?.let { type ->
         val supportsAddingMandateData = when (intent) {
-            is PaymentIntent -> intent.canSetupFutureUsage()
+            is PaymentIntent -> intent.canSetupFutureUsage() || type.requiresMandateForPaymentIntent
             is SetupIntent -> true
         }
 

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
@@ -176,6 +176,7 @@ constructor(
         @JvmField val isReusable: Boolean,
         @JvmField val isVoucher: Boolean,
         @JvmField val requiresMandate: Boolean,
+        internal val requiresMandateForPaymentIntent: Boolean,
         private val hasDelayedSettlement: Boolean,
         internal val afterRedirectAction: AfterRedirectAction = AfterRedirectAction.None,
     ) : Parcelable {
@@ -184,6 +185,7 @@ constructor(
             isReusable = false,
             isVoucher = false,
             requiresMandate = true,
+            requiresMandateForPaymentIntent = true,
             hasDelayedSettlement = false,
         ),
         Card(
@@ -191,6 +193,7 @@ constructor(
             isReusable = true,
             isVoucher = false,
             requiresMandate = false,
+            requiresMandateForPaymentIntent = false,
             hasDelayedSettlement = false,
         ),
         CardPresent(
@@ -198,6 +201,7 @@ constructor(
             isReusable = false,
             isVoucher = false,
             requiresMandate = false,
+            requiresMandateForPaymentIntent = false,
             hasDelayedSettlement = false,
         ),
         Fpx(
@@ -205,6 +209,7 @@ constructor(
             isReusable = false,
             isVoucher = false,
             requiresMandate = false,
+            requiresMandateForPaymentIntent = false,
             hasDelayedSettlement = false,
         ),
         Ideal(
@@ -212,6 +217,7 @@ constructor(
             isReusable = false,
             isVoucher = false,
             requiresMandate = true,
+            requiresMandateForPaymentIntent = false,
             hasDelayedSettlement = false,
         ),
         SepaDebit(
@@ -219,6 +225,7 @@ constructor(
             isReusable = false,
             isVoucher = false,
             requiresMandate = true,
+            requiresMandateForPaymentIntent = true,
             hasDelayedSettlement = true,
         ),
         AuBecsDebit(
@@ -226,6 +233,7 @@ constructor(
             isReusable = true,
             isVoucher = false,
             requiresMandate = true,
+            requiresMandateForPaymentIntent = true,
             hasDelayedSettlement = true,
         ),
         BacsDebit(
@@ -233,6 +241,7 @@ constructor(
             isReusable = true,
             isVoucher = false,
             requiresMandate = true,
+            requiresMandateForPaymentIntent = true,
             hasDelayedSettlement = true,
         ),
         Sofort(
@@ -240,6 +249,7 @@ constructor(
             isReusable = false,
             isVoucher = false,
             requiresMandate = true,
+            requiresMandateForPaymentIntent = false,
             hasDelayedSettlement = true,
         ),
         Upi(
@@ -247,6 +257,7 @@ constructor(
             isReusable = false,
             isVoucher = false,
             requiresMandate = false,
+            requiresMandateForPaymentIntent = false,
             hasDelayedSettlement = false,
             afterRedirectAction = AfterRedirectAction.Refresh(),
         ),
@@ -255,6 +266,7 @@ constructor(
             isReusable = false,
             isVoucher = false,
             requiresMandate = false,
+            requiresMandateForPaymentIntent = false,
             hasDelayedSettlement = false,
             // We are intentionally polling for P24 even though it uses the redirect trampoline.
             // About 20% of the time, the intent is still in `requires_action` status
@@ -267,6 +279,7 @@ constructor(
             isReusable = false,
             isVoucher = false,
             requiresMandate = true,
+            requiresMandateForPaymentIntent = true,
             hasDelayedSettlement = false,
         ),
         Giropay(
@@ -274,13 +287,15 @@ constructor(
             isReusable = false,
             isVoucher = false,
             requiresMandate = false,
+            requiresMandateForPaymentIntent = false,
             hasDelayedSettlement = false,
         ),
         Eps(
             "eps",
             isReusable = false,
             isVoucher = false,
-            requiresMandate = true,
+            requiresMandate = false,
+            requiresMandateForPaymentIntent = false,
             hasDelayedSettlement = false,
         ),
         Oxxo(
@@ -288,6 +303,7 @@ constructor(
             isReusable = false,
             isVoucher = true,
             requiresMandate = false,
+            requiresMandateForPaymentIntent = false,
             hasDelayedSettlement = true,
         ),
         Alipay(
@@ -295,6 +311,7 @@ constructor(
             isReusable = false,
             isVoucher = false,
             requiresMandate = false,
+            requiresMandateForPaymentIntent = false,
             hasDelayedSettlement = false,
         ),
         GrabPay(
@@ -302,6 +319,7 @@ constructor(
             isReusable = false,
             isVoucher = false,
             requiresMandate = false,
+            requiresMandateForPaymentIntent = false,
             hasDelayedSettlement = false,
         ),
         PayPal(
@@ -309,6 +327,7 @@ constructor(
             isReusable = false,
             isVoucher = false,
             requiresMandate = true,
+            requiresMandateForPaymentIntent = false,
             hasDelayedSettlement = false,
         ),
         AfterpayClearpay(
@@ -316,6 +335,7 @@ constructor(
             isReusable = false,
             isVoucher = false,
             requiresMandate = false,
+            requiresMandateForPaymentIntent = false,
             hasDelayedSettlement = false,
         ),
         Netbanking(
@@ -323,6 +343,7 @@ constructor(
             isReusable = false,
             isVoucher = false,
             requiresMandate = false,
+            requiresMandateForPaymentIntent = false,
             hasDelayedSettlement = false,
         ),
         Blik(
@@ -330,6 +351,7 @@ constructor(
             isReusable = false,
             isVoucher = false,
             requiresMandate = false,
+            requiresMandateForPaymentIntent = false,
             hasDelayedSettlement = false,
         ),
         WeChatPay(
@@ -337,6 +359,7 @@ constructor(
             isReusable = false,
             isVoucher = false,
             requiresMandate = false,
+            requiresMandateForPaymentIntent = false,
             hasDelayedSettlement = false,
             afterRedirectAction = AfterRedirectAction.Refresh(retryCount = MAX_RETRIES),
         ),
@@ -345,6 +368,7 @@ constructor(
             isReusable = false,
             isVoucher = false,
             requiresMandate = true,
+            requiresMandateForPaymentIntent = false,
             hasDelayedSettlement = false,
         ),
         Affirm(
@@ -352,6 +376,7 @@ constructor(
             isReusable = false,
             isVoucher = false,
             requiresMandate = false,
+            requiresMandateForPaymentIntent = false,
             hasDelayedSettlement = false,
         ),
         RevolutPay(
@@ -359,6 +384,7 @@ constructor(
             isReusable = false,
             isVoucher = false,
             requiresMandate = true,
+            requiresMandateForPaymentIntent = false,
             hasDelayedSettlement = false,
             afterRedirectAction = AfterRedirectAction.Poll(),
         ),
@@ -367,6 +393,7 @@ constructor(
             isReusable = false,
             isVoucher = false,
             requiresMandate = false,
+            requiresMandateForPaymentIntent = false,
             hasDelayedSettlement = false,
         ),
         Billie(
@@ -374,6 +401,7 @@ constructor(
             isReusable = false,
             isVoucher = false,
             requiresMandate = false,
+            requiresMandateForPaymentIntent = false,
             hasDelayedSettlement = false,
         ),
         Satispay(
@@ -381,6 +409,7 @@ constructor(
             isReusable = false,
             isVoucher = false,
             requiresMandate = false,
+            requiresMandateForPaymentIntent = false,
             hasDelayedSettlement = false,
         ),
         Crypto(
@@ -388,6 +417,7 @@ constructor(
             isReusable = false,
             isVoucher = false,
             requiresMandate = false,
+            requiresMandateForPaymentIntent = false,
             hasDelayedSettlement = false,
         ),
         AmazonPay(
@@ -395,6 +425,7 @@ constructor(
             isReusable = false,
             isVoucher = false,
             requiresMandate = true,
+            requiresMandateForPaymentIntent = false,
             hasDelayedSettlement = false,
             afterRedirectAction = AfterRedirectAction.Poll(),
         ),
@@ -403,6 +434,7 @@ constructor(
             isReusable = false,
             isVoucher = false,
             requiresMandate = false,
+            requiresMandateForPaymentIntent = false,
             hasDelayedSettlement = false,
         ),
         MobilePay(
@@ -410,6 +442,7 @@ constructor(
             isReusable = false,
             isVoucher = false,
             requiresMandate = false,
+            requiresMandateForPaymentIntent = false,
             hasDelayedSettlement = false,
         ),
         Multibanco(
@@ -417,6 +450,7 @@ constructor(
             isReusable = false,
             isVoucher = true,
             requiresMandate = false,
+            requiresMandateForPaymentIntent = false,
             hasDelayedSettlement = true,
         ),
         Zip(
@@ -424,6 +458,7 @@ constructor(
             isReusable = false,
             isVoucher = false,
             requiresMandate = false,
+            requiresMandateForPaymentIntent = false,
             hasDelayedSettlement = false,
         ),
         USBankAccount(
@@ -431,6 +466,7 @@ constructor(
             isReusable = true,
             isVoucher = false,
             requiresMandate = true,
+            requiresMandateForPaymentIntent = true,
             hasDelayedSettlement = true,
         ),
         CashAppPay(
@@ -438,6 +474,7 @@ constructor(
             isReusable = false,
             isVoucher = false,
             requiresMandate = true,
+            requiresMandateForPaymentIntent = false,
             hasDelayedSettlement = false,
             afterRedirectAction = AfterRedirectAction.Refresh(),
         ),
@@ -446,6 +483,7 @@ constructor(
             isReusable = false,
             isVoucher = true,
             requiresMandate = false,
+            requiresMandateForPaymentIntent = false,
             hasDelayedSettlement = true,
         ),
         Konbini(
@@ -453,6 +491,7 @@ constructor(
             isReusable = false,
             isVoucher = true,
             requiresMandate = false,
+            requiresMandateForPaymentIntent = false,
             hasDelayedSettlement = true,
         ),
         Swish(
@@ -460,6 +499,7 @@ constructor(
             isReusable = false,
             isVoucher = false,
             requiresMandate = false,
+            requiresMandateForPaymentIntent = false,
             hasDelayedSettlement = false,
             // We are intentionally polling for Swish even though it uses the redirect trampoline.
             // About 50% of the time, the intent is still in `requires_action` status
@@ -472,6 +512,7 @@ constructor(
             isReusable = false,
             isVoucher = false,
             requiresMandate = false,
+            requiresMandateForPaymentIntent = false,
             hasDelayedSettlement = false,
             // We are intentionally polling for Twint even though it uses the redirect trampoline.
             // About 50% of the time, the intent is still in `requires_action` status

--- a/payments-core/src/test/java/com/stripe/android/ConfirmPaymentIntentParamsFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/ConfirmPaymentIntentParamsFactoryTest.kt
@@ -6,6 +6,7 @@ import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmStripeIntentParams
 import com.stripe.android.model.MandateDataParams
 import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodOptionsParams
@@ -177,6 +178,13 @@ class ConfirmPaymentIntentParamsFactoryTest {
     )
 
     @Test
+    fun `create() without SFU should contain mandate data for sepa_debit`() = mandateDataTest(
+        setupFutureUsage = null,
+        expectedMandateDataParams = MandateDataParams(MandateDataParams.Type.Online.DEFAULT),
+        paymentMethod = PaymentMethodFixtures.SEPA_DEBIT_PAYMENT_METHOD,
+    )
+
+    @Test
     fun `create() with 'OneTime' SFU should not contain any mandate data`() = mandateDataTest(
         setupFutureUsage = StripeIntent.Usage.OneTime,
         expectedMandateDataParams = null,
@@ -196,7 +204,8 @@ class ConfirmPaymentIntentParamsFactoryTest {
 
     private fun mandateDataTest(
         setupFutureUsage: StripeIntent.Usage?,
-        expectedMandateDataParams: MandateDataParams?
+        expectedMandateDataParams: MandateDataParams?,
+        paymentMethod: PaymentMethod = PaymentMethodFactory.cashAppPay(),
     ) {
         val factoryWithConfig = ConfirmPaymentIntentParamsFactory(
             clientSecret = CLIENT_SECRET,
@@ -207,7 +216,7 @@ class ConfirmPaymentIntentParamsFactoryTest {
         )
 
         val result = factoryWithConfig.create(
-            paymentMethod = PaymentMethodFactory.cashAppPay(),
+            paymentMethod = paymentMethod,
             optionsParams = null,
         )
 

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestSepaDebit.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestSepaDebit.kt
@@ -15,6 +15,8 @@ import com.stripe.android.paymentsheet.example.playground.settings.Country
 import com.stripe.android.paymentsheet.example.playground.settings.CountrySettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.DelayedPaymentMethodsSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.GooglePaySettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.InitializationType
+import com.stripe.android.paymentsheet.example.playground.settings.InitializationTypeSettingsDefinition
 import com.stripe.android.test.core.DEFAULT_UI_TIMEOUT
 import com.stripe.android.test.core.TestParameters
 import com.stripe.android.test.core.ui.ComposeButton
@@ -30,6 +32,7 @@ internal class TestSepaDebit : BasePlaygroundTest() {
         settings[CountrySettingsDefinition] = Country.FR
         settings[DelayedPaymentMethodsSettingsDefinition] = true
         settings[GooglePaySettingsDefinition] = false
+        settings[InitializationTypeSettingsDefinition] = InitializationType.DeferredClientSideConfirmation
     }.copy(
         authorizationAction = null,
     )

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/EpsDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/EpsDefinition.kt
@@ -20,7 +20,7 @@ internal object EpsDefinition : PaymentMethodDefinition {
         AddPaymentMethodRequirement.UnsupportedForSetup,
     )
 
-    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = true
+    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
     override fun uiDefinitionFactory(): UiDefinitionFactory = EpsUiDefinitionFactory
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Some LPMs require mandates for payment intents. Updating logic to support that.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
ir-nectar-conventional

