### PR TITLE
SetAsDefaultPaymentMethodEnabled for USBankAccount

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -838,7 +838,7 @@ internal class CustomerSheetViewModel(
             onError = { error ->
                 handleViewAction(CustomerSheetViewAction.OnFormError(error))
             },
-            setAsDefaultEnabled = false,
+            setAsDefaultPaymentMethodEnabled = false,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -838,7 +838,7 @@ internal class CustomerSheetViewModel(
             onError = { error ->
                 handleViewAction(CustomerSheetViewAction.OnFormError(error))
             },
-            shouldShowSetAsDefaultCheckbox = false,
+            setAsDefaultEnabled = false,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountForm.kt
@@ -88,7 +88,7 @@ internal fun USBankAccountForm(
                 onBehalfOf = usBankAccountFormArgs.onBehalfOf,
                 savedPaymentMethod = usBankAccountFormArgs.draftPaymentSelection as? New.USBankAccount,
                 shippingDetails = usBankAccountFormArgs.shippingDetails,
-                setAsDefaultEnabled = usBankAccountFormArgs.setAsDefaultEnabled
+                setAsDefaultPaymentMethodEnabled = usBankAccountFormArgs.setAsDefaultPaymentMethodEnabled
             )
         },
     )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountForm.kt
@@ -88,7 +88,7 @@ internal fun USBankAccountForm(
                 onBehalfOf = usBankAccountFormArgs.onBehalfOf,
                 savedPaymentMethod = usBankAccountFormArgs.draftPaymentSelection as? New.USBankAccount,
                 shippingDetails = usBankAccountFormArgs.shippingDetails,
-                shouldShowSetAsDefaultCheckbox = usBankAccountFormArgs.shouldShowSetAsDefaultCheckbox
+                setAsDefaultEnabled = usBankAccountFormArgs.setAsDefaultEnabled
             )
         },
     )
