### PR TITLE
Bump Emerge Tools Gradle Plugin to 4.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ plugins {
     id 'com.google.devtools.ksp' version '2.1.10-1.0.30' apply false
     id 'dev.drewhamilton.poko' version '0.18.2' apply false
     id 'org.jetbrains.kotlin.jvm' version '2.1.10' apply false
-    id 'com.emergetools.android' version '4.0.0' apply false
+    id 'com.emergetools.android' version '4.3.0' apply false
     id 'com.google.dagger.hilt.android' version '2.55' apply false
 }
 


### PR DESCRIPTION
Link to release notes: https://github.com/EmergeTools/emerge-android/releases/tag/gradle-plugin-v4.3.0
