### PR TITLE
Adds FC availability to FC launchers.

### DIFF
--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundActivity.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundActivity.kt
@@ -65,6 +65,7 @@ import com.stripe.android.payments.bankaccount.CollectBankAccountConfiguration
 import com.stripe.android.payments.bankaccount.CollectBankAccountForInstantDebitsLauncher
 import com.stripe.android.payments.bankaccount.CollectBankAccountLauncher
 import com.stripe.android.payments.bankaccount.CollectBankAccountLauncher.Companion.HOSTED_SURFACE_PAYMENT_ELEMENT
+import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.rememberPaymentSheet
 
@@ -93,6 +94,7 @@ class FinancialConnectionsPlaygroundActivity : AppCompatActivity() {
             hostedSurface = HOSTED_SURFACE_PAYMENT_ELEMENT,
             activityResultRegistryOwner = this,
             callback = viewModel::onCollectBankAccountForInstantDebitsLauncherResult,
+            financialConnectionsAvailability = FinancialConnectionsAvailability.Full
         )
 
         setContent {

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/CollectBankAccountForACHLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/CollectBankAccountForACHLauncher.kt
@@ -2,10 +2,12 @@ package com.stripe.android.payments.bankaccount
 
 import androidx.activity.result.ActivityResultLauncher
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountContract
+import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 
 internal class CollectBankAccountForACHLauncher(
     private val hostActivityLauncher: ActivityResultLauncher<CollectBankAccountContract.Args>,
-    private val hostedSurface: String?
+    private val hostedSurface: String?,
+    private val financialConnectionsAvailability: FinancialConnectionsAvailability?
 ) : CollectBankAccountLauncher {
 
     private val attachToIntent: Boolean
@@ -28,6 +30,7 @@ internal class CollectBankAccountForACHLauncher(
                 configuration = configuration,
                 hostedSurface = hostedSurface,
                 attachToIntent = attachToIntent,
+                financialConnectionsAvailability = financialConnectionsAvailability
             )
         )
     }
@@ -46,6 +49,7 @@ internal class CollectBankAccountForACHLauncher(
                 configuration = configuration,
                 hostedSurface = hostedSurface,
                 attachToIntent = attachToIntent,
+                financialConnectionsAvailability = financialConnectionsAvailability
             )
         )
     }
@@ -70,6 +74,7 @@ internal class CollectBankAccountForACHLauncher(
                 onBehalfOf = onBehalfOf,
                 amount = amount,
                 hostedSurface = hostedSurface,
+                financialConnectionsAvailability = financialConnectionsAvailability,
                 currency = currency,
             )
         )
@@ -91,6 +96,7 @@ internal class CollectBankAccountForACHLauncher(
                 configuration = configuration,
                 customerId = customerId,
                 hostedSurface = hostedSurface,
+                financialConnectionsAvailability = financialConnectionsAvailability,
                 onBehalfOf = onBehalfOf,
             )
         )

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/CollectBankAccountForInstantDebitsLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/CollectBankAccountForInstantDebitsLauncher.kt
@@ -6,11 +6,13 @@ import androidx.annotation.RestrictTo
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountContract
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountForInstantDebitsResult
 import com.stripe.android.payments.bankaccount.navigation.toInstantDebitsResult
+import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class CollectBankAccountForInstantDebitsLauncher(
     private val hostActivityLauncher: ActivityResultLauncher<CollectBankAccountContract.Args>,
-    private val hostedSurface: String?
+    private val financialConnectionsAvailability: FinancialConnectionsAvailability?,
+    private val hostedSurface: String?,
 ) : CollectBankAccountLauncher {
 
     override fun presentWithPaymentIntent(
@@ -26,6 +28,7 @@ class CollectBankAccountForInstantDebitsLauncher(
                 clientSecret = clientSecret,
                 configuration = configuration,
                 hostedSurface = hostedSurface,
+                financialConnectionsAvailability = financialConnectionsAvailability,
                 attachToIntent = true
             )
         )
@@ -44,6 +47,7 @@ class CollectBankAccountForInstantDebitsLauncher(
                 clientSecret = clientSecret,
                 configuration = configuration,
                 hostedSurface = hostedSurface,
+                financialConnectionsAvailability = financialConnectionsAvailability,
                 attachToIntent = true
             )
         )
@@ -69,6 +73,7 @@ class CollectBankAccountForInstantDebitsLauncher(
                 onBehalfOf = onBehalfOf,
                 amount = amount,
                 hostedSurface = hostedSurface,
+                financialConnectionsAvailability = financialConnectionsAvailability,
                 currency = currency,
             )
         )
@@ -90,6 +95,7 @@ class CollectBankAccountForInstantDebitsLauncher(
                 configuration = configuration,
                 customerId = customerId,
                 onBehalfOf = onBehalfOf,
+                financialConnectionsAvailability = financialConnectionsAvailability,
                 hostedSurface = hostedSurface,
             )
         )
@@ -107,6 +113,7 @@ class CollectBankAccountForInstantDebitsLauncher(
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         fun createForPaymentSheet(
             hostedSurface: String,
+            financialConnectionsAvailability: FinancialConnectionsAvailability?,
             activityResultRegistryOwner: ActivityResultRegistryOwner,
             callback: (CollectBankAccountForInstantDebitsResult) -> Unit,
         ): CollectBankAccountLauncher {
@@ -114,6 +121,7 @@ class CollectBankAccountForInstantDebitsLauncher(
                 // TODO@carlosmuvi: if exposing this as an L1 (standalone) integration,
                 // use a separate method and ensure the correct hostedSurface is set.
                 hostedSurface = hostedSurface,
+                financialConnectionsAvailability = financialConnectionsAvailability,
                 hostActivityLauncher = activityResultRegistryOwner.activityResultRegistry.register(
                     LAUNCHER_KEY,
                     CollectBankAccountContract()

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/CollectBankAccountLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/CollectBankAccountLauncher.kt
@@ -11,6 +11,8 @@ import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountCont
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResult
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResultInternal
 import com.stripe.android.payments.bankaccount.navigation.toUSBankAccountResult
+import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
+import com.stripe.android.payments.financialconnections.GetFinancialConnectionsAvailability
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -84,7 +86,8 @@ interface CollectBankAccountLauncher {
                 hostedSurface = null,
                 hostActivityLauncher = activity.registerForActivityResult(CollectBankAccountContract()) {
                     callback(it.toUSBankAccountResult())
-                }
+                },
+                financialConnectionsAvailability = GetFinancialConnectionsAvailability(elementsSession = null),
             )
         }
 
@@ -103,7 +106,8 @@ interface CollectBankAccountLauncher {
                 hostedSurface = null,
                 hostActivityLauncher = fragment.registerForActivityResult(CollectBankAccountContract()) {
                     callback(it.toUSBankAccountResult())
-                }
+                },
+                financialConnectionsAvailability = GetFinancialConnectionsAvailability(elementsSession = null)
             )
         }
 
@@ -113,6 +117,7 @@ interface CollectBankAccountLauncher {
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         fun createForPaymentSheet(
             hostedSurface: String,
+            financialConnectionsAvailability: FinancialConnectionsAvailability?,
             activityResultRegistryOwner: ActivityResultRegistryOwner,
             callback: (CollectBankAccountResultInternal) -> Unit,
         ): CollectBankAccountLauncher {
@@ -122,7 +127,8 @@ interface CollectBankAccountLauncher {
                     LAUNCHER_KEY,
                     CollectBankAccountContract(),
                     callback,
-                )
+                ),
+                financialConnectionsAvailability = GetFinancialConnectionsAvailability(elementsSession = null)
             )
         }
     }

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/navigation/CollectBankAccountContract.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/navigation/CollectBankAccountContract.kt
@@ -10,6 +10,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.core.os.bundleOf
 import com.stripe.android.payments.bankaccount.CollectBankAccountConfiguration
 import com.stripe.android.payments.bankaccount.ui.CollectBankAccountActivity
+import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 import kotlinx.parcelize.Parcelize
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -46,6 +47,7 @@ class CollectBankAccountContract :
         open val clientSecret: String?,
         open val configuration: CollectBankAccountConfiguration,
         open val attachToIntent: Boolean,
