### PR TITLE
Remove `onPaymentResult` from `BaseSheetViewModel`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -14,7 +14,6 @@ import com.stripe.android.core.utils.requireApplication
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.SetupIntent
-import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.injection.DaggerPaymentOptionsViewModelFactoryComponent
 import com.stripe.android.paymentsheet.model.GooglePayButtonType
@@ -137,7 +136,6 @@ internal class PaymentOptionsViewModel @Inject constructor(
             setPaymentMethodMetadata(args.state.paymentMethodMetadata)
         }
         customerStateHolder.setCustomerState(args.state.customer)
-        savedStateHandle[SAVE_PROCESSING] = false
 
         updateSelection(args.state.paymentSelection)
 
@@ -195,10 +193,6 @@ internal class PaymentOptionsViewModel @Inject constructor(
                 is PaymentSelection.ExternalPaymentMethod -> processNewOrExternalPaymentMethod(paymentSelection)
             }
         }
-    }
-
-    override fun onPaymentResult(paymentResult: PaymentResult) {
-        savedStateHandle[SAVE_PROCESSING] = false
     }
 
     override fun handlePaymentMethodSelected(selection: PaymentSelection?) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -9,7 +9,6 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
-import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.LinkHandler
 import com.stripe.android.paymentsheet.MandateHandler
@@ -183,8 +182,6 @@ internal abstract class BaseSheetViewModel(
     }
 
     abstract fun onUserCancel()
-
-    abstract fun onPaymentResult(paymentResult: PaymentResult)
 
     abstract fun onError(error: ResolvableString? = null)
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/FakeBaseSheetViewModel.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/FakeBaseSheetViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
-import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.paymentsheet.LinkHandler
 import com.stripe.android.paymentsheet.NewOrExternalPaymentSelection
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -106,10 +105,6 @@ internal class FakeBaseSheetViewModel private constructor(
     }
 
     override fun onUserCancel() {
-        throw AssertionError("Not expected.")
-    }
-
-    override fun onPaymentResult(paymentResult: PaymentResult) {
         throw AssertionError("Not expected.")
     }
 }


### PR DESCRIPTION
# Summary
Remove `onPaymentResult` from `BaseSheetViewModel`

# Motivation
This function is only used in tests now and is no longer relevant to the function of `PaymentSheet` and `FlowController`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified