### PR TITLE
Add support for default PMs feature when using deferred CSC

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/ConfirmStripeIntentParamsFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/ConfirmStripeIntentParamsFactory.kt
@@ -76,12 +76,13 @@ internal class ConfirmPaymentIntentParamsFactory(
         optionsParams: PaymentMethodOptionsParams?,
         extraParams: PaymentMethodExtraParams?
     ): ConfirmPaymentIntentParams {
-        return ConfirmPaymentIntentParams.createWithPaymentMethodId(
+        return ConfirmPaymentIntentParams.createWithSetAsDefaultPaymentMethod(
             paymentMethodId = paymentMethodId,
             clientSecret = clientSecret,
             paymentMethodOptions = optionsParams,
             mandateData = mandateData(intent, paymentMethodType),
-            shipping = shipping
+            shipping = shipping,
+            setAsDefaultPaymentMethod = extraParams?.extractSetAsDefaultPaymentMethodFromExtraParams(),
         )
     }
 
@@ -111,10 +112,11 @@ internal class ConfirmSetupIntentParamsFactory(
         optionsParams: PaymentMethodOptionsParams?,
         extraParams: PaymentMethodExtraParams?,
     ): ConfirmSetupIntentParams {
-        return ConfirmSetupIntentParams.create(
+        return ConfirmSetupIntentParams.createWithSetAsDefaultPaymentMethod(
             paymentMethodId = paymentMethodId,
             clientSecret = clientSecret,
             mandateData = mandateData(intent, paymentMethodType),
+            setAsDefaultPaymentMethod = extraParams?.extractSetAsDefaultPaymentMethodFromExtraParams(),
         )
     }
 

--- a/payments-core/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
@@ -565,6 +565,30 @@ constructor(
             )
         }
 
+        internal fun createWithSetAsDefaultPaymentMethod(
+            paymentMethodId: String,
+            clientSecret: String,
+            savePaymentMethod: Boolean? = null,
+            mandateId: String? = null,
+            mandateData: MandateDataParams? = null,
+            setupFutureUsage: SetupFutureUsage? = null,
+            shipping: Shipping? = null,
+            paymentMethodOptions: PaymentMethodOptionsParams? = null,
+            setAsDefaultPaymentMethod: Boolean? = null,
+        ): ConfirmPaymentIntentParams {
+            return ConfirmPaymentIntentParams(
+                paymentMethodId = paymentMethodId,
+                clientSecret = clientSecret,
+                savePaymentMethod = savePaymentMethod,
+                mandateId = mandateId,
+                mandateData = mandateData,
+                setupFutureUsage = setupFutureUsage,
+                shipping = shipping,
+                paymentMethodOptions = paymentMethodOptions,
+                setAsDefaultPaymentMethod = setAsDefaultPaymentMethod,
+            )
+        }
+
         internal fun createForDashboard(
             clientSecret: String,
             paymentMethodId: String,

--- a/payments-core/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
@@ -230,5 +230,21 @@ constructor(
                 setAsDefaultPaymentMethod = setAsDefaultPaymentMethod
             )
         }
+
+        internal fun createWithSetAsDefaultPaymentMethod(
+            paymentMethodId: String,
+            clientSecret: String,
+            mandateData: MandateDataParams? = null,
+            mandateId: String? = null,
+            setAsDefaultPaymentMethod: Boolean?,
+        ): ConfirmSetupIntentParams {
+            return ConfirmSetupIntentParams(
+                paymentMethodId = paymentMethodId,
+                clientSecret = clientSecret,
+                mandateId = mandateId,
+                mandateData = mandateData,
+                setAsDefaultPaymentMethod = setAsDefaultPaymentMethod
+            )
+        }
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/ConfirmPaymentIntentParamsFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/ConfirmPaymentIntentParamsFactoryTest.kt
@@ -112,6 +112,34 @@ class ConfirmPaymentIntentParamsFactoryTest {
     }
 
     @Test
+    fun `create() with new card when setAsDefaultPaymentMethod is true and using paymentMethod`() {
+        val paymentIntentParams = factory.create(
+            paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+            optionsParams = PaymentMethodOptionsParams.Card(
+                setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
+            ),
+            extraParams = PaymentMethodExtraParams.Card(
+                setAsDefault = true
+            )
+        )
+        assertThat(paymentIntentParams.setAsDefaultPaymentMethod).isTrue()
+    }
+
+    @Test
+    fun `create() with new card when setAsDefaultPaymentMethod is false and using paymentMethod`() {
+        val paymentIntentParams = factory.create(
+            paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+            optionsParams = PaymentMethodOptionsParams.Card(
+                setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
+            ),
+            extraParams = PaymentMethodExtraParams.Card(
+                setAsDefault = false
+            )
+        )
+        assertThat(paymentIntentParams.setAsDefaultPaymentMethod).isFalse()
+    }
+
+    @Test
     fun `create() with saved card and shippingDetails sets shipping field`() {
         val shippingDetails = ConfirmPaymentIntentParams.Shipping(
             name = "Test",

--- a/payments-core/src/test/java/com/stripe/android/ConfirmSetupIntentParamsFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/ConfirmSetupIntentParamsFactoryTest.kt
@@ -4,8 +4,11 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.ConfirmStripeIntentParams
 import com.stripe.android.model.MandateDataParams
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.model.PaymentMethodExtraParams
+import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.testing.SetupIntentFactory
 import org.junit.Test
@@ -22,8 +25,9 @@ class ConfirmSetupIntentParamsFactoryTest {
     }
 
     @Test
-    fun `create() should set setAsDefault as true`() {
+    fun `create() should set setAsDefault as true when using create params`() {
         val result = getConfirmSetupIntentParamsForTesting(
+            createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
             extraParams = PaymentMethodExtraParams.Card(
                 setAsDefault = true
             )
@@ -35,8 +39,37 @@ class ConfirmSetupIntentParamsFactoryTest {
     }
 
     @Test
-    fun `create() should set setAsDefault as false`() {
+    fun `create() should set setAsDefault as false when using create params`() {
         val result = getConfirmSetupIntentParamsForTesting(
+            createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+            extraParams = PaymentMethodExtraParams.Card(
+                setAsDefault = false
+            )
+        )
+
+        val params = result.asConfirmSetupIntentParams()
+
+        assertThat(params.setAsDefaultPaymentMethod).isFalse()
+    }
+
+    @Test
+    fun `create() should set setAsDefault as true when using payment method`() {
+        val result = getConfirmSetupIntentParamsForTesting(
+            paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+            extraParams = PaymentMethodExtraParams.Card(
+                setAsDefault = true
+            )
+        )
+
+        val params = result.asConfirmSetupIntentParams()
+
+        assertThat(params.setAsDefaultPaymentMethod).isTrue()
+    }
+
+    @Test
+    fun `create() should set setAsDefault as false when using payment method`() {
+        val result = getConfirmSetupIntentParamsForTesting(
+            paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             extraParams = PaymentMethodExtraParams.Card(
                 setAsDefault = false
             )
@@ -61,6 +94,7 @@ class ConfirmSetupIntentParamsFactoryTest {
     }
 
     private fun getConfirmSetupIntentParamsForTesting(
+        paymentMethod: PaymentMethod,
         extraParams: PaymentMethodExtraParams
     ): ConfirmSetupIntentParams {
         val factoryWithConfig = ConfirmSetupIntentParamsFactory(
@@ -69,7 +103,23 @@ class ConfirmSetupIntentParamsFactoryTest {
         )
 
         return factoryWithConfig.create(
-            createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+            paymentMethod = paymentMethod,
+            optionsParams = null,
+            extraParams = extraParams,
+        )
+    }
+
+    private fun getConfirmSetupIntentParamsForTesting(
+        createParams: PaymentMethodCreateParams,
+        extraParams: PaymentMethodExtraParams
+    ): ConfirmSetupIntentParams {
+        val factoryWithConfig = ConfirmSetupIntentParamsFactory(
+            clientSecret = CLIENT_SECRET,
+            intent = SetupIntentFactory.create(),
+        )
+
+        return factoryWithConfig.create(
+            createParams = createParams,
             optionsParams = null,
             extraParams = extraParams,
         )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add support for default PMs feature when using deferred CSC

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
[Bug bash feedback](https://docs.google.com/document/d/1sF2u6RAcF3RyEOTI-lH-A7Tb7aprOuFSCkbyrS9OWHU/edit?tab=t.0#bookmark=id.oybs83ou2s9e)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified

Manually verified fix for setup intents and payment intents, also added test cases for both

# Screen recording
[deferred csc.webm](https://github.com/user-attachments/assets/3deac10a-dbac-40bd-a87e-caf95b20eb16)