+        open val financialConnectionsAvailability: FinancialConnectionsAvailability?,
         open val hostedSurface: String?
     ) : Parcelable {
         fun toBundle() = bundleOf(EXTRA_ARGS to this)
@@ -65,6 +67,7 @@ class CollectBankAccountContract :
             override val clientSecret: String,
             override val configuration: CollectBankAccountConfiguration,
             override val attachToIntent: Boolean,
+            override val financialConnectionsAvailability: FinancialConnectionsAvailability?,
             override val hostedSurface: String?
         ) : Args(
             publishableKey = publishableKey,
@@ -72,6 +75,7 @@ class CollectBankAccountContract :
             hostedSurface = hostedSurface,
             clientSecret = clientSecret,
             configuration = configuration,
+            financialConnectionsAvailability = financialConnectionsAvailability,
             attachToIntent = attachToIntent
         )
 
@@ -83,6 +87,7 @@ class CollectBankAccountContract :
             override val clientSecret: String,
             override val configuration: CollectBankAccountConfiguration,
             override val attachToIntent: Boolean,
+            override val financialConnectionsAvailability: FinancialConnectionsAvailability?,
             override val hostedSurface: String?
         ) : Args(
             publishableKey = publishableKey,
@@ -90,6 +95,7 @@ class CollectBankAccountContract :
             hostedSurface = hostedSurface,
             clientSecret = clientSecret,
             configuration = configuration,
+            financialConnectionsAvailability = financialConnectionsAvailability,
             attachToIntent = attachToIntent
         )
 
@@ -99,6 +105,7 @@ class CollectBankAccountContract :
             override val publishableKey: String,
             override val stripeAccountId: String?,
             override val configuration: CollectBankAccountConfiguration,
+            override val financialConnectionsAvailability: FinancialConnectionsAvailability?,
             override val hostedSurface: String?,
             val elementsSessionId: String,
             val customerId: String?,
@@ -111,6 +118,7 @@ class CollectBankAccountContract :
             hostedSurface = hostedSurface,
             clientSecret = null,
             configuration = configuration,
+            financialConnectionsAvailability = financialConnectionsAvailability,
             attachToIntent = false,
         )
 
@@ -121,6 +129,7 @@ class CollectBankAccountContract :
             override val stripeAccountId: String?,
             override val configuration: CollectBankAccountConfiguration,
             override val hostedSurface: String?,
+            override val financialConnectionsAvailability: FinancialConnectionsAvailability?,
             val elementsSessionId: String,
             val customerId: String?,
             val onBehalfOf: String?,
@@ -130,6 +139,7 @@ class CollectBankAccountContract :
             hostedSurface = hostedSurface,
             clientSecret = null,
             configuration = configuration,
+            financialConnectionsAvailability = financialConnectionsAvailability,
             attachToIntent = false
         )
 

--- a/payments-core/src/test/java/com/stripe/android/payments/bankaccount/CollectBankAccountForACHLauncherTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/bankaccount/CollectBankAccountForACHLauncherTest.kt
@@ -2,6 +2,9 @@ package com.stripe.android.payments.bankaccount
 
 import androidx.activity.result.ActivityResultLauncher
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountContract
+import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
+import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability.Full
+import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability.Lite
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
@@ -16,7 +19,9 @@ class CollectBankAccountForACHLauncherTest {
 
     @Test
     fun `presentWithPaymentIntent - launches CollectBankAccountActivity with correct arguments`() {
-        val launcher = makeLauncher()
+        val launcher = makeLauncher(
+            financialConnectionsAvailability = Lite
+        )
 
         launcher.presentWithPaymentIntent(
             publishableKey = PUBLISHABLE_KEY,
@@ -32,14 +37,18 @@ class CollectBankAccountForACHLauncherTest {
                 clientSecret = CLIENT_SECRET,
                 configuration = CONFIGURATION,
                 attachToIntent = true,
-                hostedSurface = null
+                hostedSurface = null,
+                financialConnectionsAvailability = Lite
             )
         )
     }
 
     @Test
     fun `presentWithPaymentIntent - launches with correct attachToIntent if hostedSurface not null`() {
-        val launcher = makeLauncher(hostedSurface = "payment_element")
+        val launcher = makeLauncher(
+            hostedSurface = "payment_element",
+            financialConnectionsAvailability = Full
+        )
 
         launcher.presentWithPaymentIntent(
             publishableKey = PUBLISHABLE_KEY,
@@ -56,6 +65,7 @@ class CollectBankAccountForACHLauncherTest {
                 configuration = CONFIGURATION,
                 attachToIntent = false,
                 hostedSurface = "payment_element",
+                financialConnectionsAvailability = FinancialConnectionsAvailability.Full
             )
         )
     }
@@ -78,7 +88,8 @@ class CollectBankAccountForACHLauncherTest {
                 clientSecret = CLIENT_SECRET,
                 configuration = CONFIGURATION,
                 attachToIntent = true,
-                hostedSurface = null
+                hostedSurface = null,
+                financialConnectionsAvailability = Full
             )
         )
     }
@@ -102,13 +113,16 @@ class CollectBankAccountForACHLauncherTest {
                 configuration = CONFIGURATION,
                 attachToIntent = false,
                 hostedSurface = "payment_element",
+                financialConnectionsAvailability = Full
             )
         )
     }
 
     @Test
     fun `presentWithDeferredPayment - launches CollectBankAccountActivity with correct arguments`() {
-        val launcher = makeLauncher()
+        val launcher = makeLauncher(
+            financialConnectionsAvailability = Lite
+        )
 
         launcher.presentWithDeferredPayment(
             publishableKey = PUBLISHABLE_KEY,
@@ -131,7 +145,8 @@ class CollectBankAccountForACHLauncherTest {
                 onBehalfOf = "on_behalf_of_id",
                 amount = 1000,
                 currency = "usd",
-                hostedSurface = null
+                hostedSurface = null,
+                financialConnectionsAvailability = Lite
             )
         )
     }
@@ -157,17 +172,20 @@ class CollectBankAccountForACHLauncherTest {
                 elementsSessionId = "elements_session_id",
                 customerId = "customer_id",
                 onBehalfOf = "on_behalf_of_id",
-                hostedSurface = null
+                hostedSurface = null,
+                financialConnectionsAvailability = Full
             )
         )
     }
 
     private fun makeLauncher(
         hostedSurface: String? = null,
+        financialConnectionsAvailability: FinancialConnectionsAvailability = Full
     ): CollectBankAccountForACHLauncher {
         return CollectBankAccountForACHLauncher(
             mockHostActivityLauncher,
             hostedSurface = hostedSurface,
+            financialConnectionsAvailability = financialConnectionsAvailability
         )
     }
 

--- a/payments-core/src/test/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModelTest.kt
@@ -21,6 +21,7 @@ import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResp
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResultInternal
 import com.stripe.android.payments.bankaccount.ui.CollectBankAccountViewEffect.FinishWithResult
 import com.stripe.android.payments.bankaccount.ui.CollectBankAccountViewEffect.OpenConnectionsFlow
+import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -514,7 +515,8 @@ class CollectBankAccountViewModelTest {
                 email
             ),
             attachToIntent = attachToIntent,
-            hostedSurface = "payment_element"
+            hostedSurface = "payment_element",
+            financialConnectionsAvailability = FinancialConnectionsAvailability.Full
         )
     }
 
@@ -530,7 +532,8 @@ class CollectBankAccountViewModelTest {
                 email
             ),
             attachToIntent = attachToIntent,
-            hostedSurface = "payment_element"
+            hostedSurface = "payment_element",
+            financialConnectionsAvailability = FinancialConnectionsAvailability.Full
         )
     }
 
@@ -547,7 +550,8 @@ class CollectBankAccountViewModelTest {
             onBehalfOf = "on_behalf_of_id",
             amount = 1000,
             currency = "usd",
-            hostedSurface = "payment_element"
+            hostedSurface = "payment_element",
+            financialConnectionsAvailability = FinancialConnectionsAvailability.Full
         )
     }
 
@@ -562,7 +566,8 @@ class CollectBankAccountViewModelTest {
             elementsSessionId = "elements_session_id",
             customerId = "customer_id",
             onBehalfOf = "on_behalf_of_id",
-            hostedSurface = "payment_element"
+            hostedSurface = "payment_element",
+            financialConnectionsAvailability = FinancialConnectionsAvailability.Full
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -131,7 +131,6 @@ internal class DefaultCustomerSheetLoader(
             paymentMethodSaveConsentBehavior = customerSheetSession.paymentMethodSaveConsentBehavior,
             sharedDataSpecs = sharedDataSpecs,
             isGooglePayReady = isGooglePayReadyAndEnabled,
-            isFinancialConnectionsAvailable = isFinancialConnectionsAvailable,
             isPaymentMethodSyncDefaultEnabled = isPaymentMethodSyncDefaultEnabled,
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -50,6 +50,7 @@ import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.payments.bankaccount.CollectBankAccountLauncher
 import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.payments.financialconnections.GetFinancialConnectionsAvailability
 import com.stripe.android.paymentsheet.CardUpdateParams
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.R
@@ -844,6 +845,7 @@ internal class CustomerSheetViewModel(
                 handleViewAction(CustomerSheetViewAction.OnFormError(error))
             },
             setAsDefaultPaymentMethodEnabled = false,
+            financialConnectionsAvailability = GetFinancialConnectionsAvailability(elementsSession = null),
             setAsDefaultMatchesSaveForFutureUse = FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE,
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/AddPaymentMethodRequirement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/AddPaymentMethodRequirement.kt
@@ -43,7 +43,7 @@ internal enum class AddPaymentMethodRequirement {
     /** Requires that the FinancialConnections SDK has been linked. */
     FinancialConnectionsSdk {
         override fun isMetBy(metadata: PaymentMethodMetadata): Boolean {
-            return metadata.financialConnectionsAvailable
+            return metadata.financialConnectionsAvailability != null
         }
     },
 

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -17,8 +17,8 @@ import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
-import com.stripe.android.payments.financialconnections.DefaultIsFinancialConnectionsAvailable
-import com.stripe.android.payments.financialconnections.IsFinancialConnectionsSdkAvailable
+import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
+import com.stripe.android.payments.financialconnections.GetFinancialConnectionsAvailability
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.model.PaymentMethodIncentive
@@ -59,7 +59,7 @@ internal data class PaymentMethodMetadata(
     val linkMode: LinkMode?,
     val linkState: LinkState?,
     val paymentMethodIncentive: PaymentMethodIncentive?,
-    val financialConnectionsAvailable: Boolean = DefaultIsFinancialConnectionsAvailable(),
+    val financialConnectionsAvailability: FinancialConnectionsAvailability?,
     val cardBrandFilter: CardBrandFilter,
     val elementsSessionId: String
 ) : Parcelable {
@@ -276,6 +276,7 @@ internal data class PaymentMethodMetadata(
                 isGooglePayReady = isGooglePayReady,
                 displayableCustomPaymentMethods = elementsSession.toDisplayableCustomPaymentMethods(configuration),
                 cardBrandFilter = PaymentSheetCardBrandFilter(configuration.cardBrandAcceptance),
+                financialConnectionsAvailability = GetFinancialConnectionsAvailability(elementsSession),
                 elementsSessionId = elementsSession.elementsSessionId
             )
         }
@@ -286,7 +287,6 @@ internal data class PaymentMethodMetadata(
             paymentMethodSaveConsentBehavior: PaymentMethodSaveConsentBehavior,
             sharedDataSpecs: List<SharedDataSpec>,
             isGooglePayReady: Boolean,
-            isFinancialConnectionsAvailable: IsFinancialConnectionsSdkAvailable,
             isPaymentMethodSyncDefaultEnabled: Boolean,
         ): PaymentMethodMetadata {
             return PaymentMethodMetadata(
@@ -309,7 +309,6 @@ internal data class PaymentMethodMetadata(
                 sharedDataSpecs = sharedDataSpecs,
                 isGooglePayReady = isGooglePayReady,
                 linkInlineConfiguration = null,
-                financialConnectionsAvailable = isFinancialConnectionsAvailable(),
                 paymentMethodSaveConsentBehavior = paymentMethodSaveConsentBehavior,
                 linkMode = elementsSession.linkSettings?.linkMode,
                 linkState = null,
@@ -317,7 +316,8 @@ internal data class PaymentMethodMetadata(
                 externalPaymentMethodSpecs = emptyList(),
                 displayableCustomPaymentMethods = emptyList(),
                 cardBrandFilter = PaymentSheetCardBrandFilter(configuration.cardBrandAcceptance),
-                elementsSessionId = elementsSession.elementsSessionId
+                elementsSessionId = elementsSession.elementsSessionId,
+                financialConnectionsAvailability = GetFinancialConnectionsAvailability(elementsSession)
             )
         }
 
@@ -351,7 +351,8 @@ internal data class PaymentMethodMetadata(
                 isGooglePayReady = false,
                 displayableCustomPaymentMethods = emptyList(),
                 cardBrandFilter = PaymentSheetCardBrandFilter(PaymentSheet.CardBrandAcceptance.all()),
-                elementsSessionId = configuration.elementsSessionId
+                elementsSessionId = configuration.elementsSessionId,
+                financialConnectionsAvailability = GetFinancialConnectionsAvailability(elementsSession = null)
             )
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountForm.kt
@@ -89,6 +89,7 @@ internal fun USBankAccountForm(
                 savedPaymentMethod = usBankAccountFormArgs.draftPaymentSelection as? New.USBankAccount,
                 shippingDetails = usBankAccountFormArgs.shippingDetails,
                 setAsDefaultPaymentMethodEnabled = usBankAccountFormArgs.setAsDefaultPaymentMethodEnabled,
+                financialConnectionsAvailability = usBankAccountFormArgs.financialConnectionsAvailability,
                 setAsDefaultMatchesSaveForFutureUse = usBankAccountFormArgs.setAsDefaultMatchesSaveForFutureUse,
             )
         },

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArguments.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArguments.kt
@@ -7,6 +7,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.LinkMode
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetViewModel
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
@@ -61,6 +62,7 @@ internal class USBankAccountFormArguments(
     val onUpdatePrimaryButtonState: (PrimaryButton.State) -> Unit,
     val onError: (ResolvableString?) -> Unit,
     val setAsDefaultPaymentMethodEnabled: Boolean,
+    val financialConnectionsAvailability: FinancialConnectionsAvailability?,
     val setAsDefaultMatchesSaveForFutureUse: Boolean,
 ) {
     companion object {
@@ -108,6 +110,7 @@ internal class USBankAccountFormArguments(
                 setAsDefaultPaymentMethodEnabled =
                 paymentMethodMetadata.customerMetadata?.isPaymentMethodSetAsDefaultEnabled
                     ?: IS_PAYMENT_METHOD_SET_AS_DEFAULT_ENABLED_DEFAULT_VALUE,
+                financialConnectionsAvailability = paymentMethodMetadata.financialConnectionsAvailability,
                 setAsDefaultMatchesSaveForFutureUse = viewModel.customerStateHolder.paymentMethods.value.isEmpty(),
             )
         }
@@ -156,6 +159,7 @@ internal class USBankAccountFormArguments(
                 setAsDefaultPaymentMethodEnabled =
                 paymentMethodMetadata.customerMetadata?.isPaymentMethodSetAsDefaultEnabled
                     ?: IS_PAYMENT_METHOD_SET_AS_DEFAULT_ENABLED_DEFAULT_VALUE,
+                financialConnectionsAvailability = paymentMethodMetadata.financialConnectionsAvailability,
                 setAsDefaultMatchesSaveForFutureUse = FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE,
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -29,6 +29,7 @@ import com.stripe.android.payments.bankaccount.CollectBankAccountLauncher
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountForInstantDebitsResult
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResponseInternal
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResultInternal
+import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode
@@ -296,12 +297,14 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
             CollectBankAccountForInstantDebitsLauncher.createForPaymentSheet(
                 hostedSurface = args.hostedSurface,
                 activityResultRegistryOwner = activityResultRegistryOwner,
+                financialConnectionsAvailability = args.financialConnectionsAvailability,
                 callback = ::handleInstantDebitsResult,
             )
         } else {
             CollectBankAccountLauncher.createForPaymentSheet(
                 hostedSurface = args.hostedSurface,
                 activityResultRegistryOwner = activityResultRegistryOwner,
+                financialConnectionsAvailability = args.financialConnectionsAvailability,
                 callback = ::handleCollectBankAccountResult,
             )
         }
@@ -742,6 +745,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
         val savedPaymentMethod: PaymentSelection.New.USBankAccount?,
         val shippingDetails: AddressDetails?,
         val hostedSurface: String,
+        val financialConnectionsAvailability: FinancialConnectionsAvailability?,
         val setAsDefaultPaymentMethodEnabled: Boolean,
         val setAsDefaultMatchesSaveForFutureUse: Boolean,
     )

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -15,6 +15,7 @@ import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.payments.bankaccount.CollectBankAccountLauncher
+import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
@@ -76,6 +77,7 @@ internal class CustomerSheetScreenshotTest {
         onUpdatePrimaryButtonUIState = { },
         onError = { },
         setAsDefaultPaymentMethodEnabled = false,
+        financialConnectionsAvailability = FinancialConnectionsAvailability.Full,
         setAsDefaultMatchesSaveForFutureUse = false,
     )
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -1978,7 +1978,6 @@ class CustomerSheetViewModelTest {
                     customerPaymentMethods = listOf(),
                     isGooglePayAvailable = false,
                     stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD_WITH_US_BANK_ACCOUNT,
-                    financialConnectionsAvailable = true,
                 ),
                 configuration = CustomerSheet.Configuration(
                     merchantDisplayName = "Merchant, Inc.",

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/FakeCustomerSheetLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/FakeCustomerSheetLoader.kt
@@ -10,6 +10,8 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFact
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
+import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability.Full
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import kotlinx.coroutines.delay
@@ -27,7 +29,7 @@ internal class FakeCustomerSheetLoader(
     private val isGooglePayAvailable: Boolean = false,
     private val delay: Duration = Duration.ZERO,
     private val cbcEligibility: CardBrandChoiceEligibility = CardBrandChoiceEligibility.Ineligible,
-    private val financialConnectionsAvailable: Boolean = false,
+    private val financialConnectionsAvailability: FinancialConnectionsAvailability = Full,
     private val permissions: CustomerPermissions = CustomerPermissions(
         canRemovePaymentMethods = true,
         canRemoveLastPaymentMethod = true,
@@ -46,7 +48,7 @@ internal class FakeCustomerSheetLoader(
                     PaymentMethodMetadataFactory.create(
                         stripeIntent = stripeIntent,
                         cbcEligibility = cbcEligibility,
-                        financialConnectionsAvailable = financialConnectionsAvailable,
+                        financialConnectionsAvailability = financialConnectionsAvailability,
                         paymentMethodOrder = configuration.paymentMethodOrder,
                         isGooglePayReady = isGooglePayAvailable,
                         isPaymentMethodSetAsDefaultEnabled = isPaymentMethodSyncDefaultEnabled,

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/AddPaymentMethodRequirementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/AddPaymentMethodRequirementTest.kt
@@ -9,6 +9,8 @@ import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability.Full
+import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability.Lite
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode
@@ -130,14 +132,20 @@ internal class AddPaymentMethodRequirementTest {
     }
 
     @Test
-    fun testFinancialConnectionsSdkReturnsTrue() {
-        val metadata = PaymentMethodMetadataFactory.create(financialConnectionsAvailable = true)
+    fun testFinancialConnectionsWithLiteSdkReturnsTrue() {
+        val metadata = PaymentMethodMetadataFactory.create(financialConnectionsAvailability = Lite)
+        assertThat(AddPaymentMethodRequirement.FinancialConnectionsSdk.isMetBy(metadata)).isTrue()
+    }
+
+    @Test
+    fun testFinancialConnectionsWithFullSdkReturnsTrue() {
+        val metadata = PaymentMethodMetadataFactory.create(financialConnectionsAvailability = Full)
         assertThat(AddPaymentMethodRequirement.FinancialConnectionsSdk.isMetBy(metadata)).isTrue()
     }
 
     @Test
     fun testFinancialConnectionsSdkReturnsFalse() {
-        val metadata = PaymentMethodMetadataFactory.create(financialConnectionsAvailable = false)
+        val metadata = PaymentMethodMetadataFactory.create(financialConnectionsAvailability = null)
         assertThat(AddPaymentMethodRequirement.FinancialConnectionsSdk.isMetBy(metadata)).isFalse()
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
@@ -6,6 +6,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.link.LinkInlineConfigurat
 import com.stripe.android.model.LinkMode
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
@@ -23,7 +24,6 @@ internal object PaymentMethodMetadataFactory {
             PaymentSheet.BillingDetailsCollectionConfiguration(),
         allowsDelayedPaymentMethods: Boolean = true,
         allowsPaymentMethodsRequiringShippingAddress: Boolean = false,
-        financialConnectionsAvailable: Boolean = true,
         paymentMethodOrder: List<String> = emptyList(),
         shippingDetails: AddressDetails? = null,
         cbcEligibility: CardBrandChoiceEligibility = CardBrandChoiceEligibility.Ineligible,
@@ -40,14 +40,14 @@ internal object PaymentMethodMetadataFactory {
         defaultBillingDetails: PaymentSheet.BillingDetails = PaymentSheet.BillingDetails(),
         paymentMethodIncentive: PaymentMethodIncentive? = null,
         isPaymentMethodSetAsDefaultEnabled: Boolean = IS_PAYMENT_METHOD_SET_AS_DEFAULT_ENABLED_DEFAULT_VALUE,
-        elementsSessionId: String = "session_1234"
+        elementsSessionId: String = "session_1234",
+        financialConnectionsAvailability: FinancialConnectionsAvailability? = FinancialConnectionsAvailability.Lite
     ): PaymentMethodMetadata {
         return PaymentMethodMetadata(
             stripeIntent = stripeIntent,
             billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration,
             allowsDelayedPaymentMethods = allowsDelayedPaymentMethods,
             allowsPaymentMethodsRequiringShippingAddress = allowsPaymentMethodsRequiringShippingAddress,
-            financialConnectionsAvailable = financialConnectionsAvailable,
             paymentMethodOrder = paymentMethodOrder,
             cbcEligibility = cbcEligibility,
             merchantName = PaymentSheetFixtures.MERCHANT_DISPLAY_NAME,
@@ -67,7 +67,8 @@ internal object PaymentMethodMetadataFactory {
             linkState = linkState,
             cardBrandFilter = cardBrandFilter,
             paymentMethodIncentive = paymentMethodIncentive,
-            elementsSessionId = elementsSessionId
+            elementsSessionId = elementsSessionId,
+            financialConnectionsAvailability = financialConnectionsAvailability
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -17,6 +17,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
@@ -845,7 +846,8 @@ internal class PaymentMethodMetadataTest {
             linkState = null,
             cardBrandFilter = PaymentSheetCardBrandFilter(cardBrandAcceptance),
             paymentMethodIncentive = null,
-            elementsSessionId = "session_1234"
+            elementsSessionId = "session_1234",
+            financialConnectionsAvailability = FinancialConnectionsAvailability.Full
         )
 
         assertThat(metadata).isEqualTo(expectedMetadata)
@@ -886,7 +888,6 @@ internal class PaymentMethodMetadataTest {
             paymentMethodSaveConsentBehavior = paymentMethodSaveConsentBehavior,
             sharedDataSpecs = listOf(SharedDataSpec("card")),
             isGooglePayReady = true,
-            isFinancialConnectionsAvailable = { false },
             isPaymentMethodSyncDefaultEnabled = false,
         )
 
@@ -911,8 +912,8 @@ internal class PaymentMethodMetadataTest {
             ),
             isGooglePayReady = true,
             paymentMethodSaveConsentBehavior = paymentMethodSaveConsentBehavior,
-            financialConnectionsAvailable = false,
             linkInlineConfiguration = null,
+            financialConnectionsAvailability = FinancialConnectionsAvailability.Full,
             linkMode = null,
             linkState = null,
             cardBrandFilter = PaymentSheetCardBrandFilter(cardBrandAcceptance),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
@@ -24,6 +24,7 @@ import com.stripe.android.payments.bankaccount.CollectBankAccountConfiguration
 import com.stripe.android.payments.bankaccount.CollectBankAccountLauncher
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResponseInternal
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResultInternal
+import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode
@@ -81,6 +82,7 @@ class USBankAccountFormViewModelTest {
         linkMode = null,
         setAsDefaultPaymentMethodEnabled = false,
         setAsDefaultMatchesSaveForFutureUse = false,
+        financialConnectionsAvailability = FinancialConnectionsAvailability.Full
     )
 
     private val mockCollectBankAccountLauncher = mock<CollectBankAccountLauncher>()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -30,6 +30,7 @@ import com.stripe.android.model.StripeIntent.Status.Succeeded
 import com.stripe.android.model.wallets.Wallet
 import com.stripe.android.paymentelement.ExperimentalCustomPaymentMethodsApi
 import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 import com.stripe.android.paymentsheet.ExperimentalCustomerSessionApi
 import com.stripe.android.paymentsheet.FakePrefsRepository
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -147,6 +148,7 @@ internal class DefaultPaymentElementLoaderTest {
                     linkMode = null,
                     cardBrandFilter = PaymentSheetCardBrandFilter(PaymentSheet.CardBrandAcceptance.all()),
                     hasCustomerConfiguration = true,
+                    financialConnectionsAvailability = FinancialConnectionsAvailability.Full
                 ),
             )
         )


### PR DESCRIPTION
# Summary
- `CollectBankAccountLauncher`s now take `FinancialConnectionsAvailability`, that should get computed via `GetFinancialConnectionsAvailability` when building the launcher.

Note field is not used yet, just computed and passed as args. 

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
