### PR TITLE
Payment method type for set default payment method events

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -219,12 +219,17 @@ internal class SavedPaymentMethodMutator(
             ),
             paymentMethodId = paymentMethod.id,
         ).onFailure { error ->
-            eventReporter.onSetAsDefaultPaymentMethodFailed(error = error)
+            eventReporter.onSetAsDefaultPaymentMethodFailed(
+                paymentMethodType = paymentMethod.type?.code,
+                error = error
+            )
         }.onSuccess {
             customerStateHolder.setDefaultPaymentMethod(paymentMethod = paymentMethod)
             setSelection(PaymentSelection.Saved(paymentMethod = paymentMethod))
 
-            eventReporter.onSetAsDefaultPaymentMethodSucceeded()
+            eventReporter.onSetAsDefaultPaymentMethodSucceeded(
+                paymentMethodType = paymentMethod.type?.code,
+            )
         }.map {}
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -411,17 +411,21 @@ internal class DefaultEventReporter @Inject internal constructor(
         )
     }
 
-    override fun onSetAsDefaultPaymentMethodSucceeded() {
+    override fun onSetAsDefaultPaymentMethodSucceeded(
+        paymentMethodType: String?,
+    ) {
         fireEvent(
             PaymentSheetEvent.SetAsDefaultPaymentMethodSucceeded(
                 isDeferred = isDeferred,
                 linkEnabled = linkEnabled,
                 googlePaySupported = googlePaySupported,
+                paymentMethodType = paymentMethodType,
             )
         )
     }
 
     override fun onSetAsDefaultPaymentMethodFailed(
+        paymentMethodType: String?,
         error: Throwable,
     ) {
         fireEvent(
@@ -430,6 +434,7 @@ internal class DefaultEventReporter @Inject internal constructor(
                 isDeferred = isDeferred,
                 linkEnabled = linkEnabled,
                 googlePaySupported = googlePaySupported,
+                paymentMethodType = paymentMethodType,
             )
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
@@ -183,12 +183,15 @@ internal interface EventReporter {
     /**
      * The customer has successfully set a payment method as the default.
      */
-    fun onSetAsDefaultPaymentMethodSucceeded()
+    fun onSetAsDefaultPaymentMethodSucceeded(
+        paymentMethodType: String?,
+    )
 
     /**
      * The customer has failed to set a payment method as the default.
      */
     fun onSetAsDefaultPaymentMethodFailed(
+        paymentMethodType: String?,
         error: Throwable,
     )
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -444,10 +444,13 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         override val isDeferred: Boolean,
         override val linkEnabled: Boolean,
         override val googlePaySupported: Boolean,
+        val paymentMethodType: String?,
     ) : PaymentSheetEvent() {
         override val eventName: String = "mc_set_default_payment_method"
 
-        override val additionalParams: Map<String, Any?> = emptyMap()
+        override val additionalParams: Map<String, Any?> = mapOf(
+            FIELD_PAYMENT_METHOD_TYPE to paymentMethodType,
+        )
     }
 
     class SetAsDefaultPaymentMethodFailed(
@@ -455,11 +458,13 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         override val isDeferred: Boolean,
         override val linkEnabled: Boolean,
         override val googlePaySupported: Boolean,
+        paymentMethodType: String?,
     ) : PaymentSheetEvent() {
         override val eventName: String = "mc_set_default_payment_method_failed"
 
         override val additionalParams: Map<String, Any?> = mapOf(
             FIELD_ERROR_MESSAGE to error.message,
+            FIELD_PAYMENT_METHOD_TYPE to paymentMethodType,
         ).plus(ErrorReporter.getAdditionalParamsFromError(error))
     }
 
@@ -556,6 +561,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         const val FIELD_ERROR_MESSAGE = "error_message"
         const val FIELD_ERROR_CODE = "error_code"
         const val FIELD_CBC_EVENT_SOURCE = "cbc_event_source"
+        const val FIELD_PAYMENT_METHOD_TYPE = "payment_method_type"
         const val FIELD_SET_AS_DEFAULT_ENABLED = "set_as_default_enabled"
         const val FIELD_HAS_DEFAULT_PAYMENT_METHOD = "has_default_payment_method"
         const val FIELD_SELECTED_CARD_BRAND = "selected_card_brand"

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
@@ -670,6 +670,8 @@ class SavedPaymentMethodMutatorTest {
 
             val succeededCall = eventReporter.setAsDefaultPaymentMethodSucceededCalls.awaitItem()
             assertThat(succeededCall).isInstanceOf(FakeEventReporter.SetAsDefaultPaymentMethodSucceededCall::class.java)
+            assertThat(succeededCall.paymentMethodType).isNotNull()
+            assertThat(succeededCall.paymentMethodType).isEqualTo(paymentMethods[1].type?.code)
         }
     }
 
@@ -697,6 +699,8 @@ class SavedPaymentMethodMutatorTest {
 
             val failedCall = eventReporter.setAsDefaultPaymentMethodFailedCalls.awaitItem()
             assertThat(failedCall.error.message).isEqualTo("Test failure")
+            assertThat(failedCall.paymentMethodType).isNotNull()
+            assertThat(failedCall.paymentMethodType).isEqualTo(paymentMethods[1].type?.code)
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -11,6 +11,7 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.core.utils.DurationProvider
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.LinkMode
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
@@ -538,11 +539,14 @@ class DefaultEventReporterTest {
             simulateSuccessfulSetup()
         }
 
-        customEventReporter.onSetAsDefaultPaymentMethodSucceeded()
+        customEventReporter.onSetAsDefaultPaymentMethodSucceeded(
+            paymentMethodType = PaymentMethod.Type.Card.code,
+        )
 
         verify(analyticsRequestExecutor).executeAsync(
             argWhere { req ->
-                req.params["event"] == "mc_set_default_payment_method"
+                req.params["event"] == "mc_set_default_payment_method" &&
+                    req.params["payment_method_type"] == "card"
             }
         )
     }
@@ -554,12 +558,14 @@ class DefaultEventReporterTest {
         }
 
         customEventReporter.onSetAsDefaultPaymentMethodFailed(
+            paymentMethodType = PaymentMethod.Type.Card.code,
             error = Exception("No network available!")
         )
 
         verify(analyticsRequestExecutor).executeAsync(
             argWhere { req ->
                 req.params["event"] == "mc_set_default_payment_method_failed" &&
+                    req.params["payment_method_type"] == "card" &&
                     req.params["error_message"] == "No network available!"
             }
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeEventReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeEventReporter.kt
@@ -169,15 +169,25 @@ internal class FakeEventReporter : EventReporter {
         )
     }
 
-    override fun onSetAsDefaultPaymentMethodSucceeded() {
+    override fun onSetAsDefaultPaymentMethodSucceeded(
+        paymentMethodType: String?,
+    ) {
         _setAsDefaultPaymentMethodSucceededCalls.add(
-            SetAsDefaultPaymentMethodSucceededCall()
+            SetAsDefaultPaymentMethodSucceededCall(
+                paymentMethodType = paymentMethodType,
+            )
         )
     }
 
-    override fun onSetAsDefaultPaymentMethodFailed(error: Throwable) {
+    override fun onSetAsDefaultPaymentMethodFailed(
+        paymentMethodType: String?,
+        error: Throwable,
+    ) {
         _setAsDefaultPaymentMethodFailedCalls.add(
-            SetAsDefaultPaymentMethodFailedCall(error = error)
+            SetAsDefaultPaymentMethodFailedCall(
+                paymentMethodType = paymentMethodType,
+                error = error,
+            )
         )
     }
 
@@ -202,9 +212,12 @@ internal class FakeEventReporter : EventReporter {
         val error: Throwable,
     )
 
-    class SetAsDefaultPaymentMethodSucceededCall
+    class SetAsDefaultPaymentMethodSucceededCall(
+        val paymentMethodType: String?,
+    )
 
     data class SetAsDefaultPaymentMethodFailedCall(
+        val paymentMethodType: String?,
         val error: Throwable,
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
@@ -6,6 +6,7 @@ import com.stripe.android.core.exception.APIException
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.LinkMode
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodFixtures.CARD_PAYMENT_SELECTION
@@ -1259,6 +1260,7 @@ class PaymentSheetEventTest {
             isDeferred = false,
             linkEnabled = false,
             googlePaySupported = false,
+            paymentMethodType = PaymentMethod.Type.Card.code,
         )
         assertThat(
             event.eventName
@@ -1272,6 +1274,7 @@ class PaymentSheetEventTest {
                 "is_decoupled" to false,
                 "link_enabled" to false,
                 "google_pay_enabled" to false,
+                "payment_method_type" to "card",
             )
         )
     }
@@ -1287,6 +1290,7 @@ class PaymentSheetEventTest {
             isDeferred = false,
             linkEnabled = false,
             googlePaySupported = false,
+            paymentMethodType = PaymentMethod.Type.Card.code,
         )
         assertThat(
             event.eventName
@@ -1301,6 +1305,7 @@ class PaymentSheetEventTest {
                 "is_decoupled" to false,
                 "link_enabled" to false,
                 "google_pay_enabled" to false,
+                "payment_method_type" to "card",
                 "analytics_value" to "apiError",
                 "request_id" to "request_123",
                 "error_type" to "network_error",


### PR DESCRIPTION
# Summary
Added payment method type for `mc_set_default_payment_method` and `mc_set_default_payment_method_failed` events

# Motivation
Tracking what types of payment methods end users are setting to be default. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [ ] Manually verified

# Screenshots
N.A.

# Changelog
N.A.
