### PR TITLE
Fix a bug where confirmationState had the wrong selection.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfigurationCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfigurationCoordinator.kt
@@ -65,24 +65,23 @@ internal class DefaultEmbeddedConfigurationCoordinator @Inject constructor(
         configuration: EmbeddedPaymentElement.Configuration,
     ) {
         configuration.appearance.parseAppearance()
+        val newPaymentSelection = selectionChooser.choose(
+            paymentMethodMetadata = state.paymentMethodMetadata,
+            paymentMethods = state.customer?.paymentMethods,
+            previousSelection = selectionHolder.selection.value,
+            newSelection = state.paymentSelection,
+            newConfiguration = configuration.asCommonConfiguration(),
+        )
         confirmationStateHolder.state = EmbeddedConfirmationStateHolder.State(
             paymentMethodMetadata = state.paymentMethodMetadata,
-            selection = state.paymentSelection,
+            selection = newPaymentSelection,
             initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
                 intentConfiguration
             ),
             configuration = configuration,
         )
         customerStateHolder.setCustomerState(state.customer)
-        selectionHolder.set(
-            selectionChooser.choose(
-                paymentMethodMetadata = state.paymentMethodMetadata,
-                paymentMethods = state.customer?.paymentMethods,
-                previousSelection = selectionHolder.selection.value,
-                newSelection = state.paymentSelection,
-                newConfiguration = configuration.asCommonConfiguration(),
-            )
-        )
+        selectionHolder.set(newPaymentSelection)
         embeddedContentHelper.dataLoaded(
             paymentMethodMetadata = state.paymentMethodMetadata,
             rowStyle = configuration.appearance.embeddedAppearance.style,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Fixes a bug where remaining on the same selection, but changing confirmation state by reconfiguring would cause a bug.

To repro -- Select google pay, swap from pay to setup, click confirm. The actual confirm would happen with old default payment method (ie, a saved card).