### PR TITLE
Make primary button state mapper return a StateFlow.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.createSavedStateHandle
-import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
 import com.stripe.android.analytics.SessionSavedStateHandler
 import com.stripe.android.cards.CardAccountRangeRepository
@@ -34,10 +33,8 @@ import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 
@@ -118,11 +115,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
             else -> null
         }
 
-    override val primaryButtonUiState = primaryButtonUiStateMapper.forCustomFlow().stateIn(
-        scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(),
-        initialValue = null,
-    )
+    override val primaryButtonUiState = primaryButtonUiStateMapper.forCustomFlow()
 
     init {
         SessionSavedStateHandler.attachTo(this, savedStateHandle)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -60,12 +60,10 @@ import com.stripe.android.uicore.utils.mapAsStateFlow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.withContext
@@ -172,11 +170,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
             }
         }
 
-    override val primaryButtonUiState = primaryButtonUiStateMapper.forCompleteFlow().stateIn(
-        scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(),
-        initialValue = null,
-    )
+    override val primaryButtonUiState = primaryButtonUiStateMapper.forCompleteFlow()
 
     override val error: StateFlow<ResolvableString?> = buyButtonState.mapAsStateFlow { it?.errorMessage?.message }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
@@ -462,7 +462,9 @@ private fun PrimaryButton(viewModel: BaseSheetViewModel) {
 
     LaunchedEffect(viewModel, button) {
         viewModel.primaryButtonUiState.collect { uiState ->
-            button?.updateUiState(uiState)
+            withContext(Dispatchers.Main) {
+                button?.updateUiState(uiState)
+            }
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/PrimaryButtonUiStateMapper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/PrimaryButtonUiStateMapper.kt
@@ -7,14 +7,12 @@ import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.SelectSavedPaymentMethods.CvcRecollectionState
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.utils.buyButtonLabel
-import com.stripe.android.paymentsheet.utils.combine
 import com.stripe.android.paymentsheet.utils.continueButtonLabel
 import com.stripe.android.ui.core.Amount
-import kotlinx.coroutines.flow.Flow
+import com.stripe.android.uicore.utils.combineAsStateFlow
+import com.stripe.android.uicore.utils.flatMapLatestAsStateFlow
+import com.stripe.android.uicore.utils.mapAsStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.map
 
 internal class PrimaryButtonUiStateMapper(
     private val config: PaymentSheet.Configuration,
@@ -28,8 +26,8 @@ internal class PrimaryButtonUiStateMapper(
     private val onClick: () -> Unit,
 ) {
 
-    fun forCompleteFlow(): Flow<PrimaryButton.UIState?> {
-        return combine(
+    fun forCompleteFlow(): StateFlow<PrimaryButton.UIState?> {
+        return combineAsStateFlow(
             currentScreenFlow,
             buttonsEnabledFlow,
             amountFlow,
@@ -37,7 +35,7 @@ internal class PrimaryButtonUiStateMapper(
             customPrimaryButtonUiStateFlow,
             cvcCompleteFlow
         ) { screen, buttonsEnabled, amount, selection, customPrimaryButton, cvcComplete ->
-            screen.buyButtonState.map { buyButtonState ->
+            screen.buyButtonState.mapAsStateFlow { buyButtonState ->
                 customPrimaryButton ?: PrimaryButton.UIState(
                     label = buyButtonState.buyButtonOverride?.label ?: buyButtonLabel(
                         amount,
@@ -50,11 +48,11 @@ internal class PrimaryButtonUiStateMapper(
                     lockVisible = buyButtonState.buyButtonOverride?.lockEnabled ?: true,
                 ).takeIf { buyButtonState.visible }
             }
-        }.flatMapLatest { it }
+        }.flatMapLatestAsStateFlow { it }
     }
 
-    fun forCustomFlow(): Flow<PrimaryButton.UIState?> {
-        return combine(
+    fun forCustomFlow(): StateFlow<PrimaryButton.UIState?> {
+        return combineAsStateFlow(
             currentScreenFlow,
             buttonsEnabledFlow,
             selectionFlow,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -19,12 +19,12 @@ import androidx.core.view.isVisible
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.pressBack
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
-import com.stripe.android.core.injection.WeakMapInjectorRegistry
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.PaymentIntentFixtures
@@ -40,7 +40,6 @@ import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_METHOD_CARD_TEST_TAG
 import com.stripe.android.paymentsheet.ui.TEST_TAG_LIST
 import com.stripe.android.paymentsheet.ui.getLabel
-import com.stripe.android.testing.RetryRule
 import com.stripe.android.uicore.elements.bottomsheet.BottomSheetContentTestTag
 import com.stripe.android.utils.FakeCustomerRepository
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
@@ -60,7 +59,6 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.robolectric.annotation.Config
-import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 
 @RunWith(AndroidJUnit4::class)
@@ -73,7 +71,7 @@ internal class PaymentOptionsActivityTest {
     val rule = RuleChain.emptyRuleChain()
         .around(InstantTaskExecutorRule())
         .around(composeTestRule)
-        .around(RetryRule(3))
+//        .around(RetryRule(3))
 
     private val context = ApplicationProvider.getApplicationContext<Context>()
     private val testDispatcher = UnconfinedTestDispatcher()
@@ -89,11 +87,6 @@ internal class PaymentOptionsActivityTest {
             ApplicationProvider.getApplicationContext(),
             ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
         )
-    }
-
-    @AfterTest
-    fun cleanup() {
-        WeakMapInjectorRegistry.clear()
     }
 
     @Test
@@ -197,6 +190,7 @@ internal class PaymentOptionsActivityTest {
                     .onNodeWithTag("${SAVED_PAYMENT_METHOD_CARD_TEST_TAG}_+ Add")
                     .performClick()
 
+                Espresso.onIdle()
                 assertThat(activity.continueButton.isVisible).isTrue()
 
                 // Navigate back to payment options list

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -27,6 +27,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.testing.TestLifecycleOwner
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.pressBack
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
@@ -208,9 +209,11 @@ internal class PaymentSheetActivityTest {
         val scenario = activityScenario(viewModel)
 
         scenario.launch(intent).onActivity { activity ->
+            Espresso.onIdle()
             assertThat(activity.buyButton.isEnabled).isTrue()
 
             startEditing()
+            Espresso.onIdle()
             assertThat(activity.buyButton.isEnabled).isFalse()
         }
     }
@@ -605,11 +608,13 @@ internal class PaymentSheetActivityTest {
             viewModel.updateSelection(
                 PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
             )
+            Espresso.onIdle()
             assertThat(activity.buyButton.isEnabled)
                 .isTrue()
 
             activity.buyButton.performClick()
 
+            Espresso.onIdle()
             assertThat(activity.buyButton.isEnabled)
                 .isFalse()
         }
@@ -1102,8 +1107,10 @@ internal class PaymentSheetActivityTest {
 
         scenario.launch(intent).onActivity { activity ->
             testDispatcher.scheduler.advanceTimeBy(50)
+            Espresso.onIdle()
             assertThat(activity.buyButton.externalLabel?.resolve(context)).isEqualTo("Pay")
             testDispatcher.scheduler.advanceTimeBy(250)
+            Espresso.onIdle()
             assertThat(activity.buyButton.externalLabel?.resolve(context)).isEqualTo("Pay CA\$99.99")
         }
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
I noticed tests for external payment methods were flakey. This was due to the primary button never being enabled. My hunch is that we got an initial value of null and never got an updated value.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-3866

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

