### PR TITLE
Delete usages of `removeFirst` and `removeLast`

### DIFF
--- a/payments-core/src/test/java/com/stripe/android/polling/PollingTestUtils.kt
+++ b/payments-core/src/test/java/com/stripe/android/polling/PollingTestUtils.kt
@@ -50,7 +50,7 @@ private class FakeStripeRepository(
         options: ApiRequest.Options,
         expandFields: List<String>
     ): Result<PaymentIntent> {
-        val intentStatus = queue.removeFirst()
+        val intentStatus = queue.removeAt(0)
         val paymentIntent = PaymentIntentFactory.create(status = intentStatus)
         return Result.success(paymentIntent)
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/NavigationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/NavigationHandler.kt
@@ -86,7 +86,7 @@ internal class NavigationHandler<T : Any>(
         backStack.update { screens ->
             val modifiableScreens = screens.toMutableList()
 
-            val lastScreen = modifiableScreens.removeLast()
+            val lastScreen = modifiableScreens.removeAt(modifiableScreens.lastIndex)
 
             lastScreen.onClose()
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactoryTest.kt
@@ -49,7 +49,7 @@ class PaymentOptionsStateFactoryTest {
     fun `'isModifiable' is true when multiple networks are available & is CBC eligible`() {
         val paymentMethods = PaymentMethodFixtures.createCards(3).toMutableList()
 
-        val lastPaymentMethodWithNetworks = paymentMethods.removeLast().let { paymentMethod ->
+        val lastPaymentMethodWithNetworks = paymentMethods.removeAt(paymentMethods.lastIndex).let { paymentMethod ->
             paymentMethod.copy(
                 card = paymentMethod.card?.copy(
                     networks = PaymentMethod.Card.Networks(


### PR DESCRIPTION
# Summary
Delete usages of `removeFirst` and `removeLast`

# Motivation
Starting with Android 15, native `List.removeFirst()` and `List.removeLast()` APIs have been introduced. When an app is compiled with `compileSdk 35`, the Kotlin compiler resolves calls to `removeFirst()` and `removeLast()` to the new Android List API methods instead of the previous extension functions in `kotlin-stdlib`.

If the app is run on an Android version below 15 (API Level 35), the method results in a `NoSuchMethodError` crash. This will happen if the `compileSdk` is `35` but the `minSdk` is `34` or lower.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified