### PR TITLE
[MOBILESDK-2707] Default Payment Method Analytics pt 3 update card

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -220,9 +220,13 @@ internal class SavedPaymentMethodMutator(
                 customerSessionClientSecret = customer.customerSessionClientSecret,
             ),
             paymentMethodId = paymentMethod.id,
-        ).onSuccess {
+        ).onFailure { error ->
+            eventReporter.onSetAsDefaultPaymentMethodFailed(error = error)
+        }.onSuccess {
             customerStateHolder.setDefaultPaymentMethod(paymentMethod = paymentMethod)
             setSelection(PaymentSelection.Saved(paymentMethod = paymentMethod))
+
+            eventReporter.onSetAsDefaultPaymentMethodSucceeded()
         }.map {}
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -377,6 +377,7 @@ internal class DefaultEventReporter @Inject internal constructor(
         fireEvent(
             PaymentSheetEvent.UpdatePaymentOptionSucceeded(
                 selectedBrand = selectedBrand,
+                setAsDefaultPaymentMethod = null,
                 isDeferred = isDeferred,
                 linkEnabled = linkEnabled,
                 googlePaySupported = googlePaySupported,
@@ -391,6 +392,34 @@ internal class DefaultEventReporter @Inject internal constructor(
         fireEvent(
             PaymentSheetEvent.UpdatePaymentOptionFailed(
                 selectedBrand = selectedBrand,
+                setAsDefaultPaymentMethod = null,
+                error = error,
+                isDeferred = isDeferred,
+                linkEnabled = linkEnabled,
+                googlePaySupported = googlePaySupported,
+            )
+        )
+    }
+
+    override fun onSetAsDefaultPaymentMethodSucceeded() {
+        fireEvent(
+            PaymentSheetEvent.UpdatePaymentOptionSucceeded(
+                selectedBrand = null,
+                setAsDefaultPaymentMethod = true,
+                isDeferred = isDeferred,
+                linkEnabled = linkEnabled,
+                googlePaySupported = googlePaySupported,
+            )
+        )
+    }
+
+    override fun onSetAsDefaultPaymentMethodFailed(
+        error: Throwable,
+    ) {
+        fireEvent(
+            PaymentSheetEvent.UpdatePaymentOptionFailed(
+                selectedBrand = null,
+                setAsDefaultPaymentMethod = true,
                 error = error,
                 isDeferred = isDeferred,
                 linkEnabled = linkEnabled,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -377,7 +377,6 @@ internal class DefaultEventReporter @Inject internal constructor(
         fireEvent(
             PaymentSheetEvent.UpdatePaymentOptionSucceeded(
                 selectedBrand = selectedBrand,
-                setAsDefaultPaymentMethod = null,
                 isDeferred = isDeferred,
                 linkEnabled = linkEnabled,
                 googlePaySupported = googlePaySupported,
@@ -392,7 +391,6 @@ internal class DefaultEventReporter @Inject internal constructor(
         fireEvent(
             PaymentSheetEvent.UpdatePaymentOptionFailed(
                 selectedBrand = selectedBrand,
-                setAsDefaultPaymentMethod = null,
                 error = error,
                 isDeferred = isDeferred,
                 linkEnabled = linkEnabled,
@@ -403,9 +401,7 @@ internal class DefaultEventReporter @Inject internal constructor(
 
     override fun onSetAsDefaultPaymentMethodSucceeded() {
         fireEvent(
-            PaymentSheetEvent.UpdatePaymentOptionSucceeded(
-                selectedBrand = null,
-                setAsDefaultPaymentMethod = true,
+            PaymentSheetEvent.SetAsDefaultPaymentMethodSucceeded(
                 isDeferred = isDeferred,
                 linkEnabled = linkEnabled,
                 googlePaySupported = googlePaySupported,
@@ -417,9 +413,7 @@ internal class DefaultEventReporter @Inject internal constructor(
         error: Throwable,
     ) {
         fireEvent(
-            PaymentSheetEvent.UpdatePaymentOptionFailed(
-                selectedBrand = null,
-                setAsDefaultPaymentMethod = true,
+            PaymentSheetEvent.SetAsDefaultPaymentMethodFailed(
                 error = error,
                 isDeferred = isDeferred,
                 linkEnabled = linkEnabled,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
@@ -179,12 +179,12 @@ internal interface EventReporter {
     )
 
     /**
-     * The customer has successfully set a payment method as the default
+     * The customer has successfully set a payment method as the default.
      */
     fun onSetAsDefaultPaymentMethodSucceeded()
 
     /**
-     * The customer has failed to set a payment method as the default
+     * The customer has failed to set a payment method as the default.
      */
     fun onSetAsDefaultPaymentMethodFailed(
         error: Throwable,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
@@ -179,6 +179,18 @@ internal interface EventReporter {
     )
 
     /**
+     * The customer has successfully set a payment method as the default
+     */
+    fun onSetAsDefaultPaymentMethodSucceeded()
+
+    /**
+     * The customer has failed to set a payment method as the default
+     */
+    fun onSetAsDefaultPaymentMethodFailed(
+        error: Throwable,
+    )
+
+    /**
      * The customer cannot properly return from Link payments or other LPM payments using
      * browser intents.
      *

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -546,6 +546,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         const val FIELD_SET_AS_DEFAULT_ENABLED = "set_as_default_enabled"
         const val FIELD_HAS_DEFAULT_PAYMENT_METHOD = "has_default_payment_method"
         const val FIELD_SELECTED_CARD_BRAND = "selected_card_brand"
+        const val FIELD_SET_AS_DEFAULT = "set_as_default"
         const val FIELD_LINK_CONTEXT = "link_context"
         const val FIELD_EXTERNAL_PAYMENT_METHODS = "external_payment_methods"
         const val FIELD_PAYMENT_METHOD_LAYOUT = "payment_method_layout"

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -427,24 +427,44 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         }
     }
 
+    class SetAsDefaultPaymentMethodSucceeded(
+        override val isDeferred: Boolean,
+        override val linkEnabled: Boolean,
+        override val googlePaySupported: Boolean,
+    ) : PaymentSheetEvent() {
+        override val eventName: String = "mc_set_default_payment_method"
+
+        override val additionalParams: Map<String, Any?> = emptyMap()
+    }
+
+    class SetAsDefaultPaymentMethodFailed(
+        error: Throwable,
+        override val isDeferred: Boolean,
+        override val linkEnabled: Boolean,
+        override val googlePaySupported: Boolean,
+    ) : PaymentSheetEvent() {
+        override val eventName: String = "mc_set_default_payment_method_failed"
+
+        override val additionalParams: Map<String, Any?> = mapOf(
+            FIELD_ERROR_MESSAGE to error.message,
+        ).plus(ErrorReporter.getAdditionalParamsFromError(error))
+    }
+
     class UpdatePaymentOptionSucceeded(
-        selectedBrand: CardBrand?,
-        setAsDefaultPaymentMethod: Boolean?,
+        selectedBrand: CardBrand,
         override val isDeferred: Boolean,
         override val linkEnabled: Boolean,
         override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
         override val eventName: String = "mc_update_card"
 
-        override val additionalParams: Map<String, Any?> = buildMap {
-            selectedBrand?.let { put(FIELD_SELECTED_CARD_BRAND, selectedBrand.code) }
-            setAsDefaultPaymentMethod?.let { put(FIELD_SET_AS_DEFAULT, it) }
-        }
+        override val additionalParams: Map<String, Any?> = mapOf(
+            FIELD_SELECTED_CARD_BRAND to selectedBrand.code
+        )
     }
 
     class UpdatePaymentOptionFailed(
-        selectedBrand: CardBrand?,
-        setAsDefaultPaymentMethod: Boolean?,
+        selectedBrand: CardBrand,
         error: Throwable,
         override val isDeferred: Boolean,
         override val linkEnabled: Boolean,
@@ -452,11 +472,10 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
     ) : PaymentSheetEvent() {
         override val eventName: String = "mc_update_card_failed"
 
-        override val additionalParams: Map<String, Any?> = buildMap {
-            selectedBrand?.let { put(FIELD_SELECTED_CARD_BRAND, selectedBrand.code) }
-            setAsDefaultPaymentMethod?.let { put(FIELD_SET_AS_DEFAULT, it) }
-            put(FIELD_ERROR_MESSAGE, error.message)
-        }.plus(ErrorReporter.getAdditionalParamsFromError(error))
+        override val additionalParams: Map<String, Any?> = mapOf(
+            FIELD_SELECTED_CARD_BRAND to selectedBrand.code,
+            FIELD_ERROR_MESSAGE to error.message,
+        ).plus(ErrorReporter.getAdditionalParamsFromError(error))
     }
 
     class CannotProperlyReturnFromLinkAndLPMs(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -546,7 +546,6 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         const val FIELD_SET_AS_DEFAULT_ENABLED = "set_as_default_enabled"
         const val FIELD_HAS_DEFAULT_PAYMENT_METHOD = "has_default_payment_method"
         const val FIELD_SELECTED_CARD_BRAND = "selected_card_brand"
-        const val FIELD_SET_AS_DEFAULT = "set_as_default"
         const val FIELD_LINK_CONTEXT = "link_context"
         const val FIELD_EXTERNAL_PAYMENT_METHODS = "external_payment_methods"
         const val FIELD_PAYMENT_METHOD_LAYOUT = "payment_method_layout"

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -528,8 +528,6 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         const val FIELD_HAS_DEFAULT_PAYMENT_METHOD = "has_default_payment_method"
         const val FIELD_SELECTED_CARD_BRAND = "selected_card_brand"
         const val FIELD_SET_AS_DEFAULT = "set_as_default"
-        const val FIELD_SET_AS_DEFAULT_ENABLED = "set_as_default_enabled"
-        const val FIELD_HAS_DEFAULT_PAYMENT_METHOD = "has_default_payment_method"
         const val FIELD_LINK_CONTEXT = "link_context"
         const val FIELD_EXTERNAL_PAYMENT_METHODS = "external_payment_methods"
         const val FIELD_PAYMENT_METHOD_LAYOUT = "payment_method_layout"

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -428,20 +428,23 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
     }
 
     class UpdatePaymentOptionSucceeded(
-        selectedBrand: CardBrand,
+        selectedBrand: CardBrand?,
+        setAsDefaultPaymentMethod: Boolean?,
         override val isDeferred: Boolean,
         override val linkEnabled: Boolean,
         override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
         override val eventName: String = "mc_update_card"
 
-        override val additionalParams: Map<String, Any?> = mapOf(
-            FIELD_SELECTED_CARD_BRAND to selectedBrand.code
-        )
+        override val additionalParams: Map<String, Any?> = buildMap {
+            selectedBrand?.let { put(FIELD_SELECTED_CARD_BRAND, selectedBrand.code) }
+            setAsDefaultPaymentMethod?.let { put(FIELD_SET_AS_DEFAULT, it) }
+        }
     }
 
     class UpdatePaymentOptionFailed(
-        selectedBrand: CardBrand,
+        selectedBrand: CardBrand?,
+        setAsDefaultPaymentMethod: Boolean?,
         error: Throwable,
         override val isDeferred: Boolean,
         override val linkEnabled: Boolean,
@@ -449,10 +452,11 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
     ) : PaymentSheetEvent() {
         override val eventName: String = "mc_update_card_failed"
 
-        override val additionalParams: Map<String, Any?> = mapOf(
-            FIELD_SELECTED_CARD_BRAND to selectedBrand.code,
-            FIELD_ERROR_MESSAGE to error.message,
-        ).plus(ErrorReporter.getAdditionalParamsFromError(error))
+        override val additionalParams: Map<String, Any?> = buildMap {
+            selectedBrand?.let { put(FIELD_SELECTED_CARD_BRAND, selectedBrand.code) }
+            setAsDefaultPaymentMethod?.let { put(FIELD_SET_AS_DEFAULT, it) }
+            put(FIELD_ERROR_MESSAGE, error.message)
+        }.plus(ErrorReporter.getAdditionalParamsFromError(error))
     }
 
     class CannotProperlyReturnFromLinkAndLPMs(
@@ -524,6 +528,8 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         const val FIELD_HAS_DEFAULT_PAYMENT_METHOD = "has_default_payment_method"
         const val FIELD_SELECTED_CARD_BRAND = "selected_card_brand"
         const val FIELD_SET_AS_DEFAULT = "set_as_default"
+        const val FIELD_SET_AS_DEFAULT_ENABLED = "set_as_default_enabled"
+        const val FIELD_HAS_DEFAULT_PAYMENT_METHOD = "has_default_payment_method"
         const val FIELD_LINK_CONTEXT = "link_context"
         const val FIELD_EXTERNAL_PAYMENT_METHODS = "external_payment_methods"
         const val FIELD_PAYMENT_METHOD_LAYOUT = "payment_method_layout"

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
@@ -28,10 +28,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
-import org.mockito.kotlin.argThat
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
 
 @Suppress("LargeClass")
 class SavedPaymentMethodMutatorTest {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
@@ -436,7 +436,7 @@ class SavedPaymentMethodMutatorTest {
             }
         )
 
-        val eventReporter = mock<EventReporter>()
+        val eventReporter = FakeEventReporter()
 
         runScenario(eventReporter = eventReporter, customerRepository = customerRepository) {
             customerStateHolder.setCustomerState(
@@ -451,9 +451,8 @@ class SavedPaymentMethodMutatorTest {
 
             updatePaymentMethodTurbine.awaitItem().updateExecutor(CardBrand.CartesBancaires)
 
-            verify(eventReporter).onUpdatePaymentMethodSucceeded(
-                selectedBrand = eq(CardBrand.CartesBancaires),
-            )
+            val succeededCall = eventReporter.updatePaymentMethodSucceededCalls.awaitItem()
+            assertThat(succeededCall.selectedBrand).isEqualTo(CardBrand.CartesBancaires)
         }
     }
 
@@ -511,7 +510,7 @@ class SavedPaymentMethodMutatorTest {
             }
         )
 
-        val eventReporter = mock<EventReporter>()
+        val eventReporter = FakeEventReporter()
 
         runScenario(eventReporter = eventReporter, customerRepository = customerRepository) {
             customerStateHolder.setCustomerState(
@@ -527,9 +526,8 @@ class SavedPaymentMethodMutatorTest {
                 brand = CardBrand.CartesBancaires,
             )
 
-            verify(eventReporter).onUpdatePaymentMethodSucceeded(
-                selectedBrand = CardBrand.CartesBancaires,
-            )
+            val succeededCall = eventReporter.updatePaymentMethodSucceededCalls.awaitItem()
+            assertThat(succeededCall.selectedBrand).isEqualTo(CardBrand.CartesBancaires)
         }
     }
 
@@ -576,7 +574,7 @@ class SavedPaymentMethodMutatorTest {
             }
         )
 
-        val eventReporter = mock<EventReporter>()
+        val eventReporter = FakeEventReporter()
 
         runScenario(eventReporter = eventReporter, customerRepository = customerRepository) {
             customerStateHolder.setCustomerState(
@@ -590,10 +588,9 @@ class SavedPaymentMethodMutatorTest {
             savedPaymentMethodMutator.updatePaymentMethod(displayableSavedPaymentMethod)
             updatePaymentMethodTurbine.awaitItem().updateExecutor(CardBrand.CartesBancaires)
 
-            verify(eventReporter).onUpdatePaymentMethodFailed(
-                selectedBrand = eq(CardBrand.CartesBancaires),
-                error = argThat { message == "Test failure" }
-            )
+            val failedCall = eventReporter.updatePaymentMethodFailedCalls.awaitItem()
+            assertThat(failedCall.selectedBrand).isEqualTo(CardBrand.CartesBancaires)
+            assertThat(failedCall.error.message).isEqualTo("Test failure")
         }
     }
 
@@ -656,7 +653,7 @@ class SavedPaymentMethodMutatorTest {
             }
         )
 
-        val eventReporter = mock<EventReporter>()
+        val eventReporter = FakeEventReporter()
 
         runScenario(eventReporter = eventReporter, customerRepository = customerRepository) {
             customerStateHolder.setCustomerState(
@@ -666,10 +663,10 @@ class SavedPaymentMethodMutatorTest {
                 )
             )
 
-            val newDefaultPaymentMethod = paymentMethods[1]
-            savedPaymentMethodMutator.setDefaultPaymentMethod(newDefaultPaymentMethod)
+            savedPaymentMethodMutator.setDefaultPaymentMethod(paymentMethods[1])
 
-            verify(eventReporter).onSetAsDefaultPaymentMethodSucceeded()
+            val succeededCall = eventReporter.setAsDefaultPaymentMethodSucceededCalls.awaitItem()
+            assertThat(succeededCall).isInstanceOf(FakeEventReporter.SetAsDefaultPaymentMethodSucceededCall::class.java)
         }
     }
 
@@ -683,7 +680,7 @@ class SavedPaymentMethodMutatorTest {
             }
         )
 
-        val eventReporter = mock<EventReporter>()
+        val eventReporter = FakeEventReporter()
 
         runScenario(eventReporter = eventReporter, customerRepository = customerRepository) {
             customerStateHolder.setCustomerState(
@@ -693,14 +690,10 @@ class SavedPaymentMethodMutatorTest {
                 )
             )
 
-            val newDefaultPaymentMethod = paymentMethods[1]
-            savedPaymentMethodMutator.setDefaultPaymentMethod(newDefaultPaymentMethod)
+            savedPaymentMethodMutator.setDefaultPaymentMethod(paymentMethods[1])
 
-            verify(eventReporter).onSetAsDefaultPaymentMethodFailed(
-                error = argThat {
-                    message == "Test failure"
-                }
-            )
+            val failedCall = eventReporter.setAsDefaultPaymentMethodFailedCalls.awaitItem()
+            assertThat(failedCall.error.message).isEqualTo("Test failure")
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
@@ -436,7 +436,9 @@ class SavedPaymentMethodMutatorTest {
             }
         )
 
-        runScenario(customerRepository = customerRepository) {
+        val eventReporter = mock<EventReporter>()
+
+        runScenario(eventReporter = eventReporter, customerRepository = customerRepository) {
             customerStateHolder.setCustomerState(
                 createCustomerState(
                     paymentMethods = listOf(displayableSavedPaymentMethod.paymentMethod),
@@ -457,6 +459,10 @@ class SavedPaymentMethodMutatorTest {
             val paymentMethods = customerStateHolder.paymentMethods.value
             assertThat(paymentMethods).hasSize(1)
             assertThat(paymentMethods.first().card?.brand).isEqualTo(CardBrand.CartesBancaires)
+
+            verify(eventReporter).onUpdatePaymentMethodSucceeded(
+                selectedBrand = CardBrand.CartesBancaires,
+            )
         }
 
         calledUpdate.ensureAllEventsConsumed()
@@ -473,7 +479,9 @@ class SavedPaymentMethodMutatorTest {
             }
         )
 
-        runScenario(customerRepository = customerRepository) {
+        val eventReporter = mock<EventReporter>()
+
+        runScenario(eventReporter = eventReporter, customerRepository = customerRepository) {
             customerStateHolder.setCustomerState(
                 createCustomerState(
                     paymentMethods = listOf(displayableSavedPaymentMethod.paymentMethod),
@@ -492,6 +500,11 @@ class SavedPaymentMethodMutatorTest {
             val paymentMethods = customerStateHolder.paymentMethods.value
             assertThat(paymentMethods).hasSize(1)
             assertThat(paymentMethods.first().card?.brand).isEqualTo(CardBrand.Unknown)
+
+            verify(eventReporter).onUpdatePaymentMethodFailed(
+                selectedBrand = eq(CardBrand.CartesBancaires),
+                error = argThat { message == "Test failure" }
+            )
         }
 
         calledUpdate.ensureAllEventsConsumed()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
@@ -33,6 +33,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 
+@Suppress("LargeClass")
 class SavedPaymentMethodMutatorTest {
     @Test
     fun `canEdit is correct when no payment methods`() = runScenario {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -533,6 +533,41 @@ class DefaultEventReporterTest {
     }
 
     @Test
+    fun `onSetAsDefaultPaymentMethodSucceeded() should fire analytics request with expected event value`() {
+        val customEventReporter = createEventReporter(EventReporter.Mode.Custom) {
+            simulateSuccessfulSetup()
+        }
+
+        customEventReporter.onSetAsDefaultPaymentMethodSucceeded()
+
+        verify(analyticsRequestExecutor).executeAsync(
+            argWhere { req ->
+                req.params["event"] == "mc_update_card" &&
+                    req.params["set_as_default"] == true
+            }
+        )
+    }
+
+    @Test
+    fun `onSetAsDefaultPaymentMethodFailed() should fire analytics request with expected event value`() {
+        val customEventReporter = createEventReporter(EventReporter.Mode.Custom) {
+            simulateSuccessfulSetup()
+        }
+
+        customEventReporter.onSetAsDefaultPaymentMethodFailed(
+            error = Exception("No network available!")
+        )
+
+        verify(analyticsRequestExecutor).executeAsync(
+            argWhere { req ->
+                req.params["event"] == "mc_update_card_failed" &&
+                    req.params["set_as_default"] == true &&
+                    req.params["error_message"] == "No network available!"
+            }
+        )
+    }
+
+    @Test
     fun `onPressConfirmButton() should fire analytics request with expected event value`() {
         val customEventReporter = createEventReporter(EventReporter.Mode.Custom) {
             simulateSuccessfulSetup()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -542,8 +542,7 @@ class DefaultEventReporterTest {
 
         verify(analyticsRequestExecutor).executeAsync(
             argWhere { req ->
-                req.params["event"] == "mc_update_card" &&
-                    req.params["set_as_default"] == true
+                req.params["event"] == "mc_set_default_payment_method"
             }
         )
     }
@@ -560,8 +559,7 @@ class DefaultEventReporterTest {
 
         verify(analyticsRequestExecutor).executeAsync(
             argWhere { req ->
-                req.params["event"] == "mc_update_card_failed" &&
-                    req.params["set_as_default"] == true &&
+                req.params["event"] == "mc_set_default_payment_method_failed" &&
                     req.params["error_message"] == "No network available!"
             }
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeEventReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeEventReporter.kt
@@ -16,16 +16,20 @@ internal class FakeEventReporter : EventReporter {
     val paymentFailureCalls: ReceiveTurbine<PaymentFailureCall> = _paymentFailureCalls
 
     private val _updatePaymentMethodSucceededCalls = Turbine<UpdatePaymentMethodSucceededCall>()
-    val updatePaymentMethodSucceededCalls: ReceiveTurbine<UpdatePaymentMethodSucceededCall> = _updatePaymentMethodSucceededCalls
+    val updatePaymentMethodSucceededCalls: ReceiveTurbine<UpdatePaymentMethodSucceededCall> =
+        _updatePaymentMethodSucceededCalls
 
     private val _updatePaymentMethodFailedCalls = Turbine<UpdatePaymentMethodFailedCall>()
-    val updatePaymentMethodFailedCalls: ReceiveTurbine<UpdatePaymentMethodFailedCall> = _updatePaymentMethodFailedCalls
+    val updatePaymentMethodFailedCalls: ReceiveTurbine<UpdatePaymentMethodFailedCall> =
+        _updatePaymentMethodFailedCalls
 
     private val _setAsDefaultPaymentMethodFailedCalls = Turbine<SetAsDefaultPaymentMethodFailedCall>()
-    val setAsDefaultPaymentMethodFailedCalls: ReceiveTurbine<SetAsDefaultPaymentMethodFailedCall> = _setAsDefaultPaymentMethodFailedCalls
+    val setAsDefaultPaymentMethodFailedCalls: ReceiveTurbine<SetAsDefaultPaymentMethodFailedCall> =
+        _setAsDefaultPaymentMethodFailedCalls
 
     private val _setAsDefaultPaymentMethodSucceededCalls = Turbine<SetAsDefaultPaymentMethodSucceededCall>()
-    val setAsDefaultPaymentMethodSucceededCalls: ReceiveTurbine<SetAsDefaultPaymentMethodSucceededCall> = _setAsDefaultPaymentMethodSucceededCalls
+    val setAsDefaultPaymentMethodSucceededCalls: ReceiveTurbine<SetAsDefaultPaymentMethodSucceededCall> =
+        _setAsDefaultPaymentMethodSucceededCalls
 
     override fun onInit(configuration: PaymentSheet.Configuration, isDeferred: Boolean) {
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeEventReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeEventReporter.kt
@@ -111,6 +111,10 @@ internal class FakeEventReporter : EventReporter {
     override fun onUpdatePaymentMethodFailed(selectedBrand: CardBrand, error: Throwable) {
     }
 
+    override fun onSetAsDefaultPaymentMethodSucceeded() {}
+
+    override fun onSetAsDefaultPaymentMethodFailed(error: Throwable) {}
+
     override fun onCannotProperlyReturnFromLinkAndOtherLPMs() {
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeEventReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeEventReporter.kt
@@ -15,6 +15,18 @@ internal class FakeEventReporter : EventReporter {
     private val _paymentFailureCalls = Turbine<PaymentFailureCall>()
     val paymentFailureCalls: ReceiveTurbine<PaymentFailureCall> = _paymentFailureCalls
 
+    private val _updatePaymentMethodSucceededCalls = Turbine<UpdatePaymentMethodSucceededCall>()
+    val updatePaymentMethodSucceededCalls: ReceiveTurbine<UpdatePaymentMethodSucceededCall> = _updatePaymentMethodSucceededCalls
+
+    private val _updatePaymentMethodFailedCalls = Turbine<UpdatePaymentMethodFailedCall>()
+    val updatePaymentMethodFailedCalls: ReceiveTurbine<UpdatePaymentMethodFailedCall> = _updatePaymentMethodFailedCalls
+
+    private val _setAsDefaultPaymentMethodFailedCalls = Turbine<SetAsDefaultPaymentMethodFailedCall>()
+    val setAsDefaultPaymentMethodFailedCalls: ReceiveTurbine<SetAsDefaultPaymentMethodFailedCall> = _setAsDefaultPaymentMethodFailedCalls
+
+    private val _setAsDefaultPaymentMethodSucceededCalls = Turbine<SetAsDefaultPaymentMethodSucceededCall>()
+    val setAsDefaultPaymentMethodSucceededCalls: ReceiveTurbine<SetAsDefaultPaymentMethodSucceededCall> = _setAsDefaultPaymentMethodSucceededCalls
+
     override fun onInit(configuration: PaymentSheet.Configuration, isDeferred: Boolean) {
     }
 
@@ -106,14 +118,28 @@ internal class FakeEventReporter : EventReporter {
     }
 
     override fun onUpdatePaymentMethodSucceeded(selectedBrand: CardBrand) {
+        _updatePaymentMethodSucceededCalls.add(
+            UpdatePaymentMethodSucceededCall(selectedBrand = selectedBrand)
+        )
     }
 
     override fun onUpdatePaymentMethodFailed(selectedBrand: CardBrand, error: Throwable) {
+        _updatePaymentMethodFailedCalls.add(
+            UpdatePaymentMethodFailedCall(selectedBrand = selectedBrand, error = error)
+        )
     }
 
-    override fun onSetAsDefaultPaymentMethodSucceeded() {}
+    override fun onSetAsDefaultPaymentMethodSucceeded() {
+        _setAsDefaultPaymentMethodSucceededCalls.add(
+            SetAsDefaultPaymentMethodSucceededCall()
+        )
+    }
 
-    override fun onSetAsDefaultPaymentMethodFailed(error: Throwable) {}
+    override fun onSetAsDefaultPaymentMethodFailed(error: Throwable) {
+        _setAsDefaultPaymentMethodFailedCalls.add(
+            SetAsDefaultPaymentMethodFailedCall(error = error)
+        )
+    }
 
     override fun onCannotProperlyReturnFromLinkAndOtherLPMs() {
     }
@@ -124,5 +150,20 @@ internal class FakeEventReporter : EventReporter {
     data class PaymentFailureCall(
         val paymentSelection: PaymentSelection?,
         val error: PaymentSheetConfirmationError
+    )
+
+    data class UpdatePaymentMethodSucceededCall(
+        val selectedBrand: CardBrand,
+    )
+
+    data class UpdatePaymentMethodFailedCall(
+        val selectedBrand: CardBrand,
+        val error: Throwable,
+    )
+
+    class SetAsDefaultPaymentMethodSucceededCall
+
+    data class SetAsDefaultPaymentMethodFailedCall(
+        val error: Throwable,
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
@@ -1320,6 +1320,7 @@ class PaymentSheetEventTest {
     fun `UpdatePaymentOptionSucceeded event should return expected toString()`() {
         val event = PaymentSheetEvent.UpdatePaymentOptionSucceeded(
             selectedBrand = CardBrand.CartesBancaires,
+            setAsDefaultPaymentMethod = null,
             isDeferred = false,
             linkEnabled = false,
             googlePaySupported = false,
@@ -1353,6 +1354,7 @@ class PaymentSheetEventTest {
             isDeferred = false,
             linkEnabled = false,
             googlePaySupported = false,
+            setAsDefaultPaymentMethod = null,
         )
         assertThat(
             event.eventName
@@ -1364,6 +1366,68 @@ class PaymentSheetEventTest {
         ).isEqualTo(
             mapOf(
                 "selected_card_brand" to "cartes_bancaires",
+                "error_message" to "No network available!",
+                "is_decoupled" to false,
+                "link_enabled" to false,
+                "google_pay_enabled" to false,
+                "analytics_value" to "apiError",
+                "request_id" to "request_123",
+                "error_type" to "network_error",
+                "error_code" to "error_123",
+            )
+        )
+    }
+
+    @Test
+    fun `UpdatePaymentOptionSucceeded event with setAsDefaultPaymentMethod should return expected toString()`() {
+        val event = PaymentSheetEvent.UpdatePaymentOptionSucceeded(
+            selectedBrand = null,
+            setAsDefaultPaymentMethod = true,
+            isDeferred = false,
+            linkEnabled = false,
+            googlePaySupported = false,
+        )
+        assertThat(
+            event.eventName
+        ).isEqualTo(
+            "mc_update_card"
+        )
+        assertThat(
+            event.params
+        ).isEqualTo(
+            mapOf(
+                "set_as_default" to true,
+                "is_decoupled" to false,
+                "link_enabled" to false,
+                "google_pay_enabled" to false,
+            )
+        )
+    }
+
+    @Test
+    fun `UpdatePaymentOptionFailed event with setAsDefaultPaymentMethod should return expected toString()`() {
+        val event = PaymentSheetEvent.UpdatePaymentOptionFailed(
+            selectedBrand = null,
+            error = APIException(
+                StripeError(type = "network_error", code = "error_123"),
+                requestId = "request_123",
+                message = "No network available!"
+            ),
+            isDeferred = false,
+            linkEnabled = false,
+            googlePaySupported = false,
+            setAsDefaultPaymentMethod = true,
+        )
+        assertThat(
+            event.eventName
+        ).isEqualTo(
+            "mc_update_card_failed"
+        )
+        assertThat(
+            event.params
+        ).isEqualTo(
+            mapOf(
+                "set_as_default" to true,
                 "error_message" to "No network available!",
                 "is_decoupled" to false,
                 "link_enabled" to false,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
@@ -1320,7 +1320,6 @@ class PaymentSheetEventTest {
     fun `UpdatePaymentOptionSucceeded event should return expected toString()`() {
         val event = PaymentSheetEvent.UpdatePaymentOptionSucceeded(
             selectedBrand = CardBrand.CartesBancaires,
-            setAsDefaultPaymentMethod = null,
             isDeferred = false,
             linkEnabled = false,
             googlePaySupported = false,
@@ -1354,7 +1353,6 @@ class PaymentSheetEventTest {
             isDeferred = false,
             linkEnabled = false,
             googlePaySupported = false,
-            setAsDefaultPaymentMethod = null,
         )
         assertThat(
             event.eventName
@@ -1379,10 +1377,8 @@ class PaymentSheetEventTest {
     }
 
     @Test
-    fun `UpdatePaymentOptionSucceeded event with setAsDefaultPaymentMethod should return expected toString()`() {
-        val event = PaymentSheetEvent.UpdatePaymentOptionSucceeded(
-            selectedBrand = null,
-            setAsDefaultPaymentMethod = true,
+    fun `SetAsDefaultPaymentMethodSucceeded event with setAsDefaultPaymentMethod should return expected toString()`() {
+        val event = PaymentSheetEvent.SetAsDefaultPaymentMethodSucceeded(
             isDeferred = false,
             linkEnabled = false,
             googlePaySupported = false,
@@ -1390,13 +1386,12 @@ class PaymentSheetEventTest {
         assertThat(
             event.eventName
         ).isEqualTo(
-            "mc_update_card"
+            "mc_set_default_payment_method"
         )
         assertThat(
             event.params
         ).isEqualTo(
             mapOf(
-                "set_as_default" to true,
                 "is_decoupled" to false,
                 "link_enabled" to false,
                 "google_pay_enabled" to false,
@@ -1405,9 +1400,8 @@ class PaymentSheetEventTest {
     }
 
     @Test
-    fun `UpdatePaymentOptionFailed event with setAsDefaultPaymentMethod should return expected toString()`() {
-        val event = PaymentSheetEvent.UpdatePaymentOptionFailed(
-            selectedBrand = null,
+    fun `SetAsDefaultPaymentMethodFailed event with setAsDefaultPaymentMethod should return expected toString()`() {
+        val event = PaymentSheetEvent.SetAsDefaultPaymentMethodFailed(
             error = APIException(
                 StripeError(type = "network_error", code = "error_123"),
                 requestId = "request_123",
@@ -1416,18 +1410,16 @@ class PaymentSheetEventTest {
             isDeferred = false,
             linkEnabled = false,
             googlePaySupported = false,
-            setAsDefaultPaymentMethod = true,
         )
         assertThat(
             event.eventName
         ).isEqualTo(
-            "mc_update_card_failed"
+            "mc_set_default_payment_method_failed"
         )
         assertThat(
             event.params
         ).isEqualTo(
             mapOf(
-                "set_as_default" to true,
                 "error_message" to "No network available!",
                 "is_decoupled" to false,
                 "link_enabled" to false,


### PR DESCRIPTION
# Summary
Updated payment events UpdatePaymentOptionSucceeded and UpdatePaymentOptionFailed
Added some tests

# Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-2707

Let us track when users are setting payment methods as default

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [ ] Manually verified

# Screenshots
N.A.

# Changelog
N.A.
