### PR TITLE
[MOBILESDK-3197] Default Payment Method Bugbash:  Default Label shown incorrectly

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -63,12 +63,10 @@ internal class SavedPaymentMethodMutator(
         customerStateHolder.customer,
         paymentMethodMetadataFlow
     ) { customer, paymentMethodMetadata ->
-        paymentMethodMetadata?.customerMetadata?.isPaymentMethodSetAsDefaultEnabled?.let { isEnabled ->
-            if (isEnabled) {
-                customer?.defaultPaymentMethodId
-            } else {
-                null
-            }
+        if (paymentMethodMetadata?.customerMetadata?.isPaymentMethodSetAsDefaultEnabled == true) {
+            customer?.defaultPaymentMethodId
+        } else {
+            null
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsItemsMapper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsItemsMapper.kt
@@ -31,8 +31,10 @@ internal class PaymentOptionsItemsMapper(
                 paymentMethods = customerState?.paymentMethods ?: listOf(),
                 isLinkEnabled = isLinkEnabled,
                 isGooglePayReady = isGooglePayReady,
-                defaultPaymentMethodId = customerMetadata?.isPaymentMethodSetAsDefaultEnabled?.let {
+                defaultPaymentMethodId = if (customerMetadata?.isPaymentMethodSetAsDefaultEnabled == true) {
                     customerState?.defaultPaymentMethodId
+                } else {
+                    null
                 }
             ) ?: emptyList()
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
@@ -721,16 +721,6 @@ class SavedPaymentMethodMutatorTest {
     }
 
     @Test
-    fun `defaultPaymentMethodId correctly set when isPaymentMethodSetAsDefaultEnabled = null`() {
-        runScenarioForTestingDefaultPaymentMethod(
-            initialDefaultPaymentMethodIndex = 0,
-            isPaymentMethodSetAsDefaultEnabled = false,
-        ) { _, savedPaymentMethodMutator, _ ->
-            assertThat(savedPaymentMethodMutator.defaultPaymentMethodId.value).isEqualTo(null)
-        }
-    }
-
-    @Test
     fun `defaultPaymentMethodId correctly set as null when no defaultPaymentMethodId`() {
         runScenarioForTestingDefaultPaymentMethod(
             initialDefaultPaymentMethodIndex = null,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
@@ -100,7 +100,11 @@ class SavedPaymentMethodMutatorTest {
 
     @Test
     fun `canEdit is correct CBC is enabled`() = runScenario(
-        isCbcEligible = true
+        paymentMethodMetadataFlow = stateFlowOf(
+            PaymentMethodMetadataFactory.create(
+                cbcEligibility = CardBrandChoiceEligibility.Eligible(listOf(CardBrand.Visa, CardBrand.CartesBancaires))
+            )
+        )
     ) {
         savedPaymentMethodMutator.canEdit.test {
             assertThat(awaitItem()).isFalse()
@@ -842,20 +846,13 @@ class SavedPaymentMethodMutatorTest {
     private fun runScenario(
         customerRepository: CustomerRepository = FakeCustomerRepository(),
         eventReporter: EventReporter = FakeEventReporter(),
-        isCbcEligible: Boolean = false,
         selection: MutableStateFlow<PaymentSelection?> = MutableStateFlow(null),
         customerStateHolder: CustomerStateHolder = CustomerStateHolder(
             savedStateHandle = SavedStateHandle(),
             selection = selection,
         ),
         paymentMethodMetadataFlow: StateFlow<PaymentMethodMetadata?> = stateFlowOf(
-            PaymentMethodMetadataFactory.create(
-                cbcEligibility = if (isCbcEligible) {
-                    CardBrandChoiceEligibility.Eligible(listOf(CardBrand.Visa, CardBrand.CartesBancaires))
-                } else {
-                    CardBrandChoiceEligibility.Ineligible
-                }
-            )
+            PaymentMethodMetadataFactory.create()
         ),
         block: suspend Scenario.() -> Unit
     ) {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsItemsMapperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsItemsMapperTest.kt
@@ -126,12 +126,11 @@ class PaymentOptionsItemsMapperTest {
             val state = awaitItem()
             assertThat(state).hasSize(3)
             assertThat(state[0].viewType).isEqualTo(PaymentOptionsItem.ViewType.AddCard)
-            assertThat(
-                (state[1] as? PaymentOptionsItem.SavedPaymentMethod)
-                    ?.displayableSavedPaymentMethod?.shouldShowDefaultBadge).isFalse()
-            assertThat(
-                (state[2] as? PaymentOptionsItem.SavedPaymentMethod)
-                    ?.displayableSavedPaymentMethod?.shouldShowDefaultBadge).isFalse()
+
+            val firstPaymentMethod = state[1] as? PaymentOptionsItem.SavedPaymentMethod
+            val secondPaymentMethod = state[2] as? PaymentOptionsItem.SavedPaymentMethod
+            assertThat(firstPaymentMethod?.displayableSavedPaymentMethod?.shouldShowDefaultBadge).isFalse()
+            assertThat(secondPaymentMethod?.displayableSavedPaymentMethod?.shouldShowDefaultBadge).isFalse()
         }
     }
 
@@ -168,12 +167,11 @@ class PaymentOptionsItemsMapperTest {
             val state = awaitItem()
             assertThat(state).hasSize(3)
             assertThat(state[0].viewType).isEqualTo(PaymentOptionsItem.ViewType.AddCard)
-            assertThat(
-                (state[1] as? PaymentOptionsItem.SavedPaymentMethod)
-                    ?.displayableSavedPaymentMethod?.shouldShowDefaultBadge).isFalse()
-            assertThat(
-                (state[2] as? PaymentOptionsItem.SavedPaymentMethod)
-                    ?.displayableSavedPaymentMethod?.shouldShowDefaultBadge).isTrue()
+            val firstPaymentMethod = state[1] as? PaymentOptionsItem.SavedPaymentMethod
+            val secondPaymentMethod = state[2] as? PaymentOptionsItem.SavedPaymentMethod
+
+            assertThat(firstPaymentMethod?.displayableSavedPaymentMethod?.shouldShowDefaultBadge).isFalse()
+            assertThat(secondPaymentMethod?.displayableSavedPaymentMethod?.shouldShowDefaultBadge).isTrue()
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsItemsMapperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsItemsMapperTest.kt
@@ -92,7 +92,6 @@ class PaymentOptionsItemsMapperTest {
         }
     }
 
-
     @Test
     fun `Correctly creates payment methods in paymentFlow when not isPaymentMethodSetAsDefaultEnabled`() = runTest {
         val mapper = PaymentOptionsItemsMapper(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsItemsMapperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsItemsMapperTest.kt
@@ -94,13 +94,8 @@ class PaymentOptionsItemsMapperTest {
 
     @Test
     fun `Correctly creates payment methods in paymentFlow when not isPaymentMethodSetAsDefaultEnabled`() = runTest {
-        val mapper = getMapperForTesting(
-            isSetAsDefaultEnabled = false
-        )
-
         testMapperForSetAsDefaultPaymentMethod(
-            mapper = mapper,
-            assertShouldShowDefaultBadge = { firstCardPaymentMethod, secondCardPaymentMethod ->
+            assertBlock = { firstCardPaymentMethod, secondCardPaymentMethod ->
                 assertThat(firstCardPaymentMethod?.displayableSavedPaymentMethod?.shouldShowDefaultBadge).isFalse()
                 assertThat(secondCardPaymentMethod?.displayableSavedPaymentMethod?.shouldShowDefaultBadge).isFalse()
             }
@@ -109,13 +104,8 @@ class PaymentOptionsItemsMapperTest {
 
     @Test
     fun `Correctly creates payment methods in paymentFlow when isPaymentMethodSetAsDefaultEnabled`() = runTest {
-        val mapper = getMapperForTesting(
-            isSetAsDefaultEnabled = true
-        )
-
         testMapperForSetAsDefaultPaymentMethod(
-            mapper = mapper,
-            assertShouldShowDefaultBadge = { firstCardPaymentMethod, secondCardPaymentMethod ->
+            assertBlock = { firstCardPaymentMethod, secondCardPaymentMethod ->
                 assertThat(firstCardPaymentMethod?.displayableSavedPaymentMethod?.shouldShowDefaultBadge).isFalse()
                 assertThat(secondCardPaymentMethod?.displayableSavedPaymentMethod?.shouldShowDefaultBadge).isTrue()
             }
@@ -142,12 +132,15 @@ class PaymentOptionsItemsMapperTest {
     }
 
     private suspend fun testMapperForSetAsDefaultPaymentMethod(
-        mapper: PaymentOptionsItemsMapper,
-        assertShouldShowDefaultBadge: (
+        isSetAsDefaultEnabled: Boolean = false,
+        assertBlock: (
             PaymentOptionsItem.SavedPaymentMethod?,
             PaymentOptionsItem.SavedPaymentMethod?
         ) -> Unit,
     ) {
+        val mapper = getMapperForTesting(
+            isSetAsDefaultEnabled = isSetAsDefaultEnabled
+        )
         mapper().test {
             assertThat(awaitItem()).isEqualTo(emptyList<PaymentOptionsItem>())
             val paymentMethods = PaymentMethodFixtures.createCards(2)
@@ -165,7 +158,7 @@ class PaymentOptionsItemsMapperTest {
             assertThat(state).hasSize(3)
             assertThat(state[0].viewType).isEqualTo(PaymentOptionsItem.ViewType.AddCard)
 
-            assertShouldShowDefaultBadge(
+            assertBlock(
                 state[1] as? PaymentOptionsItem.SavedPaymentMethod,
                 state[2] as? PaymentOptionsItem.SavedPaymentMethod
             )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsItemsMapperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsItemsMapperTest.kt
@@ -100,7 +100,7 @@ class PaymentOptionsItemsMapperTest {
 
         testMapperForSetAsDefaultPaymentMethod(
             mapper = mapper,
-            assertShouldShowDefaultBadge =  { firstCardPaymentMethod, secondCardPaymentMethod ->
+            assertShouldShowDefaultBadge = { firstCardPaymentMethod, secondCardPaymentMethod ->
                 assertThat(firstCardPaymentMethod?.displayableSavedPaymentMethod?.shouldShowDefaultBadge).isFalse()
                 assertThat(secondCardPaymentMethod?.displayableSavedPaymentMethod?.shouldShowDefaultBadge).isFalse()
             }
@@ -115,7 +115,7 @@ class PaymentOptionsItemsMapperTest {
 
         testMapperForSetAsDefaultPaymentMethod(
             mapper = mapper,
-            assertShouldShowDefaultBadge =  { firstCardPaymentMethod, secondCardPaymentMethod ->
+            assertShouldShowDefaultBadge = { firstCardPaymentMethod, secondCardPaymentMethod ->
                 assertThat(firstCardPaymentMethod?.displayableSavedPaymentMethod?.shouldShowDefaultBadge).isFalse()
                 assertThat(secondCardPaymentMethod?.displayableSavedPaymentMethod?.shouldShowDefaultBadge).isTrue()
             }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsItemsMapperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsItemsMapperTest.kt
@@ -105,6 +105,7 @@ class PaymentOptionsItemsMapperTest {
     @Test
     fun `Correctly creates payment methods in paymentFlow when isPaymentMethodSetAsDefaultEnabled`() = runTest {
         testMapperForSetAsDefaultPaymentMethod(
+            isSetAsDefaultEnabled = true,
             assertBlock = { firstCardPaymentMethod, secondCardPaymentMethod ->
                 assertThat(firstCardPaymentMethod?.displayableSavedPaymentMethod?.shouldShowDefaultBadge).isFalse()
                 assertThat(secondCardPaymentMethod?.displayableSavedPaymentMethod?.shouldShowDefaultBadge).isTrue()


### PR DESCRIPTION
# Summary
Check that isPaymentMethodSetAsDefaultEnabled is true instead of just checking that it is not null

# Motivation
Users are seeing the default label even when this feature is supposed to be disabled

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified

# Demo
<img src="https://github.com/user-attachments/assets/2b43bd16-566f-4348-9e1f-64cf462df461" height = 400/>

# Changelog
N.A.