### PR TITLE
Validate payment method fingerprints in deferred intent validation.

### DIFF
--- a/payments-core-testing/src/main/java/com/stripe/android/testing/PaymentMethodFactory.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/PaymentMethodFactory.kt
@@ -23,7 +23,8 @@ object PaymentMethodFactory {
     fun PaymentMethod.update(
         last4: String?,
         addCbcNetworks: Boolean,
-        brand: CardBrand = CardBrand.Visa
+        brand: CardBrand = CardBrand.Visa,
+        fingerprint: String? = null,
     ): PaymentMethod {
         return copy(
             card = card?.copy(
@@ -36,6 +37,7 @@ object PaymentMethodFactory {
                 },
                 displayBrand = "cartes_bancaries".takeIf { addCbcNetworks },
                 brand = brand,
+                fingerprint = fingerprint,
             )
         )
     }
@@ -140,6 +142,26 @@ object PaymentMethodFactory {
             liveMode = false,
             type = PaymentMethod.Type.BacsDebit,
             code = PaymentMethod.Type.BacsDebit.code,
+            bacsDebit = PaymentMethod.BacsDebit(
+                last4 = "2345",
+                sortCode = "108800",
+                fingerprint = "fingerprint",
+            ),
+        )
+    }
+
+    fun auBecsDebit(): PaymentMethod {
+        return PaymentMethod(
+            id = "pm_1234",
+            created = 123456789L,
+            liveMode = false,
+            type = PaymentMethod.Type.AuBecsDebit,
+            code = PaymentMethod.Type.AuBecsDebit.code,
+            auBecsDebit = PaymentMethod.AuBecsDebit(
+                last4 = "2345",
+                bsbNumber = "100000",
+                fingerprint = "fingerprint",
+            ),
         )
     }
 
@@ -150,6 +172,13 @@ object PaymentMethodFactory {
             liveMode = false,
             type = PaymentMethod.Type.SepaDebit,
             code = PaymentMethod.Type.SepaDebit.code,
+            sepaDebit = PaymentMethod.SepaDebit(
+                bankCode = "01",
+                branchCode = "01425",
+                country = "FR",
+                last4 = "2345",
+                fingerprint = "fingerprint",
+            )
         )
     }
 

