### PR TITLE
[MOBILESDK 2686] PaymentMethodExtraParams for Card and USBankAccount

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -4388,6 +4388,22 @@ public final class com/stripe/android/model/PaymentMethodExtraParams$BacsDebit$C
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/model/PaymentMethodExtraParams$Card$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodExtraParams$Card;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethodExtraParams$Card;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PaymentMethodExtraParams$USBankAccount$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodExtraParams$USBankAccount;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethodExtraParams$USBankAccount;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/model/PaymentMethodMessage$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodMessage;

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethodExtraParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethodExtraParams.kt
@@ -39,4 +39,36 @@ sealed class PaymentMethodExtraParams(
             const val PARAM_CONFIRMED = "confirmed"
         }
     }
+
+    @Parcelize
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    data class Card(
+        val setAsDefault: Boolean? = null
+    ) : PaymentMethodExtraParams(PaymentMethod.Type.BacsDebit) {
+        override fun createTypeParams(): List<Pair<String, Any?>> {
+            return listOf(
+                PARAM_SET_AS_DEFAULT_PAYMENT_METHOD to setAsDefault?.toString()
+            )
+        }
+
+        internal companion object {
+            const val PARAM_SET_AS_DEFAULT_PAYMENT_METHOD = "set_as_default_payment_method"
+        }
+    }
+
+    @Parcelize
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    data class USBankAccount(
+        val setAsDefault: Boolean? = null
+    ) : PaymentMethodExtraParams(PaymentMethod.Type.BacsDebit) {
+        override fun createTypeParams(): List<Pair<String, Any?>> {
+            return listOf(
+                PARAM_SET_AS_DEFAULT_PAYMENT_METHOD to setAsDefault?.toString()
+            )
+        }
+
+        internal companion object {
+            const val PARAM_SET_AS_DEFAULT_PAYMENT_METHOD = "set_as_default_payment_method"
+        }
+    }
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverter.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverter.kt
@@ -129,6 +129,14 @@ class FieldValuesToParamsMapConverter {
                 PaymentMethod.Type.BacsDebit.code -> PaymentMethodExtraParams.BacsDebit(
                     confirmed = fieldValuePairsForExtras[IdentifierSpec.BacsDebitConfirmed]?.value?.toBoolean()
                 )
+                PaymentMethod.Type.Card.code -> PaymentMethodExtraParams.Card(
+                    setAsDefault =
+                    fieldValuePairsForExtras[IdentifierSpec.SetAsDefaultPaymentMethod]?.value?.toBoolean()
+                )
+                PaymentMethod.Type.USBankAccount.code -> PaymentMethodExtraParams.USBankAccount(
+                    setAsDefault =
+                    fieldValuePairsForExtras[IdentifierSpec.SetAsDefaultPaymentMethod]?.value?.toBoolean()
+                )
 
                 else -> null
             }

--- a/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
@@ -127,6 +127,7 @@ internal class DefaultLinkConfirmationHandler @Inject constructor(
                     linkAccount = linkAccount,
                     cvc = cvc
                 ),
+                extraParams = null,
                 optionsParams = null,
                 shouldSave = false
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationOptionKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationOptionKtx.kt
@@ -52,6 +52,7 @@ private fun PaymentSelection.New.USBankAccount.toConfirmationOption(): PaymentMe
         PaymentMethodConfirmationOption.New(
             createParams = paymentMethodCreateParams,
             optionsParams = paymentMethodOptionsParams,
+            extraParams = paymentMethodExtraParams,
             shouldSave = customerRequestedSave == PaymentSelection.CustomerRequestedSave.RequestReuse,
         )
     }
@@ -88,6 +89,7 @@ private fun PaymentSelection.New.toConfirmationOption(): ConfirmationHandler.Opt
         PaymentMethodConfirmationOption.New(
             createParams = paymentMethodCreateParams,
             optionsParams = paymentMethodOptionsParams,
+            extraParams = paymentMethodExtraParams,
             shouldSave = customerRequestedSave == PaymentSelection.CustomerRequestedSave.RequestReuse,
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/PaymentMethodConfirmationOption.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/PaymentMethodConfirmationOption.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentelement.confirmation
 
 import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.PaymentMethodOptionsParams
 import kotlinx.parcelize.Parcelize
 
@@ -15,6 +16,7 @@ internal sealed interface PaymentMethodConfirmationOption : ConfirmationHandler.
     data class New(
         val createParams: PaymentMethodCreateParams,
         val optionsParams: PaymentMethodOptionsParams?,
+        val extraParams: PaymentMethodExtraParams?,
         val shouldSave: Boolean
     ) : PaymentMethodConfirmationOption
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationDefinition.kt
@@ -83,6 +83,7 @@ internal class BacsConfirmationDefinition @Inject constructor(
                 val nextConfirmationOption = PaymentMethodConfirmationOption.New(
                     createParams = confirmationOption.createParams,
                     optionsParams = null,
+                    extraParams = null,
                     shouldSave = false,
                 )
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptorKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptorKtx.kt
@@ -15,6 +15,7 @@ internal suspend fun IntentConfirmationInterceptor.intercept(
     return when (confirmationOption) {
         is PaymentMethodConfirmationOption.New -> {
             intercept(
+                // TODO paymentMethodExtraParams = confirmationOption.extraParams
                 initializationMode = initializationMode,
                 intent = intent,
                 paymentMethodOptionsParams = confirmationOption.optionsParams,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinition.kt
@@ -173,6 +173,7 @@ internal class LinkInlineSignupConfirmationDefinition(
             optionsParams = PaymentMethodOptionsParams.Card(
                 setupFutureUsage = saveOption.setupFutureUsage,
             ),
+            extraParams = null,
             shouldSave = saveOption.shouldSave(),
         )
     }
@@ -181,6 +182,7 @@ internal class LinkInlineSignupConfirmationDefinition(
         return PaymentMethodConfirmationOption.New(
             createParams = createParams,
             optionsParams = optionsParams,
+            extraParams = null,
             shouldSave = saveOption.shouldSave(),
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -104,6 +104,7 @@ internal fun FormFieldValues.transformToPaymentSelection(
                 setupFutureUsage = userRequestedReuse.setupFutureUsage
             ),
             paymentMethodCreateParams = params,
+            paymentMethodExtraParams = extras,
             brand = CardBrand.fromCode(fieldValuePairs[IdentifierSpec.CardBrand]?.value),
             customerRequestedSave = userRequestedReuse,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
@@ -49,6 +49,7 @@ class ConfirmationHandlerOptionKtxTest {
                 createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                 optionsParams = PaymentMethodOptionsParams.Card(network = "cartes_bancaires"),
                 shouldSave = false,
+                extraParams = null,
             )
         )
     }
@@ -69,6 +70,7 @@ class ConfirmationHandlerOptionKtxTest {
                 createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                 optionsParams = null,
                 shouldSave = false,
+                extraParams = null,
             )
         )
     }
@@ -89,6 +91,7 @@ class ConfirmationHandlerOptionKtxTest {
                 createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                 optionsParams = null,
                 shouldSave = true,
+                extraParams = null,
             )
         )
     }
@@ -139,6 +142,7 @@ class ConfirmationHandlerOptionKtxTest {
                 createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                 optionsParams = null,
                 shouldSave = false,
+                extraParams = null,
             )
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationDefinitionTest.kt
@@ -70,6 +70,7 @@ class IntentConfirmationDefinitionTest {
                     createParams = createParams,
                     optionsParams = null,
                     shouldSave = true,
+                    extraParams = null,
                 ),
                 confirmationParameters = CONFIRMATION_PARAMETERS,
             )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationFlowTest.kt
@@ -38,6 +38,7 @@ internal class IntentConfirmationFlowTest {
                 createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                 optionsParams = null,
                 shouldSave = false,
+                extraParams = null,
             ),
             confirmationParameters = ConfirmationDefinition.Parameters(
                 initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
@@ -80,6 +81,7 @@ internal class IntentConfirmationFlowTest {
                 createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                 optionsParams = null,
                 shouldSave = false,
+                extraParams = null,
             ),
             confirmationParameters = ConfirmationDefinition.Parameters(
                 initializationMode = PaymentElementLoader.InitializationMode.SetupIntent(
@@ -258,6 +260,7 @@ internal class IntentConfirmationFlowTest {
             createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
             optionsParams = null,
             shouldSave = false,
+            extraParams = null,
         )
 
         val DEFERRED_CONFIRMATION_PARAMETERS = ConfirmationDefinition.Parameters(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationActivityTest.kt
@@ -80,6 +80,7 @@ internal class BacsConfirmationActivityTest {
                         createParams = CONFIRMATION_OPTION.createParams,
                         optionsParams = CONFIRMATION_OPTION.optionsParams,
                         shouldSave = false,
+                        extraParams = null,
                     )
                 )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationFlowTest.kt
@@ -36,6 +36,7 @@ class BacsConfirmationFlowTest {
                 createParams = BACS_CONFIRMATION_OPTION.createParams,
                 optionsParams = BACS_CONFIRMATION_OPTION.optionsParams,
                 shouldSave = false,
+                extraParams = null,
             ),
             parameters = CONFIRMATION_PARAMETERS,
         ),

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/IdentifierSpec.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/IdentifierSpec.kt
@@ -84,7 +84,10 @@ data class IdentifierSpec(
         val SameAsShipping = IdentifierSpec("same_as_shipping", ignoreField = true)
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-        val SetAsDefaultPaymentMethod = IdentifierSpec("set_as_default_payment_method")
+        val SetAsDefaultPaymentMethod = IdentifierSpec(
+            v1 = "set_as_default_payment_method",
+            destination = ParameterDestination.Local.Extras
+        )
 
         val Upi = IdentifierSpec("upi")
         val Vpa = IdentifierSpec("upi[vpa]")


### PR DESCRIPTION
# Summary
Created PaymentMethodExtraParams and added them to PaymentMethodConfirmationOption.New

# Motivation
We want to add set as default to the backend.

https://jira.corp.stripe.com/browse/MOBILESDK-2684
https://jira.corp.stripe.com/browse/MOBILESDK-2684

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [X] Manually verified

# Screenshots
N.A.

# Changelog
N.A.
