### PR TITLE
shouldShowElementFlow to saveForFutureUseCheckedFlow

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SetAsDefaultPaymentMethodController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SetAsDefaultPaymentMethodController.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.flow.StateFlow
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class SetAsDefaultPaymentMethodController(
     setAsDefaultPaymentMethodInitialValue: Boolean = false,
-    shouldShowElementFlow: StateFlow<Boolean>,
+    saveForFutureUseCheckedFlow: StateFlow<Boolean>,
 ) : InputController {
     override val label: StateFlow<Int> = MutableStateFlow(R.string.stripe_set_as_default_payment_method)
 
@@ -21,10 +21,10 @@ class SetAsDefaultPaymentMethodController(
     val setAsDefaultPaymentMethod: StateFlow<Boolean> = _setAsDefaultPaymentMethod
 
     override val fieldValue: StateFlow<String> = combineAsStateFlow(
-        shouldShowElementFlow,
+        saveForFutureUseCheckedFlow,
         setAsDefaultPaymentMethod
-    ) { shouldShowElementFlow, setAsDefaultPaymentMethod ->
-        (shouldShowElementFlow && setAsDefaultPaymentMethod).toString()
+    ) { saveForFutureUseCheckedFlow, setAsDefaultPaymentMethod ->
+        (saveForFutureUseCheckedFlow && setAsDefaultPaymentMethod).toString()
     }
 
     override val rawFieldValue: StateFlow<String?> = fieldValue

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SetAsDefaultPaymentMethodElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SetAsDefaultPaymentMethodElement.kt
@@ -14,14 +14,18 @@ import kotlinx.coroutines.flow.StateFlow
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class SetAsDefaultPaymentMethodElement(
     val initialValue: Boolean,
-    val shouldShowElementFlow: StateFlow<Boolean>
+    val saveForFutureUseCheckedFlow: StateFlow<Boolean>
 ) : FormElement {
+
+    val shouldShowElementFlow: StateFlow<Boolean> = saveForFutureUseCheckedFlow.mapAsStateFlow {
+        it
+    }
 
     override val identifier: IdentifierSpec = IdentifierSpec.SetAsDefaultPaymentMethod
 
     override val controller: SetAsDefaultPaymentMethodController = SetAsDefaultPaymentMethodController(
         setAsDefaultPaymentMethodInitialValue = initialValue,
-        shouldShowElementFlow = shouldShowElementFlow,
+        saveForFutureUseCheckedFlow = saveForFutureUseCheckedFlow,
     )
     override val allowsUserInteraction: Boolean = true
 

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -210,7 +210,7 @@ private object CardUiDefinitionFactory : UiDefinitionFactory.Simple {
             add(
                 SetAsDefaultPaymentMethodElement(
                     initialValue = false,
-                    shouldShowElementFlow = isSaveForFutureUseCheckedFlow
+                    saveForFutureUseCheckedFlow = isSaveForFutureUseCheckedFlow
                 )
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -207,7 +207,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
     val setAsDefaultPaymentMethodElement: SetAsDefaultPaymentMethodElement =
         SetAsDefaultPaymentMethodElement(
             initialValue = false,
-            shouldShowElementFlow = shouldShowElementFlow
+            saveForFutureUseCheckedFlow = shouldShowElementFlow
         )
 
     val setAsDefaultPaymentMethod = setAsDefaultPaymentMethodElement.controller.setAsDefaultPaymentMethod

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/AccountPreviewScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/AccountPreviewScreenshotTest.kt
@@ -191,7 +191,7 @@ internal class AccountPreviewScreenshotTest {
 
     private val setAsDefaultPaymentMethodElement = SetAsDefaultPaymentMethodElement(
         initialValue = false,
-        shouldShowElementFlow = saveForFutureUseElement.controller.saveForFutureUse
+        saveForFutureUseCheckedFlow = saveForFutureUseElement.controller.saveForFutureUse
     )
 
     private fun takeAccountPreviewScreenShot(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/BillingDetailsCollectionScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/BillingDetailsCollectionScreenshotTest.kt
@@ -17,7 +17,7 @@ import com.stripe.android.uicore.elements.EmailConfig
 import com.stripe.android.uicore.elements.NameConfig
 import com.stripe.android.uicore.elements.PhoneNumberController
 import com.stripe.android.uicore.elements.TextFieldController
-import kotlinx.coroutines.flow.MutableStateFlow
+import com.stripe.android.uicore.utils.stateFlowOf
 import org.junit.Rule
 import org.junit.Test
 
@@ -129,10 +129,9 @@ internal class BillingDetailsCollectionScreenshotTest {
         merchantName = "Test Merchant",
     )
 
-    private val shouldShowElementFlow = MutableStateFlow(false)
     private val setAsDefaultPaymentMethodElement = SetAsDefaultPaymentMethodElement(
         initialValue = false,
-        shouldShowElementFlow = shouldShowElementFlow
+        saveForFutureUseCheckedFlow = stateFlowOf(false)
     )
 
     private fun testBillingDetailsCollectionScreenShot(


### PR DESCRIPTION
# Summary
Renamed shouldShowElementFlow to saveForFutureUseCheckedFlow in SetAsDefaultPaymentMethodElement and SetAsDefaultPaymentMethodController 

I retain shouldShowElementFlow in SetAsDefaultPaymentMethodElement because it will be decoupled from the value of saveForFutureUseCheckedFlow

# Motivation
I am adding a change to SetAsDefaultPaymentMethodElement where it won't show when users don't have other payment methods.

This refactor is prework to the logic part of that change

# Testing
N.A.

# Screenshots
N.A.

# Changelog
N.A.