### PR TITLE
In update card screen, only update card brand when the card brand has changed

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -325,7 +325,7 @@ internal class SavedPaymentMethodMutator(
             displayableSavedPaymentMethod: DisplayableSavedPaymentMethod,
             canRemove: Boolean,
             performRemove: suspend () -> Throwable?,
-            updateCardBrandExecutor: suspend (brand: CardBrand) -> Result<PaymentMethod>,
+            updateExecutor: suspend (brand: CardBrand) -> Result<PaymentMethod>,
         ) {
             if (displayableSavedPaymentMethod.savedPaymentMethod != SavedPaymentMethod.Unexpected) {
                 val isLiveMode = requireNotNull(viewModel.paymentMethodMetadata.value).stripeIntent.isLiveMode
@@ -340,7 +340,7 @@ internal class SavedPaymentMethodMutator(
                                 performRemove()
                             },
                             updateCardBrandExecutor = { method, brand ->
-                                updateCardBrandExecutor(brand)
+                                updateExecutor(brand)
                             },
                             onBrandChoiceOptionsShown = {
                                 viewModel.eventReporter.onShowPaymentOptionBrands(
@@ -384,16 +384,13 @@ internal class SavedPaymentMethodMutator(
                     navigateBackOnPaymentMethodRemoved(viewModel)
                 },
                 postPaymentMethodRemoveActions = {},
-                onUpdatePaymentMethod = { displayableSavedPaymentMethod,
-                                          canRemove,
-                                          performRemove,
-                                          updateCardBrandExecutor ->
+                onUpdatePaymentMethod = { displayableSavedPaymentMethod, canRemove, performRemove, updateExecutor ->
                     onUpdatePaymentMethod(
                         viewModel = viewModel,
                         displayableSavedPaymentMethod = displayableSavedPaymentMethod,
                         canRemove = canRemove,
                         performRemove = performRemove,
-                        updateCardBrandExecutor = updateCardBrandExecutor,
+                        updateExecutor = updateExecutor,
                     )
                 },
                 navigationPop = viewModel.navigationHandler::pop,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -325,7 +325,7 @@ internal class SavedPaymentMethodMutator(
             displayableSavedPaymentMethod: DisplayableSavedPaymentMethod,
             canRemove: Boolean,
             performRemove: suspend () -> Throwable?,
-            updateExecutor: suspend (brand: CardBrand) -> Result<PaymentMethod>,
+            updateCardBrandExecutor: suspend (brand: CardBrand) -> Result<PaymentMethod>,
         ) {
             if (displayableSavedPaymentMethod.savedPaymentMethod != SavedPaymentMethod.Unexpected) {
                 val isLiveMode = requireNotNull(viewModel.paymentMethodMetadata.value).stripeIntent.isLiveMode
@@ -340,7 +340,7 @@ internal class SavedPaymentMethodMutator(
                                 performRemove()
                             },
                             updateCardBrandExecutor = { method, brand ->
-                                updateExecutor(brand)
+                                updateCardBrandExecutor(brand)
                             },
                             onBrandChoiceOptionsShown = {
                                 viewModel.eventReporter.onShowPaymentOptionBrands(
@@ -384,13 +384,16 @@ internal class SavedPaymentMethodMutator(
                     navigateBackOnPaymentMethodRemoved(viewModel)
                 },
                 postPaymentMethodRemoveActions = {},
-                onUpdatePaymentMethod = { displayableSavedPaymentMethod, canRemove, performRemove, updateExecutor ->
+                onUpdatePaymentMethod = { displayableSavedPaymentMethod,
+                                          canRemove,
+                                          performRemove,
+                                          updateCardBrandExecutor ->
                     onUpdatePaymentMethod(
                         viewModel = viewModel,
                         displayableSavedPaymentMethod = displayableSavedPaymentMethod,
                         canRemove = canRemove,
                         performRemove = performRemove,
-                        updateExecutor = updateExecutor,
+                        updateCardBrandExecutor = updateCardBrandExecutor,
                     )
                 },
                 navigationPop = viewModel.navigationHandler::pop,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
@@ -185,7 +185,7 @@ internal class DefaultUpdatePaymentMethodInteractor(
 
     private suspend fun maybeUpdateCardBrand(): Result<PaymentMethod>? {
         val newCardBrand = cardBrandChoice.value.brand
-        return if (newCardBrand != getInitialCardBrandChoice().brand) {
+        return if (cardBrandHasBeenChanged.value) {
             updateCardBrandExecutor(
                 displayableSavedPaymentMethod.paymentMethod,
                 newCardBrand

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
@@ -166,23 +166,44 @@ internal class DefaultUpdatePaymentMethodInteractor(
 
     private fun savePaymentMethod() {
         coroutineScope.launch {
-            val newCardBrand = cardBrandChoice.value.brand
-
             error.emit(getInitialError())
             status.emit(UpdatePaymentMethodInteractor.Status.Updating)
 
-            val updateCardBrandResult = updateCardBrandExecutor(
-                displayableSavedPaymentMethod.paymentMethod,
-                newCardBrand
+            val updateCardBrandResult = maybeUpdateCardBrand()
+
+            val errorMessage = getErrorMessageForUpdates(
+                updateCardBrandResult = updateCardBrandResult,
             )
 
-            updateCardBrandResult.onSuccess {
+            if (errorMessage != null) {
+                error.emit(errorMessage)
+            }
+
+            status.emit(UpdatePaymentMethodInteractor.Status.Idle)
+        }
+    }
+
+    private suspend fun maybeUpdateCardBrand(): Result<PaymentMethod>? {
+        val newCardBrand = cardBrandChoice.value.brand
+        return if (newCardBrand != getInitialCardBrandChoice().brand) {
+            updateCardBrandExecutor(
+                displayableSavedPaymentMethod.paymentMethod,
+                newCardBrand
+            ).onSuccess {
                 savedCardBrand.emit(CardBrandChoice(brand = newCardBrand, enabled = true))
                 cardBrandHasBeenChanged.emit(false)
-            }.onFailure {
-                error.emit(it.stripeErrorMessage())
             }
-            status.emit(UpdatePaymentMethodInteractor.Status.Idle)
+        } else {
+            null
+        }
+    }
+
+    private fun getErrorMessageForUpdates(
+        updateCardBrandResult: Result<PaymentMethod>?,
+    ): ResolvableString? {
+        return when {
+            updateCardBrandResult?.isFailure == true -> updateCardBrandResult.exceptionOrNull()?.stripeErrorMessage()
+            else -> null
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultUpdatePaymentMethodInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultUpdatePaymentMethodInteractorTest.kt
@@ -213,6 +213,28 @@ class DefaultUpdatePaymentMethodInteractorTest {
     }
 
     @Test
+    fun updatingCardBrand_cardBrandHasNotChanged_doesNotAttemptUpdate() {
+        val initialPaymentMethod = PaymentMethodFixtures.CARD_WITH_NETWORKS_PAYMENT_METHOD
+        var cardBrandUpdateCalled = false
+
+        @Suppress("UnusedParameter")
+        fun updateCardBrandExecutor(paymentMethod: PaymentMethod, brand: CardBrand): Result<PaymentMethod> {
+            cardBrandUpdateCalled = true
+
+            return Result.success(paymentMethod)
+        }
+
+        runScenario(
+            displayableSavedPaymentMethod = initialPaymentMethod.toDisplayableSavedPaymentMethod(),
+            onUpdateCardBrand = ::updateCardBrandExecutor,
+        ) {
+            interactor.handleViewAction(UpdatePaymentMethodInteractor.ViewAction.SaveButtonPressed)
+
+            assertThat(cardBrandUpdateCalled).isFalse()
+        }
+    }
+
+    @Test
     fun saveButtonClick_failure_displaysError() {
         val updateException = IllegalStateException("Not allowed.")
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
In update card screen, only update card brand when the card brand has changed

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
When we add the set as default checkbox to this screen, it's possible that the "save" button will be enabled when the card brand hasn't been changed yet. We need to ensure that in this case, we do not attempt to update the card brand.

Also extracted some things out of the onSavePaymentMethod function so that the diff in future PRs is easier to understand

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified