### PR TITLE
Use `runCatching` in `reportResult`

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
@@ -546,8 +546,9 @@ internal class FinancialConnectionsSheetViewModel @Inject constructor(
         // We use the global scope to make sure that we can finish sending the event
         // even if the ViewModel is cleared.
         GlobalScope.launch(ioDispatcher) {
-            val manifest = getOrFetchSync().manifest
-            eventReporter.onResult(manifest.id, result)
+            runCatching { getOrFetchSync().manifest }.onSuccess {
+                eventReporter.onResult(it.id, result)
+            }
         }
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request wraps the usage of `getOrFetchSync()` in `reportResult` in a `runCatching` call to catch any exceptions.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
