### PR TITLE
Introduce CardUpdateParams to expand editable card details

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -50,6 +50,7 @@ import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.payments.bankaccount.CollectBankAccountLauncher
 import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.paymentsheet.CardUpdateParams
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.forms.FormArgumentsFactory
@@ -502,25 +503,30 @@ internal class CustomerSheetViewModel(
 
     private suspend fun modifyCardPaymentMethod(
         paymentMethod: PaymentMethod,
-        brand: CardBrand
+        cardUpdateParams: CardUpdateParams
     ): CustomerSheetDataResult<PaymentMethod> {
         return awaitPaymentMethodDataSource().updatePaymentMethod(
             paymentMethodId = paymentMethod.id!!,
             params = PaymentMethodUpdateParams.createCard(
-                networks = PaymentMethodUpdateParams.Card.Networks(
-                    preferred = brand.code
-                ),
+                networks = cardUpdateParams.cardBrand?.let {
+                    PaymentMethodUpdateParams.Card.Networks(
+                        preferred = it.code
+                    )
+                },
+                billingDetails = cardUpdateParams.billingDetails,
+                expiryMonth = cardUpdateParams.expiryMonth,
+                expiryYear = cardUpdateParams.expiryYear,
                 productUsageTokens = setOf("CustomerSheet"),
             )
         ).onSuccess { updatedMethod ->
             updatePaymentMethodInState(updatedMethod)
 
             eventReporter.onUpdatePaymentMethodSucceeded(
-                selectedBrand = brand
+                selectedBrand = cardUpdateParams.cardBrand
             )
         }.onFailure { cause, _ ->
             eventReporter.onUpdatePaymentMethodFailed(
-                selectedBrand = brand,
+                selectedBrand = cardUpdateParams.cardBrand,
                 error = cause
             )
         }
@@ -544,14 +550,14 @@ internal class CustomerSheetViewModel(
                     displayableSavedPaymentMethod = paymentMethod,
                     cardBrandFilter = PaymentSheetCardBrandFilter(customerState.configuration.cardBrandAcceptance),
                     removeExecutor = ::removeExecutor,
-                    onBrandChoiceSelected = {
+                    onBrandChoiceSelected = { brand ->
                         eventReporter.onBrandChoiceSelected(
                             source = CustomerSheetEventReporter.CardBrandChoiceEventSource.Edit,
-                            selectedBrand = it
+                            selectedBrand = brand
                         )
                     },
                     onUpdateSuccess = ::onBackPressed,
-                    updateCardBrandExecutor = ::updateCardBrandExecutor,
+                    updatePaymentMethodExecutor = ::updatePaymentMethodExecutor,
                     workContext = workContext,
                     // This checkbox is never displayed in CustomerSheet.
                     shouldShowSetAsDefaultCheckbox = false,
@@ -575,8 +581,11 @@ internal class CustomerSheetViewModel(
         }.failureOrNull()?.cause
     }
 
-    private suspend fun updateCardBrandExecutor(paymentMethod: PaymentMethod, brand: CardBrand): Result<PaymentMethod> {
-        return when (val result = modifyCardPaymentMethod(paymentMethod, brand)) {
+    private suspend fun updatePaymentMethodExecutor(
+        paymentMethod: PaymentMethod,
+        cardUpdateParams: CardUpdateParams
+    ): Result<PaymentMethod> {
+        return when (val result = modifyCardPaymentMethod(paymentMethod, cardUpdateParams)) {
             is CustomerSheetDataResult.Success -> Result.success(result.value)
             is CustomerSheetDataResult.Failure -> Result.failure(result.cause)
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
@@ -44,10 +44,10 @@ internal class DefaultEmbeddedUpdateScreenInteractorFactory @Inject constructor(
                 }
                 result
             },
-            updateCardBrandExecutor = { method, brand ->
+            updatePaymentMethodExecutor = { method, cardUpdateParams ->
                 savedPaymentMethodMutatorProvider.get().modifyCardPaymentMethod(
                     paymentMethod = method,
-                    brand = brand,
+                    cardUpdateParams = cardUpdateParams,
                     onSuccess = { paymentMethod ->
                         val currentSelection = selectionHolder.selection.value
                         if (paymentMethod.id == (currentSelection as? PaymentSelection.Saved)?.paymentMethod?.id) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/CardUpdateParams.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/CardUpdateParams.kt
@@ -1,0 +1,11 @@
+package com.stripe.android.paymentsheet
+
+import com.stripe.android.model.CardBrand
+import com.stripe.android.model.PaymentMethod
+
+internal data class CardUpdateParams(
+    val expiryMonth: Int? = null,
+    val expiryYear: Int? = null,
+    val cardBrand: CardBrand? = null,
+    val billingDetails: PaymentMethod.BillingDetails? = null,
+)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
@@ -527,7 +527,7 @@ private fun PreviewUpdatePaymentMethodUI() {
             canRemove = true,
             displayableSavedPaymentMethod = exampleCard,
             removeExecutor = { null },
-            updateCardBrandExecutor = { paymentMethod, _ -> Result.success(paymentMethod) },
+            updatePaymentMethodExecutor = { paymentMethod, _ -> Result.success(paymentMethod) },
             setDefaultPaymentMethodExecutor = { _ -> Result.success(Unit) },
             cardBrandFilter = DefaultCardBrandFilter,
             onBrandChoiceSelected = {},

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -351,7 +351,7 @@ internal class CustomerSheetScreenshotTest {
             updatePaymentMethodInteractor = DefaultUpdatePaymentMethodInteractor(
                 displayableSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
                 removeExecutor = { null },
-                updateCardBrandExecutor = { paymentMethod, _ -> Result.success(paymentMethod) },
+                updatePaymentMethodExecutor = { paymentMethod, _ -> Result.success(paymentMethod) },
                 setDefaultPaymentMethodExecutor = { _ -> Result.success(Unit) },
                 canRemove = canRemove,
                 isLiveMode = true,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
@@ -414,7 +414,8 @@ class SavedPaymentMethodMutatorTest {
             savedPaymentMethodMutator.updatePaymentMethod(displayableSavedPaymentMethod)
 
             assertThat(customerStateHolder.paymentMethods.value.first().card?.brand).isEqualTo(CardBrand.Unknown)
-            updatePaymentMethodTurbine.awaitItem().updateExecutor(CardBrand.CartesBancaires)
+            updatePaymentMethodTurbine.awaitItem()
+                .updateExecutor(CardUpdateParams(cardBrand = CardBrand.CartesBancaires))
 
             assertThat(calledUpdate.awaitItem()).isTrue()
 
@@ -452,7 +453,8 @@ class SavedPaymentMethodMutatorTest {
 
             savedPaymentMethodMutator.updatePaymentMethod(displayableSavedPaymentMethod)
 
-            updatePaymentMethodTurbine.awaitItem().updateExecutor(CardBrand.CartesBancaires)
+            updatePaymentMethodTurbine.awaitItem()
+                .updateExecutor(CardUpdateParams(cardBrand = CardBrand.CartesBancaires))
 
             val succeededCall = eventReporter.updatePaymentMethodSucceededCalls.awaitItem()
             assertThat(succeededCall.selectedBrand).isEqualTo(CardBrand.CartesBancaires)
@@ -487,7 +489,9 @@ class SavedPaymentMethodMutatorTest {
 
             savedPaymentMethodMutator.modifyCardPaymentMethod(
                 paymentMethod = displayableSavedPaymentMethod.paymentMethod,
-                brand = CardBrand.CartesBancaires,
+                cardUpdateParams = CardUpdateParams(
+                    cardBrand = CardBrand.CartesBancaires
+                ),
             )
 
             assertThat(calledUpdate.awaitItem()).isTrue()
@@ -526,7 +530,7 @@ class SavedPaymentMethodMutatorTest {
 
             savedPaymentMethodMutator.modifyCardPaymentMethod(
                 paymentMethod = displayableSavedPaymentMethod.paymentMethod,
-                brand = CardBrand.CartesBancaires,
+                cardUpdateParams = CardUpdateParams(cardBrand = CardBrand.CartesBancaires)
             )
 
             val succeededCall = eventReporter.updatePaymentMethodSucceededCalls.awaitItem()
@@ -556,7 +560,8 @@ class SavedPaymentMethodMutatorTest {
             savedPaymentMethodMutator.updatePaymentMethod(displayableSavedPaymentMethod)
 
             assertThat(customerStateHolder.paymentMethods.value.first().card?.brand).isEqualTo(CardBrand.Unknown)
-            updatePaymentMethodTurbine.awaitItem().updateExecutor(CardBrand.CartesBancaires)
+            updatePaymentMethodTurbine.awaitItem()
+                .updateExecutor(CardUpdateParams(cardBrand = CardBrand.CartesBancaires))
 
             assertThat(calledUpdate.awaitItem()).isTrue()
 
@@ -589,7 +594,8 @@ class SavedPaymentMethodMutatorTest {
             )
 
             savedPaymentMethodMutator.updatePaymentMethod(displayableSavedPaymentMethod)
-            updatePaymentMethodTurbine.awaitItem().updateExecutor(CardBrand.CartesBancaires)
+            updatePaymentMethodTurbine.awaitItem()
+                .updateExecutor(CardUpdateParams(cardBrand = CardBrand.CartesBancaires))
 
             val failedCall = eventReporter.updatePaymentMethodFailedCalls.awaitItem()
             assertThat(failedCall.selectedBrand).isEqualTo(CardBrand.CartesBancaires)
@@ -874,7 +880,8 @@ class SavedPaymentMethodMutatorTest {
                         canRemove,
                         performRemove,
                         updateExecutor,
-                        setDefaultPaymentMethodExecutor, ->
+                        setDefaultPaymentMethodExecutor,
+                    ->
                     updatePaymentMethodTurbine.add(
                         UpdateCall(
                             displayableSavedPaymentMethod,
@@ -923,7 +930,7 @@ class SavedPaymentMethodMutatorTest {
         val paymentMethod: DisplayableSavedPaymentMethod,
         val canRemove: Boolean,
         val performRemove: suspend () -> Throwable?,
-        val updateExecutor: suspend (brand: CardBrand) -> Result<PaymentMethod>,
+        val updateExecutor: suspend (cardUpdateParams: CardUpdateParams) -> Result<PaymentMethod>,
         val setSetDefaultPaymentMethodExecutor: suspend (paymentMethod: PaymentMethod) -> Result<Unit>,
     )
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Refactor card update api to use `CardUpdateParams`. `CardUpdateParams` will hold any changes to
* Card brand
* Address
* Expiry date

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
[JIRA](https://jira.corp.stripe.com/browse/MOBILESDK-3323)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
