### PR TITLE
Add dedicated Link login destination

### DIFF
--- a/financial-connections/api/financial-connections.api
+++ b/financial-connections/api/financial-connections.api
@@ -812,6 +812,7 @@ public final class com/stripe/android/financialconnections/navigation/Composable
 	public final fun getLambda-2$financial_connections_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda-20$financial_connections_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda-21$financial_connections_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-22$financial_connections_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda-3$financial_connections_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda-4$financial_connections_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda-5$financial_connections_release ()Lkotlin/jvm/functions/Function3;

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/navigation/Destination.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/navigation/Destination.kt
@@ -154,6 +154,13 @@ internal sealed class Destination(
         composable = { NetworkingLinkSignupScreen() }
     )
 
+    data object LinkLogin : Destination(
+        route = Pane.LINK_LOGIN.value,
+        closeWithoutConfirmation = false,
+        logPaneLaunched = true,
+        composable = { NetworkingLinkSignupScreen() }
+    )
+
     data object NetworkingLinkLoginWarmup : Destination(
         route = Pane.NETWORKING_LINK_LOGIN_WARMUP.value,
         extraArgs = listOf(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/navigation/DestinationMappers.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/navigation/DestinationMappers.kt
@@ -13,7 +13,7 @@ private val paneToDestination = mapOf(
     Pane.MANUAL_ENTRY to Destination.ManualEntry,
     Pane.ATTACH_LINKED_PAYMENT_ACCOUNT to Destination.AttachLinkedPaymentAccount,
     Pane.NETWORKING_LINK_SIGNUP_PANE to Destination.NetworkingLinkSignup,
-    Pane.LINK_LOGIN to Destination.NetworkingLinkSignup,
+    Pane.LINK_LOGIN to Destination.LinkLogin,
     Pane.NETWORKING_LINK_LOGIN_WARMUP to Destination.NetworkingLinkLoginWarmup,
     Pane.NETWORKING_LINK_VERIFICATION to Destination.NetworkingLinkVerification,
     Pane.NETWORKING_SAVE_TO_LINK_VERIFICATION to Destination.NetworkingSaveToLinkVerification,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
@@ -223,6 +223,7 @@ internal class FinancialConnectionsSheetNativeActivity : AppCompatActivity() {
                         composable(Destination.ManualEntrySuccess)
                         bottomSheet(Destination.Notice)
                         bottomSheet(Destination.AccountUpdateRequired)
+                        composable(Destination.LinkLogin)
                     }
                 }
             }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request, in preparation for https://github.com/stripe/stripe-android/pull/10397, adds a dedicated `LinkLogin` destination instead of reusing `NetworkingLinkSignup`. This hasn't been causing issues before, but would result in minor UX issues for the “institution picker first” flow.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
