### PR TITLE
Add analytics for Embedded confirmation

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementAnalyticsTest.kt
@@ -128,6 +128,8 @@ internal class EmbeddedPaymentElementAnalyticsTest {
             eventName = "stripe_android.paymenthandler.confirm.finished",
             query("intent_id", "pi_example"),
         )
+        validateAnalyticsRequest(eventName = "mc_confirm_button_tapped")
+        validateAnalyticsRequest(eventName = "mc_embedded_payment_success")
 
         formPage.clickPrimaryButton()
         formPage.waitUntilMissing()
@@ -189,6 +191,7 @@ internal class EmbeddedPaymentElementAnalyticsTest {
             eventName = "stripe_android.paymenthandler.confirm.finished",
             query("intent_id", "pi_example"),
         )
+        validateAnalyticsRequest(eventName = "mc_embedded_payment_success")
 
         testContext.confirm()
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationHelper.kt
@@ -9,6 +9,8 @@ import com.stripe.android.paymentelement.ExperimentalEmbeddedPaymentElementApi
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.toConfirmationOption
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.utils.reportPaymentResult
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -26,6 +28,7 @@ internal class DefaultEmbeddedConfirmationHelper @Inject constructor(
     private val confirmationStateHolder: EmbeddedConfirmationStateHolder,
     private val selectionHolder: EmbeddedSelectionHolder,
     private val embeddedContentHelper: EmbeddedContentHelper,
+    private val eventReporter: EventReporter
 ) : EmbeddedConfirmationHelper {
     init {
         confirmationStarter.register(
@@ -36,6 +39,7 @@ internal class DefaultEmbeddedConfirmationHelper @Inject constructor(
         lifecycleOwner.lifecycleScope.launch {
             confirmationStarter.result.collect { result ->
                 resultCallback.onResult(result.asEmbeddedResult())
+                eventReporter.reportPaymentResult(result, confirmationStateHolder.state?.selection)
 
                 if (result is ConfirmationHandler.Result.Succeeded) {
                     embeddedContentHelper.clearEmbeddedContent()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityConfirmationHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityConfirmationHelper.kt
@@ -10,6 +10,7 @@ import com.stripe.android.paymentelement.ExperimentalEmbeddedPaymentElementApi
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.toConfirmationOption
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -29,6 +30,7 @@ internal class DefaultFormActivityConfirmationHelper @Inject constructor(
     private val selectionHolder: EmbeddedSelectionHolder,
     private val stateHelper: FormActivityStateHelper,
     private val onClickDelegate: OnClickOverrideDelegate,
+    private val eventReporter: EventReporter,
     lifecycleOwner: LifecycleOwner,
     activityResultCaller: ActivityResultCaller
 ) : FormActivityConfirmationHelper {
@@ -46,6 +48,7 @@ internal class DefaultFormActivityConfirmationHelper @Inject constructor(
         if (onClickDelegate.onClickOverride != null) {
             onClickDelegate.onClickOverride?.invoke()
         } else {
+            eventReporter.onPressConfirmButton(selectionHolder.selection.value)
             confirmationArgs()?.let { args ->
                 confirmationHandler.start(args)
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityStateHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityStateHelper.kt
@@ -9,11 +9,13 @@ import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.ExperimentalEmbeddedPaymentElementApi
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.amount
 import com.stripe.android.paymentsheet.model.currency
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.ui.PrimaryButtonProcessingState
 import com.stripe.android.paymentsheet.utils.buyButtonLabel
+import com.stripe.android.paymentsheet.utils.reportPaymentResult
 import com.stripe.android.ui.core.Amount
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -48,6 +50,7 @@ internal class DefaultFormActivityStateHelper @Inject constructor(
     private val selectionHolder: EmbeddedSelectionHolder,
     private val configuration: EmbeddedPaymentElement.Configuration,
     private val onClickDelegate: OnClickOverrideDelegate,
+    private val eventReporter: EventReporter,
     @ViewModelScope coroutineScope: CoroutineScope,
 ) : FormActivityStateHelper {
     private val _state = MutableStateFlow(
@@ -124,6 +127,7 @@ internal class DefaultFormActivityStateHelper @Inject constructor(
     ): FormActivityStateHelper.State {
         return when (state) {
             is ConfirmationHandler.State.Complete -> {
+                eventReporter.reportPaymentResult(state.result, selectionHolder.selection.value)
                 when (state.result) {
                     is ConfirmationHandler.Result.Succeeded -> copy(
                         processingState = PrimaryButtonProcessingState.Completed,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -328,7 +328,11 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
     ) : PaymentSheetEvent() {
 
         override val eventName: String =
-            formatEventName(mode, "payment_${analyticsValue(paymentSelection)}_${result.analyticsValue}")
+            if (mode == EventReporter.Mode.Embedded) {
+                formatEventName(mode, "payment_${result.analyticsValue}")
+            } else {
+                formatEventName(mode, "payment_${analyticsValue(paymentSelection)}_${result.analyticsValue}")
+            }
 
         override val additionalParams: Map<String, Any?> = buildMap {
             put(FIELD_DURATION, duration?.asSeconds)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -46,6 +46,7 @@ import com.stripe.android.paymentsheet.state.PaymentSheetState
 import com.stripe.android.paymentsheet.ui.SepaMandateContract
 import com.stripe.android.paymentsheet.ui.SepaMandateResult
 import com.stripe.android.paymentsheet.utils.canSave
+import com.stripe.android.paymentsheet.utils.toConfirmationError
 import com.stripe.android.uicore.utils.AnimationConstants
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.collectLatest
@@ -447,7 +448,7 @@ internal class DefaultFlowController @Inject internal constructor(
                 )
             }
             is ConfirmationHandler.Result.Failed -> {
-                val error = result.type.toConfirmationError(result.cause)
+                val error = result.toConfirmationError()
 
                 error?.let {
                     eventReporter.onPaymentFailure(
@@ -536,22 +537,6 @@ internal class DefaultFlowController @Inject internal constructor(
             else -> {
                 // Nothing to do here
             }
-        }
-    }
-
-    private fun ConfirmationHandler.Result.Failed.ErrorType.toConfirmationError(
-        cause: Throwable
-    ): PaymentSheetConfirmationError? {
-        return when (this) {
-            ConfirmationHandler.Result.Failed.ErrorType.ExternalPaymentMethod ->
-                PaymentSheetConfirmationError.ExternalPaymentMethod
-            ConfirmationHandler.Result.Failed.ErrorType.Payment ->
-                PaymentSheetConfirmationError.Stripe(cause)
-            is ConfirmationHandler.Result.Failed.ErrorType.GooglePay ->
-                PaymentSheetConfirmationError.GooglePay(errorCode)
-            ConfirmationHandler.Result.Failed.ErrorType.Internal,
-            ConfirmationHandler.Result.Failed.ErrorType.MerchantIntegration,
-            ConfirmationHandler.Result.Failed.ErrorType.Fatal -> null
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/utils/ConfirmationReportingUtils.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/utils/ConfirmationReportingUtils.kt
@@ -1,0 +1,38 @@
+package com.stripe.android.paymentsheet.utils
+
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.analytics.PaymentSheetConfirmationError
+import com.stripe.android.paymentsheet.model.PaymentSelection
+
+internal fun ConfirmationHandler.Result.Failed.toConfirmationError(): PaymentSheetConfirmationError? {
+    return when (type) {
+        ConfirmationHandler.Result.Failed.ErrorType.ExternalPaymentMethod ->
+            PaymentSheetConfirmationError.ExternalPaymentMethod
+        ConfirmationHandler.Result.Failed.ErrorType.Payment ->
+            PaymentSheetConfirmationError.Stripe(cause)
+        is ConfirmationHandler.Result.Failed.ErrorType.GooglePay ->
+            PaymentSheetConfirmationError.GooglePay(type.errorCode)
+        ConfirmationHandler.Result.Failed.ErrorType.Internal,
+        ConfirmationHandler.Result.Failed.ErrorType.MerchantIntegration,
+        ConfirmationHandler.Result.Failed.ErrorType.Fatal -> null
+    }
+}
+
+internal fun EventReporter.reportPaymentResult(
+    result: ConfirmationHandler.Result,
+    paymentSelection: PaymentSelection?
+) {
+    when (result) {
+        is ConfirmationHandler.Result.Succeeded -> this.onPaymentSuccess(
+            paymentSelection,
+            result.deferredIntentConfirmationType
+        )
+        is ConfirmationHandler.Result.Failed -> {
+            result.toConfirmationError()?.let { confirmationError ->
+                this.onPaymentFailure(paymentSelection, confirmationError)
+            }
+        }
+        is ConfirmationHandler.Result.Canceled -> {}
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/utils/ConfirmationReportingUtils.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/utils/ConfirmationReportingUtils.kt
@@ -24,13 +24,13 @@ internal fun EventReporter.reportPaymentResult(
     paymentSelection: PaymentSelection?
 ) {
     when (result) {
-        is ConfirmationHandler.Result.Succeeded -> this.onPaymentSuccess(
+        is ConfirmationHandler.Result.Succeeded -> onPaymentSuccess(
             paymentSelection,
             result.deferredIntentConfirmationType
         )
         is ConfirmationHandler.Result.Failed -> {
             result.toConfirmationError()?.let { confirmationError ->
-                this.onPaymentFailure(paymentSelection, confirmationError)
+                onPaymentFailure(paymentSelection, confirmationError)
             }
         }
         is ConfirmationHandler.Result.Canceled -> {}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfirmationHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfirmationHelperTest.kt
@@ -17,6 +17,7 @@ import com.stripe.android.paymentelement.confirmation.gpay.GooglePayConfirmation
 import com.stripe.android.paymentelement.confirmation.link.LinkConfirmationOption
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
@@ -171,6 +172,7 @@ internal class DefaultEmbeddedConfirmationHelperTest {
             confirmationStateHolder = confirmationStateHolder,
             selectionHolder = selectionHolder,
             embeddedContentHelper = embeddedContentHelper,
+            eventReporter = FakeEventReporter()
         )
         assertThat(confirmationHandler.registerTurbine.awaitItem()).isNotNull()
         Scenario(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/DefaultFormActivityStateHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/DefaultFormActivityStateHelperTest.kt
@@ -15,6 +15,7 @@ import com.stripe.android.paymentelement.ExperimentalEmbeddedPaymentElementApi
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.content.EmbeddedConfirmationStateFixtures
+import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.ui.PrimaryButtonProcessingState
 import com.stripe.android.ui.core.R
@@ -263,7 +264,8 @@ class DefaultFormActivityStateHelperTest {
             selectionHolder = selectionHolder,
             configuration = config,
             coroutineScope = TestScope(UnconfinedTestDispatcher()),
-            onClickDelegate = onClickOverrideDelegate
+            onClickDelegate = onClickOverrideDelegate,
+            eventReporter = FakeEventReporter()
         )
 
         Scenario(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityConfirmationHandlerTest.kt
@@ -14,6 +14,7 @@ import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationO
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.content.EmbeddedConfirmationStateFixtures
+import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.testing.CoroutineTestRule
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -90,7 +91,8 @@ internal class FormActivityConfirmationHandlerTest {
             stateHelper = stateHelper,
             lifecycleOwner = TestLifecycleOwner(),
             activityResultCaller = mock(),
-            onClickDelegate = onClickOverrideDelegate
+            onClickDelegate = onClickOverrideDelegate,
+            eventReporter = FakeEventReporter()
         )
 
         assertThat(confirmationHandler.registerTurbine.awaitItem()).isNotNull()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityScreenShotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityScreenShotTest.kt
@@ -105,7 +105,8 @@ internal class FormActivityScreenShotTest {
             selectionHolder = selectionHolder,
             configuration = EmbeddedConfirmationStateFixtures.defaultState().configuration,
             coroutineScope = TestScope(UnconfinedTestDispatcher()),
-            onClickDelegate = OnClickDelegateOverrideImpl()
+            onClickDelegate = OnClickDelegateOverrideImpl(),
+            eventReporter = FakeEventReporter()
         )
         val formHelperFactory = EmbeddedFormHelperFactory(
             linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeEventReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeEventReporter.kt
@@ -16,6 +16,9 @@ internal class FakeEventReporter : EventReporter {
     private val _paymentFailureCalls = Turbine<PaymentFailureCall>()
     val paymentFailureCalls: ReceiveTurbine<PaymentFailureCall> = _paymentFailureCalls
 
+    private val _paymentSuccessCalls = Turbine<PaymentSuccessCall>()
+    val paymentSuccessCalls: ReceiveTurbine<PaymentSuccessCall> = _paymentSuccessCalls
+
     private val _updatePaymentMethodSucceededCalls = Turbine<UpdatePaymentMethodSucceededCall>()
     val updatePaymentMethodSucceededCalls: ReceiveTurbine<UpdatePaymentMethodSucceededCall> =
         _updatePaymentMethodSucceededCalls
@@ -50,6 +53,7 @@ internal class FakeEventReporter : EventReporter {
 
     fun validate() {
         _paymentFailureCalls.ensureAllEventsConsumed()
+        _paymentSuccessCalls.ensureAllEventsConsumed()
         _updatePaymentMethodSucceededCalls.ensureAllEventsConsumed()
         _updatePaymentMethodFailedCalls.ensureAllEventsConsumed()
         _setAsDefaultPaymentMethodFailedCalls.ensureAllEventsConsumed()
@@ -127,6 +131,12 @@ internal class FakeEventReporter : EventReporter {
         paymentSelection: PaymentSelection?,
         deferredIntentConfirmationType: DeferredIntentConfirmationType?
     ) {
+        _paymentSuccessCalls.add(
+            PaymentSuccessCall(
+                paymentSelection = paymentSelection,
+                deferredIntentConfirmationType = deferredIntentConfirmationType
+            )
+        )
     }
 
     override fun onPaymentFailure(
@@ -208,6 +218,11 @@ internal class FakeEventReporter : EventReporter {
     data class PaymentFailureCall(
         val paymentSelection: PaymentSelection?,
         val error: PaymentSheetConfirmationError
+    )
+
+    data class PaymentSuccessCall(
+        val paymentSelection: PaymentSelection?,
+        val deferredIntentConfirmationType: DeferredIntentConfirmationType?
     )
 
     data class UpdatePaymentMethodSucceededCall(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/ConfirmationReportingUtilsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/ConfirmationReportingUtilsTest.kt
@@ -1,0 +1,107 @@
+package com.stripe.android.paymentsheet.utils
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.exception.StripeException
+import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.isInstanceOf
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
+import com.stripe.android.paymentsheet.analytics.FakeEventReporter
+import com.stripe.android.paymentsheet.analytics.PaymentSheetConfirmationError
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class ConfirmationReportingUtilsTest {
+
+    @Test
+    fun `toConfirmationError returns correct error for external payment method error`() {
+        val epmError = ConfirmationHandler.Result.Failed(
+            cause = Exception(),
+            message = "Something went wrong".resolvableString,
+            type = ConfirmationHandler.Result.Failed.ErrorType.ExternalPaymentMethod
+        )
+
+        val confirmationError = epmError.toConfirmationError()
+        assertThat(confirmationError).isNotNull()
+        assertThat(confirmationError).isInstanceOf<PaymentSheetConfirmationError.ExternalPaymentMethod>()
+    }
+
+    @Test
+    fun `toConfirmationError returns correct error for stripe error`() {
+        val stripeError = ConfirmationHandler.Result.Failed(
+            cause = StripeException.create(
+                Throwable(
+                    message = "Something went wrong with Stripe",
+                )
+            ),
+            message = "Something went wrong".resolvableString,
+            type = ConfirmationHandler.Result.Failed.ErrorType.Payment
+        )
+
+        val confirmationError = stripeError.toConfirmationError()
+        assertThat(confirmationError).isNotNull()
+        assertThat(confirmationError).isInstanceOf<PaymentSheetConfirmationError.Stripe>()
+        assertThat(confirmationError?.cause?.message).isEqualTo("Something went wrong with Stripe")
+    }
+
+    @Test
+    fun `toConfirmationError returns correct error for google pay error`() {
+        val googlePayError = ConfirmationHandler.Result.Failed(
+            cause = Exception(),
+            message = "Something went wrong".resolvableString,
+            type = ConfirmationHandler.Result.Failed.ErrorType.GooglePay(12)
+        )
+
+        val confirmationError = googlePayError.toConfirmationError()
+        assertThat(confirmationError).isNotNull()
+        assertThat(confirmationError).isInstanceOf<PaymentSheetConfirmationError.GooglePay>()
+        assertThat(confirmationError?.errorCode).isEqualTo("12")
+    }
+
+    @Test
+    fun `toConfirmationError returns null for non reportable error`() {
+        val merchantError = ConfirmationHandler.Result.Failed(
+            cause = Exception(),
+            message = "Something went wrong".resolvableString,
+            type = ConfirmationHandler.Result.Failed.ErrorType.MerchantIntegration
+        )
+
+        val confirmationError = merchantError.toConfirmationError()
+        assertThat(confirmationError).isNull()
+    }
+
+    @Test
+    fun `reportPaymentResult reports success correctly`() = runTest {
+        val eventReporter = FakeEventReporter()
+        val result = ConfirmationHandler.Result.Succeeded(
+            intent = PaymentIntentFixtures.PI_SUCCEEDED,
+            deferredIntentConfirmationType = DeferredIntentConfirmationType.Client
+        )
+
+        eventReporter.reportPaymentResult(result, PaymentSelection.GooglePay)
+
+        val event = eventReporter.paymentSuccessCalls.awaitItem()
+        assertThat(event.paymentSelection).isEqualTo(PaymentSelection.GooglePay)
+        assertThat(event.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Client)
+        eventReporter.validate()
+    }
+
+    @Test
+    fun `reportPaymentResult reports failure correctly`() = runTest {
+        val eventReporter = FakeEventReporter()
+        val result = ConfirmationHandler.Result.Failed(
+            cause = Exception(),
+            message = "Something went wrong".resolvableString,
+            type = ConfirmationHandler.Result.Failed.ErrorType.GooglePay(12)
+        )
+
+        eventReporter.reportPaymentResult(result, PaymentSelection.GooglePay)
+
+        val event = eventReporter.paymentFailureCalls.awaitItem()
+        assertThat(event.paymentSelection).isEqualTo(PaymentSelection.GooglePay)
+        assertThat(event.error).isInstanceOf<PaymentSheetConfirmationError.GooglePay>()
+        eventReporter.validate()
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add `EventReporter.onPressConfirmButton` call to `FormActivityConfirmationHelper.confirm`
Add `EventReporter.onPaymentSuccess/onPaymentFailure` call to `FormActivityStateHelper` and `EmbeddedConfirmationHelper`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-3252

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [ ] Manually verified

