### PR TITLE
Stop hardcoding "AddCard" in SavedPaymentMethodsPage

### DIFF
--- a/payment-element-test-pages/src/main/java/com/stripe/paymentelementtestpages/SavedPaymentMethodsPage.kt
+++ b/payment-element-test-pages/src/main/java/com/stripe/paymentelementtestpages/SavedPaymentMethodsPage.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import com.stripe.android.paymentsheet.PaymentOptionsItem
 import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_EDIT_BUTTON_TEST_TAG
 import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_OPTION_TAB_LAYOUT_TEST_TAG
 import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_OPTION_TEST_TAG
@@ -65,8 +66,7 @@ class SavedPaymentMethodsPage(private val composeTestRule: ComposeTestRule) {
                 .fetchSemanticsNodes()
                 .isNotEmpty()
         }
-        // AddCard is the value of PaymentOptionItems.ViewType.AddCard.name()
-        val testTag = "AddCard"
+        val testTag = PaymentOptionsItem.ViewType.AddCard.name
 
         composeTestRule.waitUntil(
             timeoutMillis = 5000L

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -899,6 +899,16 @@ public final class com/stripe/android/paymentsheet/PaymentOptionResult$Succeeded
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/paymentsheet/PaymentOptionsItem$ViewType : java/lang/Enum {
+	public static final field AddCard Lcom/stripe/android/paymentsheet/PaymentOptionsItem$ViewType;
+	public static final field GooglePay Lcom/stripe/android/paymentsheet/PaymentOptionsItem$ViewType;
+	public static final field Link Lcom/stripe/android/paymentsheet/PaymentOptionsItem$ViewType;
+	public static final field SavedPaymentMethod Lcom/stripe/android/paymentsheet/PaymentOptionsItem$ViewType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentOptionsItem$ViewType;
+	public static fun values ()[Lcom/stripe/android/paymentsheet/PaymentOptionsItem$ViewType;
+}
+
 public final class com/stripe/android/paymentsheet/PaymentSheet {
 	public static final field $stable I
 	public static final field Companion Lcom/stripe/android/paymentsheet/PaymentSheet$Companion;

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -899,16 +899,6 @@ public final class com/stripe/android/paymentsheet/PaymentOptionResult$Succeeded
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/stripe/android/paymentsheet/PaymentOptionsItem$ViewType : java/lang/Enum {
-	public static final field AddCard Lcom/stripe/android/paymentsheet/PaymentOptionsItem$ViewType;
-	public static final field GooglePay Lcom/stripe/android/paymentsheet/PaymentOptionsItem$ViewType;
-	public static final field Link Lcom/stripe/android/paymentsheet/PaymentOptionsItem$ViewType;
-	public static final field SavedPaymentMethod Lcom/stripe/android/paymentsheet/PaymentOptionsItem$ViewType;
-	public static fun getEntries ()Lkotlin/enums/EnumEntries;
-	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentOptionsItem$ViewType;
-	public static fun values ()[Lcom/stripe/android/paymentsheet/PaymentOptionsItem$ViewType;
-}
-
 public final class com/stripe/android/paymentsheet/PaymentSheet {
 	public static final field $stable I
 	public static final field Companion Lcom/stripe/android/paymentsheet/PaymentSheet$Companion;

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsItem.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsItem.kt
@@ -39,6 +39,7 @@ sealed class PaymentOptionsItem {
         override val isEnabledDuringEditing: Boolean = true
     }
 
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     enum class ViewType {
         SavedPaymentMethod,
         AddCard,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsItem.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsItem.kt
@@ -1,23 +1,25 @@
 package com.stripe.android.paymentsheet
 
+import androidx.annotation.RestrictTo
 import com.stripe.android.model.PaymentMethod
 
-internal sealed class PaymentOptionsItem {
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+sealed class PaymentOptionsItem {
 
     abstract val viewType: ViewType
     abstract val isEnabledDuringEditing: Boolean
 
-    object AddCard : PaymentOptionsItem() {
+    internal object AddCard : PaymentOptionsItem() {
         override val viewType: ViewType = ViewType.AddCard
         override val isEnabledDuringEditing: Boolean = false
     }
 
-    object GooglePay : PaymentOptionsItem() {
+    internal object GooglePay : PaymentOptionsItem() {
         override val viewType: ViewType = ViewType.GooglePay
         override val isEnabledDuringEditing: Boolean = false
     }
 
-    object Link : PaymentOptionsItem() {
+    internal object Link : PaymentOptionsItem() {
         override val viewType: ViewType = ViewType.Link
         override val isEnabledDuringEditing: Boolean = false
     }
@@ -25,7 +27,7 @@ internal sealed class PaymentOptionsItem {
     /**
      * Represents a [PaymentMethod] that is already saved and attached to the current customer.
      */
-    data class SavedPaymentMethod(
+    internal data class SavedPaymentMethod(
         val displayableSavedPaymentMethod: DisplayableSavedPaymentMethod,
     ) : PaymentOptionsItem() {
         override val viewType: ViewType = ViewType.SavedPaymentMethod


### PR DESCRIPTION
# Summary
Made PaymentOptionsItem public, but everything inside of it except for viewtype internal, so we don't have to hardcode "AddCard" in SavedPaymentMethodsPage

# Motivation
Better for maintainability

