### PR TITLE
Update CvcConfig to return Valid.Limitless if cvc length is in CardBand.cvcLength but less than maxCvcLength

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcConfig.kt
@@ -33,12 +33,14 @@ class CvcConfig : CardDetailsTextFieldConfig {
                 numberAllowedDigits -> TextFieldStateConstants.Valid.Full
                 else -> TextFieldStateConstants.Valid.Limitless
             }
+        } else if (isDigitLimit && number.length == numberAllowedDigits) {
+            TextFieldStateConstants.Valid.Full
+        } else if (isDigitLimit && brand.cvcLength.contains(number.length)){
+            TextFieldStateConstants.Valid.Limitless
         } else if (isDigitLimit && number.length < numberAllowedDigits) {
             TextFieldStateConstants.Error.Incomplete(StripeR.string.stripe_invalid_cvc)
         } else if (isDigitLimit && number.length > numberAllowedDigits) {
             TextFieldStateConstants.Error.Invalid(StripeR.string.stripe_invalid_cvc)
-        } else if (isDigitLimit && number.length == numberAllowedDigits) {
-            TextFieldStateConstants.Valid.Full
         } else {
             TextFieldStateConstants.Error.Invalid(StripeR.string.stripe_invalid_cvc)
         }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcConfig.kt
@@ -35,7 +35,7 @@ class CvcConfig : CardDetailsTextFieldConfig {
             }
         } else if (isDigitLimit && number.length == numberAllowedDigits) {
             TextFieldStateConstants.Valid.Full
-        } else if (isDigitLimit && brand.cvcLength.contains(number.length)){
+        } else if (isDigitLimit && brand.cvcLength.contains(number.length)) {
             TextFieldStateConstants.Valid.Limitless
         } else if (isDigitLimit && number.length < numberAllowedDigits) {
             TextFieldStateConstants.Error.Incomplete(StripeR.string.stripe_invalid_cvc)

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CvcConfigTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CvcConfigTest.kt
@@ -59,4 +59,23 @@ class CvcConfigTest {
         Truth.assertThat(state)
             .isInstanceOf<TextFieldStateConstants.Valid.Full>()
     }
+
+    @Test
+    fun `cvc is valid for lengths 3 and 4 for amex`() {
+        var state = cvcConfig.determineState(
+            brand = CardBrand.AmericanExpress,
+            number = "123",
+            numberAllowedDigits = CardBrand.AmericanExpress.maxCvcLength
+        )
+        Truth.assertThat(state)
+            .isInstanceOf<TextFieldStateConstants.Valid.Limitless>()
+
+        state = cvcConfig.determineState(
+            brand = CardBrand.AmericanExpress,
+            number = "1234",
+            numberAllowedDigits = CardBrand.AmericanExpress.maxCvcLength
+        )
+        Truth.assertThat(state)
+            .isInstanceOf<TextFieldStateConstants.Valid.Full>()
+    }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/CvcStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/CvcStateTest.kt
@@ -34,6 +34,23 @@ class CvcStateTest {
             cvc = ""
         )
 
+        val actual = state.updateCvc("55")
+        assertThat(actual).isEqualTo(
+            CvcState(
+                cardBrand = CardBrand.AmericanExpress,
+                cvc = "55"
+            )
+        )
+        assertThat(actual.isValid).isEqualTo(false)
+    }
+
+    @Test
+    fun `cvc should be valid for cvc length in CardBrand cvcLength set - amex`() {
+        val state = CvcState(
+            cardBrand = CardBrand.AmericanExpress,
+            cvc = ""
+        )
+
         val actual = state.updateCvc("555")
         assertThat(actual).isEqualTo(
             CvcState(
@@ -41,7 +58,7 @@ class CvcStateTest {
                 cvc = "555"
             )
         )
-        assertThat(actual.isValid).isEqualTo(false)
+        assertThat(actual.isValid).isEqualTo(true)
     }
 
     @Test


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Update `CvcConfig.determineState` to check if `CardBrand.cvcLength` contains the current cvc length and return `TextFieldStateConstants.Valid.Limitless` if so. This allows a valid cvc shorter than the max length to be entered without moving focus to the next field.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-2859

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified


https://github.com/user-attachments/assets/b18534cf-d114-4f67-9cba-490729b69ad2



# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
