### PR TITLE
Add verifyPaparazziDebug to pre-push hook

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -2,7 +2,7 @@
 
 echo "Running static analysis"
 
-./gradlew ktlint detekt lintRelease apiCheck verifyReleaseResources
+./gradlew ktlint detekt lintRelease apiCheck verifyReleaseResources verifyPaparazziDebug
 
 status=$?
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Adding gradle task `verifyPaparazziDebug`, taking roughly two minutes for the first run on local machine.
After cache exists, the check is incremental and normally cost a few seconds.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Locally check if any screenshot needs update before push so we can benefit from #10104 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified
