### PR TITLE
Replace usages of `copy` on `PaymentSheet.Configuration` and internal `Configuration` objects in tests

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -81,6 +81,7 @@ import com.stripe.android.paymentsheet.ui.SHEET_NAVIGATION_BUTTON_TAG
 import com.stripe.android.paymentsheet.ui.TEST_TAG_LIST
 import com.stripe.android.paymentsheet.ui.TEST_TAG_MODIFY_BADGE
 import com.stripe.android.paymentsheet.ui.UPDATE_PM_REMOVE_BUTTON_TEST_TAG
+import com.stripe.android.paymentsheet.utils.prefilledBuilder
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.ui.core.elements.TEST_TAG_DIALOG_CONFIRM_BUTTON
@@ -944,9 +945,9 @@ internal class PaymentSheetActivityTest {
     @Test
     fun `mandate text is shown above primary button when in vertical mode`() {
         val args = PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-            config = PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY.config.copy(
-                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
-            )
+            config = PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY.config.prefilledBuilder()
+                .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Vertical)
+                .build()
         )
         val viewModel = createViewModel(args = args)
         val scenario = activityScenario(viewModel)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
@@ -15,6 +15,7 @@ import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.paymentsheet.state.PaymentSheetState
+import com.stripe.android.paymentsheet.utils.prefilledBuilder
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import org.mockito.kotlin.mock
 
@@ -215,9 +216,9 @@ internal object PaymentSheetFixtures {
 
     internal val ARGS_WITHOUT_CUSTOMER
         get() = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-            config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.copy(
-                customer = null
-            )
+            config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.prefilledBuilder()
+                .customer(null)
+                .build()
         )
 
     internal val ARGS_DEFERRED_INTENT

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -116,6 +116,8 @@ import com.stripe.android.paymentsheet.ui.CardBrandChoice
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.ui.UpdatePaymentMethodInteractor
 import com.stripe.android.paymentsheet.utils.LinkTestUtils
+import com.stripe.android.paymentsheet.utils.prefillCreate
+import com.stripe.android.paymentsheet.utils.prefilledBuilder
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel.Companion.SAVE_PROCESSING
 import com.stripe.android.testing.FakeErrorReporter
@@ -346,12 +348,14 @@ internal class PaymentSheetViewModelTest {
         )
         val viewModel = createViewModel(
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.copy(
-                    customer = PaymentSheet.CustomerConfiguration(
-                        id = "cus_1",
-                        ephemeralKeySecret = "ek_123"
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.prefilledBuilder()
+                    .customer(
+                        PaymentSheet.CustomerConfiguration(
+                            id = "cus_1",
+                            ephemeralKeySecret = "ek_123"
+                        )
                     )
-                )
+                    .build()
             ),
             customer = CustomerState(
                 id = "cus_2",
@@ -696,14 +700,16 @@ internal class PaymentSheetViewModelTest {
             createViewModel(
                 stripeIntent = stripeIntent,
                 args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-                    config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.copy(
-                        shippingDetails = AddressDetails(
-                            address = PaymentSheet.Address(
-                                country = "US"
-                            ),
-                            name = "Test Name"
+                    config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.prefilledBuilder()
+                        .shippingDetails(
+                            AddressDetails(
+                                address = PaymentSheet.Address(
+                                    country = "US"
+                                ),
+                                name = "Test Name"
+                            )
                         )
-                    )
+                        .build()
                 )
             )
         )
@@ -1330,10 +1336,10 @@ internal class PaymentSheetViewModelTest {
     fun `Verify supported payment methods exclude afterpay if no shipping and no allow flag`() {
         val viewModel = createViewModel(
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.copy(
-                    shippingDetails = null,
-                    allowsPaymentMethodsRequiringShippingAddress = false,
-                )
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.prefilledBuilder()
+                    .shippingDetails(null)
+                    .allowsPaymentMethodsRequiringShippingAddress(false)
+                    .build()
             ),
             stripeIntent = PaymentIntentFixtures.PI_WITH_SHIPPING.copy(
                 paymentMethodTypes = listOf("afterpay_clearpay"),
@@ -1348,9 +1354,9 @@ internal class PaymentSheetViewModelTest {
     fun `Verify supported payment methods include afterpay if allow flag but no shipping`() {
         val viewModel = createViewModel(
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.copy(
-                    allowsPaymentMethodsRequiringShippingAddress = true,
-                )
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.prefilledBuilder()
+                    .allowsPaymentMethodsRequiringShippingAddress(true)
+                    .build()
             ),
             stripeIntent = PaymentIntentFixtures.PI_WITH_SHIPPING.copy(
                 paymentMethodTypes = listOf("afterpay_clearpay"),
@@ -1365,9 +1371,9 @@ internal class PaymentSheetViewModelTest {
     fun `Verify supported payment methods include afterpay if shipping but no allow flag`() {
         val viewModel = createViewModel(
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.copy(
-                    allowsPaymentMethodsRequiringShippingAddress = false,
-                )
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.prefilledBuilder()
+                    .allowsPaymentMethodsRequiringShippingAddress(true)
+                    .build()
             ),
             stripeIntent = PaymentIntentFixtures.PI_WITH_SHIPPING.copy(
                 paymentMethodTypes = listOf("afterpay_clearpay"),
@@ -1621,9 +1627,9 @@ internal class PaymentSheetViewModelTest {
     fun `launched with correct screen when in horizontal mode`() = runTest {
         val viewModel = createViewModel(
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.copy(
-                    paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal
-                )
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.prefilledBuilder()
+                    .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Horizontal)
+                    .build()
             ),
         )
         viewModel.navigationHandler.currentScreen.test {
@@ -1635,9 +1641,9 @@ internal class PaymentSheetViewModelTest {
     fun `launched with correct screen when in vertical mode`() = runTest {
         val viewModel = createViewModel(
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.copy(
-                    paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical
-                )
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.prefilledBuilder()
+                    .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Vertical)
+                    .build()
             ),
         )
         viewModel.navigationHandler.currentScreen.test {
@@ -1649,9 +1655,9 @@ internal class PaymentSheetViewModelTest {
     fun `launched with correct screen when in automatic mode`() = runTest {
         val viewModel = createViewModel(
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.copy(
-                    paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Automatic
-                )
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.prefilledBuilder()
+                    .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Automatic)
+                    .build()
             ),
         )
         viewModel.navigationHandler.currentScreen.test {
@@ -1973,9 +1979,9 @@ internal class PaymentSheetViewModelTest {
         val viewModel = createViewModel(
             isGooglePayReady = true,
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.copy(
-                    allowsDelayedPaymentMethods = true,
-                ),
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.prefilledBuilder()
+                    .allowsDelayedPaymentMethods(true)
+                    .build(),
             ),
             stripeIntent = intent,
         )
@@ -2006,9 +2012,9 @@ internal class PaymentSheetViewModelTest {
         val viewModel = createViewModel(
             isGooglePayReady = true,
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.copy(
-                    allowsDelayedPaymentMethods = true,
-                ),
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.prefilledBuilder()
+                    .allowsDelayedPaymentMethods(true)
+                    .build(),
             ),
             stripeIntent = intent,
         )
@@ -2302,15 +2308,17 @@ internal class PaymentSheetViewModelTest {
         val expectedAmount = 1099L
 
         val args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-            config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.copy(
-                googlePay = PaymentSheet.GooglePayConfiguration(
-                    environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
-                    countryCode = "CA",
-                    currencyCode = "CAD",
-                    amount = 12345,
-                    label = expectedLabel,
+            config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.prefilledBuilder()
+                .googlePay(
+                    PaymentSheet.GooglePayConfiguration(
+                        environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
+                        countryCode = "CA",
+                        currencyCode = "CAD",
+                        amount = 12345,
+                        label = expectedLabel,
+                    )
                 )
-            )
+                .build()
         )
 
         val viewModel = createViewModel(
@@ -2334,15 +2342,17 @@ internal class PaymentSheetViewModelTest {
         val expectedAmount = 1234L
 
         val args = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.copy(
-            config = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.config.copy(
-                googlePay = PaymentSheet.GooglePayConfiguration(
-                    environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
-                    countryCode = "CA",
-                    currencyCode = "CAD",
-                    amount = expectedAmount,
-                    label = expectedLabel,
+            config = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.config.prefilledBuilder()
+                .googlePay(
+                    PaymentSheet.GooglePayConfiguration(
+                        environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
+                        countryCode = "CA",
+                        currencyCode = "CAD",
+                        amount = expectedAmount,
+                        label = expectedLabel,
+                    )
                 )
-            )
+                .build()
         )
 
         val viewModel = createViewModel(
@@ -2425,17 +2435,21 @@ internal class PaymentSheetViewModelTest {
     @Test
     fun `Requires email and phone with Google Pay when collection mode is set to always`() {
         val args = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.copy(
-            config = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.config.copy(
-                billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
-                    phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
-                    email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
-                ),
-                googlePay = PaymentSheet.GooglePayConfiguration(
-                    environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
-                    countryCode = "CA",
-                    currencyCode = "CAD",
+            config = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.config.prefilledBuilder()
+                .googlePay(
+                    PaymentSheet.GooglePayConfiguration(
+                        environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
+                        countryCode = "CA",
+                        currencyCode = "CAD",
+                    )
                 )
-            )
+                .billingDetailsCollectionConfiguration(
+                    PaymentSheet.BillingDetailsCollectionConfiguration(
+                        phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                        email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                    )
+                )
+                .build()
         )
 
         val viewModel = createViewModel(
@@ -2456,16 +2470,20 @@ internal class PaymentSheetViewModelTest {
     @Test
     fun `Requires full billing details with Google Pay when collection mode is set to full`() {
         val args = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.copy(
-            config = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.config.copy(
-                billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
-                    address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
-                ),
-                googlePay = PaymentSheet.GooglePayConfiguration(
-                    environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
-                    countryCode = "CA",
-                    currencyCode = "CAD",
+            config = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.config.prefilledBuilder()
+                .googlePay(
+                    PaymentSheet.GooglePayConfiguration(
+                        environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
+                        countryCode = "CA",
+                        currencyCode = "CAD",
+                    )
                 )
-            )
+                .billingDetailsCollectionConfiguration(
+                    PaymentSheet.BillingDetailsCollectionConfiguration(
+                        address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
+                    )
+                )
+                .build()
         )
 
         val viewModel = createViewModel(
@@ -2486,17 +2504,21 @@ internal class PaymentSheetViewModelTest {
     @Test
     fun `Does not require email and phone with Google Pay when collection mode is not set to always`() {
         val args = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.copy(
-            config = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.config.copy(
-                billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
-                    phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic,
-                    email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic,
-                ),
-                googlePay = PaymentSheet.GooglePayConfiguration(
-                    environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
-                    countryCode = "CA",
-                    currencyCode = "CAD",
+            config = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.config.prefilledBuilder()
+                .billingDetailsCollectionConfiguration(
+                    PaymentSheet.BillingDetailsCollectionConfiguration(
+                        phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic,
+                        email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic,
+                    )
                 )
-            )
+                .googlePay(
+                    PaymentSheet.GooglePayConfiguration(
+                        environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
+                        countryCode = "CA",
+                        currencyCode = "CAD",
+                    )
+                )
+                .build()
         )
 
         val viewModel = createViewModel(
@@ -2517,16 +2539,20 @@ internal class PaymentSheetViewModelTest {
     @Test
     fun `Does not require billing details with Google Pay when collection mode is set to never`() {
         val args = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.copy(
-            config = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.config.copy(
-                billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
-                    address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never,
-                ),
-                googlePay = PaymentSheet.GooglePayConfiguration(
-                    environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
-                    countryCode = "CA",
-                    currencyCode = "CAD",
+            config = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.config.prefilledBuilder()
+                .billingDetailsCollectionConfiguration(
+                    PaymentSheet.BillingDetailsCollectionConfiguration(
+                        address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never,
+                    )
                 )
-            )
+                .googlePay(
+                    PaymentSheet.GooglePayConfiguration(
+                        environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
+                        countryCode = "CA",
+                        currencyCode = "CAD",
+                    )
+                )
+                .build()
         )
 
         val viewModel = createViewModel(
@@ -2915,9 +2941,9 @@ internal class PaymentSheetViewModelTest {
     fun `requiresCvcRecollection should return correct value`() {
         var viewModel = createViewModel(
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.copy(
-                    paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical
-                )
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.prefilledBuilder()
+                    .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Vertical)
+                    .build()
             )
         )
 
@@ -2950,9 +2976,9 @@ internal class PaymentSheetViewModelTest {
     fun `requiresCvcRecollection should return correct value in automatic mode`() {
         var viewModel = createViewModel(
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.copy(
-                    paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Automatic
-                )
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.prefilledBuilder()
+                    .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Automatic)
+                    .build()
             )
         )
 
@@ -2985,9 +3011,9 @@ internal class PaymentSheetViewModelTest {
     fun `CvcRecollection screen should be displayed on checkout when required in vertical mode`() = runTest {
         val viewModel = createViewModel(
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.copy(
-                    paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical
-                )
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.prefilledBuilder()
+                    .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Vertical)
+                    .build()
             ),
         )
 
@@ -3005,9 +3031,9 @@ internal class PaymentSheetViewModelTest {
     fun `CvcRecollection screen should be displayed on checkout when required in automatic mode`() = runTest {
         val viewModel = createViewModel(
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.copy(
-                    paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Automatic
-                )
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.prefilledBuilder()
+                    .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Automatic)
+                    .build()
             ),
         )
 
@@ -3026,9 +3052,9 @@ internal class PaymentSheetViewModelTest {
         val cvcRecollectionInteractor = FakeCvcRecollectionInteractor()
         val viewModel = createViewModel(
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.copy(
-                    paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical
-                )
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.prefilledBuilder()
+                    .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Vertical)
+                    .build()
             ),
             cvcRecollectionInteractor = cvcRecollectionInteractor
         )
@@ -3068,9 +3094,9 @@ internal class PaymentSheetViewModelTest {
     fun `CvcRecollection screen should not be displayed on checkout when not required in vertical mode`() = runTest {
         val viewModel = createViewModel(
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.copy(
-                    paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical
-                )
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.prefilledBuilder()
+                    .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Vertical)
+                    .build()
             ),
         )
 
@@ -3088,9 +3114,9 @@ internal class PaymentSheetViewModelTest {
     fun `CvcRecollection screen should not be displayed on checkout when not required in automatic mode`() = runTest {
         val viewModel = createViewModel(
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.copy(
-                    paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Automatic
-                )
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.prefilledBuilder()
+                    .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Automatic)
+                    .build()
             ),
         )
 
@@ -3368,11 +3394,13 @@ internal class PaymentSheetViewModelTest {
         val viewModel = createViewModel(
             isGooglePayReady = true,
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.copy(
-                config = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.config.copy(
-                    googlePay = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.googlePayConfig?.copy(
-                        buttonType = buttonType
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.config.prefilledBuilder()
+                    .googlePay(
+                        ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.googlePayConfig?.prefillCreate(
+                            buttonType = buttonType,
+                        )
                     )
-                )
+                    .build()
             )
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/PaymentSheetConfigUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/PaymentSheetConfigUtils.kt
@@ -1,0 +1,51 @@
+package com.stripe.android.paymentsheet.utils
+
+import com.stripe.android.ExperimentalAllowsRemovalOfLastSavedPaymentMethodApi
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.PaymentSheet.GooglePayConfiguration
+import com.stripe.android.paymentsheet.PaymentSheet.GooglePayConfiguration.ButtonType
+import com.stripe.android.paymentsheet.PaymentSheet.GooglePayConfiguration.Environment
+
+@OptIn(ExperimentalAllowsRemovalOfLastSavedPaymentMethodApi::class)
+@Suppress("DEPRECATION")
+fun PaymentSheet.Configuration.prefilledBuilder() =
+    PaymentSheet.Configuration.Builder(merchantDisplayName)
+        .customer(customer)
+        .googlePay(googlePay)
+        .primaryButtonColor(primaryButtonColor)
+        .defaultBillingDetails(defaultBillingDetails)
+        .shippingDetails(shippingDetails)
+        .allowsDelayedPaymentMethods(allowsDelayedPaymentMethods)
+        .allowsPaymentMethodsRequiringShippingAddress(allowsPaymentMethodsRequiringShippingAddress)
+        .appearance(appearance)
+        .billingDetailsCollectionConfiguration(billingDetailsCollectionConfiguration)
+        .preferredNetworks(preferredNetworks)
+        .allowsRemovalOfLastSavedPaymentMethod(allowsRemovalOfLastSavedPaymentMethod)
+        .preferredNetworks(preferredNetworks)
+        .paymentMethodOrder(paymentMethodOrder)
+        .externalPaymentMethods(externalPaymentMethods)
+        .paymentMethodLayout(paymentMethodLayout)
+        .cardBrandAcceptance(cardBrandAcceptance)
+        .apply {
+            primaryButtonLabel?.let {
+                primaryButtonLabel(it)
+            }
+        }
+
+fun GooglePayConfiguration.prefillCreate(
+    environment: Environment = this.environment,
+    countryCode: String = this.countryCode,
+    currencyCode: String? = this.currencyCode,
+    amount: Long? = this.amount,
+    label: String? = this.label,
+    buttonType: ButtonType = this.buttonType
+): GooglePayConfiguration {
+    return GooglePayConfiguration(
+        environment = environment,
+        countryCode = countryCode,
+        currencyCode = currencyCode,
+        amount = amount,
+        label = label,
+        buttonType = buttonType,
+    )
+}


### PR DESCRIPTION
# Summary
Replace usages of `copy` on `PaymentSheet.Configuration` and internal `Configuration` objects in tests

# Motivation
Ideally, we want to migrate all our public API classes to no longer have a `data` modifier (`data class Config`). This means removing all usages of `copy` and any destructing usages.

See [this article](https://jakewharton.com/public-api-challenges-in-kotlin/) for more information.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified