### PR TITLE
Add custom payment methods to playground

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
@@ -29,7 +29,9 @@ import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.customersheet.CustomerSheetResult
 import com.stripe.android.customersheet.rememberCustomerSheet
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentelement.ConfirmCustomPaymentMethodCallback
 import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
+import com.stripe.android.paymentelement.ExperimentalCustomPaymentMethodsApi
 import com.stripe.android.paymentsheet.ExperimentalCustomerSessionApi
 import com.stripe.android.paymentsheet.ExternalPaymentMethodConfirmHandler
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -57,7 +59,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.withContext
 
-internal class PaymentSheetPlaygroundActivity : AppCompatActivity(), ExternalPaymentMethodConfirmHandler {
+@OptIn(ExperimentalCustomPaymentMethodsApi::class)
+internal class PaymentSheetPlaygroundActivity :
+    AppCompatActivity(),
+    ConfirmCustomPaymentMethodCallback,
+    ExternalPaymentMethodConfirmHandler {
     companion object {
         fun createTestIntent(settingsJson: String): Intent {
             return Intent(
@@ -90,6 +96,7 @@ internal class PaymentSheetPlaygroundActivity : AppCompatActivity(), ExternalPay
             }
             val paymentSheet = PaymentSheet.Builder(viewModel::onPaymentSheetResult)
                 .externalPaymentMethodConfirmHandler(this)
+                .confirmCustomPaymentMethodCallback(this)
                 .createIntentCallback(viewModel::createIntentCallback)
                 .analyticEventCallback(viewModel::analyticCallback)
                 .build()
@@ -98,6 +105,7 @@ internal class PaymentSheetPlaygroundActivity : AppCompatActivity(), ExternalPay
                 viewModel::onPaymentOptionSelected
             )
                 .externalPaymentMethodConfirmHandler(this)
+                .confirmCustomPaymentMethodCallback(this)
                 .createIntentCallback(viewModel::createIntentCallback)
                 .analyticEventCallback(viewModel::analyticCallback)
                 .build()
@@ -540,6 +548,13 @@ internal class PaymentSheetPlaygroundActivity : AppCompatActivity(), ExternalPay
                 .putExtra(FawryActivity.EXTRA_EXTERNAL_PAYMENT_METHOD_TYPE, externalPaymentMethodType)
                 .putExtra(FawryActivity.EXTRA_BILLING_DETAILS, billingDetails)
         )
+    }
+
+    override fun onConfirmCustomPaymentMethod(
+        customPaymentMethod: PaymentSheet.CustomPaymentMethod,
+        billingDetails: PaymentMethod.BillingDetails
+    ) {
+        error("Currently cannot handle custom payment methods!")
     }
 }
 

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/embedded/EmbeddedPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/embedded/EmbeddedPlaygroundActivity.kt
@@ -28,11 +28,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentelement.ConfirmCustomPaymentMethodCallback
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentelement.ExperimentalCustomPaymentMethodsApi
 import com.stripe.android.paymentelement.ExperimentalEmbeddedPaymentElementApi
 import com.stripe.android.paymentelement.rememberEmbeddedPaymentElement
 import com.stripe.android.paymentsheet.CreateIntentResult
 import com.stripe.android.paymentsheet.ExternalPaymentMethodConfirmHandler
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.example.playground.PlaygroundState
 import com.stripe.android.paymentsheet.example.playground.PlaygroundTheme
 import com.stripe.android.paymentsheet.example.playground.activity.FawryActivity
