### PR TITLE
Only send google pay init analytic event on first init.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncher.kt
@@ -15,7 +15,6 @@ import androidx.lifecycle.lifecycleScope
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.networking.DefaultAnalyticsRequestExecutor
-import com.stripe.android.googlepaylauncher.GooglePayLauncher.Result
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.networking.PaymentAnalyticsEvent
@@ -142,9 +141,12 @@ class GooglePayLauncher internal constructor(
     )
 
     init {
-        analyticsRequestExecutor.executeAsync(
-            paymentAnalyticsRequestFactory.createRequest(PaymentAnalyticsEvent.GooglePayLauncherInit)
-        )
+        if (!HAS_SENT_INIT_ANALYTIC_EVENT) {
+            HAS_SENT_INIT_ANALYTIC_EVENT = true
+            analyticsRequestExecutor.executeAsync(
+                paymentAnalyticsRequestFactory.createRequest(PaymentAnalyticsEvent.GooglePayLauncherInit)
+            )
+        }
 
         lifecycleScope.launch {
             val repository = googlePayRepositoryFactory(config.environment)
@@ -315,6 +317,7 @@ class GooglePayLauncher internal constructor(
 
     companion object {
         internal const val PRODUCT_USAGE = "GooglePayLauncher"
+        internal var HAS_SENT_INIT_ANALYTIC_EVENT: Boolean = false
 
         /**
          * Create a [GooglePayLauncher] used for Jetpack Compose.

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
@@ -19,7 +19,6 @@ import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.networking.DefaultAnalyticsRequestExecutor
-import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher.Result
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.networking.PaymentAnalyticsEvent
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
@@ -148,9 +147,12 @@ class GooglePayPaymentMethodLauncher @AssistedInject internal constructor(
     )
 
     init {
-        analyticsRequestExecutor.executeAsync(
-            paymentAnalyticsRequestFactory.createRequest(PaymentAnalyticsEvent.GooglePayPaymentMethodLauncherInit)
-        )
+        if (!HAS_SENT_INIT_ANALYTIC_EVENT) {
+            HAS_SENT_INIT_ANALYTIC_EVENT = true
+            analyticsRequestExecutor.executeAsync(
+                paymentAnalyticsRequestFactory.createRequest(PaymentAnalyticsEvent.GooglePayPaymentMethodLauncherInit)
+            )
+        }
 
         if (!skipReadyCheck) {
             lifecycleScope.launch {
@@ -347,6 +349,7 @@ class GooglePayPaymentMethodLauncher @AssistedInject internal constructor(
 
     companion object {
         internal const val PRODUCT_USAGE_TOKEN = "GooglePayPaymentMethodLauncher"
+        internal var HAS_SENT_INIT_ANALYTIC_EVENT: Boolean = false
 
         // Generic internal error
         const val INTERNAL_ERROR = 1

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayLauncherTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayLauncherTest.kt
@@ -34,10 +34,56 @@ internal class GooglePayLauncherTest {
             integrationTypes = listOf(LauncherIntegrationType.Activity),
             expectResult = false,
         ) { activity, _ ->
+            GooglePayLauncher.HAS_SENT_INIT_ANALYTIC_EVENT = false
             val firedEvents = mutableListOf<String>()
 
             // Have to use the internal constructor here to provide a mock request executor
             // ¯\_(ツ)_/¯
+            GooglePayLauncher(
+                lifecycleScope = activity.lifecycleScope,
+                config = CONFIG,
+                readyCallback = mock(),
+                activityResultLauncher = mock(),
+                googlePayRepositoryFactory = {
+                    FakeGooglePayRepository(value = true)
+                },
+                paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
+                    context = activity,
+                    publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+                ),
+                analyticsRequestExecutor = { firedEvents += it.params["event"].toString() },
+            )
+
+            assertThat(firedEvents).containsExactly("stripe_android.googlepaylauncher_init")
+        }
+    }
+
+    @Test
+    fun `init should fire expected event on init`() {
+        runGooglePayLauncherTest(
+            integrationTypes = listOf(LauncherIntegrationType.Activity),
+            expectResult = false,
+        ) { activity, _ ->
+            GooglePayLauncher.HAS_SENT_INIT_ANALYTIC_EVENT = false
+            val firedEvents = mutableListOf<String>()
+
+            // Have to use the internal constructor here to provide a mock request executor
+            // ¯\_(ツ)_/¯
+            GooglePayLauncher(
+                lifecycleScope = activity.lifecycleScope,
+                config = CONFIG,
+                readyCallback = mock(),
+                activityResultLauncher = mock(),
+                googlePayRepositoryFactory = {
+                    FakeGooglePayRepository(value = true)
+                },
+                paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
+                    context = activity,
+                    publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+                ),
+                analyticsRequestExecutor = { firedEvents += it.params["event"].toString() },
+            )
+
             GooglePayLauncher(
                 lifecycleScope = activity.lifecycleScope,
                 config = CONFIG,

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherTest.kt
@@ -40,6 +40,8 @@ class GooglePayPaymentMethodLauncherTest {
             integrationTypes = listOf(LauncherIntegrationType.Activity),
             expectResult = false,
         ) { activity, _ ->
+            GooglePayPaymentMethodLauncher.HAS_SENT_INIT_ANALYTIC_EVENT = false
+
             val firedEvents = mutableListOf<String>()
 
             val launcher = GooglePayPaymentMethodLauncher(
@@ -58,6 +60,52 @@ class GooglePayPaymentMethodLauncherTest {
                 cardBrandFilter = DefaultCardBrandFilter
             )
             launcher.present(currencyCode = "usd")
+
+            assertThat(firedEvents).containsExactly("stripe_android.googlepaypaymentmethodlauncher_init")
+        }
+    }
+
+    @Test
+    fun `init should fire expected event only on first init`() {
+        runGooglePayPaymentMethodLauncherTest(
+            integrationTypes = listOf(LauncherIntegrationType.Activity),
+            expectResult = false,
+        ) { activity, _ ->
+            GooglePayPaymentMethodLauncher.HAS_SENT_INIT_ANALYTIC_EVENT = false
+
+            val firedEvents = mutableListOf<String>()
+
+            GooglePayPaymentMethodLauncher(
+                lifecycleScope = activity.lifecycleScope,
+                config = CONFIG,
+                readyCallback = mock(),
+                activityResultLauncher = mock(),
+                skipReadyCheck = true,
+                context = activity,
+                googlePayRepositoryFactory = mock(),
+                paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
+                    context = activity,
+                    publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+                ),
+                analyticsRequestExecutor = { firedEvents += it.params["event"].toString() },
+                cardBrandFilter = DefaultCardBrandFilter
+            )
+
+            GooglePayPaymentMethodLauncher(
+                lifecycleScope = activity.lifecycleScope,
+                config = CONFIG,
+                readyCallback = mock(),
+                activityResultLauncher = mock(),
+                skipReadyCheck = true,
+                context = activity,
+                googlePayRepositoryFactory = mock(),
+                paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
+                    context = activity,
+                    publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+                ),
+                analyticsRequestExecutor = { firedEvents += it.params["event"].toString() },
+                cardBrandFilter = DefaultCardBrandFilter
+            )
 
             assertThat(firedEvents).containsExactly("stripe_android.googlepaypaymentmethodlauncher_init")
         }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
We were previously logging google pay init events every time the launcher constructors were called. We now only do it once per time an app is launched.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-3192

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified
