### PR TITLE
[MOBILESDK-2680] Improve Voiceover for Horizontal Mode Saved Payments

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTab.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTab.kt
@@ -26,6 +26,7 @@ import androidx.compose.material.BadgedBox
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
@@ -35,6 +36,7 @@ import androidx.compose.ui.layout.FixedScale
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.invisibleToUser
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
@@ -59,6 +61,7 @@ private val editIconBackgroundColorDark = Color(0xFF525252)
 // the remove badge on the payment method card.
 internal val SavedPaymentMethodsTopContentPadding = 12.dp
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 internal fun SavedPaymentMethodTab(
     modifier: Modifier = Modifier,
@@ -94,7 +97,15 @@ internal fun SavedPaymentMethodTab(
                         selected = isSelected,
                         enabled = isClickable,
                         onClick = onItemSelectedListener,
-                    ),
+                    )
+                    .semantics {
+                        if (!isClickable) {
+                            // This shouldn't be visible for accessibility purposes
+                            // due to it not being clickable, the user should be
+                            // interacting with the badge instead
+                            invisibleToUser()
+                        }
+                    },
             ) {
                 SavedPaymentMethodCard(
                     isSelected = isSelected,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentOptionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentOptionTest.kt
@@ -115,11 +115,6 @@ class PaymentOptionTest {
         composeTestRule.onNodeWithTag(
             testTag = TEST_TAG_MODIFY_BADGE,
             useUnmergedTree = true
-        ).assertIsEnabled()
-
-        composeTestRule.onNodeWithTag(
-            testTag = TEST_TAG_MODIFY_BADGE,
-            useUnmergedTree = true
         ).performClick()
 
         assertThat(didCallOnModifyItem).isTrue()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentOptionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentOptionTest.kt
@@ -2,11 +2,14 @@ package com.stripe.android.paymentsheet.ui
 
 import android.os.Build
 import androidx.compose.ui.test.assertContentDescriptionEquals
+import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
 import com.stripe.android.paymentsheet.R
 import org.junit.Rule
 import org.junit.Test
@@ -56,21 +59,94 @@ class PaymentOptionTest {
         ).assertExists()
     }
 
+    @Test
+    fun `Correctly hide modify badge when not editing`() {
+        setSavedPaymentMethodTabComposeTestRule(
+            shouldShowDefaultBadge = false,
+            shouldShowModifyBadge = false
+        )
+
+        composeTestRule.onNodeWithTag(
+            testTag = TEST_TAG_MODIFY_BADGE,
+            useUnmergedTree = true
+        ).assertDoesNotExist()
+    }
+
+    @Test
+    fun `Correctly shows modify badge in editMode`() {
+        setSavedPaymentMethodTabComposeTestRule(
+            shouldShowDefaultBadge = false,
+            shouldShowModifyBadge = true
+        )
+
+        composeTestRule.onNodeWithTag(
+            testTag = TEST_TAG_MODIFY_BADGE,
+            useUnmergedTree = true
+        ).assertExists()
+    }
+
+    @Test
+    fun `Correct contentDescription on modify badge`() {
+        setSavedPaymentMethodTabComposeTestRule(
+            shouldShowDefaultBadge = false,
+            shouldShowModifyBadge = true
+        )
+
+        composeTestRule.onNodeWithTag(
+            testTag = TEST_TAG_MODIFY_BADGE,
+            useUnmergedTree = true
+        ).assertContentDescriptionEquals(modifyBadgeLabel)
+    }
+
+    @Test
+    fun `Modify badge is clickable`() {
+        var didCallOnModifyItem = false
+
+        setSavedPaymentMethodTabComposeTestRule(
+            shouldShowDefaultBadge = false,
+            shouldShowModifyBadge = true,
+            onModifyListener = {
+                didCallOnModifyItem = true
+            }
+        )
+
+        assertThat(didCallOnModifyItem).isFalse()
+
+        composeTestRule.onNodeWithTag(
+            testTag = TEST_TAG_MODIFY_BADGE,
+            useUnmergedTree = true
+        ).assertIsEnabled()
+
+        composeTestRule.onNodeWithTag(
+            testTag = TEST_TAG_MODIFY_BADGE,
+            useUnmergedTree = true
+        ).performClick()
+
+        assertThat(didCallOnModifyItem).isTrue()
+    }
+
+    private val testLabel: String = "Card ending in 4242"
+    private val modifyBadgeLabel: String = "Edit Card ending in 4242"
+
     private fun setSavedPaymentMethodTabComposeTestRule(
-        label: String = "Card ending in 4242",
+        label: String = testLabel,
         shouldShowDefaultBadge: Boolean,
+        shouldShowModifyBadge: Boolean = false,
+        onModifyListener: () -> Unit = {}
     ) {
         composeTestRule.setContent {
             SavedPaymentMethodTab(
                 viewWidth = 100.dp,
                 isSelected = false,
-                shouldShowModifyBadge = false,
+                shouldShowModifyBadge = shouldShowModifyBadge,
                 shouldShowDefaultBadge = shouldShowDefaultBadge,
                 isEnabled = true,
                 iconRes = R.drawable.stripe_ic_paymentsheet_card_visa_ref,
                 labelText = label,
                 description = label,
+                onModifyListener = onModifyListener,
                 onItemSelectedListener = {},
+                onModifyAccessibilityDescription = "Edit $label"
             )
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentOptionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentOptionTest.kt
@@ -2,7 +2,6 @@ package com.stripe.android.paymentsheet.ui
 
 import android.os.Build
 import androidx.compose.ui.test.assertContentDescriptionEquals
-import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText


### PR DESCRIPTION
# Summary
Make the box content invisible to users for accessibility purposes because it is disabled during editing.

Users are interacting with the badge box instead

# Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-2680

Make navigating horizontal mode easier for users on Talkback

# Testing
<!-- How was the code tested? Be as specific as possible. -->
Specific unit tests for the visibility or traverse order of elements are not currently possible. There are no methods in our current testing library available to do this.

- [X] Added tests
- [ ] Modified tests
- [X] Manually verified

# Screenshots
Demo: (Careful loud)
https://drive.google.com/file/d/19BbYSo95vvUkdceNgYhIK2BJ47-sxMRM/view?usp=sharing
# Changelog
N.A.