### PR TITLE
Add call to `/institution_selected` endpoint

### DIFF
--- a/financial-connections/api/financial-connections.api
+++ b/financial-connections/api/financial-connections.api
@@ -610,6 +610,14 @@ public final class com/stripe/android/financialconnections/model/FinancialConnec
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/financialconnections/model/FinancialConnectionsInstitutionSelected$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/financialconnections/model/FinancialConnectionsInstitutionSelected;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/financialconnections/model/FinancialConnectionsInstitutionSelected;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/financialconnections/model/FinancialConnectionsSessionManifest$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/financialconnections/model/FinancialConnectionsSessionManifest;

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/SelectInstitution.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/SelectInstitution.kt
@@ -1,0 +1,22 @@
+package com.stripe.android.financialconnections.domain
+
+import com.stripe.android.financialconnections.FinancialConnectionsSheetConfiguration
+import com.stripe.android.financialconnections.model.FinancialConnectionsInstitution
+import com.stripe.android.financialconnections.model.FinancialConnectionsInstitutionSelected
+import com.stripe.android.financialconnections.repository.FinancialConnectionsManifestRepository
+import javax.inject.Inject
+
+internal class SelectInstitution @Inject constructor(
+    private val repository: FinancialConnectionsManifestRepository,
+    private val configuration: FinancialConnectionsSheetConfiguration,
+) {
+
+    suspend operator fun invoke(
+        institution: FinancialConnectionsInstitution,
+    ): FinancialConnectionsInstitutionSelected {
+        return repository.selectInstitution(
+            clientSecret = configuration.financialConnectionsSessionClientSecret,
+            institution = institution,
+        )
+    }
+}

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/model/FinancialConnectionsInstitutionSelected.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/model/FinancialConnectionsInstitutionSelected.kt
@@ -1,0 +1,15 @@
+package com.stripe.android.financialconnections.model
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+@Parcelize
+internal data class FinancialConnectionsInstitutionSelected(
+    @SerialName("manifest")
+    val manifest: FinancialConnectionsSessionManifest,
+    @SerialName("text")
+    val text: TextUpdate? = null,
+) : Parcelable

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/model/FinancialConnectionsSessionManifest.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/model/FinancialConnectionsSessionManifest.kt
@@ -57,6 +57,9 @@ internal data class FinancialConnectionsSessionManifest(
     @SerialName(value = "consent_required")
     val consentRequired: Boolean,
 
+    @SerialName(value = "consent_acquired_at")
+    val consentAcquiredAt: String?,
+
     @SerialName(value = "custom_manual_entry_handling")
     val customManualEntryHandling: Boolean,
 
@@ -186,6 +189,9 @@ internal data class FinancialConnectionsSessionManifest(
     @SerialName("theme")
     val theme: Theme? = null,
 ) : Parcelable {
+
+    val consentAcquired: Boolean
+        get() = !consentRequired || consentAcquiredAt != null
 
     /**
      *

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/ApiKeyFixtures.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/ApiKeyFixtures.kt
@@ -52,7 +52,9 @@ internal object ApiKeyFixtures {
         livemode = true
     )
 
-    fun sessionManifest() = FinancialConnectionsSessionManifest(
+    fun sessionManifest(
+        consentAcquiredAt: String? = "some_date",
+    ) = FinancialConnectionsSessionManifest(
         allowManualEntry = true,
         consentRequired = true,
         customManualEntryHandling = true,
@@ -73,7 +75,8 @@ internal object ApiKeyFixtures {
         manualEntryMode = ManualEntryMode.AUTOMATIC,
         successUrl = SUCCESS_URL,
         cancelUrl = CANCEL_URL,
-        hostedAuthUrl = HOSTED_AUTH_URL
+        hostedAuthUrl = HOSTED_AUTH_URL,
+        consentAcquiredAt = consentAcquiredAt,
     )
 
     fun authorizationSession() = FinancialConnectionsAuthorizationSession(

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerViewModelTest.kt
@@ -12,6 +12,7 @@ import com.stripe.android.financialconnections.domain.GetOrFetchSync
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
 import com.stripe.android.financialconnections.domain.PostAuthorizationSession
 import com.stripe.android.financialconnections.domain.SearchInstitutions
+import com.stripe.android.financialconnections.domain.SelectInstitution
 import com.stripe.android.financialconnections.domain.UpdateLocalManifest
 import com.stripe.android.financialconnections.exception.InstitutionPlannedDowntimeError
 import com.stripe.android.financialconnections.model.FinancialConnectionsAuthorizationSession
@@ -32,7 +33,10 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TestRule
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import kotlin.test.assertEquals
@@ -52,6 +56,7 @@ internal class InstitutionPickerViewModelTest {
     private val updateLocalManifest = mock<UpdateLocalManifest>()
     private val navigationManager = TestNavigationManager()
     private val postAuthorizationSession = mock<PostAuthorizationSession>()
+    private val selectInstitution = mock<SelectInstitution>()
     private val eventTracker = TestFinancialConnectionsAnalyticsTracker()
     private val nativeAuthFlowCoordinator = NativeAuthFlowCoordinator()
     private val defaultConfiguration = FinancialConnectionsSheetConfiguration(
@@ -72,6 +77,7 @@ internal class InstitutionPickerViewModelTest {
             logger = Logger.noop(),
             eventTracker = eventTracker,
             postAuthorizationSession = postAuthorizationSession,
+            selectInstitution = selectInstitution,
             handleError = handleError,
             initialState = state,
             nativeAuthFlowCoordinator = nativeAuthFlowCoordinator,
@@ -325,6 +331,41 @@ internal class InstitutionPickerViewModelTest {
             pane = Pane.INSTITUTION_PICKER,
             displayErrorScreen = true
         )
+    }
+
+    @Test
+    fun `Creates normal auth session when not in 'institution picker first' flow`() = runTest {
+        val manifest = ApiKeyFixtures.sessionManifest().copy(
+            consentRequired = true,
+            consentAcquiredAt = "some date",
+        )
+        val institution = ApiKeyFixtures.institution()
+
+        givenManifestReturns(manifest)
+        givenCreateSessionForInstitutionReturns(ApiKeyFixtures.authorizationSession())
+
+        val viewModel = buildViewModel(InstitutionPickerState())
+        viewModel.onInstitutionSelected(institution, fromFeatured = true)
+
+        verify(postAuthorizationSession).invoke(eq(institution), any())
+        verify(selectInstitution, never()).invoke(any())
+    }
+
+    @Test
+    fun `Calls institution_selected when in 'institution picker first' flow`() = runTest {
+        val manifest = ApiKeyFixtures.sessionManifest().copy(
+            consentRequired = true,
+            consentAcquiredAt = null,
+        )
+        val institution = ApiKeyFixtures.institution()
+
+        givenManifestReturns(manifest)
+
+        val viewModel = buildViewModel(InstitutionPickerState())
+        viewModel.onInstitutionSelected(institution, fromFeatured = true)
+
+        verify(postAuthorizationSession, never()).invoke(any(), any())
+        verify(selectInstitution).invoke(institution)
     }
 
     private suspend fun givenCreateSessionForInstitutionThrows(throwable: Throwable) {

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/networking/AbsFinancialConnectionsManifestRepository.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/networking/AbsFinancialConnectionsManifestRepository.kt
@@ -3,6 +3,7 @@ package com.stripe.android.financialconnections.networking
 import com.stripe.android.financialconnections.analytics.AuthSessionEvent
 import com.stripe.android.financialconnections.model.FinancialConnectionsAuthorizationSession
 import com.stripe.android.financialconnections.model.FinancialConnectionsInstitution
+import com.stripe.android.financialconnections.model.FinancialConnectionsInstitutionSelected
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
 import com.stripe.android.financialconnections.model.SynchronizeSessionResponse
 import com.stripe.android.financialconnections.repository.FinancialConnectionsManifestRepository
@@ -105,6 +106,13 @@ internal abstract class AbsFinancialConnectionsManifestRepository : FinancialCon
         supportsAppVerification: Boolean,
         reFetchCondition: (SynchronizeSessionResponse) -> Boolean
     ): SynchronizeSessionResponse {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun selectInstitution(
+        clientSecret: String,
+        institution: FinancialConnectionsInstitution
+    ): FinancialConnectionsInstitutionSelected {
         TODO("Not yet implemented")
     }
 }

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/networking/FakeFinancialConnectionsManifestRepository.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/networking/FakeFinancialConnectionsManifestRepository.kt
@@ -4,6 +4,7 @@ import com.stripe.android.financialconnections.ApiKeyFixtures
 import com.stripe.android.financialconnections.analytics.AuthSessionEvent
 import com.stripe.android.financialconnections.model.FinancialConnectionsAuthorizationSession
 import com.stripe.android.financialconnections.model.FinancialConnectionsInstitution
+import com.stripe.android.financialconnections.model.FinancialConnectionsInstitutionSelected
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
 import com.stripe.android.financialconnections.model.SynchronizeSessionResponse
 import com.stripe.android.financialconnections.repository.FinancialConnectionsManifestRepository
@@ -109,4 +110,11 @@ internal class FakeFinancialConnectionsManifestRepository : FinancialConnections
     override fun updateLocalManifest(
         block: (FinancialConnectionsSessionManifest) -> FinancialConnectionsSessionManifest
     ) = Unit
+
+    override suspend fun selectInstitution(
+        clientSecret: String,
+        institution: FinancialConnectionsInstitution
+    ): FinancialConnectionsInstitutionSelected {
+        TODO("Not yet implemented")
+    }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds support for calling the `/institution_selected` endpoint in the institution picker, which will be used by https://github.com/stripe/stripe-android/pull/10397.

(cc @mats-stripe)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
