### PR TITLE
[MOBILESDK-2707] Default Payment Method Analytics pt 2 new payments

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -6,6 +6,7 @@ import com.stripe.android.common.analytics.toAnalyticsValue
 import com.stripe.android.core.networking.AnalyticsEvent
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.LinkMode
+import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.analyticsValue
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
 import com.stripe.android.payments.core.analytics.ErrorReporter
@@ -326,6 +327,9 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
             paymentSelection.linkContext()?.let { linkContext ->
                 put(FIELD_LINK_CONTEXT, linkContext)
             }
+            paymentSelection?.getSetAsDefaultPaymentMethodFromPaymentSelection()?.let { setAsDefault ->
+                put(FIELD_SET_AS_DEFAULT, setAsDefault)
+            }
         }
 
         sealed interface Result {
@@ -519,6 +523,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         const val FIELD_SET_AS_DEFAULT_ENABLED = "set_as_default_enabled"
         const val FIELD_HAS_DEFAULT_PAYMENT_METHOD = "has_default_payment_method"
         const val FIELD_SELECTED_CARD_BRAND = "selected_card_brand"
+        const val FIELD_SET_AS_DEFAULT = "set_as_default"
         const val FIELD_LINK_CONTEXT = "link_context"
         const val FIELD_EXTERNAL_PAYMENT_METHODS = "external_payment_methods"
         const val FIELD_PAYMENT_METHOD_LAYOUT = "payment_method_layout"
@@ -534,6 +539,20 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         const val VALUE_CARD_BRAND = "brand"
 
         const val MAX_EXTERNAL_PAYMENT_METHODS = 10
+    }
+}
+
+private fun PaymentSelection.getSetAsDefaultPaymentMethodFromPaymentSelection(): Boolean? {
+    return when (this) {
+        is PaymentSelection.New.Card -> {
+            (this.paymentMethodExtraParams as? PaymentMethodExtraParams.Card)?.setAsDefault
+        }
+        is PaymentSelection.New.USBankAccount -> {
+            (this.paymentMethodExtraParams as? PaymentMethodExtraParams.USBankAccount)?.setAsDefault
+        }
+        else -> {
+            null
+        }
     }
 }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
@@ -11,6 +11,7 @@ import com.stripe.android.model.LinkMode
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.model.PaymentMethodFixtures.CARD_PAYMENT_SELECTION
 import com.stripe.android.paymentsheet.ExperimentalCustomerSessionApi
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
@@ -1602,10 +1603,7 @@ class PaymentSheetEventTest {
         result: PaymentSheetEvent.Payment.Result
     ): PaymentSheetEvent.Payment {
         return paymentMethodEvent(
-            paymentSelection = PaymentSelection.New.Card(
-                PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
-                mock(),
-                mock(),
+            paymentSelection = CARD_PAYMENT_SELECTION.copy(
                 paymentMethodExtraParams = paymentMethodExtraParams
             ),
             result = result

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
@@ -591,19 +591,7 @@ class PaymentSheetEventTest {
         ).isEqualTo(
             "mc_complete_payment_newpm_success"
         )
-        assertThat(
-            newPMEvent.params
-        ).isEqualTo(
-            mapOf(
-                "currency" to "usd",
-                "duration" to 0.001F,
-                "is_decoupled" to false,
-                "link_enabled" to false,
-                "google_pay_enabled" to false,
-                "selected_lpm" to "card",
-                "set_as_default" to true
-            )
-        )
+        assertThat(newPMEvent.params["set_as_default"]).isEqualTo(true)
     }
 
     @Test
@@ -619,19 +607,7 @@ class PaymentSheetEventTest {
         ).isEqualTo(
             "mc_complete_payment_newpm_success"
         )
-        assertThat(
-            newPMEvent.params
-        ).isEqualTo(
-            mapOf(
-                "currency" to "usd",
-                "duration" to 0.001F,
-                "is_decoupled" to false,
-                "link_enabled" to false,
-                "google_pay_enabled" to false,
-                "selected_lpm" to "card",
-                "set_as_default" to false,
-            )
-        )
+        assertThat(newPMEvent.params["set_as_default"]).isEqualTo(false)
     }
 
     @Test
@@ -910,21 +886,7 @@ class PaymentSheetEventTest {
         ).isEqualTo(
             "mc_complete_payment_newpm_failure"
         )
-        assertThat(
-            newPMEvent.params
-        ).isEqualTo(
-            mapOf(
-                "currency" to "usd",
-                "duration" to 0.001F,
-                "is_decoupled" to false,
-                "link_enabled" to false,
-                "google_pay_enabled" to false,
-                "selected_lpm" to "card",
-                "error_message" to "apiError",
-                "error_code" to null,
-                "set_as_default" to true,
-            )
-        )
+        assertThat(newPMEvent.params["set_as_default"]).isEqualTo(true)
     }
 
     @Test
@@ -942,20 +904,7 @@ class PaymentSheetEventTest {
         ).isEqualTo(
             "mc_complete_payment_newpm_failure"
         )
-        assertThat(
-            newPMEvent.params
-        ).isEqualTo(
-            mapOf(
-                "currency" to "usd",
-                "duration" to 0.001F,
-                "is_decoupled" to false,
-                "link_enabled" to false,
-                "google_pay_enabled" to false,
-                "selected_lpm" to "card",
-                "error_message" to "apiError",
-                "set_as_default" to false,
-            )
-        )
+        assertThat(newPMEvent.params["set_as_default"]).isEqualTo(false)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
@@ -9,6 +9,7 @@ import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.LinkMode
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
+import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.ExperimentalCustomerSessionApi
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -578,6 +579,61 @@ class PaymentSheetEventTest {
         )
     }
 
