### PR TITLE
Update default separatorColor

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/EmbeddedAppearanceSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/EmbeddedAppearanceSettingsDefinition.kt
@@ -57,7 +57,7 @@ internal data class EmbeddedAppearance(
     val floatingButtonSpacingDp: Float = 12.0f,
     val topSeparatorEnabled: Boolean = true,
     val bottomSeparatorEnabled: Boolean = true,
-    val separatorColor: Int = Color(0xFF787880).toArgb(),
+    val separatorColor: Int = Color(0x33787880).toArgb(),
     val selectedColor: Int = Color(0xFF007AFF).toArgb(),
     val unselectedColor: Int = Color(0x33787880).toArgb(),
     val checkmarkColor: Int = Color(0xFF007AFF).toArgb()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -1053,7 +1053,7 @@ class PaymentSheet internal constructor(
                     internal companion object {
                         val defaultLight = FlatWithRadio(
                             separatorThicknessDp = StripeThemeDefaults.flat.separatorThickness,
-                            separatorColor = StripeThemeDefaults.colorsLight.componentBorder.toArgb(),
+                            separatorColor = StripeThemeDefaults.colorsLight.componentDivider.toArgb(),
                             startSeparatorInsetDp = StripeThemeDefaults.flat.separatorInsets,
                             endSeparatorInsetDp = StripeThemeDefaults.flat.separatorInsets,
                             topSeparatorEnabled = StripeThemeDefaults.flat.topSeparatorEnabled,
@@ -1066,7 +1066,7 @@ class PaymentSheet internal constructor(
 
                         val defaultDark = FlatWithRadio(
                             separatorThicknessDp = StripeThemeDefaults.flat.separatorThickness,
-                            separatorColor = StripeThemeDefaults.colorsDark.componentBorder.toArgb(),
+                            separatorColor = StripeThemeDefaults.colorsDark.componentDivider.toArgb(),
                             startSeparatorInsetDp = StripeThemeDefaults.flat.separatorInsets,
                             endSeparatorInsetDp = StripeThemeDefaults.flat.separatorInsets,
                             topSeparatorEnabled = StripeThemeDefaults.flat.topSeparatorEnabled,
@@ -1165,7 +1165,7 @@ class PaymentSheet internal constructor(
                     internal companion object {
                         val defaultLight = FlatWithCheckmark(
                             separatorThicknessDp = StripeThemeDefaults.flat.separatorThickness,
-                            separatorColor = StripeThemeDefaults.colorsLight.componentBorder.toArgb(),
+                            separatorColor = StripeThemeDefaults.colorsLight.componentDivider.toArgb(),
                             startSeparatorInsetDp = StripeThemeDefaults.flat.separatorInsets,
                             endSeparatorInsetDp = StripeThemeDefaults.flat.separatorInsets,
                             topSeparatorEnabled = StripeThemeDefaults.flat.topSeparatorEnabled,
@@ -1178,7 +1178,7 @@ class PaymentSheet internal constructor(
 
                         val defaultDark = FlatWithCheckmark(
                             separatorThicknessDp = StripeThemeDefaults.flat.separatorThickness,
-                            separatorColor = StripeThemeDefaults.colorsDark.componentBorder.toArgb(),
+                            separatorColor = StripeThemeDefaults.colorsDark.componentDivider.toArgb(),
                             startSeparatorInsetDp = StripeThemeDefaults.flat.separatorInsets,
                             endSeparatorInsetDp = StripeThemeDefaults.flat.separatorInsets,
                             topSeparatorEnabled = StripeThemeDefaults.flat.topSeparatorEnabled,

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/StripeTheme.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/StripeTheme.kt
@@ -126,7 +126,6 @@ data class PrimaryButtonTypography(
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class EmbeddedFlatStyle(
     val separatorThickness: Float,
-    val separatorColor: Color,
     val separatorInsets: Float,
     val topSeparatorEnabled: Boolean,
     val bottomSeparatorEnabled: Boolean
@@ -233,7 +232,6 @@ object StripeThemeDefaults {
 
     val flat = EmbeddedFlatStyle(
         separatorThickness = 1.0f,
-        separatorColor = Color(0xFF787880),
         separatorInsets = 0.0f,
         topSeparatorEnabled = true,
         bottomSeparatorEnabled = true


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Set default `separatorColor` to `componentDivider`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-3155

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| ![separatorBefore](https://github.com/user-attachments/assets/3acde66e-7422-41be-9730-a2ca9ea22cad)  | ![separator_after](https://github.com/user-attachments/assets/3f006342-c19b-481a-9bd5-cebff68bca96) |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
