### PR TITLE
Fix issue with multiple emits in confirmation flow for `Embedded`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationStarter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationStarter.kt
@@ -1,0 +1,49 @@
+package com.stripe.android.paymentelement.embedded.content
+
+import androidx.activity.result.ActivityResultCaller
+import androidx.lifecycle.LifecycleOwner
+import com.stripe.android.core.injection.ViewModelScope
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+internal class EmbeddedConfirmationStarter @Inject constructor(
+    private val confirmationHandler: ConfirmationHandler,
+    @ViewModelScope private val coroutineScope: CoroutineScope,
+) {
+    init {
+        coroutineScope.launch {
+            confirmationHandler.state.collect { state ->
+                when (state) {
+                    is ConfirmationHandler.State.Confirming,
+                    is ConfirmationHandler.State.Idle -> Unit
+                    is ConfirmationHandler.State.Complete -> {
+                        _result.send(state.result)
+                    }
+                }
+            }
+        }
+    }
+
+    private val _result = Channel<ConfirmationHandler.Result>()
+    val result = _result.receiveAsFlow()
+
+    fun register(
+        activityResultCaller: ActivityResultCaller,
+        lifecycleOwner: LifecycleOwner,
+    ) {
+        confirmationHandler.register(
+            activityResultCaller = activityResultCaller,
+            lifecycleOwner = lifecycleOwner,
+        )
+    }
+
+    fun start(args: ConfirmationHandler.Args) {
+        confirmationHandler.start(args)
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfirmationHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfirmationHelperTest.kt
@@ -157,7 +157,10 @@ internal class DefaultEmbeddedConfirmationHelperTest {
         )
         confirmationStateHolder.state = loadedState
         val confirmationHelper = DefaultEmbeddedConfirmationHelper(
-            confirmationHandler = confirmationHandler,
+            confirmationStarter = EmbeddedConfirmationStarter(
+                confirmationHandler = confirmationHandler,
+                coroutineScope = backgroundScope,
+            ),
             resultCallback = {
                 resultCallbackTurbine.add(it)
             },

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationStarterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationStarterTest.kt
@@ -1,0 +1,140 @@
+package com.stripe.android.paymentelement.embedded.content
+
+import androidx.lifecycle.testing.TestLifecycleOwner
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.FakeConfirmationOption
+import com.stripe.android.paymentelement.confirmation.assertSucceeded
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.state.PaymentElementLoader
+import com.stripe.android.testing.PaymentIntentFactory
+import com.stripe.android.testing.PaymentMethodFactory
+import com.stripe.android.utils.DummyActivityResultCaller
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class EmbeddedConfirmationStarterTest {
+    @Test
+    fun `on register, should call 'register' on confirmation handler`() = test {
+        val activityResultCaller = DummyActivityResultCaller.noOp()
+        val lifecycleOwner = TestLifecycleOwner(
+            coroutineDispatcher = Dispatchers.Unconfined,
+        )
+
+        confirmationStarter.register(
+            activityResultCaller = activityResultCaller,
+            lifecycleOwner = lifecycleOwner
+        )
+
+        val registerCall = confirmationHandler.registerTurbine.awaitItem()
+
+        assertThat(registerCall.activityResultCaller).isEqualTo(activityResultCaller)
+        assertThat(registerCall.lifecycleOwner).isEqualTo(lifecycleOwner)
+    }
+
+    @Test
+    fun `on confirm, should call 'start' on confirmation handler`() = test {
+        val arguments = ConfirmationHandler.Args(
+            intent = PaymentIntentFactory.create(
+                paymentMethod = PaymentMethodFactory.card(random = true),
+            ),
+            confirmationOption = FakeConfirmationOption(),
+            appearance = PaymentSheet.Appearance(),
+            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
+                clientSecret = "pi_123_secret_123",
+            ),
+            shippingDetails = null,
+        )
+
+        confirmationStarter.start(arguments)
+
+        val startCall = confirmationHandler.startTurbine.awaitItem()
+
+        assertThat(startCall.confirmationOption).isEqualTo(arguments.confirmationOption)
+        assertThat(startCall.intent).isEqualTo(arguments.intent)
+        assertThat(startCall.appearance).isEqualTo(arguments.appearance)
+        assertThat(startCall.initializationMode).isEqualTo(arguments.initializationMode)
+        assertThat(startCall.shippingDetails).isEqualTo(arguments.shippingDetails)
+    }
+
+    @Test
+    fun `on idle state, should not emit any result events`() = test(
+        confirmationState = ConfirmationHandler.State.Idle,
+    ) {
+        confirmationStarter.result.test {
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `on confirming state, should not emit any result events`() = test(
+        confirmationState = ConfirmationHandler.State.Confirming(
+            option = FakeConfirmationOption(),
+        ),
+    ) {
+        confirmationStarter.result.test {
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `on complete state, should emit result at most once`() {
+        val intent = PaymentIntentFactory.create(
+            paymentMethod = PaymentMethodFactory.card(random = true),
+            status = StripeIntent.Status.Succeeded,
+        )
+
+        test(
+            confirmationState = ConfirmationHandler.State.Complete(
+                result = ConfirmationHandler.Result.Succeeded(
+                    intent = intent,
+                    deferredIntentConfirmationType = null,
+                ),
+            ),
+        ) {
+            confirmationStarter.result.test {
+                val result = awaitItem().assertSucceeded()
+
+                assertThat(result.intent).isEqualTo(intent)
+                assertThat(result.deferredIntentConfirmationType).isNull()
+            }
+
+            confirmationStarter.result.test {
+                expectNoEvents()
+            }
+
+            confirmationStarter.result.test {
+                expectNoEvents()
+            }
+        }
+    }
+
+    private fun test(
+        confirmationState: ConfirmationHandler.State = ConfirmationHandler.State.Idle,
+        block: suspend Scenario.() -> Unit,
+    ) = runTest {
+        val confirmationHandler = FakeConfirmationHandler(
+            state = MutableStateFlow(confirmationState)
+        )
+
+        Scenario(
+            confirmationStarter = EmbeddedConfirmationStarter(
+                confirmationHandler = confirmationHandler,
+                coroutineScope = backgroundScope,
+            ),
+            confirmationHandler = confirmationHandler,
+        ).block()
+
+        confirmationHandler.validate()
+    }
+
+    private class Scenario(
+        val confirmationStarter: EmbeddedConfirmationStarter,
+        val confirmationHandler: FakeConfirmationHandler,
+    )
+}


### PR DESCRIPTION
# Summary
Fix issue with multiple emits in confirmation flow for `Embedded`

# Motivation
Ensures events are not double emitted while also ensuring every event is properly consumed.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified