### PR TITLE
Prevent text change race condition when moving the focus

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/view/CardFormView.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardFormView.kt
@@ -351,7 +351,9 @@ class CardFormView @JvmOverloads constructor(
         cardMultilineWidget.setBackgroundResource(R.drawable.stripe_card_form_view_text_input_layout_background)
         cardMultilineWidget.cvcEditText.doAfterTextChanged { cvcText ->
             if (postalCodeContainer.isVisible && cardMultilineWidget.brand.isMaxCvc(cvcText.toString())) {
-                postalCodeView.requestFocus()
+                post {
+                    postalCodeView.requestFocus()
+                }
             }
         }
 

--- a/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -803,13 +803,17 @@ class CardInputWidget @JvmOverloads constructor(
         cardNumberEditText.possibleCardBrandsCallback = this::handlePossibleCardBrandsChanged
 
         expiryDateEditText.completionCallback = {
-            cvcEditText.requestFocus()
+            post {
+                cvcEditText.requestFocus()
+            }
             cardInputListener?.onExpirationComplete()
         }
 
         cvcEditText.completionCallback = {
             if (postalCodeEnabled) {
-                postalCodeEditText.requestFocus()
+                post {
+                    postalCodeEditText.requestFocus()
+                }
             }
         }
 

--- a/payments-core/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
@@ -382,7 +382,9 @@ class CardMultilineWidget @JvmOverloads constructor(
         initDeleteEmptyListeners()
 
         cardNumberEditText.completionCallback = {
-            expiryDateEditText.requestFocus()
+            post {
+                expiryDateEditText.requestFocus()
+            }
             cardInputListener?.onCardComplete()
         }
 
@@ -413,7 +415,9 @@ class CardMultilineWidget @JvmOverloads constructor(
         }
 
         expiryDateEditText.completionCallback = {
-            cvcEditText.requestFocus()
+            post {
+                cvcEditText.requestFocus()
+            }
             cardInputListener?.onExpirationComplete()
         }
 
@@ -426,7 +430,9 @@ class CardMultilineWidget @JvmOverloads constructor(
             if (brand.isMaxCvc(text)) {
                 updateBrandUi()
                 if (shouldShowPostalCode) {
-                    postalCodeEditText.requestFocus()
+                    post {
+                        postalCodeEditText.requestFocus()
+                    }
                 }
                 cardInputListener?.onCvcComplete()
             } else if (!showCvcIconInCvcField) {

--- a/payments-core/src/test/java/com/stripe/android/view/CardFormViewTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardFormViewTest.kt
@@ -188,6 +188,7 @@ internal class CardFormViewTest {
         assertThat(binding.postalCode.hasFocus()).isFalse()
 
         binding.cardMultilineWidget.cvcEditText.append("3")
+        idleLooper()
 
         assertThat(binding.postalCode.hasFocus()).isTrue()
     }

--- a/payments-core/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
@@ -613,6 +613,7 @@ internal class CardInputWidgetTest {
 
         expiryDateEditText.append("12")
         expiryDateEditText.append("79")
+        idleLooper()
 
         assertThat(cardInputListener.expirationCompleteCalls)
             .isEqualTo(1)
@@ -652,6 +653,9 @@ internal class CardInputWidgetTest {
 
             expiryDateEditText.append("12")
             expiryDateEditText.append("79")
+
+            idleLooper()
+
             assertThat(cvcEditText.hasFocus())
                 .isTrue()
 
@@ -673,6 +677,7 @@ internal class CardInputWidgetTest {
 
             expiryDateEditText.append("12")
             expiryDateEditText.append("79")
+            idleLooper()
             assertThat(cvcEditText.hasFocus())
                 .isTrue()
 
@@ -1178,7 +1183,7 @@ internal class CardInputWidgetTest {
         updateCardNumberAndIdle(VISA_NO_SPACES)
 
         setExpiryDate(12, 2079)
-        setCvcCode(CVC_VALUE_AMEX)
+        WaitForFocusAndSetCvcCode(CVC_VALUE_AMEX)
         clear()
 
         assertThat(cardNumberEditText.fieldText)
@@ -1203,8 +1208,8 @@ internal class CardInputWidgetTest {
         postalCodeEnabled = true
         setCardNumber(VISA_NO_SPACES)
         setExpiryDate(12, 2079)
-        setCvcCode(CVC_VALUE_AMEX)
-        setPostalCode(POSTAL_CODE_VALUE)
+        WaitForFocusAndSetCvcCode(CVC_VALUE_AMEX)
+        WaitForFocusAndSetPostalCode(POSTAL_CODE_VALUE)
         clear()
 
         assertThat(cardNumberEditText.fieldText)
@@ -1220,6 +1225,7 @@ internal class CardInputWidgetTest {
             .isEqualTo(
                 listOf(
                     CardInputListener.FocusField.Cvc,
+                    CardInputListener.FocusField.ExpiryDate,
                     CardInputListener.FocusField.PostalCode,
                     CardInputListener.FocusField.CardNumber
                 )
@@ -1830,6 +1836,16 @@ internal class CardInputWidgetTest {
     private fun CardInputWidget.updateCardNumberAndIdle(cardNumber: String) {
         cardNumberEditText.setText(cardNumber)
         idleLooper()
+    }
+
+    private fun CardInputWidget.WaitForFocusAndSetCvcCode(cvcCode: String?) {
+        idleLooper()
+        setCvcCode(cvcCode)
+    }
+
+    private fun CardInputWidget.WaitForFocusAndSetPostalCode(postalCode: String?) {
+        idleLooper()
+        setPostalCode(postalCode)
     }
 
     private class FakeCardInputListener : CardInputListener {

--- a/payments-core/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
@@ -642,6 +642,7 @@ internal class CardMultilineWidgetTest {
 
         fullGroup.expiryDateEditText.append("12")
         fullGroup.expiryDateEditText.append("50")
+        idleLooper()
         verify(fullCardListener).onExpirationComplete()
         verify(fullCardListener).onFocusChange(CardInputListener.FocusField.Cvc)
         assertThat(fullGroup.cvcEditText.hasFocus())
@@ -649,6 +650,7 @@ internal class CardMultilineWidgetTest {
 
         noZipGroup.expiryDateEditText.append("12")
         noZipGroup.expiryDateEditText.append("50")
+        idleLooper()
         verify(noZipCardListener).onExpirationComplete()
         verify(noZipCardListener).onFocusChange(CardInputListener.FocusField.Cvc)
         assertThat(noZipGroup.cvcEditText.hasFocus())
@@ -667,6 +669,7 @@ internal class CardMultilineWidgetTest {
         fullGroup.expiryDateEditText.append("12")
         fullGroup.expiryDateEditText.append("50")
         fullGroup.cvcEditText.append(CVC_VALUE_COMMON)
+        idleLooper()
         verify(fullCardListener).onCvcComplete()
         verify(fullCardListener).onFocusChange(CardInputListener.FocusField.PostalCode)
         assertThat(fullGroup.postalCodeEditText.hasFocus())
@@ -676,6 +679,7 @@ internal class CardMultilineWidgetTest {
         noZipGroup.expiryDateEditText.append("12")
         noZipGroup.expiryDateEditText.append("50")
         noZipGroup.cvcEditText.append(CVC_VALUE_COMMON)
+        idleLooper()
         verify(noZipCardListener).onCvcComplete()
         verify(noZipCardListener, never()).onFocusChange(CardInputListener.FocusField.PostalCode)
         assertThat(noZipGroup.cvcEditText.hasFocus())
@@ -689,6 +693,7 @@ internal class CardMultilineWidgetTest {
     fun deleteWhenEmpty_fromExpiry_withPostalCode_shiftsToCardNumber() = runCardMultilineWidgetTest {
         cardMultilineWidget.setCardInputListener(fullCardListener)
         fullGroup.cardNumberEditText.setText(VISA_WITH_SPACES)
+        idleLooper()
 
         assertThat(fullGroup.expiryDateEditText.hasFocus())
             .isTrue()
@@ -709,6 +714,7 @@ internal class CardMultilineWidgetTest {
     fun deleteWhenEmpty_fromExpiry_withoutPostalCode_shiftsToCardNumber() = runCardMultilineWidgetTest {
         noZipCardMultilineWidget.setCardInputListener(noZipCardListener)
         noZipGroup.cardNumberEditText.setText(VISA_WITH_SPACES)
+        idleLooper()
 
         assertThat(noZipGroup.expiryDateEditText.hasFocus())
             .isTrue()
@@ -730,6 +736,7 @@ internal class CardMultilineWidgetTest {
 
         fullGroup.expiryDateEditText.append("12")
         fullGroup.expiryDateEditText.append("50")
+        idleLooper()
 
         assertThat(fullGroup.cvcEditText.hasFocus())
             .isTrue()
@@ -743,6 +750,7 @@ internal class CardMultilineWidgetTest {
 
         noZipGroup.expiryDateEditText.append("12")
         noZipGroup.expiryDateEditText.append("50")
+        idleLooper()
 
         assertThat(noZipGroup.cvcEditText.hasFocus())
             .isTrue()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-3861
Delay the focus change when completing each card input field.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
#10178 
A rare race condition where `TextWatcher` removal during active text change callback iteration causes `IndexOutOfBoundsException`, affecting our legacy `CardInputWidget`, `CardMultilineWidget`, and `CardFormView`

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified