### PR TITLE
Remove shipping requirement for Afterpay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## XX.XX.XX - 20XX-XX-XX
 
+### PaymentSheet
+* [CHANGED][https://github.com/stripe/stripe-android/pull/10421] Afterpay no longer requires a shipping address to be shown.
+
 ## 21.7.0 - 2025-03-17
 
 ### PaymentSheet

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AfterpayClearpayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AfterpayClearpayDefinition.kt
@@ -20,7 +20,6 @@ internal object AfterpayClearpayDefinition : PaymentMethodDefinition {
     override fun requirementsToBeUsedAsNewPaymentMethod(
         hasIntentToSetup: Boolean
     ): Set<AddPaymentMethodRequirement> = setOf(
-        AddPaymentMethodRequirement.ShippingAddress,
         AddPaymentMethodRequirement.UnsupportedForSetup,
     )
 


### PR DESCRIPTION
# Summary
- Afterpay no longer requires shipping address to be shown
- https://github.com/stripe/stripe-ios/pull/4669

# Motivation
- https://jira.corp.stripe.com/browse/RUN_MOBILESDK-3945

# Testing
- Manual

# Changelog
See diff