### PR TITLE
Prevent invalid launches of address element.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivity.kt
@@ -10,10 +10,12 @@ import androidx.annotation.VisibleForTesting
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Surface
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.ViewModelProvider
+import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -22,6 +24,7 @@ import androidx.navigation.navArgument
 import com.stripe.android.common.ui.ElementsBottomSheetLayout
 import com.stripe.android.paymentsheet.parseAppearance
 import com.stripe.android.uicore.StripeTheme
+import com.stripe.android.uicore.elements.bottomsheet.StripeBottomSheetState
 import com.stripe.android.uicore.elements.bottomsheet.rememberStripeBottomSheetState
 import com.stripe.android.uicore.utils.fadeOut
 import kotlinx.coroutines.launch
@@ -33,17 +36,23 @@ internal class AddressElementActivity : ComponentActivity() {
     internal var viewModelFactory: ViewModelProvider.Factory =
         AddressElementViewModel.Factory(
             applicationSupplier = { application },
-            starterArgsSupplier = { starterArgs }
+            starterArgsSupplier = { requireNotNull(starterArgs) }
         )
 
     private val viewModel: AddressElementViewModel by viewModels { viewModelFactory }
 
     private val starterArgs by lazy {
-        requireNotNull(AddressElementActivityContract.Args.fromIntent(intent))
+        AddressElementActivityContract.Args.fromIntent(intent)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        val starterArgs = starterArgs
+        if (starterArgs == null) {
+            finish()
+            return
+        }
 
         WindowCompat.setDecorFitsSystemWindows(window, false)
         starterArgs.config?.appearance?.parseAppearance()
@@ -68,37 +77,45 @@ internal class AddressElementActivity : ComponentActivity() {
                 }
             }
 
-            StripeTheme {
-                ElementsBottomSheetLayout(
-                    state = bottomSheetState,
-                    onDismissed = viewModel.navigator::dismiss,
-                ) {
-                    Surface(modifier = Modifier.fillMaxSize()) {
-                        NavHost(
-                            navController = navController,
-                            startDestination = AddressElementScreen.InputAddress.route,
-                        ) {
-                            composable(AddressElementScreen.InputAddress.route) {
-                                InputAddressScreen(viewModel.inputAddressViewModelSubcomponentBuilderProvider)
-                            }
-                            composable(
-                                AddressElementScreen.Autocomplete.route,
-                                arguments = listOf(
-                                    navArgument(AddressElementScreen.Autocomplete.countryArg) {
-                                        type = NavType.StringType
-                                    }
+            AddressElementUi(bottomSheetState, navController)
+        }
+    }
+
+    @Composable
+    private fun AddressElementUi(
+        bottomSheetState: StripeBottomSheetState,
+        navController: NavHostController,
+    ) {
+        StripeTheme {
+            ElementsBottomSheetLayout(
+                state = bottomSheetState,
+                onDismissed = viewModel.navigator::dismiss,
+            ) {
+                Surface(modifier = Modifier.fillMaxSize()) {
+                    NavHost(
+                        navController = navController,
+                        startDestination = AddressElementScreen.InputAddress.route,
+                    ) {
+                        composable(AddressElementScreen.InputAddress.route) {
+                            InputAddressScreen(viewModel.inputAddressViewModelSubcomponentBuilderProvider)
+                        }
+                        composable(
+                            AddressElementScreen.Autocomplete.route,
+                            arguments = listOf(
+                                navArgument(AddressElementScreen.Autocomplete.countryArg) {
+                                    type = NavType.StringType
+                                }
+                            )
+                        ) { backStackEntry ->
+                            val country = backStackEntry
+                                .arguments
+                                ?.getString(
+                                    AddressElementScreen.Autocomplete.countryArg
                                 )
-                            ) { backStackEntry ->
-                                val country = backStackEntry
-                                    .arguments
-                                    ?.getString(
-                                        AddressElementScreen.Autocomplete.countryArg
-                                    )
-                                AutocompleteScreen(
-                                    viewModel.autoCompleteViewModelSubcomponentBuilderProvider,
-                                    country
-                                )
-                            }
+                            AutocompleteScreen(
+                                viewModel.autoCompleteViewModelSubcomponentBuilderProvider,
+                                country
+                            )
                         }
                     }
                 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivityContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivityContract.kt
@@ -7,7 +7,7 @@ import androidx.core.os.bundleOf
 import com.stripe.android.view.ActivityStarter
 import kotlinx.parcelize.Parcelize
 
-internal class AddressElementActivityContract :
+internal object AddressElementActivityContract :
     ActivityResultContract<AddressElementActivityContract.Args, AddressLauncherResult>() {
 
     override fun createIntent(context: Context, input: Args): Intent {
@@ -15,7 +15,7 @@ internal class AddressElementActivityContract :
     }
 
     @Suppress("DEPRECATION")
-    override fun parseResult(resultCode: Int, intent: Intent?) =
+    override fun parseResult(resultCode: Int, intent: Intent?): AddressLauncherResult =
         intent?.getParcelableExtra<Result>(EXTRA_RESULT)?.addressOptionsResult
             ?: AddressLauncherResult.Canceled
 
@@ -46,12 +46,10 @@ internal class AddressElementActivityContract :
         override fun toBundle() = bundleOf(EXTRA_RESULT to this)
     }
 
-    internal companion object {
-        const val EXTRA_ARGS =
-            "com.stripe.android.paymentsheet.addresselement" +
-                ".AddressElementActivityContract.extra_args"
-        const val EXTRA_RESULT =
-            "com.stripe.android.paymentsheet.addresselement" +
-                ".AddressElementActivityContract.extra_result"
-    }
+    const val EXTRA_ARGS =
+        "com.stripe.android.paymentsheet.addresselement" +
+            ".AddressElementActivityContract.extra_args"
+    const val EXTRA_RESULT =
+        "com.stripe.android.paymentsheet.addresselement" +
+            ".AddressElementActivityContract.extra_result"
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressLauncher.kt
@@ -34,7 +34,7 @@ class AddressLauncher internal constructor(
     ) : this(
         application = activity.application,
         activityResultLauncher = activity.registerForActivityResult(
-            AddressElementActivityContract()
+            AddressElementActivityContract
         ) {
             callback.onAddressLauncherResult(it)
         },
@@ -52,7 +52,7 @@ class AddressLauncher internal constructor(
     ) : this(
         application = fragment.requireActivity().application,
         activityResultLauncher = fragment.registerForActivityResult(
-            AddressElementActivityContract()
+            AddressElementActivityContract
         ) {
             callback.onAddressLauncherResult(it)
         },
@@ -217,7 +217,7 @@ fun rememberAddressLauncher(
     callback: AddressLauncherResultCallback
 ): AddressLauncher {
     val activityResultLauncher = rememberLauncherForActivityResult(
-        contract = AddressElementActivityContract(),
+        contract = AddressElementActivityContract,
         onResult = callback::onAddressLauncherResult
     )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivityTest.kt
@@ -1,0 +1,24 @@
+package com.stripe.android.paymentsheet.addresselement
+
+import android.os.Bundle
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class AddressElementActivityTest {
+    @Test
+    fun `when launched without args should finish with canceled result`() {
+        ActivityScenario.launchActivityForResult(
+            AddressElementActivity::class.java,
+            Bundle.EMPTY
+        ).use { activityScenario ->
+            assertThat(activityScenario.state).isEqualTo(Lifecycle.State.DESTROYED)
+            val result = AddressElementActivityContract.parseResult(0, activityScenario.result.resultData)
+            assertThat(result).isEqualTo(AddressLauncherResult.Canceled)
+        }
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Fixes an issue where attempting to launch AddressElementActivity with out valid params would cause a crash.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-3895
Fixes https://github.com/stripe/stripe-android/issues/10291

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified
