### PR TITLE
Support CBC in native Link

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -12,6 +12,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.definitions.CustomPayment
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.ExternalPaymentMethodUiDefinitionFactory
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.LinkCardBrandDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.link.LinkInlineConfiguration
+import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.LinkMode
 import com.stripe.android.model.PaymentIntent
@@ -366,8 +367,10 @@ internal data class PaymentMethodMetadata(
                 allowsPaymentMethodsRequiringShippingAddress = false,
                 paymentMethodOrder = ConfigurationDefaults.paymentMethodOrder,
                 cbcEligibility = CardBrandChoiceEligibility.create(
-                    isEligible = false,
-                    preferredNetworks = emptyList(),
+                    isEligible = configuration.cardBrandChoice?.eligible == true,
+                    preferredNetworks = configuration.cardBrandChoice?.preferredNetworks?.map { code ->
+                        CardBrand.fromCode(code)
+                    }.orEmpty(),
                 ),
                 merchantName = configuration.merchantName,
                 defaultBillingDetails = null,

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -22,6 +22,7 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.utils.LinkTestUtils
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.R
@@ -1549,6 +1550,38 @@ internal class PaymentMethodMetadataTest {
 
         val displayedPaymentMethodTypes = metadata.supportedPaymentMethodTypes()
         assertThat(displayedPaymentMethodTypes).containsExactly("card")
+    }
+
+    @Test
+    fun `Passes eligible CBC along to Link`() {
+        val linkConfiguration = LinkTestUtils.createLinkConfiguration(
+            cardBrandChoice = LinkConfiguration.CardBrandChoice(
+                eligible = true,
+                preferredNetworks = listOf("cartes_bancaires"),
+            )
+        )
+
+        val metadata = PaymentMethodMetadata.createForNativeLink(linkConfiguration)
+
+        assertThat(metadata.cbcEligibility).isEqualTo(
+            CardBrandChoiceEligibility.Eligible(
+                preferredNetworks = listOf(CardBrand.CartesBancaires)
+            )
+        )
+    }
+
+    @Test
+    fun `Passes ineligible CBC along to Link`() {
+        val linkConfiguration = LinkTestUtils.createLinkConfiguration(
+            cardBrandChoice = LinkConfiguration.CardBrandChoice(
+                eligible = false,
+                preferredNetworks = emptyList(),
+            )
+        )
+
+        val metadata = PaymentMethodMetadata.createForNativeLink(linkConfiguration)
+
+        assertThat(metadata.cbcEligibility).isEqualTo(CardBrandChoiceEligibility.Ineligible)
     }
 
     private fun createLinkInlineConfiguration(): LinkInlineConfiguration {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
@@ -48,7 +48,9 @@ internal object LinkTestUtils {
         originalParams = mock()
     )
 
-    fun createLinkConfiguration(): LinkConfiguration {
+    fun createLinkConfiguration(
+        cardBrandChoice: LinkConfiguration.CardBrandChoice? = null,
+    ): LinkConfiguration {
         return LinkConfiguration(
             stripeIntent = mock {
                 on { linkFundingSources } doReturn listOf(
@@ -60,7 +62,7 @@ internal object LinkTestUtils {
             merchantName = "Test merchant inc.",
             merchantCountryCode = "US",
             passthroughModeEnabled = false,
-            cardBrandChoice = null,
+            cardBrandChoice = cardBrandChoice,
             shippingDetails = null,
             useAttestationEndpointsForLink = false,
             suppress2faModal = false,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds basic support for card brand choice in the native Link UI when adding a new card.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
