### PR TITLE
Fetch FC playground merchants from backend

### DIFF
--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
@@ -17,12 +17,14 @@ import com.stripe.android.financialconnections.FinancialConnectionsSheetResult
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsEvent
 import com.stripe.android.financialconnections.example.data.BackendRepository
 import com.stripe.android.financialconnections.example.data.Settings
+import com.stripe.android.financialconnections.example.data.model.Merchant
 import com.stripe.android.financialconnections.example.settings.ConfirmIntentSetting
 import com.stripe.android.financialconnections.example.settings.EmailSetting
 import com.stripe.android.financialconnections.example.settings.ExperienceSetting
 import com.stripe.android.financialconnections.example.settings.FinancialConnectionsPlaygroundUrlHelper
 import com.stripe.android.financialconnections.example.settings.FlowSetting
 import com.stripe.android.financialconnections.example.settings.IntegrationTypeSetting
+import com.stripe.android.financialconnections.example.settings.MerchantSetting
 import com.stripe.android.financialconnections.example.settings.PlaygroundSettings
 import com.stripe.android.financialconnections.example.settings.StripeAccountIdSetting
 import com.stripe.android.model.ConfirmPaymentIntentParams
@@ -64,6 +66,22 @@ internal class FinancialConnectionsPlaygroundViewModel(
                         append(event.metadata.toMap().filterValues { it != null })
                     }
                 )
+            }
+        }
+
+        loadMerchants()
+    }
+
+    private fun loadMerchants() {
+        viewModelScope.launch {
+            runCatching {
+                repository.merchants()
+            }.onSuccess { response ->
+                _state.update {
+                    it.updateWithMerchants(response.merchants)
+                }
+            }.onFailure { error ->
+                Log.e("FinancialConnections", "Failed to fetch merchants from backend", error)
             }
         }
     }
@@ -430,28 +448,6 @@ internal class FinancialConnectionsPlaygroundViewModel(
     }
 }
 
-enum class Merchant(
-    val apiValue: String,
-    val canSwitchBetweenTestAndLive: Boolean = true,
-) {
-    Default("default"),
-    PartnerD("partner_d", canSwitchBetweenTestAndLive = false),
-    PartnerF("partner_f", canSwitchBetweenTestAndLive = false),
-    PartnerM("partner_m", canSwitchBetweenTestAndLive = false),
-    PlatformC("strash"),
-    Networking("networking"),
-    LiveTesting("live_testing", canSwitchBetweenTestAndLive = false),
-    TestMode("testmode", canSwitchBetweenTestAndLive = false),
-    Trusted("trusted", canSwitchBetweenTestAndLive = false),
-    Custom("other");
-
-    companion object {
-        fun fromApiValue(apiValue: String): Merchant {
-            return entries.firstOrNull { it.apiValue == apiValue } ?: Default
-        }
-    }
-}
-
 enum class Flow(val apiValue: String) {
     Data("Data"),
     Token("Token"),
@@ -531,4 +527,20 @@ internal data class FinancialConnectionsPlaygroundState(
     val flow: Flow = settings.get<FlowSetting>().selectedOption
     val stripeAccountId: String? = settings.getOrNull<StripeAccountIdSetting>()?.selectedOption
         ?.takeIf { it.isNotEmpty() }
+
+    fun updateWithMerchants(merchants: List<Merchant>): FinancialConnectionsPlaygroundState {
+        return copy(
+            settings = settings.copy(
+                settings = settings.settings.map { setting ->
+                    if (setting is MerchantSetting) {
+                        MerchantSetting(
+                            merchants = merchants,
+                        )
+                    } else {
+                        setting
+                    }
+                }
+            )
+        )
+    }
 }

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/data/BackendApiService.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/data/BackendApiService.kt
@@ -3,8 +3,10 @@ package com.stripe.android.financialconnections.example.data
 import com.stripe.android.financialconnections.example.data.model.CreateIntentResponse
 import com.stripe.android.financialconnections.example.data.model.CreateLinkAccountSessionResponse
 import com.stripe.android.financialconnections.example.data.model.LinkAccountSessionBody
+import com.stripe.android.financialconnections.example.data.model.MerchantsResponse
 import com.stripe.android.financialconnections.example.data.model.PaymentIntentBody
 import retrofit2.http.Body
+import retrofit2.http.GET
 import retrofit2.http.POST
 
 interface BackendApiService {
@@ -22,4 +24,7 @@ interface BackendApiService {
     suspend fun createPaymentIntent(
         @Body params: PaymentIntentBody
     ): CreateIntentResponse
+
+    @GET("merchants")
+    suspend fun merchants(): MerchantsResponse
 }

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/data/BackendRepository.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/data/BackendRepository.kt
@@ -3,6 +3,7 @@ package com.stripe.android.financialconnections.example.data
 import com.stripe.android.financialconnections.example.BuildConfig
 import com.stripe.android.financialconnections.example.data.model.CreateIntentResponse
 import com.stripe.android.financialconnections.example.data.model.LinkAccountSessionBody
+import com.stripe.android.financialconnections.example.data.model.MerchantsResponse
 import com.stripe.android.financialconnections.example.data.model.PaymentIntentBody
 
 class BackendRepository(
@@ -31,4 +32,6 @@ class BackendRepository(
     ): CreateIntentResponse = backendService.createPaymentIntent(
         paymentIntentBody
     )
+
+    suspend fun merchants(): MerchantsResponse = backendService.merchants()
 }

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/data/model/MerchantsResponse.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/data/model/MerchantsResponse.kt
@@ -1,0 +1,23 @@
+package com.stripe.android.financialconnections.example.data.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MerchantsResponse(
+    val merchants: List<Merchant>
+)
+
+@Serializable
+data class Merchant(
+    val name: String,
+    val value: String,
+    val canSwitchBetweenTestAndLive: Boolean,
+) {
+
+    companion object {
+
+        fun default(): Merchant {
+            return Merchant("Default", "default", canSwitchBetweenTestAndLive = true)
+        }
+    }
+}

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/ConfirmIntentSetting.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/ConfirmIntentSetting.kt
@@ -2,8 +2,8 @@ package com.stripe.android.financialconnections.example.settings
 
 import com.stripe.android.financialconnections.example.Experience
 import com.stripe.android.financialconnections.example.Flow
-import com.stripe.android.financialconnections.example.Merchant
 import com.stripe.android.financialconnections.example.data.model.LinkAccountSessionBody
+import com.stripe.android.financialconnections.example.data.model.Merchant
 import com.stripe.android.financialconnections.example.data.model.PaymentIntentBody
 
 data class ConfirmIntentSetting(

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/CustomerIdSetting.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/CustomerIdSetting.kt
@@ -2,8 +2,8 @@ package com.stripe.android.financialconnections.example.settings
 
 import com.stripe.android.financialconnections.example.Experience
 import com.stripe.android.financialconnections.example.Flow
-import com.stripe.android.financialconnections.example.Merchant
 import com.stripe.android.financialconnections.example.data.model.LinkAccountSessionBody
+import com.stripe.android.financialconnections.example.data.model.Merchant
 import com.stripe.android.financialconnections.example.data.model.PaymentIntentBody
 
 internal data class CustomerIdSetting(

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/FlowSetting.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/FlowSetting.kt
@@ -2,8 +2,8 @@ package com.stripe.android.financialconnections.example.settings
 
 import com.stripe.android.financialconnections.example.Experience
 import com.stripe.android.financialconnections.example.Flow
-import com.stripe.android.financialconnections.example.Merchant
 import com.stripe.android.financialconnections.example.data.model.LinkAccountSessionBody
+import com.stripe.android.financialconnections.example.data.model.Merchant
 import com.stripe.android.financialconnections.example.data.model.PaymentIntentBody
 
 data class FlowSetting(

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/MerchantSetting.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/MerchantSetting.kt
@@ -1,30 +1,41 @@
 package com.stripe.android.financialconnections.example.settings
 
-import com.stripe.android.financialconnections.example.Merchant
 import com.stripe.android.financialconnections.example.data.model.LinkAccountSessionBody
+import com.stripe.android.financialconnections.example.data.model.Merchant
 import com.stripe.android.financialconnections.example.data.model.PaymentIntentBody
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 
 data class MerchantSetting(
-    override val selectedOption: Merchant = Merchant.Default,
+    val merchants: List<Merchant> = listOf(Merchant.default()),
+    override val selectedOption: Merchant = merchants.first(),
     override val key: String = "merchant"
 ) : Saveable<Merchant>, SingleChoiceSetting<Merchant>(
     displayName = "Merchant",
-    options = Merchant.entries.map { Option(it.name, it) },
+    options = merchants.map { Option(it.name, it) },
     selectedOption = selectedOption
 ) {
     override fun lasRequest(body: LinkAccountSessionBody): LinkAccountSessionBody = body.copy(
-        flow = selectedOption.apiValue
+        flow = selectedOption.value
     )
 
     override fun paymentIntentRequest(body: PaymentIntentBody): PaymentIntentBody = body.copy(
-        flow = selectedOption.apiValue
+        flow = selectedOption.value
     )
 
     override fun valueUpdated(currentSettings: List<Setting<*>>, value: Merchant): List<Setting<*>> {
         return replace(currentSettings, this.copy(selectedOption = value))
     }
 
-    override fun convertToString(value: Merchant): String = value.apiValue
+    override fun convertToString(value: Merchant): String {
+        return Json.encodeToString(value)
+    }
 
-    override fun convertToValue(value: String): Merchant = Merchant.fromApiValue(value)
+    override fun convertToValue(value: String): Merchant {
+        return runCatching {
+            Json.decodeFromString<Merchant>(value)
+        }.getOrElse {
+            merchants.first()
+        }
+    }
 }

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/PrivateKeySetting.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/PrivateKeySetting.kt
@@ -2,8 +2,8 @@ package com.stripe.android.financialconnections.example.settings
 
 import com.stripe.android.financialconnections.example.Experience
 import com.stripe.android.financialconnections.example.Flow
-import com.stripe.android.financialconnections.example.Merchant
 import com.stripe.android.financialconnections.example.data.model.LinkAccountSessionBody
+import com.stripe.android.financialconnections.example.data.model.Merchant
 import com.stripe.android.financialconnections.example.data.model.PaymentIntentBody
 
 internal data class PrivateKeySetting(
@@ -34,7 +34,7 @@ internal data class PrivateKeySetting(
         flow: Flow,
         experience: Experience,
     ): Boolean {
-        return merchant == Merchant.Custom
+        return merchant.name == "Custom"
     }
 
     override fun convertToString(value: String): String = value

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/PublicKeySetting.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/PublicKeySetting.kt
@@ -2,8 +2,8 @@ package com.stripe.android.financialconnections.example.settings
 
 import com.stripe.android.financialconnections.example.Experience
 import com.stripe.android.financialconnections.example.Flow
-import com.stripe.android.financialconnections.example.Merchant
 import com.stripe.android.financialconnections.example.data.model.LinkAccountSessionBody
+import com.stripe.android.financialconnections.example.data.model.Merchant
 import com.stripe.android.financialconnections.example.data.model.PaymentIntentBody
 
 internal data class PublicKeySetting(
@@ -35,7 +35,7 @@ internal data class PublicKeySetting(
         flow: Flow,
         experience: Experience,
     ): Boolean {
-        return merchant == Merchant.Custom
+        return merchant.name == "Custom"
     }
 
     override fun convertToString(value: String): String = value

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/RelinkAuthorizationSetting.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/RelinkAuthorizationSetting.kt
@@ -2,8 +2,8 @@ package com.stripe.android.financialconnections.example.settings
 
 import com.stripe.android.financialconnections.example.Experience
 import com.stripe.android.financialconnections.example.Flow
-import com.stripe.android.financialconnections.example.Merchant
 import com.stripe.android.financialconnections.example.data.model.LinkAccountSessionBody
+import com.stripe.android.financialconnections.example.data.model.Merchant
 import com.stripe.android.financialconnections.example.data.model.PaymentIntentBody
 
 internal data class RelinkAuthorizationSetting(

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/Setting.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/Setting.kt
@@ -2,8 +2,8 @@ package com.stripe.android.financialconnections.example.settings
 
 import com.stripe.android.financialconnections.example.Experience
 import com.stripe.android.financialconnections.example.Flow
-import com.stripe.android.financialconnections.example.Merchant
 import com.stripe.android.financialconnections.example.data.model.LinkAccountSessionBody
+import com.stripe.android.financialconnections.example.data.model.Merchant
 import com.stripe.android.financialconnections.example.data.model.PaymentIntentBody
 
 sealed class Setting<T> {

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/StripeAccountIdSetting.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/StripeAccountIdSetting.kt
@@ -2,8 +2,8 @@ package com.stripe.android.financialconnections.example.settings
 
 import com.stripe.android.financialconnections.example.Experience
 import com.stripe.android.financialconnections.example.Flow
-import com.stripe.android.financialconnections.example.Merchant
 import com.stripe.android.financialconnections.example.data.model.LinkAccountSessionBody
+import com.stripe.android.financialconnections.example.data.model.Merchant
 import com.stripe.android.financialconnections.example.data.model.PaymentIntentBody
 
 internal data class StripeAccountIdSetting(

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/TestModeSetting.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/TestModeSetting.kt
@@ -2,8 +2,8 @@ package com.stripe.android.financialconnections.example.settings
 
 import com.stripe.android.financialconnections.example.Experience
 import com.stripe.android.financialconnections.example.Flow
-import com.stripe.android.financialconnections.example.Merchant
 import com.stripe.android.financialconnections.example.data.model.LinkAccountSessionBody
+import com.stripe.android.financialconnections.example.data.model.Merchant
 import com.stripe.android.financialconnections.example.data.model.PaymentIntentBody
 
 data class TestModeSetting(
@@ -34,7 +34,7 @@ data class TestModeSetting(
         flow: Flow,
         experience: Experience,
     ): Boolean {
-        return merchant != Merchant.Custom && merchant.canSwitchBetweenTestAndLive
+        return merchant.canSwitchBetweenTestAndLive
     }
 
     override fun convertToValue(value: String): Boolean = value.toBoolean()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request updates the Financial Connections playground to fetch test merchants from the backend, instead of hard-coding them. This allows us to easily add new test merchants that are gated into specific features we’re working on.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
