### PR TITLE
[connect-example] Fix Settings accounts sometimes not populating

### DIFF
--- a/connect-example/src/androidTest/java/com/stripe/android/connect/example/BaseConnectTest.kt
+++ b/connect-example/src/androidTest/java/com/stripe/android/connect/example/BaseConnectTest.kt
@@ -15,6 +15,10 @@ import org.junit.Before
 import org.junit.Rule
 import javax.inject.Inject
 
+/**
+ * Base class for Connect SDK instrumentation tests. Provides common setup and helper methods,
+ * including a screen DSL for writing tests in a more readable way.
+ */
 abstract class BaseConnectTest {
 
     @get:Rule(order = 0)
@@ -36,17 +40,17 @@ abstract class BaseConnectTest {
         embeddedComponentService.accounts.value = Success(merchants)
     }
 
-    protected inner class MainContext {
+    protected inner class MainScreen {
         val titleText get() = composeTestRule.onNodeWithTextRes(R.string.connect_sdk_example)
         val loadingText get() = composeTestRule.onNodeWithTextRes(R.string.warming_up_the_server)
     }
 
     @Suppress("TestFunctionName")
-    protected fun Main(f: MainContext.() -> Unit) {
-        MainContext().apply(f)
+    protected fun Main(f: MainScreen.() -> Unit) {
+        MainScreen().apply(f)
     }
 
-    protected inner class ComponentListContext {
+    protected inner class ComponentListScreen {
         val accountOnboardingItem get() = composeTestRule.onNodeWithTextRes(R.string.account_onboarding)
 
         fun openSettings() {
@@ -55,20 +59,20 @@ abstract class BaseConnectTest {
     }
 
     @Suppress("TestFunctionName")
-    protected fun ComponentList(f: ComponentListContext.() -> Unit) {
-        ComponentListContext().apply(f)
+    protected fun ComponentList(f: ComponentListScreen.() -> Unit) {
+        ComponentListScreen().apply(f)
     }
 
-    protected inner class SettingsContext {
+    protected inner class SettingsScreen {
         val demoAccountHeader get() = composeTestRule.onNodeWithTextRes(R.string.select_demo_account)
 
-        fun hasAccount(id: String) {
+        fun assertHasAccount(id: String) {
             composeTestRule.onNodeWithText(id).assertIsDisplayed()
         }
     }
 
     @Suppress("TestFunctionName")
-    protected fun Settings(f: SettingsContext.() -> Unit) {
-        SettingsContext().apply(f)
+    protected fun Settings(f: SettingsScreen.() -> Unit) {
+        SettingsScreen().apply(f)
     }
 }

--- a/connect-example/src/androidTest/java/com/stripe/android/connect/example/BaseConnectTest.kt
+++ b/connect-example/src/androidTest/java/com/stripe/android/connect/example/BaseConnectTest.kt
@@ -7,16 +7,15 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.stripe.android.connect.example.core.Success
 import com.stripe.android.connect.example.data.FakeEmbeddedComponentService
+import com.stripe.android.connect.example.data.Merchant
 import com.stripe.android.connect.example.util.Fixtures
 import com.stripe.android.connect.example.util.onNodeWithTextRes
 import dagger.hilt.android.testing.HiltAndroidRule
-import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Before
 import org.junit.Rule
 import javax.inject.Inject
 
-@HiltAndroidTest
-abstract class ConnectTest {
+abstract class BaseConnectTest {
 
     @get:Rule(order = 0)
     val hiltRule by lazy { HiltAndroidRule(this) }
@@ -32,21 +31,22 @@ abstract class ConnectTest {
         hiltRule.inject()
     }
 
-    protected fun loadData() {
+    protected fun loadData(merchants: List<Merchant> = listOf(Fixtures.merchant())) {
         embeddedComponentService.publishableKey.value = "fake_key"
-        embeddedComponentService.accounts.value = Success(listOf(Fixtures.merchant()))
+        embeddedComponentService.accounts.value = Success(merchants)
     }
 
-    inner class MainContext {
+    protected inner class MainContext {
         val titleText get() = composeTestRule.onNodeWithTextRes(R.string.connect_sdk_example)
         val loadingText get() = composeTestRule.onNodeWithTextRes(R.string.warming_up_the_server)
     }
 
+    @Suppress("TestFunctionName")
     protected fun Main(f: MainContext.() -> Unit) {
         MainContext().apply(f)
     }
 
-    inner class ComponentListContext {
+    protected inner class ComponentListContext {
         val accountOnboardingItem get() = composeTestRule.onNodeWithTextRes(R.string.account_onboarding)
 
         fun openSettings() {
@@ -54,11 +54,12 @@ abstract class ConnectTest {
         }
     }
 
+    @Suppress("TestFunctionName")
     protected fun ComponentList(f: ComponentListContext.() -> Unit) {
         ComponentListContext().apply(f)
     }
 
-    inner class SettingsContext {
+    protected inner class SettingsContext {
         val demoAccountHeader get() = composeTestRule.onNodeWithTextRes(R.string.select_demo_account)
 
         fun hasAccount(id: String) {
@@ -66,6 +67,7 @@ abstract class ConnectTest {
         }
     }
 
+    @Suppress("TestFunctionName")
     protected fun Settings(f: SettingsContext.() -> Unit) {
         SettingsContext().apply(f)
     }

--- a/connect-example/src/androidTest/java/com/stripe/android/connect/example/ConnectTest.kt
+++ b/connect-example/src/androidTest/java/com/stripe/android/connect/example/ConnectTest.kt
@@ -1,0 +1,72 @@
+package com.stripe.android.connect.example
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.stripe.android.connect.example.core.Success
+import com.stripe.android.connect.example.data.FakeEmbeddedComponentService
+import com.stripe.android.connect.example.util.Fixtures
+import com.stripe.android.connect.example.util.onNodeWithTextRes
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Before
+import org.junit.Rule
+import javax.inject.Inject
+
+@HiltAndroidTest
+abstract class ConnectTest {
+
+    @get:Rule(order = 0)
+    val hiltRule by lazy { HiltAndroidRule(this) }
+
+    @get:Rule(order = 1)
+    val composeTestRule by lazy { createAndroidComposeRule<MainActivity>() }
+
+    @Inject
+    lateinit var embeddedComponentService: FakeEmbeddedComponentService
+
+    @Before
+    fun init() {
+        hiltRule.inject()
+    }
+
+    protected fun loadData() {
+        embeddedComponentService.publishableKey.value = "fake_key"
+        embeddedComponentService.accounts.value = Success(listOf(Fixtures.merchant()))
+    }
+
+    inner class MainContext {
+        val titleText get() = composeTestRule.onNodeWithTextRes(R.string.connect_sdk_example)
+        val loadingText get() = composeTestRule.onNodeWithTextRes(R.string.warming_up_the_server)
+    }
+
+    protected fun Main(f: MainContext.() -> Unit) {
+        MainContext().apply(f)
+    }
+
+    inner class ComponentListContext {
+        val accountOnboardingItem get() = composeTestRule.onNodeWithTextRes(R.string.account_onboarding)
+
+        fun openSettings() {
+            composeTestRule.onNodeWithContentDescription("Settings").performClick()
+        }
+    }
+
+    protected fun ComponentList(f: ComponentListContext.() -> Unit) {
+        ComponentListContext().apply(f)
+    }
+
+    inner class SettingsContext {
+        val demoAccountHeader get() = composeTestRule.onNodeWithTextRes(R.string.select_demo_account)
+
+        fun hasAccount(id: String) {
+            composeTestRule.onNodeWithText(id).assertIsDisplayed()
+        }
+    }
+
+    protected fun Settings(f: SettingsContext.() -> Unit) {
+        SettingsContext().apply(f)
+    }
+}

--- a/connect-example/src/androidTest/java/com/stripe/android/connect/example/SettingsTest.kt
+++ b/connect-example/src/androidTest/java/com/stripe/android/connect/example/SettingsTest.kt
@@ -6,16 +6,34 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Test
 
 @HiltAndroidTest
-class SettingsTest : ConnectTest() {
+class SettingsTest : BaseConnectTest() {
     @Test
-    fun testSettingsOpensWithAccountsLoaded() {
+    fun testSettingsOpens() {
         loadData()
+        navigateToSettings()
+    }
+
+    @Test
+    fun testAccountsListUpdatesOnDataChanges() {
+        val merchants = listOf(
+            Fixtures.merchant(merchantId = "acct_123"),
+            Fixtures.merchant(merchantId = "acct_456"),
+        )
+        loadData(merchants.subList(0, 1))
+        navigateToSettings()
+        Settings {
+            hasAccount(merchants[0].merchantId)
+            loadData(merchants)
+            hasAccount(merchants[1].merchantId)
+        }
+    }
+
+    private fun navigateToSettings() {
         ComponentList {
             openSettings()
         }
         Settings {
             demoAccountHeader.assertIsDisplayed()
-            hasAccount(Fixtures.merchant().merchantId)
         }
     }
 }

--- a/connect-example/src/androidTest/java/com/stripe/android/connect/example/SettingsTest.kt
+++ b/connect-example/src/androidTest/java/com/stripe/android/connect/example/SettingsTest.kt
@@ -22,9 +22,9 @@ class SettingsTest : BaseConnectTest() {
         loadData(merchants.subList(0, 1))
         navigateToSettings()
         Settings {
-            hasAccount(merchants[0].merchantId)
+            assertHasAccount(merchants[0].merchantId)
             loadData(merchants)
-            hasAccount(merchants[1].merchantId)
+            assertHasAccount(merchants[1].merchantId)
         }
     }
 

--- a/connect-example/src/androidTest/java/com/stripe/android/connect/example/SettingsTest.kt
+++ b/connect-example/src/androidTest/java/com/stripe/android/connect/example/SettingsTest.kt
@@ -1,0 +1,21 @@
+package com.stripe.android.connect.example
+
+import androidx.compose.ui.test.assertIsDisplayed
+import com.stripe.android.connect.example.util.Fixtures
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Test
+
+@HiltAndroidTest
+class SettingsTest : ConnectTest() {
+    @Test
+    fun testSettingsOpensWithAccountsLoaded() {
+        loadData()
+        ComponentList {
+            openSettings()
+        }
+        Settings {
+            demoAccountHeader.assertIsDisplayed()
+            hasAccount(Fixtures.merchant().merchantId)
+        }
+    }
+}

--- a/connect-example/src/androidTest/java/com/stripe/android/connect/example/SmokeTest.kt
+++ b/connect-example/src/androidTest/java/com/stripe/android/connect/example/SmokeTest.kt
@@ -1,48 +1,26 @@
 package com.stripe.android.connect.example
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.isDisplayed
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import com.stripe.android.connect.example.data.FakeEmbeddedComponentService
-import com.stripe.android.connect.example.util.Fixtures
-import com.stripe.android.connect.example.util.onNodeWithTextRes
-import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
-import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 import javax.inject.Inject
 
 @HiltAndroidTest
-class SmokeTest {
-
-    @get:Rule(order = 0)
-    val hiltRule = HiltAndroidRule(this)
-
-    @get:Rule(order = 1)
-    val composeTestRule = createAndroidComposeRule<MainActivity>()
-
-    @Inject
-    lateinit var embeddedComponentService: FakeEmbeddedComponentService
-
-    @Before
-    fun init() {
-        hiltRule.inject()
-    }
-
+class SmokeTest : ConnectTest() {
     @Test
     fun testAppOpensToLoading() {
-        composeTestRule.onNodeWithTextRes(R.string.connect_sdk_example).assertIsDisplayed()
-        composeTestRule.onNodeWithTextRes(R.string.warming_up_the_server).assertIsDisplayed()
+        Main {
+            titleText.assertIsDisplayed()
+            loadingText.assertIsDisplayed()
+        }
     }
 
     @Test
     fun testOpenComponentListWhenDataLoads() {
-        embeddedComponentService.publishableKey.value = "fake_key"
-        embeddedComponentService.accounts.value = listOf(Fixtures.merchant())
-
-        composeTestRule.waitUntil(timeoutMillis = 5_000L) {
-            composeTestRule.onNodeWithTextRes(R.string.account_onboarding).isDisplayed()
+        loadData()
+        ComponentList {
+            accountOnboardingItem.assertIsDisplayed()
         }
     }
 }

--- a/connect-example/src/androidTest/java/com/stripe/android/connect/example/SmokeTest.kt
+++ b/connect-example/src/androidTest/java/com/stripe/android/connect/example/SmokeTest.kt
@@ -1,13 +1,11 @@
 package com.stripe.android.connect.example
 
 import androidx.compose.ui.test.assertIsDisplayed
-import com.stripe.android.connect.example.data.FakeEmbeddedComponentService
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Test
-import javax.inject.Inject
 
 @HiltAndroidTest
-class SmokeTest : ConnectTest() {
+class SmokeTest : BaseConnectTest() {
     @Test
     fun testAppOpensToLoading() {
         Main {

--- a/connect-example/src/main/java/com/stripe/android/connect/example/core/Async.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/core/Async.kt
@@ -21,7 +21,7 @@ data object Uninitialized : Async<Nothing>(complete = false, shouldLoad = true, 
 
 data class Loading<out T>(private val value: T? = null) : Async<T>(complete = false, shouldLoad = false, value = value)
 
-data class Success<out T>(private val value: T) : Async<T>(complete = true, shouldLoad = false, value = value)
+data class Success<out T>(val value: T) : Async<T>(complete = true, shouldLoad = false, value = value)
 
 data class Fail<out T>(
     val error: Throwable,

--- a/connect-example/src/main/java/com/stripe/android/connect/example/data/EmbeddedComponentService.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/data/EmbeddedComponentService.kt
@@ -7,12 +7,12 @@ import com.github.kittinunf.fuel.core.Request
 import com.github.kittinunf.fuel.core.Response
 import com.github.kittinunf.fuel.core.awaitResult
 import com.github.kittinunf.result.Result
-import com.stripe.android.connect.example.data.EmbeddedComponentService.Companion.DEFAULT_SERVER_BASE_URL
 import com.stripe.android.connect.example.core.Async
 import com.stripe.android.connect.example.core.Fail
 import com.stripe.android.connect.example.core.Loading
 import com.stripe.android.connect.example.core.Success
 import com.stripe.android.connect.example.core.Uninitialized
+import com.stripe.android.connect.example.data.EmbeddedComponentService.Companion.DEFAULT_SERVER_BASE_URL
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainer.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainer.kt
@@ -256,7 +256,7 @@ internal class StripeConnectWebViewContainerImpl<Listener, Props>(
 
     internal fun setPropsFromXml(props: Props) {
         // Only set props if uninitialized.
-        if (viewModel == null) {
+        if (this.embeddedComponentManager == null) {
             this.propsJson = props.toJsonObject()
         }
     }


### PR DESCRIPTION
# Summary
Fixes a bug where the list of accounts in Settings is not populated caused by a race condition in `SettingsViewModel`.

# Motivation
https://jira.corp.stripe.com/browse/CAX-3803
https://jira.corp.stripe.com/browse/CAX-3890

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots

## Before

https://github.com/user-attachments/assets/a1c72e07-6271-4fd6-85ef-d5bd5cd62ad4

## After

https://github.com/user-attachments/assets/27d29f0a-7164-4d9a-81d3-1a234f7cd356
