### PR TITLE
Fix merchant restoration issue in FC playground

### DIFF
--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
@@ -544,9 +544,7 @@ internal data class FinancialConnectionsPlaygroundState(
             settings = settings.copy(
                 settings = settings.settings.map { setting ->
                     if (setting is MerchantSetting) {
-                        MerchantSetting(
-                            merchants = merchants,
-                        )
+                        setting.updateWithMerchants(merchants)
                     } else {
                         setting
                     }

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/MerchantSetting.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/settings/MerchantSetting.kt
@@ -40,4 +40,12 @@ data class MerchantSetting(
             merchants.first()
         }
     }
+
+    fun updateWithMerchants(merchants: List<Merchant>): MerchantSetting {
+        val selectedOption = selectedOption.takeIf { it in merchants } ?: merchants.first()
+        return copy(
+            merchants = merchants,
+            selectedOption = selectedOption,
+        )
+    }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where we weren’t restoring the previously set merchant when re-opening the Financial Connections playground.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
