### PR TITLE
Add error handling to browserstack build status.

### DIFF
--- a/scripts/browserstack.py
+++ b/scripts/browserstack.py
@@ -373,8 +373,11 @@ def waitForBuildComplete(buildId):
     while responseStatus == "running":
         time.sleep(10)
         print(".", end="")
-        response = get_build_status(buildId)
-        responseStatus = response.json()["status"]
+        try:
+            response = get_build_status(buildId)
+            responseStatus = response.json()["status"]
+        except:
+            print("Failed to get build status, trying again.")
     print("DONE.\nRESULT is: " + responseStatus)
     if responseStatus == "passed":
         return 0


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
We've seen an issue where fetching the build status failed (probably an API error on the browserstack side). This will continue retrying even if the API request fails.

