### PR TITLE
Move save button state on update PM screen to interactor

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
@@ -30,6 +30,7 @@ internal interface UpdatePaymentMethodInteractor {
     val isModifiablePaymentMethod: Boolean
     val hasValidBrandChoices: Boolean
     val shouldShowSetAsDefaultCheckbox: Boolean
+    val shouldShowSaveButton: Boolean
 
     val state: StateFlow<State>
 
@@ -37,8 +38,8 @@ internal interface UpdatePaymentMethodInteractor {
         val error: ResolvableString?,
         val status: Status,
         val cardBrandChoice: CardBrandChoice,
-        val cardBrandHasBeenChanged: Boolean,
         val setAsDefaultCheckboxChecked: Boolean,
+        val isSaveButtonEnabled: Boolean,
     )
 
     enum class Status(val isPerformingNetworkOperation: Boolean) {
@@ -122,6 +123,8 @@ internal class DefaultUpdatePaymentMethodInteractor(
         editable = PaymentSheetTopBarState.Editable.Never,
     )
 
+    override val shouldShowSaveButton: Boolean = isModifiablePaymentMethod || shouldShowSetAsDefaultCheckbox
+
     private val _state = combineAsStateFlow(
         error,
         status,
@@ -129,12 +132,15 @@ internal class DefaultUpdatePaymentMethodInteractor(
         cardBrandHasBeenChanged,
         setAsDefaultCheckboxChecked,
     ) { error, status, cardBrandChoice, cardBrandHasBeenChanged, setAsDefaultCheckboxChecked ->
+        val isSaveButtonEnabled = (cardBrandHasBeenChanged || setAsDefaultCheckboxChecked) &&
+            status == UpdatePaymentMethodInteractor.Status.Idle
+
         UpdatePaymentMethodInteractor.State(
             error = error,
             status = status,
             cardBrandChoice = cardBrandChoice,
-            cardBrandHasBeenChanged = cardBrandHasBeenChanged,
             setAsDefaultCheckboxChecked = setAsDefaultCheckboxChecked,
+            isSaveButtonEnabled = isSaveButtonEnabled,
         )
     }
     override val state = _state

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
@@ -158,8 +158,7 @@ private fun SetAsDefaultPaymentMethodCheckbox(
 private fun UpdatePaymentMethodButtons(
     interactor: UpdatePaymentMethodInteractor,
 ) {
-    val shouldShowUpdatePaymentMethodUi =
-        interactor.isModifiablePaymentMethod || interactor.shouldShowSetAsDefaultCheckbox
+    val shouldShowUpdatePaymentMethodUi = interactor.shouldShowSaveButton
 
     if (shouldShowUpdatePaymentMethodUi) {
         Spacer(modifier = Modifier.requiredHeight(32.dp))
@@ -327,13 +326,16 @@ private fun UpdatePaymentMethodUi(interactor: UpdatePaymentMethodInteractor) {
     val state by interactor.state.collectAsState()
 
     val isLoading = state.status == UpdatePaymentMethodInteractor.Status.Updating
+    val isEnabled = state.isSaveButtonEnabled
+
     PrimaryButton(
         label = stringResource(id = PaymentSheetR.string.stripe_paymentsheet_save),
         isLoading = isLoading,
-        isEnabled = (state.cardBrandHasBeenChanged || state.setAsDefaultCheckboxChecked) &&
-            state.status == UpdatePaymentMethodInteractor.Status.Idle,
+        isEnabled = state.isSaveButtonEnabled,
         onButtonClick = { interactor.handleViewAction(UpdatePaymentMethodInteractor.ViewAction.SaveButtonPressed) },
-        modifier = Modifier.testTag(UPDATE_PM_SAVE_BUTTON_TEST_TAG).testMetadata("isLoading=$isLoading")
+        modifier = Modifier
+            .testTag(UPDATE_PM_SAVE_BUTTON_TEST_TAG)
+            .testMetadata("isLoading=$isLoading")
     )
 }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/InitialManageScreenFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/InitialManageScreenFactoryTest.kt
@@ -57,10 +57,11 @@ internal class InitialManageScreenFactoryTest {
                         error = null,
                         status = UpdatePaymentMethodInteractor.Status.Idle,
                         cardBrandChoice = CardBrandChoice(brand = CardBrand.Visa, enabled = true),
-                        cardBrandHasBeenChanged = false,
                         setAsDefaultCheckboxChecked = false,
+                        isSaveButtonEnabled = false,
                     ),
                     shouldShowSetAsDefaultCheckbox = false,
+                    shouldShowSaveButton = false,
                 )
             },
             manageInteractorFactory = {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultUpdatePaymentMethodInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultUpdatePaymentMethodInteractorTest.kt
@@ -186,7 +186,7 @@ class DefaultUpdatePaymentMethodInteractorTest {
                 )
             )
             interactor.state.test {
-                assertThat(awaitItem().cardBrandHasBeenChanged).isTrue()
+                assertThat(awaitItem().isSaveButtonEnabled).isTrue()
             }
 
             interactor.handleViewAction(UpdatePaymentMethodInteractor.ViewAction.SaveButtonPressed)
@@ -223,7 +223,7 @@ class DefaultUpdatePaymentMethodInteractorTest {
                 )
             )
             interactor.state.test {
-                assertThat(awaitItem().cardBrandHasBeenChanged).isTrue()
+                assertThat(awaitItem().isSaveButtonEnabled).isTrue()
             }
 
             interactor.handleViewAction(UpdatePaymentMethodInteractor.ViewAction.SaveButtonPressed)
@@ -233,7 +233,7 @@ class DefaultUpdatePaymentMethodInteractorTest {
             // We reset the cardBrandHasBeenChanged value when saving a new card brand, so that a user could change
             // their card brand back to the original value if they wanted to.
             interactor.state.test {
-                assertThat(awaitItem().cardBrandHasBeenChanged).isFalse()
+                assertThat(awaitItem().isSaveButtonEnabled).isFalse()
             }
 
             // Re-clicking on the already saved card brand doesn't update cardBrandHasBeenChanged incorectly.
@@ -243,7 +243,7 @@ class DefaultUpdatePaymentMethodInteractorTest {
                 )
             )
             interactor.state.test {
-                assertThat(awaitItem().cardBrandHasBeenChanged).isFalse()
+                assertThat(awaitItem().isSaveButtonEnabled).isFalse()
             }
         }
     }
@@ -297,8 +297,8 @@ class DefaultUpdatePaymentMethodInteractorTest {
 
             interactor.state.test {
                 val state = awaitItem()
-                // Card brand has been changed is still true -- the user could try again.
-                assertThat(state.cardBrandHasBeenChanged).isTrue()
+                // Save button is still enabled -- the user could try again.
+                assertThat(state.isSaveButtonEnabled).isTrue()
                 assertThat(state.error).isEqualTo(updateCardBrandErrorMessage)
             }
         }
@@ -347,6 +347,7 @@ class DefaultUpdatePaymentMethodInteractorTest {
 
         interactor.state.test {
             assertThat(awaitItem().setAsDefaultCheckboxChecked).isEqualTo(expectedUpdatedCheckedValue)
+            assertThat(awaitItem().isSaveButtonEnabled).isTrue()
         }
     }
 
@@ -485,6 +486,41 @@ class DefaultUpdatePaymentMethodInteractorTest {
                 assertThat(awaitItem().error).isEqualTo(updatesFailedErrorMessage)
             }
         }
+    }
+
+    @Test
+    fun shouldShowSaveButton_whenCardIsModifiable() = runScenario(
+        displayableSavedPaymentMethod = PaymentMethodFixtures
+            .CARD_WITH_NETWORKS_PAYMENT_METHOD
+            .toDisplayableSavedPaymentMethod(),
+    ) {
+        assertThat(interactor.shouldShowSaveButton).isTrue()
+    }
+
+    @Test
+    fun shouldShowSaveButton_whenSetAsDefaultCheckboxShown() = runScenario(
+        displayableSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
+        shouldShowSetAsDefaultCheckbox = true,
+    ) {
+        assertThat(interactor.shouldShowSaveButton).isTrue()
+    }
+
+    @Test
+    fun shouldShowSaveButton_whenCardIsModifiable_andSetAsDefaultCheckboxShown() = runScenario(
+        displayableSavedPaymentMethod = PaymentMethodFixtures
+            .CARD_WITH_NETWORKS_PAYMENT_METHOD
+            .toDisplayableSavedPaymentMethod(),
+        shouldShowSetAsDefaultCheckbox = true,
+    ) {
+        assertThat(interactor.shouldShowSaveButton).isTrue()
+    }
+
+    @Test
+    fun shouldNotShowSaveButton_whenNothingIsChangeable() = runScenario(
+        displayableSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
+        shouldShowSetAsDefaultCheckbox = false,
+    ) {
+        assertThat(interactor.shouldShowSaveButton).isFalse()
     }
 
     private fun updateCardBrandAndDefaultPaymentMethod(interactor: UpdatePaymentMethodInteractor) {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeUpdatePaymentMethodInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeUpdatePaymentMethodInteractor.kt
@@ -16,6 +16,7 @@ internal class FakeUpdatePaymentMethodInteractor(
     override val hasValidBrandChoices: Boolean = true,
     override val cardBrandFilter: CardBrandFilter = DefaultCardBrandFilter,
     override val shouldShowSetAsDefaultCheckbox: Boolean,
+    override val shouldShowSaveButton: Boolean,
     val viewActionRecorder: ViewActionRecorder<UpdatePaymentMethodInteractor.ViewAction>?,
     initialState: UpdatePaymentMethodInteractor.State,
 ) : UpdatePaymentMethodInteractor {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreenUpdatePaymentMethodScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreenUpdatePaymentMethodScreenshotTest.kt
@@ -141,9 +141,10 @@ internal class PaymentSheetScreenUpdatePaymentMethodScreenshotTest {
                 error = error?.resolvableString,
                 status = UpdatePaymentMethodInteractor.Status.Idle,
                 cardBrandChoice = CardBrandChoice(brand = initialCardBrand, enabled = true),
-                cardBrandHasBeenChanged = false,
                 setAsDefaultCheckboxChecked = false,
+                isSaveButtonEnabled = false,
             ),
+            shouldShowSaveButton = isModifiablePaymentMethod || shouldShowSetAsDefaultCheckbox,
         )
         val screen = com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.UpdatePaymentMethod(interactor)
         val metadata = PaymentMethodMetadataFactory.create()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUITest.kt
@@ -3,13 +3,16 @@ package com.stripe.android.paymentsheet.ui
 import android.os.Build
 import android.os.Parcel
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertAll
 import androidx.compose.ui.test.assertContentDescriptionEquals
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
-import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.isEnabled
+import androidx.compose.ui.test.isNotEnabled
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.onChild
+import androidx.compose.ui.test.onChildren
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import com.google.common.truth.Truth.assertThat
@@ -183,40 +186,35 @@ class UpdatePaymentMethodUITest {
     }
 
     @Test
-    fun isModifiablePMIsTrue_saveButtonHidden() = runScenario(
-        isModifiablePaymentMethod = true,
+    fun shouldShowSaveButton_saveButtonIsDisplayed() = runScenario(
+        shouldShowSaveButton = true,
     ) {
-        composeRule.onNodeWithTag(UPDATE_PM_SAVE_BUTTON_TEST_TAG).assertExists()
+        composeRule.onNodeWithTag(UPDATE_PM_SAVE_BUTTON_TEST_TAG).assertIsDisplayed()
     }
 
     @Test
-    fun cardBrandHasNotBeenChanged_saveButtonNotEnabled() = runScenario(
-        isModifiablePaymentMethod = true,
-        cardBrandHasBeenChanged = false,
+    fun shouldNotShowSaveButton_saveButtonIsHidden() = runScenario(
+        shouldShowSaveButton = false,
     ) {
-        // The actual button is a child of the composable used for this button.
-        composeRule.onNodeWithTag(UPDATE_PM_SAVE_BUTTON_TEST_TAG).onChild().assertIsNotEnabled()
+        composeRule.onNodeWithTag(UPDATE_PM_SAVE_BUTTON_TEST_TAG).assertDoesNotExist()
     }
 
     @Test
-    fun cardBrandHasBeenChanged_saveButtonEnabled() = runScenario(
-        isModifiablePaymentMethod = true,
-        cardBrandHasBeenChanged = true,
+    fun isSaveButtonEnabled_saveButtonIsEnabled() = runScenario(
+        shouldShowSaveButton = true,
+        isSaveButtonEnabled = true,
     ) {
-        // The actual button is a child of the composable used for this button.
-        composeRule.onNodeWithTag(UPDATE_PM_SAVE_BUTTON_TEST_TAG).onChild().assertIsEnabled()
+        composeRule.onNodeWithTag(UPDATE_PM_SAVE_BUTTON_TEST_TAG).assertIsDisplayed()
+        composeRule.onNodeWithTag(UPDATE_PM_SAVE_BUTTON_TEST_TAG).onChildren().assertAll(isEnabled())
     }
 
     @Test
-    fun clickingSaveButton_sendsSaveButtonPressedAction() = runScenario(
-        isModifiablePaymentMethod = true,
-        cardBrandHasBeenChanged = true,
+    fun isSaveButtonEnabledIsFalse_saveButtonIsNotEnabled() = runScenario(
+        shouldShowSaveButton = true,
+        isSaveButtonEnabled = false,
     ) {
-        assertThat(viewActionRecorder.viewActions).isEmpty()
-        composeRule.onNodeWithTag(UPDATE_PM_SAVE_BUTTON_TEST_TAG).performClick()
-
-        viewActionRecorder.consume(UpdatePaymentMethodInteractor.ViewAction.SaveButtonPressed)
-        assertThat(viewActionRecorder.viewActions).isEmpty()
+        composeRule.onNodeWithTag(UPDATE_PM_SAVE_BUTTON_TEST_TAG).assertIsDisplayed()
+        composeRule.onNodeWithTag(UPDATE_PM_SAVE_BUTTON_TEST_TAG).onChildren().assertAll(isNotEnabled())
     }
 
     @Test
@@ -477,19 +475,6 @@ class UpdatePaymentMethodUITest {
     }
 
     @Test
-    fun `When set as default checkbox is checked, save button is visible and enabled`() {
-        runScenario(
-            shouldShowSetAsDefaultCheckbox = true,
-            setAsDefaultCheckboxChecked = true,
-        ) {
-            val setAsDefaultCheckbox = composeRule.onNodeWithTag(UPDATE_PM_SAVE_BUTTON_TEST_TAG)
-
-            setAsDefaultCheckbox.assertExists()
-            setAsDefaultCheckbox.assertIsEnabled()
-        }
-    }
-
-    @Test
     fun `Clicking set as default checkbox sends SetDefaultCheckboxChanged view action`() {
         val initialCheckedValue = false
         runScenario(
@@ -524,13 +509,14 @@ class UpdatePaymentMethodUITest {
         isExpiredCard: Boolean = false,
         errorMessage: ResolvableString? = null,
         initialCardBrand: CardBrand = CardBrand.Unknown,
-        cardBrandHasBeenChanged: Boolean = false,
         canRemove: Boolean = true,
         isModifiablePaymentMethod: Boolean = true,
         hasValidBrandChoices: Boolean = true,
         setAsDefaultCheckboxChecked: Boolean = false,
         cardBrandFilter: CardBrandFilter = DefaultCardBrandFilter,
         shouldShowSetAsDefaultCheckbox: Boolean = false,
+        shouldShowSaveButton: Boolean = false,
+        isSaveButtonEnabled: Boolean = false,
         testBlock: Scenario.() -> Unit,
     ) {
         val viewActionRecorder = ViewActionRecorder<UpdatePaymentMethodInteractor.ViewAction>()
@@ -543,12 +529,13 @@ class UpdatePaymentMethodUITest {
             viewActionRecorder = viewActionRecorder,
             hasValidBrandChoices = hasValidBrandChoices,
             shouldShowSetAsDefaultCheckbox = shouldShowSetAsDefaultCheckbox,
+            shouldShowSaveButton = shouldShowSaveButton,
             initialState = UpdatePaymentMethodInteractor.State(
                 error = errorMessage,
                 status = UpdatePaymentMethodInteractor.Status.Idle,
                 cardBrandChoice = CardBrandChoice(brand = initialCardBrand, enabled = true),
-                cardBrandHasBeenChanged = cardBrandHasBeenChanged,
                 setAsDefaultCheckboxChecked = setAsDefaultCheckboxChecked,
+                isSaveButtonEnabled = isSaveButtonEnabled,
             ),
         )
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Move save button state on update PM screen to interactor

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
This logic is complex enough that it should live in the interactor -- and I'm about to make it even more complex in a follow up PR! So refactoring ahead of that change

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [ ] Manually verified
