### PR TITLE
Add `ForceNativeBankFlowTestRule` for bank auth flow

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestInstantDebits.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestInstantDebits.kt
@@ -3,6 +3,7 @@ package com.stripe.android.lpm
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.isEnabled
 import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BasePlaygroundTest
 import com.stripe.android.model.PaymentMethod
@@ -21,11 +22,11 @@ import com.stripe.android.test.core.AuthorizeAction
 import com.stripe.android.test.core.DEFAULT_UI_TIMEOUT
 import com.stripe.android.test.core.TestParameters
 import com.stripe.android.test.core.ui.ComposeButton
-import org.junit.Ignore
+import com.stripe.android.utils.ForceNativeBankFlowTestRule
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@Ignore("Tests currently failing, ignoring while we work on a fix so we can merge other PRs.")
 @RunWith(AndroidJUnit4::class)
 internal class TestInstantDebits : BasePlaygroundTest() {
 
@@ -42,6 +43,11 @@ internal class TestInstantDebits : BasePlaygroundTest() {
             PaymentMethod.Type.Link
         ).joinToString(",")
     }
+
+    @get:Rule
+    val forceNativeBankFlowTestRule = ForceNativeBankFlowTestRule(
+        context = ApplicationProvider.getApplicationContext()
+    )
 
     @Test
     fun testInstantDebitsSuccess() {

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestLinkCardBrand.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestLinkCardBrand.kt
@@ -3,6 +3,7 @@ package com.stripe.android.lpm
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.isEnabled
 import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BasePlaygroundTest
 import com.stripe.android.paymentsheet.example.playground.settings.AutomaticPaymentMethodsSettingsDefinition
@@ -20,6 +21,8 @@ import com.stripe.android.test.core.AuthorizeAction
 import com.stripe.android.test.core.DEFAULT_UI_TIMEOUT
 import com.stripe.android.test.core.TestParameters
 import com.stripe.android.test.core.ui.ComposeButton
+import com.stripe.android.utils.ForceNativeBankFlowTestRule
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -36,6 +39,11 @@ internal class TestLinkCardBrand : BasePlaygroundTest() {
         settings[LinkSettingsDefinition] = true
         settings[SupportedPaymentMethodsSettingsDefinition] = "card"
     }
+
+    @get:Rule
+    val forceNativeBankFlowTestRule = ForceNativeBankFlowTestRule(
+        context = ApplicationProvider.getApplicationContext()
+    )
 
     @Test
     fun testLinkCardBrandSuccess() {

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestUSBankAccount.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestUSBankAccount.kt
@@ -3,6 +3,7 @@ package com.stripe.android.lpm
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.isEnabled
 import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BasePlaygroundTest
 import com.stripe.android.paymentsheet.example.playground.settings.Country
@@ -19,11 +20,11 @@ import com.stripe.android.test.core.DEFAULT_UI_TIMEOUT
 import com.stripe.android.test.core.TestParameters
 import com.stripe.android.test.core.ui.ComposeButton
 import com.stripe.android.test.core.ui.PaymentSelection
-import org.junit.Ignore
+import com.stripe.android.utils.ForceNativeBankFlowTestRule
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@Ignore("Tests currently failing, ignoring while we work on a fix so we can merge other PRs.")
 @RunWith(AndroidJUnit4::class)
 internal class TestUSBankAccount : BasePlaygroundTest() {
     private val testParameters = TestParameters.create(
@@ -34,6 +35,11 @@ internal class TestUSBankAccount : BasePlaygroundTest() {
         settings[CurrencySettingsDefinition] = Currency.USD
         settings[DelayedPaymentMethodsSettingsDefinition] = true
     }
+
+    @get:Rule
+    val forceNativeBankFlowTestRule = ForceNativeBankFlowTestRule(
+        context = ApplicationProvider.getApplicationContext()
+    )
 
     @Test
     fun testUSBankAccountSuccess() {

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestUsBankAccountInCustomerSheet.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestUsBankAccountInCustomerSheet.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.lpm
 
+import androidx.test.core.app.ApplicationProvider
 import com.stripe.android.BasePlaygroundTest
 import com.stripe.android.paymentsheet.example.playground.settings.Country
 import com.stripe.android.paymentsheet.example.playground.settings.CountrySettingsDefinition
@@ -8,10 +9,10 @@ import com.stripe.android.paymentsheet.example.playground.settings.CustomerSheet
 import com.stripe.android.paymentsheet.example.playground.settings.PaymentMethodMode
 import com.stripe.android.test.core.AuthorizeAction
 import com.stripe.android.test.core.TestParameters
-import org.junit.Ignore
+import com.stripe.android.utils.ForceNativeBankFlowTestRule
+import org.junit.Rule
 import org.junit.Test
 
-@Ignore("Tests currently failing, ignoring while we work on a fix so we can merge other PRs.")
 internal class TestUsBankAccountInCustomerSheet : BasePlaygroundTest() {
     private val testParameters = TestParameters.create(
         paymentMethodCode = "us_bank_account",
@@ -21,6 +22,11 @@ internal class TestUsBankAccountInCustomerSheet : BasePlaygroundTest() {
         settings[CountrySettingsDefinition] = Country.US
         settings[CustomerSheetPaymentMethodModeDefinition] = PaymentMethodMode.SetupIntent
     }
+
+    @get:Rule
+    val forceNativeBankFlowTestRule = ForceNativeBankFlowTestRule(
+        context = ApplicationProvider.getApplicationContext()
+    )
 
     @Test
     fun testUSBankAccount() {

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/utils/ForceNativeBankFlowTestRule.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/utils/ForceNativeBankFlowTestRule.kt
@@ -1,0 +1,45 @@
+package com.stripe.android.utils
+
+import android.content.Context
+import androidx.core.content.edit
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+class ForceNativeBankFlowTestRule(
+    private val context: Context,
+) : TestWatcher() {
+
+    override fun starting(description: Description) {
+        super.starting(description)
+        forceNativeBankAuth(true)
+    }
+
+    override fun finished(description: Description) {
+        forceNativeBankAuth(false)
+        super.finished(description)
+    }
+
+    private fun forceNativeBankAuth(force: Boolean) {
+        val sharedPrefs = context.getSharedPreferences(
+            "FINANCIAL_CONNECTIONS_DEBUG",
+            Context.MODE_PRIVATE
+        )
+
+        val settings = sharedPrefs.getString("json", null)
+        val settingsJson = settings?.let { Json.decodeFromString(JsonObject.serializer(), it) } ?: JsonObject(emptyMap())
+        val newSettings = settingsJson.toMutableMap().apply {
+            if (force) {
+                put("financial_connections_override_native", JsonPrimitive("native"))
+            } else {
+                remove("financial_connections_override_native")
+            }
+        }
+
+        sharedPrefs.edit {
+            putString("json", JsonObject(newSettings).toString())
+        }
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds a `ForceNativeBankFlowTestRule` to make sure that end-to-end tests always use the native flow, regardless of app attestation status.

Shampoo runs: https://github.com/stripe/stripe-android/pull/10243

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
