### PR TITLE
CBC update local state fix

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -104,6 +104,7 @@ internal class SavedPaymentMethodMutator(
     init {
         coroutineScope.launch {
             selection.collect { selection ->
+                // This gets fired without an outdated copy of the payment selection when cbc is saved
                 if (selection is PaymentSelection.Saved) {
                     customerStateHolder.updateMostRecentlySelectedSavedPaymentMethod(selection.paymentMethod)
                 }
@@ -279,7 +280,7 @@ internal class SavedPaymentMethodMutator(
             )
         ).onSuccess { updatedMethod ->
             withContext(uiContext) {
-                customerStateHolder.updateMostRecentlySelectedSavedPaymentMethod(updatedMethod)
+//                customerStateHolder.updateMostRecentlySelectedSavedPaymentMethod(updatedMethod)
                 customerStateHolder.setCustomerState(
                     currentCustomer.copy(
                         paymentMethods = currentCustomer.paymentMethods.map { savedMethod ->

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -104,7 +104,7 @@ internal class SavedPaymentMethodMutator(
     init {
         coroutineScope.launch {
             selection.collect { selection ->
-                // This gets fired without an outdated copy of the payment selection when cbc is saved
+                // This gets fired with an outdated copy of the payment selection when cbc is saved
                 if (selection is PaymentSelection.Saved) {
                     customerStateHolder.updateMostRecentlySelectedSavedPaymentMethod(selection.paymentMethod)
                 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
`mostRecentlySelectedSavedPaymentMethod` was being updated with an old copy of the paymentMethod. This meant that the paymentMethod list was uses a version of the paymentMethod object with an old CBC.

`mostRecentlySelectedSavedPaymentMethod` has multiple (possibly concurrent) callers so its hard to make sure the most up-to-date paymentMethod is used.

The main changes include:

* Refactoring the `mostRecentlySelectedSavedPaymentMethod` to use the payment method ID instead of the full PaymentMethod object. This ensures we always use the latest copy of the payment method.

* Implementing a new flow that combines the payment methods list with the selected payment method ID to retrieve the most up-to-date payment method information.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots

https://github.com/user-attachments/assets/5a47a94f-21c3-431a-8528-3cb5c3be0960



# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
