### PR TITLE
Fix Postal Code content description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## XX.XX.XX - 20XX-XX-XX
 
+### PaymentSheet
+* [FIXED][10327](https://github.com/stripe/stripe-android/pull/10327) Improve accessibility for postal code.
+
 ## 21.6.0 - 2025-03-03
 
 ### PaymentSheet

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/Accessibility.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/Accessibility.kt
@@ -1,5 +1,0 @@
-package com.stripe.android.ui.core
-
-internal fun String.asIndividualDigits(): String {
-    return toCharArray().joinToString(separator = " ")
-}

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
@@ -93,9 +93,7 @@ internal class CardDetailsController(
             textFieldConfig = DateConfig(),
             initialValue = initialValues[IdentifierSpec.CardExpMonth] +
                 initialValues[IdentifierSpec.CardExpYear]?.takeLast(2),
-            overrideContentDescriptionProvider = ::formatExpirationDateForAccessibility,
-            shouldAnnounceFieldValue = false,
-            shouldAnnounceLabel = false
+            overrideContentDescriptionProvider = ::formatExpirationDateForAccessibility
         )
     )
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
@@ -27,7 +27,6 @@ import com.stripe.android.model.AccountRange
 import com.stripe.android.model.CardBrand
 import com.stripe.android.stripecardscan.cardscan.CardScanSheetResult
 import com.stripe.android.ui.core.R
-import com.stripe.android.ui.core.asIndividualDigits
 import com.stripe.android.ui.core.elements.events.LocalCardBrandDisallowedReporter
 import com.stripe.android.ui.core.elements.events.LocalCardNumberCompletedEventReporter
 import com.stripe.android.uicore.elements.FieldError
@@ -38,6 +37,7 @@ import com.stripe.android.uicore.elements.TextFieldIcon
 import com.stripe.android.uicore.elements.TextFieldState
 import com.stripe.android.uicore.elements.TextFieldStateConstants
 import com.stripe.android.uicore.forms.FormFieldEntry
+import com.stripe.android.uicore.utils.asIndividualDigits
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import com.stripe.android.uicore.utils.stateFlowOf

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcController.kt
@@ -9,12 +9,12 @@ import androidx.compose.ui.unit.LayoutDirection
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.CardBrand
-import com.stripe.android.ui.core.asIndividualDigits
 import com.stripe.android.uicore.elements.FieldError
 import com.stripe.android.uicore.elements.TextFieldController
 import com.stripe.android.uicore.elements.TextFieldIcon
 import com.stripe.android.uicore.elements.TextFieldState
 import com.stripe.android.uicore.forms.FormFieldEntry
+import com.stripe.android.uicore.utils.asIndividualDigits
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import com.stripe.android.uicore.utils.stateFlowOf

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/FieldPopulator.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/FieldPopulator.kt
@@ -18,6 +18,7 @@ import com.stripe.android.paymentsheet.example.playground.settings.DefaultBillin
 import com.stripe.android.test.core.ui.Selectors
 import com.stripe.android.ui.core.elements.TranslationId
 import com.stripe.android.ui.core.elements.formatExpirationDateForAccessibility
+import com.stripe.android.uicore.utils.asIndividualDigits
 import com.stripe.android.core.R as CoreR
 
 internal class FieldPopulator(
@@ -142,10 +143,10 @@ internal class FieldPopulator(
     private fun validateZip() {
         if (usesZip()) {
             selectors.getZip()
-                .ifExistsAssertContentDescriptionEquals(values.zip)
+                .ifExistsAssertContentDescriptionEquals(values.zip.asIndividualDigits())
         } else {
             selectors.getPostalCode()
-                .ifExistsAssertContentDescriptionEquals(values.zip)
+                .ifExistsAssertContentDescriptionEquals(values.zip.asIndividualDigits())
         }
     }
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/TransformAddressToElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/TransformAddressToElement.kt
@@ -4,6 +4,8 @@ import androidx.annotation.RestrictTo
 import androidx.annotation.StringRes
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
+import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.uicore.R
 import com.stripe.android.uicore.elements.AdministrativeAreaConfig
 import com.stripe.android.uicore.elements.AdministrativeAreaElement
@@ -18,6 +20,7 @@ import com.stripe.android.uicore.elements.SimpleTextElement
 import com.stripe.android.uicore.elements.SimpleTextFieldConfig
 import com.stripe.android.uicore.elements.SimpleTextFieldController
 import com.stripe.android.uicore.elements.TextFieldConfig
+import com.stripe.android.uicore.utils.asIndividualDigits
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.ListSerializer
@@ -269,6 +272,7 @@ private fun FieldType.toElement(
                 keyboardType = keyboardType,
                 countryCode = countryCode
             ),
+            overrideContentDescriptionProvider = getOverrideContentDescription(),
             showOptionalLabel = showOptionalLabel
         )
     )
@@ -314,6 +318,15 @@ private fun FieldType.toConfig(
             capitalization = capitalization,
             keyboard = keyboardType
         )
+    }
+}
+
+private fun FieldType.getOverrideContentDescription(): ((fieldValue: String) -> ResolvableString)? {
+    return when (this) {
+        FieldType.PostalCode -> {
+            { it.asIndividualDigits().resolvableString }
+        }
+        else -> null
     }
 }
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldController.kt
@@ -53,7 +53,10 @@ class AddressTextFieldController(
 
     override val layoutDirection: LayoutDirection? = null
 
-    override val contentDescription: StateFlow<ResolvableString> = _fieldValue.mapAsStateFlow { it.resolvableString }
+    override val contentDescription: StateFlow<ResolvableString> = _fieldValue.mapAsStateFlow {
+        println("YEET AddressTextFieldController content description here?")
+        it.resolvableString
+    }
 
     private val _fieldState = MutableStateFlow<TextFieldState>(TextFieldStateConstants.Error.Blank)
     override val fieldState: StateFlow<TextFieldState> = _fieldState.asStateFlow()

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldController.kt
@@ -53,10 +53,7 @@ class AddressTextFieldController(
 
     override val layoutDirection: LayoutDirection? = null
 
-    override val contentDescription: StateFlow<ResolvableString> = _fieldValue.mapAsStateFlow {
-        println("YEET AddressTextFieldController content description here?")
-        it.resolvableString
-    }
+    override val contentDescription: StateFlow<ResolvableString> = _fieldValue.mapAsStateFlow { it.resolvableString }
 
     private val _fieldState = MutableStateFlow<TextFieldState>(TextFieldStateConstants.Error.Blank)
     override val fieldState: StateFlow<TextFieldState> = _fieldState.asStateFlow()

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DateConfig.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DateConfig.kt
@@ -25,6 +25,8 @@ class DateConfig : TextFieldConfig {
     override val trailingIcon: StateFlow<TextFieldIcon?> = MutableStateFlow(null)
     override val loading: StateFlow<Boolean> = MutableStateFlow(false)
     override val layoutDirection: LayoutDirection = LayoutDirection.Ltr
+    override val shouldAnnounceFieldValue = false
+    override val shouldAnnounceLabel = false
 
     override fun filter(userTyped: String) = userTyped.filter { it.isDigit() }
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PostalCodeConfig.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PostalCodeConfig.kt
@@ -34,6 +34,7 @@ class PostalCodeConfig(
     override val visualTransformation: VisualTransformation =
         PostalCodeVisualTransformation(format)
     override val loading: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    override val shouldAnnounceFieldValue = false
 
     override fun determineState(input: String): TextFieldState = object : TextFieldState {
         override fun shouldShowError(hasFocus: Boolean) = getError() != null && !hasFocus

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldConfig.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldConfig.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.LayoutDirection
+import com.stripe.android.core.strings.ResolvableString
 import kotlinx.coroutines.flow.StateFlow
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
@@ -33,6 +34,15 @@ interface TextFieldConfig {
     val loading: StateFlow<Boolean>
 
     val placeHolder: String?
+        get() = null
+
+    val shouldAnnounceLabel: Boolean
+        get() = true
+
+    val shouldAnnounceFieldValue: Boolean
+        get() = true
+
+    val overrideContentDescriptionProvider: ((fieldValue: String) -> ResolvableString)?
         get() = null
 
     /** This will determine the state of the field based on the text */

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldController.kt
@@ -129,8 +129,6 @@ class SimpleTextFieldController(
     override val showOptionalLabel: Boolean = false,
     override val initialValue: String? = null,
     private val overrideContentDescriptionProvider: ((fieldValue: String) -> ResolvableString)? = null,
-    private val shouldAnnounceLabel: Boolean = true,
-    private val shouldAnnounceFieldValue: Boolean = true
 ) : TextFieldController {
     override val trailingIcon: StateFlow<TextFieldIcon?> = textFieldConfig.trailingIcon
     override val capitalization: KeyboardCapitalization = textFieldConfig.capitalization
@@ -245,8 +243,8 @@ class SimpleTextFieldController(
             modifier = modifier,
             nextFocusDirection = nextFocusDirection,
             previousFocusDirection = previousFocusDirection,
-            shouldAnnounceLabel = shouldAnnounceLabel,
-            shouldAnnounceFieldValue = shouldAnnounceFieldValue
+            shouldAnnounceLabel = textFieldConfig.shouldAnnounceLabel,
+            shouldAnnounceFieldValue = textFieldConfig.shouldAnnounceFieldValue
         )
     }
 }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/utils/Accessibility.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/utils/Accessibility.kt
@@ -1,0 +1,8 @@
+package com.stripe.android.uicore.utils
+
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun String.asIndividualDigits(): String {
+    return toCharArray().joinToString(separator = " ")
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Refactor `shouldAnnounceLabel` and `shouldAnnounceFieldValue` to `TextFieldConfig`
Add `contentDescriptionOverride` to read Postal Code as individual digits/chars

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-2674

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [X] Manually verified

## Before
https://github.com/user-attachments/assets/99d67e6a-3f5a-442a-bf9b-016189390a56

## After
https://github.com/user-attachments/assets/a95161e0-a4a3-496c-a73b-01533ac0b97b


