### PR TITLE
Remove suppression of MaxLineLength in DefaultPaymentMethodsTest

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/DefaultPaymentMethodsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/DefaultPaymentMethodsTest.kt
@@ -202,9 +202,9 @@ internal class DefaultPaymentMethodsTest {
         testContext.markTestSucceeded()
     }
 
-    @Suppress("MaxLineLength")
     @Test
-    fun setNewCardAsDefault_withSavedPaymentMethods_uncheckSetAsDefault_doesNotSendSetAsDefaultParamInConfirmCall() = runProductIntegrationTest(
+    fun setNewCardAsDefault_withSavedPaymentMethods_uncheckSetAsDefault_doesNotSendSetAsDefaultParamInConfirmCall() =
+        runProductIntegrationTest(
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
@@ -238,9 +238,9 @@ internal class DefaultPaymentMethodsTest {
         paymentSheetPage.clickPrimaryButton()
     }
 
-    @Suppress("MaxLineLength")
     @Test
-    fun setNewCardAsDefault_withSavedPaymentMethods_uncheckSaveForFuture_doesNotSendSetAsDefaultParamInConfirmCall() = runProductIntegrationTest(
+    fun setNewCardAsDefault_withSavedPaymentMethods_uncheckSaveForFuture_doesNotSendSetAsDefaultParamInConfirmCall() =
+        runProductIntegrationTest(
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,


### PR DESCRIPTION
# Summary
Indented the name of this function to remove the maxLineLength Supresss