### PR TITLE
Move elements sessions for default PMs tests from a string to a json file

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/DefaultPaymentMethodsUtils.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/DefaultPaymentMethodsUtils.kt
@@ -5,6 +5,8 @@ import androidx.compose.ui.test.junit4.ComposeTestRule
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatchers
+import com.stripe.android.networktesting.ResponseReplacement
+import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentsheet.ExperimentalCustomerSessionApi
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_OPTION_TAB_LAYOUT_TEST_TAG
@@ -18,16 +20,34 @@ internal object DefaultPaymentMethodsUtils {
         cards: List<PaymentMethod> = emptyList(),
         defaultPaymentMethod: String? = null,
     ) {
+        val cardsArray = JSONArray()
+
+        cards.forEach { card ->
+            cardsArray.put(PaymentMethodFactory.convertCardToJson(card))
+        }
+
+        val responseFile = if (isDeferredIntent) {
+            "elements-sessions-deferred_intent_and_default_pms_enabled.json"
+        } else {
+            "elements-sessions-with_pi_and_default_pms_enabled.json"
+        }
+
         networkRule.enqueue(
             RequestMatchers.host("api.stripe.com"),
             RequestMatchers.method("GET"),
             RequestMatchers.path("/v1/elements/sessions"),
         ) { response ->
-            response.setBody(
-                createElementsSessionResponse(
-                    cards = cards,
-                    defaultPaymentMethod = defaultPaymentMethod,
-                    isDeferredIntent = isDeferredIntent,
+            response.testBodyFromFile(
+                responseFile,
+                replacements = listOf(
+                    ResponseReplacement(
+                        "DEFAULT_PAYMENT_METHOD_HERE",
+                        defaultPaymentMethod.toString()
+                    ),
+                    ResponseReplacement(
+                        "[PAYMENT_METHODS_HERE]",
+                        cardsArray.toString(2),
+                    )
                 )
             )
         }
@@ -59,207 +79,5 @@ internal object DefaultPaymentMethodsUtils {
                     .isNotEmpty()
             }
         }
-    }
-
-    private fun createElementsSessionResponse(
-        cards: List<PaymentMethod>,
-        defaultPaymentMethod: String?,
-        isDeferredIntent: Boolean,
-    ): String {
-        val cardsArray = JSONArray()
-
-        cards.forEach { card ->
-            cardsArray.put(PaymentMethodFactory.convertCardToJson(card))
-        }
-
-        val cardsStringified = cardsArray.toString(2)
-
-        return if (isDeferredIntent) {
-            deferredIntentElementsSessionResponse(
-                paymentMethods = cardsStringified,
-                defaultPaymentMethod = defaultPaymentMethod,
-            )
-        } else {
-            intentFirstElementsSessionResponse(
-                paymentMethods = cardsStringified,
-                defaultPaymentMethod = defaultPaymentMethod,
-            )
-        }
-    }
-
-    private fun intentFirstElementsSessionResponse(
-        paymentMethods: String,
-        defaultPaymentMethod: String?,
-    ): String {
-        return """
-                {
-                  "business_name": "Mobile Example Account",
-                  "google_pay_preference": "enabled",
-                  "merchant_country": "US",
-                  "merchant_currency": "usd",
-                  "merchant_id": "acct_1HvTI7Lu5o3P18Zp",
-                  "meta_pay_signed_container_context": null,
-                  "order": null,
-                  "ordered_payment_method_types_and_wallets": [
-                    "card"
-                  ],
-                  "customer": {
-                    "payment_methods": $paymentMethods,
-                    "customer_session": {
-                      "id": "cuss_654321",
-                      "livemode": false,
-                      "api_key": "ek_12345",
-                      "api_key_expiry": 1899787184,
-                      "customer": "cus_1",
-                      "components": {
-                        "mobile_payment_element": {
-                          "enabled": true,
-                          "features": {
-                            "payment_method_save": "enabled",
-                            "payment_method_remove": "enabled",
-                            "payment_method_remove_last": "enabled",
-                            "payment_method_save_allow_redisplay_override": null,
-                            "payment_method_set_as_default": "enabled"
-                          }
-                        },
-                        "customer_sheet": {
-                          "enabled": false,
-                          "features": null
-                        }
-                      }
-                    },
-                    "default_payment_method": $defaultPaymentMethod
-                  },
-                  "payment_method_preference": {
-                    "object": "payment_method_preference",
-                    "country_code": "US",
-                    "ordered_payment_method_types": [
-                      "card"
-                    ],               "payment_intent": {
-                      "id": "pi_example",
-                      "object": "payment_intent",
-                      "amount": 5099,
-                      "amount_details": {
-                        "tip": {}
-                      },
-                      "automatic_payment_methods": {
-                        "enabled": true
-                      },
-                      "canceled_at": null,
-                      "cancellation_reason": null,
-                      "capture_method": "automatic",
-                      "client_secret": "pi_example_secret_example",
-                      "confirmation_method": "automatic",
-                      "created": 1674750417,
-                      "currency": "usd",
-                      "description": null,
-                      "last_payment_error": null,
-                      "livemode": false,
-                      "next_action": null,
-                      "payment_method": null,
-                      "payment_method_options": {
-                        "us_bank_account": {
-                          "verification_method": "automatic"
-                        }
-                      },
-                      "payment_method_types": [
-                        "card"
-                      ],
-                      "processing": null,
-                      "receipt_email": null,
-                      "setup_future_usage": null,
-                      "shipping": null,
-                      "source": null,
-                      "status": "requires_payment_method"
-                    }, 
-                    "type": "payment_intent"
-                  },
-                  "payment_method_specs": [
-                    {
-                      "async": false,
-                      "fields": [],
-                      "type": "card"
-                    }
-                  ],
-                  "paypal_express_config": {
-                    "client_id": null,
-                    "paypal_merchant_id": null
-                  },
-                  "shipping_address_settings": {
-                    "autocomplete_allowed": true
-                  },
-                  "unactivated_payment_method_types": []
-                }
-            """.trimIndent()
-    }
-
-    private fun deferredIntentElementsSessionResponse(
-        paymentMethods: String,
-        defaultPaymentMethod: String?,
-    ): String {
-        return """
-                {
-                  "business_name": "Mobile Example Account",
-                  "google_pay_preference": "enabled",
-                  "merchant_country": "US",
-                  "merchant_currency": "usd",
-                  "merchant_id": "acct_1HvTI7Lu5o3P18Zp",
-                  "meta_pay_signed_container_context": null,
-                  "order": null,
-                  "ordered_payment_method_types_and_wallets": [
-                    "card"
-                  ],
-                  "customer": {
-                    "payment_methods": $paymentMethods,
-                    "customer_session": {
-                      "id": "cuss_654321",
-                      "livemode": false,
-                      "api_key": "ek_12345",
-                      "api_key_expiry": 1899787184,
-                      "customer": "cus_1",
-                      "components": {
-                        "mobile_payment_element": {
-                          "enabled": true,
-                          "features": {
-                            "payment_method_save": "enabled",
-                            "payment_method_remove": "enabled",
-                            "payment_method_remove_last": "enabled",
-                            "payment_method_save_allow_redisplay_override": null,
-                            "payment_method_set_as_default": "enabled"
-                          }
-                        },
-                        "customer_sheet": {
-                          "enabled": false,
-                          "features": null
-                        }
-                      }
-                    },
-                    "default_payment_method": $defaultPaymentMethod
-                  },
-                  "payment_method_preference": {
-                    "object": "payment_method_preference",
-                    "country_code": "US",
-                    "ordered_payment_method_types": [
-                      "card"
-                    ],
-                    "type": "deferred_intent"
-                  },
-                  "payment_method_specs": [
-                    {
-                      "async": false,
-                      "fields": [],
-                      "type": "card"
-                    }
-                  ],
-                  "paypal_express_config": {
-                    "client_id": null,
-                    "paypal_merchant_id": null
-                  },
-                  "shipping_address_settings": {
-                    "autocomplete_allowed": true
-                  },
-                  "unactivated_payment_method_types": []
-                }
-            """.trimIndent()
     }
 }

--- a/paymentsheet/src/androidTest/resources/elements-sessions-deferred_intent_and_default_pms_enabled.json
+++ b/paymentsheet/src/androidTest/resources/elements-sessions-deferred_intent_and_default_pms_enabled.json
@@ -7,7 +7,8 @@
   "meta_pay_signed_container_context": null,
   "order": null,
   "ordered_payment_method_types_and_wallets": [
-    "card"
+    "card",
+    "us_bank_account"
   ],
   "customer": {
     "payment_methods": [PAYMENT_METHODS_HERE],
@@ -40,7 +41,8 @@
     "object": "payment_method_preference",
     "country_code": "US",
     "ordered_payment_method_types": [
-      "card"
+      "card",
+      "us_bank_account"
     ],
     "type": "deferred_intent"
   },

--- a/paymentsheet/src/androidTest/resources/elements-sessions-deferred_intent_and_default_pms_enabled.json
+++ b/paymentsheet/src/androidTest/resources/elements-sessions-deferred_intent_and_default_pms_enabled.json
@@ -1,0 +1,62 @@
+{
+  "business_name": "Mobile Example Account",
+  "google_pay_preference": "enabled",
+  "merchant_country": "US",
+  "merchant_currency": "usd",
+  "merchant_id": "acct_1HvTI7Lu5o3P18Zp",
+  "meta_pay_signed_container_context": null,
+  "order": null,
+  "ordered_payment_method_types_and_wallets": [
+    "card"
+  ],
+  "customer": {
+    "payment_methods": [PAYMENT_METHODS_HERE],
+    "customer_session": {
+      "id": "cuss_654321",
+      "livemode": false,
+      "api_key": "ek_12345",
+      "api_key_expiry": 1899787184,
+      "customer": "cus_1",
+      "components": {
+        "mobile_payment_element": {
+          "enabled": true,
+          "features": {
+            "payment_method_save": "enabled",
+            "payment_method_remove": "enabled",
+            "payment_method_remove_last": "enabled",
+            "payment_method_save_allow_redisplay_override": null,
+            "payment_method_set_as_default": "enabled"
+          }
+        },
+        "customer_sheet": {
+          "enabled": false,
+          "features": null
+        }
+      }
+    },
+    "default_payment_method": DEFAULT_PAYMENT_METHOD_HERE
+  },
+  "payment_method_preference": {
+    "object": "payment_method_preference",
+    "country_code": "US",
+    "ordered_payment_method_types": [
+      "card"
+    ],
+    "type": "deferred_intent"
+  },
+  "payment_method_specs": [
+    {
+      "async": false,
+      "fields": [],
+      "type": "card"
+    }
+  ],
+  "paypal_express_config": {
+    "client_id": null,
+    "paypal_merchant_id": null
+  },
+  "shipping_address_settings": {
+    "autocomplete_allowed": true
+  },
+  "unactivated_payment_method_types": []
+}

--- a/paymentsheet/src/androidTest/resources/elements-sessions-with_pi_and_default_pms_enabled.json
+++ b/paymentsheet/src/androidTest/resources/elements-sessions-with_pi_and_default_pms_enabled.json
@@ -7,7 +7,8 @@
   "meta_pay_signed_container_context": null,
   "order": null,
   "ordered_payment_method_types_and_wallets": [
-    "card"
+    "card",
+    "us_bank_account"
   ],
   "customer": {
     "payment_methods": [PAYMENT_METHODS_HERE],
@@ -40,8 +41,10 @@
     "object": "payment_method_preference",
     "country_code": "US",
     "ordered_payment_method_types": [
-      "card"
-    ],               "payment_intent": {
+      "card",
+      "us_bank_account"
+    ],
+    "payment_intent": {
       "id": "pi_example",
       "object": "payment_intent",
       "amount": 5099,
@@ -69,7 +72,8 @@
         }
       },
       "payment_method_types": [
-        "card"
+        "card",
+        "us_bank_account"
       ],
       "processing": null,
       "receipt_email": null,

--- a/paymentsheet/src/androidTest/resources/elements-sessions-with_pi_and_default_pms_enabled.json
+++ b/paymentsheet/src/androidTest/resources/elements-sessions-with_pi_and_default_pms_enabled.json
@@ -1,0 +1,98 @@
+{
+  "business_name": "Mobile Example Account",
+  "google_pay_preference": "enabled",
+  "merchant_country": "US",
+  "merchant_currency": "usd",
+  "merchant_id": "acct_1HvTI7Lu5o3P18Zp",
+  "meta_pay_signed_container_context": null,
+  "order": null,
+  "ordered_payment_method_types_and_wallets": [
+    "card"
+  ],
+  "customer": {
+    "payment_methods": [PAYMENT_METHODS_HERE],
+    "customer_session": {
+      "id": "cuss_654321",
+      "livemode": false,
+      "api_key": "ek_12345",
+      "api_key_expiry": 1899787184,
+      "customer": "cus_1",
+      "components": {
+        "mobile_payment_element": {
+          "enabled": true,
+          "features": {
+            "payment_method_save": "enabled",
+            "payment_method_remove": "enabled",
+            "payment_method_remove_last": "enabled",
+            "payment_method_save_allow_redisplay_override": null,
+            "payment_method_set_as_default": "enabled"
+          }
+        },
+        "customer_sheet": {
+          "enabled": false,
+          "features": null
+        }
+      }
+    },
+    "default_payment_method": DEFAULT_PAYMENT_METHOD_HERE
+  },
+  "payment_method_preference": {
+    "object": "payment_method_preference",
+    "country_code": "US",
+    "ordered_payment_method_types": [
+      "card"
+    ],               "payment_intent": {
+      "id": "pi_example",
+      "object": "payment_intent",
+      "amount": 5099,
+      "amount_details": {
+        "tip": {}
+      },
+      "automatic_payment_methods": {
+        "enabled": true
+      },
+      "canceled_at": null,
+      "cancellation_reason": null,
+      "capture_method": "automatic",
+      "client_secret": "pi_example_secret_example",
+      "confirmation_method": "automatic",
+      "created": 1674750417,
+      "currency": "usd",
+      "description": null,
+      "last_payment_error": null,
+      "livemode": false,
+      "next_action": null,
+      "payment_method": null,
+      "payment_method_options": {
+        "us_bank_account": {
+          "verification_method": "automatic"
+        }
+      },
+      "payment_method_types": [
+        "card"
+      ],
+      "processing": null,
+      "receipt_email": null,
+      "setup_future_usage": null,
+      "shipping": null,
+      "source": null,
+      "status": "requires_payment_method"
+    },
+    "type": "payment_intent"
+  },
+  "payment_method_specs": [
+    {
+      "async": false,
+      "fields": [],
+      "type": "card"
+    }
+  ],
+  "paypal_express_config": {
+    "client_id": null,
+    "paypal_merchant_id": null
+  },
+  "shipping_address_settings": {
+    "autocomplete_allowed": true
+  },
+  "unactivated_payment_method_types": []
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Move elements sessions for default PMs tests from a string to a json …

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Follow up to https://github.com/stripe/stripe-android/pull/10290#discussion_r1980715901

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

Existing tests continue passing