### PR TITLE
[connect] Fix injecting `Logger`

### DIFF
--- a/connect-example/src/main/java/com/stripe/android/connect/example/App.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/App.kt
@@ -18,7 +18,7 @@ class App : Application() {
 
     @Inject lateinit var embeddedComponentService: EmbeddedComponentService
 
-    private val logger: Logger = Logger.getInstance(enableLogging = BuildConfig.DEBUG)
+    @Inject lateinit var logger: Logger
 
     override fun onCreate() {
         super.onCreate()

--- a/connect-example/src/main/java/com/stripe/android/connect/example/AppModule.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/AppModule.kt
@@ -1,0 +1,24 @@
+package com.stripe.android.connect.example
+
+import com.stripe.android.core.Logger
+import com.stripe.android.core.injection.ENABLE_LOGGING
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+class AppModule {
+    @Provides
+    @Named(ENABLE_LOGGING)
+    fun provideEnableLogging(): Boolean = BuildConfig.DEBUG
+
+    @Singleton
+    @Provides
+    fun provideLogger(@Named(ENABLE_LOGGING) enabled: Boolean): Logger {
+        return Logger.getInstance(enableLogging = enabled)
+    }
+}

--- a/connect-example/src/main/java/com/stripe/android/connect/example/data/EmbeddedComponentManagerFactory.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/data/EmbeddedComponentManagerFactory.kt
@@ -5,7 +5,6 @@ import com.stripe.android.connect.EmbeddedComponentManager
 import com.stripe.android.connect.FetchClientSecretCallback.ClientSecretResultCallback
 import com.stripe.android.connect.PrivateBetaConnectSDK
 import com.stripe.android.connect.appearance.fonts.CustomFontSource
-import com.stripe.android.core.BuildConfig
 import com.stripe.android.core.Logger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -19,9 +18,9 @@ import javax.inject.Singleton
 class EmbeddedComponentManagerFactory @Inject constructor(
     private val embeddedComponentService: EmbeddedComponentService,
     private val settingsService: SettingsService,
+    private val logger: Logger,
 ) {
     private val loggingTag = this::class.java.simpleName
-    private val logger: Logger = Logger.getInstance(enableLogging = BuildConfig.DEBUG)
     private val ioScope: CoroutineScope by lazy { CoroutineScope(Dispatchers.IO) }
 
     /**

--- a/connect-example/src/main/java/com/stripe/android/connect/example/data/EmbeddedComponentService.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/data/EmbeddedComponentService.kt
@@ -13,6 +13,7 @@ import com.stripe.android.connect.example.core.Loading
 import com.stripe.android.connect.example.core.Success
 import com.stripe.android.connect.example.core.Uninitialized
 import com.stripe.android.connect.example.data.EmbeddedComponentService.Companion.DEFAULT_SERVER_BASE_URL
+import com.stripe.android.core.Logger
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -53,6 +54,7 @@ interface EmbeddedComponentService {
 
 class EmbeddedComponentServiceImpl @Inject constructor(
     private val settingsService: SettingsService,
+    private val logger: Logger,
 ) : EmbeddedComponentService {
     override var serverBaseUrl: String = settingsService.getSelectedServerBaseURL() ?: DEFAULT_SERVER_BASE_URL
         private set
@@ -80,8 +82,8 @@ class EmbeddedComponentServiceImpl @Inject constructor(
             timeoutReadInMillisecond = 30_000
 
             // add logging
-            addRequestInterceptor(RequestLogger(tag = "EmbeddedComponentService"))
-            addResponseInterceptor(ResponseLogger(tag = "EmbeddedComponentService"))
+            addRequestInterceptor(RequestLogger(tag = "EmbeddedComponentService", logger = logger))
+            addResponseInterceptor(ResponseLogger(tag = "EmbeddedComponentService", logger = logger))
 
             // add headers
             addRequestInterceptor(ApplicationJsonHeaderInterceptor)

--- a/connect-example/src/main/java/com/stripe/android/connect/example/data/NetworkingInterceptors.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/data/NetworkingInterceptors.kt
@@ -6,7 +6,6 @@ import com.github.kittinunf.fuel.core.FoldableResponseInterceptor
 import com.github.kittinunf.fuel.core.RequestTransformer
 import com.github.kittinunf.fuel.core.ResponseTransformer
 import com.github.kittinunf.fuel.core.extensions.cUrlString
-import com.stripe.android.connect.example.BuildConfig
 import com.stripe.android.core.Logger
 import com.stripe.android.core.version.StripeSdkVersion
 
@@ -40,7 +39,7 @@ object UserAgentHeader : FoldableRequestInterceptor {
 
 class RequestLogger(
     private val tag: String,
-    private val logger: Logger = Logger.getInstance(enableLogging = BuildConfig.DEBUG),
+    private val logger: Logger,
 ) : FoldableRequestInterceptor {
     override fun invoke(next: RequestTransformer): RequestTransformer {
         return { request ->
@@ -52,7 +51,7 @@ class RequestLogger(
 
 class ResponseLogger(
     private val tag: String,
-    private val logger: Logger = Logger.getInstance(enableLogging = BuildConfig.DEBUG),
+    private val logger: Logger,
 ) : FoldableResponseInterceptor {
     override fun invoke(next: ResponseTransformer): ResponseTransformer {
         return { request, response ->

--- a/connect-example/src/main/java/com/stripe/android/connect/example/ui/appearance/AppearanceViewModel.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/ui/appearance/AppearanceViewModel.kt
@@ -2,7 +2,6 @@ package com.stripe.android.connect.example.ui.appearance
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.stripe.android.connect.BuildConfig
 import com.stripe.android.connect.example.data.SettingsService
 import com.stripe.android.core.Logger
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -17,9 +16,8 @@ import javax.inject.Inject
 @HiltViewModel
 class AppearanceViewModel @Inject constructor(
     private val settingsService: SettingsService,
+    private val logger: Logger,
 ) : ViewModel() {
-
-    private val logger: Logger = Logger.getInstance(enableLogging = BuildConfig.DEBUG)
     private val loggingTag = this::class.java.simpleName
 
     private val _state = MutableStateFlow(AppearanceState())

--- a/connect-example/src/main/java/com/stripe/android/connect/example/ui/embeddedcomponentmanagerloader/EmbeddedComponentLoaderViewModel.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/ui/embeddedcomponentmanagerloader/EmbeddedComponentLoaderViewModel.kt
@@ -8,7 +8,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.viewModelScope
 import com.github.kittinunf.fuel.core.FuelError
 import com.stripe.android.connect.PrivateBetaConnectSDK
-import com.stripe.android.connect.example.BuildConfig
 import com.stripe.android.connect.example.core.Fail
 import com.stripe.android.connect.example.core.Loading
 import com.stripe.android.connect.example.core.Success
@@ -35,9 +34,9 @@ class EmbeddedComponentLoaderViewModel @Inject constructor(
     private val embeddedComponentService: EmbeddedComponentService,
     private val embeddedComponentManagerFactory: EmbeddedComponentManagerFactory,
     private val settingsService: SettingsService,
+    private val logger: Logger,
 ) : ViewModel(), DefaultLifecycleObserver {
 
-    private val logger: Logger = Logger.getInstance(enableLogging = BuildConfig.DEBUG)
     private val loggingTag = this::class.java.simpleName
 
     private val _state = MutableStateFlow(EmbeddedComponentManagerLoaderState())

--- a/connect-example/src/main/java/com/stripe/android/connect/example/ui/settings/SettingsViewModel.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/ui/settings/SettingsViewModel.kt
@@ -2,7 +2,6 @@ package com.stripe.android.connect.example.ui.settings
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.stripe.android.connect.BuildConfig
 import com.stripe.android.connect.example.core.Async
 import com.stripe.android.connect.example.core.Uninitialized
 import com.stripe.android.connect.example.data.EmbeddedComponentService
@@ -26,10 +25,10 @@ import javax.inject.Inject
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
     private val embeddedComponentService: EmbeddedComponentService,
-    private val settingsService: SettingsService
+    private val settingsService: SettingsService,
+    private val logger: Logger,
 ) : ViewModel() {
 
-    private val logger: Logger = Logger.getInstance(enableLogging = BuildConfig.DEBUG)
     private val loggingTag = this::class.java.simpleName
 
     private val _state = MutableStateFlow(SettingsState(serverUrl = embeddedComponentService.serverBaseUrl))

--- a/connect/src/main/java/com/stripe/android/connect/di/StripeConnectComponent.kt
+++ b/connect/src/main/java/com/stripe/android/connect/di/StripeConnectComponent.kt
@@ -4,6 +4,7 @@ import com.stripe.android.connect.BuildConfig
 import com.stripe.android.connect.analytics.ConnectAnalyticsModule
 import com.stripe.android.connect.analytics.ConnectAnalyticsServiceFactory
 import com.stripe.android.connect.manager.EmbeddedComponentManagerComponent
+import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.ENABLE_LOGGING
 import dagger.BindsInstance
@@ -24,16 +25,19 @@ import javax.inject.Singleton
 )
 internal interface StripeConnectComponent {
 
+    val logger: Logger
+
     val analyticsServiceFactory: ConnectAnalyticsServiceFactory
 
     val coordinatorComponentProvider: Provider<EmbeddedComponentManagerComponent.Factory>
 
-    @Component.Builder
-    interface Builder {
-        @BindsInstance
-        fun loggingEnabled(@Named(ENABLE_LOGGING) enabled: Boolean): Builder
-
-        fun build(): StripeConnectComponent
+    @Component.Factory
+    interface Factory {
+        fun build(
+            @BindsInstance
+            @Named(ENABLE_LOGGING)
+            enableLogging: Boolean,
+        ): StripeConnectComponent
     }
 
     companion object {
@@ -42,9 +46,8 @@ internal interface StripeConnectComponent {
         internal val instance: StripeConnectComponent
             get() = synchronized(StripeConnectComponent) {
                 _instance
-                    ?: DaggerStripeConnectComponent.builder()
-                        .loggingEnabled(BuildConfig.DEBUG)
-                        .build()
+                    ?: DaggerStripeConnectComponent.factory()
+                        .build(enableLogging = BuildConfig.DEBUG)
                         .also { _instance = it }
             }
 

--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainer.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainer.kt
@@ -17,7 +17,6 @@ import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.findViewTreeViewModelStoreOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.viewmodel.MutableCreationExtras
-import com.stripe.android.connect.BuildConfig
 import com.stripe.android.connect.ComponentEvent
 import com.stripe.android.connect.ComponentListenerDelegate
 import com.stripe.android.connect.ComponentProps
@@ -25,6 +24,7 @@ import com.stripe.android.connect.EmbeddedComponentManager
 import com.stripe.android.connect.PrivateBetaConnectSDK
 import com.stripe.android.connect.StripeEmbeddedComponent
 import com.stripe.android.connect.StripeEmbeddedComponentListener
+import com.stripe.android.connect.di.StripeConnectComponent
 import com.stripe.android.connect.toJsonObject
 import com.stripe.android.connect.util.AndroidClock
 import com.stripe.android.core.Logger
@@ -65,7 +65,7 @@ internal class StripeConnectWebViewContainerImpl<Listener, Props>(
     override var listener: Listener?,
     props: Props?,
     private val listenerDelegate: ComponentListenerDelegate<Listener> = ComponentListenerDelegate(),
-    private val logger: Logger = Logger.getInstance(enableLogging = BuildConfig.DEBUG),
+    private val logger: Logger = StripeConnectComponent.instance.logger,
 ) : StripeConnectWebViewContainer<Listener, Props>,
     View.OnAttachStateChangeListener
     where Props : ComponentProps,

--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerViewModel.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerViewModel.kt
@@ -20,13 +20,13 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.lifecycle.viewmodel.CreationExtras
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
-import com.stripe.android.connect.BuildConfig
 import com.stripe.android.connect.ComponentEvent
 import com.stripe.android.connect.EmbeddedComponentManager
 import com.stripe.android.connect.PrivateBetaConnectSDK
 import com.stripe.android.connect.StripeEmbeddedComponent
 import com.stripe.android.connect.analytics.ComponentAnalyticsService
 import com.stripe.android.connect.analytics.ConnectAnalyticsEvent
+import com.stripe.android.connect.di.StripeConnectComponent
 import com.stripe.android.connect.util.Clock
 import com.stripe.android.connect.util.isInInstrumentationTest
 import com.stripe.android.connect.webview.StripeConnectWebView.Delegate
@@ -77,8 +77,8 @@ internal class StripeConnectWebViewContainerViewModel(
     private val embeddedComponentManager: EmbeddedComponentManager,
     private val embeddedComponent: StripeEmbeddedComponent,
     private val analyticsService: ComponentAnalyticsService,
+    private val logger: Logger,
     private val stripeIntentLauncher: StripeIntentLauncher = StripeIntentLauncherImpl(),
-    private val logger: Logger = Logger.getInstance(enableLogging = BuildConfig.DEBUG),
     createWebView: CreateWebView = CreateWebView(::StripeConnectWebView),
 ) : ViewModel(),
     DefaultLifecycleObserver {
@@ -407,7 +407,7 @@ internal class StripeConnectWebViewContainerViewModel(
         val embeddedComponentManager: EmbeddedComponentManager,
         val embeddedComponent: StripeEmbeddedComponent,
         val stripeIntentLauncher: StripeIntentLauncher = StripeIntentLauncherImpl(),
-        val logger: Logger = Logger.getInstance(enableLogging = BuildConfig.DEBUG),
+        val logger: Logger = StripeConnectComponent.instance.logger,
     ) {
         val analyticsService = embeddedComponentManager.coordinator.getComponentAnalyticsService(embeddedComponent)
     }

--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeIntentLauncher.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeIntentLauncher.kt
@@ -6,7 +6,7 @@ import android.content.Intent
 import android.net.Uri
 import androidx.browser.customtabs.CustomTabsIntent
 import com.stripe.android.connect.R
-import com.stripe.android.core.BuildConfig
+import com.stripe.android.connect.di.StripeConnectComponent
 import com.stripe.android.core.Logger
 
 internal interface StripeIntentLauncher {
@@ -28,7 +28,7 @@ internal interface StripeIntentLauncher {
 
 internal class StripeIntentLauncherImpl(
     private val toastManagerImpl: StripeToastManagerImpl = StripeToastManagerImpl(),
-    private val logger: Logger = Logger.getInstance(enableLogging = BuildConfig.DEBUG)
+    private val logger: Logger = StripeConnectComponent.instance.logger,
 ) : StripeIntentLauncher {
 
     override fun launchSecureExternalWebTab(context: Context, uri: Uri) {

--- a/connect/src/test/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerViewModelTest.kt
+++ b/connect/src/test/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerViewModelTest.kt
@@ -112,10 +112,11 @@ class StripeConnectWebViewContainerViewModelTest {
     fun `WebView delegate is set`() {
         val viewModel = StripeConnectWebViewContainerViewModel(
             application = RuntimeEnvironment.getApplication(),
-            analyticsService = analyticsService,
             clock = androidClock,
             embeddedComponentManager = embeddedComponentManager,
             embeddedComponent = embeddedComponent,
+            analyticsService = analyticsService,
+            logger = Logger.noop(),
             // Default `createWebView` value
         )
         assertThat(viewModel.webView.delegate).isEqualTo(viewModel.delegate)

--- a/connect/src/test/java/com/stripe/android/connect/webview/StripeConnectWebViewTest.kt
+++ b/connect/src/test/java/com/stripe/android/connect/webview/StripeConnectWebViewTest.kt
@@ -42,7 +42,7 @@ class StripeConnectWebViewTest {
         webView = StripeConnectWebView(
             application = RuntimeEnvironment.getApplication(),
             delegate = mockDelegate,
-            logger = Logger.getInstance(enableLogging = false)
+            logger = Logger.getInstance(enableLogging = true)
         )
     }
 


### PR DESCRIPTION
# Summary
In multiple places, fix instantiating `Logger` instead of getting it from the dagger graph. This was a particular nuisance when I was trying to debug an issue in release builds and I needed to temporarily enable logging.

# Motivation
https://jira.corp.stripe.com/browse/CAX-3890
https://jira.corp.stripe.com/browse/CAX-3889

# Testing
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified
