### PR TITLE
Make manage test less flakey.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/ManageActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/ManageActivity.kt
@@ -84,14 +84,18 @@ internal class ManageActivity : AppCompatActivity() {
                         finish()
                     }
                 ) {
-                    val screen by manageNavigator.screen.collectAsState()
-                    Box(modifier = Modifier.padding(bottom = 20.dp)) {
-                        ScreenContent(manageNavigator, screen)
-                    }
-                    LaunchedEffect(screen) {
-                        manageNavigator.result.collect { result ->
-                            setManageResult()
-                            finish()
+                    var hasResult by remember { mutableStateOf(false) }
+                    if (!hasResult) {
+                        val screen by manageNavigator.screen.collectAsState()
+                        Box(modifier = Modifier.padding(bottom = 20.dp)) {
+                            ScreenContent(manageNavigator, screen)
+                        }
+                        LaunchedEffect(screen) {
+                            manageNavigator.result.collect { result ->
+                                setManageResult()
+                                finish()
+                                hasResult = true
+                            }
                         }
                     }
                 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/ManageActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/ManageActivityTest.kt
@@ -151,6 +151,7 @@ internal class ManageActivityTest {
         editPage.waitUntilVisible()
         editPage.setCardBrand("Visa")
         editPage.update()
+        editPage.waitUntilMissing()
         val updatedCbcCard = completedResultPaymentMethods().single()
         assertThat(updatedCbcCard.card?.displayBrand).isEqualTo("visa")
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/EditPage.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/EditPage.kt
@@ -28,6 +28,15 @@ internal class EditPage(
         }
     }
 
+    fun waitUntilMissing() {
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule
+                .onAllNodes(hasTestTag(UPDATE_PM_SCREEN_TEST_TAG))
+                .fetchSemanticsNodes(atLeastOneRootRequired = false)
+                .isEmpty()
+        }
+    }
+
     fun assertIsVisible() {
         composeTestRule
             .onNodeWithTag(UPDATE_PM_SCREEN_TEST_TAG)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
There was no way to wait without making this change to production code. Now we know when the activity has finished.

There is no visual difference to the user (that I could tell) between the production implementations.

I ran this with ShampooRule(1000), and no flakes. Before the change we got a flake about every 30 iterations.
