### PR TITLE
Trigger Link CVC recollection for `STATE_INVALID`

### DIFF
--- a/payments-model/src/main/java/com/stripe/android/model/CvcCheck.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/CvcCheck.kt
@@ -10,10 +10,11 @@ enum class CvcCheck(
     Fail("FAIL"),
     Unavailable("UNAVAILABLE"),
     Unchecked("UNCHECKED"),
+    StateInvalid("STATE_INVALID"),
     Unknown("UNKNOWN");
 
     val requiresRecollection: Boolean
-        get() = this in setOf(Fail, Unavailable, Unchecked)
+        get() = this in setOf(Fail, Unavailable, Unchecked, StateInvalid)
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     companion object {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request updates the native Link experience to trigger CVC recollection for `STATE_INVALID` CVC checks.

(cc @davidme-stripe)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

https://github.com/stripe/stripe-ios/pull/4456

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
