### PR TITLE
Defer cbc eligibility check until card number input

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -28,6 +28,7 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
 import androidx.core.view.doOnPreDraw
 import androidx.core.view.updateLayoutParams
+import androidx.core.widget.addTextChangedListener
 import androidx.core.widget.doAfterTextChanged
 import androidx.lifecycle.ViewModelStoreOwner
 import com.stripe.android.PaymentConfiguration

--- a/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -28,7 +28,6 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
 import androidx.core.view.doOnPreDraw
 import androidx.core.view.updateLayoutParams
-import androidx.core.widget.addTextChangedListener
 import androidx.core.widget.doAfterTextChanged
 import androidx.lifecycle.ViewModelStoreOwner
 import com.stripe.android.PaymentConfiguration

--- a/payments-core/src/main/java/com/stripe/android/view/CardNumberEditText.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardNumberEditText.kt
@@ -8,6 +8,7 @@ import android.text.InputFilter
 import android.util.AttributeSet
 import android.view.View
 import androidx.annotation.VisibleForTesting
+import androidx.core.widget.addTextChangedListener
 import androidx.lifecycle.ViewModelStoreOwner
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.DefaultCardBrandFilter
@@ -238,6 +239,10 @@ class CardNumberEditText internal constructor(
         }
 
         doWithCardWidgetViewModel(viewModelStoreOwner) { viewModel ->
+            addTextChangedListener { text ->
+                viewModel.updateCardNumber(text?.toString())
+            }
+
             viewModel.isCbcEligible.launchAndCollect { isCbcEligible ->
                 this@CardNumberEditText.isCbcEligible = isCbcEligible
 

--- a/payments-core/src/main/java/com/stripe/android/view/CardWidgetViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardWidgetViewModel.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.mapLatest
@@ -38,11 +39,13 @@ internal class CardWidgetViewModel(
     private val cardNumberHasContent = MutableSharedFlow<Unit>(replay = 1)
     private val _onBehalfOf = MutableStateFlow<String?>(null)
 
-    val isCbcEligible: Flow<Boolean> = cardNumberHasContent.flatMapLatest {
-        _onBehalfOf
-    }.mapLatest {
-        determineCbcEligibility()
-    }.flowOn(dispatcher)
+    val isCbcEligible: Flow<Boolean> = cardNumberHasContent
+        .distinctUntilChanged()
+        .flatMapLatest {
+            _onBehalfOf
+        }.mapLatest {
+            determineCbcEligibility()
+        }.flowOn(dispatcher)
 
     val onBehalfOf: String?
         get() = _onBehalfOf.value

--- a/payments-core/src/test/java/com/stripe/android/utils/FakeCardElementConfigRepository.kt
+++ b/payments-core/src/test/java/com/stripe/android/utils/FakeCardElementConfigRepository.kt
@@ -4,37 +4,37 @@ import com.stripe.android.core.exception.APIConnectionException
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.MobileCardElementConfig
 import com.stripe.android.testing.AbsFakeStripeRepository
-import kotlinx.coroutines.channels.Channel
 
 class FakeCardElementConfigRepository : AbsFakeStripeRepository() {
 
-    private val channel = Channel<Result<MobileCardElementConfig>>()
+    private var result = Result.success(
+        value = MobileCardElementConfig(
+            cardBrandChoice = MobileCardElementConfig.CardBrandChoice(eligible = true),
+        )
+    )
 
     fun enqueueEligible() {
         val config = MobileCardElementConfig(
             cardBrandChoice = MobileCardElementConfig.CardBrandChoice(eligible = true),
         )
-        val result = Result.success(config)
-        channel.trySend(result)
+        this.result = Result.success(config)
     }
 
     fun enqueueNotEligible() {
         val config = MobileCardElementConfig(
             cardBrandChoice = MobileCardElementConfig.CardBrandChoice(eligible = false),
         )
-        val result = Result.success(config)
-        channel.trySend(result)
+        this.result = Result.success(config)
     }
 
     fun enqueueFailure() {
-        val result = Result.failure<MobileCardElementConfig>(APIConnectionException())
-        channel.trySend(result)
+        result = Result.failure(APIConnectionException())
     }
 
     override suspend fun retrieveCardElementConfig(
         requestOptions: ApiRequest.Options,
         params: Map<String, String>?
     ): Result<MobileCardElementConfig> {
-        return channel.receive()
+        return result
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/view/CardWidgetViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardWidgetViewModelTest.kt
@@ -29,8 +29,12 @@ class CardWidgetViewModelTest {
             )
 
             viewModel.isCbcEligible.test {
-                assertThat(awaitItem()).isFalse()
+                expectNoEvents()
                 stripeRepository.enqueueEligible()
+                expectNoEvents()
+                viewModel.updateCardNumber("")
+                expectNoEvents()
+                viewModel.updateCardNumber("1")
                 assertThat(awaitItem()).isTrue()
             }
         }
@@ -47,9 +51,10 @@ class CardWidgetViewModelTest {
             )
 
             viewModel.isCbcEligible.test {
-                assertThat(awaitItem()).isFalse()
-                stripeRepository.enqueueNotEligible()
                 expectNoEvents()
+                stripeRepository.enqueueNotEligible()
+                viewModel.updateCardNumber("1")
+                assertThat(awaitItem()).isFalse()
             }
         }
 
@@ -64,9 +69,10 @@ class CardWidgetViewModelTest {
         )
 
         viewModel.isCbcEligible.test {
-            assertThat(awaitItem()).isFalse()
-            stripeRepository.enqueueFailure()
             expectNoEvents()
+            stripeRepository.enqueueFailure()
+            viewModel.updateCardNumber("1")
+            assertThat(awaitItem()).isFalse()
         }
     }
 
@@ -80,10 +86,14 @@ class CardWidgetViewModelTest {
             dispatcher = testDispatcher
         )
 
+        viewModel.updateCardNumber("1")
+
         viewModel.isCbcEligible.test {
-            assertThat(awaitItem()).isFalse()
             stripeRepository.enqueueEligible()
+            assertThat(awaitItem()).isTrue()
             viewModel.setOnBehalfOf("valid_obo")
+            assertThat(awaitItem()).isTrue()
+            viewModel.setOnBehalfOf("valid_obo_2")
             assertThat(awaitItem()).isTrue()
         }
     }
@@ -101,6 +111,8 @@ class CardWidgetViewModelTest {
         stripeRepository.enqueueEligible()
 
         viewModel.isCbcEligible.test {
+            viewModel.updateCardNumber("1")
+            assertThat(awaitItem()).isTrue()
             viewModel.setOnBehalfOf("valid_obo")
             assertThat(awaitItem()).isTrue()
             stripeRepository.enqueueNotEligible()


### PR DESCRIPTION
# Summary (Proof of Concept)
<!-- Simple summary of what was changed. -->
* Convert `isCbcEligibile` to cold flow so that it only starts computation when it is subscribed to
* Wait until card number changes before kicking off cbc eligibility request

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots

## PROTOTYPE 

https://github.com/user-attachments/assets/17a2a518-5a8c-443f-9942-f494c77118e5

## MASTER

https://github.com/user-attachments/assets/daaa73f5-e060-4d4d-8961-c89f82e043e4


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