@@ -136,7 +136,7 @@ internal fun BankAccountForm(
     lastTextFieldIdentifier: IdentifierSpec?,
     sameAsShippingElement: SameAsShippingElement?,
     saveForFutureUseElement: SaveForFutureUseElement,
-    setAsDefaultPaymentMethodElement: SetAsDefaultPaymentMethodElement,
+    setAsDefaultPaymentMethodElement: SetAsDefaultPaymentMethodElement?,
     modifier: Modifier = Modifier,
     enabled: Boolean,
     onRemoveAccount: () -> Unit,
@@ -378,7 +378,7 @@ private fun AccountDetailsForm(
     last4: String?,
     promoBadgeState: PromoBadgeState?,
     saveForFutureUseElement: SaveForFutureUseElement,
-    setAsDefaultPaymentMethodElement: SetAsDefaultPaymentMethodElement,
+    setAsDefaultPaymentMethodElement: SetAsDefaultPaymentMethodElement?,
     onRemoveAccount: () -> Unit,
 ) {
     var openDialog by rememberSaveable { mutableStateOf(false) }
@@ -409,11 +409,13 @@ private fun AccountDetailsForm(
                 modifier = Modifier.padding(top = 8.dp)
             )
 
-            SetAsDefaultPaymentMethodElementUI(
-                enabled = true,
-                element = setAsDefaultPaymentMethodElement,
-                modifier = Modifier.padding(top = 8.dp),
-            )
+            setAsDefaultPaymentMethodElement?.let {
+                SetAsDefaultPaymentMethodElementUI(
+                    enabled = true,
+                    element = it,
+                    modifier = Modifier.padding(top = 8.dp),
+                )
+            }
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArguments.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArguments.kt
@@ -59,7 +59,7 @@ internal class USBankAccountFormArguments(
     val onUpdatePrimaryButtonUIState: ((PrimaryButton.UIState?) -> (PrimaryButton.UIState?)) -> Unit,
     val onUpdatePrimaryButtonState: (PrimaryButton.State) -> Unit,
     val onError: (ResolvableString?) -> Unit,
-    val setAsDefaultEnabled: Boolean
+    val setAsDefaultPaymentMethodEnabled: Boolean
 ) {
     companion object {
         fun create(
@@ -103,7 +103,7 @@ internal class USBankAccountFormArguments(
                 onUpdatePrimaryButtonState = viewModel::updatePrimaryButtonState,
                 onError = viewModel::onError,
                 incentive = paymentMethodMetadata.paymentMethodIncentive,
-                setAsDefaultEnabled =
+                setAsDefaultPaymentMethodEnabled =
                 paymentMethodMetadata.customerMetadata?.isPaymentMethodSetAsDefaultEnabled
                     ?: IS_PAYMENT_METHOD_SET_AS_DEFAULT_ENABLED_DEFAULT_VALUE,
             )
@@ -150,7 +150,7 @@ internal class USBankAccountFormArguments(
                 },
                 onError = onError,
                 incentive = paymentMethodMetadata.paymentMethodIncentive,
-                setAsDefaultEnabled =
+                setAsDefaultPaymentMethodEnabled =
                 paymentMethodMetadata.customerMetadata?.isPaymentMethodSetAsDefaultEnabled
                     ?: IS_PAYMENT_METHOD_SET_AS_DEFAULT_ENABLED_DEFAULT_VALUE,
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArguments.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArguments.kt
@@ -59,7 +59,7 @@ internal class USBankAccountFormArguments(
     val onUpdatePrimaryButtonUIState: ((PrimaryButton.UIState?) -> (PrimaryButton.UIState?)) -> Unit,
     val onUpdatePrimaryButtonState: (PrimaryButton.State) -> Unit,
     val onError: (ResolvableString?) -> Unit,
-    val shouldShowSetAsDefaultCheckbox: Boolean
+    val setAsDefaultEnabled: Boolean
 ) {
     companion object {
         fun create(
@@ -103,7 +103,7 @@ internal class USBankAccountFormArguments(
                 onUpdatePrimaryButtonState = viewModel::updatePrimaryButtonState,
                 onError = viewModel::onError,
                 incentive = paymentMethodMetadata.paymentMethodIncentive,
-                shouldShowSetAsDefaultCheckbox =
+                setAsDefaultEnabled =
                 paymentMethodMetadata.customerMetadata?.isPaymentMethodSetAsDefaultEnabled
                     ?: IS_PAYMENT_METHOD_SET_AS_DEFAULT_ENABLED_DEFAULT_VALUE,
             )
@@ -150,7 +150,7 @@ internal class USBankAccountFormArguments(
                 },
                 onError = onError,
                 incentive = paymentMethodMetadata.paymentMethodIncentive,
-                shouldShowSetAsDefaultCheckbox =
+                setAsDefaultEnabled =
                 paymentMethodMetadata.customerMetadata?.isPaymentMethodSetAsDefaultEnabled
                     ?: IS_PAYMENT_METHOD_SET_AS_DEFAULT_ENABLED_DEFAULT_VALUE,
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -201,7 +201,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
     val saveForFutureUseCheckedFlow: StateFlow<Boolean> = saveForFutureUseElement.controller.saveForFutureUse
 
     val setAsDefaultPaymentMethodElement: SetAsDefaultPaymentMethodElement? =
-        if (args.setAsDefaultEnabled) {
+        if (args.setAsDefaultPaymentMethodEnabled) {
             SetAsDefaultPaymentMethodElement(
                 initialValue = false,
                 saveForFutureUseCheckedFlow = saveForFutureUseCheckedFlow
@@ -741,7 +741,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
         val savedPaymentMethod: PaymentSelection.New.USBankAccount?,
         val shippingDetails: AddressDetails?,
         val hostedSurface: String,
-        val setAsDefaultEnabled: Boolean,
+        val setAsDefaultPaymentMethodEnabled: Boolean,
     )
 
     private companion object {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -200,15 +200,11 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
 
     val saveForFutureUseCheckedFlow: StateFlow<Boolean> = saveForFutureUseElement.controller.saveForFutureUse
 
-    private val shouldShowElementFlow = saveForFutureUseCheckedFlow.mapAsStateFlow {
-        it && args.setAsDefaultEnabled
-    }
-
     val setAsDefaultPaymentMethodElement: SetAsDefaultPaymentMethodElement? =
         if (args.setAsDefaultEnabled) {
             SetAsDefaultPaymentMethodElement(
                 initialValue = false,
-                saveForFutureUseCheckedFlow = shouldShowElementFlow
+                saveForFutureUseCheckedFlow = saveForFutureUseCheckedFlow
             )
         } else {
             null

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -75,7 +75,7 @@ internal class CustomerSheetScreenshotTest {
         onUpdatePrimaryButtonState = { },
         onUpdatePrimaryButtonUIState = { },
         onError = { },
-        setAsDefaultEnabled = false
+        setAsDefaultPaymentMethodEnabled = false
     )
 
     private val selectPaymentMethodViewState = CustomerSheetViewState.SelectPaymentMethod(

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -75,7 +75,7 @@ internal class CustomerSheetScreenshotTest {
         onUpdatePrimaryButtonState = { },
         onUpdatePrimaryButtonUIState = { },
         onError = { },
-        shouldShowSetAsDefaultCheckbox = false
+        setAsDefaultEnabled = false
     )
 
     private val selectPaymentMethodViewState = CustomerSheetViewState.SelectPaymentMethod(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
@@ -10,6 +10,7 @@ import com.stripe.android.financialconnections.FinancialConnectionsSheet.Element
 import com.stripe.android.financialconnections.model.BankAccount
 import com.stripe.android.financialconnections.model.FinancialConnectionsAccount
 import com.stripe.android.financialconnections.model.FinancialConnectionsSession
+import com.stripe.android.lpmfoundations.paymentmethod.IS_PAYMENT_METHOD_SET_AS_DEFAULT_ENABLED_DEFAULT_VALUE
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.model.Address
 import com.stripe.android.model.ConfirmPaymentIntentParams
@@ -75,7 +76,7 @@ class USBankAccountFormViewModelTest {
         shippingDetails = null,
         hostedSurface = CollectBankAccountLauncher.HOSTED_SURFACE_PAYMENT_ELEMENT,
         linkMode = null,
-        shouldShowSetAsDefaultCheckbox = false,
+        setAsDefaultEnabled = false,
     )
 
     private val mockCollectBankAccountLauncher = mock<CollectBankAccountLauncher>()
@@ -563,19 +564,19 @@ class USBankAccountFormViewModelTest {
                 showCheckbox = true,
             ),
         )
-        assertThat(viewModel.saveForFutureUse.value).isFalse()
+        assertThat(viewModel.saveForFutureUseCheckedFlow.value).isFalse()
     }
 
     @Test
-    fun `Doesn't set setAsDefaultPaymentMethod by default`() = runTest {
+    fun `Doesn't set setAsDefaultPaymentMethodElement by default`() = runTest {
         val viewModel = createViewModel(
             args = defaultArgs.copy(
                 formArgs = defaultArgs.formArgs,
                 showCheckbox = true,
-                shouldShowSetAsDefaultCheckbox = false,
+                setAsDefaultEnabled = IS_PAYMENT_METHOD_SET_AS_DEFAULT_ENABLED_DEFAULT_VALUE,
             ),
         )
-        assertThat(viewModel.setAsDefaultPaymentMethodElement.controller.setAsDefaultPaymentMethod.value).isFalse()
+        assertThat(viewModel.setAsDefaultPaymentMethodElement).isNull()
     }
 
     @Test
@@ -1321,7 +1322,7 @@ class USBankAccountFormViewModelTest {
         val viewModel = createViewModel(
             args = defaultArgs.copy(
                 showCheckbox = true,
-                shouldShowSetAsDefaultCheckbox = true
+                setAsDefaultEnabled = true
             )
         )
 
@@ -1333,7 +1334,7 @@ class USBankAccountFormViewModelTest {
             viewModel.handleCollectBankAccountResult(mockVerifiedBankAccount())
             viewModel.saveForFutureUseElement.controller.onValueChange(true)
 
-            assertThat(viewModel.setAsDefaultPaymentMethodElement.shouldShowElementFlow.value).isTrue()
+            assertThat(viewModel.setAsDefaultPaymentMethodElement!!.shouldShowElementFlow.value).isTrue()
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -1343,7 +1344,7 @@ class USBankAccountFormViewModelTest {
         val viewModel = createViewModel(
             args = defaultArgs.copy(
                 showCheckbox = true,
-                shouldShowSetAsDefaultCheckbox = true
+                setAsDefaultEnabled = true
             )
         )
 
@@ -1355,7 +1356,7 @@ class USBankAccountFormViewModelTest {
             viewModel.handleCollectBankAccountResult(mockVerifiedBankAccount())
             viewModel.saveForFutureUseElement.controller.onValueChange(true)
 
-            assertThat(viewModel.setAsDefaultPaymentMethodElement.shouldShowElementFlow.value).isTrue()
+            assertThat(viewModel.setAsDefaultPaymentMethodElement!!.shouldShowElementFlow.value).isTrue()
 
             viewModel.saveForFutureUseElement.controller.onValueChange(false)
 
@@ -1369,7 +1370,7 @@ class USBankAccountFormViewModelTest {
         val viewModel = createViewModel(
             args = defaultArgs.copy(
                 showCheckbox = true,
-                shouldShowSetAsDefaultCheckbox = true
+                setAsDefaultEnabled = true
             )
         )
 
@@ -1383,7 +1384,7 @@ class USBankAccountFormViewModelTest {
 
             assertThat((awaitItem()?.paymentMethodExtraParams as PaymentMethodExtraParams.USBankAccount).setAsDefault)
                 .isFalse()
-            assertThat(viewModel.setAsDefaultPaymentMethodElement.shouldShowElementFlow.value)
+            assertThat(viewModel.setAsDefaultPaymentMethodElement!!.shouldShowElementFlow.value)
                 .isTrue()
 
             assertThat(awaitItem()?.input?.saveForFutureUse).isTrue()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
@@ -76,7 +76,7 @@ class USBankAccountFormViewModelTest {
         shippingDetails = null,
         hostedSurface = CollectBankAccountLauncher.HOSTED_SURFACE_PAYMENT_ELEMENT,
         linkMode = null,
-        setAsDefaultEnabled = false,
+        setAsDefaultPaymentMethodEnabled = false,
     )
 
     private val mockCollectBankAccountLauncher = mock<CollectBankAccountLauncher>()
@@ -573,7 +573,7 @@ class USBankAccountFormViewModelTest {
             args = defaultArgs.copy(
                 formArgs = defaultArgs.formArgs,
                 showCheckbox = true,
-                setAsDefaultEnabled = IS_PAYMENT_METHOD_SET_AS_DEFAULT_ENABLED_DEFAULT_VALUE,
+                setAsDefaultPaymentMethodEnabled = IS_PAYMENT_METHOD_SET_AS_DEFAULT_ENABLED_DEFAULT_VALUE,
             ),
         )
         assertThat(viewModel.setAsDefaultPaymentMethodElement).isNull()
@@ -1322,7 +1322,7 @@ class USBankAccountFormViewModelTest {
         val viewModel = createViewModel(
             args = defaultArgs.copy(
                 showCheckbox = true,
-                setAsDefaultEnabled = true
+                setAsDefaultPaymentMethodEnabled = true
             )
         )
 
@@ -1344,7 +1344,7 @@ class USBankAccountFormViewModelTest {
         val viewModel = createViewModel(
             args = defaultArgs.copy(
                 showCheckbox = true,
-                setAsDefaultEnabled = true
+                setAsDefaultPaymentMethodEnabled = true
             )
         )
 
@@ -1370,7 +1370,7 @@ class USBankAccountFormViewModelTest {
         val viewModel = createViewModel(
             args = defaultArgs.copy(
                 showCheckbox = true,
-                setAsDefaultEnabled = true
+                setAsDefaultPaymentMethodEnabled = true
             )
         )
 


### PR DESCRIPTION
# Summary
Changed shouldShowSetAsDefaultCheckbox to setAsDefaultEnabled
Removed shouldShowElementFlow. 

# Motivation
I will be decoupling showing the setAsDefaultEnabled from the value of saveForFutureUse.

It doesn't make sense to have the field shouldShowElementFlow when that is no longer the sole determinant of if the setAsDefaultPaymentElement is shown.

In subsequent PRs I will be refactoring SetAsDefaultPaymentMethodElement to reflect this. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [X] Manually verified

# Screenshots
N.A.

# Changelog
N.A.
