### PR TITLE
Add unit tests that set as default checkbox is shown for saved cards and US bank accounts

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultUpdatePaymentMethodInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultUpdatePaymentMethodInteractorTest.kt
@@ -314,6 +314,22 @@ class DefaultUpdatePaymentMethodInteractorTest {
     }
 
     @Test
+    fun setAsDefaultCheckbox_shownForCards() = runScenario(
+        displayableSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
+        shouldShowSetAsDefaultCheckbox = true,
+    ) {
+        assertThat(interactor.shouldShowSetAsDefaultCheckbox).isTrue()
+    }
+
+    @Test
+    fun setAsDefaultCheckbox_shownForUsBankAccount() = runScenario(
+        displayableSavedPaymentMethod = PaymentMethodFixtures.US_BANK_ACCOUNT.toDisplayableSavedPaymentMethod(),
+        shouldShowSetAsDefaultCheckbox = true,
+    ) {
+        assertThat(interactor.shouldShowSetAsDefaultCheckbox).isTrue()
+    }
+
+    @Test
     fun setAsDefaultCheckboxChangedViewAction_updatesState() = runScenario(
         shouldShowSetAsDefaultCheckbox = true,
     ) {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add unit tests that set as default checkbox is shown for saved cards and US bank accounts

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-2692

Ensuring we have test coverage of the set as default checkbox being shown for saved US bank accounts. Most of the logic for the checkbox is actually completely agnostic of the PM type (ie logic for what happens when you check the checkbox, etc), so we don't need many tests for US bank accounts specifically, but we should have these tests to ensure the checkbox is shown. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified