### PR TITLE
Disable checkboxes on US bank account form when processing

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountForm.kt
@@ -405,14 +405,14 @@ private fun AccountDetailsForm(
         )
         if (showCheckboxes) {
             SaveForFutureUseElementUI(
-                enabled = true,
+                enabled = enabled,
                 element = saveForFutureUseElement,
                 modifier = Modifier.padding(top = 8.dp)
             )
 
             setAsDefaultPaymentMethodElement?.let {
                 SetAsDefaultPaymentMethodElementUI(
-                    enabled = true,
+                    enabled = enabled,
                     element = it,
                     modifier = Modifier.padding(top = 8.dp),
                 )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Disable checkboxes on US bank account form when processing

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-3291

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

We don't have automated tests covering this

# Screen recordings
Before:
[us bank checkboxes - before.webm](https://github.com/user-attachments/assets/fb37c392-428f-4cfd-a7ab-80f28b186fbd)

After:

[us bank checkboxes - after.webm](https://github.com/user-attachments/assets/48e84495-53cd-492a-8478-57a3deebde6d)
