### PR TITLE
Wrap `switchToWebFlow` in `runCatching`

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
@@ -557,27 +557,37 @@ internal class FinancialConnectionsSheetViewModel @Inject constructor(
      */
     private fun switchToWebFlow(prefillDetails: PrefillDetails?) {
         viewModelScope.launch {
-            val sync = getOrFetchSync()
-            val hostedAuthUrl = HostedAuthUrlBuilder.create(
-                args = initialState.initialArgs,
-                manifest = sync.manifest,
-                prefillDetails = prefillDetails
-            )
+            runCatching { getOrFetchSync() }.onSuccess { sync ->
+                switchToWebFlow(sync.manifest, prefillDetails)
+            }.onFailure { error ->
+                finishWithResult(Failed(error))
+            }
+        }
+    }
 
-            if (hostedAuthUrl != null) {
-                setState {
-                    copy(
-                        manifest = manifest,
-                        // Use intermediate state to prevent the flow from closing in [onResume].
-                        webAuthFlowStatus = AuthFlowStatus.INTERMEDIATE_DEEPLINK,
-                        viewEffect = OpenAuthFlowWithUrl(hostedAuthUrl)
-                    )
-                }
-            } else {
-                finishWithResult(
-                    result = Failed(IllegalArgumentException("hostedAuthUrl is required to switch to web flow!"))
+    private fun switchToWebFlow(
+        manifest: FinancialConnectionsSessionManifest,
+        prefillDetails: PrefillDetails?,
+    ) {
+        val hostedAuthUrl = HostedAuthUrlBuilder.create(
+            args = initialState.initialArgs,
+            manifest = manifest,
+            prefillDetails = prefillDetails
+        )
+
+        if (hostedAuthUrl != null) {
+            setState {
+                copy(
+                    manifest = manifest,
+                    // Use intermediate state to prevent the flow from closing in [onResume].
+                    webAuthFlowStatus = AuthFlowStatus.INTERMEDIATE_DEEPLINK,
+                    viewEffect = OpenAuthFlowWithUrl(hostedAuthUrl)
                 )
             }
+        } else {
+            finishWithResult(
+                result = Failed(IllegalArgumentException("hostedAuthUrl is required to switch to web flow!"))
+            )
         }
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request wraps the `getOrFetchSync()` call in `switchToWebFlow` in a `runCatching` block.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