@@ -47,8 +50,11 @@ import com.stripe.android.paymentsheet.example.samples.ui.shared.BuyButton
 import com.stripe.android.paymentsheet.example.samples.ui.shared.PaymentMethodSelector
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalEmbeddedPaymentElementApi::class)
-internal class EmbeddedPlaygroundActivity : AppCompatActivity(), ExternalPaymentMethodConfirmHandler {
+@OptIn(ExperimentalEmbeddedPaymentElementApi::class, ExperimentalCustomPaymentMethodsApi::class)
+internal class EmbeddedPlaygroundActivity :
+    AppCompatActivity(),
+    ConfirmCustomPaymentMethodCallback,
+    ExternalPaymentMethodConfirmHandler {
     companion object {
         const val PLAYGROUND_STATE_KEY = "playgroundState"
 
@@ -88,7 +94,9 @@ internal class EmbeddedPlaygroundActivity : AppCompatActivity(), ExternalPayment
                 )
             },
             resultCallback = ::handleEmbeddedResult,
-        ).externalPaymentMethodConfirmHandler(this)
+        )
+            .confirmCustomPaymentMethodCallback(this)
+            .externalPaymentMethodConfirmHandler(this)
         val embeddedViewDisplaysMandateText =
             initialPlaygroundState.snapshot[EmbeddedViewDisplaysMandateSettingDefinition]
         setContent {
@@ -279,5 +287,12 @@ internal class EmbeddedPlaygroundActivity : AppCompatActivity(), ExternalPayment
 
         @Composable
         abstract fun Content(embeddedPaymentElement: EmbeddedPaymentElement, retry: () -> Unit)
+    }
+
+    override fun onConfirmCustomPaymentMethod(
+        customPaymentMethod: PaymentSheet.CustomPaymentMethod,
+        billingDetails: PaymentMethod.BillingDetails
+    ) {
+        error("Currently cannot handle custom payment methods!")
     }
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomPaymentMethodsSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomPaymentMethodsSettingsDefinition.kt
@@ -1,0 +1,76 @@
+package com.stripe.android.paymentsheet.example.playground.settings
+
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentelement.ExperimentalCustomPaymentMethodsApi
+import com.stripe.android.paymentelement.ExperimentalEmbeddedPaymentElementApi
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.example.playground.PlaygroundState
+
+@OptIn(ExperimentalEmbeddedPaymentElementApi::class, ExperimentalCustomPaymentMethodsApi::class)
+internal object CustomPaymentMethodsSettingDefinition :
+    PlaygroundSettingDefinition<CustomPaymentMethodPlaygroundType>,
+    PlaygroundSettingDefinition.Saveable<CustomPaymentMethodPlaygroundType> by EnumSaveable(
+        key = "customPaymentMethods",
+        values = CustomPaymentMethodPlaygroundType.entries.toTypedArray(),
+        defaultValue = CustomPaymentMethodPlaygroundType.Off,
+    ),
+    PlaygroundSettingDefinition.Displayable<CustomPaymentMethodPlaygroundType> {
+    override val displayName: String = "Custom payment methods"
+
+    override fun createOptions(
+        configurationData: PlaygroundConfigurationData
+    ) = CustomPaymentMethodPlaygroundType.entries.map {
+        option(it.displayName, it)
+    }
+
+    override fun configure(
+        value: CustomPaymentMethodPlaygroundType,
+        configurationBuilder: EmbeddedPaymentElement.Configuration.Builder,
+        playgroundState: PlaygroundState.Payment,
+        configurationData: PlaygroundSettingDefinition.EmbeddedConfigurationData
+    ) {
+        configurationBuilder.customPaymentMethods(createCustomPaymentMethodsFromType(value))
+    }
+
+    override fun configure(
+        value: CustomPaymentMethodPlaygroundType,
+        configurationBuilder: PaymentSheet.Configuration.Builder,
+        playgroundState: PlaygroundState.Payment,
+        configurationData: PlaygroundSettingDefinition.PaymentSheetConfigurationData
+    ) {
+        configurationBuilder.customPaymentMethods(createCustomPaymentMethodsFromType(value))
+    }
+
+    private fun createCustomPaymentMethodsFromType(
+        value: CustomPaymentMethodPlaygroundType
+    ): List<PaymentSheet.CustomPaymentMethod> {
+        return when (value) {
+            CustomPaymentMethodPlaygroundType.On -> createCustomPaymentMethods(disableBillingDetails = true)
+            CustomPaymentMethodPlaygroundType.OnWithBillingDetailsCollection ->
+                createCustomPaymentMethods(disableBillingDetails = false)
+            CustomPaymentMethodPlaygroundType.Off -> emptyList()
+        }
+    }
+}
+
+enum class CustomPaymentMethodPlaygroundType(
+    val displayName: String
+) : ValueEnum {
+    On("On"),
+    OnWithBillingDetailsCollection("On with billing details collection"),
+    Off("Off");
+
+    override val value: String
+        get() = name
+}
+
+@OptIn(ExperimentalCustomPaymentMethodsApi::class)
+private fun createCustomPaymentMethods(disableBillingDetails: Boolean): List<PaymentSheet.CustomPaymentMethod> {
+    return listOf(
+        PaymentSheet.CustomPaymentMethod(
+            id = "cpmt_1QpIMNLu5o3P18Zpwln1Sm6I",
+            subtitle = "Pay now with BufoPay",
+            disableBillingDetailCollection = disableBillingDetails,
+        )
+    )
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -449,6 +449,7 @@ internal class PlaygroundSettings private constructor(
             AllowsRemovalOfLastSavedPaymentMethodSettingsDefinition,
             PaymentMethodOrderSettingsDefinition,
             ExternalPaymentMethodSettingsDefinition,
+            CustomPaymentMethodsSettingDefinition,
             LayoutSettingsDefinition,
             CardBrandAcceptanceSettingsDefinition,
             FeatureFlagSettingsDefinition(FeatureFlags.instantDebitsIncentives),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -237,7 +237,8 @@ class PaymentSheet internal constructor(
          * [Configuration.Builder.customPaymentMethods] to specify custom payment methods.
          */
         @ExperimentalCustomPaymentMethodsApi
-        internal fun confirmCustomPaymentMethodCallback(callback: ConfirmCustomPaymentMethodCallback) = apply {
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        fun confirmCustomPaymentMethodCallback(callback: ConfirmCustomPaymentMethodCallback) = apply {
             callbacksBuilder.confirmCustomPaymentMethodCallback(callback)
         }
 
@@ -891,7 +892,8 @@ class PaymentSheet internal constructor(
              * If set, Payment Sheet will display the defined list of custom payment methods in the UI.
              */
             @ExperimentalCustomPaymentMethodsApi
-            internal fun customPaymentMethods(
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            fun customPaymentMethods(
                 customPaymentMethods: List<CustomPaymentMethod>,
             ) = apply {
                 this.customPaymentMethods = customPaymentMethods


### PR DESCRIPTION
# Summary
Add custom payment methods to playground

# Motivation
Allows for eventual testing of custom payment methods rendering & confirmation.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified