### PR TITLE
Include managedDevice reports in bitrise artifacts.

### DIFF
--- a/scripts/copy_test_results_to_tmp.sh
+++ b/scripts/copy_test_results_to_tmp.sh
@@ -17,6 +17,7 @@ touch "/tmp/test_results/.keep"
 
 copy_test_results ".*/build/reports/tests/testDebugUnitTest$"
 copy_test_results ".*/build/reports/androidTests/connected$"
+copy_test_results ".*/build/reports/androidTests/managedDevice$"
 
 # If screenshots were requested, and it's a failure.
 if [ "$INCLUDE_SCREENSHOT_ON_FAILURE" == "true" ] && [ "$BITRISE_BUILD_STATUS" == 1 ]; then


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
I was recently investigating a flake that was quite hard to debug due to missing logs. This adds logs when we run instrumentation tests via managed devices.
