### PR TITLE
Fix flake in EmbeddedPaymentElementAnalyticsTest

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedFormPage.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedFormPage.kt
@@ -57,6 +57,15 @@ internal class EmbeddedFormPage(
         }
     }
 
+    fun waitUntilMissing() {
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule
+                .onAllNodes(hasTestTag(FORM_ELEMENT_TEST_TAG))
+                .fetchSemanticsNodes()
+                .isEmpty()
+        }
+    }
+
     fun clickPrimaryButton() {
         composeTestRule.waitUntil {
             composeTestRule.onAllNodes(hasTestTag(EMBEDDED_FORM_ACTIVITY_PRIMARY_BUTTON).and(isEnabled()))

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementAnalyticsTest.kt
@@ -129,6 +129,7 @@ internal class EmbeddedPaymentElementAnalyticsTest {
         )
 
         formPage.clickPrimaryButton()
+        formPage.waitUntilMissing()
     }
 
     @Test


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Fix flake in EmbeddedPaymentElementAnalyticsTest

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
I noticed this failed on one of my PRs and confirmed via ShampooRule locally that it was flaky. After this change, I was able to run with it without RetryRule + with ShampooRule(100) and it passed

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified