### PR TITLE
Apply filter to cards after CustomerSheet refresh

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -1070,9 +1070,13 @@ internal class CustomerSheetViewModel(
                 }?.let {
                     PaymentSelection.Saved(it)
                 } ?: state.currentSelection
-
+                val filteredPaymentMethods = paymentMethods.filter { paymentMethod ->
+                    paymentMethod.card?.let { card ->
+                        PaymentSheetCardBrandFilter(configuration.cardBrandAcceptance).isAccepted(card.brand)
+                    } ?: true
+                }
                 state.copy(
-                    paymentMethods = sortPaymentMethods(paymentMethods, selection as? PaymentSelection.Saved),
+                    paymentMethods = sortPaymentMethods(filteredPaymentMethods, selection as? PaymentSelection.Saved),
                     currentSelection = selection,
                 )
             }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -30,6 +30,7 @@ import com.stripe.android.model.PaymentMethodFixtures.US_BANK_ACCOUNT_VERIFIED
 import com.stripe.android.model.PaymentMethodFixtures.toDisplayableSavedPaymentMethod
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -41,6 +42,7 @@ import com.stripe.android.paymentsheet.ui.UpdatePaymentMethodInteractor
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.PaymentMethodFactory
+import com.stripe.android.testing.PaymentMethodFactory.update
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.ui.core.elements.CardBillingAddressElement
 import com.stripe.android.ui.core.elements.CardDetailsSectionElement
@@ -3063,6 +3065,83 @@ class CustomerSheetViewModelTest {
                 assertThat(viewStateAfterRemoval.topBarState {}.showEditMenu).isFalse()
             }
         }
+
+    @Test
+    fun `When refreshing payment methods, payment methods should be filtered based on card brand acceptance`() = runTest(testDispatcher) {
+        val acceptedCardPaymentMethod = CARD_PAYMENT_METHOD.update(
+            last4 = "4242",
+            addCbcNetworks = false,
+            brand = CardBrand.Visa
+        )
+
+        val rejectedCardPaymentMethod = CARD_PAYMENT_METHOD.update(
+            last4 = "3782",
+            addCbcNetworks = false,
+            brand = CardBrand.AmericanExpress
+        )
+        val allPaymentMethods = listOf(acceptedCardPaymentMethod, rejectedCardPaymentMethod)
+
+        val viewModel = createViewModel(
+            workContext = testDispatcher,
+            configuration = CustomerSheet.Configuration(
+                merchantDisplayName = "Merchant",
+                // Only accept Visa and Mastercard
+                cardBrandAcceptance = PaymentSheet.CardBrandAcceptance.allowed(
+                    listOf(
+                        PaymentSheet.CardBrandAcceptance.BrandCategory.Visa,
+                        PaymentSheet.CardBrandAcceptance.BrandCategory.Mastercard
+                    )
+                )
+            ),
+            customerSheetLoader = FakeCustomerSheetLoader(
+                customerPaymentMethods = listOf(),
+                isGooglePayAvailable = false
+            ),
+            paymentMethodDataSource = FakeCustomerSheetPaymentMethodDataSource(
+                paymentMethods = CustomerSheetDataResult.success(allPaymentMethods),
+                onAttachPaymentMethod = {
+                    CustomerSheetDataResult.success(acceptedCardPaymentMethod)
+                }
+            ),
+            stripeRepository = FakeStripeRepository(
+                createPaymentMethodResult = Result.success(acceptedCardPaymentMethod),
+            ),
+            intentDataSource = FakeCustomerSheetIntentDataSource(
+                canCreateSetupIntents = false
+            )
+        )
+
+        // Call refreshAndUpdatePaymentMethods indirectly through the attachment flow
+        viewModel.handleViewAction(CustomerSheetViewAction.OnAddCardPressed)
+        viewModel.handleViewAction(CustomerSheetViewAction.OnFormFieldValuesCompleted(TEST_FORM_VALUES))
+
+        viewModel.viewState.test {
+            // Initial state is AddPaymentMethod
+            assertThat(awaitItem()).isInstanceOf<AddPaymentMethod>()
+
+            // Trigger refresh by saving the payment method
+            viewModel.handleViewAction(CustomerSheetViewAction.OnPrimaryButtonPressed)
+
+            val processingState = awaitItem()
+            assertThat(processingState).isInstanceOf<AddPaymentMethod>()
+            assertThat((processingState as AddPaymentMethod).isProcessing).isTrue()
+
+            var currentState: CustomerSheetViewState? = null
+            while (currentState !is SelectPaymentMethod) {
+                currentState = awaitItem()
+            }
+
+            val selectPaymentMethodState = currentState as SelectPaymentMethod
+
+            // Should only include the accepted card payment method and the non-card payment method
+            assertThat(selectPaymentMethodState.savedPaymentMethods).hasSize(2)
+            assertThat(selectPaymentMethodState.savedPaymentMethods)
+                .containsExactly(acceptedCardPaymentMethod)
+
+            // Should not include the rejected card payment method
+            assertThat(selectPaymentMethodState.savedPaymentMethods).doesNotContain(rejectedCardPaymentMethod)
+        }
+    }
 
     @Test
     fun `When card number input is completed, should report event`() = runTest(testDispatcher) {

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -3133,8 +3133,8 @@ class CustomerSheetViewModelTest {
 
             val selectPaymentMethodState = currentState as SelectPaymentMethod
 
-            // Should only include the accepted card payment method and the non-card payment method
-            assertThat(selectPaymentMethodState.savedPaymentMethods).hasSize(2)
+            // Should only include the accepted card payment method
+            assertThat(selectPaymentMethodState.savedPaymentMethods).hasSize(1)
             assertThat(selectPaymentMethodState.savedPaymentMethods)
                 .containsExactly(acceptedCardPaymentMethod)
 


### PR DESCRIPTION
# Summary
- Applies a filter to the customer's payment methods after refreshing in CustomerSheet.

# Motivation
- Just noticed! https://stripe.slack.com/archives/CFA2HJ99A/p1739403975575399

# Testing
- Manual
- New unit test

# Changelog
N/A
