### PR TITLE
Add support for default PMs when using link inline signup

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationOptionKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationOptionKtx.kt
@@ -65,8 +65,7 @@ private fun PaymentSelection.New.LinkInline.toConfirmationOption(
         LinkInlineSignupConfirmationOption(
             createParams = paymentMethodCreateParams,
             optionsParams = paymentMethodOptionsParams,
-            userInput = input,
-            linkConfiguration = linkConfiguration,
+            extraParams = paymentMethodExtraParams,
             saveOption = when (customerRequestedSave) {
                 PaymentSelection.CustomerRequestedSave.RequestReuse ->
                     LinkInlineSignupConfirmationOption.PaymentMethodSaveOption.RequestedReuse
@@ -74,7 +73,9 @@ private fun PaymentSelection.New.LinkInline.toConfirmationOption(
                     LinkInlineSignupConfirmationOption.PaymentMethodSaveOption.RequestedNoReuse
                 PaymentSelection.CustomerRequestedSave.NoRequest ->
                     LinkInlineSignupConfirmationOption.PaymentMethodSaveOption.NoRequest
-            }
+            },
+            linkConfiguration = linkConfiguration,
+            userInput = input
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinition.kt
@@ -11,6 +11,7 @@ import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.model.wallets.Wallet
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
@@ -118,6 +119,7 @@ internal class LinkInlineSignupConfirmationDefinition(
 
         val createParams = linkInlineSignupConfirmationOption.createParams
         val saveOption = linkInlineSignupConfirmationOption.saveOption
+        val extraParams = linkInlineSignupConfirmationOption.extraParams
 
         val linkPaymentDetails = linkConfigurationCoordinator.attachNewCardToAccount(
             linkInlineSignupConfirmationOption.linkConfiguration,
@@ -128,7 +130,7 @@ internal class LinkInlineSignupConfirmationDefinition(
             is LinkPaymentDetails.New -> {
                 linkStore.markLinkAsUsed()
 
-                linkPaymentDetails.toNewOption(saveOption)
+                linkPaymentDetails.toNewOption(saveOption, extraParams)
             }
             is LinkPaymentDetails.Saved -> {
                 linkStore.markLinkAsUsed()
@@ -166,14 +168,15 @@ internal class LinkInlineSignupConfirmationDefinition(
     }
 
     private fun LinkPaymentDetails.New.toNewOption(
-        saveOption: LinkInlineSignupConfirmationOption.PaymentMethodSaveOption
+        saveOption: LinkInlineSignupConfirmationOption.PaymentMethodSaveOption,
+        extraParams: PaymentMethodExtraParams?,
     ): PaymentMethodConfirmationOption.New {
         return PaymentMethodConfirmationOption.New(
             createParams = paymentMethodCreateParams,
             optionsParams = PaymentMethodOptionsParams.Card(
                 setupFutureUsage = saveOption.setupFutureUsage,
             ),
-            extraParams = null,
+            extraParams = extraParams,
             shouldSave = saveOption.shouldSave(),
         )
     }
@@ -182,7 +185,7 @@ internal class LinkInlineSignupConfirmationDefinition(
         return PaymentMethodConfirmationOption.New(
             createParams = createParams,
             optionsParams = optionsParams,
-            extraParams = null,
+            extraParams = extraParams,
             shouldSave = saveOption.shouldSave(),
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationOption.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationOption.kt
@@ -4,6 +4,7 @@ import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import kotlinx.parcelize.Parcelize
@@ -12,6 +13,7 @@ import kotlinx.parcelize.Parcelize
 internal data class LinkInlineSignupConfirmationOption(
     val createParams: PaymentMethodCreateParams,
     val optionsParams: PaymentMethodOptionsParams?,
+    val extraParams: PaymentMethodExtraParams?,
     val saveOption: PaymentMethodSaveOption,
     val linkConfiguration: LinkConfiguration,
     val userInput: UserInput,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
@@ -643,6 +643,7 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
         return LinkInlineSignupConfirmationOption(
             createParams = createParams,
             optionsParams = null,
+            extraParams = null,
             saveOption = saveOption,
             linkConfiguration = LinkConfiguration(
                 stripeIntent = PaymentIntentFactory.create(),


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add support for default PMs when using link inline signup

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Bug bash feedback: https://docs.google.com/document/d/1sF2u6RAcF3RyEOTI-lH-A7Tb7aprOuFSCkbyrS9OWHU/edit?tab=t.0#bookmark=id.rvahcmwst8ws

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified

# Screen recording
[link inline sign up fix.webm](https://github.com/user-attachments/assets/cc477a82-5792-4bf4-8cf1-b19456c7c44a)

