### PR TITLE
[MOBILESDK-3197] First saved payment method is automatically set as default

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SetAsDefaultPaymentMethodController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SetAsDefaultPaymentMethodController.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.StateFlow
 class SetAsDefaultPaymentMethodController(
     setAsDefaultPaymentMethodInitialValue: Boolean = false,
     saveForFutureUseCheckedFlow: StateFlow<Boolean>,
+    hasOtherPaymentMethods: Boolean,
 ) : InputController {
     override val label: StateFlow<Int> = MutableStateFlow(R.string.stripe_set_as_default_payment_method)
 
@@ -24,7 +25,9 @@ class SetAsDefaultPaymentMethodController(
         saveForFutureUseCheckedFlow,
         setAsDefaultPaymentMethodChecked
     ) { saveForFutureUseCheckedFlow, setAsDefaultPaymentMethodChecked ->
-        (saveForFutureUseCheckedFlow && setAsDefaultPaymentMethodChecked).toString()
+        // Payment method must be saved for future use and
+        // is either the first payment method or has been checked to be the defaultPaymentMethod
+        (saveForFutureUseCheckedFlow && (!hasOtherPaymentMethods || setAsDefaultPaymentMethodChecked)).toString()
     }
 
     override val rawFieldValue: StateFlow<String?> = fieldValue

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SetAsDefaultPaymentMethodElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SetAsDefaultPaymentMethodElement.kt
@@ -8,17 +8,21 @@ import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+const val HAS_OTHER_PAYMENT_METHODS_DEFAULT_VALUE = true
+
 /**
  * Element that allows users to set a new payment method as their default.
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class SetAsDefaultPaymentMethodElement(
     val initialValue: Boolean,
-    val saveForFutureUseCheckedFlow: StateFlow<Boolean>
+    val saveForFutureUseCheckedFlow: StateFlow<Boolean>,
+    val hasOtherPaymentMethods: Boolean,
 ) : FormElement {
 
     val shouldShowElementFlow: StateFlow<Boolean> = saveForFutureUseCheckedFlow.mapAsStateFlow {
-        it
+        it && hasOtherPaymentMethods
     }
 
     override val identifier: IdentifierSpec = IdentifierSpec.SetAsDefaultPaymentMethod
@@ -26,6 +30,7 @@ data class SetAsDefaultPaymentMethodElement(
     override val controller: SetAsDefaultPaymentMethodController = SetAsDefaultPaymentMethodController(
         setAsDefaultPaymentMethodInitialValue = initialValue,
         saveForFutureUseCheckedFlow = saveForFutureUseCheckedFlow,
+        hasOtherPaymentMethods = hasOtherPaymentMethods,
     )
     override val allowsUserInteraction: Boolean = true
 

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -66,6 +66,7 @@ import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.ui.transformToPaymentMethodCreateParams
 import com.stripe.android.paymentsheet.ui.transformToPaymentSelection
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
+import com.stripe.android.ui.core.elements.HAS_OTHER_PAYMENT_METHODS_DEFAULT_VALUE
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import kotlinx.coroutines.Dispatchers
@@ -839,6 +840,7 @@ internal class CustomerSheetViewModel(
                 handleViewAction(CustomerSheetViewAction.OnFormError(error))
             },
             setAsDefaultPaymentMethodEnabled = false,
+            hasOtherPaymentMethods = HAS_OTHER_PAYMENT_METHODS_DEFAULT_VALUE,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionFactory.kt
@@ -15,6 +15,7 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.toIdentifierMap
 import com.stripe.android.paymentsheet.model.PaymentMethodIncentive
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
+import com.stripe.android.ui.core.elements.HAS_OTHER_PAYMENT_METHODS_DEFAULT_VALUE
 import com.stripe.android.ui.core.elements.SharedDataSpec
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
@@ -33,6 +34,7 @@ internal sealed interface UiDefinitionFactory {
         val requiresMandate: Boolean,
         val onLinkInlineSignupStateChanged: (InlineSignupViewState) -> Unit,
         val cardBrandFilter: CardBrandFilter,
+        val hasOtherPaymentMethods: Boolean,
     ) {
         interface Factory {
             fun create(
@@ -47,6 +49,7 @@ internal sealed interface UiDefinitionFactory {
                 private val paymentMethodCreateParams: PaymentMethodCreateParams? = null,
                 private val paymentMethodExtraParams: PaymentMethodExtraParams? = null,
                 private val initialLinkUserInput: UserInput? = null,
+                private val hasOtherPaymentMethods: Boolean = HAS_OTHER_PAYMENT_METHODS_DEFAULT_VALUE,
             ) : Factory {
                 override fun create(
                     metadata: PaymentMethodMetadata,
@@ -69,6 +72,7 @@ internal sealed interface UiDefinitionFactory {
                         onLinkInlineSignupStateChanged = onLinkInlineSignupStateChanged,
                         cardBrandFilter = metadata.cardBrandFilter,
                         initialLinkUserInput = initialLinkUserInput,
+                        hasOtherPaymentMethods = hasOtherPaymentMethods
                     )
                 }
             }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -210,7 +210,8 @@ private object CardUiDefinitionFactory : UiDefinitionFactory.Simple {
             add(
                 SetAsDefaultPaymentMethodElement(
                     initialValue = false,
-                    saveForFutureUseCheckedFlow = isSaveForFutureUseCheckedFlow
+                    saveForFutureUseCheckedFlow = isSaveForFutureUseCheckedFlow,
+                    hasOtherPaymentMethods = arguments.hasOtherPaymentMethods,
                 )
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedFormHelperFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedFormHelperFactory.kt
@@ -8,6 +8,7 @@ import com.stripe.android.paymentsheet.FormHelper
 import com.stripe.android.paymentsheet.LinkInlineHandler
 import com.stripe.android.paymentsheet.NewOrExternalPaymentSelection
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.ui.core.elements.HAS_OTHER_PAYMENT_METHODS_DEFAULT_VALUE
 import kotlinx.coroutines.CoroutineScope
 import javax.inject.Inject
 
@@ -39,6 +40,7 @@ internal class EmbeddedFormHelperFactory @Inject constructor(
             },
             selectionUpdater = selectionUpdater,
             linkConfigurationCoordinator = linkConfigurationCoordinator,
+            hasOtherPaymentMethods = HAS_OTHER_PAYMENT_METHODS_DEFAULT_VALUE, // TODO for embedded
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultFormHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultFormHelper.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet
 
 import androidx.lifecycle.viewModelScope
+import com.stripe.android.ExperimentalAllowsRemovalOfLastSavedPaymentMethodApi
 import com.stripe.android.cards.CardAccountRangeRepository
 import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
@@ -17,6 +18,7 @@ import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.ui.transformToPaymentMethodCreateParams
 import com.stripe.android.paymentsheet.ui.transformToPaymentSelection
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
+import com.stripe.android.ui.core.elements.HAS_OTHER_PAYMENT_METHODS_DEFAULT_VALUE
 import com.stripe.android.uicore.elements.FormElement
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
@@ -32,6 +34,7 @@ internal class DefaultFormHelper(
     private val newPaymentSelectionProvider: () -> NewOrExternalPaymentSelection?,
     private val selectionUpdater: (PaymentSelection?) -> Unit,
     private val linkConfigurationCoordinator: LinkConfigurationCoordinator?,
+    private val hasOtherPaymentMethods: Boolean,
 ) : FormHelper {
     companion object {
         fun create(
@@ -51,6 +54,7 @@ internal class DefaultFormHelper(
                 selectionUpdater = {
                     viewModel.updateSelection(it)
                 },
+                hasOtherPaymentMethods = viewModel.customerStateHolder.paymentMethods.value.isNotEmpty(),
             )
         }
 
@@ -67,6 +71,7 @@ internal class DefaultFormHelper(
                 newPaymentSelectionProvider = { null },
                 linkConfigurationCoordinator = null,
                 selectionUpdater = {},
+                hasOtherPaymentMethods = HAS_OTHER_PAYMENT_METHODS_DEFAULT_VALUE,
             )
         }
     }
@@ -128,7 +133,8 @@ internal class DefaultFormHelper(
                 initialLinkUserInput = when (val selection = currentSelection?.paymentSelection) {
                     is PaymentSelection.New.LinkInline -> selection.input
                     else -> null
-                }
+                },
+                hasOtherPaymentMethods = hasOtherPaymentMethods,
             ),
         ) ?: emptyList()
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultFormHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultFormHelper.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentsheet
 
 import androidx.lifecycle.viewModelScope
-import com.stripe.android.ExperimentalAllowsRemovalOfLastSavedPaymentMethodApi
 import com.stripe.android.cards.CardAccountRangeRepository
 import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/FormControllerModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/FormControllerModule.kt
@@ -9,6 +9,7 @@ import com.stripe.android.lpmfoundations.luxe.TransformSpecToElements
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
+import com.stripe.android.ui.core.elements.HAS_OTHER_PAYMENT_METHODS_DEFAULT_VALUE
 import com.stripe.android.uicore.elements.IdentifierSpec
 import dagger.Module
 import dagger.Provides
@@ -44,7 +45,8 @@ internal object FormControllerModule {
                     "`InlineSignUpViewState` updates should not be received by `FormController`!"
                 )
             },
-            cardBrandFilter = DefaultCardBrandFilter
+            cardBrandFilter = DefaultCardBrandFilter,
+            hasOtherPaymentMethods = HAS_OTHER_PAYMENT_METHODS_DEFAULT_VALUE,
         )
     )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountForm.kt
@@ -88,7 +88,8 @@ internal fun USBankAccountForm(
                 onBehalfOf = usBankAccountFormArgs.onBehalfOf,
                 savedPaymentMethod = usBankAccountFormArgs.draftPaymentSelection as? New.USBankAccount,
                 shippingDetails = usBankAccountFormArgs.shippingDetails,
-                setAsDefaultPaymentMethodEnabled = usBankAccountFormArgs.setAsDefaultPaymentMethodEnabled
+                setAsDefaultPaymentMethodEnabled = usBankAccountFormArgs.setAsDefaultPaymentMethodEnabled,
+                hasOtherPaymentMethods = usBankAccountFormArgs.hasOtherPaymentMethods,
             )
         },
     )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArguments.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArguments.kt
@@ -17,6 +17,7 @@ import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.verticalmode.BankFormInteractor
 import com.stripe.android.paymentsheet.verticalmode.PaymentMethodIncentiveInteractor
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
+import com.stripe.android.ui.core.elements.HAS_OTHER_PAYMENT_METHODS_DEFAULT_VALUE
 import kotlinx.coroutines.flow.update
 
 /**
@@ -59,7 +60,8 @@ internal class USBankAccountFormArguments(
     val onUpdatePrimaryButtonUIState: ((PrimaryButton.UIState?) -> (PrimaryButton.UIState?)) -> Unit,
     val onUpdatePrimaryButtonState: (PrimaryButton.State) -> Unit,
     val onError: (ResolvableString?) -> Unit,
-    val setAsDefaultPaymentMethodEnabled: Boolean
+    val setAsDefaultPaymentMethodEnabled: Boolean,
+    val hasOtherPaymentMethods: Boolean,
 ) {
     companion object {
         fun create(
@@ -106,6 +108,7 @@ internal class USBankAccountFormArguments(
                 setAsDefaultPaymentMethodEnabled =
                 paymentMethodMetadata.customerMetadata?.isPaymentMethodSetAsDefaultEnabled
                     ?: IS_PAYMENT_METHOD_SET_AS_DEFAULT_ENABLED_DEFAULT_VALUE,
+                hasOtherPaymentMethods = viewModel.customerStateHolder.paymentMethods.value.isNotEmpty(),
             )
         }
 
@@ -153,6 +156,7 @@ internal class USBankAccountFormArguments(
                 setAsDefaultPaymentMethodEnabled =
                 paymentMethodMetadata.customerMetadata?.isPaymentMethodSetAsDefaultEnabled
                     ?: IS_PAYMENT_METHOD_SET_AS_DEFAULT_ENABLED_DEFAULT_VALUE,
+                hasOtherPaymentMethods = HAS_OTHER_PAYMENT_METHODS_DEFAULT_VALUE,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -677,7 +677,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
             ),
             paymentMethodExtraParams = if (setAsDefaultPaymentMethodElement != null) {
                 PaymentMethodExtraParams.USBankAccount(
-                    setAsDefault = setAsDefaultPaymentMethodElement.controller.setAsDefaultPaymentMethodChecked.value
+                    setAsDefault = setAsDefaultPaymentMethodElement.controller.shouldPaymentMethodBeSetAsDefault.value
                 )
             } else {
                 null

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -204,7 +204,8 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
         if (args.setAsDefaultPaymentMethodEnabled) {
             SetAsDefaultPaymentMethodElement(
                 initialValue = false,
-                saveForFutureUseCheckedFlow = saveForFutureUseCheckedFlow
+                saveForFutureUseCheckedFlow = saveForFutureUseCheckedFlow,
+                hasOtherPaymentMethods = args.hasOtherPaymentMethods,
             )
         } else {
             null
@@ -742,6 +743,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
         val shippingDetails: AddressDetails?,
         val hostedSurface: String,
         val setAsDefaultPaymentMethodEnabled: Boolean,
+        val hasOtherPaymentMethods: Boolean,
     )
 
     private companion object {

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -28,6 +28,7 @@ import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.SetupIntentFactory
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
+import com.stripe.android.ui.core.elements.HAS_OTHER_PAYMENT_METHODS_DEFAULT_VALUE
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance
 import org.junit.Rule
@@ -75,7 +76,8 @@ internal class CustomerSheetScreenshotTest {
         onUpdatePrimaryButtonState = { },
         onUpdatePrimaryButtonUIState = { },
         onError = { },
-        setAsDefaultPaymentMethodEnabled = false
+        setAsDefaultPaymentMethodEnabled = false,
+        hasOtherPaymentMethods = HAS_OTHER_PAYMENT_METHODS_DEFAULT_VALUE,
     )
 
     private val selectPaymentMethodViewState = CustomerSheetViewState.SelectPaymentMethod(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/FormElementsBuilderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/FormElementsBuilderTest.kt
@@ -9,6 +9,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.ui.core.elements.EmptyFormElement
+import com.stripe.android.ui.core.elements.HAS_OTHER_PAYMENT_METHODS_DEFAULT_VALUE
 import com.stripe.android.uicore.elements.IdentifierSpec
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -111,7 +112,8 @@ class FormElementsBuilderTest {
             requiresMandate = false,
             linkConfigurationCoordinator = null,
             onLinkInlineSignupStateChanged = { throw AssertionError("Not implemented") },
-            cardBrandFilter = DefaultCardBrandFilter
+            cardBrandFilter = DefaultCardBrandFilter,
+            hasOtherPaymentMethods = HAS_OTHER_PAYMENT_METHODS_DEFAULT_VALUE,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElementsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElementsTest.kt
@@ -16,6 +16,7 @@ import com.stripe.android.ui.core.elements.DropdownItemSpec
 import com.stripe.android.ui.core.elements.DropdownSpec
 import com.stripe.android.ui.core.elements.EmailElement
 import com.stripe.android.ui.core.elements.EmailSpec
+import com.stripe.android.ui.core.elements.HAS_OTHER_PAYMENT_METHODS_DEFAULT_VALUE
 import com.stripe.android.ui.core.elements.KeyboardType
 import com.stripe.android.ui.core.elements.MandateTextElement
 import com.stripe.android.ui.core.elements.NameSpec
@@ -390,7 +391,8 @@ private object TransformSpecToElementsFactory {
                 requiresMandate = requiresMandate,
                 linkConfigurationCoordinator = null,
                 onLinkInlineSignupStateChanged = { throw AssertionError("Not implemented") },
-                cardBrandFilter = DefaultCardBrandFilter
+                cardBrandFilter = DefaultCardBrandFilter,
+                hasOtherPaymentMethods = HAS_OTHER_PAYMENT_METHODS_DEFAULT_VALUE,
             )
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/TestUiDefinitionFactoryArgumentsFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/TestUiDefinitionFactoryArgumentsFactory.kt
@@ -17,6 +17,7 @@ internal object TestUiDefinitionFactoryArgumentsFactory {
         paymentMethodExtraParams: PaymentMethodExtraParams? = null,
         linkConfigurationCoordinator: LinkConfigurationCoordinator? = null,
         initialLinkUserInput: UserInput? = null,
+        hasOtherPaymentMethods: Boolean = true,
     ): UiDefinitionFactory.Arguments.Factory {
         val context: Context? = try {
             ApplicationProvider.getApplicationContext<Application>()
@@ -30,6 +31,7 @@ internal object TestUiDefinitionFactoryArgumentsFactory {
             linkConfigurationCoordinator = linkConfigurationCoordinator,
             initialLinkUserInput = initialLinkUserInput,
             onLinkInlineSignupStateChanged = { throw AssertionError("Not implemented") },
+            hasOtherPaymentMethods = hasOtherPaymentMethods,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionTestHelper.kt
@@ -12,6 +12,7 @@ internal fun PaymentMethodDefinition.formElements(
     paymentMethodExtraParams: PaymentMethodExtraParams? = null,
     initialLinkUserInput: UserInput? = null,
     linkConfigurationCoordinator: LinkConfigurationCoordinator? = null,
+    hasOtherPaymentMethods: Boolean = true,
 ): List<FormElement> {
     return requireNotNull(
         metadata.formElementsForCode(
@@ -21,6 +22,7 @@ internal fun PaymentMethodDefinition.formElements(
                 paymentMethodExtraParams = paymentMethodExtraParams,
                 linkConfigurationCoordinator = linkConfigurationCoordinator,
                 initialLinkUserInput = initialLinkUserInput,
+                hasOtherPaymentMethods = hasOtherPaymentMethods,
             )
         )
     )

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinitionTest.kt
@@ -108,36 +108,80 @@ class CardDefinitionTest {
 
     @Test
     fun `set_as_default_payment_method shown correctly when save_for_future_use checked`() {
-        val formElements = getFormElementsWithSaveForFutureUseAndSetAsDefaultPaymentMethod(
-            isPaymentMethodSetAsDefaultEnabled = true,
-        )
+        testSetAsDefaultElements(
+            hasOtherPaymentMethods = true,
+        ) { saveForFutureUseElement, setAsDefaultPaymentMethodElement ->
+            val saveForFutureUseController = saveForFutureUseElement.controller
 
-        val saveForFutureUseElement = formElements[1] as SaveForFutureUseElement
-        val saveForFutureUseController = saveForFutureUseElement.controller
-        val setAsDefaultPaymentMethodElement = formElements[2] as SetAsDefaultPaymentMethodElement
+            saveForFutureUseController.onValueChange(true)
 
-        saveForFutureUseController.onValueChange(true)
-
-        assertThat(setAsDefaultPaymentMethodElement.shouldShowElementFlow.value).isTrue()
+            assertThat(setAsDefaultPaymentMethodElement.shouldShowElementFlow.value).isTrue()
+        }
     }
 
     @Test
     fun `set_as_default_payment_method hidden correctly when save_for_future_use unchecked`() {
-        val formElements = getFormElementsWithSaveForFutureUseAndSetAsDefaultPaymentMethod(
-            isPaymentMethodSetAsDefaultEnabled = true,
-        )
+        testSetAsDefaultElements(
+            hasOtherPaymentMethods = true,
+        ) { saveForFutureUseElement, setAsDefaultPaymentMethodElement ->
+            val saveForFutureUseController = saveForFutureUseElement.controller
 
-        val saveForFutureUseElement = formElements[1] as SaveForFutureUseElement
-        val saveForFutureUseController = saveForFutureUseElement.controller
-        val setAsDefaultPaymentMethodElement = formElements[2] as SetAsDefaultPaymentMethodElement
+            saveForFutureUseController.onValueChange(true)
 
-        saveForFutureUseController.onValueChange(true)
+            assertThat(setAsDefaultPaymentMethodElement.shouldShowElementFlow.value).isTrue()
 
-        assertThat(setAsDefaultPaymentMethodElement.shouldShowElementFlow.value).isTrue()
+            saveForFutureUseController.onValueChange(false)
 
-        saveForFutureUseController.onValueChange(false)
+            assertThat(setAsDefaultPaymentMethodElement.shouldShowElementFlow.value).isFalse()
+        }
+    }
 
-        assertThat(setAsDefaultPaymentMethodElement.shouldShowElementFlow.value).isFalse()
+    @Test
+    fun `set_as_default_payment_method hidden when save_for_future_use unchecked & hasOtherPaymentMethods`() {
+        testSetAsDefaultElements(
+            hasOtherPaymentMethods = false,
+        ) { saveForFutureUseElement, setAsDefaultPaymentMethodElement ->
+            val saveForFutureUseController = saveForFutureUseElement.controller
+
+            saveForFutureUseController.onValueChange(false)
+            assertThat(setAsDefaultPaymentMethodElement.shouldShowElementFlow.value).isFalse()
+        }
+    }
+
+    @Test
+    fun `set_as_default_payment_method field false when save_for_future_use unchecked & hasOtherPaymentMethods`() {
+        testSetAsDefaultElements(
+            hasOtherPaymentMethods = false,
+        ) { saveForFutureUseElement, setAsDefaultPaymentMethodElement ->
+            val saveForFutureUseController = saveForFutureUseElement.controller
+
+            saveForFutureUseController.onValueChange(false)
+            assertThat(setAsDefaultPaymentMethodElement.controller.fieldValue.value.toBoolean()).isFalse()
+        }
+    }
+
+    @Test
+    fun `set_as_default_payment_method hidden when save_for_future_use checked & hasOtherPaymentMethods`() {
+        testSetAsDefaultElements(
+            hasOtherPaymentMethods = false,
+        ) { saveForFutureUseElement, setAsDefaultPaymentMethodElement ->
+            val saveForFutureUseController = saveForFutureUseElement.controller
+
+            saveForFutureUseController.onValueChange(true)
+            assertThat(setAsDefaultPaymentMethodElement.shouldShowElementFlow.value).isFalse()
+        }
+    }
+
+    @Test
+    fun `set_as_default_payment_method field true when save_for_future_use checked & hasOtherPaymentMethods`() {
+        testSetAsDefaultElements(
+            hasOtherPaymentMethods = false,
+        ) { saveForFutureUseElement, setAsDefaultPaymentMethodElement ->
+            val saveForFutureUseController = saveForFutureUseElement.controller
+
+            saveForFutureUseController.onValueChange(true)
+            assertThat(setAsDefaultPaymentMethodElement.controller.fieldValue.value.toBoolean()).isTrue()
+        }
     }
 
     @Test
@@ -220,17 +264,34 @@ class CardDefinitionTest {
         return this as MandateTextElement
     }
 
+    private fun testSetAsDefaultElements(
+        hasOtherPaymentMethods: Boolean,
+        block: (SaveForFutureUseElement, SetAsDefaultPaymentMethodElement) -> Unit
+    ) {
+        val formElements = getFormElementsWithSaveForFutureUseAndSetAsDefaultPaymentMethod(
+            isPaymentMethodSetAsDefaultEnabled = true,
+            hasOtherPaymentMethods = hasOtherPaymentMethods,
+        )
+
+        val saveForFutureUseElement = formElements[1] as SaveForFutureUseElement
+        val setAsDefaultPaymentMethodElement = formElements[2] as SetAsDefaultPaymentMethodElement
+
+        block(saveForFutureUseElement, setAsDefaultPaymentMethodElement)
+    }
+
     private fun getFormElementsWithSaveForFutureUseAndSetAsDefaultPaymentMethod(
-        isPaymentMethodSetAsDefaultEnabled: Boolean
+        isPaymentMethodSetAsDefaultEnabled: Boolean,
+        hasOtherPaymentMethods: Boolean = true,
     ): List<FormElement> {
         return CardDefinition.formElements(
-            PaymentMethodMetadataFactory.create(
+            metadata = PaymentMethodMetadataFactory.create(
                 billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
                     address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never
                 ),
                 hasCustomerConfiguration = true,
-                isPaymentMethodSetAsDefaultEnabled = isPaymentMethodSetAsDefaultEnabled
-            )
+                isPaymentMethodSetAsDefaultEnabled = isPaymentMethodSetAsDefaultEnabled,
+            ),
+            hasOtherPaymentMethods = hasOtherPaymentMethods,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperTest.kt
@@ -22,13 +22,13 @@ import com.stripe.android.model.PaymentMethodCreateParams.Companion.getNameFromP
 import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.model.SetupIntentFixtures
-import com.stripe.android.model.setupFutureUsage
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.transformToPaymentMethodCreateParams
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.R
+import com.stripe.android.ui.core.elements.HAS_OTHER_PAYMENT_METHODS_DEFAULT_VALUE
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
@@ -520,6 +520,7 @@ internal class FormHelperTest {
             linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
             linkInlineHandler = linkInlineHandler,
             selectionUpdater = selectionUpdater,
+            hasOtherPaymentMethods = HAS_OTHER_PAYMENT_METHODS_DEFAULT_VALUE,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/FormControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/FormControllerTest.kt
@@ -12,6 +12,7 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.ui.core.elements.CountrySpec
 import com.stripe.android.ui.core.elements.EmailSpec
+import com.stripe.android.ui.core.elements.HAS_OTHER_PAYMENT_METHODS_DEFAULT_VALUE
 import com.stripe.android.ui.core.elements.LayoutSpec
 import com.stripe.android.ui.core.elements.NameSpec
 import com.stripe.android.uicore.elements.IdentifierSpec
@@ -47,7 +48,8 @@ class FormControllerTest {
             requiresMandate = false,
             linkConfigurationCoordinator = null,
             onLinkInlineSignupStateChanged = { throw AssertionError("Not implemented") },
-            cardBrandFilter = DefaultCardBrandFilter
+            cardBrandFilter = DefaultCardBrandFilter,
+            hasOtherPaymentMethods = HAS_OTHER_PAYMENT_METHODS_DEFAULT_VALUE,
         )
     )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/AccountPreviewScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/AccountPreviewScreenshotTest.kt
@@ -11,6 +11,7 @@ import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.screenshottesting.PaparazziRule
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
+import com.stripe.android.ui.core.elements.HAS_OTHER_PAYMENT_METHODS_DEFAULT_VALUE
 import com.stripe.android.ui.core.elements.SaveForFutureUseElement
 import com.stripe.android.ui.core.elements.SetAsDefaultPaymentMethodElement
 import com.stripe.android.uicore.elements.EmailConfig
@@ -169,6 +170,24 @@ internal class AccountPreviewScreenshotTest {
         )
     }
 
+    @Test
+    fun testPaymentFlowWhenDoesNotHaveOtherPaymentMethods() {
+        saveForFutureUseElement.controller.onValueChange(true)
+
+        setAsDefaultPaymentMethodElement.controller.onValueChange(true)
+
+        takeAccountPreviewScreenShot(
+            state = BankFormScreenStateFactory.createWithSession(
+                sessionId = "session_1234",
+            ),
+            instantDebits = false,
+            isPaymentFlow = true,
+            enabled = true,
+            showCheckboxes = true,
+            hasOtherPaymentMethods = false
+        )
+    }
+
     private val defaultFormArguments = FormArguments(
         paymentMethodCode = PaymentMethod.Type.USBankAccount.code,
         merchantName = "Test Merchant",
@@ -191,7 +210,8 @@ internal class AccountPreviewScreenshotTest {
 
     private val setAsDefaultPaymentMethodElement = SetAsDefaultPaymentMethodElement(
         initialValue = false,
-        saveForFutureUseCheckedFlow = saveForFutureUseElement.controller.saveForFutureUse
+        saveForFutureUseCheckedFlow = saveForFutureUseElement.controller.saveForFutureUse,
+        hasOtherPaymentMethods = HAS_OTHER_PAYMENT_METHODS_DEFAULT_VALUE,
     )
 
     private fun takeAccountPreviewScreenShot(
@@ -202,6 +222,7 @@ internal class AccountPreviewScreenshotTest {
         fillAddress: Boolean = false,
         enabled: Boolean = true,
         showCheckboxes: Boolean = false,
+        hasOtherPaymentMethods: Boolean = HAS_OTHER_PAYMENT_METHODS_DEFAULT_VALUE,
     ) {
         paparazzi.snapshot {
             BankAccountForm(
@@ -215,7 +236,9 @@ internal class AccountPreviewScreenshotTest {
                 addressController = createAddressController(fillAddress = fillAddress),
                 sameAsShippingElement = sameAsShippingElement,
                 saveForFutureUseElement = saveForFutureUseElement,
-                setAsDefaultPaymentMethodElement = setAsDefaultPaymentMethodElement,
+                setAsDefaultPaymentMethodElement = setAsDefaultPaymentMethodElement.copy(
+                    hasOtherPaymentMethods = hasOtherPaymentMethods
+                ),
                 showCheckboxes = showCheckboxes,
                 lastTextFieldIdentifier = null,
                 onRemoveAccount = {},

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/BillingDetailsCollectionScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/BillingDetailsCollectionScreenshotTest.kt
@@ -11,6 +11,7 @@ import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.screenshottesting.PaparazziRule
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
+import com.stripe.android.ui.core.elements.HAS_OTHER_PAYMENT_METHODS_DEFAULT_VALUE
 import com.stripe.android.ui.core.elements.SaveForFutureUseElement
 import com.stripe.android.ui.core.elements.SetAsDefaultPaymentMethodElement
 import com.stripe.android.uicore.elements.EmailConfig
@@ -131,7 +132,8 @@ internal class BillingDetailsCollectionScreenshotTest {
 
     private val setAsDefaultPaymentMethodElement = SetAsDefaultPaymentMethodElement(
         initialValue = false,
-        saveForFutureUseCheckedFlow = stateFlowOf(false)
+        saveForFutureUseCheckedFlow = stateFlowOf(false),
+        hasOtherPaymentMethods = HAS_OTHER_PAYMENT_METHODS_DEFAULT_VALUE,
     )
 
     private fun testBillingDetailsCollectionScreenShot(


### PR DESCRIPTION
# Summary
Added hasOtherPaymentMethods to SetAsDefaultPaymentMethodController and SetAsDefaultPaymentMethodElement
Plumbing hasOtherPaymentMethods to controller and element
Updated Tests

#Todo for this task
Fix edge case in horizontal mode where user deletes last payment method

Add support for Embedded,  behavior is currently unchanges

# Motivation
We want the first saved payment method to be set as default for end users. It ensures that new users will always have a default payment method

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [X] Manually verified

# Screenshots
|US Bank Account|Cards|
|-|-|
|![1000000154](https://github.com/user-attachments/assets/68936493-7194-44c5-b005-39ac39866a9d)|![1000000153](https://github.com/user-attachments/assets/03a385f8-453d-4cb0-9e07-3fcec1d63a44)|

# Changelog
N.A.