### PR TITLE
Add `PaymentElementCallbacks` builder helper

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElementKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElementKtx.kt
@@ -36,11 +36,11 @@ fun rememberEmbeddedPaymentElement(
 
     val callbacks = remember(builder) {
         @OptIn(ExperimentalCustomPaymentMethodsApi::class)
-        PaymentElementCallbacks(
-            createIntentCallback = builder.createIntentCallback,
-            customPaymentMethodConfirmHandler = builder.customPaymentMethodConfirmHandler,
-            externalPaymentMethodConfirmHandler = builder.externalPaymentMethodConfirmHandler,
-        )
+        PaymentElementCallbacks.Builder()
+            .createIntentCallback(builder.createIntentCallback)
+            .customPaymentMethodConfirmHandler(builder.customPaymentMethodConfirmHandler)
+            .externalPaymentMethodConfirmHandler(builder.externalPaymentMethodConfirmHandler)
+            .build()
     }
 
     UpdateCallbacks(paymentElementCallbackIdentifier, callbacks)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/callbacks/PaymentElementCallbacks.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/callbacks/PaymentElementCallbacks.kt
@@ -6,8 +6,38 @@ import com.stripe.android.paymentsheet.CreateIntentCallback
 import com.stripe.android.paymentsheet.ExternalPaymentMethodConfirmHandler
 
 @OptIn(ExperimentalCustomPaymentMethodsApi::class)
-internal class PaymentElementCallbacks(
+internal data class PaymentElementCallbacks private constructor(
     val createIntentCallback: CreateIntentCallback?,
     val customPaymentMethodConfirmHandler: CustomPaymentMethodConfirmHandler?,
     val externalPaymentMethodConfirmHandler: ExternalPaymentMethodConfirmHandler?,
-)
+) {
+    class Builder {
+        private var createIntentCallback: CreateIntentCallback? = null
+        private var customPaymentMethodConfirmHandler: CustomPaymentMethodConfirmHandler? = null
+        private var externalPaymentMethodConfirmHandler: ExternalPaymentMethodConfirmHandler? = null
+
+        fun createIntentCallback(createIntentCallback: CreateIntentCallback?) = apply {
+            this.createIntentCallback = createIntentCallback
+        }
+
+        fun customPaymentMethodConfirmHandler(
+            customPaymentMethodConfirmHandler: CustomPaymentMethodConfirmHandler?
+        ) = apply {
+            this.customPaymentMethodConfirmHandler = customPaymentMethodConfirmHandler
+        }
+
+        fun externalPaymentMethodConfirmHandler(
+            externalPaymentMethodConfirmHandler: ExternalPaymentMethodConfirmHandler?
+        ) = apply {
+            this.externalPaymentMethodConfirmHandler = externalPaymentMethodConfirmHandler
+        }
+
+        fun build(): PaymentElementCallbacks {
+            return PaymentElementCallbacks(
+                createIntentCallback = createIntentCallback,
+                customPaymentMethodConfirmHandler = customPaymentMethodConfirmHandler,
+                externalPaymentMethodConfirmHandler = externalPaymentMethodConfirmHandler,
+            )
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/FlowControllerCompose.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/FlowControllerCompose.kt
@@ -7,8 +7,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import com.stripe.android.common.ui.UpdateCallbacks
-import com.stripe.android.paymentelement.CustomPaymentMethodConfirmHandler
-import com.stripe.android.paymentelement.ExperimentalCustomPaymentMethodsApi
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbacks
 import com.stripe.android.paymentsheet.flowcontroller.FlowControllerFactory
 import com.stripe.android.utils.rememberActivity
@@ -27,13 +25,15 @@ fun rememberPaymentSheetFlowController(
     paymentOptionCallback: PaymentOptionCallback,
     paymentResultCallback: PaymentSheetResultCallback,
 ): PaymentSheet.FlowController {
-    @OptIn(ExperimentalCustomPaymentMethodsApi::class)
+    val callbacks = remember {
+        PaymentElementCallbacks.Builder()
+            .build()
+    }
+
     return internalRememberPaymentSheetFlowController(
         paymentOptionCallback = paymentOptionCallback,
         paymentResultCallback = paymentResultCallback,
-        customPaymentMethodConfirmHandler = null,
-        createIntentCallback = null,
-        externalPaymentMethodConfirmHandler = null,
+        callbacks = callbacks,
     )
 }
 
@@ -54,13 +54,16 @@ fun rememberPaymentSheetFlowController(
     paymentOptionCallback: PaymentOptionCallback,
     paymentResultCallback: PaymentSheetResultCallback,
 ): PaymentSheet.FlowController {
-    @OptIn(ExperimentalCustomPaymentMethodsApi::class)
+    val callbacks = remember(createIntentCallback) {
+        PaymentElementCallbacks.Builder()
+            .createIntentCallback(createIntentCallback)
+            .build()
+    }
+
     return internalRememberPaymentSheetFlowController(
         paymentOptionCallback = paymentOptionCallback,
         paymentResultCallback = paymentResultCallback,
-        customPaymentMethodConfirmHandler = null,
-        createIntentCallback = createIntentCallback,
-        externalPaymentMethodConfirmHandler = null,
+        callbacks = callbacks,
     )
 }
 
@@ -85,13 +88,17 @@ fun rememberPaymentSheetFlowController(
     paymentOptionCallback: PaymentOptionCallback,
     paymentResultCallback: PaymentSheetResultCallback,
 ): PaymentSheet.FlowController {
-    @OptIn(ExperimentalCustomPaymentMethodsApi::class)
+    val callbacks = remember(createIntentCallback, externalPaymentMethodConfirmHandler) {
+        PaymentElementCallbacks.Builder()
+            .createIntentCallback(createIntentCallback)
+            .externalPaymentMethodConfirmHandler(externalPaymentMethodConfirmHandler)
+            .build()
+    }
+
     return internalRememberPaymentSheetFlowController(
         paymentOptionCallback = paymentOptionCallback,
         paymentResultCallback = paymentResultCallback,
-        customPaymentMethodConfirmHandler = null,
-        createIntentCallback = createIntentCallback,
-        externalPaymentMethodConfirmHandler = externalPaymentMethodConfirmHandler
+        callbacks = callbacks,
     )
 }
 
@@ -148,24 +155,13 @@ private fun internalRememberPaymentSheetFlowController(
 }
 
 @Composable
-@OptIn(ExperimentalCustomPaymentMethodsApi::class)
 internal fun internalRememberPaymentSheetFlowController(
-    createIntentCallback: CreateIntentCallback?,
-    externalPaymentMethodConfirmHandler: ExternalPaymentMethodConfirmHandler?,
-    customPaymentMethodConfirmHandler: CustomPaymentMethodConfirmHandler?,
+    callbacks: PaymentElementCallbacks,
     paymentOptionCallback: PaymentOptionCallback,
     paymentResultCallback: PaymentSheetResultCallback,
 ): PaymentSheet.FlowController {
     val paymentElementCallbackIdentifier = rememberSaveable {
         UUID.randomUUID().toString()
-    }
-
-    val callbacks = remember(createIntentCallback, externalPaymentMethodConfirmHandler) {
-        PaymentElementCallbacks(
-            createIntentCallback = createIntentCallback,
-            customPaymentMethodConfirmHandler = customPaymentMethodConfirmHandler,
-            externalPaymentMethodConfirmHandler = externalPaymentMethodConfirmHandler,
-        )
     }
 
     UpdateCallbacks(paymentElementCallbackIdentifier, callbacks)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -72,10 +72,10 @@ class PaymentSheet internal constructor(
     ) : this(
         DefaultPaymentSheetLauncher(activity, callback)
     ) {
-        @OptIn(ExperimentalCustomPaymentMethodsApi::class)
         setPaymentSheetCallbacks(
-            createIntentCallback = null,
-            externalPaymentMethodConfirmHandler = externalPaymentMethodConfirmHandler,
+            PaymentElementCallbacks.Builder()
+                .externalPaymentMethodConfirmHandler(externalPaymentMethodConfirmHandler)
+                .build()
         )
     }
 
@@ -95,10 +95,10 @@ class PaymentSheet internal constructor(
     ) : this(
         DefaultPaymentSheetLauncher(activity, paymentResultCallback)
     ) {
-        @OptIn(ExperimentalCustomPaymentMethodsApi::class)
         setPaymentSheetCallbacks(
-            createIntentCallback = createIntentCallback,
-            externalPaymentMethodConfirmHandler = null,
+            PaymentElementCallbacks.Builder()
+                .createIntentCallback(createIntentCallback)
+                .build()
         )
     }
 
@@ -121,10 +121,11 @@ class PaymentSheet internal constructor(
     ) : this(
         DefaultPaymentSheetLauncher(activity, paymentResultCallback)
     ) {
-        @OptIn(ExperimentalCustomPaymentMethodsApi::class)
         setPaymentSheetCallbacks(
-            createIntentCallback = createIntentCallback,
-            externalPaymentMethodConfirmHandler = externalPaymentMethodConfirmHandler,
+            PaymentElementCallbacks.Builder()
+                .createIntentCallback(createIntentCallback)
+                .externalPaymentMethodConfirmHandler(externalPaymentMethodConfirmHandler)
+                .build()
         )
     }
 
@@ -156,10 +157,10 @@ class PaymentSheet internal constructor(
     ) : this(
         DefaultPaymentSheetLauncher(fragment, callback)
     ) {
-        @OptIn(ExperimentalCustomPaymentMethodsApi::class)
         setPaymentSheetCallbacks(
-            createIntentCallback = null,
-            externalPaymentMethodConfirmHandler = externalPaymentMethodConfirmHandler,
+            PaymentElementCallbacks.Builder()
+                .externalPaymentMethodConfirmHandler(externalPaymentMethodConfirmHandler)
+                .build()
         )
     }
 
@@ -179,10 +180,10 @@ class PaymentSheet internal constructor(
     ) : this(
         DefaultPaymentSheetLauncher(fragment, paymentResultCallback)
     ) {
-        @OptIn(ExperimentalCustomPaymentMethodsApi::class)
         setPaymentSheetCallbacks(
-            createIntentCallback = createIntentCallback,
-            externalPaymentMethodConfirmHandler = null,
+            PaymentElementCallbacks.Builder()
+                .createIntentCallback(createIntentCallback)
+                .build()
         )
     }
 
@@ -205,10 +206,11 @@ class PaymentSheet internal constructor(
     ) : this(
         DefaultPaymentSheetLauncher(fragment, paymentResultCallback)
     ) {
-        @OptIn(ExperimentalCustomPaymentMethodsApi::class)
         setPaymentSheetCallbacks(
-            createIntentCallback = createIntentCallback,
-            externalPaymentMethodConfirmHandler = externalPaymentMethodConfirmHandler,
+            PaymentElementCallbacks.Builder()
+                .createIntentCallback(createIntentCallback)
+                .externalPaymentMethodConfirmHandler(externalPaymentMethodConfirmHandler)
+                .build()
         )
     }
 
@@ -218,21 +220,14 @@ class PaymentSheet internal constructor(
      * @param resultCallback Called with the result of the payment after [PaymentSheet] is dismissed.
      */
     class Builder(internal val resultCallback: PaymentSheetResultCallback) {
-        internal var externalPaymentMethodConfirmHandler: ExternalPaymentMethodConfirmHandler? = null
-            private set
-
-        @OptIn(ExperimentalCustomPaymentMethodsApi::class)
-        internal var customPaymentMethodConfirmHandler: CustomPaymentMethodConfirmHandler? = null
-            private set
-        internal var createIntentCallback: CreateIntentCallback? = null
-            private set
+        private val callbacksBuilder = PaymentElementCallbacks.Builder()
 
         /**
          * @param handler Called when a user confirms payment for an external payment method. Use with
          * [Configuration.Builder.externalPaymentMethods] to specify external payment methods.
          */
         fun externalPaymentMethodConfirmHandler(handler: ExternalPaymentMethodConfirmHandler) = apply {
-            externalPaymentMethodConfirmHandler = handler
+            callbacksBuilder.externalPaymentMethodConfirmHandler(handler)
         }
 
         /**
@@ -241,7 +236,7 @@ class PaymentSheet internal constructor(
          */
         @ExperimentalCustomPaymentMethodsApi
         internal fun customPaymentMethodConfirmHandler(handler: CustomPaymentMethodConfirmHandler) = apply {
-            customPaymentMethodConfirmHandler = handler
+            callbacksBuilder.customPaymentMethodConfirmHandler(handler)
         }
 
         /**
@@ -249,7 +244,7 @@ class PaymentSheet internal constructor(
          * Only used when [presentWithIntentConfiguration] is called for a deferred flow.
          */
         fun createIntentCallback(callback: CreateIntentCallback) = apply {
-            createIntentCallback = callback
+            callbacksBuilder.createIntentCallback(callback)
         }
 
         /**
@@ -280,22 +275,14 @@ class PaymentSheet internal constructor(
             /*
              * Callbacks are initialized & updated internally by the internal composable function
              */
-            @OptIn(ExperimentalCustomPaymentMethodsApi::class)
             return internalRememberPaymentSheet(
-                createIntentCallback = createIntentCallback,
-                externalPaymentMethodConfirmHandler = externalPaymentMethodConfirmHandler,
-                customPaymentMethodConfirmHandler = customPaymentMethodConfirmHandler,
+                callbacks = callbacksBuilder.build(),
                 paymentResultCallback = resultCallback,
             )
         }
 
         private fun initializeCallbacks() {
-            @OptIn(ExperimentalCustomPaymentMethodsApi::class)
-            setPaymentSheetCallbacks(
-                createIntentCallback = createIntentCallback,
-                customPaymentMethodConfirmHandler = customPaymentMethodConfirmHandler,
-                externalPaymentMethodConfirmHandler = externalPaymentMethodConfirmHandler,
-            )
+            setPaymentSheetCallbacks(callbacksBuilder.build())
         }
     }
 
@@ -2264,21 +2251,13 @@ class PaymentSheet internal constructor(
             internal val resultCallback: PaymentSheetResultCallback,
             internal val paymentOptionCallback: PaymentOptionCallback
         ) {
-            internal var externalPaymentMethodConfirmHandler: ExternalPaymentMethodConfirmHandler? = null
-                private set
-
-            @OptIn(ExperimentalCustomPaymentMethodsApi::class)
-            internal var customPaymentMethodConfirmHandler: CustomPaymentMethodConfirmHandler? = null
-                private set
-
-            internal var createIntentCallback: CreateIntentCallback? = null
-                private set
+            private val callbacksBuilder = PaymentElementCallbacks.Builder()
 
             /**
              * @param handler Called when a user confirms payment for an external payment method.
              */
             fun externalPaymentMethodConfirmHandler(handler: ExternalPaymentMethodConfirmHandler) = apply {
-                externalPaymentMethodConfirmHandler = handler
+                callbacksBuilder.externalPaymentMethodConfirmHandler(handler)
             }
 
             /**
@@ -2287,14 +2266,14 @@ class PaymentSheet internal constructor(
             @ExperimentalCustomPaymentMethodsApi
             @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
             fun customPaymentMethodConfirmHandler(handler: CustomPaymentMethodConfirmHandler) = apply {
-                customPaymentMethodConfirmHandler = handler
+                callbacksBuilder.customPaymentMethodConfirmHandler(handler)
             }
 
             /**
              * @param callback If specified, called when the customer confirms the payment or setup.
              */
             fun createIntentCallback(callback: CreateIntentCallback) = apply {
-                createIntentCallback = callback
+                callbacksBuilder.createIntentCallback(callback)
             }
 
             /**
@@ -2325,23 +2304,15 @@ class PaymentSheet internal constructor(
                 /*
                  * Callbacks are initialized & updated internally by the internal composable function
                  */
-                @OptIn(ExperimentalCustomPaymentMethodsApi::class)
                 return internalRememberPaymentSheetFlowController(
-                    createIntentCallback = createIntentCallback,
-                    externalPaymentMethodConfirmHandler = externalPaymentMethodConfirmHandler,
-                    customPaymentMethodConfirmHandler = customPaymentMethodConfirmHandler,
+                    callbacks = callbacksBuilder.build(),
                     paymentOptionCallback = paymentOptionCallback,
                     paymentResultCallback = resultCallback,
                 )
             }
 
             private fun initializeCallbacks() {
-                @OptIn(ExperimentalCustomPaymentMethodsApi::class)
-                setFlowControllerCallbacks(
-                    createIntentCallback = createIntentCallback,
-                    customPaymentMethodConfirmHandler = customPaymentMethodConfirmHandler,
-                    externalPaymentMethodConfirmHandler = externalPaymentMethodConfirmHandler,
-                )
+                setFlowControllerCallbacks(callbacks = callbacksBuilder.build())
             }
         }
 
@@ -2405,8 +2376,11 @@ class PaymentSheet internal constructor(
                 paymentOptionCallback: PaymentOptionCallback,
                 paymentResultCallback: PaymentSheetResultCallback
             ): FlowController {
-                @OptIn(ExperimentalCustomPaymentMethodsApi::class)
-                setFlowControllerCallbacks(externalPaymentMethodConfirmHandler = externalPaymentMethodConfirmHandler)
+                setFlowControllerCallbacks(
+                    PaymentElementCallbacks.Builder()
+                        .externalPaymentMethodConfirmHandler(externalPaymentMethodConfirmHandler)
+                        .build()
+                )
                 return FlowControllerFactory(
                     activity,
                     paymentOptionCallback,
@@ -2432,8 +2406,11 @@ class PaymentSheet internal constructor(
                 createIntentCallback: CreateIntentCallback,
                 paymentResultCallback: PaymentSheetResultCallback,
             ): FlowController {
-                @OptIn(ExperimentalCustomPaymentMethodsApi::class)
-                setFlowControllerCallbacks(createIntentCallback = createIntentCallback)
+                setFlowControllerCallbacks(
+                    PaymentElementCallbacks.Builder()
+                        .createIntentCallback(createIntentCallback)
+                        .build()
+                )
                 return FlowControllerFactory(
                     activity,
                     paymentOptionCallback,
@@ -2464,10 +2441,11 @@ class PaymentSheet internal constructor(
                 createIntentCallback: CreateIntentCallback,
                 paymentResultCallback: PaymentSheetResultCallback,
             ): FlowController {
-                @OptIn(ExperimentalCustomPaymentMethodsApi::class)
                 setFlowControllerCallbacks(
-                    createIntentCallback = createIntentCallback,
-                    externalPaymentMethodConfirmHandler = externalPaymentMethodConfirmHandler,
+                    PaymentElementCallbacks.Builder()
+                        .createIntentCallback(createIntentCallback)
+                        .externalPaymentMethodConfirmHandler(externalPaymentMethodConfirmHandler)
+                        .build()
                 )
                 return FlowControllerFactory(
                     activity,
@@ -2516,8 +2494,11 @@ class PaymentSheet internal constructor(
                 paymentOptionCallback: PaymentOptionCallback,
                 paymentResultCallback: PaymentSheetResultCallback
             ): FlowController {
-                @OptIn(ExperimentalCustomPaymentMethodsApi::class)
-                setFlowControllerCallbacks(externalPaymentMethodConfirmHandler = externalPaymentMethodConfirmHandler)
+                setFlowControllerCallbacks(
+                    PaymentElementCallbacks.Builder()
+                        .externalPaymentMethodConfirmHandler(externalPaymentMethodConfirmHandler)
+                        .build()
+                )
                 return FlowControllerFactory(
                     fragment,
                     paymentOptionCallback,
@@ -2543,8 +2524,11 @@ class PaymentSheet internal constructor(
                 createIntentCallback: CreateIntentCallback,
                 paymentResultCallback: PaymentSheetResultCallback,
             ): FlowController {
-                @OptIn(ExperimentalCustomPaymentMethodsApi::class)
-                setFlowControllerCallbacks(createIntentCallback = createIntentCallback)
+                setFlowControllerCallbacks(
+                    PaymentElementCallbacks.Builder()
+                        .createIntentCallback(createIntentCallback)
+                        .build()
+                )
                 return FlowControllerFactory(
                     fragment,
                     paymentOptionCallback,
@@ -2575,10 +2559,11 @@ class PaymentSheet internal constructor(
                 externalPaymentMethodConfirmHandler: ExternalPaymentMethodConfirmHandler,
                 paymentResultCallback: PaymentSheetResultCallback,
             ): FlowController {
-                @OptIn(ExperimentalCustomPaymentMethodsApi::class)
                 setFlowControllerCallbacks(
-                    createIntentCallback = createIntentCallback,
-                    externalPaymentMethodConfirmHandler = externalPaymentMethodConfirmHandler,
+                    PaymentElementCallbacks.Builder()
+                        .createIntentCallback(createIntentCallback)
+                        .externalPaymentMethodConfirmHandler(externalPaymentMethodConfirmHandler)
+                        .build()
                 )
                 return FlowControllerFactory(
                     fragment,
@@ -2590,30 +2575,12 @@ class PaymentSheet internal constructor(
     }
 
     companion object {
-        @OptIn(ExperimentalCustomPaymentMethodsApi::class)
-        private fun setPaymentSheetCallbacks(
-            createIntentCallback: CreateIntentCallback? = null,
-            customPaymentMethodConfirmHandler: CustomPaymentMethodConfirmHandler? = null,
-            externalPaymentMethodConfirmHandler: ExternalPaymentMethodConfirmHandler? = null,
-        ) {
-            PaymentElementCallbackReferences[PAYMENT_SHEET_DEFAULT_CALLBACK_IDENTIFIER] = PaymentElementCallbacks(
-                createIntentCallback = createIntentCallback,
-                customPaymentMethodConfirmHandler = customPaymentMethodConfirmHandler,
-                externalPaymentMethodConfirmHandler = externalPaymentMethodConfirmHandler,
-            )
+        private fun setPaymentSheetCallbacks(callbacks: PaymentElementCallbacks) {
+            PaymentElementCallbackReferences[PAYMENT_SHEET_DEFAULT_CALLBACK_IDENTIFIER] = callbacks
         }
 
-        @OptIn(ExperimentalCustomPaymentMethodsApi::class)
-        private fun setFlowControllerCallbacks(
-            createIntentCallback: CreateIntentCallback? = null,
-            customPaymentMethodConfirmHandler: CustomPaymentMethodConfirmHandler? = null,
-            externalPaymentMethodConfirmHandler: ExternalPaymentMethodConfirmHandler? = null,
-        ) {
-            PaymentElementCallbackReferences[FLOW_CONTROLLER_DEFAULT_CALLBACK_IDENTIFIER] = PaymentElementCallbacks(
-                createIntentCallback = createIntentCallback,
-                customPaymentMethodConfirmHandler = customPaymentMethodConfirmHandler,
-                externalPaymentMethodConfirmHandler = externalPaymentMethodConfirmHandler,
-            )
+        private fun setFlowControllerCallbacks(callbacks: PaymentElementCallbacks) {
+            PaymentElementCallbackReferences[FLOW_CONTROLLER_DEFAULT_CALLBACK_IDENTIFIER] = callbacks
         }
 
         /**

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetCompose.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetCompose.kt
@@ -10,8 +10,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.stripe.android.common.ui.UpdateCallbacks
-import com.stripe.android.paymentelement.CustomPaymentMethodConfirmHandler
-import com.stripe.android.paymentelement.ExperimentalCustomPaymentMethodsApi
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbacks
 import com.stripe.android.utils.rememberActivity
 import java.util.UUID
@@ -27,10 +25,13 @@ import java.util.UUID
 fun rememberPaymentSheet(
     paymentResultCallback: PaymentSheetResultCallback,
 ): PaymentSheet {
-    @OptIn(ExperimentalCustomPaymentMethodsApi::class)
+    val callbacks = remember {
+        PaymentElementCallbacks.Builder()
+            .build()
+    }
+
     return internalRememberPaymentSheet(
-        createIntentCallback = null,
-        externalPaymentMethodConfirmHandler = null,
+        callbacks = callbacks,
         paymentResultCallback = paymentResultCallback,
     )
 }
@@ -50,10 +51,14 @@ fun rememberPaymentSheet(
     createIntentCallback: CreateIntentCallback,
     paymentResultCallback: PaymentSheetResultCallback,
 ): PaymentSheet {
-    @OptIn(ExperimentalCustomPaymentMethodsApi::class)
+    val callbacks = remember(createIntentCallback) {
+        PaymentElementCallbacks.Builder()
+            .createIntentCallback(createIntentCallback)
+            .build()
+    }
+
     return internalRememberPaymentSheet(
-        createIntentCallback = createIntentCallback,
-        externalPaymentMethodConfirmHandler = null,
+        callbacks = callbacks,
         paymentResultCallback = paymentResultCallback,
     )
 }
@@ -77,32 +82,26 @@ fun rememberPaymentSheet(
     externalPaymentMethodConfirmHandler: ExternalPaymentMethodConfirmHandler,
     paymentResultCallback: PaymentSheetResultCallback,
 ): PaymentSheet {
-    @OptIn(ExperimentalCustomPaymentMethodsApi::class)
+    val callbacks = remember(createIntentCallback, externalPaymentMethodConfirmHandler) {
+        PaymentElementCallbacks.Builder()
+            .createIntentCallback(createIntentCallback)
+            .externalPaymentMethodConfirmHandler(externalPaymentMethodConfirmHandler)
+            .build()
+    }
+
     return internalRememberPaymentSheet(
-        createIntentCallback = createIntentCallback,
-        externalPaymentMethodConfirmHandler = externalPaymentMethodConfirmHandler,
+        callbacks = callbacks,
         paymentResultCallback = paymentResultCallback,
     )
 }
 
 @Composable
-@OptIn(ExperimentalCustomPaymentMethodsApi::class)
 internal fun internalRememberPaymentSheet(
-    createIntentCallback: CreateIntentCallback? = null,
-    externalPaymentMethodConfirmHandler: ExternalPaymentMethodConfirmHandler? = null,
-    customPaymentMethodConfirmHandler: CustomPaymentMethodConfirmHandler? = null,
+    callbacks: PaymentElementCallbacks,
     paymentResultCallback: PaymentSheetResultCallback,
 ): PaymentSheet {
     val paymentElementCallbackIdentifier = rememberSaveable {
         UUID.randomUUID().toString()
-    }
-
-    val callbacks = remember(createIntentCallback, externalPaymentMethodConfirmHandler) {
-        PaymentElementCallbacks(
-            createIntentCallback = createIntentCallback,
-            customPaymentMethodConfirmHandler = customPaymentMethodConfirmHandler,
-            externalPaymentMethodConfirmHandler = externalPaymentMethodConfirmHandler,
-        )
     }
 
     UpdateCallbacks(paymentElementCallbackIdentifier, callbacks)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/callbacks/PaymentElementCallbackReferencesTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/callbacks/PaymentElementCallbackReferencesTest.kt
@@ -55,17 +55,17 @@ class PaymentElementCallbackReferencesTest {
 
     @OptIn(ExperimentalCustomPaymentMethodsApi::class)
     private fun createCallbacks(): PaymentElementCallbacks {
-        return PaymentElementCallbacks(
-            createIntentCallback = { _, _ ->
-                error("Should not be called!")
-            },
-            customPaymentMethodConfirmHandler = { _, _ ->
-                error("Should not be called!")
-            },
-            externalPaymentMethodConfirmHandler = { _, _ ->
+        return PaymentElementCallbacks.Builder()
+            .createIntentCallback { _, _ ->
                 error("Should not be called!")
             }
-        )
+            .customPaymentMethodConfirmHandler { _, _ ->
+                error("Should not be called!")
+            }
+            .externalPaymentMethodConfirmHandler { _, _ ->
+                error("Should not be called!")
+            }
+            .build()
     }
 
     private companion object {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationActivityTest.kt
@@ -16,7 +16,6 @@ import com.stripe.android.core.exception.LocalStripeException
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.isInstanceOf
 import com.stripe.android.model.PaymentMethod
-import com.stripe.android.paymentelement.ExperimentalCustomPaymentMethodsApi
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbacks
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
@@ -46,7 +45,6 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 @RunWith(RobolectricTestRunner::class)
-@OptIn(ExperimentalCustomPaymentMethodsApi::class)
 internal class ExternalPaymentMethodConfirmationActivityTest {
     private val application = ApplicationProvider.getApplicationContext<Application>()
 
@@ -61,13 +59,11 @@ internal class ExternalPaymentMethodConfirmationActivityTest {
 
     @Before
     fun setup() {
-        PaymentElementCallbackReferences["ConfirmationTestIdentifier"] = PaymentElementCallbacks(
-            createIntentCallback = null,
-            customPaymentMethodConfirmHandler = null,
-            externalPaymentMethodConfirmHandler = { _, _ ->
+        PaymentElementCallbackReferences["ConfirmationTestIdentifier"] = PaymentElementCallbacks.Builder()
+            .externalPaymentMethodConfirmHandler { _, _ ->
                 error("Should not be called!")
             }
-        )
+            .build()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/foundations/CreateIntentFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/foundations/CreateIntentFactory.kt
@@ -2,7 +2,6 @@ package com.stripe.android.paymentelement.confirmation.lpms.foundations
 
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
-import com.stripe.android.paymentelement.ExperimentalCustomPaymentMethodsApi
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbacks
 import com.stripe.android.paymentelement.confirmation.lpms.foundations.network.MerchantCountry
@@ -13,7 +12,6 @@ import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.SetupIntentFactory
 
-@OptIn(ExperimentalCustomPaymentMethodsApi::class)
 internal class CreateIntentFactory(
     private val paymentElementCallbackIdentifier: String,
     private val paymentMethodType: PaymentMethod.Type,
@@ -49,8 +47,8 @@ internal class CreateIntentFactory(
     ): Result<CreateIntentData> {
         PaymentElementCallbackReferences.set(
             key = paymentElementCallbackIdentifier,
-            callbacks = PaymentElementCallbacks(
-                createIntentCallback = { paymentMethod, _ ->
+            callbacks = PaymentElementCallbacks.Builder()
+                .createIntentCallback { paymentMethod, _ ->
                     testClient.createPaymentIntent(
                         country = country,
                         amount = amount,
@@ -69,10 +67,8 @@ internal class CreateIntentFactory(
                             )
                         }
                     )
-                },
-                customPaymentMethodConfirmHandler = null,
-                externalPaymentMethodConfirmHandler = null,
-            )
+                }
+                .build()
         )
 
         return Result.success(
@@ -115,8 +111,8 @@ internal class CreateIntentFactory(
     ): Result<CreateIntentData> {
         PaymentElementCallbackReferences.set(
             key = paymentElementCallbackIdentifier,
-            callbacks = PaymentElementCallbacks(
-                createIntentCallback = { paymentMethod, _ ->
+            callbacks = PaymentElementCallbacks.Builder()
+                .createIntentCallback { paymentMethod, _ ->
                     testClient.createSetupIntent(
                         country = country,
                         paymentMethodType = paymentMethodType,
@@ -132,10 +128,8 @@ internal class CreateIntentFactory(
                             )
                         }
                     )
-                },
-                customPaymentMethodConfirmHandler = null,
-                externalPaymentMethodConfirmHandler = null,
-            )
+                }
+                .build()
         )
 
         return Result.success(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementInitializerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementInitializerTest.kt
@@ -39,17 +39,17 @@ internal class EmbeddedPaymentElementInitializerTest {
     @OptIn(ExperimentalCustomPaymentMethodsApi::class)
     fun `when lifecycle is destroyed, should un-initialize callbacks`() {
         val owner = TestLifecycleOwner()
-        val callbacks = PaymentElementCallbacks(
-            createIntentCallback = { _, _ ->
-                error("Not implemented")
-            },
-            customPaymentMethodConfirmHandler = { _, _ ->
-                error("Not implemented")
-            },
-            externalPaymentMethodConfirmHandler = { _, _ ->
+        val callbacks = PaymentElementCallbacks.Builder()
+            .createIntentCallback { _, _ ->
                 error("Not implemented")
             }
-        )
+            .customPaymentMethodConfirmHandler { _, _ ->
+                error("Not implemented")
+            }
+            .externalPaymentMethodConfirmHandler { _, _ ->
+                error("Not implemented")
+            }
+            .build()
 
         PaymentElementCallbackReferences[PAYMENT_ELEMENT_CALLBACK_TEST_IDENTIFIER] = callbacks
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultPaymentSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultPaymentSheetLauncherTest.kt
@@ -88,13 +88,11 @@ class DefaultPaymentSheetLauncherTest {
 
     @Test
     fun `Clears out CreateIntentCallback when lifecycle owner is destroyed`() {
-        PaymentElementCallbackReferences[PAYMENT_SHEET_DEFAULT_CALLBACK_IDENTIFIER] = PaymentElementCallbacks(
-            createIntentCallback = { _, _ ->
+        PaymentElementCallbackReferences[PAYMENT_SHEET_DEFAULT_CALLBACK_IDENTIFIER] = PaymentElementCallbacks.Builder()
+            .createIntentCallback { _, _ ->
                 error("I’m alive")
-            },
-            customPaymentMethodConfirmHandler = null,
-            externalPaymentMethodConfirmHandler = null,
-        )
+            }
+            .build()
 
         val lifecycleOwner = TestLifecycleOwner()
 
@@ -118,13 +116,11 @@ class DefaultPaymentSheetLauncherTest {
 
     @Test
     fun `Clears out externalPaymentMethodConfirmHandler when lifecycle owner is destroyed`() {
-        PaymentElementCallbackReferences[PAYMENT_SHEET_DEFAULT_CALLBACK_IDENTIFIER] = PaymentElementCallbacks(
-            createIntentCallback = null,
-            customPaymentMethodConfirmHandler = null,
-            externalPaymentMethodConfirmHandler = { _, _ ->
+        PaymentElementCallbackReferences[PAYMENT_SHEET_DEFAULT_CALLBACK_IDENTIFIER] = PaymentElementCallbacks.Builder()
+            .externalPaymentMethodConfirmHandler { _, _ ->
                 error("I’m alive")
-            },
-        )
+            }
+            .build()
 
         val lifecycleOwner = TestLifecycleOwner()
 
@@ -157,13 +153,11 @@ class DefaultPaymentSheetLauncherTest {
 
     @Test
     fun `Clears out customPaymentMethodConfirmHandler when lifecycle owner is destroyed`() {
-        PaymentElementCallbackReferences[PAYMENT_SHEET_DEFAULT_CALLBACK_IDENTIFIER] = PaymentElementCallbacks(
-            createIntentCallback = null,
-            customPaymentMethodConfirmHandler = { _, _ ->
+        PaymentElementCallbackReferences[PAYMENT_SHEET_DEFAULT_CALLBACK_IDENTIFIER] = PaymentElementCallbacks.Builder()
+            .customPaymentMethodConfirmHandler { _, _ ->
                 error("I’m alive")
-            },
-            externalPaymentMethodConfirmHandler = null,
-        )
+            }
+            .build()
 
         val lifecycleOwner = TestLifecycleOwner()
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ExternalPaymentMethodProxyActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ExternalPaymentMethodProxyActivityTest.kt
@@ -11,7 +11,6 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
-import com.stripe.android.paymentelement.ExperimentalCustomPaymentMethodsApi
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbacks
 import com.stripe.android.testing.FakeErrorReporter
@@ -23,7 +22,6 @@ import kotlin.test.fail
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.Q])
-@OptIn(ExperimentalCustomPaymentMethodsApi::class)
 class ExternalPaymentMethodProxyActivityTest {
 
     private val context: Context = ApplicationProvider.getApplicationContext()
@@ -38,11 +36,9 @@ class ExternalPaymentMethodProxyActivityTest {
         val expectedBillingDetails =
             PaymentMethod.BillingDetails(name = "Joe", address = Address(city = "Seattle", line1 = "123 Main St"))
 
-        PaymentElementCallbackReferences["ExternalPaymentMethod"] = PaymentElementCallbacks(
-            createIntentCallback = null,
-            customPaymentMethodConfirmHandler = null,
-            externalPaymentMethodConfirmHandler = confirmHandler,
-        )
+        PaymentElementCallbackReferences["ExternalPaymentMethod"] = PaymentElementCallbacks.Builder()
+            .externalPaymentMethodConfirmHandler(confirmHandler)
+            .build()
 
         activityLauncher.launch(
             input = ExternalPaymentMethodInput(
@@ -68,11 +64,9 @@ class ExternalPaymentMethodProxyActivityTest {
             context,
         )
 
-        PaymentElementCallbackReferences["ExternalPaymentMethod"] = PaymentElementCallbacks(
-            createIntentCallback = null,
-            customPaymentMethodConfirmHandler = null,
-            externalPaymentMethodConfirmHandler = confirmHandler,
-        )
+        PaymentElementCallbackReferences["ExternalPaymentMethod"] = PaymentElementCallbacks.Builder()
+            .externalPaymentMethodConfirmHandler(confirmHandler)
+            .build()
 
         activityLauncher.launch(
             input = ExternalPaymentMethodInput(
@@ -141,17 +135,13 @@ class ExternalPaymentMethodProxyActivityTest {
             context,
         )
 
-        PaymentElementCallbackReferences["ExternalPaymentMethodTestIdentifierOne"] = PaymentElementCallbacks(
-            createIntentCallback = null,
-            customPaymentMethodConfirmHandler = null,
-            externalPaymentMethodConfirmHandler = firstConfirmHandler,
-        )
+        PaymentElementCallbackReferences["ExternalPaymentMethodTestIdentifierOne"] = PaymentElementCallbacks.Builder()
+            .externalPaymentMethodConfirmHandler(firstConfirmHandler)
+            .build()
 
-        PaymentElementCallbackReferences["ExternalPaymentMethodTestIdentifierTwo"] = PaymentElementCallbacks(
-            createIntentCallback = null,
-            customPaymentMethodConfirmHandler = null,
-            externalPaymentMethodConfirmHandler = secondConfirmHandler,
-        )
+        PaymentElementCallbackReferences["ExternalPaymentMethodTestIdentifierTwo"] = PaymentElementCallbacks.Builder()
+            .externalPaymentMethodConfirmHandler(secondConfirmHandler)
+            .build()
 
         activityLauncher.launch(
             input = ExternalPaymentMethodInput(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -2124,17 +2124,17 @@ internal class PaymentSheetViewModelTest {
 
     @Test
     fun `Sends correct analytics event when using deferred intent with client-side confirmation`() = runTest {
-        PaymentElementCallbackReferences[PAYMENT_SHEET_CALLBACK_TEST_IDENTIFIER] = PaymentElementCallbacks(
-            createIntentCallback = { _, _ ->
+        PaymentElementCallbackReferences[PAYMENT_SHEET_CALLBACK_TEST_IDENTIFIER] = PaymentElementCallbacks.Builder()
+            .createIntentCallback { _, _ ->
                 error("Should not be called!")
-            },
-            customPaymentMethodConfirmHandler = { _, _ ->
+            }
+            .customPaymentMethodConfirmHandler { _, _ ->
                 error("Should not be called!")
-            },
-            externalPaymentMethodConfirmHandler = { _, _ ->
+            }
+            .externalPaymentMethodConfirmHandler { _, _ ->
                 error("Should not be called!")
-            },
-        )
+            }
+            .build()
 
         createViewModelForDeferredIntent()
 
@@ -2146,17 +2146,17 @@ internal class PaymentSheetViewModelTest {
 
     @Test
     fun `Sends correct analytics event when using deferred intent with server-side confirmation`() = runTest {
-        PaymentElementCallbackReferences[PAYMENT_SHEET_CALLBACK_TEST_IDENTIFIER] = PaymentElementCallbacks(
-            createIntentCallback = { _, _ ->
+        PaymentElementCallbackReferences[PAYMENT_SHEET_CALLBACK_TEST_IDENTIFIER] = PaymentElementCallbacks.Builder()
+            .createIntentCallback { _, _ ->
                 error("Should not be called!")
-            },
-            customPaymentMethodConfirmHandler = { _, _ ->
+            }
+            .customPaymentMethodConfirmHandler { _, _ ->
                 error("Should not be called!")
-            },
-            externalPaymentMethodConfirmHandler = { _, _ ->
+            }
+            .externalPaymentMethodConfirmHandler { _, _ ->
                 error("Should not be called!")
-            },
-        )
+            }
+            .build()
 
         createViewModelForDeferredIntent()
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -1464,17 +1464,18 @@ internal class DefaultFlowControllerTest {
         )
 
         for ((clientSecret, deferredIntentConfirmationType) in clientSecrets) {
-            PaymentElementCallbackReferences[FLOW_CONTROLLER_CALLBACK_TEST_IDENTIFIER] = PaymentElementCallbacks(
-                createIntentCallback = { _, _ ->
-                    error("Should not be called!")
-                },
-                customPaymentMethodConfirmHandler = { _, _ ->
-                    error("Should not be called!")
-                },
-                externalPaymentMethodConfirmHandler = { _, _ ->
-                    error("Should not be called!")
-                },
-            )
+            PaymentElementCallbackReferences[FLOW_CONTROLLER_CALLBACK_TEST_IDENTIFIER] =
+                PaymentElementCallbacks.Builder()
+                    .createIntentCallback { _, _ ->
+                        error("Should not be called!")
+                    }
+                    .customPaymentMethodConfirmHandler { _, _ ->
+                        error("Should not be called!")
+                    }
+                    .externalPaymentMethodConfirmHandler { _, _ ->
+                        error("Should not be called!")
+                    }
+                    .build()
 
             val flowController = createAndConfigureFlowControllerForDeferredIntent()
             val savedSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
@@ -1907,13 +1908,11 @@ internal class DefaultFlowControllerTest {
 
     @Test
     fun `Clears out CreateIntentCallback when lifecycle owner is destroyed`() {
-        PaymentElementCallbackReferences[FLOW_CONTROLLER_CALLBACK_TEST_IDENTIFIER] = PaymentElementCallbacks(
-            createIntentCallback = { _, _ ->
+        PaymentElementCallbackReferences[FLOW_CONTROLLER_CALLBACK_TEST_IDENTIFIER] = PaymentElementCallbacks.Builder()
+            .createIntentCallback { _, _ ->
                 error("I’m alive")
-            },
-            customPaymentMethodConfirmHandler = null,
-            externalPaymentMethodConfirmHandler = null,
-        )
+            }
+            .build()
 
         createFlowController()
 
@@ -1938,13 +1937,11 @@ internal class DefaultFlowControllerTest {
 
     @Test
     fun `Clears out externalPaymentMethodConfirmHandler when lifecycle owner is destroyed`() {
-        PaymentElementCallbackReferences[FLOW_CONTROLLER_CALLBACK_TEST_IDENTIFIER] = PaymentElementCallbacks(
-            createIntentCallback = null,
-            customPaymentMethodConfirmHandler = null,
-            externalPaymentMethodConfirmHandler = { _, _ ->
+        PaymentElementCallbackReferences[FLOW_CONTROLLER_CALLBACK_TEST_IDENTIFIER] = PaymentElementCallbacks.Builder()
+            .externalPaymentMethodConfirmHandler { _, _ ->
                 error("I’m alive")
             }
-        )
+            .build()
 
         createFlowController()
 
@@ -1969,13 +1966,11 @@ internal class DefaultFlowControllerTest {
 
     @Test
     fun `Clears out customPaymentMethodConfirmHandler when lifecycle owner is destroyed`() {
-        PaymentElementCallbackReferences[FLOW_CONTROLLER_CALLBACK_TEST_IDENTIFIER] = PaymentElementCallbacks(
-            createIntentCallback = null,
-            customPaymentMethodConfirmHandler = { _, _ ->
-                error("Should not be called!")
-            },
-            externalPaymentMethodConfirmHandler = null
-        )
+        PaymentElementCallbackReferences[FLOW_CONTROLLER_CALLBACK_TEST_IDENTIFIER] = PaymentElementCallbacks.Builder()
+            .customPaymentMethodConfirmHandler { _, _ ->
+                error("I’m alive")
+            }
+            .build()
 
         createFlowController()
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandlerTest.kt
@@ -452,17 +452,17 @@ class FlowControllerConfigurationHandlerTest {
         val configureTurbine = Turbine<Throwable?>()
         val configurationHandler = createConfigurationHandler()
 
-        PaymentElementCallbackReferences[FLOW_CONTROLLER_CALLBACK_TEST_IDENTIFIER] = PaymentElementCallbacks(
-            createIntentCallback = { _, _ ->
+        PaymentElementCallbackReferences[FLOW_CONTROLLER_CALLBACK_TEST_IDENTIFIER] = PaymentElementCallbacks.Builder()
+            .createIntentCallback { _, _ ->
                 error("Should not be called!")
-            },
-            customPaymentMethodConfirmHandler = { _, _ ->
+            }
+            .customPaymentMethodConfirmHandler { _, _ ->
                 error("Should not be called!")
-            },
-            externalPaymentMethodConfirmHandler = { _, _ ->
+            }
+            .externalPaymentMethodConfirmHandler { _, _ ->
                 error("Should not be called!")
-            },
-        )
+            }
+            .build()
 
         configurationHandler.configure(
             scope = this,
@@ -493,17 +493,17 @@ class FlowControllerConfigurationHandlerTest {
         val configureTurbine = Turbine<Throwable?>()
         val configurationHandler = createConfigurationHandler()
 
-        PaymentElementCallbackReferences[FLOW_CONTROLLER_CALLBACK_TEST_IDENTIFIER] = PaymentElementCallbacks(
-            createIntentCallback = { _, _ ->
+        PaymentElementCallbackReferences[FLOW_CONTROLLER_CALLBACK_TEST_IDENTIFIER] = PaymentElementCallbacks.Builder()
+            .createIntentCallback { _, _ ->
                 error("Should not be called!")
-            },
-            customPaymentMethodConfirmHandler = { _, _ ->
+            }
+            .customPaymentMethodConfirmHandler { _, _ ->
                 error("Should not be called!")
-            },
-            externalPaymentMethodConfirmHandler = { _, _ ->
+            }
+            .externalPaymentMethodConfirmHandler { _, _ ->
                 error("Should not be called!")
-            },
-        )
+            }
+            .build()
 
         configurationHandler.configure(
             scope = this,


### PR DESCRIPTION
# Summary
Add a `Builder` class for creating `PaymentElementsCallback` and use everywhere in both production code and tests to make it easy to scale with additional callbacks.

# Motivation
We recently added custom payment method confirming as a callback type and analytics will soon follow. As we add more callbacks, the constructor will be harder to scale.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified