### PR TITLE
Refactor PaymentMethodMetadata.create to add what setting create method is for

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
@@ -12,7 +12,6 @@ import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkPaymentDetails
 import com.stripe.android.link.account.LinkAccountManager
-import com.stripe.android.link.account.linkAccountUpdate
 import com.stripe.android.link.confirmation.LinkConfirmationHandler
 import com.stripe.android.link.confirmation.Result
 import com.stripe.android.link.injection.NativeLinkComponent
@@ -151,7 +150,7 @@ internal class PaymentMethodViewModel @Inject constructor(
                         formHelper = DefaultFormHelper.create(
                             coroutineScope = parentComponent.viewModel.viewModelScope,
                             cardAccountRangeRepositoryFactory = parentComponent.cardAccountRangeRepositoryFactory,
-                            paymentMethodMetadata = PaymentMethodMetadata.create(
+                            paymentMethodMetadata = PaymentMethodMetadata.createForNativeLink(
                                 configuration = parentComponent.configuration,
                             ),
                         ),

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -315,7 +315,7 @@ internal data class PaymentMethodMetadata(
             )
         }
 
-        internal fun create(
+        internal fun createForNativeLink(
             configuration: LinkConfiguration,
         ): PaymentMethodMetadata {
             return PaymentMethodMetadata(


### PR DESCRIPTION
# Summary
Renamed companion object builder to createForNativeLink.
Renamed companion object builder to createForPaymentElement.


# Motivation
Make it clear that this is the builder method for native link or paymentElement. We renamed another of these to createForCustomerSheet

# Testing
N.A.

# Screenshots
N.A.

# Changelog
N.A.