### PR TITLE
Add EmbeddedResultCallbackHelper

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/DefaultEmbeddedResultCallbackHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/DefaultEmbeddedResultCallbackHelper.kt
@@ -1,0 +1,27 @@
+package com.stripe.android.paymentelement.embedded
+
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentelement.ExperimentalEmbeddedPaymentElementApi
+import com.stripe.android.paymentelement.embedded.content.EmbeddedPaymentElementScope
+import com.stripe.android.paymentelement.embedded.content.EmbeddedStateHelper
+import javax.inject.Inject
+
+@OptIn(ExperimentalEmbeddedPaymentElementApi::class)
+internal interface EmbeddedResultCallbackHelper {
+    fun setResult(result: EmbeddedPaymentElement.Result)
+}
+
+@OptIn(ExperimentalEmbeddedPaymentElementApi::class)
+@EmbeddedPaymentElementScope
+internal class DefaultEmbeddedResultCallbackHelper @Inject constructor(
+    private val resultCallback: EmbeddedPaymentElement.ResultCallback,
+    private val stateHelper: EmbeddedStateHelper
+) : EmbeddedResultCallbackHelper {
+
+    override fun setResult(result: EmbeddedPaymentElement.Result) {
+        resultCallback.onResult(result)
+        if (result is EmbeddedPaymentElement.Result.Completed) {
+            stateHelper.state = null
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/DefaultEmbeddedResultCallbackHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/DefaultEmbeddedResultCallbackHelper.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalEmbeddedPaymentElementApi::class)
+
 package com.stripe.android.paymentelement.embedded
 
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
@@ -6,12 +8,10 @@ import com.stripe.android.paymentelement.embedded.content.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.embedded.content.EmbeddedStateHelper
 import javax.inject.Inject
 
-@OptIn(ExperimentalEmbeddedPaymentElementApi::class)
 internal interface EmbeddedResultCallbackHelper {
     fun setResult(result: EmbeddedPaymentElement.Result)
 }
 
-@OptIn(ExperimentalEmbeddedPaymentElementApi::class)
 @EmbeddedPaymentElementScope
 internal class DefaultEmbeddedResultCallbackHelper @Inject constructor(
     private val resultCallback: EmbeddedPaymentElement.ResultCallback,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
@@ -48,8 +48,6 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
     private val errorReporter: ErrorReporter,
     @Named(STATUS_BAR_COLOR) private val statusBarColor: Int?,
     @PaymentElementCallbackIdentifier private val paymentElementCallbackIdentifier: String,
-//    resultCallback: EmbeddedPaymentElement.ResultCallback,
-//    private val stateHelper: EmbeddedStateHelper,
     embeddedResultCallbackHelper: EmbeddedResultCallbackHelper
 ) : EmbeddedSheetLauncher {
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
@@ -8,6 +8,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.ExperimentalEmbeddedPaymentElementApi
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
+import com.stripe.android.paymentelement.embedded.EmbeddedResultCallbackHelper
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.form.FormContract
 import com.stripe.android.paymentelement.embedded.form.FormResult
@@ -47,8 +48,9 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
     private val errorReporter: ErrorReporter,
     @Named(STATUS_BAR_COLOR) private val statusBarColor: Int?,
     @PaymentElementCallbackIdentifier private val paymentElementCallbackIdentifier: String,
-    resultCallback: EmbeddedPaymentElement.ResultCallback,
-    private val stateHelper: EmbeddedStateHelper,
+//    resultCallback: EmbeddedPaymentElement.ResultCallback,
+//    private val stateHelper: EmbeddedStateHelper,
+    embeddedResultCallbackHelper: EmbeddedResultCallbackHelper
 ) : EmbeddedSheetLauncher {
 
     init {
@@ -68,8 +70,9 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
             sheetStateHolder.sheetIsOpen = false
             selectionHolder.setTemporary(null)
             if (result is FormResult.Complete) {
-                resultCallback.onResult(EmbeddedPaymentElement.Result.Completed())
-                stateHelper.state = null
+                embeddedResultCallbackHelper.setResult(
+                    EmbeddedPaymentElement.Result.Completed()
+                )
             }
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementSubcomponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementSubcomponent.kt
@@ -6,6 +6,8 @@ import androidx.activity.result.ActivityResultCaller
 import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.ExperimentalEmbeddedPaymentElementApi
+import com.stripe.android.paymentelement.embedded.DefaultEmbeddedResultCallbackHelper
+import com.stripe.android.paymentelement.embedded.EmbeddedResultCallbackHelper
 import dagger.Binds
 import dagger.BindsInstance
 import dagger.Module
@@ -47,4 +49,7 @@ internal interface EmbeddedPaymentElementModule {
     fun bindsConfirmationHelper(
         confirmationHelper: DefaultEmbeddedConfirmationHelper
     ): EmbeddedConfirmationHelper
+
+    @Binds
+    fun bindsEmbeddedResultCallbackHelper(helper: DefaultEmbeddedResultCallbackHelper): EmbeddedResultCallbackHelper
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedResultCallbackHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedResultCallbackHelperTest.kt
@@ -1,0 +1,64 @@
+package com.stripe.android.paymentelement.embedded.content
+
+import app.cash.turbine.ReceiveTurbine
+import app.cash.turbine.Turbine
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.isInstanceOf
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentelement.ExperimentalEmbeddedPaymentElementApi
+import com.stripe.android.paymentelement.embedded.DefaultEmbeddedResultCallbackHelper
+import com.stripe.android.paymentelement.embedded.EmbeddedResultCallbackHelper
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+@OptIn(ExperimentalEmbeddedPaymentElementApi::class)
+internal class DefaultEmbeddedResultCallbackHelperTest {
+
+    @Test
+    fun `invokes callback on setResult and does not clear state if failed`() = testScenario {
+        helper.setResult(EmbeddedPaymentElement.Result.Failed(Throwable("oops")))
+        val callbackResult = resultCallbackTurbine.awaitItem()
+        assertThat(stateHelper.stateTurbine.awaitItem()).isNotNull()
+        assertThat(callbackResult).isInstanceOf<EmbeddedPaymentElement.Result.Failed>()
+        stateHelper.stateTurbine.expectNoEvents()
+    }
+
+    @Test
+    fun `invokes callback on setResult and clears state if completed`() = testScenario {
+        helper.setResult(EmbeddedPaymentElement.Result.Completed())
+        val callbackResult = resultCallbackTurbine.awaitItem()
+        assertThat(stateHelper.stateTurbine.awaitItem()).isNotNull()
+        assertThat(callbackResult).isInstanceOf<EmbeddedPaymentElement.Result.Completed>()
+        assertThat(stateHelper.stateTurbine.awaitItem()).isNull()
+    }
+
+    private fun testScenario(
+        block: suspend Scenario.() -> Unit
+    ) = runTest {
+        val stateHelper = FakeEmbeddedStateHelper()
+        stateHelper.state = EmbeddedPaymentElement.State(
+            confirmationState = EmbeddedConfirmationStateFixtures.defaultState(),
+            customer = null
+        )
+        val resultCallbackTurbine = Turbine<EmbeddedPaymentElement.Result>()
+        val helper = DefaultEmbeddedResultCallbackHelper(
+            resultCallback = {
+                resultCallbackTurbine.add(it)
+            },
+            stateHelper = stateHelper
+        )
+        Scenario(
+            stateHelper = stateHelper,
+            resultCallbackTurbine = resultCallbackTurbine,
+            helper = helper
+        ).block()
+        resultCallbackTurbine.ensureAllEventsConsumed()
+        stateHelper.validate()
+    }
+
+    private class Scenario(
+        val stateHelper: FakeEmbeddedStateHelper,
+        val resultCallbackTurbine: ReceiveTurbine<EmbeddedPaymentElement.Result>,
+        val helper: EmbeddedResultCallbackHelper
+    )
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/FakeEmbeddedResultCallbackHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/FakeEmbeddedResultCallbackHelper.kt
@@ -1,0 +1,27 @@
+package com.stripe.android.paymentelement.embedded.content
+
+import app.cash.turbine.ReceiveTurbine
+import app.cash.turbine.Turbine
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentelement.ExperimentalEmbeddedPaymentElementApi
+import com.stripe.android.paymentelement.embedded.EmbeddedResultCallbackHelper
+
+@OptIn(ExperimentalEmbeddedPaymentElementApi::class)
+internal class FakeEmbeddedResultCallbackHelper(
+    val stateHelper: FakeEmbeddedStateHelper
+) : EmbeddedResultCallbackHelper {
+    private val _callbackTurbine = Turbine<EmbeddedPaymentElement.Result>()
+    val callbackTurbine: ReceiveTurbine<EmbeddedPaymentElement.Result> = _callbackTurbine
+
+    override fun setResult(result: EmbeddedPaymentElement.Result) {
+        _callbackTurbine.add(result)
+        if (result is EmbeddedPaymentElement.Result.Completed) {
+            stateHelper.state = null
+        }
+    }
+
+    fun validate() {
+        stateHelper.validate()
+        _callbackTurbine.ensureAllEventsConsumed()
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Adds `EmbeddedResultCallbackHelper` to invoke `EmbeddedPaymentElement.ResultCallback` and clear state if completed.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-3086

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [ ] Manually verified

