### PR TITLE
Send `las_id` in FC events

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
@@ -64,6 +64,8 @@ import com.stripe.android.financialconnections.presentation.FinancialConnections
 import com.stripe.android.financialconnections.ui.FinancialConnectionsSheetNativeActivity
 import com.stripe.android.financialconnections.utils.parcelable
 import com.stripe.attestation.IntegrityRequestManager
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
@@ -86,6 +88,7 @@ internal class FinancialConnectionsSheetViewModel @Inject constructor(
     private val nativeRouter: NativeAuthFlowRouter,
     nativeAuthFlowCoordinator: NativeAuthFlowCoordinator,
     private val initialState: FinancialConnectionsSheetState,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : FinancialConnectionsViewModel<FinancialConnectionsSheetState>(initialState, nativeAuthFlowCoordinator) {
 
     private val mutex = Mutex()
@@ -542,7 +545,7 @@ internal class FinancialConnectionsSheetViewModel @Inject constructor(
     private fun reportResult(result: FinancialConnectionsSheetActivityResult) {
         // We use the global scope to make sure that we can finish sending the event
         // even if the ViewModel is cleared.
-        GlobalScope.launch {
+        GlobalScope.launch(ioDispatcher) {
             val manifest = getOrFetchSync().manifest
             eventReporter.onResult(manifest.id, result)
         }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/analytics/DefaultFinancialConnectionsEventReporter.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/analytics/DefaultFinancialConnectionsEventReporter.kt
@@ -4,7 +4,6 @@ import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.networking.AnalyticsEvent
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.networking.AnalyticsRequestFactory
-import com.stripe.android.financialconnections.FinancialConnectionsSheet
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetActivityResult
 import com.stripe.android.financialconnections.utils.filterNotNullValues
 import kotlinx.coroutines.CoroutineScope
@@ -18,17 +17,12 @@ internal class DefaultFinancialConnectionsEventReporter @Inject constructor(
     @IOContext private val workContext: CoroutineContext
 ) : FinancialConnectionsEventReporter {
 
-    override fun onPresented(configuration: FinancialConnectionsSheet.Configuration) {
-        fireEvent(
-            Event(
-                Event.Code.SheetPresented,
-                mapOf(PARAM_CLIENT_SECRET to configuration.financialConnectionsSessionClientSecret)
-            )
-        )
+    override fun onPresented() {
+        fireEvent(Event(Event.Code.SheetPresented))
     }
 
     override fun onResult(
-        configuration: FinancialConnectionsSheet.Configuration,
+        session: String,
         financialConnectionsSheetResult: FinancialConnectionsSheetActivityResult
     ) {
         val event = when (financialConnectionsSheetResult) {
@@ -36,7 +30,7 @@ internal class DefaultFinancialConnectionsEventReporter @Inject constructor(
                 Event(
                     Event.Code.SheetClosed,
                     mapOf(
-                        PARAM_CLIENT_SECRET to configuration.financialConnectionsSessionClientSecret,
+                        PARAM_SESSION_ID to session,
                         PARAM_SESSION_RESULT to "completed"
                     )
                 )
@@ -45,7 +39,7 @@ internal class DefaultFinancialConnectionsEventReporter @Inject constructor(
                 Event(
                     Event.Code.SheetClosed,
                     mapOf(
-                        PARAM_CLIENT_SECRET to configuration.financialConnectionsSessionClientSecret,
+                        PARAM_SESSION_ID to session,
                         PARAM_SESSION_RESULT to "cancelled"
                     )
                 )
@@ -54,7 +48,7 @@ internal class DefaultFinancialConnectionsEventReporter @Inject constructor(
                 Event(
                     Event.Code.SheetFailed,
                     mapOf(
-                        PARAM_CLIENT_SECRET to configuration.financialConnectionsSessionClientSecret,
+                        PARAM_SESSION_ID to session,
                         PARAM_SESSION_RESULT to "failure"
                     ).plus(
                         financialConnectionsSheetResult.error
@@ -102,7 +96,7 @@ internal class DefaultFinancialConnectionsEventReporter @Inject constructor(
     }
 
     internal companion object {
-        const val PARAM_CLIENT_SECRET = "las_client_secret"
+        const val PARAM_SESSION_ID = "las_id"
         const val PARAM_SESSION_RESULT = "session_result"
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/analytics/DefaultFinancialConnectionsEventReporter.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/analytics/DefaultFinancialConnectionsEventReporter.kt
@@ -22,7 +22,7 @@ internal class DefaultFinancialConnectionsEventReporter @Inject constructor(
     }
 
     override fun onResult(
-        session: String,
+        sessionId: String,
         financialConnectionsSheetResult: FinancialConnectionsSheetActivityResult
     ) {
         val event = when (financialConnectionsSheetResult) {
@@ -30,7 +30,7 @@ internal class DefaultFinancialConnectionsEventReporter @Inject constructor(
                 Event(
                     Event.Code.SheetClosed,
                     mapOf(
-                        PARAM_SESSION_ID to session,
+                        PARAM_SESSION_ID to sessionId,
                         PARAM_SESSION_RESULT to "completed"
                     )
                 )
@@ -39,7 +39,7 @@ internal class DefaultFinancialConnectionsEventReporter @Inject constructor(
                 Event(
                     Event.Code.SheetClosed,
                     mapOf(
-                        PARAM_SESSION_ID to session,
+                        PARAM_SESSION_ID to sessionId,
                         PARAM_SESSION_RESULT to "cancelled"
                     )
                 )
@@ -48,7 +48,7 @@ internal class DefaultFinancialConnectionsEventReporter @Inject constructor(
                 Event(
                     Event.Code.SheetFailed,
                     mapOf(
-                        PARAM_SESSION_ID to session,
+                        PARAM_SESSION_ID to sessionId,
                         PARAM_SESSION_RESULT to "failure"
                     ).plus(
                         financialConnectionsSheetResult.error

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/analytics/FinancialConnectionsAnalyticsTracker.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/analytics/FinancialConnectionsAnalyticsTracker.kt
@@ -109,10 +109,7 @@ internal class FinancialConnectionsAnalyticsTrackerImpl(
     private suspend fun commonParams(): Map<String, String?> {
         val manifest = getOrFetchSync().manifest
         return mapOf(
-            "las_client_secret" to configuration.financialConnectionsSessionClientSecret,
-//            "las_creator_client_secret": this.linkAccountSessionCreatorClientSecret,
-//        "las_creator_type": this.linkAccountSessionCreatorType,
-//        "las_creator_id": this.linkAccountSessionCreatorId,
+            "las_id" to manifest.id,
             "key" to configuration.publishableKey,
             "stripe_account" to configuration.stripeAccountId,
             "navigator_language" to locale.toLanguageTag(),

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/analytics/FinancialConnectionsEventReporter.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/analytics/FinancialConnectionsEventReporter.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.financialconnections.analytics
 
-import com.stripe.android.financialconnections.FinancialConnectionsSheet
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetActivityResult
 
 /**
@@ -13,10 +12,10 @@ import com.stripe.android.financialconnections.launcher.FinancialConnectionsShee
  */
 internal interface FinancialConnectionsEventReporter {
 
-    fun onPresented(configuration: FinancialConnectionsSheet.Configuration)
+    fun onPresented()
 
     fun onResult(
-        configuration: FinancialConnectionsSheet.Configuration,
+        session: String,
         financialConnectionsSheetResult: FinancialConnectionsSheetActivityResult
     )
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/analytics/FinancialConnectionsEventReporter.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/analytics/FinancialConnectionsEventReporter.kt
@@ -15,7 +15,7 @@ internal interface FinancialConnectionsEventReporter {
     fun onPresented()
 
     fun onResult(
-        session: String,
+        sessionId: String,
         financialConnectionsSheetResult: FinancialConnectionsSheetActivityResult
     )
 }

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModelTest.kt
@@ -39,7 +39,6 @@ import com.stripe.android.model.IncentiveEligibilitySession
 import com.stripe.android.model.LinkMode
 import com.stripe.attestation.IntegrityRequestManager
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -58,8 +57,10 @@ import org.mockito.kotlin.whenever
 @RunWith(AndroidJUnit4::class)
 class FinancialConnectionsSheetViewModelTest {
 
+    private val testDispatcher = UnconfinedTestDispatcher()
+
     @get:Rule
-    val rule: TestRule = CoroutineTestRule(UnconfinedTestDispatcher())
+    val rule: TestRule = CoroutineTestRule(testDispatcher)
 
     private val eventReporter = mock<FinancialConnectionsEventReporter>()
     private val configuration = FinancialConnectionsSheet.Configuration(
@@ -459,9 +460,6 @@ class FinancialConnectionsSheetViewModelTest {
         // When
         viewModel.handleOnNewIntent(Intent("error_url"))
 
-        // A bad workaround for now
-        delay(300)
-
         // Then
         verify(eventReporter)
             .onResult(eq(sessionId), any<Failed>())
@@ -508,9 +506,6 @@ class FinancialConnectionsSheetViewModelTest {
             // When
             // end auth flow
             viewModel.handleOnNewIntent(cancelIntent)
-
-            // A bad workaround for now
-            delay(300)
 
             // Then
             verify(eventReporter)
@@ -755,9 +750,6 @@ class FinancialConnectionsSheetViewModelTest {
             // auth flow ends (activity received result without new intent received)
             viewModel.onBrowserActivityResult()
 
-            // A bad workaround for now
-            delay(300)
-
             // Then
             withState(viewModel) {
                 assertThat(it.webAuthFlowStatus).isEqualTo(AuthFlowStatus.ON_EXTERNAL_ACTIVITY)
@@ -861,7 +853,8 @@ class FinancialConnectionsSheetViewModelTest {
             nativeAuthFlowCoordinator = mock(),
             integrityRequestManager = integrityRequestManager,
             integrityVerdictManager = mock(),
-            logger = Logger.noop()
+            logger = Logger.noop(),
+            ioDispatcher = testDispatcher,
         )
     }
 }

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/analytics/DefaultConnectionsEventReportTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/analytics/DefaultConnectionsEventReportTest.kt
@@ -92,7 +92,7 @@ class DefaultConnectionsEventReportTest {
     @Test
     fun `onResult() should fire analytics request with expected event value for failure`() {
         eventReporter.onResult(
-            session = financialConnectionsSession.id,
+            sessionId = financialConnectionsSession.id,
             financialConnectionsSheetResult = FinancialConnectionsSheetActivityResult.Failed(Exception()),
         )
         verify(analyticsRequestExecutor).executeAsync(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request updates the Financial Connections events to include the Link Account Session ID.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