--- a/payments-core-testing/src/main/java/com/stripe/android/testing/PaymentMethodFactory.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/PaymentMethodFactory.kt
@@ -24,7 +24,7 @@ object PaymentMethodFactory {
         last4: String?,
         addCbcNetworks: Boolean,
         brand: CardBrand = CardBrand.Visa,
-        fingerprint: String? = null,
+        fingerprint: String? = card?.fingerprint,
     ): PaymentMethod {
         return copy(
             card = card?.copy(

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -3163,6 +3163,8 @@ public final class com/stripe/android/model/PaymentMethod$BacsDebit : com/stripe
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethod$BacsDebit;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethod$BacsDebit;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethod$BacsDebit;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getType ()Lcom/stripe/android/model/PaymentMethod$Type;
@@ -3484,6 +3486,8 @@ public final class com/stripe/android/model/PaymentMethod$SepaDebit : com/stripe
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethod$SepaDebit;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethod$SepaDebit;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethod$SepaDebit;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getType ()Lcom/stripe/android/model/PaymentMethod$Type;

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
@@ -1036,7 +1036,9 @@ constructor(
      * [sepa_debit](https://stripe.com/docs/api/payment_methods/object#payment_method_object-sepa_debit)
      */
     @Parcelize
-    data class SepaDebit internal constructor(
+    data class SepaDebit
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    constructor(
         /**
          * Bank code of bank associated with the bank account.
          *
@@ -1087,7 +1089,9 @@ constructor(
     }
 
     @Parcelize
-    data class BacsDebit internal constructor(
+    data class BacsDebit
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    constructor(
         @JvmField val fingerprint: String?,
         @JvmField val last4: String?,
         @JvmField val sortCode: String?

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptor.kt
@@ -440,7 +440,7 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
         intent: StripeIntent,
         paymentMethod: PaymentMethod
     ): NextStep {
-        return kotlin.runCatching {
+        return runCatching {
             DeferredIntentValidator.validatePaymentMethod(intent, paymentMethod)
             NextStep.HandleNextAction(clientSecret)
         }.getOrElse {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptor.kt
@@ -414,16 +414,7 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
                 failIfSetAsDefaultFeatureIsEnabled(paymentMethodExtraParams)
                 NextStep.Complete(isForceSuccess = false)
             } else if (intent.requiresAction()) {
-                val attachedPaymentMethodId = intent.paymentMethodId
-
-                if (attachedPaymentMethodId != null && attachedPaymentMethodId != paymentMethod.id) {
-                    NextStep.Fail(
-                        cause = InvalidDeferredIntentUsageException(),
-                        message = resolvableString(R.string.stripe_paymentsheet_invalid_deferred_intent_usage),
-                    )
-                } else {
-                    NextStep.HandleNextAction(clientSecret)
-                }
+                createHandleNextActionStep(clientSecret, intent, paymentMethod)
             } else {
                 DeferredIntentValidator.validate(intent, intentConfiguration, allowsManualConfirmation)
                 createConfirmStep(
@@ -440,6 +431,22 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
             NextStep.Fail(
                 cause = error,
                 message = resolvableString(GENERIC_STRIPE_MESSAGE),
+            )
+        }
+    }
+
+    private fun createHandleNextActionStep(
+        clientSecret: String,
+        intent: StripeIntent,
+        paymentMethod: PaymentMethod
+    ): NextStep {
+        return kotlin.runCatching {
+            DeferredIntentValidator.validatePaymentMethod(intent, paymentMethod)
+            NextStep.HandleNextAction(clientSecret)
+        }.getOrElse {
+            NextStep.Fail(
+                cause = InvalidDeferredIntentUsageException(),
+                message = resolvableString(R.string.stripe_paymentsheet_invalid_deferred_intent_usage),
             )
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DeferredIntentValidatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DeferredIntentValidatorTest.kt
@@ -1,12 +1,17 @@
 package com.stripe.android.paymentsheet
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.isInstanceOf
 import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.PaymentSheet.IntentConfiguration
 import com.stripe.android.testing.PaymentIntentFactory
+import com.stripe.android.testing.PaymentMethodFactory
+import com.stripe.android.testing.PaymentMethodFactory.update
 import kotlin.test.Test
+import kotlin.test.assertFails
 import kotlin.test.assertFailsWith
 
 internal class DeferredIntentValidatorTest {
@@ -224,6 +229,156 @@ internal class DeferredIntentValidatorTest {
         )
 
         assertThat(result).isEqualTo(setupIntent)
+    }
+
+    @Test
+    fun `PM validation succeeds if no PM attached to intent`() {
+        val providedCard = PaymentMethodFactory.card(id = "pm_1")
+
+        val result = DeferredIntentValidator.validatePaymentMethod(
+            intent = PaymentIntentFactory.create(paymentMethod = null),
+            paymentMethod = providedCard,
+        )
+
+        assertThat(result).isNotNull()
+    }
+
+    @Test
+    fun `PM validation fails if PMs are different types`() {
+        val providedCard = PaymentMethodFactory.card(random = true)
+        val attachedUsBankAccount = PaymentMethodFactory.usBankAccount()
+
+        val exception = assertFails {
+            DeferredIntentValidator.validatePaymentMethod(
+                intent = PaymentIntentFactory.create(attachedUsBankAccount),
+                paymentMethod = providedCard,
+            )
+        }
+
+        assertThat(exception).isInstanceOf<java.lang.IllegalArgumentException>()
+        assertThat(exception.message).isEqualTo(
+            "Your payment method (${attachedUsBankAccount.id}) attached to the intent does not " +
+                "match the provided payment method (${providedCard.id})!"
+        )
+    }
+
+    @Test
+    fun `Card validation succeeds when fingerprints are the same`() = sameFingerprintTest { id, fingerprint ->
+        PaymentMethodFactory.card(id = id)
+            .update(
+                last4 = "4242",
+                addCbcNetworks = false,
+                fingerprint = fingerprint
+            )
+    }
+
+    @Test
+    fun `Card validation fails when IDs & fingerprints are different`() =
+        differentFingerprintTest { id, fingerprint ->
+            PaymentMethodFactory.card(id = id)
+                .update(
+                    last4 = "4242",
+                    addCbcNetworks = false,
+                    fingerprint = fingerprint,
+                )
+        }
+
+    @Test
+    fun `US Bank account validation succeeds when fingerprints are the same`() =
+        sameFingerprintTest { id, fingerprint ->
+            PaymentMethodFactory.usBankAccount().run {
+                copy(id = id, usBankAccount = usBankAccount?.copy(fingerprint = fingerprint))
+            }
+        }
+
+    @Test
+    fun `US Bank account validation fails when IDs & fingerprints are different`() =
+        differentFingerprintTest { id, fingerprint ->
+            PaymentMethodFactory.usBankAccount().run {
+                copy(id = id, usBankAccount = usBankAccount?.copy(fingerprint = fingerprint))
+            }
+        }
+
+    @Test
+    fun `Au Becs Debit account validation succeeds when fingerprints are the same`() =
+        sameFingerprintTest { id, fingerprint ->
+            PaymentMethodFactory.auBecsDebit().run {
+                copy(id = id, auBecsDebit = auBecsDebit?.copy(fingerprint = fingerprint))
+            }
+        }
+
+    @Test
+    fun `Au Becs Debit account validation fails when IDs & fingerprints are different`() =
+        differentFingerprintTest { id, fingerprint ->
+            PaymentMethodFactory.auBecsDebit().run {
+                copy(id = id, auBecsDebit = auBecsDebit?.copy(fingerprint = fingerprint))
+            }
+        }
+
+    @Test
+    fun `Bacs Debit account validation succeeds when fingerprints are the same`() =
+        sameFingerprintTest { id, fingerprint ->
+            PaymentMethodFactory.bacs().run {
+                copy(id = id, bacsDebit = bacsDebit?.copy(fingerprint = fingerprint))
+            }
+        }
+
+    @Test
+    fun `Bacs Debit account validation fails when IDs & fingerprints are different`() =
+        differentFingerprintTest { id, fingerprint ->
+            PaymentMethodFactory.bacs().run {
+                copy(id = id, bacsDebit = bacsDebit?.copy(fingerprint = fingerprint))
+            }
+        }
+
+    @Test
+    fun `Sepa Debit account validation succeeds when fingerprints are the same`() =
+        sameFingerprintTest { id, fingerprint ->
+            PaymentMethodFactory.sepaDebit().run {
+                copy(id = id, sepaDebit = sepaDebit?.copy(fingerprint = fingerprint))
+            }
+        }
+
+    @Test
+    fun `Sepa Debit account validation fails when IDs & fingerprints are different`() =
+        differentFingerprintTest { id, fingerprint ->
+            PaymentMethodFactory.sepaDebit().run {
+                copy(id = id, sepaDebit = sepaDebit?.copy(fingerprint = fingerprint))
+            }
+        }
+
+    private fun sameFingerprintTest(
+        createPaymentMethod: (id: String, fingerprint: String) -> PaymentMethod,
+    ) {
+        val attachedPaymentMethod = createPaymentMethod("pm_1", "fingerprint")
+        val providedPaymentMethod = createPaymentMethod("pm_2", "fingerprint")
+
+        val result = DeferredIntentValidator.validatePaymentMethod(
+            intent = PaymentIntentFactory.create(attachedPaymentMethod),
+            paymentMethod = providedPaymentMethod,
+        )
+
+        assertThat(result).isNotNull()
+    }
+
+    private fun differentFingerprintTest(
+        createPaymentMethod: (id: String, fingerprint: String) -> PaymentMethod,
+    ) {
+        val attachedPaymentMethod = createPaymentMethod("pm_1", "fingerprint1")
+        val providedPaymentMethod = createPaymentMethod("pm_2", "fingerprint2")
+
+        val exception = assertFails {
+            DeferredIntentValidator.validatePaymentMethod(
+                intent = PaymentIntentFactory.create(attachedPaymentMethod),
+                paymentMethod = providedPaymentMethod,
+            )
+        }
+
+        assertThat(exception).isInstanceOf<java.lang.IllegalArgumentException>()
+        assertThat(exception.message).isEqualTo(
+            "Your payment method (${attachedPaymentMethod.id}) attached to the intent does not " +
+                "match the provided payment method (${providedPaymentMethod.id})!"
+        )
     }
 
     private fun makeIntentConfigurationForPayment(


### PR DESCRIPTION
# Summary
Validate payment method fingerprints in deferred intent validation.

# Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-1818

We originally had this issue resolved but didn't close it. Turns out iOS recently changed their strategy to allow for `fingerprint` (indicates same card/bank account) checks if the PM ids are not the same to solve a use case where a merchant was cloning the payment method during confirmation. We don't have this logic on Android so I'm adding it here for PM types that allow for `fingerprint` matching.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified