### PR TITLE
Actually update default payment method when set as default checkbox checked on manage PM screen

### DIFF
--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -66,6 +66,8 @@
   <string name="stripe_paymentsheet_card_details_cannot_be_changed">Card details cannot be changed.</string>
   <!-- Text displayed below a credit card entry form when the card will be saved to make future payments. -->
   <string name="stripe_paymentsheet_card_mandate">By providing your card information, you allow %s to charge your card for future payments in accordance with their terms.</string>
+  <!-- Error message displayed when updating a card fails. -->
+  <string name="stripe_paymentsheet_card_updates_failed_error_message">Card was not updated. Please try again.</string>
   <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">Choose a payment method</string>
   <string name="stripe_paymentsheet_close">Close</string>
@@ -141,6 +143,8 @@
   <string name="stripe_paymentsheet_select_your_payment_method">Select your payment method</string>
   <!-- Text displayed on manage SEPA debit screen when SEPA debit details are not editable. -->
   <string name="stripe_paymentsheet_sepa_debit_details_cannot_be_changed">SEPA debit details cannot be changed.</string>
+  <!-- Error message displayed when setting a default payment method fails. -->
+  <string name="stripe_paymentsheet_set_default_payment_method_failed_error_message">Default payment method was not changed. Please try again.</string>
   <!-- Label indicating the total amount that the user is authorizing (e.g. "Total: $25.00") -->
   <string name="stripe_paymentsheet_total_amount">Total: %s</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -557,10 +557,15 @@ internal class CustomerSheetViewModel(
                     },
                     onUpdateSuccess = ::onBackPressed,
                     updateCardBrandExecutor = ::updateCardBrandExecutor,
-                    setDefaultPaymentMethodExecutor = { TODO() },
                     workContext = workContext,
                     // This checkbox is never displayed in CustomerSheet.
                     shouldShowSetAsDefaultCheckbox = false,
+                    // Should never be called from CustomerSheet, because we don't enable the set as default checkbox.
+                    setDefaultPaymentMethodExecutor = {
+                        Result.failure(
+                            IllegalStateException("Unexpected attempt to update default from CustomerSheet.")
+                        )
+                    },
                 ),
                 isLiveMode = isLiveModeProvider(),
             )

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -557,6 +557,7 @@ internal class CustomerSheetViewModel(
                     },
                     onUpdateSuccess = ::onBackPressed,
                     updateCardBrandExecutor = ::updateCardBrandExecutor,
+                    setDefaultPaymentMethodExecutor = { TODO() },
                     workContext = workContext,
                     // This checkbox is never displayed in CustomerSheet.
                     shouldShowSetAsDefaultCheckbox = false,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
@@ -205,7 +205,7 @@ internal class DefaultEmbeddedContentHelper @Inject constructor(
             customerStateHolder = customerStateHolder,
             prePaymentMethodRemoveActions = {},
             postPaymentMethodRemoveActions = {},
-            onUpdatePaymentMethod = { _, _, _, _ ->
+            onUpdatePaymentMethod = { _, _, _, _, _ ->
                 sheetLauncher?.launchManage(
                     paymentMethodMetadata = paymentMethodMetadata,
                     customerState = requireNotNull(customerStateHolder.customer.value),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
@@ -56,7 +56,9 @@ internal class DefaultEmbeddedUpdateScreenInteractorFactory @Inject constructor(
                     },
                 )
             },
-            setDefaultPaymentMethodExecutor = { TODO() },
+            setDefaultPaymentMethodExecutor = { method ->
+                savedPaymentMethodMutatorProvider.get().setDefaultPaymentMethod(method)
+            },
             onBrandChoiceOptionsShown = {
                 eventReporter.onShowPaymentOptionBrands(
                     source = EventReporter.CardBrandChoiceEventSource.Edit,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
@@ -56,6 +56,7 @@ internal class DefaultEmbeddedUpdateScreenInteractorFactory @Inject constructor(
                     },
                 )
             },
+            setDefaultPaymentMethodExecutor = { TODO() },
             onBrandChoiceOptionsShown = {
                 eventReporter.onShowPaymentOptionBrands(
                     source = EventReporter.CardBrandChoiceEventSource.Edit,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/ManageSavedPaymentMethodMutatorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/ManageSavedPaymentMethodMutatorFactory.kt
@@ -54,7 +54,7 @@ internal class ManageSavedPaymentMethodMutatorFactory @Inject constructor(
                 }
             },
             postPaymentMethodRemoveActions = ::onPaymentMethodRemoved,
-            onUpdatePaymentMethod = { displayableSavedPaymentMethod, _, _, _ ->
+            onUpdatePaymentMethod = { displayableSavedPaymentMethod, _, _, _, _ ->
                 onUpdatePaymentMethod(displayableSavedPaymentMethod)
             },
             isLinkEnabled = stateFlowOf(false), // Link is never enabled in the manage screen.

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/CustomerStateHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/CustomerStateHolder.kt
@@ -50,6 +50,13 @@ internal class CustomerStateHolder(
         updateMostRecentlySelectedSavedPaymentMethod(newSelection)
     }
 
+    fun setDefaultPaymentMethod(paymentMethod: PaymentMethod?) {
+        val newCustomer = customer.value?.copy(defaultPaymentMethodId = paymentMethod?.id)
+
+        savedStateHandle[SAVED_CUSTOMER] = newCustomer
+        updateMostRecentlySelectedSavedPaymentMethod(paymentMethod = paymentMethod)
+    }
+
     fun updateMostRecentlySelectedSavedPaymentMethod(paymentMethod: PaymentMethod?) {
         savedStateHandle[SAVED_PM_SELECTION] = paymentMethod
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -339,6 +339,7 @@ internal class SavedPaymentMethodMutator(
                             updateCardBrandExecutor = { method, brand ->
                                 updateCardBrandExecutor(brand)
                             },
+                            setDefaultPaymentMethodExecutor = { TODO() },
                             onBrandChoiceOptionsShown = {
                                 viewModel.eventReporter.onShowPaymentOptionBrands(
                                     source = EventReporter.CardBrandChoiceEventSource.Edit,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -54,6 +54,7 @@ internal class SavedPaymentMethodMutator(
         canRemove: Boolean,
         performRemove: suspend () -> Throwable?,
         updateExecutor: suspend (brand: CardBrand) -> Result<PaymentMethod>,
+        setDefaultPaymentMethodExecutor: suspend (paymentMethod: PaymentMethod) -> Result<Unit>,
     ) -> Unit,
     isLinkEnabled: StateFlow<Boolean?>,
     isNotPaymentFlow: Boolean,
@@ -201,8 +202,27 @@ internal class SavedPaymentMethodMutator(
             },
             { cardBrand ->
                 modifyCardPaymentMethod(paymentMethod, cardBrand)
-            }
+            },
+            ::setDefaultPaymentMethod,
         )
+    }
+
+    internal suspend fun setDefaultPaymentMethod(paymentMethod: PaymentMethod): Result<Unit> {
+        val customer = customerStateHolder.customer.value
+            ?: return Result.failure(
+                IllegalStateException("Unable to set default payment method when customer is null.")
+            )
+
+        return customerRepository.setDefaultPaymentMethod(
+            customerInfo = CustomerRepository.CustomerInfo(
+                id = customer.id,
+                ephemeralKeySecret = customer.ephemeralKeySecret,
+                customerSessionClientSecret = customer.customerSessionClientSecret,
+            ),
+            paymentMethodId = paymentMethod.id,
+        ).onSuccess {
+            customerStateHolder.setDefaultPaymentMethod(paymentMethod = paymentMethod)
+        }.map {}
     }
 
     suspend fun removePaymentMethodInEditScreen(paymentMethod: PaymentMethod): Throwable? {
@@ -323,6 +343,7 @@ internal class SavedPaymentMethodMutator(
             canRemove: Boolean,
             performRemove: suspend () -> Throwable?,
             updateCardBrandExecutor: suspend (brand: CardBrand) -> Result<PaymentMethod>,
+            setDefaultPaymentMethodExecutor: suspend (paymentMethod: PaymentMethod) -> Result<Unit>,
         ) {
             if (displayableSavedPaymentMethod.savedPaymentMethod != SavedPaymentMethod.Unexpected) {
                 val isLiveMode = requireNotNull(viewModel.paymentMethodMetadata.value).stripeIntent.isLiveMode
@@ -339,7 +360,7 @@ internal class SavedPaymentMethodMutator(
                             updateCardBrandExecutor = { method, brand ->
                                 updateCardBrandExecutor(brand)
                             },
-                            setDefaultPaymentMethodExecutor = { TODO() },
+                            setDefaultPaymentMethodExecutor = setDefaultPaymentMethodExecutor,
                             onBrandChoiceOptionsShown = {
                                 viewModel.eventReporter.onShowPaymentOptionBrands(
                                     source = EventReporter.CardBrandChoiceEventSource.Edit,
@@ -386,13 +407,15 @@ internal class SavedPaymentMethodMutator(
                 onUpdatePaymentMethod = { displayableSavedPaymentMethod,
                                           canRemove,
                                           performRemove,
-                                          updateCardBrandExecutor ->
+                                          updateCardBrandExecutor,
+                                          setDefaultPaymentMethodExecutor, ->
                     onUpdatePaymentMethod(
                         viewModel = viewModel,
                         displayableSavedPaymentMethod = displayableSavedPaymentMethod,
                         canRemove = canRemove,
                         performRemove = performRemove,
                         updateCardBrandExecutor = updateCardBrandExecutor,
+                        setDefaultPaymentMethodExecutor = setDefaultPaymentMethodExecutor,
                     )
                 },
                 isLinkEnabled = viewModel.linkHandler.isLinkEnabled,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.ui
 
+import androidx.annotation.VisibleForTesting
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.core.strings.ResolvableString
@@ -175,9 +176,11 @@ internal class DefaultUpdatePaymentMethodInteractor(
             status.emit(UpdatePaymentMethodInteractor.Status.Updating)
 
             val updateCardBrandResult = maybeUpdateCardBrand()
+            val setDefaultPaymentMethodResult = maybeSetDefaultPaymentMethod()
 
             val updateResult = getUpdateResult(
                 updateCardBrandResult = updateCardBrandResult,
+                setDefaultPaymentMethodResult = setDefaultPaymentMethodResult,
             )
 
             when (updateResult) {
@@ -205,16 +208,30 @@ internal class DefaultUpdatePaymentMethodInteractor(
         }
     }
 
+    private suspend fun maybeSetDefaultPaymentMethod(): Result<Unit>? {
+        return if (setAsDefaultCheckboxChecked.value) {
+            setDefaultPaymentMethodExecutor(displayableSavedPaymentMethod.paymentMethod)
+        } else {
+            null
+        }
+    }
+
     private fun getUpdateResult(
         updateCardBrandResult: Result<PaymentMethod>?,
+        setDefaultPaymentMethodResult: Result<Unit>?,
     ): UpdateResult {
-        return when {
-            updateCardBrandResult == null -> UpdateResult.NoUpdatesMade
-            updateCardBrandResult.isFailure -> UpdateResult.Error(
-                updateCardBrandResult.exceptionOrNull()?.stripeErrorMessage()
-            )
-            updateCardBrandResult.isSuccess -> UpdateResult.Success
-            else -> UpdateResult.NoUpdatesMade
+        if (updateCardBrandResult == null && setDefaultPaymentMethodResult == null) {
+            return UpdateResult.NoUpdatesMade
+        }
+
+        return if (updateCardBrandResult?.isFailure == true && setDefaultPaymentMethodResult?.isFailure == true) {
+            UpdateResult.Error(setDefaultPaymentMethodErrorMessage)
+        } else if (updateCardBrandResult?.isFailure == true) {
+            UpdateResult.Error(updateCardBrandResult.exceptionOrNull()?.stripeErrorMessage())
+        } else if (setDefaultPaymentMethodResult?.isFailure == true) {
+            UpdateResult.Error(updatesFailedErrorMessage)
+        } else {
+            UpdateResult.Success
         }
     }
 
@@ -259,6 +276,17 @@ internal class DefaultUpdatePaymentMethodInteractor(
         data class Error(val errorMessage: ResolvableString?) : UpdateResult()
         data object Success : UpdateResult()
         data object NoUpdatesMade : UpdateResult()
+    }
+
+    companion object {
+
+        @VisibleForTesting
+        internal val setDefaultPaymentMethodErrorMessage =
+            R.string.stripe_paymentsheet_set_default_payment_method_failed_error_message.resolvableString
+
+        @VisibleForTesting
+        internal val updatesFailedErrorMessage =
+            R.string.stripe_paymentsheet_set_default_payment_method_failed_error_message.resolvableString
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
@@ -76,6 +76,9 @@ internal typealias UpdateCardBrandOperation = suspend (
     paymentMethod: PaymentMethod,
     brand: CardBrand
 ) -> Result<PaymentMethod>
+internal typealias PaymentMethodSetAsDefaultOperation = suspend (
+    paymentMethod: PaymentMethod
+) -> Result<Unit>
 
 internal class DefaultUpdatePaymentMethodInteractor(
     isLiveMode: Boolean,
@@ -85,6 +88,7 @@ internal class DefaultUpdatePaymentMethodInteractor(
     shouldShowSetAsDefaultCheckbox: Boolean,
     private val removeExecutor: PaymentMethodRemoveOperation,
     private val updateCardBrandExecutor: UpdateCardBrandOperation,
+    private val setDefaultPaymentMethodExecutor: PaymentMethodSetAsDefaultOperation,
     private val onBrandChoiceOptionsShown: (CardBrand) -> Unit,
     private val onBrandChoiceOptionsDismissed: (CardBrand) -> Unit,
     private val onUpdateSuccess: () -> Unit,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
@@ -530,6 +530,7 @@ private fun PreviewUpdatePaymentMethodUI() {
             displayableSavedPaymentMethod = exampleCard,
             removeExecutor = { null },
             updateCardBrandExecutor = { paymentMethod, _ -> Result.success(paymentMethod) },
+            setDefaultPaymentMethodExecutor = { _ -> Result.success(Unit) },
             cardBrandFilter = DefaultCardBrandFilter,
             onBrandChoiceOptionsShown = {},
             onBrandChoiceOptionsDismissed = {},

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -350,6 +350,7 @@ internal class CustomerSheetScreenshotTest {
                 displayableSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
                 removeExecutor = { null },
                 updateCardBrandExecutor = { paymentMethod, _ -> Result.success(paymentMethod) },
+                setDefaultPaymentMethodExecutor = { _ -> Result.success(Unit) },
                 canRemove = canRemove,
                 isLiveMode = true,
                 cardBrandFilter = DefaultCardBrandFilter,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/CustomerState.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/CustomerState.kt
@@ -5,8 +5,9 @@ import com.stripe.android.paymentsheet.state.CustomerState
 
 internal fun createCustomerState(
     paymentMethods: List<PaymentMethod>,
-    isRemoveEnabled: Boolean,
-    canRemoveLastPaymentMethod: Boolean,
+    isRemoveEnabled: Boolean = true,
+    canRemoveLastPaymentMethod: Boolean = true,
+    defaultPaymentMethodId: String? = null,
 ): CustomerState {
     return CustomerState(
         id = "cus_1",
@@ -18,6 +19,6 @@ internal fun createCustomerState(
             canRemoveDuplicates = true,
             canRemoveLastPaymentMethod = canRemoveLastPaymentMethod,
         ),
-        defaultPaymentMethodId = null,
+        defaultPaymentMethodId = defaultPaymentMethodId,
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultUpdatePaymentMethodInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultUpdatePaymentMethodInteractorTest.kt
@@ -341,6 +341,7 @@ class DefaultUpdatePaymentMethodInteractorTest {
         displayableSavedPaymentMethod: DisplayableSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
         onRemovePaymentMethod: (PaymentMethod) -> Throwable? = { notImplemented() },
         onUpdateCardBrand: (PaymentMethod, CardBrand) -> Result<PaymentMethod> = { _, _ -> notImplemented() },
+        onSetDefaultPaymentMethod: (PaymentMethod) -> Result<Unit> = { _ -> notImplemented() },
         onUpdateSuccess: () -> Unit = { notImplemented() },
         shouldShowSetAsDefaultCheckbox: Boolean = false,
         testBlock: suspend TestParams.() -> Unit
@@ -351,6 +352,7 @@ class DefaultUpdatePaymentMethodInteractorTest {
             displayableSavedPaymentMethod = displayableSavedPaymentMethod,
             removeExecutor = onRemovePaymentMethod,
             updateCardBrandExecutor = onUpdateCardBrand,
+            setDefaultPaymentMethodExecutor = onSetDefaultPaymentMethod,
             workContext = UnconfinedTestDispatcher(),
             cardBrandFilter = DefaultCardBrandFilter,
             onBrandChoiceOptionsShown = {},


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Actually update default payment method when set as default checkbox checked on manage PM screen

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-2690

This PR sets the default PM in the backend. There's still a little more work to do here, because the other manage PM screens don't update their selection properly after the new default is set. I'm going to follow up with the remaining behavior changes to make this 💯 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified

# Screen recording
[set default in backend.webm](https://github.com/user-attachments/assets/e9ce2174-3fab-41e8-9011-6ea4d4c6d717)
