### PR TITLE
Increase timeout.

### DIFF
--- a/stripecardscan/src/test/java/com/stripe/android/stripecardscan/framework/LoopTest.kt
+++ b/stripecardscan/src/test/java/com/stripe/android/stripecardscan/framework/LoopTest.kt
@@ -30,7 +30,7 @@ import kotlin.time.Duration.Companion.nanoseconds
 
 class LoopTest {
 
-    @Test(timeout = 2000)
+    @Test(timeout = 3000)
     @SmallTest
     @ExperimentalCoroutinesApi
     fun processBoundAnalyzerLoop_analyzeData() = runTest {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
I've seen this test flaking lately. Increased timeout and ran with ShapooRule(1000).