### PR TITLE
10393 PR fast follow

### DIFF
--- a/payment-element-test-pages/src/main/java/com/stripe/paymentelementtestpages/SavedPaymentMethodsPage.kt
+++ b/payment-element-test-pages/src/main/java/com/stripe/paymentelementtestpages/SavedPaymentMethodsPage.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import com.stripe.android.paymentsheet.PaymentOptionsItemViewType
 import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_EDIT_BUTTON_TEST_TAG
 import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_OPTION_TAB_LAYOUT_TEST_TAG
 import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_OPTION_TEST_TAG
@@ -65,8 +66,8 @@ class SavedPaymentMethodsPage(private val composeTestRule: ComposeTestRule) {
                 .fetchSemanticsNodes()
                 .isNotEmpty()
         }
-        // AddCard is the value of PaymentOptionItems.ViewType.AddCard.name()
-        val testTag = "AddCard"
+
+        val testTag = PaymentOptionsItemViewType.AddCard.name
 
         composeTestRule.waitUntil(
             timeoutMillis = 5000L

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/DefaultPaymentMethodsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/DefaultPaymentMethodsTest.kt
@@ -202,9 +202,9 @@ internal class DefaultPaymentMethodsTest {
         testContext.markTestSucceeded()
     }
 
-    @Suppress("MaxLineLength")
     @Test
-    fun setNewCardAsDefault_withSavedPaymentMethods_uncheckSetAsDefault_doesNotSendSetAsDefaultParamInConfirmCall() = runProductIntegrationTest(
+    fun setNewCardAsDefault_withSavedPaymentMethods_uncheckSetAsDefault_doesNotSendSetAsDefaultParamInConfirmCall() =
+        runProductIntegrationTest(
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
@@ -238,9 +238,9 @@ internal class DefaultPaymentMethodsTest {
         paymentSheetPage.clickPrimaryButton()
     }
 
-    @Suppress("MaxLineLength")
     @Test
-    fun setNewCardAsDefault_withSavedPaymentMethods_uncheckSaveForFuture_doesNotSendSetAsDefaultParamInConfirmCall() = runProductIntegrationTest(
+    fun setNewCardAsDefault_withSavedPaymentMethods_uncheckSaveForFuture_doesNotSendSetAsDefaultParamInConfirmCall() =
+        runProductIntegrationTest(
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsItem.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsItem.kt
@@ -1,24 +1,25 @@
 package com.stripe.android.paymentsheet
 
+import androidx.annotation.RestrictTo
 import com.stripe.android.model.PaymentMethod
 
 internal sealed class PaymentOptionsItem {
 
-    abstract val viewType: ViewType
+    abstract val viewType: PaymentOptionsItemViewType
     abstract val isEnabledDuringEditing: Boolean
 
     object AddCard : PaymentOptionsItem() {
-        override val viewType: ViewType = ViewType.AddCard
+        override val viewType: PaymentOptionsItemViewType = PaymentOptionsItemViewType.AddCard
         override val isEnabledDuringEditing: Boolean = false
     }
 
     object GooglePay : PaymentOptionsItem() {
-        override val viewType: ViewType = ViewType.GooglePay
+        override val viewType: PaymentOptionsItemViewType = PaymentOptionsItemViewType.GooglePay
         override val isEnabledDuringEditing: Boolean = false
     }
 
     object Link : PaymentOptionsItem() {
-        override val viewType: ViewType = ViewType.Link
+        override val viewType: PaymentOptionsItemViewType = PaymentOptionsItemViewType.Link
         override val isEnabledDuringEditing: Boolean = false
     }
 
@@ -28,7 +29,7 @@ internal sealed class PaymentOptionsItem {
     data class SavedPaymentMethod(
         val displayableSavedPaymentMethod: DisplayableSavedPaymentMethod,
     ) : PaymentOptionsItem() {
-        override val viewType: ViewType = ViewType.SavedPaymentMethod
+        override val viewType: PaymentOptionsItemViewType = PaymentOptionsItemViewType.SavedPaymentMethod
 
         val displayName = displayableSavedPaymentMethod.displayName
         val paymentMethod = displayableSavedPaymentMethod.paymentMethod
@@ -36,13 +37,14 @@ internal sealed class PaymentOptionsItem {
 
         override val isEnabledDuringEditing: Boolean = true
     }
+}
 
-    enum class ViewType {
-        SavedPaymentMethod,
-        AddCard,
-        GooglePay,
-        Link,
-    }
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+enum class PaymentOptionsItemViewType {
+    SavedPaymentMethod,
+    AddCard,
+    GooglePay,
+    Link,
 }
 
 internal val PaymentOptionsItem.key: String

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsItemsMapperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsItemsMapperTest.kt
@@ -8,6 +8,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.PaymentOptionsItem
+import com.stripe.android.paymentsheet.PaymentOptionsItemViewType
 import com.stripe.android.paymentsheet.state.CustomerState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
@@ -51,11 +52,11 @@ class PaymentOptionsItemsMapperTest {
 
             val state = awaitItem()
             assertThat(state).hasSize(5)
-            assertThat(state[0].viewType).isEqualTo(PaymentOptionsItem.ViewType.AddCard)
-            assertThat(state[1].viewType).isEqualTo(PaymentOptionsItem.ViewType.GooglePay)
-            assertThat(state[2].viewType).isEqualTo(PaymentOptionsItem.ViewType.Link)
-            assertThat(state[3].viewType).isEqualTo(PaymentOptionsItem.ViewType.SavedPaymentMethod)
-            assertThat(state[4].viewType).isEqualTo(PaymentOptionsItem.ViewType.SavedPaymentMethod)
+            assertThat(state[0].viewType).isEqualTo(PaymentOptionsItemViewType.AddCard)
+            assertThat(state[1].viewType).isEqualTo(PaymentOptionsItemViewType.GooglePay)
+            assertThat(state[2].viewType).isEqualTo(PaymentOptionsItemViewType.Link)
+            assertThat(state[3].viewType).isEqualTo(PaymentOptionsItemViewType.SavedPaymentMethod)
+            assertThat(state[4].viewType).isEqualTo(PaymentOptionsItemViewType.SavedPaymentMethod)
         }
     }
 
@@ -157,7 +158,7 @@ class PaymentOptionsItemsMapperTest {
 
             val state = awaitItem()
             assertThat(state).hasSize(3)
-            assertThat(state[0].viewType).isEqualTo(PaymentOptionsItem.ViewType.AddCard)
+            assertThat(state[0].viewType).isEqualTo(PaymentOptionsItemViewType.AddCard)
 
             assertBlock(
                 state[1] as? PaymentOptionsItem.SavedPaymentMethod,


### PR DESCRIPTION
# Summary
Fast Follow for this PR https://github.com/stripe/stripe-android/pull/10393

Removing unneeded suppress for max line
Refactoring PaymentOptionsItem.ViewType, so we don't hardcode in SavedPaymentMethodsPage tests

# Motivation
Addressing some comments that were not addressed prior to merging


# Testing
- [ ] Added tests
- [X] Modified tests
- [ ] Manually verified

# Screenshots
N.A.

# Changelog
N.A.
