### PR TITLE
Add saved card network tests

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/CardLpmTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/CardLpmTest.kt
@@ -16,28 +16,39 @@ internal class CardLpmTest(
     fun `Confirm a card with US merchant`() = test(
         testType = testType,
         country = MerchantCountry.US,
-        createParams = PaymentMethodCreateParams.createCard(
-            cardParams = CardParams(
-                number = "4242424242424242",
-                expMonth = 12,
-                expYear = 2032,
-                cvc = "454",
+        params = PaymentMethodTestParams.New(
+            createParams = PaymentMethodCreateParams.createCard(
+                cardParams = CardParams(
+                    number = "4242424242424242",
+                    expMonth = 12,
+                    expYear = 2032,
+                    cvc = "454",
+                )
             )
-        ),
+        )
     )
 
     @Test
     fun `Confirm a card with FR merchant`() = test(
         testType = testType,
         country = MerchantCountry.FR,
-        createParams = PaymentMethodCreateParams.createCard(
-            cardParams = CardParams(
-                number = "4242424242424242",
-                expMonth = 12,
-                expYear = 2032,
-                cvc = "454",
+        params = PaymentMethodTestParams.New(
+            createParams = PaymentMethodCreateParams.createCard(
+                cardParams = CardParams(
+                    number = "4242424242424242",
+                    expMonth = 12,
+                    expYear = 2032,
+                    cvc = "454",
+                )
             )
-        ),
+        )
+    )
+
+    @Test
+    fun `Confirm a card with saved card`() = test(
+        testType = testType,
+        country = MerchantCountry.US,
+        params = PaymentMethodTestParams.Saved()
     )
 
     companion object {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/CashAppLpmTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/CashAppLpmTest.kt
@@ -13,7 +13,9 @@ internal class CashAppLpmTest(
     @Test
     fun `Confirm Cash App LPM`() = test(
         testType = testType,
-        createParams = PaymentMethodCreateParams.createCashAppPay(),
+        params = PaymentMethodTestParams.New(
+            createParams = PaymentMethodCreateParams.createCashAppPay(),
+        )
     )
 
     companion object {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/PaymentMethodTestParams.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/PaymentMethodTestParams.kt
@@ -1,0 +1,65 @@
+package com.stripe.android.paymentelement.confirmation.lpms
+
+import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.model.PaymentMethodExtraParams
+import com.stripe.android.model.PaymentMethodOptionsParams
+import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
+import com.stripe.android.paymentelement.confirmation.lpms.foundations.network.MerchantCountry
+import com.stripe.android.paymentelement.confirmation.lpms.foundations.network.StripeNetworkTestClient
+
+internal sealed interface PaymentMethodTestParams {
+    data class ConfirmParams(
+        val customerId: String?,
+        val option: PaymentMethodConfirmationOption,
+    )
+
+    suspend fun create(
+        country: MerchantCountry,
+        client: StripeNetworkTestClient
+    ): Result<ConfirmParams>
+
+    data class New(
+        val createParams: PaymentMethodCreateParams,
+        val optionsParams: PaymentMethodOptionsParams? = null,
+        val extraParams: PaymentMethodExtraParams? = null,
+        val customerRequestedSave: Boolean = false,
+    ) : PaymentMethodTestParams {
+        override suspend fun create(
+            country: MerchantCountry,
+            client: StripeNetworkTestClient
+        ): Result<ConfirmParams> {
+            return Result.success(
+                ConfirmParams(
+                    customerId = null,
+                    option = PaymentMethodConfirmationOption.New(
+                        createParams = createParams,
+                        optionsParams = optionsParams,
+                        extraParams = extraParams,
+                        shouldSave = customerRequestedSave,
+                    ),
+                )
+            )
+        }
+    }
+
+    data class Saved(
+        val optionsParams: PaymentMethodOptionsParams? = null,
+    ) : PaymentMethodTestParams {
+        override suspend fun create(
+            country: MerchantCountry,
+            client: StripeNetworkTestClient
+        ): Result<ConfirmParams> = kotlin.runCatching {
+            val savedPm = client.retrievePaymentMethod(country).getOrThrow()
+
+            return Result.success(
+                ConfirmParams(
+                    customerId = savedPm.customerId,
+                    option = PaymentMethodConfirmationOption.Saved(
+                        paymentMethod = savedPm.paymentMethod,
+                        optionsParams = optionsParams,
+                    )
+                )
+            )
+        }
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/TestType.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/TestType.kt
@@ -5,6 +5,7 @@ import com.stripe.android.paymentelement.confirmation.lpms.foundations.network.M
 
 internal interface TestType {
     suspend fun createIntent(
+        customerId: String?,
         country: MerchantCountry,
         factory: CreateIntentFactory
     ): Result<CreateIntentFactory.CreateIntentData>
@@ -50,6 +51,7 @@ internal data class PaymentIntentTestType(
     private val createWithSetupFutureUsage: Boolean,
 ) : TestType {
     override suspend fun createIntent(
+        customerId: String?,
         country: MerchantCountry,
         factory: CreateIntentFactory,
     ): Result<CreateIntentFactory.CreateIntentData> {
@@ -58,17 +60,20 @@ internal data class PaymentIntentTestType(
             amount = amount,
             currency = currency,
             createWithSetupFutureUsage = createWithSetupFutureUsage,
+            customerId = customerId,
         )
     }
 }
 
 internal data object SetupIntentTestType : TestType {
     override suspend fun createIntent(
+        customerId: String?,
         country: MerchantCountry,
         factory: CreateIntentFactory,
     ): Result<CreateIntentFactory.CreateIntentData> {
         return factory.createSetupIntent(
             country = country,
+            customerId = customerId,
         )
     }
 }
@@ -79,6 +84,7 @@ internal data class DeferredPaymentIntentTestType(
     private val createWithSetupFutureUsage: Boolean,
 ) : TestType {
     override suspend fun createIntent(
+        customerId: String?,
         country: MerchantCountry,
         factory: CreateIntentFactory,
     ): Result<CreateIntentFactory.CreateIntentData> {
@@ -87,17 +93,20 @@ internal data class DeferredPaymentIntentTestType(
             amount = amount,
             currency = currency,
             createWithSetupFutureUsage = createWithSetupFutureUsage,
+            customerId = customerId,
         )
     }
 }
 
 internal data object DeferredSetupIntentTestType : TestType {
     override suspend fun createIntent(
+        customerId: String?,
         country: MerchantCountry,
         factory: CreateIntentFactory,
     ): Result<CreateIntentFactory.CreateIntentData> {
         return factory.createDeferredSetupIntent(
             country = country,
+            customerId = customerId,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/foundations/CreateIntentFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/foundations/CreateIntentFactory.kt
@@ -21,6 +21,7 @@ internal class CreateIntentFactory(
         country: MerchantCountry,
         amount: Int,
         currency: String,
+        customerId: String?,
         createWithSetupFutureUsage: Boolean
     ): Result<CreateIntentData> {
         return testClient.createPaymentIntent(
@@ -28,6 +29,7 @@ internal class CreateIntentFactory(
             amount = amount,
             currency = currency,
             paymentMethodType = paymentMethodType,
+            customerId = customerId,
             createWithSetupFutureUsage = createWithSetupFutureUsage,
         ).mapCatching { clientSecret ->
             CreateIntentData(
@@ -43,6 +45,7 @@ internal class CreateIntentFactory(
         country: MerchantCountry,
         amount: Int,
         currency: String,
+        customerId: String?,
         createWithSetupFutureUsage: Boolean,
     ): Result<CreateIntentData> {
         PaymentElementCallbackReferences.set(
@@ -55,6 +58,7 @@ internal class CreateIntentFactory(
                         currency = currency,
                         paymentMethodType = paymentMethodType,
                         paymentMethodId = paymentMethod.id,
+                        customerId = customerId,
                         createWithSetupFutureUsage = createWithSetupFutureUsage,
                     ).fold(
                         onSuccess = {
@@ -92,10 +96,12 @@ internal class CreateIntentFactory(
 
     suspend fun createSetupIntent(
         country: MerchantCountry,
+        customerId: String?,
     ): Result<CreateIntentData> {
         return testClient.createSetupIntent(
             country = country,
             paymentMethodType = paymentMethodType,
+            customerId = customerId,
         ).mapCatching { clientSecret ->
             CreateIntentData(
                 initializationMode = PaymentElementLoader.InitializationMode.SetupIntent(
@@ -108,6 +114,7 @@ internal class CreateIntentFactory(
 
     fun createDeferredSetupIntent(
         country: MerchantCountry,
+        customerId: String?,
     ): Result<CreateIntentData> {
         PaymentElementCallbackReferences.set(
             key = paymentElementCallbackIdentifier,
@@ -117,6 +124,7 @@ internal class CreateIntentFactory(
                         country = country,
                         paymentMethodType = paymentMethodType,
                         paymentMethodId = paymentMethod.id,
+                        customerId = customerId,
                     ).fold(
                         onSuccess = {
                             CreateIntentResult.Success(it)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/foundations/network/CreatePaymentIntentRequest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/foundations/network/CreatePaymentIntentRequest.kt
@@ -24,6 +24,8 @@ internal data class CreatePaymentIntentRequest(
         val paymentMethodTypes: List<String>,
         @SerialName("payment_method")
         val paymentMethodId: String?,
+        @SerialName("customer")
+        val customerId: String?,
         @SerialName("setup_future_usage")
         val setupFutureUsage: SetupFutureUsage?,
     ) {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/foundations/network/CreatePaymentMethodRequest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/foundations/network/CreatePaymentMethodRequest.kt
@@ -1,0 +1,18 @@
+package com.stripe.android.paymentelement.confirmation.lpms.foundations.network
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class CreatePaymentMethodRequest(
+    @SerialName("account")
+    val country: MerchantCountry,
+) {
+    @Serializable
+    internal data class Response(
+        @SerialName("payment_method_id")
+        val paymentMethodId: String,
+        @SerialName("customer_id")
+        val customerId: String,
+    )
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/foundations/network/CreateSetupIntentRequest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/foundations/network/CreateSetupIntentRequest.kt
@@ -20,6 +20,8 @@ internal data class CreateSetupIntentRequest(
         val paymentMethodTypes: List<String>,
         @SerialName("payment_method")
         val paymentMethodId: String?,
+        @SerialName("customer")
+        val customerId: String?,
     )
 
     @Serializable

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/foundations/network/SavedPaymentMethod.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/foundations/network/SavedPaymentMethod.kt
@@ -1,0 +1,8 @@
+package com.stripe.android.paymentelement.confirmation.lpms.foundations.network
+
+import com.stripe.android.model.PaymentMethod
+
+data class SavedPaymentMethod(
+    val customerId: String,
+    val paymentMethod: PaymentMethod,
+)


### PR DESCRIPTION
# Summary
Add saved card network tests

# Motivation
Allows for testing saved cards using local network tests.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified