### PR TITLE
[connect] Extend timeout for WebView alert tests

### DIFF
--- a/connect/src/androidTest/java/com/stripe/android/connect/FullScreenComponentTest.kt
+++ b/connect/src/androidTest/java/com/stripe/android/connect/FullScreenComponentTest.kt
@@ -144,7 +144,7 @@ class FullScreenComponentTest {
     fun testCustomJsAlertContents() {
         checkDialogIsDisplayed()
         val alertJs = testAlertJs
-        performWebViewAlert(ALERT, alertJs)
+        performWebViewAlertWithoutChecks(ALERT, alertJs)
         onView(withText(alertJs.title)).check(matches(isDisplayed()))
         onView(withText(alertJs.message)).check(matches(isDisplayed()))
         onView(withText(alertJs.buttons!!.ok)).check(matches(isDisplayed()))
@@ -155,7 +155,7 @@ class FullScreenComponentTest {
     fun testCustomJsAlertDefaultContents() {
         checkDialogIsDisplayed()
         val alertJs = AlertJs(message = testAlertJs.message)
-        performWebViewAlert(ALERT, alertJs)
+        performWebViewAlertWithoutChecks(ALERT, alertJs)
         onView(withText(alertJs.message)).check(matches(isDisplayed()))
         onView(withText("OK")).check(matches(isDisplayed()))
     }
@@ -164,7 +164,7 @@ class FullScreenComponentTest {
     fun testCustomJsConfirmDefaultContents() {
         checkDialogIsDisplayed()
         val alertJs = AlertJs(message = testAlertJs.message)
-        performWebViewAlert(CONFIRM, alertJs)
+        performWebViewAlertWithoutChecks(CONFIRM, alertJs)
         onView(withText(alertJs.message)).check(matches(isDisplayed()))
         onView(withText("OK")).check(matches(isDisplayed()))
         onView(withText("Cancel")).check(matches(isDisplayed()))
@@ -187,7 +187,7 @@ class FullScreenComponentTest {
             DismissActionTestCase(CONFIRM, pressCancel, "false"),
             DismissActionTestCase(CONFIRM, pressOk, "true"),
         ).forEach { testCase ->
-            performWebViewAlert(testCase.method, alertJs)
+            performWebViewAlertWithoutChecks(testCase.method, alertJs)
             testCase.action()
             checkDialogIsDisplayed()
             checkWebViewAlertResult(testCase.expected)
@@ -205,7 +205,7 @@ class FullScreenComponentTest {
         checkDialogIsDisplayed()
         val alertJs = testAlertJs
         // Show the alert then rotate the screen.
-        performWebViewAlert(ALERT, alertJs)
+        performWebViewAlertWithoutChecks(ALERT, alertJs)
         onView(withText(alertJs.message)).check(matches(isDisplayed()))
         activityRule.scenario.onActivity {
             it.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER_LANDSCAPE
@@ -216,7 +216,7 @@ class FullScreenComponentTest {
             .check(doesNotExist())
         // Show the alert again. If the alert is *not* shown, it's an indication that the
         // WebView is hanging because it never got a result from the first alert.
-        performWebViewAlert(ALERT, alertJs)
+        performWebViewAlertWithoutChecks(ALERT, alertJs)
         onView(withText(alertJs.message)).check(matches(isDisplayed()))
     }
 
@@ -224,7 +224,7 @@ class FullScreenComponentTest {
     fun testPlainJsAlertWorks() {
         checkDialogIsDisplayed()
         val message = testAlertJs.message
-        performWebViewAlert(ALERT, message)
+        performWebViewAlertWithoutChecks(ALERT, message)
         onView(withText(message)).check(matches(isDisplayed()))
         onView(withText("OK")).check(matches(isDisplayed()))
     }
@@ -233,7 +233,7 @@ class FullScreenComponentTest {
     fun testPlainJsConfirmWorks() {
         checkDialogIsDisplayed()
         val message = testAlertJs.message
-        performWebViewAlert(CONFIRM, message)
+        performWebViewAlertWithoutChecks(CONFIRM, message)
         onView(withText(message)).check(matches(isDisplayed()))
         onView(withText("OK")).check(matches(isDisplayed()))
         onView(withText("Cancel")).check(matches(isDisplayed()))
@@ -253,20 +253,19 @@ class FullScreenComponentTest {
             .check(doesNotExist())
     }
 
-    private fun performWebViewAlert(method: String, alertJs: AlertJs) {
+    private fun performWebViewAlertWithoutChecks(method: String, alertJs: AlertJs) {
         val alertString = ConnectJson.encodeToString(alertJs)
-        performWebViewAlert(method, alertString)
+        performWebViewAlertWithoutChecks(method, alertString)
     }
 
-    private fun performWebViewAlert(method: String, message: String) {
+    private fun performWebViewAlertWithoutChecks(method: String, message: String) {
         try {
             onWebView()
-                .withTimeout(500L, TimeUnit.MILLISECONDS)
+                .withTimeout(5_000L, TimeUnit.MILLISECONDS) // Allow slower CI machines more time.
                 .perform(script("function performWebViewAlert() { $ALERT_RESULT_VAR = $method(`$message`); }"))
         } catch (_: NoMatchingViewException) {
             // HACK: After the JS executes, the alert dialog prevents the WebView from
-            //  being interacted with. Assume the alert was shown -- we'll be verifying
-            //  the dialog below anyway.
+            //  being interacted with. Assume the alert was shown.
         }
     }
 


### PR DESCRIPTION
# Summary
Address `FullScreenComponentTest` flakiness

# Motivation
Address test flakiness ([example build](https://app.bitrise.io/build/2b6452ca-6248-4bbd-a9ad-6768fe1b5615))

# Testing
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified
