### PR TITLE
[connect] Refactor appearance classes using Builders; hide getters

### DIFF
--- a/connect-example/src/main/java/com/stripe/android/connect/example/ui/appearance/AppearanceInfo.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/ui/appearance/AppearanceInfo.kt
@@ -53,27 +53,27 @@ data class AppearanceInfo(
         private fun ogreAppearance(context: Context) = AppearanceInfo(
             appearanceId = AppearanceId.Ogre,
             appearance = Appearance.Builder()
-                .setColors(
+                .colors(
                     Colors.Builder()
-                        .setPrimary(context.getColorCompat(R.color.ogre_primary))
-                        .setBackground(context.getColorCompat(R.color.ogre_background))
-                        .setText(context.getColorCompat(R.color.ogre_text))
+                        .primary(context.getColorCompat(R.color.ogre_primary))
+                        .background(context.getColorCompat(R.color.ogre_background))
+                        .text(context.getColorCompat(R.color.ogre_text))
                         .build()
                 )
-                .setButtonPrimary(
+                .buttonPrimary(
                     Button(
                         colorBackground = context.getColorCompat(R.color.ogre_button_primary_background),
                         colorBorder = context.getColorCompat(R.color.ogre_button_primary_border),
                         colorText = context.getColorCompat(R.color.ogre_button_primary_text)
                     )
                 )
-                .setButtonSecondary(
+                .buttonSecondary(
                     Button(
                         colorBackground = context.getColorCompat(R.color.ogre_button_secondary_background),
                         colorText = context.getColorCompat(R.color.ogre_button_secondary_text)
                     )
                 )
-                .setBadgeNeutral(
+                .badgeNeutral(
                     Badge(
                         colorBackground = context.getColorCompat(R.color.ogre_badge_neutral_background),
                         colorText = context.getColorCompat(R.color.ogre_badge_neutral_text)
@@ -85,38 +85,38 @@ data class AppearanceInfo(
         private fun hotDogAppearance(context: Context) = AppearanceInfo(
             appearanceId = AppearanceId.HotDog,
             appearance = Appearance.Builder()
-                .setColors(
+                .colors(
                     Colors.Builder()
-                        .setPrimary(context.getColorCompat(R.color.hot_dog_primary))
-                        .setBackground(context.getColorCompat(R.color.hot_dog_background))
-                        .setText(context.getColorCompat(R.color.hot_dog_text))
-                        .setSecondaryText(context.getColorCompat(R.color.hot_dog_secondary_text))
-                        .setOffsetBackground(context.getColorCompat(R.color.hot_dog_offset_background))
+                        .primary(context.getColorCompat(R.color.hot_dog_primary))
+                        .background(context.getColorCompat(R.color.hot_dog_background))
+                        .text(context.getColorCompat(R.color.hot_dog_text))
+                        .secondaryText(context.getColorCompat(R.color.hot_dog_secondary_text))
+                        .offsetBackground(context.getColorCompat(R.color.hot_dog_offset_background))
                         .build()
                 )
-                .setButtonPrimary(
+                .buttonPrimary(
                     Button(
                         colorBackground = context.getColorCompat(R.color.hot_dog_button_primary_background),
                         colorBorder = context.getColorCompat(R.color.hot_dog_button_primary_border),
                         colorText = context.getColorCompat(R.color.hot_dog_button_primary_text)
                     )
                 )
-                .setButtonSecondary(
+                .buttonSecondary(
                     Button(
                         colorBackground = context.getColorCompat(R.color.hot_dog_button_secondary_background),
                         colorBorder = context.getColorCompat(R.color.hot_dog_button_secondary_border)
                     )
                 )
-                .setBadgeDanger(
+                .badgeDanger(
                     Badge(colorText = context.getColorCompat(R.color.hot_dog_badge_danger_text))
                 )
-                .setBadgeWarning(
+                .badgeWarning(
                     Badge(colorBackground = context.getColorCompat(R.color.hot_dog_badge_warning_background))
                 )
-                .setCornerRadius(
+                .cornerRadius(
                     @Suppress("MagicNumber")
                     CornerRadius.Builder()
-                        .setBase(0f)
+                        .base(0f)
                         .build()
                 )
                 .build()
@@ -125,25 +125,25 @@ data class AppearanceInfo(
         private fun oceanBreezeAppearance(context: Context) = AppearanceInfo(
             appearanceId = AppearanceId.OceanBreeze,
             appearance = Appearance.Builder()
-                .setColors(
+                .colors(
                     Colors.Builder()
-                        .setBackground(context.getColorCompat(R.color.ocean_breeze_background))
-                        .setPrimary(context.getColorCompat(R.color.ocean_breeze_primary))
-                        .setText(context.getColorCompat(R.color.ocean_breeze_text))
+                        .background(context.getColorCompat(R.color.ocean_breeze_background))
+                        .primary(context.getColorCompat(R.color.ocean_breeze_primary))
+                        .text(context.getColorCompat(R.color.ocean_breeze_text))
                         .build()
                 )
-                .setButtonSecondary(
+                .buttonSecondary(
                     Button(
                         colorText = context.getColorCompat(R.color.ocean_breeze_button_secondary_text),
                         colorBorder = context.getColorCompat(R.color.ocean_breeze_button_secondary_border)
                     )
                 )
-                .setBadgeSuccess(Badge(colorText = context.getColorCompat(R.color.ocean_breeze_badge_success_text)))
-                .setBadgeNeutral(Badge(colorText = context.getColorCompat(R.color.ocean_breeze_badge_neutral_text)))
-                .setCornerRadius(
+                .badgeSuccess(Badge(colorText = context.getColorCompat(R.color.ocean_breeze_badge_success_text)))
+                .badgeNeutral(Badge(colorText = context.getColorCompat(R.color.ocean_breeze_badge_neutral_text)))
+                .cornerRadius(
                     @Suppress("MagicNumber")
                     CornerRadius.Builder()
-                        .setBase(23f)
+                        .base(23f)
                         .build()
                 )
                 .build()
@@ -152,39 +152,39 @@ data class AppearanceInfo(
         private fun linkAppearance(context: Context) = AppearanceInfo(
             appearanceId = AppearanceId.Link,
             appearance = Appearance.Builder()
-                .setColors(
+                .colors(
                     Colors.Builder()
-                        .setPrimary(context.getColorCompat(R.color.link_primary))
-                        .setBackground(context.getColorCompat(R.color.link_background))
-                        .setText(context.getColorCompat(R.color.link_text))
-                        .setSecondaryText(context.getColorCompat(R.color.link_secondary_text))
-                        .setActionPrimaryText(context.getColorCompat(R.color.link_action_primary_text))
+                        .primary(context.getColorCompat(R.color.link_primary))
+                        .background(context.getColorCompat(R.color.link_background))
+                        .text(context.getColorCompat(R.color.link_text))
+                        .secondaryText(context.getColorCompat(R.color.link_secondary_text))
+                        .actionPrimaryText(context.getColorCompat(R.color.link_action_primary_text))
                         .build()
                 )
-                .setButtonPrimary(
+                .buttonPrimary(
                     Button(
                         colorBackground = context.getColorCompat(R.color.link_button_primary_background),
                         colorBorder = context.getColorCompat(R.color.link_button_primary_border),
                         colorText = context.getColorCompat(R.color.link_button_primary_text)
                     )
                 )
-                .setBadgeSuccess(
+                .badgeSuccess(
                     Badge(
                         colorBackground = context.getColorCompat(R.color.link_badge_success_background),
                         colorBorder = context.getColorCompat(R.color.link_badge_success_border),
                         colorText = context.getColorCompat(R.color.link_badge_success_text)
                     )
                 )
-                .setBadgeNeutral(
+                .badgeNeutral(
                     Badge(
                         colorBackground = context.getColorCompat(R.color.link_badge_neutral_background),
                         colorText = context.getColorCompat(R.color.link_badge_neutral_text)
                     )
                 )
-                .setCornerRadius(
+                .cornerRadius(
                     @Suppress("MagicNumber")
                     CornerRadius.Builder()
-                        .setBase(5f)
+                        .base(5f)
                         .build()
                 )
                 .build()
@@ -194,54 +194,54 @@ data class AppearanceInfo(
         private fun dynamicAppearance(context: Context) = AppearanceInfo(
             appearanceId = AppearanceId.Dynamic,
             appearance = Appearance.Builder()
-                .setColors(
+                .colors(
                     Colors.Builder()
-                        .setPrimary(context.getColorCompat(R.color.dynamic_colors_primary))
-                        .setText(context.getColorCompat(R.color.dynamic_colors_text))
-                        .setBackground(context.getColorCompat(R.color.dynamic_colors_background))
-                        .setBorder(context.getColorCompat(R.color.dynamic_colors_border))
-                        .setSecondaryText(context.getColorCompat(R.color.dynamic_colors_secondary_text))
-                        .setActionPrimaryText(context.getColorCompat(R.color.dynamic_colors_action_primary_text))
-                        .setActionSecondaryText(context.getColorCompat(R.color.dynamic_colors_action_secondary_text))
-                        .setFormAccent(context.getColorCompat(R.color.dynamic_colors_form_accent))
-                        .setFormHighlightBorder(context.getColorCompat(R.color.dynamic_colors_form_highlight_border))
-                        .setDanger(context.getColorCompat(R.color.dynamic_colors_danger))
-                        .setOffsetBackground(context.getColorCompat(R.color.dynamic_colors_offset_background))
+                        .primary(context.getColorCompat(R.color.dynamic_colors_primary))
+                        .text(context.getColorCompat(R.color.dynamic_colors_text))
+                        .background(context.getColorCompat(R.color.dynamic_colors_background))
+                        .border(context.getColorCompat(R.color.dynamic_colors_border))
+                        .secondaryText(context.getColorCompat(R.color.dynamic_colors_secondary_text))
+                        .actionPrimaryText(context.getColorCompat(R.color.dynamic_colors_action_primary_text))
+                        .actionSecondaryText(context.getColorCompat(R.color.dynamic_colors_action_secondary_text))
+                        .formAccent(context.getColorCompat(R.color.dynamic_colors_form_accent))
+                        .formHighlightBorder(context.getColorCompat(R.color.dynamic_colors_form_highlight_border))
+                        .danger(context.getColorCompat(R.color.dynamic_colors_danger))
+                        .offsetBackground(context.getColorCompat(R.color.dynamic_colors_offset_background))
                         .build()
                 )
-                .setButtonPrimary(
+                .buttonPrimary(
                     Button(
                         colorBackground = context.getColorCompat(R.color.dynamic_colors_button_primary_background),
                         colorBorder = context.getColorCompat(R.color.dynamic_colors_button_primary_border),
                         colorText = context.getColorCompat(R.color.dynamic_colors_button_primary_text)
                     )
                 )
-                .setButtonSecondary(
+                .buttonSecondary(
                     Button(
                         colorBackground = context.getColorCompat(R.color.dynamic_colors_button_secondary_background),
                         colorBorder = context.getColorCompat(R.color.dynamic_colors_button_secondary_border),
                         colorText = context.getColorCompat(R.color.dynamic_colors_button_secondary_text)
                     )
                 )
-                .setBadgeSuccess(
+                .badgeSuccess(
                     Badge(
                         colorBorder = context.getColorCompat(R.color.dynamic_colors_badge_success_border),
                         colorText = context.getColorCompat(R.color.dynamic_colors_badge_success_text)
                     )
                 )
-                .setBadgeNeutral(
+                .badgeNeutral(
                     Badge(
                         colorBorder = context.getColorCompat(R.color.dynamic_colors_badge_neutral_border),
                         colorText = context.getColorCompat(R.color.dynamic_colors_badge_neutral_text),
                     )
                 )
-                .setBadgeWarning(
+                .badgeWarning(
                     Badge(
                         colorBorder = context.getColorCompat(R.color.dynamic_colors_badge_warning_border),
                         colorText = context.getColorCompat(R.color.dynamic_colors_badge_warning_text)
                     )
                 )
-                .setBadgeDanger(
+                .badgeDanger(
                     Badge(
                         colorBorder = context.getColorCompat(R.color.dynamic_colors_badge_danger_border),
                         colorText = context.getColorCompat(R.color.dynamic_colors_badge_danger_text)
@@ -253,9 +253,9 @@ data class AppearanceInfo(
         private fun customFont() = AppearanceInfo(
             appearanceId = AppearanceId.CustomFont,
             appearance = Appearance.Builder()
-                .setTypography(
+                .typography(
                     Typography.Builder()
-                        .setFontFamily("doto")
+                        .fontFamily("doto")
                         .build()
                 )
                 .build()

--- a/connect-example/src/main/java/com/stripe/android/connect/example/ui/appearance/AppearanceInfo.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/ui/appearance/AppearanceInfo.kt
@@ -2,6 +2,7 @@ package com.stripe.android.connect.example.ui.appearance
 
 import android.content.Context
 import android.os.Parcelable
+import androidx.annotation.ColorRes
 import androidx.annotation.StringRes
 import androidx.core.content.ContextCompat
 import com.stripe.android.connect.PrivateBetaConnectSDK
@@ -46,167 +47,221 @@ data class AppearanceInfo(
 
         private fun defaultAppearance() = AppearanceInfo(
             appearanceId = AppearanceId.Default,
-            appearance = Appearance()
+            appearance = Appearance.Builder().build()
         )
 
         private fun ogreAppearance(context: Context) = AppearanceInfo(
             appearanceId = AppearanceId.Ogre,
-            appearance = Appearance(
-                colors = Colors(
-                    primary = ContextCompat.getColor(context, R.color.ogre_primary),
-                    background = ContextCompat.getColor(context, R.color.ogre_background),
-                    text = ContextCompat.getColor(context, R.color.ogre_text)
-                ),
-                buttonPrimary = Button(
-                    colorBackground = ContextCompat.getColor(context, R.color.ogre_button_primary_background),
-                    colorBorder = ContextCompat.getColor(context, R.color.ogre_button_primary_border),
-                    colorText = ContextCompat.getColor(context, R.color.ogre_button_primary_text)
-                ),
-                buttonSecondary = Button(
-                    colorBackground = ContextCompat.getColor(context, R.color.ogre_button_secondary_background),
-                    colorText = ContextCompat.getColor(context, R.color.ogre_button_secondary_text)
-                ),
-                badgeNeutral = Badge(
-                    colorBackground = ContextCompat.getColor(context, R.color.ogre_badge_neutral_background),
-                    colorText = ContextCompat.getColor(context, R.color.ogre_badge_neutral_text)
+            appearance = Appearance.Builder()
+                .setColors(
+                    Colors.Builder()
+                        .setPrimary(context.getColorCompat(R.color.ogre_primary))
+                        .setBackground(context.getColorCompat(R.color.ogre_background))
+                        .setText(context.getColorCompat(R.color.ogre_text))
+                        .build()
                 )
-            )
+                .setButtonPrimary(
+                    Button(
+                        colorBackground = context.getColorCompat(R.color.ogre_button_primary_background),
+                        colorBorder = context.getColorCompat(R.color.ogre_button_primary_border),
+                        colorText = context.getColorCompat(R.color.ogre_button_primary_text)
+                    )
+                )
+                .setButtonSecondary(
+                    Button(
+                        colorBackground = context.getColorCompat(R.color.ogre_button_secondary_background),
+                        colorText = context.getColorCompat(R.color.ogre_button_secondary_text)
+                    )
+                )
+                .setBadgeNeutral(
+                    Badge(
+                        colorBackground = context.getColorCompat(R.color.ogre_badge_neutral_background),
+                        colorText = context.getColorCompat(R.color.ogre_badge_neutral_text)
+                    )
+                )
+                .build()
         )
 
         private fun hotDogAppearance(context: Context) = AppearanceInfo(
             appearanceId = AppearanceId.HotDog,
-            appearance = Appearance(
-                colors = Colors(
-                    primary = ContextCompat.getColor(context, R.color.hot_dog_primary),
-                    background = ContextCompat.getColor(context, R.color.hot_dog_background),
-                    text = ContextCompat.getColor(context, R.color.hot_dog_text),
-                    secondaryText = ContextCompat.getColor(context, R.color.hot_dog_secondary_text),
-                    offsetBackground = ContextCompat.getColor(context, R.color.hot_dog_offset_background)
-                ),
-                buttonPrimary = Button(
-                    colorBackground = ContextCompat.getColor(context, R.color.hot_dog_button_primary_background),
-                    colorBorder = ContextCompat.getColor(context, R.color.hot_dog_button_primary_border),
-                    colorText = ContextCompat.getColor(context, R.color.hot_dog_button_primary_text)
-                ),
-                buttonSecondary = Button(
-                    colorBackground = ContextCompat.getColor(context, R.color.hot_dog_button_secondary_background),
-                    colorBorder = ContextCompat.getColor(context, R.color.hot_dog_button_secondary_border)
-                ),
-                badgeDanger = Badge(
-                    colorText = ContextCompat.getColor(context, R.color.hot_dog_badge_danger_text)
-                ),
-                badgeWarning = Badge(
-                    colorBackground = ContextCompat.getColor(context, R.color.hot_dog_badge_warning_background)
-                ),
-                cornerRadius = CornerRadius(base = 0f)
-            )
+            appearance = Appearance.Builder()
+                .setColors(
+                    Colors.Builder()
+                        .setPrimary(context.getColorCompat(R.color.hot_dog_primary))
+                        .setBackground(context.getColorCompat(R.color.hot_dog_background))
+                        .setText(context.getColorCompat(R.color.hot_dog_text))
+                        .setSecondaryText(context.getColorCompat(R.color.hot_dog_secondary_text))
+                        .setOffsetBackground(context.getColorCompat(R.color.hot_dog_offset_background))
+                        .build()
+                )
+                .setButtonPrimary(
+                    Button(
+                        colorBackground = context.getColorCompat(R.color.hot_dog_button_primary_background),
+                        colorBorder = context.getColorCompat(R.color.hot_dog_button_primary_border),
+                        colorText = context.getColorCompat(R.color.hot_dog_button_primary_text)
+                    )
+                )
+                .setButtonSecondary(
+                    Button(
+                        colorBackground = context.getColorCompat(R.color.hot_dog_button_secondary_background),
+                        colorBorder = context.getColorCompat(R.color.hot_dog_button_secondary_border)
+                    )
+                )
+                .setBadgeDanger(
+                    Badge(colorText = context.getColorCompat(R.color.hot_dog_badge_danger_text))
+                )
+                .setBadgeWarning(
+                    Badge(colorBackground = context.getColorCompat(R.color.hot_dog_badge_warning_background))
+                )
+                .setCornerRadius(
+                    @Suppress("MagicNumber")
+                    CornerRadius.Builder()
+                        .setBase(0f)
+                        .build()
+                )
+                .build()
         )
 
         private fun oceanBreezeAppearance(context: Context) = AppearanceInfo(
             appearanceId = AppearanceId.OceanBreeze,
-            appearance = Appearance(
-                colors = Colors(
-                    background = ContextCompat.getColor(context, R.color.ocean_breeze_background),
-                    primary = ContextCompat.getColor(context, R.color.ocean_breeze_primary),
-                    text = ContextCompat.getColor(context, R.color.ocean_breeze_text),
-                ),
-                buttonSecondary = Button(
-                    colorText = ContextCompat.getColor(context, R.color.ocean_breeze_button_secondary_text),
-                    colorBorder = ContextCompat.getColor(context, R.color.ocean_breeze_button_secondary_border)
-                ),
-                badgeSuccess = Badge(
-                    colorText = ContextCompat.getColor(context, R.color.ocean_breeze_badge_success_text)
-                ),
-                badgeNeutral = Badge(
-                    colorText = ContextCompat.getColor(context, R.color.ocean_breeze_badge_neutral_text)
-                ),
-                cornerRadius = CornerRadius(base = 23f)
-            )
+            appearance = Appearance.Builder()
+                .setColors(
+                    Colors.Builder()
+                        .setBackground(context.getColorCompat(R.color.ocean_breeze_background))
+                        .setPrimary(context.getColorCompat(R.color.ocean_breeze_primary))
+                        .setText(context.getColorCompat(R.color.ocean_breeze_text))
+                        .build()
+                )
+                .setButtonSecondary(
+                    Button(
+                        colorText = context.getColorCompat(R.color.ocean_breeze_button_secondary_text),
+                        colorBorder = context.getColorCompat(R.color.ocean_breeze_button_secondary_border)
+                    )
+                )
+                .setBadgeSuccess(Badge(colorText = context.getColorCompat(R.color.ocean_breeze_badge_success_text)))
+                .setBadgeNeutral(Badge(colorText = context.getColorCompat(R.color.ocean_breeze_badge_neutral_text)))
+                .setCornerRadius(
+                    @Suppress("MagicNumber")
+                    CornerRadius.Builder()
+                        .setBase(23f)
+                        .build()
+                )
+                .build()
         )
 
         private fun linkAppearance(context: Context) = AppearanceInfo(
             appearanceId = AppearanceId.Link,
-            appearance = Appearance(
-                colors = Colors(
-                    primary = ContextCompat.getColor(context, R.color.link_primary),
-                    background = ContextCompat.getColor(context, R.color.link_background),
-                    text = ContextCompat.getColor(context, R.color.link_text),
-                    secondaryText = ContextCompat.getColor(context, R.color.link_secondary_text),
-                    actionPrimaryText = ContextCompat.getColor(context, R.color.link_action_primary_text)
-                ),
-                buttonPrimary = Button(
-                    colorBackground = ContextCompat.getColor(context, R.color.link_button_primary_background),
-                    colorBorder = ContextCompat.getColor(context, R.color.link_button_primary_border),
-                    colorText = ContextCompat.getColor(context, R.color.link_button_primary_text)
-                ),
-                badgeSuccess = Badge(
-                    colorBackground = ContextCompat.getColor(context, R.color.link_badge_success_background),
-                    colorBorder = ContextCompat.getColor(context, R.color.link_badge_success_border),
-                    colorText = ContextCompat.getColor(context, R.color.link_badge_success_text)
-                ),
-                badgeNeutral = Badge(
-                    colorBackground = ContextCompat.getColor(context, R.color.link_badge_neutral_background),
-                    colorText = ContextCompat.getColor(context, R.color.link_badge_neutral_text)
-                ),
-                cornerRadius = CornerRadius(base = 5f)
-            )
+            appearance = Appearance.Builder()
+                .setColors(
+                    Colors.Builder()
+                        .setPrimary(context.getColorCompat(R.color.link_primary))
+                        .setBackground(context.getColorCompat(R.color.link_background))
+                        .setText(context.getColorCompat(R.color.link_text))
+                        .setSecondaryText(context.getColorCompat(R.color.link_secondary_text))
+                        .setActionPrimaryText(context.getColorCompat(R.color.link_action_primary_text))
+                        .build()
+                )
+                .setButtonPrimary(
+                    Button(
+                        colorBackground = context.getColorCompat(R.color.link_button_primary_background),
+                        colorBorder = context.getColorCompat(R.color.link_button_primary_border),
+                        colorText = context.getColorCompat(R.color.link_button_primary_text)
+                    )
+                )
+                .setBadgeSuccess(
+                    Badge(
+                        colorBackground = context.getColorCompat(R.color.link_badge_success_background),
+                        colorBorder = context.getColorCompat(R.color.link_badge_success_border),
+                        colorText = context.getColorCompat(R.color.link_badge_success_text)
+                    )
+                )
+                .setBadgeNeutral(
+                    Badge(
+                        colorBackground = context.getColorCompat(R.color.link_badge_neutral_background),
+                        colorText = context.getColorCompat(R.color.link_badge_neutral_text)
+                    )
+                )
+                .setCornerRadius(
+                    @Suppress("MagicNumber")
+                    CornerRadius.Builder()
+                        .setBase(5f)
+                        .build()
+                )
+                .build()
         )
 
+        @Suppress("LongMethod")
         private fun dynamicAppearance(context: Context) = AppearanceInfo(
             appearanceId = AppearanceId.Dynamic,
-            appearance = Appearance(
-                colors = Colors(
-                    primary = ContextCompat.getColor(context, R.color.dynamic_colors_primary),
-                    text = ContextCompat.getColor(context, R.color.dynamic_colors_text),
-                    background = ContextCompat.getColor(context, R.color.dynamic_colors_background),
-                    border = ContextCompat.getColor(context, R.color.dynamic_colors_border),
-                    secondaryText = ContextCompat.getColor(context, R.color.dynamic_colors_secondary_text),
-                    actionPrimaryText = ContextCompat.getColor(context, R.color.dynamic_colors_action_primary_text),
-                    actionSecondaryText = ContextCompat.getColor(context, R.color.dynamic_colors_action_secondary_text),
-                    formAccent = ContextCompat.getColor(context, R.color.dynamic_colors_form_accent),
-                    formHighlightBorder = ContextCompat.getColor(context, R.color.dynamic_colors_form_highlight_border),
-                    danger = ContextCompat.getColor(context, R.color.dynamic_colors_danger),
-                    offsetBackground = ContextCompat.getColor(context, R.color.dynamic_colors_offset_background),
-                ),
-                buttonPrimary = Button(
-                    colorBackground = ContextCompat.getColor(context, R.color.dynamic_colors_button_primary_background),
-                    colorBorder = ContextCompat.getColor(context, R.color.dynamic_colors_button_primary_border),
-                    colorText = ContextCompat.getColor(context, R.color.dynamic_colors_button_primary_text)
-                ),
-                buttonSecondary = Button(
-                    colorBackground = ContextCompat.getColor(
-                        context,
-                        R.color.dynamic_colors_button_secondary_background
-                    ),
-                    colorBorder = ContextCompat.getColor(context, R.color.dynamic_colors_button_secondary_border),
-                    colorText = ContextCompat.getColor(context, R.color.dynamic_colors_button_secondary_text)
-                ),
-                badgeSuccess = Badge(
-                    colorBorder = ContextCompat.getColor(context, R.color.dynamic_colors_badge_success_border),
-                    colorText = ContextCompat.getColor(context, R.color.dynamic_colors_badge_success_text)
-                ),
-                badgeNeutral = Badge(
-                    colorBorder = ContextCompat.getColor(context, R.color.dynamic_colors_badge_neutral_border),
-                    colorText = ContextCompat.getColor(context, R.color.dynamic_colors_badge_neutral_text),
-                ),
-                badgeWarning = Badge(
-                    colorBorder = ContextCompat.getColor(context, R.color.dynamic_colors_badge_warning_border),
-                    colorText = ContextCompat.getColor(context, R.color.dynamic_colors_badge_warning_text)
-                ),
-                badgeDanger = Badge(
-                    colorBorder = ContextCompat.getColor(context, R.color.dynamic_colors_badge_danger_border),
-                    colorText = ContextCompat.getColor(context, R.color.dynamic_colors_badge_danger_text)
-                ),
-            )
+            appearance = Appearance.Builder()
+                .setColors(
+                    Colors.Builder()
+                        .setPrimary(context.getColorCompat(R.color.dynamic_colors_primary))
+                        .setText(context.getColorCompat(R.color.dynamic_colors_text))
+                        .setBackground(context.getColorCompat(R.color.dynamic_colors_background))
+                        .setBorder(context.getColorCompat(R.color.dynamic_colors_border))
+                        .setSecondaryText(context.getColorCompat(R.color.dynamic_colors_secondary_text))
+                        .setActionPrimaryText(context.getColorCompat(R.color.dynamic_colors_action_primary_text))
+                        .setActionSecondaryText(context.getColorCompat(R.color.dynamic_colors_action_secondary_text))
+                        .setFormAccent(context.getColorCompat(R.color.dynamic_colors_form_accent))
+                        .setFormHighlightBorder(context.getColorCompat(R.color.dynamic_colors_form_highlight_border))
+                        .setDanger(context.getColorCompat(R.color.dynamic_colors_danger))
+                        .setOffsetBackground(context.getColorCompat(R.color.dynamic_colors_offset_background))
+                        .build()
+                )
+                .setButtonPrimary(
+                    Button(
+                        colorBackground = context.getColorCompat(R.color.dynamic_colors_button_primary_background),
+                        colorBorder = context.getColorCompat(R.color.dynamic_colors_button_primary_border),
+                        colorText = context.getColorCompat(R.color.dynamic_colors_button_primary_text)
+                    )
+                )
+                .setButtonSecondary(
+                    Button(
+                        colorBackground = context.getColorCompat(R.color.dynamic_colors_button_secondary_background),
+                        colorBorder = context.getColorCompat(R.color.dynamic_colors_button_secondary_border),
+                        colorText = context.getColorCompat(R.color.dynamic_colors_button_secondary_text)
+                    )
+                )
+                .setBadgeSuccess(
+                    Badge(
+                        colorBorder = context.getColorCompat(R.color.dynamic_colors_badge_success_border),
+                        colorText = context.getColorCompat(R.color.dynamic_colors_badge_success_text)
+                    )
+                )
+                .setBadgeNeutral(
+                    Badge(
+                        colorBorder = context.getColorCompat(R.color.dynamic_colors_badge_neutral_border),
+                        colorText = context.getColorCompat(R.color.dynamic_colors_badge_neutral_text),
+                    )
+                )
+                .setBadgeWarning(
+                    Badge(
+                        colorBorder = context.getColorCompat(R.color.dynamic_colors_badge_warning_border),
+                        colorText = context.getColorCompat(R.color.dynamic_colors_badge_warning_text)
+                    )
+                )
+                .setBadgeDanger(
+                    Badge(
+                        colorBorder = context.getColorCompat(R.color.dynamic_colors_badge_danger_border),
+                        colorText = context.getColorCompat(R.color.dynamic_colors_badge_danger_text)
+                    )
+                )
+                .build()
         )
 
         private fun customFont() = AppearanceInfo(
-            appearanceId = AppearanceId.Link,
-            appearance = Appearance(
-                typography = Typography(
-                    fontFamily = "doto",
+            appearanceId = AppearanceId.CustomFont,
+            appearance = Appearance.Builder()
+                .setTypography(
+                    Typography.Builder()
+                        .setFontFamily("doto")
+                        .build()
                 )
-            )
+                .build()
         )
+
+        private fun Context.getColorCompat(@ColorRes colorRes: Int): Int =
+            ContextCompat.getColor(this, colorRes)
     }
 }

--- a/connect/api/connect.api
+++ b/connect/api/connect.api
@@ -54,23 +54,27 @@ public final class com/stripe/android/connect/StripeEmbeddedComponentListener$De
 public final class com/stripe/android/connect/appearance/Appearance : android/os/Parcelable {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> ()V
-	public fun <init> (Lcom/stripe/android/connect/appearance/Colors;Lcom/stripe/android/connect/appearance/CornerRadius;Lcom/stripe/android/connect/appearance/Typography;Lcom/stripe/android/connect/appearance/Button;Lcom/stripe/android/connect/appearance/Button;Lcom/stripe/android/connect/appearance/Badge;Lcom/stripe/android/connect/appearance/Badge;Lcom/stripe/android/connect/appearance/Badge;Lcom/stripe/android/connect/appearance/Badge;)V
-	public synthetic fun <init> (Lcom/stripe/android/connect/appearance/Colors;Lcom/stripe/android/connect/appearance/CornerRadius;Lcom/stripe/android/connect/appearance/Typography;Lcom/stripe/android/connect/appearance/Button;Lcom/stripe/android/connect/appearance/Button;Lcom/stripe/android/connect/appearance/Badge;Lcom/stripe/android/connect/appearance/Badge;Lcom/stripe/android/connect/appearance/Badge;Lcom/stripe/android/connect/appearance/Badge;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lcom/stripe/android/connect/appearance/Colors;Lcom/stripe/android/connect/appearance/CornerRadius;Lcom/stripe/android/connect/appearance/Typography;Lcom/stripe/android/connect/appearance/Button;Lcom/stripe/android/connect/appearance/Button;Lcom/stripe/android/connect/appearance/Badge;Lcom/stripe/android/connect/appearance/Badge;Lcom/stripe/android/connect/appearance/Badge;Lcom/stripe/android/connect/appearance/Badge;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getBadgeDanger ()Lcom/stripe/android/connect/appearance/Badge;
-	public final fun getBadgeNeutral ()Lcom/stripe/android/connect/appearance/Badge;
-	public final fun getBadgeSuccess ()Lcom/stripe/android/connect/appearance/Badge;
-	public final fun getBadgeWarning ()Lcom/stripe/android/connect/appearance/Badge;
-	public final fun getButtonPrimary ()Lcom/stripe/android/connect/appearance/Button;
-	public final fun getButtonSecondary ()Lcom/stripe/android/connect/appearance/Button;
-	public final fun getColors ()Lcom/stripe/android/connect/appearance/Colors;
-	public final fun getCornerRadius ()Lcom/stripe/android/connect/appearance/CornerRadius;
-	public final fun getTypography ()Lcom/stripe/android/connect/appearance/Typography;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public final fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/connect/appearance/Appearance$Builder {
+	public static final field $stable I
+	public fun <init> ()V
+	public final fun build ()Lcom/stripe/android/connect/appearance/Appearance;
+	public final fun setBadgeDanger (Lcom/stripe/android/connect/appearance/Badge;)Lcom/stripe/android/connect/appearance/Appearance$Builder;
+	public final fun setBadgeNeutral (Lcom/stripe/android/connect/appearance/Badge;)Lcom/stripe/android/connect/appearance/Appearance$Builder;
+	public final fun setBadgeSuccess (Lcom/stripe/android/connect/appearance/Badge;)Lcom/stripe/android/connect/appearance/Appearance$Builder;
+	public final fun setBadgeWarning (Lcom/stripe/android/connect/appearance/Badge;)Lcom/stripe/android/connect/appearance/Appearance$Builder;
+	public final fun setButtonPrimary (Lcom/stripe/android/connect/appearance/Button;)Lcom/stripe/android/connect/appearance/Appearance$Builder;
+	public final fun setButtonSecondary (Lcom/stripe/android/connect/appearance/Button;)Lcom/stripe/android/connect/appearance/Appearance$Builder;
+	public final fun setColors (Lcom/stripe/android/connect/appearance/Colors;)Lcom/stripe/android/connect/appearance/Appearance$Builder;
+	public final fun setCornerRadius (Lcom/stripe/android/connect/appearance/CornerRadius;)Lcom/stripe/android/connect/appearance/Appearance$Builder;
+	public final fun setTypography (Lcom/stripe/android/connect/appearance/Typography;)Lcom/stripe/android/connect/appearance/Appearance$Builder;
 }
 
 public final class com/stripe/android/connect/appearance/Appearance$Creator : android/os/Parcelable$Creator {
@@ -89,9 +93,6 @@ public final class com/stripe/android/connect/appearance/Badge : android/os/Parc
 	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getColorBackground ()Ljava/lang/Integer;
-	public final fun getColorBorder ()Ljava/lang/Integer;
-	public final fun getColorText ()Ljava/lang/Integer;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public final fun writeToParcel (Landroid/os/Parcel;I)V
@@ -113,9 +114,6 @@ public final class com/stripe/android/connect/appearance/Button : android/os/Par
 	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getColorBackground ()Ljava/lang/Integer;
-	public final fun getColorBorder ()Ljava/lang/Integer;
-	public final fun getColorText ()Ljava/lang/Integer;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public final fun writeToParcel (Landroid/os/Parcel;I)V
@@ -132,26 +130,30 @@ public final class com/stripe/android/connect/appearance/Button$Creator : androi
 public final class com/stripe/android/connect/appearance/Colors : android/os/Parcelable {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> ()V
-	public fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;)V
-	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getActionPrimaryText ()Ljava/lang/Integer;
-	public final fun getActionSecondaryText ()Ljava/lang/Integer;
-	public final fun getBackground ()Ljava/lang/Integer;
-	public final fun getBorder ()Ljava/lang/Integer;
-	public final fun getDanger ()Ljava/lang/Integer;
-	public final fun getFormAccent ()Ljava/lang/Integer;
-	public final fun getFormBackground ()Ljava/lang/Integer;
-	public final fun getFormHighlightBorder ()Ljava/lang/Integer;
-	public final fun getOffsetBackground ()Ljava/lang/Integer;
-	public final fun getPrimary ()Ljava/lang/Integer;
-	public final fun getSecondaryText ()Ljava/lang/Integer;
-	public final fun getText ()Ljava/lang/Integer;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public final fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/connect/appearance/Colors$Builder {
+	public static final field $stable I
+	public fun <init> ()V
+	public final fun build ()Lcom/stripe/android/connect/appearance/Colors;
+	public final fun setActionPrimaryText (Ljava/lang/Integer;)Lcom/stripe/android/connect/appearance/Colors$Builder;
+	public final fun setActionSecondaryText (Ljava/lang/Integer;)Lcom/stripe/android/connect/appearance/Colors$Builder;
+	public final fun setBackground (Ljava/lang/Integer;)Lcom/stripe/android/connect/appearance/Colors$Builder;
+	public final fun setBorder (Ljava/lang/Integer;)Lcom/stripe/android/connect/appearance/Colors$Builder;
+	public final fun setDanger (Ljava/lang/Integer;)Lcom/stripe/android/connect/appearance/Colors$Builder;
+	public final fun setFormAccent (Ljava/lang/Integer;)Lcom/stripe/android/connect/appearance/Colors$Builder;
+	public final fun setFormBackground (Ljava/lang/Integer;)Lcom/stripe/android/connect/appearance/Colors$Builder;
+	public final fun setFormHighlightBorder (Ljava/lang/Integer;)Lcom/stripe/android/connect/appearance/Colors$Builder;
+	public final fun setOffsetBackground (Ljava/lang/Integer;)Lcom/stripe/android/connect/appearance/Colors$Builder;
+	public final fun setPrimary (Ljava/lang/Integer;)Lcom/stripe/android/connect/appearance/Colors$Builder;
+	public final fun setSecondaryText (Ljava/lang/Integer;)Lcom/stripe/android/connect/appearance/Colors$Builder;
+	public final fun setText (Ljava/lang/Integer;)Lcom/stripe/android/connect/appearance/Colors$Builder;
 }
 
 public final class com/stripe/android/connect/appearance/Colors$Creator : android/os/Parcelable$Creator {
@@ -165,19 +167,23 @@ public final class com/stripe/android/connect/appearance/Colors$Creator : androi
 public final class com/stripe/android/connect/appearance/CornerRadius : android/os/Parcelable {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> ()V
-	public fun <init> (Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;)V
-	public synthetic fun <init> (Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getBadge ()Ljava/lang/Float;
-	public final fun getBase ()Ljava/lang/Float;
-	public final fun getButton ()Ljava/lang/Float;
-	public final fun getForm ()Ljava/lang/Float;
-	public final fun getOverlay ()Ljava/lang/Float;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public final fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/connect/appearance/CornerRadius$Builder {
+	public static final field $stable I
+	public fun <init> ()V
+	public final fun build ()Lcom/stripe/android/connect/appearance/CornerRadius;
+	public final fun setBadge (Ljava/lang/Float;)Lcom/stripe/android/connect/appearance/CornerRadius$Builder;
+	public final fun setBase (Ljava/lang/Float;)Lcom/stripe/android/connect/appearance/CornerRadius$Builder;
+	public final fun setButton (Ljava/lang/Float;)Lcom/stripe/android/connect/appearance/CornerRadius$Builder;
+	public final fun setForm (Ljava/lang/Float;)Lcom/stripe/android/connect/appearance/CornerRadius$Builder;
+	public final fun setOverlay (Ljava/lang/Float;)Lcom/stripe/android/connect/appearance/CornerRadius$Builder;
 }
 
 public final class com/stripe/android/connect/appearance/CornerRadius$Creator : android/os/Parcelable$Creator {
@@ -201,25 +207,29 @@ public final class com/stripe/android/connect/appearance/TextTransform : java/la
 public final class com/stripe/android/connect/appearance/Typography : android/os/Parcelable {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/Float;Lcom/stripe/android/connect/appearance/Typography$Style;Lcom/stripe/android/connect/appearance/Typography$Style;Lcom/stripe/android/connect/appearance/Typography$Style;Lcom/stripe/android/connect/appearance/Typography$Style;Lcom/stripe/android/connect/appearance/Typography$Style;Lcom/stripe/android/connect/appearance/Typography$Style;Lcom/stripe/android/connect/appearance/Typography$Style;Lcom/stripe/android/connect/appearance/Typography$Style;Lcom/stripe/android/connect/appearance/Typography$Style;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Float;Lcom/stripe/android/connect/appearance/Typography$Style;Lcom/stripe/android/connect/appearance/Typography$Style;Lcom/stripe/android/connect/appearance/Typography$Style;Lcom/stripe/android/connect/appearance/Typography$Style;Lcom/stripe/android/connect/appearance/Typography$Style;Lcom/stripe/android/connect/appearance/Typography$Style;Lcom/stripe/android/connect/appearance/Typography$Style;Lcom/stripe/android/connect/appearance/Typography$Style;Lcom/stripe/android/connect/appearance/Typography$Style;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Float;Lcom/stripe/android/connect/appearance/Typography$Style;Lcom/stripe/android/connect/appearance/Typography$Style;Lcom/stripe/android/connect/appearance/Typography$Style;Lcom/stripe/android/connect/appearance/Typography$Style;Lcom/stripe/android/connect/appearance/Typography$Style;Lcom/stripe/android/connect/appearance/Typography$Style;Lcom/stripe/android/connect/appearance/Typography$Style;Lcom/stripe/android/connect/appearance/Typography$Style;Lcom/stripe/android/connect/appearance/Typography$Style;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getBodyMd ()Lcom/stripe/android/connect/appearance/Typography$Style;
-	public final fun getBodySm ()Lcom/stripe/android/connect/appearance/Typography$Style;
-	public final fun getFontFamily ()Ljava/lang/String;
-	public final fun getFontSizeBase ()Ljava/lang/Float;
-	public final fun getHeadingLg ()Lcom/stripe/android/connect/appearance/Typography$Style;
-	public final fun getHeadingMd ()Lcom/stripe/android/connect/appearance/Typography$Style;
-	public final fun getHeadingSm ()Lcom/stripe/android/connect/appearance/Typography$Style;
-	public final fun getHeadingXl ()Lcom/stripe/android/connect/appearance/Typography$Style;
-	public final fun getHeadingXs ()Lcom/stripe/android/connect/appearance/Typography$Style;
-	public final fun getLabelMd ()Lcom/stripe/android/connect/appearance/Typography$Style;
-	public final fun getLabelSm ()Lcom/stripe/android/connect/appearance/Typography$Style;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public final fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/connect/appearance/Typography$Builder {
+	public static final field $stable I
+	public fun <init> ()V
+	public final fun build ()Lcom/stripe/android/connect/appearance/Typography;
+	public final fun setBodyMd (Lcom/stripe/android/connect/appearance/Typography$Style;)Lcom/stripe/android/connect/appearance/Typography$Builder;
+	public final fun setBodySm (Lcom/stripe/android/connect/appearance/Typography$Style;)Lcom/stripe/android/connect/appearance/Typography$Builder;
+	public final fun setFontFamily (Ljava/lang/String;)Lcom/stripe/android/connect/appearance/Typography$Builder;
+	public final fun setFontSizeBase (Ljava/lang/Float;)Lcom/stripe/android/connect/appearance/Typography$Builder;
+	public final fun setHeadingLg (Lcom/stripe/android/connect/appearance/Typography$Style;)Lcom/stripe/android/connect/appearance/Typography$Builder;
+	public final fun setHeadingMd (Lcom/stripe/android/connect/appearance/Typography$Style;)Lcom/stripe/android/connect/appearance/Typography$Builder;
+	public final fun setHeadingSm (Lcom/stripe/android/connect/appearance/Typography$Style;)Lcom/stripe/android/connect/appearance/Typography$Builder;
+	public final fun setHeadingXl (Lcom/stripe/android/connect/appearance/Typography$Style;)Lcom/stripe/android/connect/appearance/Typography$Builder;
+	public final fun setHeadingXs (Lcom/stripe/android/connect/appearance/Typography$Style;)Lcom/stripe/android/connect/appearance/Typography$Builder;
+	public final fun setLabelMd (Lcom/stripe/android/connect/appearance/Typography$Style;)Lcom/stripe/android/connect/appearance/Typography$Builder;
+	public final fun setLabelSm (Lcom/stripe/android/connect/appearance/Typography$Style;)Lcom/stripe/android/connect/appearance/Typography$Builder;
 }
 
 public final class com/stripe/android/connect/appearance/Typography$Creator : android/os/Parcelable$Creator {
@@ -237,9 +247,9 @@ public final class com/stripe/android/connect/appearance/Typography$Style : andr
 	public fun <init> (Ljava/lang/Float;Ljava/lang/Integer;Lcom/stripe/android/connect/appearance/TextTransform;)V
 	public synthetic fun <init> (Ljava/lang/Float;Ljava/lang/Integer;Lcom/stripe/android/connect/appearance/TextTransform;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun describeContents ()I
-	public final fun getFontSize ()Ljava/lang/Float;
-	public final fun getFontWeight ()Ljava/lang/Integer;
-	public final fun getTextTransform ()Lcom/stripe/android/connect/appearance/TextTransform;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 	public final fun writeToParcel (Landroid/os/Parcel;I)V
 }
 

--- a/connect/api/connect.api
+++ b/connect/api/connect.api
@@ -65,16 +65,16 @@ public final class com/stripe/android/connect/appearance/Appearance : android/os
 public final class com/stripe/android/connect/appearance/Appearance$Builder {
 	public static final field $stable I
 	public fun <init> ()V
+	public final fun badgeDanger (Lcom/stripe/android/connect/appearance/Badge;)Lcom/stripe/android/connect/appearance/Appearance$Builder;
+	public final fun badgeNeutral (Lcom/stripe/android/connect/appearance/Badge;)Lcom/stripe/android/connect/appearance/Appearance$Builder;
+	public final fun badgeSuccess (Lcom/stripe/android/connect/appearance/Badge;)Lcom/stripe/android/connect/appearance/Appearance$Builder;
+	public final fun badgeWarning (Lcom/stripe/android/connect/appearance/Badge;)Lcom/stripe/android/connect/appearance/Appearance$Builder;
 	public final fun build ()Lcom/stripe/android/connect/appearance/Appearance;
-	public final fun setBadgeDanger (Lcom/stripe/android/connect/appearance/Badge;)Lcom/stripe/android/connect/appearance/Appearance$Builder;
-	public final fun setBadgeNeutral (Lcom/stripe/android/connect/appearance/Badge;)Lcom/stripe/android/connect/appearance/Appearance$Builder;
-	public final fun setBadgeSuccess (Lcom/stripe/android/connect/appearance/Badge;)Lcom/stripe/android/connect/appearance/Appearance$Builder;
-	public final fun setBadgeWarning (Lcom/stripe/android/connect/appearance/Badge;)Lcom/stripe/android/connect/appearance/Appearance$Builder;
-	public final fun setButtonPrimary (Lcom/stripe/android/connect/appearance/Button;)Lcom/stripe/android/connect/appearance/Appearance$Builder;
-	public final fun setButtonSecondary (Lcom/stripe/android/connect/appearance/Button;)Lcom/stripe/android/connect/appearance/Appearance$Builder;
-	public final fun setColors (Lcom/stripe/android/connect/appearance/Colors;)Lcom/stripe/android/connect/appearance/Appearance$Builder;
-	public final fun setCornerRadius (Lcom/stripe/android/connect/appearance/CornerRadius;)Lcom/stripe/android/connect/appearance/Appearance$Builder;
-	public final fun setTypography (Lcom/stripe/android/connect/appearance/Typography;)Lcom/stripe/android/connect/appearance/Appearance$Builder;
+	public final fun buttonPrimary (Lcom/stripe/android/connect/appearance/Button;)Lcom/stripe/android/connect/appearance/Appearance$Builder;
+	public final fun buttonSecondary (Lcom/stripe/android/connect/appearance/Button;)Lcom/stripe/android/connect/appearance/Appearance$Builder;
+	public final fun colors (Lcom/stripe/android/connect/appearance/Colors;)Lcom/stripe/android/connect/appearance/Appearance$Builder;
+	public final fun cornerRadius (Lcom/stripe/android/connect/appearance/CornerRadius;)Lcom/stripe/android/connect/appearance/Appearance$Builder;
+	public final fun typography (Lcom/stripe/android/connect/appearance/Typography;)Lcom/stripe/android/connect/appearance/Appearance$Builder;
 }
 
 public final class com/stripe/android/connect/appearance/Appearance$Creator : android/os/Parcelable$Creator {
@@ -141,19 +141,19 @@ public final class com/stripe/android/connect/appearance/Colors : android/os/Par
 public final class com/stripe/android/connect/appearance/Colors$Builder {
 	public static final field $stable I
 	public fun <init> ()V
+	public final fun actionPrimaryText (Ljava/lang/Integer;)Lcom/stripe/android/connect/appearance/Colors$Builder;
+	public final fun actionSecondaryText (Ljava/lang/Integer;)Lcom/stripe/android/connect/appearance/Colors$Builder;
+	public final fun background (Ljava/lang/Integer;)Lcom/stripe/android/connect/appearance/Colors$Builder;
+	public final fun border (Ljava/lang/Integer;)Lcom/stripe/android/connect/appearance/Colors$Builder;
 	public final fun build ()Lcom/stripe/android/connect/appearance/Colors;
-	public final fun setActionPrimaryText (Ljava/lang/Integer;)Lcom/stripe/android/connect/appearance/Colors$Builder;
-	public final fun setActionSecondaryText (Ljava/lang/Integer;)Lcom/stripe/android/connect/appearance/Colors$Builder;
-	public final fun setBackground (Ljava/lang/Integer;)Lcom/stripe/android/connect/appearance/Colors$Builder;
-	public final fun setBorder (Ljava/lang/Integer;)Lcom/stripe/android/connect/appearance/Colors$Builder;
-	public final fun setDanger (Ljava/lang/Integer;)Lcom/stripe/android/connect/appearance/Colors$Builder;
-	public final fun setFormAccent (Ljava/lang/Integer;)Lcom/stripe/android/connect/appearance/Colors$Builder;
-	public final fun setFormBackground (Ljava/lang/Integer;)Lcom/stripe/android/connect/appearance/Colors$Builder;
-	public final fun setFormHighlightBorder (Ljava/lang/Integer;)Lcom/stripe/android/connect/appearance/Colors$Builder;
-	public final fun setOffsetBackground (Ljava/lang/Integer;)Lcom/stripe/android/connect/appearance/Colors$Builder;
-	public final fun setPrimary (Ljava/lang/Integer;)Lcom/stripe/android/connect/appearance/Colors$Builder;
-	public final fun setSecondaryText (Ljava/lang/Integer;)Lcom/stripe/android/connect/appearance/Colors$Builder;
-	public final fun setText (Ljava/lang/Integer;)Lcom/stripe/android/connect/appearance/Colors$Builder;
+	public final fun danger (Ljava/lang/Integer;)Lcom/stripe/android/connect/appearance/Colors$Builder;
+	public final fun formAccent (Ljava/lang/Integer;)Lcom/stripe/android/connect/appearance/Colors$Builder;
+	public final fun formBackground (Ljava/lang/Integer;)Lcom/stripe/android/connect/appearance/Colors$Builder;
+	public final fun formHighlightBorder (Ljava/lang/Integer;)Lcom/stripe/android/connect/appearance/Colors$Builder;
+	public final fun offsetBackground (Ljava/lang/Integer;)Lcom/stripe/android/connect/appearance/Colors$Builder;
+	public final fun primary (Ljava/lang/Integer;)Lcom/stripe/android/connect/appearance/Colors$Builder;
+	public final fun secondaryText (Ljava/lang/Integer;)Lcom/stripe/android/connect/appearance/Colors$Builder;
+	public final fun text (Ljava/lang/Integer;)Lcom/stripe/android/connect/appearance/Colors$Builder;
 }
 
 public final class com/stripe/android/connect/appearance/Colors$Creator : android/os/Parcelable$Creator {
@@ -178,12 +178,12 @@ public final class com/stripe/android/connect/appearance/CornerRadius : android/
 public final class com/stripe/android/connect/appearance/CornerRadius$Builder {
 	public static final field $stable I
 	public fun <init> ()V
+	public final fun badge (Ljava/lang/Float;)Lcom/stripe/android/connect/appearance/CornerRadius$Builder;
+	public final fun base (Ljava/lang/Float;)Lcom/stripe/android/connect/appearance/CornerRadius$Builder;
 	public final fun build ()Lcom/stripe/android/connect/appearance/CornerRadius;
-	public final fun setBadge (Ljava/lang/Float;)Lcom/stripe/android/connect/appearance/CornerRadius$Builder;
-	public final fun setBase (Ljava/lang/Float;)Lcom/stripe/android/connect/appearance/CornerRadius$Builder;
-	public final fun setButton (Ljava/lang/Float;)Lcom/stripe/android/connect/appearance/CornerRadius$Builder;
-	public final fun setForm (Ljava/lang/Float;)Lcom/stripe/android/connect/appearance/CornerRadius$Builder;
-	public final fun setOverlay (Ljava/lang/Float;)Lcom/stripe/android/connect/appearance/CornerRadius$Builder;
+	public final fun button (Ljava/lang/Float;)Lcom/stripe/android/connect/appearance/CornerRadius$Builder;
+	public final fun form (Ljava/lang/Float;)Lcom/stripe/android/connect/appearance/CornerRadius$Builder;
+	public final fun overlay (Ljava/lang/Float;)Lcom/stripe/android/connect/appearance/CornerRadius$Builder;
 }
 
 public final class com/stripe/android/connect/appearance/CornerRadius$Creator : android/os/Parcelable$Creator {
@@ -218,18 +218,18 @@ public final class com/stripe/android/connect/appearance/Typography : android/os
 public final class com/stripe/android/connect/appearance/Typography$Builder {
 	public static final field $stable I
 	public fun <init> ()V
+	public final fun bodyMd (Lcom/stripe/android/connect/appearance/Typography$Style;)Lcom/stripe/android/connect/appearance/Typography$Builder;
+	public final fun bodySm (Lcom/stripe/android/connect/appearance/Typography$Style;)Lcom/stripe/android/connect/appearance/Typography$Builder;
 	public final fun build ()Lcom/stripe/android/connect/appearance/Typography;
-	public final fun setBodyMd (Lcom/stripe/android/connect/appearance/Typography$Style;)Lcom/stripe/android/connect/appearance/Typography$Builder;
-	public final fun setBodySm (Lcom/stripe/android/connect/appearance/Typography$Style;)Lcom/stripe/android/connect/appearance/Typography$Builder;
-	public final fun setFontFamily (Ljava/lang/String;)Lcom/stripe/android/connect/appearance/Typography$Builder;
-	public final fun setFontSizeBase (Ljava/lang/Float;)Lcom/stripe/android/connect/appearance/Typography$Builder;
-	public final fun setHeadingLg (Lcom/stripe/android/connect/appearance/Typography$Style;)Lcom/stripe/android/connect/appearance/Typography$Builder;
-	public final fun setHeadingMd (Lcom/stripe/android/connect/appearance/Typography$Style;)Lcom/stripe/android/connect/appearance/Typography$Builder;
-	public final fun setHeadingSm (Lcom/stripe/android/connect/appearance/Typography$Style;)Lcom/stripe/android/connect/appearance/Typography$Builder;
-	public final fun setHeadingXl (Lcom/stripe/android/connect/appearance/Typography$Style;)Lcom/stripe/android/connect/appearance/Typography$Builder;
-	public final fun setHeadingXs (Lcom/stripe/android/connect/appearance/Typography$Style;)Lcom/stripe/android/connect/appearance/Typography$Builder;
-	public final fun setLabelMd (Lcom/stripe/android/connect/appearance/Typography$Style;)Lcom/stripe/android/connect/appearance/Typography$Builder;
-	public final fun setLabelSm (Lcom/stripe/android/connect/appearance/Typography$Style;)Lcom/stripe/android/connect/appearance/Typography$Builder;
+	public final fun fontFamily (Ljava/lang/String;)Lcom/stripe/android/connect/appearance/Typography$Builder;
+	public final fun fontSizeBase (Ljava/lang/Float;)Lcom/stripe/android/connect/appearance/Typography$Builder;
+	public final fun headingLg (Lcom/stripe/android/connect/appearance/Typography$Style;)Lcom/stripe/android/connect/appearance/Typography$Builder;
+	public final fun headingMd (Lcom/stripe/android/connect/appearance/Typography$Style;)Lcom/stripe/android/connect/appearance/Typography$Builder;
+	public final fun headingSm (Lcom/stripe/android/connect/appearance/Typography$Style;)Lcom/stripe/android/connect/appearance/Typography$Builder;
+	public final fun headingXl (Lcom/stripe/android/connect/appearance/Typography$Style;)Lcom/stripe/android/connect/appearance/Typography$Builder;
+	public final fun headingXs (Lcom/stripe/android/connect/appearance/Typography$Style;)Lcom/stripe/android/connect/appearance/Typography$Builder;
+	public final fun labelMd (Lcom/stripe/android/connect/appearance/Typography$Style;)Lcom/stripe/android/connect/appearance/Typography$Builder;
+	public final fun labelSm (Lcom/stripe/android/connect/appearance/Typography$Style;)Lcom/stripe/android/connect/appearance/Typography$Builder;
 }
 
 public final class com/stripe/android/connect/appearance/Typography$Creator : android/os/Parcelable$Creator {

--- a/connect/src/main/java/com/stripe/android/connect/EmbeddedComponentManager.kt
+++ b/connect/src/main/java/com/stripe/android/connect/EmbeddedComponentManager.kt
@@ -16,7 +16,7 @@ import kotlinx.parcelize.Parcelize
 class EmbeddedComponentManager @JvmOverloads constructor(
     configuration: Configuration,
     fetchClientSecretCallback: FetchClientSecretCallback,
-    appearance: Appearance = Appearance(),
+    appearance: Appearance = Appearance.default(),
     customFonts: List<CustomFontSource> = emptyList(),
 ) {
     internal val coordinator: EmbeddedComponentCoordinator =

--- a/connect/src/main/java/com/stripe/android/connect/appearance/Appearance.kt
+++ b/connect/src/main/java/com/stripe/android/connect/appearance/Appearance.kt
@@ -34,55 +34,55 @@ class Appearance private constructor(
         /**
          * Describes the colors used in embedded components.
          */
-        fun setColors(colors: Colors) =
+        fun colors(colors: Colors) =
             apply { this.colors = colors }
 
         /**
          * Describes the corner radius used in embedded components.
          */
-        fun setCornerRadius(cornerRadius: CornerRadius) =
+        fun cornerRadius(cornerRadius: CornerRadius) =
             apply { this.cornerRadius = cornerRadius }
 
         /**
          * Describes the typography used for text.
          */
-        fun setTypography(typography: Typography) =
+        fun typography(typography: Typography) =
             apply { this.typography = typography }
 
         /**
          * Describes the primary button appearance settings.
          */
-        fun setButtonPrimary(buttonPrimary: Button) =
+        fun buttonPrimary(buttonPrimary: Button) =
             apply { this.buttonPrimary = buttonPrimary }
 
         /**
          * Describes the secondary button appearance settings.
          */
-        fun setButtonSecondary(buttonSecondary: Button) =
+        fun buttonSecondary(buttonSecondary: Button) =
             apply { this.buttonSecondary = buttonSecondary }
 
         /**
          * Describes the neutral badge appearance settings.
          */
-        fun setBadgeNeutral(badgeNeutral: Badge) =
+        fun badgeNeutral(badgeNeutral: Badge) =
             apply { this.badgeNeutral = badgeNeutral }
 
         /**
          * Describes the success badge appearance settings.
          */
-        fun setBadgeSuccess(badgeSuccess: Badge) =
+        fun badgeSuccess(badgeSuccess: Badge) =
             apply { this.badgeSuccess = badgeSuccess }
 
         /**
          * Describes the warning badge appearance settings.
          */
-        fun setBadgeWarning(badgeWarning: Badge) =
+        fun badgeWarning(badgeWarning: Badge) =
             apply { this.badgeWarning = badgeWarning }
 
         /**
          * Describes the danger badge appearance settings.
          */
-        fun setBadgeDanger(badgeDanger: Badge) =
+        fun badgeDanger(badgeDanger: Badge) =
             apply { this.badgeDanger = badgeDanger }
 
         fun build(): Appearance {

--- a/connect/src/main/java/com/stripe/android/connect/appearance/Appearance.kt
+++ b/connect/src/main/java/com/stripe/android/connect/appearance/Appearance.kt
@@ -8,49 +8,99 @@ import kotlinx.parcelize.Parcelize
 @PrivateBetaConnectSDK
 @Parcelize
 @Poko
-class Appearance(
-    /**
-     * Describes the colors used in embedded components.
-     */
-    val colors: Colors = Colors.default,
+class Appearance private constructor(
+    internal val colors: Colors,
+    internal val cornerRadius: CornerRadius,
+    internal val typography: Typography,
+    internal val buttonPrimary: Button,
+    internal val buttonSecondary: Button,
+    internal val badgeNeutral: Badge,
+    internal val badgeSuccess: Badge,
+    internal val badgeWarning: Badge,
+    internal val badgeDanger: Badge,
+) : Parcelable {
 
-    /**
-     * Describes the corner radius used in embedded components.
-     */
-    val cornerRadius: CornerRadius = CornerRadius.default,
+    class Builder {
+        private var colors: Colors = Colors.default()
+        private var cornerRadius: CornerRadius = CornerRadius.default()
+        private var typography: Typography = Typography.default()
+        private var buttonPrimary: Button = Button.default()
+        private var buttonSecondary: Button = Button.default()
+        private var badgeNeutral: Badge = Badge.default()
+        private var badgeSuccess: Badge = Badge.default()
+        private var badgeWarning: Badge = Badge.default()
+        private var badgeDanger: Badge = Badge.default()
 
-    /**
-     * Describes the typography used for text.
-     */
-    val typography: Typography = Typography.default,
+        /**
+         * Describes the colors used in embedded components.
+         */
+        fun setColors(colors: Colors) =
+            apply { this.colors = colors }
 
-    /**
-     * Describes the primary button appearance settings.
-     */
-    val buttonPrimary: Button = Button.default,
+        /**
+         * Describes the corner radius used in embedded components.
+         */
+        fun setCornerRadius(cornerRadius: CornerRadius) =
+            apply { this.cornerRadius = cornerRadius }
 
-    /**
-     * Describes the secondary button appearance settings.
-     */
-    val buttonSecondary: Button = Button.default,
+        /**
+         * Describes the typography used for text.
+         */
+        fun setTypography(typography: Typography) =
+            apply { this.typography = typography }
 
-    /**
-     * Describes the neutral badge appearance settings.
-     */
-    val badgeNeutral: Badge = Badge.default,
+        /**
+         * Describes the primary button appearance settings.
+         */
+        fun setButtonPrimary(buttonPrimary: Button) =
+            apply { this.buttonPrimary = buttonPrimary }
 
-    /**
-     * Describes the success badge appearance settings.
-     */
-    val badgeSuccess: Badge = Badge.default,
+        /**
+         * Describes the secondary button appearance settings.
+         */
+        fun setButtonSecondary(buttonSecondary: Button) =
+            apply { this.buttonSecondary = buttonSecondary }
 
-    /**
-     * Describes the warning badge appearance settings.
-     */
-    val badgeWarning: Badge = Badge.default,
+        /**
+         * Describes the neutral badge appearance settings.
+         */
+        fun setBadgeNeutral(badgeNeutral: Badge) =
+            apply { this.badgeNeutral = badgeNeutral }
 
-    /**
-     * Describes the danger badge appearance settings.
-     */
-    val badgeDanger: Badge = Badge.default,
-) : Parcelable
+        /**
+         * Describes the success badge appearance settings.
+         */
+        fun setBadgeSuccess(badgeSuccess: Badge) =
+            apply { this.badgeSuccess = badgeSuccess }
+
+        /**
+         * Describes the warning badge appearance settings.
+         */
+        fun setBadgeWarning(badgeWarning: Badge) =
+            apply { this.badgeWarning = badgeWarning }
+
+        /**
+         * Describes the danger badge appearance settings.
+         */
+        fun setBadgeDanger(badgeDanger: Badge) =
+            apply { this.badgeDanger = badgeDanger }
+
+        fun build(): Appearance {
+            return Appearance(
+                colors = colors,
+                cornerRadius = cornerRadius,
+                typography = typography,
+                buttonPrimary = buttonPrimary,
+                buttonSecondary = buttonSecondary,
+                badgeNeutral = badgeNeutral,
+                badgeSuccess = badgeSuccess,
+                badgeWarning = badgeWarning,
+                badgeDanger = badgeDanger
+            )
+        }
+    }
+
+    internal companion object {
+        internal fun default() = Builder().build()
+    }
+}

--- a/connect/src/main/java/com/stripe/android/connect/appearance/Appearance.kt
+++ b/connect/src/main/java/com/stripe/android/connect/appearance/Appearance.kt
@@ -34,55 +34,55 @@ class Appearance private constructor(
         /**
          * Describes the colors used in embedded components.
          */
-        fun colors(colors: Colors) =
+        fun colors(colors: Colors): Builder =
             apply { this.colors = colors }
 
         /**
          * Describes the corner radius used in embedded components.
          */
-        fun cornerRadius(cornerRadius: CornerRadius) =
+        fun cornerRadius(cornerRadius: CornerRadius): Builder =
             apply { this.cornerRadius = cornerRadius }
 
         /**
          * Describes the typography used for text.
          */
-        fun typography(typography: Typography) =
+        fun typography(typography: Typography): Builder =
             apply { this.typography = typography }
 
         /**
          * Describes the primary button appearance settings.
          */
-        fun buttonPrimary(buttonPrimary: Button) =
+        fun buttonPrimary(buttonPrimary: Button): Builder =
             apply { this.buttonPrimary = buttonPrimary }
 
         /**
          * Describes the secondary button appearance settings.
          */
-        fun buttonSecondary(buttonSecondary: Button) =
+        fun buttonSecondary(buttonSecondary: Button): Builder =
             apply { this.buttonSecondary = buttonSecondary }
 
         /**
          * Describes the neutral badge appearance settings.
          */
-        fun badgeNeutral(badgeNeutral: Badge) =
+        fun badgeNeutral(badgeNeutral: Badge): Builder =
             apply { this.badgeNeutral = badgeNeutral }
 
         /**
          * Describes the success badge appearance settings.
          */
-        fun badgeSuccess(badgeSuccess: Badge) =
+        fun badgeSuccess(badgeSuccess: Badge): Builder =
             apply { this.badgeSuccess = badgeSuccess }
 
         /**
          * Describes the warning badge appearance settings.
          */
-        fun badgeWarning(badgeWarning: Badge) =
+        fun badgeWarning(badgeWarning: Badge): Builder =
             apply { this.badgeWarning = badgeWarning }
 
         /**
          * Describes the danger badge appearance settings.
          */
-        fun badgeDanger(badgeDanger: Badge) =
+        fun badgeDanger(badgeDanger: Badge): Builder =
             apply { this.badgeDanger = badgeDanger }
 
         fun build(): Appearance {

--- a/connect/src/main/java/com/stripe/android/connect/appearance/Badge.kt
+++ b/connect/src/main/java/com/stripe/android/connect/appearance/Badge.kt
@@ -6,26 +6,20 @@ import com.stripe.android.connect.PrivateBetaConnectSDK
 import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
+/**
+ * @param colorBackground The background color of the badge. If null the default will be used.
+ * @param colorBorder The border color of the badge. If null the default will be used.
+ * @param colorText The text color of the badge. If null the default will be used.
+ */
 @PrivateBetaConnectSDK
 @Parcelize
 @Poko
 class Badge(
-    /**
-     * The background color of the badge. If null the default will be used.
-     */
-    @ColorInt val colorBackground: Int? = null,
-
-    /**
-     * The text color of the badge. If null the default will be used.
-     */
-    @ColorInt val colorText: Int? = null,
-
-    /**
-     * The border color of the badge. If null the default will be used.
-     */
-    @ColorInt val colorBorder: Int? = null,
+    @ColorInt internal val colorBackground: Int? = null,
+    @ColorInt internal val colorBorder: Int? = null,
+    @ColorInt internal val colorText: Int? = null,
 ) : Parcelable {
     internal companion object {
-        internal val default = Badge()
+        internal fun default() = Badge()
     }
 }

--- a/connect/src/main/java/com/stripe/android/connect/appearance/Button.kt
+++ b/connect/src/main/java/com/stripe/android/connect/appearance/Button.kt
@@ -6,26 +6,20 @@ import com.stripe.android.connect.PrivateBetaConnectSDK
 import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
+/**
+ * @param colorBackground The background color of the button. If null the default will be used.
+ * @param colorBorder The border color of the button. If null the default will be used.
+ * @param colorText The text color of the button. If null the default will be used.
+ */
 @PrivateBetaConnectSDK
 @Parcelize
 @Poko
 class Button(
-    /**
-     * The background color of the button. If null the default will be used.
-     */
-    @ColorInt val colorBackground: Int? = null,
-
-    /**
-     * The border color of the button. If null the default will be used.
-     */
-    @ColorInt val colorBorder: Int? = null,
-
-    /**
-     * The text color of the button. If null the default will be used.
-     */
-    @ColorInt val colorText: Int? = null,
+    @ColorInt internal val colorBackground: Int? = null,
+    @ColorInt internal val colorBorder: Int? = null,
+    @ColorInt internal val colorText: Int? = null,
 ) : Parcelable {
     internal companion object {
-        internal val default = Button()
+        internal fun default() = Button()
     }
 }

--- a/connect/src/main/java/com/stripe/android/connect/appearance/Colors.kt
+++ b/connect/src/main/java/com/stripe/android/connect/appearance/Colors.kt
@@ -53,74 +53,74 @@ class Colors private constructor(
         /**
          * The primary color used throughout the components. If null the default will be used.
          */
-        fun primary(@ColorInt primary: Int?) =
+        fun primary(@ColorInt primary: Int?): Builder =
             apply { this.primary = primary }
 
         /**
          * The background color for components. If null the default will be used.
          */
-        fun background(@ColorInt background: Int?) =
+        fun background(@ColorInt background: Int?): Builder =
             apply { this.background = background }
 
         /**
          * The primary text color used for regular content. If null the default will be used.
          */
-        fun text(@ColorInt text: Int?) =
+        fun text(@ColorInt text: Int?): Builder =
             apply { this.text = text }
 
         /**
          * The secondary text color used for less emphasized content. If null the default will be used.
          */
-        fun secondaryText(@ColorInt secondaryText: Int?) =
+        fun secondaryText(@ColorInt secondaryText: Int?): Builder =
             apply { this.secondaryText = secondaryText }
 
         /**
          * The color used to indicate errors or destructive actions. If null the default will be used.
          */
-        fun danger(@ColorInt danger: Int?) =
+        fun danger(@ColorInt danger: Int?): Builder =
             apply { this.danger = danger }
 
         /**
          * The color used for component borders. If null the default will be used.
          */
-        fun border(@ColorInt border: Int?) =
+        fun border(@ColorInt border: Int?): Builder =
             apply { this.border = border }
 
         /**
          * The color used for primary actions and link text. If null the default will be used.
          */
-        fun actionPrimaryText(@ColorInt actionPrimaryText: Int?) =
+        fun actionPrimaryText(@ColorInt actionPrimaryText: Int?): Builder =
             apply { this.actionPrimaryText = actionPrimaryText }
 
         /**
          * The color used for secondary actions and link text. If null the default will be used.
          */
-        fun actionSecondaryText(@ColorInt actionSecondaryText: Int?) =
+        fun actionSecondaryText(@ColorInt actionSecondaryText: Int?): Builder =
             apply { this.actionSecondaryText = actionSecondaryText }
 
         /**
          * The background color used to highlight information. If null the default will be used.
          */
-        fun offsetBackground(@ColorInt offsetBackground: Int?) =
+        fun offsetBackground(@ColorInt offsetBackground: Int?): Builder =
             apply { this.offsetBackground = offsetBackground }
 
         /**
          * The background color used for form fields. If null the default will be used.
          */
-        fun formBackground(@ColorInt formBackground: Int?) =
+        fun formBackground(@ColorInt formBackground: Int?): Builder =
             apply { this.formBackground = formBackground }
 
         /**
          * The border color used to highlight form items when focused. If null the default will be used.
          */
-        fun formHighlightBorder(@ColorInt formHighlightBorder: Int?) =
+        fun formHighlightBorder(@ColorInt formHighlightBorder: Int?): Builder =
             apply { this.formHighlightBorder = formHighlightBorder }
 
         /**
          * The accent color used for filling form elements like checkboxes or radio buttons.
          * If null the default will be used.
          */
-        fun formAccent(@ColorInt formAccent: Int?) =
+        fun formAccent(@ColorInt formAccent: Int?): Builder =
             apply { this.formAccent = formAccent }
 
         fun build(): Colors {

--- a/connect/src/main/java/com/stripe/android/connect/appearance/Colors.kt
+++ b/connect/src/main/java/com/stripe/android/connect/appearance/Colors.kt
@@ -9,69 +9,139 @@ import kotlinx.parcelize.Parcelize
 @PrivateBetaConnectSDK
 @Parcelize
 @Poko
-class Colors(
-    /**
-     * The primary color used throughout the components. If null the default will be used.
-     */
-    @ColorInt val primary: Int? = null,
-
-    /**
-     * The background color for components. If null the default will be used.
-     */
-    @ColorInt val background: Int? = null,
-
-    /**
-     * The primary text color used for regular content. If null the default will be used.
-     */
-    @ColorInt val text: Int? = null,
-
-    /**
-     * The secondary text color used for less emphasized content. If null the default will be used.
-     */
-    @ColorInt val secondaryText: Int? = null,
-
-    /**
-     * The color used to indicate errors or destructive actions. If null the default will be used.
-     */
-    @ColorInt val danger: Int? = null,
-
-    /**
-     * The color used for component borders. If null the default will be used.
-     */
-    @ColorInt val border: Int? = null,
-
-    /**
-     * The color used for primary actions and link text. If null the default will be used.
-     */
-    @ColorInt val actionPrimaryText: Int? = null,
-
-    /**
-     * The color used for secondary actions and link text. If null the default will be used.
-     */
-    @ColorInt val actionSecondaryText: Int? = null,
-
-    /**
-     * The background color used to highlight information. If null the default will be used.
-     */
-    @ColorInt val offsetBackground: Int? = null,
-
-    /**
-     * The background color used for form fields. If null the default will be used.
-     */
-    @ColorInt val formBackground: Int? = null,
-
-    /**
-     * The border color used to highlight form items when focused. If null the default will be used.
-     */
-    @ColorInt val formHighlightBorder: Int? = null,
-
-    /**
-     * The accent color used for filling form elements like checkboxes or radio buttons.
-     * If null the default will be used.
-     */
-    @ColorInt val formAccent: Int? = null,
+class Colors private constructor(
+    @ColorInt internal val primary: Int?,
+    @ColorInt internal val background: Int?,
+    @ColorInt internal val text: Int?,
+    @ColorInt internal val secondaryText: Int?,
+    @ColorInt internal val danger: Int?,
+    @ColorInt internal val border: Int?,
+    @ColorInt internal val actionPrimaryText: Int?,
+    @ColorInt internal val actionSecondaryText: Int?,
+    @ColorInt internal val offsetBackground: Int?,
+    @ColorInt internal val formBackground: Int?,
+    @ColorInt internal val formHighlightBorder: Int?,
+    @ColorInt internal val formAccent: Int?
 ) : Parcelable {
+
+    @Suppress("TooManyFunctions")
+    class Builder {
+        @ColorInt private var primary: Int? = null
+
+        @ColorInt private var background: Int? = null
+
+        @ColorInt private var text: Int? = null
+
+        @ColorInt private var secondaryText: Int? = null
+
+        @ColorInt private var danger: Int? = null
+
+        @ColorInt private var border: Int? = null
+
+        @ColorInt private var actionPrimaryText: Int? = null
+
+        @ColorInt private var actionSecondaryText: Int? = null
+
+        @ColorInt private var offsetBackground: Int? = null
+
+        @ColorInt private var formBackground: Int? = null
+
+        @ColorInt private var formHighlightBorder: Int? = null
+
+        @ColorInt private var formAccent: Int? = null
+
+        /**
+         * The primary color used throughout the components. If null the default will be used.
+         */
+        fun setPrimary(@ColorInt primary: Int?) =
+            apply { this.primary = primary }
+
+        /**
+         * The background color for components. If null the default will be used.
+         */
+        fun setBackground(@ColorInt background: Int?) =
+            apply { this.background = background }
+
+        /**
+         * The primary text color used for regular content. If null the default will be used.
+         */
+        fun setText(@ColorInt text: Int?) =
+            apply { this.text = text }
+
+        /**
+         * The secondary text color used for less emphasized content. If null the default will be used.
+         */
+        fun setSecondaryText(@ColorInt secondaryText: Int?) =
+            apply { this.secondaryText = secondaryText }
+
+        /**
+         * The color used to indicate errors or destructive actions. If null the default will be used.
+         */
+        fun setDanger(@ColorInt danger: Int?) =
+            apply { this.danger = danger }
+
+        /**
+         * The color used for component borders. If null the default will be used.
+         */
+        fun setBorder(@ColorInt border: Int?) =
+            apply { this.border = border }
+
+        /**
+         * The color used for primary actions and link text. If null the default will be used.
+         */
+        fun setActionPrimaryText(@ColorInt actionPrimaryText: Int?) =
+            apply { this.actionPrimaryText = actionPrimaryText }
+
+        /**
+         * The color used for secondary actions and link text. If null the default will be used.
+         */
+        fun setActionSecondaryText(@ColorInt actionSecondaryText: Int?) =
+            apply { this.actionSecondaryText = actionSecondaryText }
+
+        /**
+         * The background color used to highlight information. If null the default will be used.
+         */
+        fun setOffsetBackground(@ColorInt offsetBackground: Int?) =
+            apply { this.offsetBackground = offsetBackground }
+
+        /**
+         * The background color used for form fields. If null the default will be used.
+         */
+        fun setFormBackground(@ColorInt formBackground: Int?) =
+            apply { this.formBackground = formBackground }
+
+        /**
+         * The border color used to highlight form items when focused. If null the default will be used.
+         */
+        fun setFormHighlightBorder(@ColorInt formHighlightBorder: Int?) =
+            apply { this.formHighlightBorder = formHighlightBorder }
+
+        /**
+         * The accent color used for filling form elements like checkboxes or radio buttons.
+         * If null the default will be used.
+         */
+        fun setFormAccent(@ColorInt formAccent: Int?) =
+            apply { this.formAccent = formAccent }
+
+        fun build(): Colors {
+            return Colors(
+                primary = primary,
+                background = background,
+                text = text,
+                secondaryText = secondaryText,
+                danger = danger,
+                border = border,
+                actionPrimaryText = actionPrimaryText,
+                actionSecondaryText = actionSecondaryText,
+                offsetBackground = offsetBackground,
+                formBackground = formBackground,
+                formHighlightBorder = formHighlightBorder,
+                formAccent = formAccent
+            )
+        }
+    }
+
     internal companion object {
-        internal val default = Colors()
+        internal fun default() = Builder().build()
     }
 }

--- a/connect/src/main/java/com/stripe/android/connect/appearance/Colors.kt
+++ b/connect/src/main/java/com/stripe/android/connect/appearance/Colors.kt
@@ -53,74 +53,74 @@ class Colors private constructor(
         /**
          * The primary color used throughout the components. If null the default will be used.
          */
-        fun setPrimary(@ColorInt primary: Int?) =
+        fun primary(@ColorInt primary: Int?) =
             apply { this.primary = primary }
 
         /**
          * The background color for components. If null the default will be used.
          */
-        fun setBackground(@ColorInt background: Int?) =
+        fun background(@ColorInt background: Int?) =
             apply { this.background = background }
 
         /**
          * The primary text color used for regular content. If null the default will be used.
          */
-        fun setText(@ColorInt text: Int?) =
+        fun text(@ColorInt text: Int?) =
             apply { this.text = text }
 
         /**
          * The secondary text color used for less emphasized content. If null the default will be used.
          */
-        fun setSecondaryText(@ColorInt secondaryText: Int?) =
+        fun secondaryText(@ColorInt secondaryText: Int?) =
             apply { this.secondaryText = secondaryText }
 
         /**
          * The color used to indicate errors or destructive actions. If null the default will be used.
          */
-        fun setDanger(@ColorInt danger: Int?) =
+        fun danger(@ColorInt danger: Int?) =
             apply { this.danger = danger }
 
         /**
          * The color used for component borders. If null the default will be used.
          */
-        fun setBorder(@ColorInt border: Int?) =
+        fun border(@ColorInt border: Int?) =
             apply { this.border = border }
 
         /**
          * The color used for primary actions and link text. If null the default will be used.
          */
-        fun setActionPrimaryText(@ColorInt actionPrimaryText: Int?) =
+        fun actionPrimaryText(@ColorInt actionPrimaryText: Int?) =
             apply { this.actionPrimaryText = actionPrimaryText }
 
         /**
          * The color used for secondary actions and link text. If null the default will be used.
          */
-        fun setActionSecondaryText(@ColorInt actionSecondaryText: Int?) =
+        fun actionSecondaryText(@ColorInt actionSecondaryText: Int?) =
             apply { this.actionSecondaryText = actionSecondaryText }
 
         /**
          * The background color used to highlight information. If null the default will be used.
          */
-        fun setOffsetBackground(@ColorInt offsetBackground: Int?) =
+        fun offsetBackground(@ColorInt offsetBackground: Int?) =
             apply { this.offsetBackground = offsetBackground }
 
         /**
          * The background color used for form fields. If null the default will be used.
          */
-        fun setFormBackground(@ColorInt formBackground: Int?) =
+        fun formBackground(@ColorInt formBackground: Int?) =
             apply { this.formBackground = formBackground }
 
         /**
          * The border color used to highlight form items when focused. If null the default will be used.
          */
-        fun setFormHighlightBorder(@ColorInt formHighlightBorder: Int?) =
+        fun formHighlightBorder(@ColorInt formHighlightBorder: Int?) =
             apply { this.formHighlightBorder = formHighlightBorder }
 
         /**
          * The accent color used for filling form elements like checkboxes or radio buttons.
          * If null the default will be used.
          */
-        fun setFormAccent(@ColorInt formAccent: Int?) =
+        fun formAccent(@ColorInt formAccent: Int?) =
             apply { this.formAccent = formAccent }
 
         fun build(): Colors {

--- a/connect/src/main/java/com/stripe/android/connect/appearance/CornerRadius.kt
+++ b/connect/src/main/java/com/stripe/android/connect/appearance/CornerRadius.kt
@@ -26,31 +26,31 @@ class CornerRadius private constructor(
         /**
          * The general border radius used throughout the components in dp.
          */
-        fun setBase(base: Float?) =
+        fun base(base: Float?) =
             apply { this.base = base }
 
         /**
          * The corner radius used specifically for buttons in dp.
          */
-        fun setButton(button: Float?) =
+        fun button(button: Float?) =
             apply { this.button = button }
 
         /**
          * The corner radius used specifically for badges in dp.
          */
-        fun setBadge(badge: Float?) =
+        fun badge(badge: Float?) =
             apply { this.badge = badge }
 
         /**
          * The corner radius used for overlays in dp.
          */
-        fun setOverlay(overlay: Float?) =
+        fun overlay(overlay: Float?) =
             apply { this.overlay = overlay }
 
         /**
          * The corner radius used for form elements in dp.
          */
-        fun setForm(form: Float?) =
+        fun form(form: Float?) =
             apply { this.form = form }
 
         fun build(): CornerRadius {

--- a/connect/src/main/java/com/stripe/android/connect/appearance/CornerRadius.kt
+++ b/connect/src/main/java/com/stripe/android/connect/appearance/CornerRadius.kt
@@ -26,31 +26,31 @@ class CornerRadius private constructor(
         /**
          * The general border radius used throughout the components in dp.
          */
-        fun base(base: Float?) =
+        fun base(base: Float?): Builder =
             apply { this.base = base }
 
         /**
          * The corner radius used specifically for buttons in dp.
          */
-        fun button(button: Float?) =
+        fun button(button: Float?): Builder =
             apply { this.button = button }
 
         /**
          * The corner radius used specifically for badges in dp.
          */
-        fun badge(badge: Float?) =
+        fun badge(badge: Float?): Builder =
             apply { this.badge = badge }
 
         /**
          * The corner radius used for overlays in dp.
          */
-        fun overlay(overlay: Float?) =
+        fun overlay(overlay: Float?): Builder =
             apply { this.overlay = overlay }
 
         /**
          * The corner radius used for form elements in dp.
          */
-        fun form(form: Float?) =
+        fun form(form: Float?): Builder =
             apply { this.form = form }
 
         fun build(): CornerRadius {

--- a/connect/src/main/java/com/stripe/android/connect/appearance/CornerRadius.kt
+++ b/connect/src/main/java/com/stripe/android/connect/appearance/CornerRadius.kt
@@ -8,33 +8,63 @@ import kotlinx.parcelize.Parcelize
 @PrivateBetaConnectSDK
 @Parcelize
 @Poko
-class CornerRadius(
-    /**
-     * The general border radius used throughout the components in dp.
-     */
-    val base: Float? = null,
-
-    /**
-     * The corner radius used specifically for buttons in dp.
-     */
-    val button: Float? = null,
-
-    /**
-     * The corner radius used specifically for badges in dp.
-     */
-    val badge: Float? = null,
-
-    /**
-     * The corner radius used for overlays in dp.
-     */
-    val overlay: Float? = null,
-
-    /**
-     * The corner radius used for form elements in dp.
-     */
-    val form: Float? = null
+class CornerRadius private constructor(
+    internal val base: Float?,
+    internal val button: Float?,
+    internal val badge: Float?,
+    internal val overlay: Float?,
+    internal val form: Float?
 ) : Parcelable {
+
+    class Builder {
+        private var base: Float? = null
+        private var button: Float? = null
+        private var badge: Float? = null
+        private var overlay: Float? = null
+        private var form: Float? = null
+
+        /**
+         * The general border radius used throughout the components in dp.
+         */
+        fun setBase(base: Float?) =
+            apply { this.base = base }
+
+        /**
+         * The corner radius used specifically for buttons in dp.
+         */
+        fun setButton(button: Float?) =
+            apply { this.button = button }
+
+        /**
+         * The corner radius used specifically for badges in dp.
+         */
+        fun setBadge(badge: Float?) =
+            apply { this.badge = badge }
+
+        /**
+         * The corner radius used for overlays in dp.
+         */
+        fun setOverlay(overlay: Float?) =
+            apply { this.overlay = overlay }
+
+        /**
+         * The corner radius used for form elements in dp.
+         */
+        fun setForm(form: Float?) =
+            apply { this.form = form }
+
+        fun build(): CornerRadius {
+            return CornerRadius(
+                base = base,
+                button = button,
+                badge = badge,
+                overlay = overlay,
+                form = form
+            )
+        }
+    }
+
     internal companion object {
-        internal val default = CornerRadius()
+        internal fun default() = Builder().build()
     }
 }

--- a/connect/src/main/java/com/stripe/android/connect/appearance/Typography.kt
+++ b/connect/src/main/java/com/stripe/android/connect/appearance/Typography.kt
@@ -41,70 +41,70 @@ class Typography private constructor(
          * The font family used throughout the application. Refers to the [CustomFontSource] field.
          * If null the default will be used.
          */
-        fun fontFamily(fontFamily: String?) =
+        fun fontFamily(fontFamily: String?): Builder =
             apply { this.fontFamily = fontFamily }
 
         /**
          * The base font size used for typography in sp.
          * This scales the value of other font size variables. If null the default will be used.
          */
-        fun fontSizeBase(fontSizeBase: Float?) =
+        fun fontSizeBase(fontSizeBase: Float?): Builder =
             apply { this.fontSizeBase = fontSizeBase }
 
         /**
          * The style for extra-large headings. If null the default will be used.
          */
-        fun headingXl(headingXl: Style?) =
+        fun headingXl(headingXl: Style?): Builder =
             apply { this.headingXl = headingXl }
 
         /**
          * The style for large headings. If null the default will be used.
          */
-        fun headingLg(headingLg: Style?) =
+        fun headingLg(headingLg: Style?): Builder =
             apply { this.headingLg = headingLg }
 
         /**
          * The style for medium headings. If null the default will be used.
          */
-        fun headingMd(headingMd: Style?) =
+        fun headingMd(headingMd: Style?): Builder =
             apply { this.headingMd = headingMd }
 
         /**
          * The style for small headings. If null the default will be used.
          */
-        fun headingSm(headingSm: Style?) =
+        fun headingSm(headingSm: Style?): Builder =
             apply { this.headingSm = headingSm }
 
         /**
          * The style for extra-small headings. If null the default will be used.
          */
-        fun headingXs(headingXs: Style?) =
+        fun headingXs(headingXs: Style?): Builder =
             apply { this.headingXs = headingXs }
 
         /**
          * The style for medium body text. If null the default will be used.
          * The `textTransform` property is ignored.
          */
-        fun bodyMd(bodyMd: Style?) =
+        fun bodyMd(bodyMd: Style?): Builder =
             apply { this.bodyMd = bodyMd }
 
         /**
          * The style for small body text. If null the default will be used.
          * The `textTransform` property is ignored.
          */
-        fun bodySm(bodySm: Style?) =
+        fun bodySm(bodySm: Style?): Builder =
             apply { this.bodySm = bodySm }
 
         /**
          * The style for medium label text. If null the default will be used.
          */
-        fun labelMd(labelMd: Style?) =
+        fun labelMd(labelMd: Style?): Builder =
             apply { this.labelMd = labelMd }
 
         /**
          * The style for small label text. If null the default will be used.
          */
-        fun labelSm(labelSm: Style?) =
+        fun labelSm(labelSm: Style?): Builder =
             apply { this.labelSm = labelSm }
 
         fun build(): Typography {

--- a/connect/src/main/java/com/stripe/android/connect/appearance/Typography.kt
+++ b/connect/src/main/java/com/stripe/android/connect/appearance/Typography.kt
@@ -9,88 +9,137 @@ import kotlinx.parcelize.Parcelize
 @PrivateBetaConnectSDK
 @Parcelize
 @Poko
-class Typography(
-    /**
-     * The font family used throughout the application. Refers to the [CustomFontSource] field.
-     * If null the default will be used.
-     */
-    val fontFamily: String? = null,
-
-    /**
-     * The base font size used for typography in sp.
-     * This scales the value of other font size variables. If null the default will be used.
-     */
-    val fontSizeBase: Float? = null,
-
-    /**
-     * The style for extra-large headings. If null the default will be used. If null the default will be used.
-     */
-    val headingXl: Style? = null,
-
-    /**
-     * The style for large headings. If null the default will be used. If null the default will be used.
-     */
-    val headingLg: Style? = null,
-
-    /**
-     * The style for medium headings. If null the default will be used.
-     */
-    val headingMd: Style? = null,
-
-    /**
-     * The style for small headings. If null the default will be used.
-     */
-    val headingSm: Style? = null,
-
-    /**
-     * The style for extra-small headings. If null the default will be used.
-     */
-    val headingXs: Style? = null,
-
-    /**
-     * The style for medium body text. If null the default will be used.
-     * The `textTransform` property is ignored.
-     */
-    val bodyMd: Style? = null,
-
-    /**
-     * The style for small body text. If null the default will be used.
-     * The `textTransform` property is ignored.
-     */
-    val bodySm: Style? = null,
-
-    /**
-     * The style for medium label text. If null the default will be used.
-     */
-    val labelMd: Style? = null,
-
-    /**
-     * The style for small label text. If null the default will be used.
-     */
-    val labelSm: Style? = null
+class Typography private constructor(
+    internal val fontFamily: String?,
+    internal val fontSizeBase: Float?,
+    internal val headingXl: Style?,
+    internal val headingLg: Style?,
+    internal val headingMd: Style?,
+    internal val headingSm: Style?,
+    internal val headingXs: Style?,
+    internal val bodyMd: Style?,
+    internal val bodySm: Style?,
+    internal val labelMd: Style?,
+    internal val labelSm: Style?
 ) : Parcelable {
-    internal companion object {
-        internal val default = Typography()
-    }
 
-    @PrivateBetaConnectSDK
-    @Parcelize
-    class Style(
-        /**
-         * The font size for the typography style in sp. If null the default will be used.
-         */
-        val fontSize: Float? = null,
+    @Suppress("TooManyFunctions")
+    class Builder {
+        private var fontFamily: String? = null
+        private var fontSizeBase: Float? = null
+        private var headingXl: Style? = null
+        private var headingLg: Style? = null
+        private var headingMd: Style? = null
+        private var headingSm: Style? = null
+        private var headingXs: Style? = null
+        private var bodyMd: Style? = null
+        private var bodySm: Style? = null
+        private var labelMd: Style? = null
+        private var labelSm: Style? = null
 
         /**
-         * The weight of the font used in this style (e.g., bold, normal) between 0-1000.
+         * The font family used throughout the application. Refers to the [CustomFontSource] field.
          * If null the default will be used.
          */
-        val fontWeight: Int? = null,
+        fun setFontFamily(fontFamily: String?) =
+            apply { this.fontFamily = fontFamily }
 
         /**
-         * The text transformation applied (e.g., uppercase, lowercase).
-         * Default is 'none'.
+         * The base font size used for typography in sp.
+         * This scales the value of other font size variables. If null the default will be used.
          */
-        val textTransform: TextTransform = TextTransform.None
+        fun setFontSizeBase(fontSizeBase: Float?) =
+            apply { this.fontSizeBase = fontSizeBase }
+
+        /**
+         * The style for extra-large headings. If null the default will be used.
+         */
+        fun setHeadingXl(headingXl: Style?) =
+            apply { this.headingXl = headingXl }
+
+        /**
+         * The style for large headings. If null the default will be used.
+         */
+        fun setHeadingLg(headingLg: Style?) =
+            apply { this.headingLg = headingLg }
+
+        /**
+         * The style for medium headings. If null the default will be used.
+         */
+        fun setHeadingMd(headingMd: Style?) =
+            apply { this.headingMd = headingMd }
+
+        /**
+         * The style for small headings. If null the default will be used.
+         */
+        fun setHeadingSm(headingSm: Style?) =
+            apply { this.headingSm = headingSm }
+
+        /**
+         * The style for extra-small headings. If null the default will be used.
+         */
+        fun setHeadingXs(headingXs: Style?) =
+            apply { this.headingXs = headingXs }
+
+        /**
+         * The style for medium body text. If null the default will be used.
+         * The `textTransform` property is ignored.
+         */
+        fun setBodyMd(bodyMd: Style?) =
+            apply { this.bodyMd = bodyMd }
+
+        /**
+         * The style for small body text. If null the default will be used.
+         * The `textTransform` property is ignored.
+         */
+        fun setBodySm(bodySm: Style?) =
+            apply { this.bodySm = bodySm }
+
+        /**
+         * The style for medium label text. If null the default will be used.
+         */
+        fun setLabelMd(labelMd: Style?) =
+            apply { this.labelMd = labelMd }
+
+        /**
+         * The style for small label text. If null the default will be used.
+         */
+        fun setLabelSm(labelSm: Style?) =
+            apply { this.labelSm = labelSm }
+
+        fun build(): Typography {
+            return Typography(
+                fontFamily = fontFamily,
+                fontSizeBase = fontSizeBase,
+                headingXl = headingXl,
+                headingLg = headingLg,
+                headingMd = headingMd,
+                headingSm = headingSm,
+                headingXs = headingXs,
+                bodyMd = bodyMd,
+                bodySm = bodySm,
+                labelMd = labelMd,
+                labelSm = labelSm
+            )
+        }
+    }
+
+    internal companion object {
+        internal fun default() = Builder().build()
+    }
+
+    /**
+     * @param fontSize The font size for the typography style in sp. If null the default will be used.
+     * @param fontWeight The weight of the font used in this style (e.g., bold, normal) between 0-1000.
+     *  If null the default will be used.
+     * @param textTransform The text transformation applied (e.g., uppercase, lowercase). Default is 'none'.
+     */
+    @PrivateBetaConnectSDK
+    @Parcelize
+    @Poko
+    class Style(
+        internal val fontSize: Float? = null,
+        internal val fontWeight: Int? = null,
+        internal val textTransform: TextTransform = TextTransform.None
     ) : Parcelable
 }

--- a/connect/src/main/java/com/stripe/android/connect/appearance/Typography.kt
+++ b/connect/src/main/java/com/stripe/android/connect/appearance/Typography.kt
@@ -41,70 +41,70 @@ class Typography private constructor(
          * The font family used throughout the application. Refers to the [CustomFontSource] field.
          * If null the default will be used.
          */
-        fun setFontFamily(fontFamily: String?) =
+        fun fontFamily(fontFamily: String?) =
             apply { this.fontFamily = fontFamily }
 
         /**
          * The base font size used for typography in sp.
          * This scales the value of other font size variables. If null the default will be used.
          */
-        fun setFontSizeBase(fontSizeBase: Float?) =
+        fun fontSizeBase(fontSizeBase: Float?) =
             apply { this.fontSizeBase = fontSizeBase }
 
         /**
          * The style for extra-large headings. If null the default will be used.
          */
-        fun setHeadingXl(headingXl: Style?) =
+        fun headingXl(headingXl: Style?) =
             apply { this.headingXl = headingXl }
 
         /**
          * The style for large headings. If null the default will be used.
          */
-        fun setHeadingLg(headingLg: Style?) =
+        fun headingLg(headingLg: Style?) =
             apply { this.headingLg = headingLg }
 
         /**
          * The style for medium headings. If null the default will be used.
          */
-        fun setHeadingMd(headingMd: Style?) =
+        fun headingMd(headingMd: Style?) =
             apply { this.headingMd = headingMd }
 
         /**
          * The style for small headings. If null the default will be used.
          */
-        fun setHeadingSm(headingSm: Style?) =
+        fun headingSm(headingSm: Style?) =
             apply { this.headingSm = headingSm }
 
         /**
          * The style for extra-small headings. If null the default will be used.
          */
-        fun setHeadingXs(headingXs: Style?) =
+        fun headingXs(headingXs: Style?) =
             apply { this.headingXs = headingXs }
 
         /**
          * The style for medium body text. If null the default will be used.
          * The `textTransform` property is ignored.
          */
-        fun setBodyMd(bodyMd: Style?) =
+        fun bodyMd(bodyMd: Style?) =
             apply { this.bodyMd = bodyMd }
 
         /**
          * The style for small body text. If null the default will be used.
          * The `textTransform` property is ignored.
          */
-        fun setBodySm(bodySm: Style?) =
+        fun bodySm(bodySm: Style?) =
             apply { this.bodySm = bodySm }
 
         /**
          * The style for medium label text. If null the default will be used.
          */
-        fun setLabelMd(labelMd: Style?) =
+        fun labelMd(labelMd: Style?) =
             apply { this.labelMd = labelMd }
 
         /**
          * The style for small label text. If null the default will be used.
          */
-        fun setLabelSm(labelSm: Style?) =
+        fun labelSm(labelSm: Style?) =
             apply { this.labelSm = labelSm }
 
         fun build(): Typography {

--- a/connect/src/test/java/com/stripe/android/connect/StripeComponentDialogFragmentViewTest.kt
+++ b/connect/src/test/java/com/stripe/android/connect/StripeComponentDialogFragmentViewTest.kt
@@ -88,16 +88,16 @@ class StripeComponentDialogFragmentViewTest {
 
     private fun createAppearance(includeFont: Boolean = false) =
         Appearance.Builder()
-            .setColors(
+            .colors(
                 Colors.Builder()
-                    .setText(Color.argb(255, 255, 0, 0))
-                    .setBorder(Color.argb(255, 0, 255, 0))
-                    .setBackground(Color.argb(255, 0, 0, 255))
+                    .text(Color.argb(255, 255, 0, 0))
+                    .border(Color.argb(255, 0, 255, 0))
+                    .background(Color.argb(255, 0, 0, 255))
                     .build()
             )
-            .setTypography(
+            .typography(
                 Typography.Builder()
-                    .setFontFamily("doto".takeIf { includeFont })
+                    .fontFamily("doto".takeIf { includeFont })
                     .build()
             )
             .build()

--- a/connect/src/test/java/com/stripe/android/connect/StripeComponentDialogFragmentViewTest.kt
+++ b/connect/src/test/java/com/stripe/android/connect/StripeComponentDialogFragmentViewTest.kt
@@ -67,7 +67,7 @@ class StripeComponentDialogFragmentViewTest {
 
     private fun snapshot(
         title: String = "Account Onboarding",
-        appearance: Appearance = Appearance(),
+        appearance: Appearance = Appearance.default(),
         applyView: StripeComponentDialogFragmentView<TestComponentView>.(Context) -> Unit = {},
     ) {
         paparazziRule.snapshot {
@@ -87,14 +87,20 @@ class StripeComponentDialogFragmentViewTest {
     }
 
     private fun createAppearance(includeFont: Boolean = false) =
-        Appearance(
-            colors = Colors(
-                text = Color.argb(255, 255, 0, 0),
-                border = Color.argb(255, 0, 255, 0),
-                background = Color.argb(255, 0, 0, 255),
-            ),
-            typography = Typography(fontFamily = "doto".takeIf { includeFont })
-        )
+        Appearance.Builder()
+            .setColors(
+                Colors.Builder()
+                    .setText(Color.argb(255, 255, 0, 0))
+                    .setBorder(Color.argb(255, 0, 255, 0))
+                    .setBackground(Color.argb(255, 0, 0, 255))
+                    .build()
+            )
+            .setTypography(
+                Typography.Builder()
+                    .setFontFamily("doto".takeIf { includeFont })
+                    .build()
+            )
+            .build()
 
     private class TestStripeComponentDialogFragmentView(
         context: Context

--- a/connect/src/test/java/com/stripe/android/connect/StripeComponentViewTest.kt
+++ b/connect/src/test/java/com/stripe/android/connect/StripeComponentViewTest.kt
@@ -45,11 +45,13 @@ class StripeComponentViewTest {
                 bindViewModelState(
                     StripeConnectWebViewContainerState(
                         isNativeLoadingIndicatorVisible = true,
-                        appearance = Appearance(
-                            colors = Colors(
-                                secondaryText = Color.RED
+                        appearance = Appearance.Builder()
+                            .colors(
+                                Colors.Builder()
+                                    .secondaryText(Color.RED)
+                                    .build()
                             )
-                        )
+                            .build()
                     )
                 )
             }

--- a/connect/src/test/java/com/stripe/android/connect/manager/EmbeddedComponentCoordinatorTest.kt
+++ b/connect/src/test/java/com/stripe/android/connect/manager/EmbeddedComponentCoordinatorTest.kt
@@ -52,7 +52,7 @@ class EmbeddedComponentCoordinatorTest {
                 configuration = configuration,
                 fetchClientSecretCallback = mockFetchClientSecretCallback,
                 logger = Logger.noop(),
-                appearance = Appearance(),
+                appearance = Appearance.default(),
                 customFonts = emptyList(),
             )
         testActivityController = Robolectric.buildActivity(ComponentActivity::class.java).create()

--- a/connect/src/test/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerViewModelTest.kt
+++ b/connect/src/test/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerViewModelTest.kt
@@ -253,9 +253,9 @@ class StripeConnectWebViewContainerViewModelTest {
         val appearances = listOf(
             Appearance.default(),
             Appearance.Builder()
-                .setColors(
+                .colors(
                     Colors.Builder()
-                        .setPrimary(Color.CYAN)
+                        .primary(Color.CYAN)
                         .build()
                 )
                 .build()

--- a/connect/src/test/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerViewModelTest.kt
+++ b/connect/src/test/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerViewModelTest.kt
@@ -77,7 +77,7 @@ class StripeConnectWebViewContainerViewModelTest {
     }
     private val embeddedComponent: StripeEmbeddedComponent = StripeEmbeddedComponent.PAYOUTS
 
-    private val appearanceFlow = MutableStateFlow(Appearance())
+    private val appearanceFlow = MutableStateFlow(Appearance.default())
     private val receivedComponentEvents = mutableListOf<ComponentEvent>()
 
     private val mockStripeIntentLauncher: StripeIntentLauncher = mock()
@@ -181,7 +181,7 @@ class StripeConnectWebViewContainerViewModelTest {
         assertThat(viewModel.stateFlow.value.appearance).isNull()
 
         viewModel.onCreate(lifecycleOwner)
-        val newAppearance = Appearance()
+        val newAppearance = Appearance.default()
         appearanceFlow.emit(newAppearance)
 
         assertThat(viewModel.stateFlow.value.appearance).isEqualTo(newAppearance)
@@ -250,7 +250,16 @@ class StripeConnectWebViewContainerViewModelTest {
 
     @Test
     fun `view should update appearance`() = runTest(testDispatcher) {
-        val appearances = listOf(Appearance(), Appearance(colors = Colors(primary = Color.CYAN)))
+        val appearances = listOf(
+            Appearance.default(),
+            Appearance.Builder()
+                .setColors(
+                    Colors.Builder()
+                        .setPrimary(Color.CYAN)
+                        .build()
+                )
+                .build()
+        )
         viewModel.onCreate(lifecycleOwner)
 
         // Shouldn't update appearance until pageDidLoad is received.


### PR DESCRIPTION
# Summary
Large PR, but it's a very straightforward refactoring:
1. Apply the Builder pattern to appearance classes with many properties with the same type.
2. Hide public properties to reduce API surface.
3. Move kdocs off of `internal val`s so they're generated in dokka docs.

# Motivation
Tighten the API prior to release.
https://jira.corp.stripe.com/browse/CAX-3994
Follow-up to https://github.com/stripe/stripe-android/pull/10478

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified
