### PR TITLE
Centralize state handling for embedded content.

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -574,6 +574,14 @@ public final class com/stripe/android/paymentelement/EmbeddedPaymentElement$Conf
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/paymentelement/EmbeddedPaymentElement$State$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentelement/EmbeddedPaymentElement$State;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentelement/EmbeddedPaymentElement$State;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/paymentelement/confirmation/ConfirmationDefinition$Parameters$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentelement/confirmation/ConfirmationDefinition$Parameters;

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
@@ -21,6 +21,7 @@ import com.stripe.android.model.SetupIntent
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.content.EmbeddedConfigurationCoordinator
 import com.stripe.android.paymentelement.embedded.content.EmbeddedConfirmationHelper
+import com.stripe.android.paymentelement.embedded.content.EmbeddedConfirmationStateHolder
 import com.stripe.android.paymentelement.embedded.content.EmbeddedContentHelper
 import com.stripe.android.paymentelement.embedded.content.EmbeddedPaymentElementScope
 import com.stripe.android.paymentelement.embedded.content.EmbeddedPaymentElementViewModel
@@ -29,6 +30,7 @@ import com.stripe.android.paymentsheet.CreateIntentCallback
 import com.stripe.android.paymentsheet.ExternalPaymentMethodConfirmHandler
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
+import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.paymentsheet.utils.applicationIsTaskOwner
 import com.stripe.android.uicore.image.rememberDrawablePainter
 import com.stripe.android.uicore.utils.collectAsState
@@ -510,6 +512,17 @@ class EmbeddedPaymentElement @Inject internal constructor(
     fun interface ResultCallback {
         fun onResult(result: Result)
     }
+
+    /**
+     * A [Parcelable] state used to reconfigure [EmbeddedPaymentElement] across activity boundaries.
+     */
+    @ExperimentalEmbeddedPaymentElementApi
+    @Poko
+    @Parcelize
+    internal class State internal constructor(
+        internal val confirmationState: EmbeddedConfirmationStateHolder.State,
+        internal val customer: CustomerState?,
+    ) : Parcelable
 
     internal companion object {
         @ExperimentalEmbeddedPaymentElementApi

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
@@ -48,7 +48,7 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
     @Named(STATUS_BAR_COLOR) private val statusBarColor: Int?,
     @PaymentElementCallbackIdentifier private val paymentElementCallbackIdentifier: String,
     resultCallback: EmbeddedPaymentElement.ResultCallback,
-    private val embeddedContentHelper: EmbeddedContentHelper,
+    private val stateHelper: EmbeddedStateHelper,
 ) : EmbeddedSheetLauncher {
 
     init {
@@ -68,9 +68,8 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
             sheetStateHolder.sheetIsOpen = false
             selectionHolder.setTemporary(null)
             if (result is FormResult.Complete) {
-                embeddedContentHelper.clearEmbeddedContent()
                 resultCallback.onResult(EmbeddedPaymentElement.Result.Completed())
-                selectionHolder.set(null)
+                stateHelper.state = null
             }
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfigurationCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfigurationCoordinator.kt
@@ -8,9 +8,7 @@ import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.EmbeddedPaymentElement.ConfigureResult
 import com.stripe.android.paymentelement.ExperimentalEmbeddedPaymentElementApi
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
-import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.paymentsheet.parseAppearance
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
@@ -30,8 +28,7 @@ internal class DefaultEmbeddedConfigurationCoordinator @Inject constructor(
     private val configurationHandler: EmbeddedConfigurationHandler,
     private val selectionHolder: EmbeddedSelectionHolder,
     private val selectionChooser: EmbeddedSelectionChooser,
-    private val customerStateHolder: CustomerStateHolder,
-    private val embeddedContentHelper: EmbeddedContentHelper,
+    private val stateHelper: EmbeddedStateHelper,
     @ViewModelScope private val viewModelScope: CoroutineScope,
 ) : EmbeddedConfigurationCoordinator {
     override suspend fun configure(
@@ -64,7 +61,6 @@ internal class DefaultEmbeddedConfigurationCoordinator @Inject constructor(
         intentConfiguration: PaymentSheet.IntentConfiguration,
         configuration: EmbeddedPaymentElement.Configuration,
     ) {
-        configuration.appearance.parseAppearance()
         val newPaymentSelection = selectionChooser.choose(
             paymentMethodMetadata = state.paymentMethodMetadata,
             paymentMethods = state.customer?.paymentMethods,
@@ -72,20 +68,16 @@ internal class DefaultEmbeddedConfigurationCoordinator @Inject constructor(
             newSelection = state.paymentSelection,
             newConfiguration = configuration.asCommonConfiguration(),
         )
-        confirmationStateHolder.state = EmbeddedConfirmationStateHolder.State(
-            paymentMethodMetadata = state.paymentMethodMetadata,
-            selection = newPaymentSelection,
-            initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
-                intentConfiguration
+        stateHelper.state = EmbeddedPaymentElement.State(
+            confirmationState = EmbeddedConfirmationStateHolder.State(
+                paymentMethodMetadata = state.paymentMethodMetadata,
+                selection = newPaymentSelection,
+                initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
+                    intentConfiguration
+                ),
+                configuration = configuration,
             ),
-            configuration = configuration,
-        )
-        customerStateHolder.setCustomerState(state.customer)
-        selectionHolder.set(newPaymentSelection)
-        embeddedContentHelper.dataLoaded(
-            paymentMethodMetadata = state.paymentMethodMetadata,
-            rowStyle = configuration.appearance.embeddedAppearance.style,
-            embeddedViewDisplaysMandateText = configuration.embeddedViewDisplaysMandateText,
+            customer = state.customer,
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationHelper.kt
@@ -8,7 +8,6 @@ import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.ExperimentalEmbeddedPaymentElementApi
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.toConfirmationOption
-import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -24,8 +23,7 @@ internal class DefaultEmbeddedConfirmationHelper @Inject constructor(
     private val activityResultCaller: ActivityResultCaller,
     private val lifecycleOwner: LifecycleOwner,
     private val confirmationStateHolder: EmbeddedConfirmationStateHolder,
-    private val selectionHolder: EmbeddedSelectionHolder,
-    private val embeddedContentHelper: EmbeddedContentHelper,
+    private val stateHelper: EmbeddedStateHelper,
 ) : EmbeddedConfirmationHelper {
     init {
         confirmationStarter.register(
@@ -38,9 +36,7 @@ internal class DefaultEmbeddedConfirmationHelper @Inject constructor(
                 resultCallback.onResult(result.asEmbeddedResult())
 
                 if (result is ConfirmationHandler.Result.Succeeded) {
-                    embeddedContentHelper.clearEmbeddedContent()
-                    confirmationStateHolder.state = null
-                    selectionHolder.set(null)
+                    stateHelper.state = null
                 }
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModelComponent.kt
@@ -93,6 +93,11 @@ internal interface EmbeddedPaymentElementViewModelComponent {
 )
 internal interface EmbeddedPaymentElementViewModelModule {
     @Binds
+    fun bindsEmbeddedStateHelper(
+        stateHelper: DefaultEmbeddedStateHelper
+    ): EmbeddedStateHelper
+
+    @Binds
     fun bindsPaymentOptionDisplayDataHolder(
         paymentOptionDisplayDataHolder: DefaultPaymentOptionDisplayDataHolder
     ): PaymentOptionDisplayDataHolder

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedStateHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedStateHelper.kt
@@ -1,0 +1,59 @@
+@file:OptIn(ExperimentalEmbeddedPaymentElementApi::class)
+
+package com.stripe.android.paymentelement.embedded.content
+
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentelement.ExperimentalEmbeddedPaymentElementApi
+import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.paymentsheet.CustomerStateHolder
+import com.stripe.android.paymentsheet.parseAppearance
+import javax.inject.Inject
+
+internal interface EmbeddedStateHelper {
+    var state: EmbeddedPaymentElement.State?
+}
+
+internal class DefaultEmbeddedStateHelper @Inject constructor(
+    private val selectionHolder: EmbeddedSelectionHolder,
+    private val customerStateHolder: CustomerStateHolder,
+    private val confirmationStateHolder: EmbeddedConfirmationStateHolder,
+    private val embeddedContentHelper: EmbeddedContentHelper,
+) : EmbeddedStateHelper {
+    override var state: EmbeddedPaymentElement.State?
+        get() {
+            return confirmationStateHolder.state?.let {
+                EmbeddedPaymentElement.State(
+                    confirmationState = it,
+                    customer = customerStateHolder.customer.value,
+                )
+            }
+        }
+        set(value) {
+            if (value != null) {
+                handleLoadedState(value)
+            } else {
+                clearState()
+            }
+        }
+
+    private fun handleLoadedState(
+        state: EmbeddedPaymentElement.State,
+    ) {
+        state.confirmationState.configuration.appearance.parseAppearance()
+        confirmationStateHolder.state = state.confirmationState
+        customerStateHolder.setCustomerState(state.customer)
+        selectionHolder.set(state.confirmationState.selection)
+        embeddedContentHelper.dataLoaded(
+            paymentMethodMetadata = state.confirmationState.paymentMethodMetadata,
+            rowStyle = state.confirmationState.configuration.appearance.embeddedAppearance.style,
+            embeddedViewDisplaysMandateText = state.confirmationState.configuration.embeddedViewDisplaysMandateText,
+        )
+    }
+
+    private fun clearState() {
+        embeddedContentHelper.clearEmbeddedContent()
+        confirmationStateHolder.state = null
+        selectionHolder.set(null)
+        customerStateHolder.setCustomerState(null)
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfirmationHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfirmationHelperTest.kt
@@ -48,34 +48,33 @@ internal class DefaultEmbeddedConfirmationHelperTest {
         assertThat(resultCallbackTurbine.awaitItem()).isEqualTo(
             EmbeddedPaymentElement.Result.Failed(exception)
         )
+        assertThat(stateHelper.stateTurbine.awaitItem()).isNotNull()
     }
 
     @Test
-    fun `successful confirm clears confirmationState and selection`() = testScenario {
+    fun `successful confirm clears state`() = testScenario {
         assertThat(confirmationStateHolder.state).isNotNull()
-        assertThat(selectionHolder.selection.value).isNotNull()
+        assertThat(stateHelper.stateTurbine.awaitItem()).isNotNull()
         confirmationHandler.state.value = ConfirmationHandler.State.Complete(
             ConfirmationHandler.Result.Succeeded(
                 intent = PaymentIntentFixtures.PI_SUCCEEDED,
                 deferredIntentConfirmationType = null,
             )
         )
-        assertThat(embeddedContentHelper.clearEmbeddedContentTurbine.awaitItem()).isEqualTo(Unit)
+        assertThat(stateHelper.stateTurbine.awaitItem()).isNull()
         assertThat(resultCallbackTurbine.awaitItem()).isInstanceOf<EmbeddedPaymentElement.Result.Completed>()
-        assertThat(confirmationStateHolder.state).isNull()
-        assertThat(selectionHolder.selection.value).isNull()
     }
 
     @Test
-    fun `cancelled confirm does not clear confirmationState and selection`() = testScenario {
+    fun `cancelled confirm does not clear state`() = testScenario {
         assertThat(confirmationStateHolder.state).isNotNull()
-        assertThat(selectionHolder.selection.value).isNotNull()
+        assertThat(stateHelper.stateTurbine.expectMostRecentItem()).isNotNull()
         confirmationHandler.state.value = ConfirmationHandler.State.Complete(
             ConfirmationHandler.Result.Canceled(ConfirmationHandler.Result.Canceled.Action.InformCancellation)
         )
         assertThat(resultCallbackTurbine.awaitItem()).isInstanceOf<EmbeddedPaymentElement.Result.Canceled>()
         assertThat(confirmationStateHolder.state).isNotNull()
-        assertThat(selectionHolder.selection.value).isNotNull()
+        stateHelper.stateTurbine.ensureAllEventsConsumed()
     }
 
     @Test
@@ -84,6 +83,7 @@ internal class DefaultEmbeddedConfirmationHelperTest {
     ) {
         confirmationHelper.confirm()
         assertThat(resultCallbackTurbine.awaitItem()).isInstanceOf<EmbeddedPaymentElement.Result.Failed>()
+        assertThat(stateHelper.stateTurbine.awaitItem()).isNull()
     }
 
     @Test
@@ -92,6 +92,7 @@ internal class DefaultEmbeddedConfirmationHelperTest {
     ) {
         confirmationHelper.confirm()
         assertThat(resultCallbackTurbine.awaitItem()).isInstanceOf<EmbeddedPaymentElement.Result.Failed>()
+        assertThat(stateHelper.stateTurbine.awaitItem()).isNotNull()
     }
 
     @Test
@@ -99,6 +100,7 @@ internal class DefaultEmbeddedConfirmationHelperTest {
         confirmationHelper.confirm()
         val args = confirmationHandler.startTurbine.awaitItem()
         assertThat(args.confirmationOption).isInstanceOf<GooglePayConfirmationOption>()
+        assertThat(stateHelper.stateTurbine.awaitItem()).isNotNull()
     }
 
     @Test
@@ -117,6 +119,7 @@ internal class DefaultEmbeddedConfirmationHelperTest {
         confirmationHelper.confirm()
         val args = confirmationHandler.startTurbine.awaitItem()
         assertThat(args.confirmationOption).isInstanceOf<LinkConfirmationOption>()
+        assertThat(stateHelper.stateTurbine.awaitItem()).isNotNull()
     }
 
     private fun defaultLoadedState(): EmbeddedConfirmationStateHolder.State {
@@ -157,7 +160,8 @@ internal class DefaultEmbeddedConfirmationHelperTest {
             coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
         )
         confirmationStateHolder.state = loadedState
-        val embeddedContentHelper = FakeEmbeddedContentHelper()
+        val stateHelper = FakeEmbeddedStateHelper()
+        stateHelper.state = if (loadedState != null) EmbeddedPaymentElement.State(loadedState, null) else null
         val confirmationHelper = DefaultEmbeddedConfirmationHelper(
             confirmationStarter = EmbeddedConfirmationStarter(
                 confirmationHandler = confirmationHandler,
@@ -169,8 +173,7 @@ internal class DefaultEmbeddedConfirmationHelperTest {
             activityResultCaller = mock(),
             lifecycleOwner = TestLifecycleOwner(coroutineDispatcher = Dispatchers.Unconfined),
             confirmationStateHolder = confirmationStateHolder,
-            selectionHolder = selectionHolder,
-            embeddedContentHelper = embeddedContentHelper,
+            stateHelper = stateHelper,
         )
         assertThat(confirmationHandler.registerTurbine.awaitItem()).isNotNull()
         Scenario(
@@ -178,12 +181,11 @@ internal class DefaultEmbeddedConfirmationHelperTest {
             confirmationHandler = confirmationHandler,
             resultCallbackTurbine = resultCallbackTurbine,
             confirmationStateHolder = confirmationStateHolder,
-            selectionHolder = selectionHolder,
-            embeddedContentHelper = embeddedContentHelper,
+            stateHelper = stateHelper,
         ).block()
         resultCallbackTurbine.ensureAllEventsConsumed()
         confirmationHandler.validate()
-        embeddedContentHelper.validate()
+        stateHelper.validate()
     }
 
     private class Scenario(
@@ -191,7 +193,6 @@ internal class DefaultEmbeddedConfirmationHelperTest {
         val confirmationHandler: FakeConfirmationHandler,
         val resultCallbackTurbine: ReceiveTurbine<EmbeddedPaymentElement.Result>,
         val confirmationStateHolder: EmbeddedConfirmationStateHolder,
-        val selectionHolder: EmbeddedSelectionHolder,
-        val embeddedContentHelper: FakeEmbeddedContentHelper,
+        val stateHelper: FakeEmbeddedStateHelper,
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
@@ -90,8 +90,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
         val callback = formRegisterCall.callback.asCallbackFor<FormResult>()
 
         callback.onActivityResult(result)
-        assertThat(embeddedContentHelper.clearEmbeddedContentTurbine.awaitItem()).isEqualTo(Unit)
-        assertThat(selectionHolder.selection.value).isNull()
+        assertThat(stateHelper.stateTurbine.awaitItem()).isNull()
         assertThat(sheetStateHolder.sheetIsOpen).isFalse()
         assertThat(selectionHolder.temporarySelection.value).isNull()
         assertThat(resultCallbackTurbine.awaitItem()).isInstanceOf<EmbeddedPaymentElement.Result.Completed>()
@@ -186,7 +185,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
         val sheetStateHolder = SheetStateHolder(savedStateHandle)
         val errorReporter = FakeErrorReporter()
         val resultCallbackTurbine = Turbine<EmbeddedPaymentElement.Result>()
-        val embeddedContentHelper = FakeEmbeddedContentHelper()
+        val stateHelper = FakeEmbeddedStateHelper()
 
         DummyActivityResultCaller.test {
             val sheetLauncher = DefaultEmbeddedSheetLauncher(
@@ -201,7 +200,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
                 resultCallback = {
                     resultCallbackTurbine.add(it)
                 },
-                embeddedContentHelper = embeddedContentHelper,
+                stateHelper = stateHelper,
             )
             val formRegisterCall = awaitRegisterCall()
             val manageRegisterCall = awaitRegisterCall()
@@ -228,11 +227,11 @@ internal class DefaultEmbeddedSheetLauncherTest {
                 sheetStateHolder = sheetStateHolder,
                 errorReporter = errorReporter,
                 resultCallbackTurbine = resultCallbackTurbine,
-                embeddedContentHelper = embeddedContentHelper,
+                stateHelper = stateHelper,
             ).block()
 
             resultCallbackTurbine.ensureAllEventsConsumed()
-            embeddedContentHelper.validate()
+            stateHelper.validate()
         }
     }
 
@@ -249,6 +248,6 @@ internal class DefaultEmbeddedSheetLauncherTest {
         val sheetStateHolder: SheetStateHolder,
         val errorReporter: FakeErrorReporter,
         val resultCallbackTurbine: Turbine<EmbeddedPaymentElement.Result>,
-        val embeddedContentHelper: FakeEmbeddedContentHelper,
+        val stateHelper: FakeEmbeddedStateHelper,
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedStateHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedStateHelperTest.kt
@@ -1,0 +1,164 @@
+@file:OptIn(ExperimentalEmbeddedPaymentElementApi::class)
+
+package com.stripe.android.paymentelement.embedded.content
+
+import androidx.compose.ui.graphics.Color
+import androidx.lifecycle.SavedStateHandle
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentelement.ExperimentalEmbeddedPaymentElementApi
+import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.paymentsheet.CustomerStateHolder
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded
+import com.stripe.android.paymentsheet.PaymentSheetFixtures
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.parseAppearance
+import com.stripe.android.paymentsheet.state.CustomerState
+import com.stripe.android.paymentsheet.state.PaymentElementLoader
+import com.stripe.android.uicore.StripeTheme
+import com.stripe.android.uicore.StripeThemeDefaults
+import com.stripe.android.utils.screenshots.PaymentSheetAppearance
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+internal class DefaultEmbeddedStateHelperTest {
+    @Test
+    fun `setting state correctly sets row style`() = testScenario {
+        setState {
+            appearance(
+                PaymentSheet.Appearance(
+                    embeddedAppearance = Embedded(
+                        Embedded.RowStyle.FlatWithRadio.default
+                    )
+                )
+            )
+        }
+
+        assertThat(embeddedContentHelper.dataLoadedTurbine.awaitItem().rowStyle)
+            .isEqualTo(Embedded.RowStyle.FlatWithRadio.default)
+    }
+
+    @Test
+    fun `setting state correctly parses appearance`() = testScenario {
+        assertThat(StripeTheme.colorsLightMutable.componentBorder)
+            .isEqualTo(
+                StripeThemeDefaults.colorsLight.componentBorder
+            )
+
+        setState {
+            appearance(
+                PaymentSheet.Appearance(
+                    colorsLight = PaymentSheetAppearance.CrazyAppearance.appearance.colorsLight,
+                )
+            )
+        }
+
+        assertThat(StripeTheme.colorsLightMutable.componentBorder)
+            .isEqualTo(
+                Color(
+                    PaymentSheetAppearance.CrazyAppearance.appearance.colorsLight.componentBorder
+                )
+            )
+
+        // Reset appearance
+        PaymentSheet.Appearance().parseAppearance()
+        embeddedContentHelper.dataLoadedTurbine.awaitItem()
+    }
+
+    @Test
+    fun `setting state correctly sets state holders and null clears all state holders`() = testScenario {
+        assertThat(confirmationStateHolder.state).isNull()
+        assertThat(customerStateHolder.customer.value).isNull()
+        assertThat(selectionHolder.selection.value).isNull()
+
+        setState(
+            selection = PaymentSelection.GooglePay,
+            customer = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE,
+        )
+
+        assertThat(stateHelper.state).isNotNull()
+        assertThat(confirmationStateHolder.state).isNotNull()
+        assertThat(customerStateHolder.customer.value).isEqualTo(PaymentSheetFixtures.EMPTY_CUSTOMER_STATE)
+        assertThat(selectionHolder.selection.value).isEqualTo(PaymentSelection.GooglePay)
+        assertThat(embeddedContentHelper.dataLoadedTurbine.awaitItem()).isNotNull()
+
+        stateHelper.state = null
+
+        assertThat(stateHelper.state).isNull()
+        assertThat(confirmationStateHolder.state).isNull()
+        assertThat(customerStateHolder.customer.value).isNull()
+        assertThat(selectionHolder.selection.value).isNull()
+        assertThat(embeddedContentHelper.clearEmbeddedContentTurbine.awaitItem()).isEqualTo(Unit)
+    }
+
+    private fun testScenario(
+        block: suspend Scenario.() -> Unit,
+    ) = runTest {
+        val savedStateHandle = SavedStateHandle()
+        val selectionHolder = EmbeddedSelectionHolder(savedStateHandle)
+        val customerStateHolder = CustomerStateHolder(savedStateHandle, selectionHolder.selection)
+        val confirmationStateHolder = EmbeddedConfirmationStateHolder(
+            savedStateHandle = savedStateHandle,
+            selectionHolder = selectionHolder,
+            coroutineScope = CoroutineScope(Dispatchers.Unconfined),
+        )
+        val embeddedContentHelper = FakeEmbeddedContentHelper()
+        val stateHelper = DefaultEmbeddedStateHelper(
+            selectionHolder = selectionHolder,
+            customerStateHolder = customerStateHolder,
+            confirmationStateHolder = confirmationStateHolder,
+            embeddedContentHelper = embeddedContentHelper,
+        )
+
+        Scenario(
+            confirmationStateHolder = confirmationStateHolder,
+            customerStateHolder = customerStateHolder,
+            selectionHolder = selectionHolder,
+            embeddedContentHelper = embeddedContentHelper,
+            stateHelper = stateHelper,
+        ).block()
+
+        embeddedContentHelper.validate()
+    }
+
+    private class Scenario(
+        val confirmationStateHolder: EmbeddedConfirmationStateHolder,
+        val customerStateHolder: CustomerStateHolder,
+        val selectionHolder: EmbeddedSelectionHolder,
+        val embeddedContentHelper: FakeEmbeddedContentHelper,
+        val stateHelper: EmbeddedStateHelper,
+    ) {
+        fun setState(
+            paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+            selection: PaymentSelection? = selectionHolder.selection.value,
+            customer: CustomerState? = customerStateHolder.customer.value,
+            configurationBuilder: EmbeddedPaymentElement.Configuration.Builder.() ->
+            EmbeddedPaymentElement.Configuration.Builder = { this },
+        ) {
+            val configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc")
+                .configurationBuilder()
+                .build()
+            stateHelper.state = EmbeddedPaymentElement.State(
+                confirmationState = EmbeddedConfirmationStateHolder.State(
+                    paymentMethodMetadata = paymentMethodMetadata,
+                    selection = selection,
+                    initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
+                        intentConfiguration = PaymentSheet.IntentConfiguration(
+                            mode = PaymentSheet.IntentConfiguration.Mode.Payment(
+                                amount = 5050,
+                                currency = "USD"
+                            )
+                        ),
+                    ),
+                    configuration = configuration,
+                ),
+                customer = customer,
+            )
+        }
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/FakeEmbeddedStateHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/FakeEmbeddedStateHelper.kt
@@ -1,0 +1,23 @@
+@file:OptIn(ExperimentalEmbeddedPaymentElementApi::class)
+
+package com.stripe.android.paymentelement.embedded.content
+
+import app.cash.turbine.ReceiveTurbine
+import app.cash.turbine.Turbine
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentelement.ExperimentalEmbeddedPaymentElementApi
+
+internal class FakeEmbeddedStateHelper : EmbeddedStateHelper {
+    private val _stateTurbine = Turbine<EmbeddedPaymentElement.State?>()
+    val stateTurbine: ReceiveTurbine<EmbeddedPaymentElement.State?> = _stateTurbine
+
+    override var state: EmbeddedPaymentElement.State?
+        get() = _stateTurbine.takeItem()
+        set(value) {
+            _stateTurbine.add(value)
+        }
+
+    fun validate() {
+        _stateTurbine.ensureAllEventsConsumed()
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Working towards enabling the 2 step flow (kinda like flow controller) for embedded. This centralizes our data modeling, which will make it easier to expose a state from `EmbeddedPaymentElement` in a follow up.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-3312

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

