### PR TITLE
Report field interaction for FormActivity

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/EmbeddedFormInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/EmbeddedFormInteractorFactory.kt
@@ -6,6 +6,7 @@ import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.payments.bankaccount.CollectBankAccountLauncher.Companion.HOSTED_SURFACE_PAYMENT_ELEMENT
+import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormArguments
 import com.stripe.android.paymentsheet.verticalmode.DefaultVerticalModeFormInteractor
 import com.stripe.android.paymentsheet.verticalmode.PaymentMethodIncentiveInteractor
@@ -20,7 +21,8 @@ internal class EmbeddedFormInteractorFactory @Inject constructor(
     private val embeddedSelectionHolder: EmbeddedSelectionHolder,
     private val embeddedFormHelperFactory: EmbeddedFormHelperFactory,
     @ViewModelScope private val viewModelScope: CoroutineScope,
-    private val formActivityStateHelper: FormActivityStateHelper
+    private val formActivityStateHelper: FormActivityStateHelper,
+    private val eventReporter: EventReporter
 ) {
     fun create(): DefaultVerticalModeFormInteractor {
         val formHelper = embeddedFormHelperFactory.create(
@@ -49,8 +51,7 @@ internal class EmbeddedFormInteractorFactory @Inject constructor(
             formElements = formHelper.formElementsForCode(paymentMethodCode),
             onFormFieldValuesChanged = formHelper::onFormFieldValuesChanged,
             usBankAccountArguments = usBankAccountFormArguments,
-            reportFieldInteraction = {
-            },
+            reportFieldInteraction = eventReporter::onPaymentMethodFormInteraction,
             headerInformation = paymentMethodMetadata.formHeaderInformationForCode(
                 code = paymentMethodCode,
                 customerHasSavedPaymentMethods = hasSavedPaymentMethods

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityScreenShotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityScreenShotTest.kt
@@ -112,6 +112,7 @@ internal class FormActivityScreenShotTest {
             embeddedSelectionHolder = selectionHolder,
             cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory
         )
+        val eventReporter = FakeEventReporter()
         val interactor = EmbeddedFormInteractorFactory(
             paymentMethodMetadata = paymentMethodMetadata,
             paymentMethodCode = "card",
@@ -120,6 +121,7 @@ internal class FormActivityScreenShotTest {
             embeddedFormHelperFactory = formHelperFactory,
             viewModelScope = TestScope(UnconfinedTestDispatcher()),
             formActivityStateHelper = stateHolder,
+            eventReporter = eventReporter
         ).create()
 
         stateHolder.updateConfirmationState(confirmationState)
@@ -129,7 +131,7 @@ internal class FormActivityScreenShotTest {
         ViewModelStoreOwnerContext {
             FormActivityUI(
                 interactor = interactor,
-                eventReporter = FakeEventReporter(),
+                eventReporter = eventReporter,
                 onClick = {},
                 onProcessingCompleted = {},
                 state = state.copy(isEnabled = enabled),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityUiTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityUiTest.kt
@@ -61,6 +61,7 @@ class FormActivityUiTest {
             coroutineScope = TestScope(UnconfinedTestDispatcher()),
             onClickDelegate = OnClickDelegateOverrideImpl()
         )
+        val eventReporter = FakeEventReporter()
         val interactor = EmbeddedFormInteractorFactory(
             paymentMethodMetadata = paymentMethodMetadata,
             paymentMethodCode = "card",
@@ -68,14 +69,15 @@ class FormActivityUiTest {
             embeddedSelectionHolder = embeddedSelectionHolder,
             embeddedFormHelperFactory = embeddedFormHelperFactory,
             viewModelScope = testScope,
-            formActivityStateHelper = stateHelper
+            formActivityStateHelper = stateHelper,
+            eventReporter = eventReporter
         ).create()
 
         composeRule.setContent {
             val state by stateHelper.state.collectAsState()
             FormActivityUI(
                 interactor = interactor,
-                eventReporter = FakeEventReporter(),
+                eventReporter = eventReporter,
                 onDismissed = {},
                 onClick = {},
                 onProcessingCompleted = {},


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Pass `EventReporter.onPaymentMethodFormInteraction` to `DefaultVerticalModeFormInteractor`
This will report form interaction when the user opens FormActivity and interacts with any the fields. If the user closes FormActivity and re-opens with the same PaymentMethodCode, the interaction will be sent again. This matches the behavior of iOS.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-3118

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

No tests added as this behavior is already tested by `DefaultVerticalModeFormInteractorTest`