+    fun `New payment method set as default true event should return expected event`() {
+        val newPMEvent = newCardPaymentMethod(
+            paymentMethodExtraParams = PaymentMethodExtraParams.Card(
+                setAsDefault = true
+            ),
+            result = PaymentSheetEvent.Payment.Result.Success,
+        )
+        assertThat(
+            newPMEvent.eventName
+        ).isEqualTo(
+            "mc_complete_payment_newpm_success"
+        )
+        assertThat(
+            newPMEvent.params
+        ).isEqualTo(
+            mapOf(
+                "currency" to "usd",
+                "duration" to 0.001F,
+                "is_decoupled" to false,
+                "link_enabled" to false,
+                "google_pay_enabled" to false,
+                "selected_lpm" to "card",
+                "set_as_default" to true
+            )
+        )
+    }
+
+    @Test
+    fun `New payment method set as default false event should return expected event`() {
+        val newPMEvent = newCardPaymentMethod(
+            paymentMethodExtraParams = PaymentMethodExtraParams.Card(
+                setAsDefault = false
+            ),
+            result = PaymentSheetEvent.Payment.Result.Success,
+        )
+        assertThat(
+            newPMEvent.eventName
+        ).isEqualTo(
+            "mc_complete_payment_newpm_success"
+        )
+        assertThat(
+            newPMEvent.params
+        ).isEqualTo(
+            mapOf(
+                "currency" to "usd",
+                "duration" to 0.001F,
+                "is_decoupled" to false,
+                "link_enabled" to false,
+                "google_pay_enabled" to false,
+                "selected_lpm" to "card",
+                "set_as_default" to false,
+            )
+        )
+    }
+
     @Test
     fun `Saved payment method event should return expected event`() {
         val savedPMEvent = PaymentSheetEvent.Payment(
@@ -836,6 +892,68 @@ class PaymentSheetEventTest {
                 "google_pay_enabled" to false,
                 "selected_lpm" to "card",
                 "error_message" to "apiError",
+            )
+        )
+    }
+
+    fun `New payment method failure setAsDefault true event should return expected event`() {
+        val newPMEvent = newCardPaymentMethod(
+            paymentMethodExtraParams = PaymentMethodExtraParams.Card(
+                setAsDefault = true
+            ),
+            result = PaymentSheetEvent.Payment.Result.Failure(
+                error = PaymentSheetConfirmationError.Stripe(APIException()),
+            )
+        )
+        assertThat(
+            newPMEvent.eventName
+        ).isEqualTo(
+            "mc_complete_payment_newpm_failure"
+        )
+        assertThat(
+            newPMEvent.params
+        ).isEqualTo(
+            mapOf(
+                "currency" to "usd",
+                "duration" to 0.001F,
+                "is_decoupled" to false,
+                "link_enabled" to false,
+                "google_pay_enabled" to false,
+                "selected_lpm" to "card",
+                "error_message" to "apiError",
+                "error_code" to null,
+                "set_as_default" to true,
+            )
+        )
+    }
+
+    @Test
+    fun `New payment method failure setAsDefault false event should return expected event`() {
+        val newPMEvent = newCardPaymentMethod(
+            paymentMethodExtraParams = PaymentMethodExtraParams.Card(
+                setAsDefault = false
+            ),
+            result = PaymentSheetEvent.Payment.Result.Failure(
+                error = PaymentSheetConfirmationError.Stripe(APIException()),
+            )
+        )
+        assertThat(
+            newPMEvent.eventName
+        ).isEqualTo(
+            "mc_complete_payment_newpm_failure"
+        )
+        assertThat(
+            newPMEvent.params
+        ).isEqualTo(
+            mapOf(
+                "currency" to "usd",
+                "duration" to 0.001F,
+                "is_decoupled" to false,
+                "link_enabled" to false,
+                "google_pay_enabled" to false,
+                "selected_lpm" to "card",
+                "error_message" to "apiError",
+                "set_as_default" to false,
             )
         )
     }
@@ -1527,6 +1645,38 @@ class PaymentSheetEventTest {
                 "link_enabled" to false,
                 "google_pay_enabled" to false,
             )
+        )
+    }
+
+    private fun newCardPaymentMethod(
+        paymentMethodExtraParams: PaymentMethodExtraParams? = null,
+        result: PaymentSheetEvent.Payment.Result
+    ): PaymentSheetEvent.Payment {
+        return paymentMethodEvent(
+            paymentSelection = PaymentSelection.New.Card(
+                PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                mock(),
+                mock(),
+                paymentMethodExtraParams = paymentMethodExtraParams
+            ),
+            result = result
+        )
+    }
+
+    private fun paymentMethodEvent(
+        paymentSelection: PaymentSelection,
+        result: PaymentSheetEvent.Payment.Result,
+    ): PaymentSheetEvent.Payment {
+        return PaymentSheetEvent.Payment(
+            mode = EventReporter.Mode.Complete,
+            paymentSelection = paymentSelection,
+            duration = 1.milliseconds,
+            result = result,
+            currency = "usd",
+            isDeferred = false,
+            linkEnabled = false,
+            googlePaySupported = false,
+            deferredIntentConfirmationType = null,
         )
     }
 


### PR DESCRIPTION
# Summary
Added SetAsDefaultPaymentMethod to Payment event
Added some tests 

# Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-2707

Let us track default Payment Methods when we're paying with a new payment method (cards and US bank accounts)


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
N.A.

# Changelog
N.A.
