### PR TITLE
Fix regression where default label was not shown in horizontal mode

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -80,7 +80,7 @@ internal class SavedPaymentMethodMutator(
 
     private val paymentOptionsItemsMapper: PaymentOptionsItemsMapper by lazy {
         PaymentOptionsItemsMapper(
-            customerMetadata = paymentMethodMetadataFlow.value?.customerMetadata,
+            customerMetadata = paymentMethodMetadataFlow.mapAsStateFlow { it?.customerMetadata },
             customerState = customerStateHolder.customer,
             isGooglePayReady = paymentMethodMetadataFlow.mapAsStateFlow { it?.isGooglePayReady == true },
             isLinkEnabled = isLinkEnabled,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsItemsMapper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsItemsMapper.kt
@@ -11,7 +11,7 @@ import com.stripe.android.uicore.utils.combineAsStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 internal class PaymentOptionsItemsMapper(
-    private val customerMetadata: CustomerMetadata?,
+    private val customerMetadata: StateFlow<CustomerMetadata?>,
     private val customerState: StateFlow<CustomerState?>,
     private val isGooglePayReady: StateFlow<Boolean>,
     private val isLinkEnabled: StateFlow<Boolean?>,
@@ -25,7 +25,8 @@ internal class PaymentOptionsItemsMapper(
             customerState,
             isLinkEnabled,
             isGooglePayReady,
-        ) { customerState, isLinkEnabled, isGooglePayReady ->
+            customerMetadata,
+        ) { customerState, isLinkEnabled, isGooglePayReady, customerMetadata ->
             createPaymentOptionsItems(
                 paymentMethods = customerState?.paymentMethods ?: listOf(),
                 isLinkEnabled = isLinkEnabled,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/CustomerSessionPaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/CustomerSessionPaymentSheetActivityTest.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.hasAnyAncestor
 import androidx.compose.ui.test.hasAnyDescendant
@@ -12,6 +13,7 @@ import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isEnabled
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
@@ -26,6 +28,7 @@ import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_EDIT_BUTTON_TEST_TAG
 import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_OPTION_TAB_LAYOUT_TEST_TAG
 import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_OPTION_TEST_TAG
+import com.stripe.android.paymentsheet.ui.TEST_TAG_DEFAULT_PAYMENT_METHOD_LABEL
 import com.stripe.android.paymentsheet.ui.TEST_TAG_MODIFY_BADGE
 import com.stripe.android.paymentsheet.ui.UPDATE_PM_REMOVE_BUTTON_TEST_TAG
 import com.stripe.android.testing.PaymentConfigurationTestRule
@@ -332,6 +335,23 @@ internal class CustomerSessionPaymentSheetActivityTest {
         }
     }
 
+    @Test
+    fun `Default badge displayed in edit mode when set as default feature enabled`() {
+        val cards = PaymentMethodFixtures.createCards(2)
+        runTest(
+            cards = cards,
+            setAsDefaultFeatureEnabled = true,
+            defaultPaymentMethod = cards.first().id,
+        ) {
+            composeTestRule.onEditButton().performClick()
+
+            composeTestRule.onAllNodesWithTag(
+                TEST_TAG_DEFAULT_PAYMENT_METHOD_LABEL,
+                useUnmergedTree = true
+            ).assertCountEquals(1)
+        }
+    }
+
     private fun setDefaultPaymentMethod() {
         editPage.waitUntilVisible()
         editPage.clickSetAsDefaultCheckbox()
@@ -354,6 +374,7 @@ internal class CustomerSessionPaymentSheetActivityTest {
         canRemoveLastPaymentMethodServer: Boolean = true,
         setAsDefaultFeatureEnabled: Boolean = false,
         paymentMethodLayout: PaymentSheet.PaymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+        defaultPaymentMethod: String? = null,
         test: (PaymentSheetActivity) -> Unit,
     ) {
         networkRule.enqueue(
@@ -367,6 +388,7 @@ internal class CustomerSessionPaymentSheetActivityTest {
                     isPaymentMethodRemoveEnabled = isPaymentMethodRemoveEnabled,
                     canRemoveLastPaymentMethod = canRemoveLastPaymentMethodServer,
                     setAsDefaultFeatureEnabled = setAsDefaultFeatureEnabled,
+                    defaultPaymentMethod = defaultPaymentMethod,
                 )
             )
         }
@@ -451,6 +473,7 @@ internal class CustomerSessionPaymentSheetActivityTest {
             isPaymentMethodRemoveEnabled: Boolean,
             canRemoveLastPaymentMethod: Boolean,
             setAsDefaultFeatureEnabled: Boolean,
+            defaultPaymentMethod: String?,
         ): String {
             val cardsArray = JSONArray()
 
@@ -505,7 +528,7 @@ internal class CustomerSessionPaymentSheetActivityTest {
                         }
                       }
                     },
-                    "default_payment_method": null
+                    "default_payment_method": $defaultPaymentMethod
                   },
                   "payment_method_preference": {
                     "object": "payment_method_preference",

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsItemsMapperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsItemsMapperTest.kt
@@ -32,9 +32,11 @@ class PaymentOptionsItemsMapperTest {
             isNotPaymentFlow = true,
             nameProvider = { it!!.resolvableString },
             isCbcEligible = { false },
-            customerMetadata = CustomerMetadata(
-                hasCustomerConfiguration = false,
-                isPaymentMethodSetAsDefaultEnabled = false
+            customerMetadata = MutableStateFlow(
+                CustomerMetadata(
+                    hasCustomerConfiguration = false,
+                    isPaymentMethodSetAsDefaultEnabled = false
+                )
             ),
         )
 
@@ -66,9 +68,11 @@ class PaymentOptionsItemsMapperTest {
             isNotPaymentFlow = false,
             nameProvider = { it!!.resolvableString },
             isCbcEligible = { false },
-            customerMetadata = CustomerMetadata(
-                hasCustomerConfiguration = false,
-                isPaymentMethodSetAsDefaultEnabled = false
+            customerMetadata = MutableStateFlow(
+                CustomerMetadata(
+                    hasCustomerConfiguration = false,
+                    isPaymentMethodSetAsDefaultEnabled = false
+                )
             ),
         )
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Fix regression where default label was not shown in horizontal mode

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
In https://github.com/stripe/stripe-android/pull/10117, we went from using a stateflow to figure out the value of the default PM ID to using a static value. This lead to us missing a state change where the default PM ID went from null -> non-null and a bug where the default label was never shown in horizontal mode.

Found this while I was testing out various features getting ready for bug bash/quality review

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified
