### PR TITLE
Display set as default checkbox for default PM in disabled state

### DIFF
--- a/payment-element-test-pages/src/main/java/com/stripe/paymentelementtestpages/EditPage.kt
+++ b/payment-element-test-pages/src/main/java/com/stripe/paymentelementtestpages/EditPage.kt
@@ -17,6 +17,7 @@ import com.stripe.android.ui.core.elements.TEST_TAG_DIALOG_CONFIRM_BUTTON
 import com.stripe.android.uicore.elements.DROPDOWN_MENU_CLICKABLE_TEST_TAG
 import com.stripe.android.uicore.elements.TEST_TAG_DROP_DOWN_CHOICE
 
+@SuppressWarnings("TooManyFunctions")
 class EditPage(
     private val composeTestRule: ComposeTestRule
 ) {
@@ -118,9 +119,13 @@ class EditPage(
         }
     }
 
-    fun clickSetAsDefaultCheckbox() {
-        composeTestRule.onNodeWithTag(
+    fun onSetAsDefaultCheckbox(): SemanticsNodeInteraction {
+        return composeTestRule.onNodeWithTag(
             UPDATE_PM_SET_AS_DEFAULT_CHECKBOX_TEST_TAG
-        ).performClick()
+        )
+    }
+
+    fun clickSetAsDefaultCheckbox() {
+        onSetAsDefaultCheckbox().performClick()
     }
 }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/DefaultPaymentMethodsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/DefaultPaymentMethodsTest.kt
@@ -90,6 +90,38 @@ internal class DefaultPaymentMethodsTest {
         testContext.markTestSucceeded()
     }
 
+    @Test
+    fun updatePaymentMethodScreen_defaultPaymentMethod_setAsDefaultCheckboxDisplayedAndDisabled() =
+        runProductIntegrationTest(
+            networkRule = networkRule,
+            integrationType = integrationType,
+            resultCallback = {},
+        ) { testContext ->
+        val cards = listOf(
+            PaymentMethodFactory.card(last4 = "4242", id = "pm_1"),
+            PaymentMethodFactory.card(last4 = "1001", id = "pm_2")
+        )
+
+        val defaultPaymentMethod = cards[0]
+
+        enqueueElementsSessionResponse(
+            cards = cards,
+            defaultPaymentMethod = defaultPaymentMethod.id,
+        )
+
+        launch(
+            testContext = testContext,
+            paymentMethodLayout = layoutType.paymentMethodLayout,
+        )
+
+        layoutType.assertSetDefaultPaymentMethodCheckboxDisplayedAndDisabled(
+            composeTestRule = composeTestRule,
+            paymentMethod = defaultPaymentMethod,
+        )
+
+        testContext.markTestSucceeded()
+    }
+
     private fun enqueueSetDefaultPaymentMethodRequest() {
         networkRule.enqueue(
             RequestMatchers.host("api.stripe.com"),

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/PaymentSheetLayoutType.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/PaymentSheetLayoutType.kt
@@ -2,6 +2,8 @@ package com.stripe.android.paymentsheet.utils
 
 import android.content.Context
 import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.isEnabled
 import androidx.compose.ui.test.junit4.ComposeTestRule
@@ -33,6 +35,11 @@ internal sealed class PaymentSheetLayoutType(val paymentMethodLayout: PaymentShe
         newDefaultPaymentMethod: PaymentMethod,
     )
 
+    abstract fun assertSetDefaultPaymentMethodCheckboxDisplayedAndDisabled(
+        composeTestRule: ComposeTestRule,
+        paymentMethod: PaymentMethod,
+    )
+
     abstract fun assertDefaultPaymentMethodBadgeDisplayed(
         composeTestRule: ComposeTestRule,
     )
@@ -49,6 +56,22 @@ internal sealed class PaymentSheetLayoutType(val paymentMethodLayout: PaymentShe
                 .assertIsSelected()
         }
 
+        override fun assertSetDefaultPaymentMethodCheckboxDisplayedAndDisabled(
+            composeTestRule: ComposeTestRule,
+            paymentMethod: PaymentMethod,
+        ) {
+            val savedPaymentMethodsPage = SavedPaymentMethodsPage(composeTestRule)
+            val editPage = EditPage(composeTestRule)
+
+            navigateToEditPage(
+                savedPaymentMethodsPage = savedPaymentMethodsPage,
+                editPage = editPage,
+                paymentMethod = paymentMethod,
+            )
+
+            assertSetAsDefaultCheckboxDisplayedAndDisabled(editPage = editPage)
+        }
+
         override fun setDefaultPaymentMethod(
             composeTestRule: ComposeTestRule,
             newDefaultPaymentMethod: PaymentMethod
@@ -56,13 +79,12 @@ internal sealed class PaymentSheetLayoutType(val paymentMethodLayout: PaymentShe
             val savedPaymentMethodsPage = SavedPaymentMethodsPage(composeTestRule)
             val editPage = EditPage(composeTestRule)
 
-            savedPaymentMethodsPage.onEditButton().performClick()
+            navigateToEditPage(
+                savedPaymentMethodsPage = savedPaymentMethodsPage,
+                editPage = editPage,
+                paymentMethod = newDefaultPaymentMethod,
+            )
 
-            savedPaymentMethodsPage.onModifyBadgeFor(
-                newDefaultPaymentMethod.card!!.last4!!
-            ).performClick()
-
-            editPage.waitUntilVisible()
             editPage.clickSetAsDefaultCheckbox()
 
             editPage.update()
@@ -78,6 +100,20 @@ internal sealed class PaymentSheetLayoutType(val paymentMethodLayout: PaymentShe
             savedPaymentMethodsPage.onEditButton().performClick()
 
             assertExactlyOneDefaultLabelShown(composeTestRule)
+        }
+
+        private fun navigateToEditPage(
+            savedPaymentMethodsPage: SavedPaymentMethodsPage,
+            editPage: EditPage,
+            paymentMethod: PaymentMethod,
+        ) {
+            savedPaymentMethodsPage.onEditButton().performClick()
+
+            savedPaymentMethodsPage.onModifyBadgeFor(
+                paymentMethod.card!!.last4!!
+            ).performClick()
+
+            editPage.waitUntilVisible()
         }
     }
 
@@ -101,18 +137,36 @@ internal sealed class PaymentSheetLayoutType(val paymentMethodLayout: PaymentShe
             Espresso.pressBack()
         }
 
+        override fun assertSetDefaultPaymentMethodCheckboxDisplayedAndDisabled(
+            composeTestRule: ComposeTestRule,
+            paymentMethod: PaymentMethod
+        ) {
+            val verticalModePage = VerticalModePage(composeTestRule)
+            val managePage = ManagePage(composeTestRule)
+            val editPage = EditPage(composeTestRule)
+
+            navigateToEditPage(
+                verticalModePage = verticalModePage,
+                managePage = managePage,
+                editPage = editPage,
+                paymentMethod = paymentMethod,
+            )
+
+            assertSetAsDefaultCheckboxDisplayedAndDisabled(editPage = editPage)
+        }
+
         override fun setDefaultPaymentMethod(composeTestRule: ComposeTestRule, newDefaultPaymentMethod: PaymentMethod) {
             val verticalModePage = VerticalModePage(composeTestRule)
             val managePage = ManagePage(composeTestRule)
             val editPage = EditPage(composeTestRule)
 
-            verticalModePage.clickViewMore()
-            managePage.waitUntilVisible()
+            navigateToEditPage(
+                verticalModePage = verticalModePage,
+                managePage = managePage,
+                editPage = editPage,
+                paymentMethod = newDefaultPaymentMethod,
+            )
 
-            managePage.clickEdit()
-            managePage.clickEdit(newDefaultPaymentMethod.id!!)
-
-            editPage.waitUntilVisible()
             editPage.clickSetAsDefaultCheckbox()
 
             editPage.update()
@@ -133,6 +187,21 @@ internal sealed class PaymentSheetLayoutType(val paymentMethodLayout: PaymentShe
 
             assertExactlyOneDefaultLabelShown(composeTestRule)
         }
+
+        private fun navigateToEditPage(
+            verticalModePage: VerticalModePage,
+            managePage: ManagePage,
+            editPage: EditPage,
+            paymentMethod: PaymentMethod,
+        ) {
+            verticalModePage.clickViewMore()
+            managePage.waitUntilVisible()
+
+            managePage.clickEdit()
+            managePage.clickEdit(paymentMethod.id!!)
+
+            editPage.waitUntilVisible()
+        }
     }
 
     private companion object {
@@ -141,6 +210,13 @@ internal sealed class PaymentSheetLayoutType(val paymentMethodLayout: PaymentShe
                 TEST_TAG_DEFAULT_PAYMENT_METHOD_LABEL,
                 useUnmergedTree = true
             ).assertCountEquals(1)
+        }
+
+        fun assertSetAsDefaultCheckboxDisplayedAndDisabled(
+            editPage: EditPage,
+        ) {
+            editPage.onSetAsDefaultCheckbox().assertIsDisplayed()
+            editPage.onSetAsDefaultCheckbox().assertIsNotEnabled()
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -560,6 +560,7 @@ internal class CustomerSheetViewModel(
                     workContext = workContext,
                     // This checkbox is never displayed in CustomerSheet.
                     shouldShowSetAsDefaultCheckbox = false,
+                    isDefaultPaymentMethod = false,
                     // Should never be called from CustomerSheet, because we don't enable the set as default checkbox.
                     setDefaultPaymentMethodExecutor = {
                         Result.failure(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
@@ -72,10 +72,12 @@ internal class DefaultEmbeddedUpdateScreenInteractorFactory @Inject constructor(
                 )
             },
             shouldShowSetAsDefaultCheckbox = (
-                paymentMethodMetadata.customerMetadata?.isPaymentMethodSetAsDefaultEnabled == true &&
-                    !displayableSavedPaymentMethod.isDefaultPaymentMethod(
-                        defaultPaymentMethodId = customerStateHolder.customer.value?.defaultPaymentMethodId
-                    )
+                paymentMethodMetadata.customerMetadata?.isPaymentMethodSetAsDefaultEnabled == true
+                ),
+            isDefaultPaymentMethod = (
+                displayableSavedPaymentMethod.isDefaultPaymentMethod(
+                    defaultPaymentMethodId = customerStateHolder.customer.value?.defaultPaymentMethodId
+                )
                 ),
             onUpdateSuccess = {
                 manageNavigatorProvider.get().performAction(ManageNavigator.Action.Back)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -379,11 +379,13 @@ internal class SavedPaymentMethodMutator(
                             shouldShowSetAsDefaultCheckbox = (
                                 viewModel
                                     .paymentMethodMetadata
-                                    .value?.customerMetadata?.isPaymentMethodSetAsDefaultEnabled == true &&
-                                    !displayableSavedPaymentMethod.isDefaultPaymentMethod(
-                                        defaultPaymentMethodId =
-                                        viewModel.customerStateHolder.customer.value?.defaultPaymentMethodId
-                                    )
+                                    .value?.customerMetadata?.isPaymentMethodSetAsDefaultEnabled == true
+                                ),
+                            isDefaultPaymentMethod = (
+                                displayableSavedPaymentMethod.isDefaultPaymentMethod(
+                                    defaultPaymentMethodId =
+                                    viewModel.customerStateHolder.customer.value?.defaultPaymentMethodId
+                                )
                                 ),
                             onUpdateSuccess = viewModel.navigationHandler::pop,
                         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
@@ -30,6 +30,7 @@ internal interface UpdatePaymentMethodInteractor {
     val isModifiablePaymentMethod: Boolean
     val hasValidBrandChoices: Boolean
     val shouldShowSetAsDefaultCheckbox: Boolean
+    val setAsDefaultCheckboxEnabled: Boolean
     val shouldShowSaveButton: Boolean
 
     val state: StateFlow<State>
@@ -87,6 +88,7 @@ internal class DefaultUpdatePaymentMethodInteractor(
     override val canRemove: Boolean,
     override val displayableSavedPaymentMethod: DisplayableSavedPaymentMethod,
     override val cardBrandFilter: CardBrandFilter,
+    val isDefaultPaymentMethod: Boolean,
     shouldShowSetAsDefaultCheckbox: Boolean,
     private val removeExecutor: PaymentMethodRemoveOperation,
     private val updateCardBrandExecutor: UpdateCardBrandOperation,
@@ -101,7 +103,7 @@ internal class DefaultUpdatePaymentMethodInteractor(
     private val status = MutableStateFlow(UpdatePaymentMethodInteractor.Status.Idle)
     private val cardBrandChoice = MutableStateFlow(getInitialCardBrandChoice())
     private val cardBrandHasBeenChanged = MutableStateFlow(false)
-    private val setAsDefaultCheckboxChecked = MutableStateFlow(false)
+    private val setAsDefaultCheckboxChecked = MutableStateFlow(isDefaultPaymentMethod)
     private val savedCardBrand = MutableStateFlow(getInitialCardBrandChoice())
 
     // We don't yet support setting SEPA payment methods as defaults, so we hide the checkbox for now.
@@ -122,6 +124,7 @@ internal class DefaultUpdatePaymentMethodInteractor(
         isLiveMode = isLiveMode,
         editable = PaymentSheetTopBarState.Editable.Never,
     )
+    override val setAsDefaultCheckboxEnabled: Boolean = !isDefaultPaymentMethod
 
     override val shouldShowSaveButton: Boolean = isModifiablePaymentMethod || shouldShowSetAsDefaultCheckbox
 
@@ -139,8 +142,8 @@ internal class DefaultUpdatePaymentMethodInteractor(
             error = error,
             status = status,
             cardBrandChoice = cardBrandChoice,
-            setAsDefaultCheckboxChecked = setAsDefaultCheckboxChecked,
             isSaveButtonEnabled = isSaveButtonEnabled,
+            setAsDefaultCheckboxChecked = isDefaultPaymentMethod || setAsDefaultCheckboxChecked,
         )
     }
     override val state = _state

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
@@ -103,7 +103,8 @@ internal class DefaultUpdatePaymentMethodInteractor(
     private val status = MutableStateFlow(UpdatePaymentMethodInteractor.Status.Idle)
     private val cardBrandChoice = MutableStateFlow(getInitialCardBrandChoice())
     private val cardBrandHasBeenChanged = MutableStateFlow(false)
-    private val setAsDefaultCheckboxChecked = MutableStateFlow(isDefaultPaymentMethod)
+    private val initialSetAsDefaultCheckedValue = isDefaultPaymentMethod
+    private val setAsDefaultCheckboxChecked = MutableStateFlow(initialSetAsDefaultCheckedValue)
     private val savedCardBrand = MutableStateFlow(getInitialCardBrandChoice())
 
     // We don't yet support setting SEPA payment methods as defaults, so we hide the checkbox for now.
@@ -126,7 +127,8 @@ internal class DefaultUpdatePaymentMethodInteractor(
     )
     override val setAsDefaultCheckboxEnabled: Boolean = !isDefaultPaymentMethod
 
-    override val shouldShowSaveButton: Boolean = isModifiablePaymentMethod || shouldShowSetAsDefaultCheckbox
+    override val shouldShowSaveButton: Boolean = isModifiablePaymentMethod ||
+        (shouldShowSetAsDefaultCheckbox && !isDefaultPaymentMethod)
 
     private val _state = combineAsStateFlow(
         error,
@@ -135,7 +137,8 @@ internal class DefaultUpdatePaymentMethodInteractor(
         cardBrandHasBeenChanged,
         setAsDefaultCheckboxChecked,
     ) { error, status, cardBrandChoice, cardBrandHasBeenChanged, setAsDefaultCheckboxChecked ->
-        val isSaveButtonEnabled = (cardBrandHasBeenChanged || setAsDefaultCheckboxChecked) &&
+        val setAsDefaultValueChanged = setAsDefaultCheckboxChecked != initialSetAsDefaultCheckedValue
+        val isSaveButtonEnabled = (cardBrandHasBeenChanged || setAsDefaultValueChanged) &&
             status == UpdatePaymentMethodInteractor.Status.Idle
 
         UpdatePaymentMethodInteractor.State(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
@@ -98,6 +98,7 @@ internal fun UpdatePaymentMethodUI(interactor: UpdatePaymentMethodInteractor, mo
         if (interactor.shouldShowSetAsDefaultCheckbox) {
             SetAsDefaultPaymentMethodCheckbox(
                 isChecked = state.setAsDefaultCheckboxChecked,
+                isEnabled = interactor.setAsDefaultCheckboxEnabled,
                 onCheckChanged = { newCheckedValue ->
                     interactor.handleViewAction(
                         UpdatePaymentMethodInteractor.ViewAction.SetAsDefaultCheckboxChanged(newCheckedValue)
@@ -143,12 +144,13 @@ private fun DetailsCannotBeChangedText(
 @Composable
 private fun SetAsDefaultPaymentMethodCheckbox(
     isChecked: Boolean,
+    isEnabled: Boolean,
     onCheckChanged: (Boolean) -> Unit,
 ) {
     CheckboxElementUI(
         isChecked = isChecked,
         onValueChange = onCheckChanged,
-        isEnabled = true,
+        isEnabled = isEnabled,
         label = (com.stripe.android.ui.core.R.string.stripe_set_as_default_payment_method).resolvableString.resolve(),
         modifier = Modifier.padding(top = 12.dp).testTag(UPDATE_PM_SET_AS_DEFAULT_CHECKBOX_TEST_TAG)
     )
@@ -541,6 +543,7 @@ private fun PreviewUpdatePaymentMethodUI() {
             onBrandChoiceOptionsShown = {},
             onBrandChoiceOptionsDismissed = {},
             shouldShowSetAsDefaultCheckbox = true,
+            isDefaultPaymentMethod = false,
             onUpdateSuccess = {},
         ),
         modifier = Modifier

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -359,6 +359,7 @@ internal class CustomerSheetScreenshotTest {
                 onBrandChoiceOptionsShown = {},
                 // This checkbox is never displayed in CustomerSheet.
                 shouldShowSetAsDefaultCheckbox = false,
+                isDefaultPaymentMethod = false,
                 onUpdateSuccess = {},
             ),
             isLiveMode = true,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultUpdatePaymentMethodInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultUpdatePaymentMethodInteractorTest.kt
@@ -330,6 +330,35 @@ class DefaultUpdatePaymentMethodInteractorTest {
     }
 
     @Test
+    fun isDefaultPaymentMethod_setAsDefaultCheckboxChecked() = runScenario(
+        displayableSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
+        shouldShowSetAsDefaultCheckbox = true,
+        isDefaultPaymentMethod = true,
+    ) {
+        interactor.state.test {
+            assertThat(awaitItem().setAsDefaultCheckboxChecked).isTrue()
+        }
+    }
+
+    @Test
+    fun isDefaultPaymentMethod_setAsDefaultCheckboxDisabled() = runScenario(
+        displayableSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
+        shouldShowSetAsDefaultCheckbox = true,
+        isDefaultPaymentMethod = true,
+    ) {
+        assertThat(interactor.setAsDefaultCheckboxEnabled).isFalse()
+    }
+
+    @Test
+    fun isNotDefaultPaymentMethod_setAsDefaultCheckboxEnabled() = runScenario(
+        displayableSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
+        shouldShowSetAsDefaultCheckbox = true,
+        isDefaultPaymentMethod = false,
+    ) {
+        assertThat(interactor.setAsDefaultCheckboxEnabled).isTrue()
+    }
+
+    @Test
     fun setAsDefaultCheckboxChangedViewAction_updatesState() = runScenario(
         shouldShowSetAsDefaultCheckbox = true,
     ) {
@@ -552,6 +581,7 @@ class DefaultUpdatePaymentMethodInteractorTest {
         onSetDefaultPaymentMethod: (PaymentMethod) -> Result<Unit> = { _ -> notImplemented() },
         onUpdateSuccess: () -> Unit = { notImplemented() },
         shouldShowSetAsDefaultCheckbox: Boolean = false,
+        isDefaultPaymentMethod: Boolean = false,
         testBlock: suspend TestParams.() -> Unit
     ) {
         val interactor = DefaultUpdatePaymentMethodInteractor(
@@ -566,6 +596,7 @@ class DefaultUpdatePaymentMethodInteractorTest {
             onBrandChoiceOptionsShown = {},
             onBrandChoiceOptionsDismissed = {},
             shouldShowSetAsDefaultCheckbox = shouldShowSetAsDefaultCheckbox,
+            isDefaultPaymentMethod = isDefaultPaymentMethod,
             onUpdateSuccess = onUpdateSuccess,
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultUpdatePaymentMethodInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultUpdatePaymentMethodInteractorTest.kt
@@ -330,6 +330,49 @@ class DefaultUpdatePaymentMethodInteractorTest {
     }
 
     @Test
+    fun isDefaultPaymentMethod_saveButtonHidden() = runScenario(
+        displayableSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
+        shouldShowSetAsDefaultCheckbox = true,
+        isDefaultPaymentMethod = true,
+    ) {
+        assertThat(interactor.shouldShowSaveButton).isFalse()
+    }
+
+    @Test
+    fun isDefaultPaymentMethod_cbcEligibleCard_saveButtonShown() = runScenario(
+        displayableSavedPaymentMethod = PaymentMethodFixtures
+            .CARD_WITH_NETWORKS_PAYMENT_METHOD
+            .toDisplayableSavedPaymentMethod(),
+        shouldShowSetAsDefaultCheckbox = true,
+        isDefaultPaymentMethod = true,
+    ) {
+        assertThat(interactor.shouldShowSaveButton).isTrue()
+    }
+
+    @Test
+    fun isDefaultPaymentMethod_cbcEligibleCard_saveButtonEnabledCorrectly() = runScenario(
+        displayableSavedPaymentMethod = PaymentMethodFixtures
+            .CARD_WITH_NETWORKS_PAYMENT_METHOD
+            .toDisplayableSavedPaymentMethod(),
+        shouldShowSetAsDefaultCheckbox = true,
+        isDefaultPaymentMethod = true,
+    ) {
+        interactor.state.test {
+            assertThat(awaitItem().isSaveButtonEnabled).isFalse()
+        }
+
+        interactor.handleViewAction(
+            UpdatePaymentMethodInteractor.ViewAction.BrandChoiceChanged(
+                cardBrandChoice = CardBrandChoice(brand = CardBrand.Visa, enabled = true)
+            )
+        )
+
+        interactor.state.test {
+            assertThat(awaitItem().isSaveButtonEnabled).isTrue()
+        }
+    }
+
+    @Test
     fun isDefaultPaymentMethod_setAsDefaultCheckboxChecked() = runScenario(
         displayableSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
         shouldShowSetAsDefaultCheckbox = true,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeUpdatePaymentMethodInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeUpdatePaymentMethodInteractor.kt
@@ -29,6 +29,7 @@ internal class FakeUpdatePaymentMethodInteractor(
         setAsDefaultCheckboxChecked = false,
         isSaveButtonEnabled = false,
     ),
+    override val setAsDefaultCheckboxEnabled: Boolean = true,
 ) : UpdatePaymentMethodInteractor {
     override val state: StateFlow<UpdatePaymentMethodInteractor.State> = MutableStateFlow(initialState)
     override val screenTitle: ResolvableString? = UpdatePaymentMethodInteractor.screenTitle(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreenUpdatePaymentMethodScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreenUpdatePaymentMethodScreenshotTest.kt
@@ -136,6 +136,7 @@ internal class PaymentSheetScreenUpdatePaymentMethodScreenshotTest {
             isExpiredCard = isExpiredCard,
             isModifiablePaymentMethod = isModifiablePaymentMethod,
             shouldShowSetAsDefaultCheckbox = shouldShowSetAsDefaultCheckbox,
+            setAsDefaultCheckboxEnabled = false,
             viewActionRecorder = null,
             initialState = UpdatePaymentMethodInteractor.State(
                 error = error?.resolvableString,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreenUpdatePaymentMethodScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreenUpdatePaymentMethodScreenshotTest.kt
@@ -136,7 +136,7 @@ internal class PaymentSheetScreenUpdatePaymentMethodScreenshotTest {
             isExpiredCard = isExpiredCard,
             isModifiablePaymentMethod = isModifiablePaymentMethod,
             shouldShowSetAsDefaultCheckbox = shouldShowSetAsDefaultCheckbox,
-            setAsDefaultCheckboxEnabled = false,
+            setAsDefaultCheckboxEnabled = true,
             viewActionRecorder = null,
             initialState = UpdatePaymentMethodInteractor.State(
                 error = error?.resolvableString,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUITest.kt
@@ -470,7 +470,45 @@ class UpdatePaymentMethodUITest {
             val setAsDefaultCheckbox = composeRule.onNodeWithTag(UPDATE_PM_SET_AS_DEFAULT_CHECKBOX_TEST_TAG)
 
             setAsDefaultCheckbox.assertExists()
+        }
+    }
+
+    @Test
+    fun `When set as default checkbox is checked, save button is visible and enabled`() {
+        runScenario(
+            shouldShowSetAsDefaultCheckbox = true,
+            setAsDefaultCheckboxChecked = true,
+        ) {
+            val saveButton = composeRule.onNodeWithTag(UPDATE_PM_SAVE_BUTTON_TEST_TAG)
+
+            saveButton.assertExists()
+            saveButton.assertIsEnabled()
+        }
+    }
+
+    @Test
+    fun `setAsDefaultCheckboxEnabled true -- set as default checkbox is enabled`() {
+        runScenario(
+            shouldShowSetAsDefaultCheckbox = true,
+            setAsDefaultCheckboxEnabled = true,
+        ) {
+            val setAsDefaultCheckbox = composeRule.onNodeWithTag(UPDATE_PM_SET_AS_DEFAULT_CHECKBOX_TEST_TAG)
+
+            setAsDefaultCheckbox.assertExists()
             setAsDefaultCheckbox.assertIsEnabled()
+        }
+    }
+
+    @Test
+    fun `setAsDefaultCheckboxEnabled false -- set as default checkbox is not enabled`() {
+        runScenario(
+            shouldShowSetAsDefaultCheckbox = true,
+            setAsDefaultCheckboxEnabled = false,
+        ) {
+            val setAsDefaultCheckbox = composeRule.onNodeWithTag(UPDATE_PM_SET_AS_DEFAULT_CHECKBOX_TEST_TAG)
+
+            setAsDefaultCheckbox.assertExists()
+            setAsDefaultCheckbox.assertIsNotEnabled()
         }
     }
 
@@ -513,6 +551,7 @@ class UpdatePaymentMethodUITest {
         isModifiablePaymentMethod: Boolean = true,
         hasValidBrandChoices: Boolean = true,
         setAsDefaultCheckboxChecked: Boolean = false,
+        setAsDefaultCheckboxEnabled: Boolean = true,
         cardBrandFilter: CardBrandFilter = DefaultCardBrandFilter,
         shouldShowSetAsDefaultCheckbox: Boolean = false,
         shouldShowSaveButton: Boolean = false,
@@ -530,6 +569,7 @@ class UpdatePaymentMethodUITest {
             hasValidBrandChoices = hasValidBrandChoices,
             shouldShowSetAsDefaultCheckbox = shouldShowSetAsDefaultCheckbox,
             shouldShowSaveButton = shouldShowSaveButton,
+            setAsDefaultCheckboxEnabled = setAsDefaultCheckboxEnabled,
             initialState = UpdatePaymentMethodInteractor.State(
                 error = errorMessage,
                 status = UpdatePaymentMethodInteractor.Status.Idle,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUITest.kt
@@ -475,19 +475,6 @@ class UpdatePaymentMethodUITest {
     }
 
     @Test
-    fun `When set as default checkbox is checked, save button is visible and enabled`() {
-        runScenario(
-            shouldShowSetAsDefaultCheckbox = true,
-            setAsDefaultCheckboxChecked = true,
-        ) {
-            val saveButton = composeRule.onNodeWithTag(UPDATE_PM_SAVE_BUTTON_TEST_TAG)
-
-            saveButton.assertExists()
-            saveButton.assertIsEnabled()
-        }
-    }
-
-    @Test
     fun `setAsDefaultCheckboxEnabled true -- set as default checkbox is enabled`() {
         runScenario(
             shouldShowSetAsDefaultCheckbox = true,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUITest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.assertAll
 import androidx.compose.ui.test.assertContentDescriptionEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.isEnabled


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Display set as default checkbox for default PM in disabled state

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Bug bash + quality review feedback was that we should show the checkbox for default PMs but in a disabled state

https://jira.corp.stripe.com/browse/MOBILESDK-3261

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified

# Screen recording
[set default checkbox disabled.webm](https://github.com/user-attachments/assets/2894d491-1106-41d9-b7c7-6475046231c8)
