### PR TITLE
Refactor SetAsDefaultPaymentMethodController. setAsDefaultPaymentMethod

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SetAsDefaultPaymentMethodController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SetAsDefaultPaymentMethodController.kt
@@ -17,12 +17,12 @@ class SetAsDefaultPaymentMethodController(
 ) : InputController {
     override val label: StateFlow<Int> = MutableStateFlow(R.string.stripe_set_as_default_payment_method)
 
-    private val _setAsDefaultPaymentMethod = MutableStateFlow(setAsDefaultPaymentMethodInitialValue)
-    val setAsDefaultPaymentMethod: StateFlow<Boolean> = _setAsDefaultPaymentMethod
+    private val _setAsDefaultPaymentMethodChecked = MutableStateFlow(setAsDefaultPaymentMethodInitialValue)
+    val setAsDefaultPaymentMethodChecked: StateFlow<Boolean> = _setAsDefaultPaymentMethodChecked
 
     override val fieldValue: StateFlow<String> = combineAsStateFlow(
         saveForFutureUseCheckedFlow,
-        setAsDefaultPaymentMethod
+        setAsDefaultPaymentMethodChecked
     ) { saveForFutureUseCheckedFlow, setAsDefaultPaymentMethod ->
         (saveForFutureUseCheckedFlow && setAsDefaultPaymentMethod).toString()
     }
@@ -37,8 +37,8 @@ class SetAsDefaultPaymentMethodController(
             FormFieldEntry(value, complete)
         }
 
-    fun onValueChange(setAsDefaultPaymentMethod: Boolean) {
-        _setAsDefaultPaymentMethod.value = setAsDefaultPaymentMethod
+    fun onValueChange(setAsDefaultPaymentMethodChecked: Boolean) {
+        _setAsDefaultPaymentMethodChecked.value = setAsDefaultPaymentMethodChecked
     }
 
     override fun onRawValueChange(rawValue: String) {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SetAsDefaultPaymentMethodController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SetAsDefaultPaymentMethodController.kt
@@ -23,8 +23,8 @@ class SetAsDefaultPaymentMethodController(
     override val fieldValue: StateFlow<String> = combineAsStateFlow(
         saveForFutureUseCheckedFlow,
         setAsDefaultPaymentMethodChecked
-    ) { saveForFutureUseCheckedFlow, setAsDefaultPaymentMethod ->
-        (saveForFutureUseCheckedFlow && setAsDefaultPaymentMethod).toString()
+    ) { saveForFutureUseCheckedFlow, setAsDefaultPaymentMethodChecked ->
+        (saveForFutureUseCheckedFlow && setAsDefaultPaymentMethodChecked).toString()
     }
 
     override val rawFieldValue: StateFlow<String?> = fieldValue

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SetAsDefaultPaymentMethodElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SetAsDefaultPaymentMethodElementUI.kt
@@ -19,7 +19,7 @@ fun SetAsDefaultPaymentMethodElementUI(
     modifier: Modifier = Modifier,
 ) {
     val controller = element.controller
-    val checked by controller.setAsDefaultPaymentMethod.collectAsState()
+    val checked by controller.setAsDefaultPaymentMethodChecked.collectAsState()
     val label by controller.label.collectAsState()
     val resources = LocalContext.current.resources
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -233,7 +233,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
     val linkedAccount: StateFlow<PaymentSelection.New.USBankAccount?> = combineAsStateFlow(
         currentScreenState,
         billingDetails,
-        setAsDefaultPaymentMethodElement?.controller?.setAsDefaultPaymentMethod ?: stateFlowOf(false),
+        setAsDefaultPaymentMethodElement?.controller?.setAsDefaultPaymentMethodChecked ?: stateFlowOf(false),
     ) { state, billingDetails, _ ->
         state.toPaymentSelection(billingDetails)
     }
@@ -676,7 +676,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
             ),
             paymentMethodExtraParams = if (setAsDefaultPaymentMethodElement != null) {
                 PaymentMethodExtraParams.USBankAccount(
-                    setAsDefault = setAsDefaultPaymentMethodElement.controller.setAsDefaultPaymentMethod.value
+                    setAsDefault = setAsDefaultPaymentMethodElement.controller.setAsDefaultPaymentMethodChecked.value
                 )
             } else {
                 null


### PR DESCRIPTION

# Summary
Renamed SetAsDefaultPaymentMethodController. setAsDefaultPaymentMethod to setAsDefaultPaymentMethodChecked

# Motivation
Make it more clear in the controller where these values come from, decoupling the field value of this from what appears to the user

I am adding a change to SetAsDefaultPaymentMethodElement where it won't show when users don't have other payment methods.

This refactor is prework to the logic part of that change

# Testing
N.A.

# Screenshots
N.A.

# Changelog
N.A.
