### PR TITLE
[MOBILESDK 2686] When “Set as default” checkbox is checked, set set_as_default_payment_method on PaymentIntent/SetupIntent

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -4388,6 +4388,22 @@ public final class com/stripe/android/model/PaymentMethodExtraParams$BacsDebit$C
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/model/PaymentMethodExtraParams$Card$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodExtraParams$Card;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethodExtraParams$Card;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PaymentMethodExtraParams$USBankAccount$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodExtraParams$USBankAccount;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethodExtraParams$USBankAccount;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/model/PaymentMethodMessage$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodMessage;

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -1982,6 +1982,7 @@ public final class com/stripe/android/model/ConfirmPaymentIntentParams : com/str
 	public final fun component12 ()Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;
 	public final fun component13 ()Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;
 	public final fun component14 ()Ljava/lang/String;
+	public final fun component15 ()Ljava/lang/Boolean;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Lcom/stripe/android/model/SourceParams;
 	public final fun component4 ()Ljava/lang/String;
@@ -1989,8 +1990,8 @@ public final class com/stripe/android/model/ConfirmPaymentIntentParams : com/str
 	public final fun component6 ()Ljava/lang/String;
 	public final fun component7 ()Ljava/lang/Boolean;
 	public final fun component9 ()Lcom/stripe/android/model/PaymentMethodOptionsParams;
-	public final fun copy (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/SourceParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ZLcom/stripe/android/model/PaymentMethodOptionsParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/ConfirmPaymentIntentParams;Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/SourceParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ZLcom/stripe/android/model/PaymentMethodOptionsParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public final fun copy (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/SourceParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ZLcom/stripe/android/model/PaymentMethodOptionsParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;Ljava/lang/String;Ljava/lang/Boolean;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/ConfirmPaymentIntentParams;Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/SourceParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ZLcom/stripe/android/model/PaymentMethodOptionsParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;Ljava/lang/String;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
 	public static final fun create (Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
 	public static final fun create (Ljava/lang/String;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
 	public static final fun create (Ljava/lang/String;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
@@ -2003,6 +2004,7 @@ public final class com/stripe/android/model/ConfirmPaymentIntentParams : com/str
 	public static final fun createWithPaymentMethodCreateParams (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
 	public static final fun createWithPaymentMethodCreateParams (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
 	public static final fun createWithPaymentMethodCreateParams (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;Lcom/stripe/android/model/PaymentMethodOptionsParams;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public static final fun createWithPaymentMethodCreateParams (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;Lcom/stripe/android/model/PaymentMethodOptionsParams;Ljava/lang/Boolean;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
 	public static final fun createWithPaymentMethodId (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
 	public static final fun createWithPaymentMethodId (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
 	public static final fun createWithPaymentMethodId (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lcom/stripe/android/model/PaymentMethodOptionsParams;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
@@ -2027,6 +2029,7 @@ public final class com/stripe/android/model/ConfirmPaymentIntentParams : com/str
 	public final fun getReceiptEmail ()Ljava/lang/String;
 	public fun getReturnUrl ()Ljava/lang/String;
 	public final fun getSavePaymentMethod ()Ljava/lang/Boolean;
+	public final fun getSetAsDefaultPaymentMethod ()Ljava/lang/Boolean;
 	public final fun getSetupFutureUsage ()Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;
 	public final fun getShipping ()Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;
 	public final fun getSourceId ()Ljava/lang/String;
@@ -2038,6 +2041,7 @@ public final class com/stripe/android/model/ConfirmPaymentIntentParams : com/str
 	public final fun setReceiptEmail (Ljava/lang/String;)V
 	public fun setReturnUrl (Ljava/lang/String;)V
 	public final fun setSavePaymentMethod (Ljava/lang/Boolean;)V
+	public final fun setSetAsDefaultPaymentMethod (Ljava/lang/Boolean;)V
 	public final fun setSetupFutureUsage (Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;)V
 	public final fun setShipping (Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;)V
 	public final fun shouldSavePaymentMethod ()Z
@@ -2063,7 +2067,8 @@ public final class com/stripe/android/model/ConfirmPaymentIntentParams$Companion
 	public final fun createWithPaymentMethodCreateParams (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
 	public final fun createWithPaymentMethodCreateParams (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
 	public final fun createWithPaymentMethodCreateParams (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;Lcom/stripe/android/model/PaymentMethodOptionsParams;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
-	public static synthetic fun createWithPaymentMethodCreateParams$default (Lcom/stripe/android/model/ConfirmPaymentIntentParams$Companion;Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;Lcom/stripe/android/model/PaymentMethodOptionsParams;ILjava/lang/Object;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public final fun createWithPaymentMethodCreateParams (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;Lcom/stripe/android/model/PaymentMethodOptionsParams;Ljava/lang/Boolean;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public static synthetic fun createWithPaymentMethodCreateParams$default (Lcom/stripe/android/model/ConfirmPaymentIntentParams$Companion;Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;Lcom/stripe/android/model/PaymentMethodOptionsParams;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
 	public final fun createWithPaymentMethodId (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
 	public final fun createWithPaymentMethodId (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
 	public final fun createWithPaymentMethodId (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lcom/stripe/android/model/PaymentMethodOptionsParams;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
@@ -2133,11 +2138,13 @@ public final class com/stripe/android/model/ConfirmSetupIntentParams : com/strip
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component6 ()Ljava/lang/String;
 	public final fun component7 ()Lcom/stripe/android/model/MandateDataParams;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;ZLjava/lang/String;Lcom/stripe/android/model/MandateDataParams;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/ConfirmSetupIntentParams;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;ZLjava/lang/String;Lcom/stripe/android/model/MandateDataParams;ILjava/lang/Object;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public final fun component8 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;ZLjava/lang/String;Lcom/stripe/android/model/MandateDataParams;Ljava/lang/Boolean;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/ConfirmSetupIntentParams;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;ZLjava/lang/String;Lcom/stripe/android/model/MandateDataParams;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Ljava/lang/String;Ljava/lang/Boolean;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public static final fun create (Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$Type;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public static final fun create (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public static final fun create (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
@@ -2149,10 +2156,12 @@ public final class com/stripe/android/model/ConfirmSetupIntentParams : com/strip
 	public final fun getMandateData ()Lcom/stripe/android/model/MandateDataParams;
 	public final fun getMandateId ()Ljava/lang/String;
 	public fun getReturnUrl ()Ljava/lang/String;
+	public final fun getSetAsDefaultPaymentMethod ()Ljava/lang/Boolean;
 	public fun hashCode ()I
 	public final fun setMandateData (Lcom/stripe/android/model/MandateDataParams;)V
 	public final fun setMandateId (Ljava/lang/String;)V
 	public fun setReturnUrl (Ljava/lang/String;)V
+	public final fun setSetAsDefaultPaymentMethod (Ljava/lang/Boolean;)V
 	public fun shouldUseStripeSdk ()Z
 	public fun toParamMap ()Ljava/util/Map;
 	public fun toString ()Ljava/lang/String;
@@ -2165,11 +2174,12 @@ public final class com/stripe/android/model/ConfirmSetupIntentParams$Companion {
 	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Ljava/lang/String;Ljava/lang/Boolean;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public final fun create (Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$Type;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public final fun create (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public final fun create (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public final fun create (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
-	public static synthetic fun create$default (Lcom/stripe/android/model/ConfirmSetupIntentParams$Companion;Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public static synthetic fun create$default (Lcom/stripe/android/model/ConfirmSetupIntentParams$Companion;Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Ljava/lang/String;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public static synthetic fun create$default (Lcom/stripe/android/model/ConfirmSetupIntentParams$Companion;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public final fun createWithoutPaymentMethod (Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 }

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -1982,7 +1982,6 @@ public final class com/stripe/android/model/ConfirmPaymentIntentParams : com/str
 	public final fun component12 ()Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;
 	public final fun component13 ()Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;
 	public final fun component14 ()Ljava/lang/String;
-	public final fun component15 ()Ljava/lang/Boolean;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Lcom/stripe/android/model/SourceParams;
 	public final fun component4 ()Ljava/lang/String;
@@ -2004,7 +2003,6 @@ public final class com/stripe/android/model/ConfirmPaymentIntentParams : com/str
 	public static final fun createWithPaymentMethodCreateParams (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
 	public static final fun createWithPaymentMethodCreateParams (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
 	public static final fun createWithPaymentMethodCreateParams (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;Lcom/stripe/android/model/PaymentMethodOptionsParams;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
-	public static final fun createWithPaymentMethodCreateParams (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;Lcom/stripe/android/model/PaymentMethodOptionsParams;Ljava/lang/Boolean;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
 	public static final fun createWithPaymentMethodId (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
 	public static final fun createWithPaymentMethodId (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
 	public static final fun createWithPaymentMethodId (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lcom/stripe/android/model/PaymentMethodOptionsParams;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
@@ -2029,7 +2027,6 @@ public final class com/stripe/android/model/ConfirmPaymentIntentParams : com/str
 	public final fun getReceiptEmail ()Ljava/lang/String;
 	public fun getReturnUrl ()Ljava/lang/String;
 	public final fun getSavePaymentMethod ()Ljava/lang/Boolean;
-	public final fun getSetAsDefaultPaymentMethod ()Ljava/lang/Boolean;
 	public final fun getSetupFutureUsage ()Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;
 	public final fun getShipping ()Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;
 	public final fun getSourceId ()Ljava/lang/String;
@@ -2041,7 +2038,6 @@ public final class com/stripe/android/model/ConfirmPaymentIntentParams : com/str
 	public final fun setReceiptEmail (Ljava/lang/String;)V
 	public fun setReturnUrl (Ljava/lang/String;)V
 	public final fun setSavePaymentMethod (Ljava/lang/Boolean;)V
-	public final fun setSetAsDefaultPaymentMethod (Ljava/lang/Boolean;)V
 	public final fun setSetupFutureUsage (Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;)V
 	public final fun setShipping (Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;)V
 	public final fun shouldSavePaymentMethod ()Z
@@ -2067,8 +2063,7 @@ public final class com/stripe/android/model/ConfirmPaymentIntentParams$Companion
 	public final fun createWithPaymentMethodCreateParams (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
 	public final fun createWithPaymentMethodCreateParams (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
 	public final fun createWithPaymentMethodCreateParams (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;Lcom/stripe/android/model/PaymentMethodOptionsParams;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
-	public final fun createWithPaymentMethodCreateParams (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;Lcom/stripe/android/model/PaymentMethodOptionsParams;Ljava/lang/Boolean;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
-	public static synthetic fun createWithPaymentMethodCreateParams$default (Lcom/stripe/android/model/ConfirmPaymentIntentParams$Companion;Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;Lcom/stripe/android/model/PaymentMethodOptionsParams;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public static synthetic fun createWithPaymentMethodCreateParams$default (Lcom/stripe/android/model/ConfirmPaymentIntentParams$Companion;Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;Lcom/stripe/android/model/PaymentMethodOptionsParams;ILjava/lang/Object;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
 	public final fun createWithPaymentMethodId (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
 	public final fun createWithPaymentMethodId (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
 	public final fun createWithPaymentMethodId (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lcom/stripe/android/model/PaymentMethodOptionsParams;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
@@ -2138,13 +2133,11 @@ public final class com/stripe/android/model/ConfirmSetupIntentParams : com/strip
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component6 ()Ljava/lang/String;
 	public final fun component7 ()Lcom/stripe/android/model/MandateDataParams;
-	public final fun component8 ()Ljava/lang/Boolean;
 	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;ZLjava/lang/String;Lcom/stripe/android/model/MandateDataParams;Ljava/lang/Boolean;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public static synthetic fun copy$default (Lcom/stripe/android/model/ConfirmSetupIntentParams;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;ZLjava/lang/String;Lcom/stripe/android/model/MandateDataParams;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
-	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Ljava/lang/String;Ljava/lang/Boolean;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public static final fun create (Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$Type;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public static final fun create (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public static final fun create (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
@@ -2156,12 +2149,10 @@ public final class com/stripe/android/model/ConfirmSetupIntentParams : com/strip
 	public final fun getMandateData ()Lcom/stripe/android/model/MandateDataParams;
 	public final fun getMandateId ()Ljava/lang/String;
 	public fun getReturnUrl ()Ljava/lang/String;
-	public final fun getSetAsDefaultPaymentMethod ()Ljava/lang/Boolean;
 	public fun hashCode ()I
 	public final fun setMandateData (Lcom/stripe/android/model/MandateDataParams;)V
 	public final fun setMandateId (Ljava/lang/String;)V
 	public fun setReturnUrl (Ljava/lang/String;)V
-	public final fun setSetAsDefaultPaymentMethod (Ljava/lang/Boolean;)V
 	public fun shouldUseStripeSdk ()Z
 	public fun toParamMap ()Ljava/util/Map;
 	public fun toString ()Ljava/lang/String;
@@ -2174,12 +2165,11 @@ public final class com/stripe/android/model/ConfirmSetupIntentParams$Companion {
 	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
-	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Ljava/lang/String;Ljava/lang/Boolean;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public final fun create (Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$Type;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public final fun create (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public final fun create (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public final fun create (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
-	public static synthetic fun create$default (Lcom/stripe/android/model/ConfirmSetupIntentParams$Companion;Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Ljava/lang/String;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public static synthetic fun create$default (Lcom/stripe/android/model/ConfirmSetupIntentParams$Companion;Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public static synthetic fun create$default (Lcom/stripe/android/model/ConfirmSetupIntentParams$Companion;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public final fun createWithoutPaymentMethod (Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 }

--- a/payments-core/src/main/java/com/stripe/android/ConfirmStripeIntentParamsFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/ConfirmStripeIntentParamsFactory.kt
@@ -90,7 +90,7 @@ internal class ConfirmPaymentIntentParamsFactory(
         optionsParams: PaymentMethodOptionsParams?,
         extraParams: PaymentMethodExtraParams?,
     ): ConfirmPaymentIntentParams {
-        return ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
+        return ConfirmPaymentIntentParams.createWithSetAsDefaultPaymentMethod(
             paymentMethodCreateParams = createParams,
             clientSecret = clientSecret,
             paymentMethodOptions = optionsParams,
@@ -123,7 +123,7 @@ internal class ConfirmSetupIntentParamsFactory(
         optionsParams: PaymentMethodOptionsParams?,
         extraParams: PaymentMethodExtraParams?,
     ): ConfirmSetupIntentParams {
-        return ConfirmSetupIntentParams.create(
+        return ConfirmSetupIntentParams.createWithSetAsDefaultPaymentMethod(
             paymentMethodCreateParams = createParams,
             clientSecret = clientSecret,
             setAsDefaultPaymentMethod = extraParams?.extractSetAsDefaultPaymentMethodFromExtraParams()

--- a/payments-core/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
@@ -124,7 +124,8 @@ constructor(
      * Indicates that this should be the default payment method going forward
      */
     var setAsDefaultPaymentMethod: Boolean? = null,
-    ) : ConfirmStripeIntentParams {
+
+) : ConfirmStripeIntentParams {
     fun shouldSavePaymentMethod(): Boolean {
         return savePaymentMethod == true
     }
@@ -399,7 +400,7 @@ constructor(
             mandateId: String? = null,
             mandateData: MandateDataParams? = null,
             setupFutureUsage: SetupFutureUsage? = null,
-            shipping: Shipping? = null
+            shipping: Shipping? = null,
         ): ConfirmPaymentIntentParams {
             return ConfirmPaymentIntentParams(
                 clientSecret = clientSecret,
@@ -409,7 +410,7 @@ constructor(
                 mandateId = mandateId,
                 mandateData = mandateData,
                 setupFutureUsage = setupFutureUsage,
-                shipping = shipping
+                shipping = shipping,
             )
         }
 
@@ -441,7 +442,8 @@ constructor(
             mandateData: MandateDataParams? = null,
             setupFutureUsage: SetupFutureUsage? = null,
             shipping: Shipping? = null,
-            paymentMethodOptions: PaymentMethodOptionsParams? = null
+            paymentMethodOptions: PaymentMethodOptionsParams? = null,
+            setAsDefaultPaymentMethod: Boolean? = null,
         ): ConfirmPaymentIntentParams {
             return ConfirmPaymentIntentParams(
                 clientSecret = clientSecret,
@@ -451,7 +453,8 @@ constructor(
                 mandateData = mandateData,
                 setupFutureUsage = setupFutureUsage,
                 shipping = shipping,
-                paymentMethodOptions = paymentMethodOptions
+                paymentMethodOptions = paymentMethodOptions,
+                setAsDefaultPaymentMethod = setAsDefaultPaymentMethod,
             )
         }
 

--- a/payments-core/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
@@ -443,9 +443,8 @@ constructor(
             setupFutureUsage: SetupFutureUsage? = null,
             shipping: Shipping? = null,
             paymentMethodOptions: PaymentMethodOptionsParams? = null,
-            setAsDefaultPaymentMethod: Boolean? = null,
         ): ConfirmPaymentIntentParams {
-            return ConfirmPaymentIntentParams(
+            return createWithSetAsDefaultPaymentMethod(
                 clientSecret = clientSecret,
                 paymentMethodCreateParams = paymentMethodCreateParams,
                 savePaymentMethod = savePaymentMethod,
@@ -454,7 +453,7 @@ constructor(
                 setupFutureUsage = setupFutureUsage,
                 shipping = shipping,
                 paymentMethodOptions = paymentMethodOptions,
-                setAsDefaultPaymentMethod = setAsDefaultPaymentMethod,
+                setAsDefaultPaymentMethod = null,
             )
         }
 
@@ -539,6 +538,30 @@ constructor(
                 // return_url is no longer used by is still required by the backend
                 // TODO(smaskell): remove this when no longer required
                 returnUrl = "stripe://return_url"
+            )
+        }
+
+        internal fun createWithSetAsDefaultPaymentMethod(
+            paymentMethodCreateParams: PaymentMethodCreateParams,
+            clientSecret: String,
+            savePaymentMethod: Boolean? = null,
+            mandateId: String? = null,
+            mandateData: MandateDataParams? = null,
+            setupFutureUsage: SetupFutureUsage? = null,
+            shipping: Shipping? = null,
+            paymentMethodOptions: PaymentMethodOptionsParams? = null,
+            setAsDefaultPaymentMethod: Boolean?,
+        ): ConfirmPaymentIntentParams {
+            return ConfirmPaymentIntentParams(
+                clientSecret = clientSecret,
+                paymentMethodCreateParams = paymentMethodCreateParams,
+                savePaymentMethod = savePaymentMethod,
+                mandateId = mandateId,
+                mandateData = mandateData,
+                setupFutureUsage = setupFutureUsage,
+                shipping = shipping,
+                paymentMethodOptions = paymentMethodOptions,
+                setAsDefaultPaymentMethod = setAsDefaultPaymentMethod,
             )
         }
 

--- a/payments-core/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
@@ -123,7 +123,7 @@ constructor(
     /**
      * Indicates that this should be the default payment method going forward
      */
-    var setAsDefaultPaymentMethod: Boolean? = null,
+    internal val setAsDefaultPaymentMethod: Boolean? = null,
 
 ) : ConfirmStripeIntentParams {
     fun shouldSavePaymentMethod(): Boolean {

--- a/payments-core/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
@@ -8,6 +8,7 @@ import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_MANDAT
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_PAYMENT_METHOD_DATA
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_PAYMENT_METHOD_ID
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_RETURN_URL
+import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_SET_AS_DEFAULT_PAYMENT_METHOD
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_USE_STRIPE_SDK
 import kotlinx.parcelize.Parcelize
 
@@ -118,7 +119,12 @@ constructor(
      * See [receipt_email](https://stripe.com/docs/api/payment_intents/confirm#confirm_payment_intent-receipt_email).
      */
     var receiptEmail: String? = null,
-) : ConfirmStripeIntentParams {
+
+    /**
+     * Indicates that this should be the default payment method going forward
+     */
+    var setAsDefaultPaymentMethod: Boolean? = null,
+    ) : ConfirmStripeIntentParams {
     fun shouldSavePaymentMethod(): Boolean {
         return savePaymentMethod == true
     }
@@ -157,6 +163,10 @@ constructor(
         ).plus(
             setupFutureUsage?.let {
                 mapOf(PARAM_SETUP_FUTURE_USAGE to it.code)
+            }.orEmpty()
+        ).plus(
+            setAsDefaultPaymentMethod?.let {
+                mapOf(PARAM_SET_AS_DEFAULT_PAYMENT_METHOD to it)
             }.orEmpty()
         ).plus(
             shipping?.let {

--- a/payments-core/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
@@ -121,7 +121,7 @@ constructor(
     var receiptEmail: String? = null,
 
     /**
-     * Indicates that this should be the default payment method going forward
+     * Indicates that this should be the default payment method going forward.
      */
     internal val setAsDefaultPaymentMethod: Boolean? = null,
 

--- a/payments-core/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
@@ -53,7 +53,8 @@ constructor(
     /**
      * Indicates that this should be the default payment method going forward
      */
-    var setAsDefaultPaymentMethod: Boolean? = null,
+    internal val setAsDefaultPaymentMethod: Boolean? = null,
+    
 ) : ConfirmStripeIntentParams {
 
     override fun shouldUseStripeSdk(): Boolean {

--- a/payments-core/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
@@ -7,6 +7,7 @@ import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_MANDAT
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_PAYMENT_METHOD_DATA
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_PAYMENT_METHOD_ID
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_RETURN_URL
+import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_SET_AS_DEFAULT_PAYMENT_METHOD
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_USE_STRIPE_SDK
 import kotlinx.parcelize.Parcelize
 
@@ -48,6 +49,11 @@ constructor(
      * See [mandate_data](https://stripe.com/docs/api/setup_intents/confirm#confirm_setup_intent-mandate_data).
      */
     var mandateData: MandateDataParams? = null,
+
+    /**
+     * Indicates that this should be the default payment method going forward
+     */
+    var setAsDefaultPaymentMethod: Boolean? = null,
 ) : ConfirmStripeIntentParams {
 
     override fun shouldUseStripeSdk(): Boolean {
@@ -73,6 +79,10 @@ constructor(
         ).plus(
             mandateDataParams?.let {
                 mapOf(PARAM_MANDATE_DATA to it)
+            }.orEmpty()
+        ).plus(
+            setAsDefaultPaymentMethod?.let {
+                mapOf(PARAM_SET_AS_DEFAULT_PAYMENT_METHOD to it)
             }.orEmpty()
         ).plus(paymentMethodParamMap)
     }

--- a/payments-core/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
@@ -204,13 +204,15 @@ constructor(
             paymentMethodCreateParams: PaymentMethodCreateParams,
             clientSecret: String,
             mandateData: MandateDataParams? = null,
-            mandateId: String? = null
+            mandateId: String? = null,
+            setAsDefaultPaymentMethod: Boolean? = null,
         ): ConfirmSetupIntentParams {
             return ConfirmSetupIntentParams(
                 clientSecret = clientSecret,
                 paymentMethodCreateParams = paymentMethodCreateParams,
                 mandateId = mandateId,
-                mandateData = mandateData
+                mandateData = mandateData,
+                setAsDefaultPaymentMethod = setAsDefaultPaymentMethod
             )
         }
     }

--- a/payments-core/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
@@ -51,10 +51,9 @@ constructor(
     var mandateData: MandateDataParams? = null,
 
     /**
-     * Indicates that this should be the default payment method going forward
+     * Indicates that this should be the default payment method going forward.
      */
     internal val setAsDefaultPaymentMethod: Boolean? = null,
-    
 ) : ConfirmStripeIntentParams {
 
     override fun shouldUseStripeSdk(): Boolean {

--- a/payments-core/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
@@ -205,7 +205,22 @@ constructor(
             clientSecret: String,
             mandateData: MandateDataParams? = null,
             mandateId: String? = null,
-            setAsDefaultPaymentMethod: Boolean? = null,
+        ): ConfirmSetupIntentParams {
+            return createWithSetAsDefaultPaymentMethod(
+                clientSecret = clientSecret,
+                paymentMethodCreateParams = paymentMethodCreateParams,
+                mandateId = mandateId,
+                mandateData = mandateData,
+                setAsDefaultPaymentMethod = null,
+            )
+        }
+
+        internal fun createWithSetAsDefaultPaymentMethod(
+            paymentMethodCreateParams: PaymentMethodCreateParams,
+            clientSecret: String,
+            mandateData: MandateDataParams? = null,
+            mandateId: String? = null,
+            setAsDefaultPaymentMethod: Boolean?,
         ): ConfirmSetupIntentParams {
             return ConfirmSetupIntentParams(
                 clientSecret = clientSecret,

--- a/payments-core/src/main/java/com/stripe/android/model/ConfirmStripeIntentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConfirmStripeIntentParams.kt
@@ -25,6 +25,7 @@ sealed interface ConfirmStripeIntentParams : StripeParamsModel, Parcelable {
         internal const val PARAM_USE_STRIPE_SDK: String = "use_stripe_sdk"
         internal const val PARAM_MANDATE_ID: String = "mandate"
         internal const val PARAM_MANDATE_DATA = "mandate_data"
+        internal const val PARAM_SET_AS_DEFAULT_PAYMENT_METHOD = "set_as_default_payment_method"
     }
 }
 

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethodExtraParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethodExtraParams.kt
@@ -39,4 +39,36 @@ sealed class PaymentMethodExtraParams(
             const val PARAM_CONFIRMED = "confirmed"
         }
     }
+
+    @Parcelize
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    data class Card(
+        val setAsDefault: Boolean? = null
+    ) : PaymentMethodExtraParams(PaymentMethod.Type.BacsDebit) {
+        override fun createTypeParams(): List<Pair<String, Any?>> {
+            return listOf(
+                PARAM_SET_AS_DEFAULT_PAYMENT_METHOD to setAsDefault?.toString()
+            )
+        }
+
+        internal companion object {
+            const val PARAM_SET_AS_DEFAULT_PAYMENT_METHOD = "set_as_default_payment_method"
+        }
+    }
+
+    @Parcelize
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    data class USBankAccount(
+        val setAsDefault: Boolean? = null
+    ) : PaymentMethodExtraParams(PaymentMethod.Type.BacsDebit) {
+        override fun createTypeParams(): List<Pair<String, Any?>> {
+            return listOf(
+                PARAM_SET_AS_DEFAULT_PAYMENT_METHOD to setAsDefault?.toString()
+            )
+        }
+
+        internal companion object {
+            const val PARAM_SET_AS_DEFAULT_PAYMENT_METHOD = "set_as_default_payment_method"
+        }
+    }
 }

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethodExtraParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethodExtraParams.kt
@@ -2,6 +2,7 @@ package com.stripe.android.model
 
 import android.os.Parcelable
 import androidx.annotation.RestrictTo
+import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_SET_AS_DEFAULT_PAYMENT_METHOD
 import kotlinx.parcelize.Parcelize
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -44,15 +45,11 @@ sealed class PaymentMethodExtraParams(
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     data class Card(
         val setAsDefault: Boolean? = null
-    ) : PaymentMethodExtraParams(PaymentMethod.Type.BacsDebit) {
+    ) : PaymentMethodExtraParams(PaymentMethod.Type.Card) {
         override fun createTypeParams(): List<Pair<String, Any?>> {
             return listOf(
                 PARAM_SET_AS_DEFAULT_PAYMENT_METHOD to setAsDefault?.toString()
             )
-        }
-
-        internal companion object {
-            const val PARAM_SET_AS_DEFAULT_PAYMENT_METHOD = "set_as_default_payment_method"
         }
     }
 
@@ -60,15 +57,11 @@ sealed class PaymentMethodExtraParams(
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     data class USBankAccount(
         val setAsDefault: Boolean? = null
-    ) : PaymentMethodExtraParams(PaymentMethod.Type.BacsDebit) {
+    ) : PaymentMethodExtraParams(PaymentMethod.Type.USBankAccount) {
         override fun createTypeParams(): List<Pair<String, Any?>> {
             return listOf(
                 PARAM_SET_AS_DEFAULT_PAYMENT_METHOD to setAsDefault?.toString()
             )
-        }
-
-        internal companion object {
-            const val PARAM_SET_AS_DEFAULT_PAYMENT_METHOD = "set_as_default_payment_method"
         }
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/ConfirmPaymentIntentParamsFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/ConfirmPaymentIntentParamsFactoryTest.kt
@@ -7,6 +7,7 @@ import com.stripe.android.model.ConfirmStripeIntentParams
 import com.stripe.android.model.MandateDataParams
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
+import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.model.StripeIntent
@@ -76,9 +77,39 @@ class ConfirmPaymentIntentParamsFactoryTest {
                 paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                 clientSecret = CLIENT_SECRET,
                 setupFutureUsage = null,
+                setAsDefaultPaymentMethod = null,
                 paymentMethodOptions = PaymentMethodOptionsParams.Card()
             )
         )
+    }
+
+    @Test
+    fun `create() with new card when setAsDefaultPaymentMethod is true`() {
+        val paymentIntentParams = factory.create(
+            createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+            optionsParams = PaymentMethodOptionsParams.Card(
+                setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
+            ),
+            extraParams = PaymentMethodExtraParams.Card(
+                setAsDefault = true
+            )
+        )
+        assertThat(paymentIntentParams.setAsDefaultPaymentMethod).isEqualTo(true)
+    }
+
+
+    @Test
+    fun `create() with new card when setAsDefaultPaymentMethod is false`() {
+        val paymentIntentParams = factory.create(
+            createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+            optionsParams = PaymentMethodOptionsParams.Card(
+                setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
+            ),
+            extraParams = PaymentMethodExtraParams.Card(
+                setAsDefault = false
+            )
+        )
+        assertThat(paymentIntentParams.setAsDefaultPaymentMethod).isEqualTo(false)
     }
 
     @Test
@@ -215,6 +246,7 @@ class ConfirmPaymentIntentParamsFactoryTest {
         val result = factoryWithConfig.create(
             paymentMethod = PaymentMethodFactory.cashAppPay(),
             optionsParams = null,
+            extraParams = null,
         )
 
         assertThat(result).isInstanceOf(ConfirmPaymentIntentParams::class.java)

--- a/payments-core/src/test/java/com/stripe/android/ConfirmPaymentIntentParamsFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/ConfirmPaymentIntentParamsFactoryTest.kt
@@ -77,7 +77,6 @@ class ConfirmPaymentIntentParamsFactoryTest {
                 paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                 clientSecret = CLIENT_SECRET,
                 setupFutureUsage = null,
-                setAsDefaultPaymentMethod = null,
                 paymentMethodOptions = PaymentMethodOptionsParams.Card()
             )
         )

--- a/payments-core/src/test/java/com/stripe/android/ConfirmPaymentIntentParamsFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/ConfirmPaymentIntentParamsFactoryTest.kt
@@ -94,7 +94,7 @@ class ConfirmPaymentIntentParamsFactoryTest {
                 setAsDefault = true
             )
         )
-        assertThat(paymentIntentParams.setAsDefaultPaymentMethod).isEqualTo(true)
+        assertThat(paymentIntentParams.setAsDefaultPaymentMethod).isTrue()
     }
 
     @Test
@@ -108,7 +108,7 @@ class ConfirmPaymentIntentParamsFactoryTest {
                 setAsDefault = false
             )
         )
-        assertThat(paymentIntentParams.setAsDefaultPaymentMethod).isEqualTo(false)
+        assertThat(paymentIntentParams.setAsDefaultPaymentMethod).isFalse()
     }
 
     @Test

--- a/payments-core/src/test/java/com/stripe/android/ConfirmPaymentIntentParamsFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/ConfirmPaymentIntentParamsFactoryTest.kt
@@ -98,7 +98,11 @@ class ConfirmPaymentIntentParamsFactoryTest {
             shipping = shippingDetails,
         )
 
-        val result = factoryWithConfig.create(PaymentMethodFixtures.CARD_PAYMENT_METHOD, optionsParams = null)
+        val result = factoryWithConfig.create(
+            paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+            optionsParams = null,
+            extraParams = null
+        )
         assertThat(result.shipping).isEqualTo(shippingDetails)
     }
 
@@ -139,6 +143,7 @@ class ConfirmPaymentIntentParamsFactoryTest {
             optionsParams = PaymentMethodOptionsParams.Card(
                 setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.Blank
             ),
+            extraParams = null,
         )
 
         assertThat(result.paymentMethodOptions).isEqualTo(
@@ -161,6 +166,7 @@ class ConfirmPaymentIntentParamsFactoryTest {
             optionsParams = PaymentMethodOptionsParams.Card(
                 setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
             ),
+            extraParams = null,
         )
 
         assertThat(result.paymentMethodOptions).isEqualTo(

--- a/payments-core/src/test/java/com/stripe/android/ConfirmPaymentIntentParamsFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/ConfirmPaymentIntentParamsFactoryTest.kt
@@ -97,7 +97,6 @@ class ConfirmPaymentIntentParamsFactoryTest {
         assertThat(paymentIntentParams.setAsDefaultPaymentMethod).isEqualTo(true)
     }
 
-
     @Test
     fun `create() with new card when setAsDefaultPaymentMethod is false`() {
         val paymentIntentParams = factory.create(

--- a/payments-core/src/test/java/com/stripe/android/ConfirmSetupIntentParamsFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/ConfirmSetupIntentParamsFactoryTest.kt
@@ -4,6 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.ConfirmStripeIntentParams
 import com.stripe.android.model.MandateDataParams
+import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.testing.SetupIntentFactory
 import org.junit.Test
@@ -11,21 +12,53 @@ import org.junit.Test
 class ConfirmSetupIntentParamsFactoryTest {
     @Test
     fun `create() should contain mandate data`() {
-        val factoryWithConfig = ConfirmSetupIntentParamsFactory(
-            clientSecret = CLIENT_SECRET,
-            intent = SetupIntentFactory.create(),
-        )
-
-        val result = factoryWithConfig.create(
-            paymentMethod = PaymentMethodFactory.cashAppPay(),
-            optionsParams = null,
-        )
-
+        val result = getConfirmSetupIntentParamsForTesting()
         assertThat(result).isInstanceOf(ConfirmSetupIntentParams::class.java)
 
         val params = result.asConfirmSetupIntentParams()
 
         assertThat(params.mandateData).isEqualTo(MandateDataParams(MandateDataParams.Type.Online.DEFAULT))
+    }
+
+    @Test
+    fun `create() should set setAsDefault as true`() {
+        val result = getConfirmSetupIntentParamsForTesting(
+            extraParams = PaymentMethodExtraParams.Card(
+                setAsDefault = true
+            )
+        )
+
+        val params = result.asConfirmSetupIntentParams()
+
+        assertThat(params.setAsDefaultPaymentMethod).isEqualTo(true)
+    }
+
+    @Test
+    fun `create() should set setAsDefault as false`() {
+        val result = getConfirmSetupIntentParamsForTesting(
+            extraParams = PaymentMethodExtraParams.Card(
+                setAsDefault = false
+            )
+        )
+
+        val params = result.asConfirmSetupIntentParams()
+
+        assertThat(params.setAsDefaultPaymentMethod).isEqualTo(false)
+    }
+
+    private fun getConfirmSetupIntentParamsForTesting(
+        extraParams: PaymentMethodExtraParams? = null
+    ) : ConfirmSetupIntentParams {
+        val factoryWithConfig = ConfirmSetupIntentParamsFactory(
+            clientSecret = CLIENT_SECRET,
+            intent = SetupIntentFactory.create(),
+        )
+
+        return factoryWithConfig.create(
+            paymentMethod = PaymentMethodFactory.cashAppPay(),
+            optionsParams = null,
+            extraParams = extraParams,
+        )
     }
 
     private fun ConfirmStripeIntentParams.asConfirmSetupIntentParams(): ConfirmSetupIntentParams {

--- a/payments-core/src/test/java/com/stripe/android/ConfirmSetupIntentParamsFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/ConfirmSetupIntentParamsFactoryTest.kt
@@ -4,6 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.ConfirmStripeIntentParams
 import com.stripe.android.model.MandateDataParams
+import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.testing.SetupIntentFactory
@@ -30,7 +31,7 @@ class ConfirmSetupIntentParamsFactoryTest {
 
         val params = result.asConfirmSetupIntentParams()
 
-        assertThat(params.setAsDefaultPaymentMethod).isEqualTo(true)
+        assertThat(params.setAsDefaultPaymentMethod).isTrue()
     }
 
     @Test
@@ -43,12 +44,10 @@ class ConfirmSetupIntentParamsFactoryTest {
 
         val params = result.asConfirmSetupIntentParams()
 
-        assertThat(params.setAsDefaultPaymentMethod).isEqualTo(false)
+        assertThat(params.setAsDefaultPaymentMethod).isFalse()
     }
 
-    private fun getConfirmSetupIntentParamsForTesting(
-        extraParams: PaymentMethodExtraParams? = null
-    ) : ConfirmSetupIntentParams {
+    private fun getConfirmSetupIntentParamsForTesting(): ConfirmSetupIntentParams {
         val factoryWithConfig = ConfirmSetupIntentParamsFactory(
             clientSecret = CLIENT_SECRET,
             intent = SetupIntentFactory.create(),
@@ -56,6 +55,21 @@ class ConfirmSetupIntentParamsFactoryTest {
 
         return factoryWithConfig.create(
             paymentMethod = PaymentMethodFactory.cashAppPay(),
+            optionsParams = null,
+            extraParams = null,
+        )
+    }
+
+    private fun getConfirmSetupIntentParamsForTesting(
+        extraParams: PaymentMethodExtraParams
+    ): ConfirmSetupIntentParams {
+        val factoryWithConfig = ConfirmSetupIntentParamsFactory(
+            clientSecret = CLIENT_SECRET,
+            intent = SetupIntentFactory.create(),
+        )
+
+        return factoryWithConfig.create(
+            createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
             optionsParams = null,
             extraParams = extraParams,
         )

--- a/payments-core/src/test/java/com/stripe/android/model/ConfirmPaymentIntentParamsTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/ConfirmPaymentIntentParamsTest.kt
@@ -78,6 +78,27 @@ class ConfirmPaymentIntentParamsTest {
     }
 
     @Test
+    fun toParamMap_withSetAsDefaultPaymentMethod_shouldCreateExpectedMap() {
+        val params = ConfirmPaymentIntentParams
+            .createWithSetAsDefaultPaymentMethod(
+                PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                CLIENT_SECRET,
+                setAsDefaultPaymentMethod = true,
+            )
+            .toParamMap()
+
+        assertThat(params)
+            .isEqualTo(
+                mapOf(
+                    "client_secret" to CLIENT_SECRET,
+                    "use_stripe_sdk" to false,
+                    "payment_method_data" to PaymentMethodCreateParamsFixtures.DEFAULT_CARD.toParamMap(),
+                    "set_as_default_payment_method" to true,
+                )
+            )
+    }
+
+    @Test
     fun toParamMap_withPaymentMethodId_shouldCreateExpectedMap() {
         val params = ConfirmPaymentIntentParams
             .createWithPaymentMethodId(PM_ID, CLIENT_SECRET)

--- a/payments-core/src/test/java/com/stripe/android/model/ConfirmSetupIntentParamsTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/ConfirmSetupIntentParamsTest.kt
@@ -68,6 +68,24 @@ class ConfirmSetupIntentParamsTest {
     }
 
     @Test
+    fun toParamMap_withSetAsDefaultPaymentMethod_shouldCreateExpectedMap() {
+        assertThat(
+            ConfirmSetupIntentParams.createWithSetAsDefaultPaymentMethod(
+                paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                clientSecret = CLIENT_SECRET,
+                setAsDefaultPaymentMethod = true
+            ).toParamMap()
+        ).isEqualTo(
+            mapOf(
+                "client_secret" to CLIENT_SECRET,
+                "use_stripe_sdk" to false,
+                "payment_method_data" to PaymentMethodCreateParamsFixtures.DEFAULT_CARD.toParamMap(),
+                "set_as_default_payment_method" to true,
+            )
+        )
+    }
+
+    @Test
     fun toParamMap_withSepaDebitPaymentMethodParams_shouldUseDefaultMandateDataIfNotSpecified() {
         assertThat(
             ConfirmSetupIntentParams.create(

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverter.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverter.kt
@@ -129,6 +129,14 @@ class FieldValuesToParamsMapConverter {
                 PaymentMethod.Type.BacsDebit.code -> PaymentMethodExtraParams.BacsDebit(
                     confirmed = fieldValuePairsForExtras[IdentifierSpec.BacsDebitConfirmed]?.value?.toBoolean()
                 )
+                PaymentMethod.Type.Card.code -> PaymentMethodExtraParams.Card(
+                    setAsDefault =
+                    fieldValuePairsForExtras[IdentifierSpec.SetAsDefaultPaymentMethod]?.value?.toBoolean()
+                )
+                PaymentMethod.Type.USBankAccount.code -> PaymentMethodExtraParams.USBankAccount(
+                    setAsDefault =
+                    fieldValuePairsForExtras[IdentifierSpec.SetAsDefaultPaymentMethod]?.value?.toBoolean()
+                )
 
                 else -> null
             }

--- a/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
@@ -127,6 +127,7 @@ internal class DefaultLinkConfirmationHandler @Inject constructor(
                     linkAccount = linkAccount,
                     cvc = cvc
                 ),
+                extraParams = null,
                 optionsParams = null,
                 shouldSave = false
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationOptionKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationOptionKtx.kt
@@ -52,6 +52,7 @@ private fun PaymentSelection.New.USBankAccount.toConfirmationOption(): PaymentMe
         PaymentMethodConfirmationOption.New(
             createParams = paymentMethodCreateParams,
             optionsParams = paymentMethodOptionsParams,
+            extraParams = paymentMethodExtraParams,
             shouldSave = customerRequestedSave == PaymentSelection.CustomerRequestedSave.RequestReuse,
         )
     }
@@ -88,6 +89,7 @@ private fun PaymentSelection.New.toConfirmationOption(): ConfirmationHandler.Opt
         PaymentMethodConfirmationOption.New(
             createParams = paymentMethodCreateParams,
             optionsParams = paymentMethodOptionsParams,
+            extraParams = paymentMethodExtraParams,
             shouldSave = customerRequestedSave == PaymentSelection.CustomerRequestedSave.RequestReuse,
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/PaymentMethodConfirmationOption.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/PaymentMethodConfirmationOption.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentelement.confirmation
 
 import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.PaymentMethodOptionsParams
 import kotlinx.parcelize.Parcelize
 
@@ -15,6 +16,7 @@ internal sealed interface PaymentMethodConfirmationOption : ConfirmationHandler.
     data class New(
         val createParams: PaymentMethodCreateParams,
         val optionsParams: PaymentMethodOptionsParams?,
+        val extraParams: PaymentMethodExtraParams?,
         val shouldSave: Boolean
     ) : PaymentMethodConfirmationOption
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationDefinition.kt
@@ -83,6 +83,7 @@ internal class BacsConfirmationDefinition @Inject constructor(
                 val nextConfirmationOption = PaymentMethodConfirmationOption.New(
                     createParams = confirmationOption.createParams,
                     optionsParams = null,
+                    extraParams = null,
                     shouldSave = false,
                 )
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptor.kt
@@ -12,6 +12,7 @@ import com.stripe.android.model.ConfirmStripeIntentParams
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
@@ -79,6 +80,7 @@ internal interface IntentConfirmationInterceptor {
         intent: StripeIntent,
         paymentMethodCreateParams: PaymentMethodCreateParams,
         paymentMethodOptionsParams: PaymentMethodOptionsParams? = null,
+        paymentMethodExtraParams: PaymentMethodExtraParams? = null,
         shippingValues: ConfirmPaymentIntentParams.Shipping?,
         customerRequestedSave: Boolean,
     ): NextStep
@@ -88,6 +90,7 @@ internal interface IntentConfirmationInterceptor {
         intent: StripeIntent,
         paymentMethod: PaymentMethod,
         paymentMethodOptionsParams: PaymentMethodOptionsParams?,
+        paymentMethodExtraParams: PaymentMethodExtraParams?,
         shippingValues: ConfirmPaymentIntentParams.Shipping?,
     ): NextStep
 
@@ -151,6 +154,7 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
         intent: StripeIntent,
         paymentMethodCreateParams: PaymentMethodCreateParams,
         paymentMethodOptionsParams: PaymentMethodOptionsParams?,
+        paymentMethodExtraParams: PaymentMethodExtraParams?,
         shippingValues: ConfirmPaymentIntentParams.Shipping?,
         customerRequestedSave: Boolean,
     ): NextStep {
@@ -166,6 +170,7 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
                     shippingValues = shippingValues,
                     paymentMethodCreateParams = paymentMethodCreateParams,
                     paymentMethodOptionsParams = paymentMethodOptionsParams,
+                    paymentMethodExtraParams = paymentMethodExtraParams,
                     customerRequestedSave = customerRequestedSave,
                 )
             }
@@ -177,6 +182,7 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
                     shippingValues = shippingValues,
                     paymentMethodCreateParams = paymentMethodCreateParams,
                     paymentMethodOptionsParams = paymentMethodOptionsParams,
+                    paymentMethodExtraParams = paymentMethodExtraParams,
                 )
             }
 
@@ -186,6 +192,7 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
                     intent = intent,
                     shippingValues = shippingValues,
                     paymentMethodCreateParams = paymentMethodCreateParams,
+                    paymentMethodExtraParams = paymentMethodExtraParams,
                 )
             }
         }
@@ -196,6 +203,7 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
         intent: StripeIntent,
         paymentMethod: PaymentMethod,
         paymentMethodOptionsParams: PaymentMethodOptionsParams?,
+        paymentMethodExtraParams: PaymentMethodExtraParams?,
         shippingValues: ConfirmPaymentIntentParams.Shipping?,
     ): NextStep {
         return when (initializationMode) {
@@ -205,6 +213,7 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
                     intentConfiguration = initializationMode.intentConfiguration,
                     paymentMethod = paymentMethod,
                     paymentMethodOptionsParams = paymentMethodOptionsParams,
+                    paymentMethodExtraParams = paymentMethodExtraParams,
                     shippingValues = shippingValues,
                     shouldSavePaymentMethod = paymentMethodOptionsParams?.setupFutureUsage() == offSession,
                 )
@@ -217,6 +226,7 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
                     shippingValues = shippingValues,
                     paymentMethod = paymentMethod,
                     paymentMethodOptionsParams = paymentMethodOptionsParams,
+                    paymentMethodExtraParams = paymentMethodExtraParams,
                     isDeferred = false,
                 )
             }
@@ -228,6 +238,7 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
                     shippingValues = shippingValues,
                     paymentMethod = paymentMethod,
                     paymentMethodOptionsParams = paymentMethodOptionsParams,
+                    paymentMethodExtraParams = paymentMethodExtraParams,
                     isDeferred = false,
                 )
             }
@@ -238,6 +249,7 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
         intentConfiguration: PaymentSheet.IntentConfiguration,
         paymentMethodCreateParams: PaymentMethodCreateParams,
         paymentMethodOptionsParams: PaymentMethodOptionsParams?,
+        paymentMethodExtraParams: PaymentMethodExtraParams?,
         shippingValues: ConfirmPaymentIntentParams.Shipping?,
         customerRequestedSave: Boolean,
     ): NextStep {
@@ -259,6 +271,7 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
                     intentConfiguration = intentConfiguration,
                     paymentMethod = paymentMethod,
                     paymentMethodOptionsParams = paymentMethodOptionsParams,
+                    paymentMethodExtraParams = paymentMethodExtraParams,
                     shippingValues = shippingValues,
                     shouldSavePaymentMethod = customerRequestedSave,
                 )
@@ -276,6 +289,7 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
         intentConfiguration: PaymentSheet.IntentConfiguration,
         paymentMethod: PaymentMethod,
         paymentMethodOptionsParams: PaymentMethodOptionsParams?,
+        paymentMethodExtraParams: PaymentMethodExtraParams?,
         shippingValues: ConfirmPaymentIntentParams.Shipping?,
         shouldSavePaymentMethod: Boolean,
     ): NextStep {
@@ -286,6 +300,7 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
                     intentConfiguration = intentConfiguration,
                     paymentMethod = paymentMethod,
                     paymentMethodOptionsParams = paymentMethodOptionsParams,
+                    paymentMethodExtraParams = paymentMethodExtraParams,
                     shouldSavePaymentMethod = shouldSavePaymentMethod,
                     shippingValues = shippingValues,
                 )
@@ -348,6 +363,7 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
         intentConfiguration: PaymentSheet.IntentConfiguration,
         paymentMethod: PaymentMethod,
         paymentMethodOptionsParams: PaymentMethodOptionsParams?,
+        paymentMethodExtraParams: PaymentMethodExtraParams?,
         shouldSavePaymentMethod: Boolean,
         shippingValues: ConfirmPaymentIntentParams.Shipping?,
     ): NextStep {
@@ -366,6 +382,7 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
                         intentConfiguration = intentConfiguration,
                         paymentMethod = paymentMethod,
                         paymentMethodOptionsParams = paymentMethodOptionsParams,
+                        paymentMethodExtraParams = paymentMethodExtraParams,
                         shippingValues = shippingValues,
                     )
                 }
@@ -386,6 +403,7 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
         intentConfiguration: PaymentSheet.IntentConfiguration,
         paymentMethod: PaymentMethod,
         paymentMethodOptionsParams: PaymentMethodOptionsParams?,
+        paymentMethodExtraParams: PaymentMethodExtraParams?,
         shippingValues: ConfirmPaymentIntentParams.Shipping?,
     ): NextStep {
         return retrieveStripeIntent(clientSecret).mapCatching { intent ->
@@ -410,6 +428,7 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
                     shippingValues,
                     paymentMethod,
                     paymentMethodOptionsParams = paymentMethodOptionsParams,
+                    paymentMethodExtraParams = paymentMethodExtraParams,
                     isDeferred = true,
                 )
             }
@@ -434,6 +453,7 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
         shippingValues: ConfirmPaymentIntentParams.Shipping?,
         paymentMethod: PaymentMethod,
         paymentMethodOptionsParams: PaymentMethodOptionsParams?,
+        paymentMethodExtraParams: PaymentMethodExtraParams?,
         isDeferred: Boolean,
     ): NextStep {
         val factory = ConfirmStripeIntentParamsFactory.createFactory(
@@ -449,6 +469,7 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
         val confirmParams = factory.create(
             paymentMethod = paymentMethod,
             optionsParams = paymentMethodOptionsParams,
+            extraParams = paymentMethodExtraParams,
         )
         return NextStep.Confirm(
             confirmParams = confirmParams,
@@ -462,6 +483,7 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
         shippingValues: ConfirmPaymentIntentParams.Shipping?,
         paymentMethodCreateParams: PaymentMethodCreateParams,
         paymentMethodOptionsParams: PaymentMethodOptionsParams? = null,
+        paymentMethodExtraParams: PaymentMethodExtraParams? = null,
     ): NextStep {
         val paramsFactory = ConfirmStripeIntentParamsFactory.createFactory(
             clientSecret = clientSecret,
@@ -476,6 +498,7 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
         val confirmParams = paramsFactory.create(
             paymentMethodCreateParams,
             paymentMethodOptionsParams,
+            paymentMethodExtraParams,
         )
 
         return NextStep.Confirm(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptor.kt
@@ -90,7 +90,7 @@ internal interface IntentConfirmationInterceptor {
         intent: StripeIntent,
         paymentMethod: PaymentMethod,
         paymentMethodOptionsParams: PaymentMethodOptionsParams?,
-        paymentMethodExtraParams: PaymentMethodExtraParams?,
+        paymentMethodExtraParams: PaymentMethodExtraParams? = null,
         shippingValues: ConfirmPaymentIntentParams.Shipping?,
     ): NextStep
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptorKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptorKtx.kt
@@ -19,6 +19,7 @@ internal suspend fun IntentConfirmationInterceptor.intercept(
                 intent = intent,
                 paymentMethodOptionsParams = confirmationOption.optionsParams,
                 paymentMethodCreateParams = confirmationOption.createParams,
+                paymentMethodExtraParams = confirmationOption.extraParams,
                 shippingValues = shippingDetails?.toConfirmPaymentIntentShipping(),
                 customerRequestedSave = confirmationOption.shouldSave,
             )
@@ -29,6 +30,7 @@ internal suspend fun IntentConfirmationInterceptor.intercept(
                 intent = intent,
                 paymentMethod = confirmationOption.paymentMethod,
                 paymentMethodOptionsParams = confirmationOption.optionsParams,
+                paymentMethodExtraParams = null,
                 shippingValues = shippingDetails?.toConfirmPaymentIntentShipping(),
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinition.kt
@@ -173,6 +173,7 @@ internal class LinkInlineSignupConfirmationDefinition(
             optionsParams = PaymentMethodOptionsParams.Card(
                 setupFutureUsage = saveOption.setupFutureUsage,
             ),
+            extraParams = null,
             shouldSave = saveOption.shouldSave(),
         )
     }
@@ -181,6 +182,7 @@ internal class LinkInlineSignupConfirmationDefinition(
         return PaymentMethodConfirmationOption.New(
             createParams = createParams,
             optionsParams = optionsParams,
+            extraParams = null,
             shouldSave = saveOption.shouldSave(),
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -104,6 +104,7 @@ internal fun FormFieldValues.transformToPaymentSelection(
                 setupFutureUsage = userRequestedReuse.setupFutureUsage
             ),
             paymentMethodCreateParams = params,
+            paymentMethodExtraParams = extras,
             brand = CardBrand.fromCode(fieldValuePairs[IdentifierSpec.CardBrand]?.value),
             customerRequestedSave = userRequestedReuse,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
@@ -49,6 +49,7 @@ class ConfirmationHandlerOptionKtxTest {
                 createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                 optionsParams = PaymentMethodOptionsParams.Card(network = "cartes_bancaires"),
                 shouldSave = false,
+                extraParams = null,
             )
         )
     }
@@ -69,6 +70,7 @@ class ConfirmationHandlerOptionKtxTest {
                 createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                 optionsParams = null,
                 shouldSave = false,
+                extraParams = null,
             )
         )
     }
@@ -89,6 +91,7 @@ class ConfirmationHandlerOptionKtxTest {
                 createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                 optionsParams = null,
                 shouldSave = true,
+                extraParams = null,
             )
         )
     }
@@ -139,6 +142,7 @@ class ConfirmationHandlerOptionKtxTest {
                 createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                 optionsParams = null,
                 shouldSave = false,
+                extraParams = null,
             )
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultIntentConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultIntentConfirmationInterceptorTest.kt
@@ -69,6 +69,7 @@ class DefaultIntentConfirmationInterceptorTest {
             paymentMethod = paymentMethod,
             paymentMethodOptionsParams = null,
             shippingValues = null,
+            paymentMethodExtraParams = null,
         )
 
         val confirmNextStep = nextStep as? IntentConfirmationInterceptor.NextStep.Confirm
@@ -159,6 +160,7 @@ class DefaultIntentConfirmationInterceptorTest {
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             paymentMethodOptionsParams = null,
             shippingValues = null,
+            paymentMethodExtraParams = null,
         )
     }
 
@@ -214,6 +216,7 @@ class DefaultIntentConfirmationInterceptorTest {
             intent = PaymentIntentFactory.create(),
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             paymentMethodOptionsParams = null,
+            paymentMethodExtraParams = null,
             shippingValues = null,
         )
     }
@@ -261,6 +264,7 @@ class DefaultIntentConfirmationInterceptorTest {
                     intent = PaymentIntentFactory.create(),
                     paymentMethod = paymentMethod,
                     paymentMethodOptionsParams = null,
+                    paymentMethodExtraParams = null,
                     shippingValues = null,
                 )
             }
@@ -357,6 +361,7 @@ class DefaultIntentConfirmationInterceptorTest {
             intent = PaymentIntentFactory.create(),
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             paymentMethodOptionsParams = null,
+            paymentMethodExtraParams = null,
             shippingValues = null,
         )
 
@@ -387,6 +392,7 @@ class DefaultIntentConfirmationInterceptorTest {
             intent = PaymentIntentFactory.create(),
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             paymentMethodOptionsParams = null,
+            paymentMethodExtraParams = null,
             shippingValues = null,
         )
 
@@ -415,6 +421,7 @@ class DefaultIntentConfirmationInterceptorTest {
             intent = PaymentIntentFactory.create(),
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             paymentMethodOptionsParams = null,
+            paymentMethodExtraParams = null,
             shippingValues = null,
         )
 
@@ -464,6 +471,7 @@ class DefaultIntentConfirmationInterceptorTest {
             intent = PaymentIntentFactory.create(),
             paymentMethod = paymentMethod,
             paymentMethodOptionsParams = null,
+            paymentMethodExtraParams = null,
             shippingValues = null,
         )
 
@@ -504,6 +512,7 @@ class DefaultIntentConfirmationInterceptorTest {
             intent = PaymentIntentFactory.create(),
             paymentMethod = paymentMethod,
             paymentMethodOptionsParams = null,
+            paymentMethodExtraParams = null,
             shippingValues = null,
         )
 
@@ -551,6 +560,7 @@ class DefaultIntentConfirmationInterceptorTest {
             intent = PaymentIntentFactory.create(),
             paymentMethod = paymentMethod,
             paymentMethodOptionsParams = null,
+            paymentMethodExtraParams = null,
             shippingValues = null,
         )
 
@@ -603,6 +613,7 @@ class DefaultIntentConfirmationInterceptorTest {
                 paymentMethodOptionsParams = PaymentMethodOptionsParams.Card(
                     setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
                 ).takeIf { input },
+                paymentMethodExtraParams = null,
                 shippingValues = null,
             )
         }
@@ -639,6 +650,7 @@ class DefaultIntentConfirmationInterceptorTest {
             intent = PaymentIntentFactory.create(),
             paymentMethod = paymentMethod,
             paymentMethodOptionsParams = null,
+            paymentMethodExtraParams = null,
             shippingValues = null,
         )
 
@@ -681,6 +693,7 @@ class DefaultIntentConfirmationInterceptorTest {
                 intent = PaymentIntentFactory.create(),
                 paymentMethod = paymentMethod,
                 paymentMethodOptionsParams = null,
+                paymentMethodExtraParams = null,
                 shippingValues = null,
             )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationDefinitionTest.kt
@@ -70,6 +70,7 @@ class IntentConfirmationDefinitionTest {
                     createParams = createParams,
                     optionsParams = null,
                     shouldSave = true,
+                    extraParams = null,
                 ),
                 confirmationParameters = CONFIRMATION_PARAMETERS,
             )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationFlowTest.kt
@@ -241,7 +241,8 @@ internal class IntentConfirmationFlowTest {
         val actualParams = action.asLaunch().launcherArguments.asConfirm().confirmNextParams
 
         assertThat(actualParams).isInstanceOf(ConfirmPaymentIntentParams::class.java)
-        assertThat((actualParams as ConfirmPaymentIntentParams).paymentMethodCreateParams).isEqualTo(PaymentMethodCreateParamsFixtures.DEFAULT_CARD)
+        assertThat((actualParams as ConfirmPaymentIntentParams).paymentMethodCreateParams)
+            .isEqualTo(PaymentMethodCreateParamsFixtures.DEFAULT_CARD)
         assertThat(actualParams.clientSecret).isEqualTo("pi_123_secret_123")
         assertThat(actualParams.setAsDefaultPaymentMethod).isEqualTo(true)
     }
@@ -285,7 +286,7 @@ internal class IntentConfirmationFlowTest {
     private fun defaultConfirmationDefinitionParams(
         initializationMode: PaymentElementLoader.InitializationMode,
         intent: StripeIntent,
-    ) : ConfirmationDefinition.Parameters {
+    ): ConfirmationDefinition.Parameters {
         return ConfirmationDefinition.Parameters(
             initializationMode = initializationMode,
             intent = intent,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationFlowTest.kt
@@ -216,7 +216,7 @@ internal class IntentConfirmationFlowTest {
 
         assertThat(actualParams).isInstanceOf(ConfirmSetupIntentParams::class.java)
         assertThat((actualParams as ConfirmSetupIntentParams).clientSecret).isEqualTo("seti_123_secret_123")
-        assertThat(actualParams.setAsDefaultPaymentMethod).isEqualTo(true)
+        assertThat(actualParams.toParamMap().get("set_as_default_payment_method")).isEqualTo(true)
     }
 
     @Test
@@ -244,7 +244,7 @@ internal class IntentConfirmationFlowTest {
         assertThat((actualParams as ConfirmPaymentIntentParams).paymentMethodCreateParams)
             .isEqualTo(PaymentMethodCreateParamsFixtures.DEFAULT_CARD)
         assertThat(actualParams.clientSecret).isEqualTo("pi_123_secret_123")
-        assertThat(actualParams.setAsDefaultPaymentMethod).isEqualTo(true)
+        assertThat(actualParams.toParamMap().get("set_as_default_payment_method")).isEqualTo(true)
     }
 
     private fun createIntentConfirmationDefinition(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationFlowTest.kt
@@ -10,6 +10,7 @@ import com.stripe.android.model.ConfirmStripeIntentParams
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
+import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.PaymentMethodFixtures.CARD_PAYMENT_METHOD
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.model.StripeIntent
@@ -40,16 +41,9 @@ internal class IntentConfirmationFlowTest {
                 shouldSave = false,
                 extraParams = null,
             ),
-            confirmationParameters = ConfirmationDefinition.Parameters(
-                initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
-                    clientSecret = "pi_123_secret_123",
-                ),
+            confirmationParameters = defaultConfirmationDefinitionParams(
+                initializationMode = defaultPaymentIntentInitializationMode,
                 intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
-                shippingDetails = AddressDetails(
-                    name = "John Doe",
-                    phoneNumber = "1234567890"
-                ),
-                appearance = PaymentSheet.Appearance(),
             ),
         )
 
@@ -83,16 +77,9 @@ internal class IntentConfirmationFlowTest {
                 shouldSave = false,
                 extraParams = null,
             ),
-            confirmationParameters = ConfirmationDefinition.Parameters(
-                initializationMode = PaymentElementLoader.InitializationMode.SetupIntent(
-                    clientSecret = "seti_123_secret_123",
-                ),
+            confirmationParameters = defaultConfirmationDefinitionParams(
+                initializationMode = defaultSetupIntentInitializationMode,
                 intent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
-                shippingDetails = AddressDetails(
-                    name = "John Doe",
-                    phoneNumber = "1234567890"
-                ),
-                appearance = PaymentSheet.Appearance(),
             ),
         )
 
@@ -206,6 +193,59 @@ internal class IntentConfirmationFlowTest {
         assertThat(failAction.errorType).isEqualTo(ConfirmationHandler.Result.Failed.ErrorType.Payment)
     }
 
+    @Test
+    fun `setup intent, should be created with setAsDefault true`() = runTest {
+        val intentConfirmationDefinition = createIntentConfirmationDefinition()
+
+        val action = intentConfirmationDefinition.action(
+            confirmationOption = PaymentMethodConfirmationOption.New(
+                createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                optionsParams = null,
+                shouldSave = true,
+                extraParams = PaymentMethodExtraParams.Card(
+                    setAsDefault = true
+                ),
+            ),
+            confirmationParameters = defaultConfirmationDefinitionParams(
+                initializationMode = defaultSetupIntentInitializationMode,
+                intent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
+            ),
+        )
+
+        val actualParams = action.asLaunch().launcherArguments.asConfirm().confirmNextParams
+
+        assertThat(actualParams).isInstanceOf(ConfirmSetupIntentParams::class.java)
+        assertThat((actualParams as ConfirmSetupIntentParams).clientSecret).isEqualTo("seti_123_secret_123")
+        assertThat(actualParams.setAsDefaultPaymentMethod).isEqualTo(true)
+    }
+
+    @Test
+    fun `payment intent, should be created with setAsDefault true`() = runTest {
+        val intentConfirmationDefinition = createIntentConfirmationDefinition()
+
+        val action = intentConfirmationDefinition.action(
+            confirmationOption = PaymentMethodConfirmationOption.New(
+                createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                optionsParams = null,
+                shouldSave = true,
+                extraParams = PaymentMethodExtraParams.Card(
+                    setAsDefault = true
+                ),
+            ),
+            confirmationParameters = defaultConfirmationDefinitionParams(
+                initializationMode = defaultPaymentIntentInitializationMode,
+                intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            ),
+        )
+
+        val actualParams = action.asLaunch().launcherArguments.asConfirm().confirmNextParams
+
+        assertThat(actualParams).isInstanceOf(ConfirmPaymentIntentParams::class.java)
+        assertThat((actualParams as ConfirmPaymentIntentParams).paymentMethodCreateParams).isEqualTo(PaymentMethodCreateParamsFixtures.DEFAULT_CARD)
+        assertThat(actualParams.clientSecret).isEqualTo("pi_123_secret_123")
+        assertThat(actualParams.setAsDefaultPaymentMethod).isEqualTo(true)
+    }
+
     private fun createIntentConfirmationDefinition(
         createPaymentMethodResult: Result<PaymentMethod> = Result.success(CARD_PAYMENT_METHOD),
         intentResult: Result<StripeIntent> =
@@ -229,6 +269,31 @@ internal class IntentConfirmationFlowTest {
             paymentLauncherFactory = {
                 FakePaymentLauncher()
             }
+        )
+    }
+
+    private val defaultSetupIntentInitializationMode =
+        PaymentElementLoader.InitializationMode.SetupIntent(
+            clientSecret = "seti_123_secret_123",
+        )
+
+    private val defaultPaymentIntentInitializationMode =
+        PaymentElementLoader.InitializationMode.PaymentIntent(
+            clientSecret = "pi_123_secret_123",
+        )
+
+    private fun defaultConfirmationDefinitionParams(
+        initializationMode: PaymentElementLoader.InitializationMode,
+        intent: StripeIntent,
+    ) : ConfirmationDefinition.Parameters {
+        return ConfirmationDefinition.Parameters(
+            initializationMode = initializationMode,
+            intent = intent,
+            shippingDetails = AddressDetails(
+                name = "John Doe",
+                phoneNumber = "1234567890"
+            ),
+            appearance = PaymentSheet.Appearance(),
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationFlowTest.kt
@@ -38,6 +38,7 @@ internal class IntentConfirmationFlowTest {
                 createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                 optionsParams = null,
                 shouldSave = false,
+                extraParams = null,
             ),
             confirmationParameters = ConfirmationDefinition.Parameters(
                 initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
@@ -80,6 +81,7 @@ internal class IntentConfirmationFlowTest {
                 createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                 optionsParams = null,
                 shouldSave = false,
+                extraParams = null,
             ),
             confirmationParameters = ConfirmationDefinition.Parameters(
                 initializationMode = PaymentElementLoader.InitializationMode.SetupIntent(
@@ -258,6 +260,7 @@ internal class IntentConfirmationFlowTest {
             createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
             optionsParams = null,
             shouldSave = false,
+            extraParams = null,
         )
 
         val DEFERRED_CONFIRMATION_PARAMETERS = ConfirmationDefinition.Parameters(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationActivityTest.kt
@@ -80,6 +80,7 @@ internal class BacsConfirmationActivityTest {
                         createParams = CONFIRMATION_OPTION.createParams,
                         optionsParams = CONFIRMATION_OPTION.optionsParams,
                         shouldSave = false,
+                        extraParams = null,
                     )
                 )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationFlowTest.kt
@@ -36,6 +36,7 @@ class BacsConfirmationFlowTest {
                 createParams = BACS_CONFIRMATION_OPTION.createParams,
                 optionsParams = BACS_CONFIRMATION_OPTION.optionsParams,
                 shouldSave = false,
+                extraParams = null,
             ),
             parameters = CONFIRMATION_PARAMETERS,
         ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperTest.kt
@@ -19,8 +19,10 @@ import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodCreateParams.Companion.getNameFromParams
+import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.model.SetupIntentFixtures
+import com.stripe.android.model.setupFutureUsage
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.transformToPaymentMethodCreateParams
@@ -215,7 +217,9 @@ internal class FormHelperTest {
                     paymentMethodOptionsParams = PaymentMethodOptionsParams.Card(
                         setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.Blank,
                     ),
-                    paymentMethodExtraParams = null,
+                    paymentMethodExtraParams = PaymentMethodExtraParams.Card(
+                        setAsDefault = null
+                    ),
                     brand = CardBrand.Visa,
                     customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestNoReuse,
                     input = userInput,
@@ -261,7 +265,9 @@ internal class FormHelperTest {
                     paymentMethodOptionsParams = PaymentMethodOptionsParams.Card(
                         setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.Blank,
                     ),
-                    paymentMethodExtraParams = null,
+                    paymentMethodExtraParams = PaymentMethodExtraParams.Card(
+                        setAsDefault = null
+                    ),
                     brand = CardBrand.Visa,
                     customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestNoReuse,
                 )
@@ -361,7 +367,9 @@ internal class FormHelperTest {
                     paymentMethodOptionsParams = PaymentMethodOptionsParams.Card(
                         setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.Blank,
                     ),
-                    paymentMethodExtraParams = null,
+                    paymentMethodExtraParams = PaymentMethodExtraParams.Card(
+                        setAsDefault = null
+                    ),
                     brand = CardBrand.Visa,
                     customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestNoReuse,
                 )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -1009,7 +1009,7 @@ internal class PaymentSheetViewModelTest {
                         setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
                     )
                 ),
-                paymentMethodExtraParams = null,
+                paymentMethodExtraParams = isNull(),
                 shippingValues = isNull(),
             )
         }
@@ -1045,7 +1045,7 @@ internal class PaymentSheetViewModelTest {
                         setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.Blank
                     )
                 ),
-                paymentMethodExtraParams = null,
+                paymentMethodExtraParams = isNull(),
                 shippingValues = isNull(),
             )
         }
@@ -2615,6 +2615,7 @@ internal class PaymentSheetViewModelTest {
                 intent = any(),
                 paymentMethodCreateParams = any(),
                 paymentMethodOptionsParams = isNull(),
+                paymentMethodExtraParams = isNull(),
                 shippingValues = isNull(),
                 customerRequestedSave = eq(false),
             )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -1009,6 +1009,7 @@ internal class PaymentSheetViewModelTest {
                         setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
                     )
                 ),
+                paymentMethodExtraParams = null,
                 shippingValues = isNull(),
             )
         }
@@ -1044,6 +1045,7 @@ internal class PaymentSheetViewModelTest {
                         setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.Blank
                     )
                 ),
+                paymentMethodExtraParams = null,
                 shippingValues = isNull(),
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -1199,7 +1199,7 @@ internal class DefaultFlowControllerTest {
             )
 
             verify(paymentLauncher).confirm(
-                argWhere { params: ConfirmPaymentIntentParams ->
+                argWhere<ConfirmPaymentIntentParams> { params: ConfirmPaymentIntentParams ->
                     params.paymentMethodId == "pm_123456789"
                 }
             )
@@ -2109,6 +2109,7 @@ internal class DefaultFlowControllerTest {
                 shippingValues = null,
                 paymentMethodCreateParams = card,
                 paymentMethodOptionsParams = null,
+                paymentMethodExtraParams = null,
                 customerRequestedSave = true,
             )
         )

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeIntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeIntentConfirmationInterceptor.kt
@@ -7,6 +7,7 @@ import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmStripeIntentParams
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentelement.confirmation.intent.IntentConfirmationInterceptor
@@ -54,6 +55,7 @@ internal class FakeIntentConfirmationInterceptor : IntentConfirmationInterceptor
         intent: StripeIntent,
         paymentMethodCreateParams: PaymentMethodCreateParams,
         paymentMethodOptionsParams: PaymentMethodOptionsParams?,
+        paymentMethodExtraParams: PaymentMethodExtraParams?,
         shippingValues: ConfirmPaymentIntentParams.Shipping?,
         customerRequestedSave: Boolean,
     ): IntentConfirmationInterceptor.NextStep {
@@ -62,6 +64,7 @@ internal class FakeIntentConfirmationInterceptor : IntentConfirmationInterceptor
                 initializationMode = initializationMode,
                 paymentMethodCreateParams = paymentMethodCreateParams,
                 paymentMethodOptionsParams = paymentMethodOptionsParams,
+                paymentMethodExtraParams = paymentMethodExtraParams,
                 shippingValues = shippingValues,
                 customerRequestedSave = customerRequestedSave,
             )
@@ -75,6 +78,7 @@ internal class FakeIntentConfirmationInterceptor : IntentConfirmationInterceptor
         intent: StripeIntent,
         paymentMethod: PaymentMethod,
         paymentMethodOptionsParams: PaymentMethodOptionsParams?,
+        paymentMethodExtraParams: PaymentMethodExtraParams?,
         shippingValues: ConfirmPaymentIntentParams.Shipping?,
     ): IntentConfirmationInterceptor.NextStep {
         _calls.add(
@@ -94,6 +98,7 @@ internal class FakeIntentConfirmationInterceptor : IntentConfirmationInterceptor
             val initializationMode: PaymentElementLoader.InitializationMode,
             val paymentMethodCreateParams: PaymentMethodCreateParams,
             val paymentMethodOptionsParams: PaymentMethodOptionsParams?,
+            val paymentMethodExtraParams: PaymentMethodExtraParams?,
             val shippingValues: ConfirmPaymentIntentParams.Shipping?,
             val customerRequestedSave: Boolean,
         ) : InterceptCall

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/IdentifierSpec.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/IdentifierSpec.kt
@@ -84,7 +84,10 @@ data class IdentifierSpec(
         val SameAsShipping = IdentifierSpec("same_as_shipping", ignoreField = true)
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-        val SetAsDefaultPaymentMethod = IdentifierSpec("set_as_default_payment_method")
+        val SetAsDefaultPaymentMethod = IdentifierSpec(
+            v1 = "set_as_default_payment_method",
+            destination = ParameterDestination.Local.Extras
+        )
 
         val Upi = IdentifierSpec("upi")
         val Vpa = IdentifierSpec("upi[vpa]")


### PR DESCRIPTION
# Summary

- Created PaymentMethodExtraParams for Card and USBankAccount
- Added PaymentMethodExtraParams to PaymentMethodConfirmationOption.New 
- Reading extraParams from PaymentMethodConfirmationOption.New to IntentConfirmationInterceptor, and passing value to ConfirmPaymentIntentParams and ConfirmSetupIntentParams
- Added setAsDefaultPaymentMethod to ConfirmPaymentIntentParams and ConfirmSetupIntentParams, 

1. FormElement -> 
2. PaymentMethodExtraParams -> 
3. transformToPaymentMethodExtraParams -> 
4. PaymentSelection.New.Card ->
5.  PaymentMethodConfirmationOption.New -> 
6. IntentConfirmationInterceptor ->
7. ConfirmPaymentIntentParams and ConfirmSetupIntentParams


# Motivation
Pass the value of set_as_default_payment_method to PaymentIntent and SetupIntent. 

https://jira.corp.stripe.com/browse/MOBILESDK-2684
https://jira.corp.stripe.com/browse/MOBILESDK-2686


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [X] Manually verified

# Screenshots
N.A.

# Changelog
N.A.