### PR TITLE
[connect] Handle redirects back to the app after opening authenticated webview

### DIFF
--- a/connect/build.gradle
+++ b/connect/build.gradle
@@ -68,6 +68,7 @@ dependencies {
     androidTestImplementation (testLibs.espresso.contrib) {
         exclude group: 'org.checkerframework', module: 'checker'
     }
+    androidTestImplementation testLibs.espresso.intents
     androidTestImplementation testLibs.espresso.web
     androidTestImplementation testLibs.mockito.core
     androidTestImplementation testLibs.mockito.inline

--- a/connect/src/androidTest/java/com/stripe/android/connect/StripeConnectRedirectActivityTest.kt
+++ b/connect/src/androidTest/java/com/stripe/android/connect/StripeConnectRedirectActivityTest.kt
@@ -29,7 +29,6 @@ internal class StripeConnectRedirectActivityTest {
     private val redirectIntentMatcher
         get() = hasComponent(StripeConnectRedirectActivity::class.java.name)
 
-
     private fun chromeIntentMatcher(url: String? = null): Matcher<Intent> {
         val matchers = listOfNotNull(
             IntentMatchers.hasAction(Intent.ACTION_VIEW),

--- a/connect/src/androidTest/java/com/stripe/android/connect/StripeConnectRedirectActivityTest.kt
+++ b/connect/src/androidTest/java/com/stripe/android/connect/StripeConnectRedirectActivityTest.kt
@@ -83,7 +83,7 @@ internal class StripeConnectRedirectActivityTest {
         launchWithCustomTabUrl(customTabUrl).use {
             assertThat(it.state).isEqualTo(Lifecycle.State.CREATED)
             closeCustomTab()
-            pollUntil(10.seconds) { it.state == Lifecycle.State.DESTROYED }
+            pollUntil(5.seconds) { it.state == Lifecycle.State.DESTROYED }
         }
     }
 
@@ -105,10 +105,9 @@ internal class StripeConnectRedirectActivityTest {
     }
 
     private fun closeCustomTab() {
-        val result = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-            .findObject(UiSelector().descriptionContains("Close tab"))
-            .click()
-        assertThat(result).isTrue()
+        val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+        device.findObject(UiSelector().packageName("com.android.chrome")).waitForExists(5_000L)
+        device.pressBack()
     }
 
     private suspend inline fun pollUntil(timeout: Duration, crossinline condition: () -> Boolean) {

--- a/connect/src/androidTest/java/com/stripe/android/connect/StripeConnectRedirectActivityTest.kt
+++ b/connect/src/androidTest/java/com/stripe/android/connect/StripeConnectRedirectActivityTest.kt
@@ -1,0 +1,96 @@
+package com.stripe.android.connect
+
+import android.app.Application
+import android.content.Intent
+import android.net.Uri
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.Intents.intended
+import androidx.test.espresso.intent.matcher.IntentMatchers
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import org.hamcrest.CoreMatchers
+import org.hamcrest.Matcher
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+internal class StripeConnectRedirectActivityTest {
+
+    private val packageName = ApplicationProvider.getApplicationContext<Application>().packageName
+    private val deepLinkUri = "stripe-connect://$packageName"
+    private val customTabUrl = "https://localhost:443/"
+
+    private val redirectIntentMatcher
+        get() = hasComponent(StripeConnectRedirectActivity::class.java.name)
+
+
+    private fun chromeIntentMatcher(url: String? = null): Matcher<Intent> {
+        val matchers = listOfNotNull(
+            IntentMatchers.hasAction(Intent.ACTION_VIEW),
+            IntentMatchers.toPackage("com.android.chrome"),
+            url?.let { IntentMatchers.hasData(Uri.parse(it)) }
+        )
+        return CoreMatchers.allOf(matchers)
+    }
+
+    @Before
+    fun setUp() {
+        Intents.init()
+    }
+
+    @Test
+    fun testDefaultOpensAndFinishesImmediately() {
+        launch(viewIntent(deepLinkUri)).use {
+            assertThat(it.state).isEqualTo(Lifecycle.State.DESTROYED)
+            intended(redirectIntentMatcher)
+        }
+    }
+
+    @Test
+    fun testIntentWithUrlOpensCustomTab() {
+        launchWithCustomTabUrl(customTabUrl).use {
+            assertThat(it.state).isEqualTo(Lifecycle.State.CREATED)
+            intended(redirectIntentMatcher)
+            intended(chromeIntentMatcher(customTabUrl))
+        }
+    }
+
+    @Test
+    fun testNewIntentFinishes() {
+        launchWithCustomTabUrl(customTabUrl).use { scenario ->
+            assertThat(scenario.state).isEqualTo(Lifecycle.State.CREATED)
+            launch(viewIntent(deepLinkUri)).use { innerScenario ->
+                assertThat(innerScenario.state).isEqualTo(Lifecycle.State.DESTROYED)
+            }
+            assertThat(scenario.state).isEqualTo(Lifecycle.State.DESTROYED)
+        }
+    }
+
+    private fun viewIntent(uri: String): Intent {
+        return Intent(Intent.ACTION_VIEW, Uri.parse(uri))
+    }
+
+    private fun launch(intent: Intent): ActivityScenario<StripeConnectRedirectActivity> {
+        return ActivityScenario.launch(intent)
+    }
+
+    private fun launchWithCustomTabUrl(url: String): ActivityScenario<StripeConnectRedirectActivity> {
+        val intent =
+            StripeConnectRedirectActivity.customTabIntent(
+                context = ApplicationProvider.getApplicationContext(),
+                url = url
+            )
+        return ActivityScenario.launch(intent)
+    }
+
+    @After
+    fun tearDown() {
+        Intents.release()
+    }
+}

--- a/connect/src/main/AndroidManifest.xml
+++ b/connect/src/main/AndroidManifest.xml
@@ -1,8 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
-    <uses-permission android:name="android.permission.CAMERA"/>
-    <uses-feature android:name="android.hardware.camera" android:required="false" />
+    <uses-permission android:name="android.permission.CAMERA" />
+
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
+
+    <application>
+        <activity
+            android:name=".StripeConnectRedirectActivity"
+            android:launchMode="singleTask"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="stripe-connect"
+                    android:host="${applicationId}" />
+            </intent-filter>
+        </activity>
+    </application>
 </manifest>

--- a/connect/src/main/AndroidManifest.xml
+++ b/connect/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
     <application>
         <activity
             android:name=".StripeConnectRedirectActivity"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar"
             android:launchMode="singleTask"
             android:exported="true">
             <intent-filter>

--- a/connect/src/main/java/com/stripe/android/connect/StripeConnectRedirectActivity.kt
+++ b/connect/src/main/java/com/stripe/android/connect/StripeConnectRedirectActivity.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import androidx.annotation.RestrictTo
 import androidx.browser.customtabs.CustomTabsIntent
 
 /**
@@ -19,6 +20,7 @@ import androidx.browser.customtabs.CustomTabsIntent
  *      it was closed
  *    - no additional task is added to the Android "Recents" screen
  */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class StripeConnectRedirectActivity : Activity() {
     private var didPause = false
 
@@ -65,7 +67,7 @@ class StripeConnectRedirectActivity : Activity() {
         didPause = true
     }
 
-    companion object {
+    internal companion object {
         private const val EXTRA_CUSTOM_TAB_URL = "custom_tab_url"
 
         fun customTabIntent(context: Context, url: String): Intent {

--- a/connect/src/main/java/com/stripe/android/connect/StripeConnectRedirectActivity.kt
+++ b/connect/src/main/java/com/stripe/android/connect/StripeConnectRedirectActivity.kt
@@ -1,0 +1,11 @@
+package com.stripe.android.connect
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+
+class StripeConnectRedirectActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        finish()
+    }
+}

--- a/connect/src/main/java/com/stripe/android/connect/StripeConnectRedirectActivity.kt
+++ b/connect/src/main/java/com/stripe/android/connect/StripeConnectRedirectActivity.kt
@@ -1,11 +1,77 @@
 package com.stripe.android.connect
 
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
+import androidx.browser.customtabs.CustomTabsIntent
 
-class StripeConnectRedirectActivity : AppCompatActivity() {
+/**
+ * An activity used to (re)open the app via redirect deep link, e.g. stripe-connect//com.example.app.
+ * It is designed to resume where the user was left off after opening a Chrome Custom Tab.
+ *
+ * Features:
+ *  - Opening the redirect deep link will close the Custom Tab and resume the launching activity,
+ *    even while the app is in the foreground
+ *  - Custom Tab is opened in the same task as the launching activity, so:
+ *    - the launching activity is *always* resumed after the Custom Tab is closed, no matter how
+ *      it was closed
+ *    - no additional task is added to the Android "Recents" screen
+ */
+class StripeConnectRedirectActivity : Activity() {
+    private var didPause = false
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val customTabUrl = intent.getStringExtra(EXTRA_CUSTOM_TAB_URL)
+        if (customTabUrl != null) {
+            // Open the Custom Tab, but don't finish. The activity needs to be under the
+            // Custom Tab activity so when the redirect is received, the task is cleared
+            // via the combination of:
+            //  - this activity having launchMode="singleTask"
+            //  - intent flags FLAG_ACTIVITY_SINGLE_TOP and FLAG_ACTIVITY_CLEAR_TOP
+            // With the task cleared, the activity finishes in `onNewIntent()`
+            val customTabsIntent = CustomTabsIntent.Builder().build()
+            customTabsIntent.launchUrl(this, Uri.parse(customTabUrl))
+        } else {
+            // Shouldn't happen under normal circumstances -- just finish.
+            finish()
+        }
+    }
+
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        // See comment in `onCreate()`.
         finish()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        // When launching a Custom Tab, this activity will briefly resume before immediately
+        // pausing when the Custom Tab activity opens. We don't want to `finish()` in this
+        // initial case (see comment in `onCreate()`).
+        //
+        // However, we *do* want to `finish()` in subsequent resumes because it means the
+        // Custom Tab has closed.
+        if (didPause) {
+            finish()
+        }
+    }
+
+    override fun onPause() {
+        super.onPause()
+        // See `onResume()`.
+        didPause = true
+    }
+
+    companion object {
+        private const val EXTRA_CUSTOM_TAB_URL = "custom_tab_url"
+
+        fun customTabIntent(context: Context, url: String): Intent {
+            return Intent(context, StripeConnectRedirectActivity::class.java)
+                .setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                .putExtra(EXTRA_CUSTOM_TAB_URL, url)
+        }
     }
 }

--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebView.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebView.kt
@@ -136,6 +136,15 @@ internal class StripeConnectWebView private constructor(
         )
     }
 
+    fun returnedFromAuthenticatedWebView(url: String?) {
+        evaluateSdkJs(
+            function = "returnedFromAuthenticatedWebView",
+            payload = buildJsonObject {
+                put("url", url)
+            },
+        )
+    }
+
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
         // We need the Activity context for some UI to work, like web-triggered dialogs

--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebView.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebView.kt
@@ -32,6 +32,7 @@ import com.stripe.android.connect.util.findActivity
 import com.stripe.android.connect.util.isInInstrumentationTest
 import com.stripe.android.connect.webview.serialization.AccountSessionClaimedMessage
 import com.stripe.android.connect.webview.serialization.AlertJs
+import com.stripe.android.connect.webview.serialization.AppInfoJs
 import com.stripe.android.connect.webview.serialization.ConnectInstanceJs
 import com.stripe.android.connect.webview.serialization.ConnectJson
 import com.stripe.android.connect.webview.serialization.OpenAuthenticatedWebViewMessage
@@ -443,6 +444,12 @@ internal class StripeConnectWebView private constructor(
             val initialParams = delegate.getInitialParams(context)
             logger.debug("($loggerTag) InitParams fetched: ${initialParams.toDebugString()}")
             return ConnectJson.encodeToString(initialParams)
+        }
+
+        @JavascriptInterface
+        fun fetchAppInfo(): String {
+            logger.debug("($loggerTag) fetchAppInfo called")
+            return ConnectJson.encodeToString(AppInfoJs(applicationId = context.packageName))
         }
 
         @JavascriptInterface

--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerState.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerState.kt
@@ -5,6 +5,7 @@ import androidx.annotation.ColorInt
 import com.stripe.android.connect.PrivateBetaConnectSDK
 import com.stripe.android.connect.appearance.Appearance
 import com.stripe.android.connect.util.getContrastingColor
+import com.stripe.android.connect.webview.serialization.OpenAuthenticatedWebViewMessage
 
 @OptIn(PrivateBetaConnectSDK::class)
 internal data class StripeConnectWebViewContainerState(
@@ -35,9 +36,9 @@ internal data class StripeConnectWebViewContainerState(
     val receivedCloseWebView: Boolean = false,
 
     /**
-     * URL launched from the last `receivedOpenAuthenticatedWebViewUrl` message.
+     * Message from the last `receivedOpenAuthenticatedWebViewUrl` message.
      */
-    val receivedOpenAuthenticatedWebViewUrl: String? = null,
+    val receivedOpenAuthenticatedWebViewMessage: OpenAuthenticatedWebViewMessage? = null,
 
     /**
      * The appearance to use for the view.

--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerState.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerState.kt
@@ -36,7 +36,7 @@ internal data class StripeConnectWebViewContainerState(
     val receivedCloseWebView: Boolean = false,
 
     /**
-     * Message from the last `receivedOpenAuthenticatedWebViewUrl` message.
+     * Message from the last `openAuthenticatedWebView` message.
      */
     val receivedOpenAuthenticatedWebViewMessage: OpenAuthenticatedWebViewMessage? = null,
 

--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerState.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerState.kt
@@ -35,6 +35,11 @@ internal data class StripeConnectWebViewContainerState(
     val receivedCloseWebView: Boolean = false,
 
     /**
+     * URL launched from the last `receivedOpenAuthenticatedWebViewUrl` message.
+     */
+    val receivedOpenAuthenticatedWebViewUrl: String? = null,
+
+    /**
      * The appearance to use for the view.
      */
     val appearance: Appearance? = null

--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerViewModel.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerViewModel.kt
@@ -152,6 +152,14 @@ internal class StripeConnectWebViewContainerViewModel(
         }
     }
 
+    override fun onResume(owner: LifecycleOwner) {
+        val receivedOpenAuthenticatedWebViewUrl = stateFlow.value.receivedOpenAuthenticatedWebViewUrl
+        if (receivedOpenAuthenticatedWebViewUrl != null) {
+            updateState { copy(receivedOpenAuthenticatedWebViewUrl = null) }
+            webView.returnedFromAuthenticatedWebView(receivedOpenAuthenticatedWebViewUrl)
+        }
+    }
+
     @VisibleForTesting
     @Suppress("TooManyFunctions")
     internal inner class StripeConnectWebViewDelegate : Delegate {
@@ -321,6 +329,7 @@ internal class StripeConnectWebViewContainerViewModel(
             message: OpenAuthenticatedWebViewMessage
         ) {
             stripeIntentLauncher.launchSecureExternalWebTab(activity, message.url.toUri())
+            updateState { copy(receivedOpenAuthenticatedWebViewUrl = message.url) }
             analyticsService.track(
                 ConnectAnalyticsEvent.AuthenticatedWebOpened(
                     pageViewId = stateFlow.value.pageViewId,

--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeIntentLauncher.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeIntentLauncher.kt
@@ -4,8 +4,8 @@ import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import androidx.browser.customtabs.CustomTabsIntent
 import com.stripe.android.connect.R
+import com.stripe.android.connect.StripeConnectRedirectActivity
 import com.stripe.android.connect.di.StripeConnectComponent
 import com.stripe.android.core.Logger
 
@@ -32,8 +32,12 @@ internal class StripeIntentLauncherImpl(
 ) : StripeIntentLauncher {
 
     override fun launchSecureExternalWebTab(context: Context, uri: Uri) {
-        val customTabsIntent = CustomTabsIntent.Builder().build()
-        customTabsIntent.launchUrl(context, uri)
+        context.startActivity(
+            StripeConnectRedirectActivity.customTabIntent(
+                context = context,
+                url = uri.toString()
+            )
+        )
     }
 
     override fun launchUrlWithSystemHandler(context: Context, uri: Uri) {

--- a/connect/src/main/java/com/stripe/android/connect/webview/serialization/AppInfoJs.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/serialization/AppInfoJs.kt
@@ -1,0 +1,8 @@
+package com.stripe.android.connect.webview.serialization
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class AppInfoJs(
+    val applicationId: String
+)

--- a/connect/src/test/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerViewModelTest.kt
+++ b/connect/src/test/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerViewModelTest.kt
@@ -43,6 +43,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.doReturn
@@ -317,6 +318,27 @@ class StripeConnectWebViewContainerViewModelTest {
                 authenticatedViewId = message.id,
             )
         )
+    }
+
+    @Test
+    fun `should invoke returnedFromAuthenticatedWebView when resumed from ChromeCustomTab`() {
+        val uri = Uri.parse("https://test.stripe.com/")
+        val message = OpenAuthenticatedWebViewMessage(
+            id = "message-id",
+            url = uri.toString(),
+        )
+
+        viewModel.onResume(lifecycleOwner)
+        verify(webView, never()).returnedFromAuthenticatedWebView(anyOrNull())
+
+        viewModel.delegate.onReceivedOpenAuthenticatedWebView(mockActivity, message)
+        assertThat(viewModel.stateFlow.value.receivedOpenAuthenticatedWebViewUrl)
+            .isEqualTo(uri.toString())
+
+        viewModel.onResume(lifecycleOwner)
+        verify(webView).returnedFromAuthenticatedWebView(uri.toString())
+        assertThat(viewModel.stateFlow.value.receivedOpenAuthenticatedWebViewUrl)
+            .isNull()
     }
 
     @Test

--- a/connect/src/test/java/com/stripe/android/connect/webview/StripeConnectWebViewTest.kt
+++ b/connect/src/test/java/com/stripe/android/connect/webview/StripeConnectWebViewTest.kt
@@ -13,6 +13,7 @@ import androidx.activity.ComponentActivity
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.connect.PrivateBetaConnectSDK
 import com.stripe.android.connect.webview.serialization.AccountSessionClaimedMessage
+import com.stripe.android.connect.webview.serialization.AppInfoJs
 import com.stripe.android.connect.webview.serialization.ConnectInstanceJs
 import com.stripe.android.connect.webview.serialization.ConnectJson
 import com.stripe.android.connect.webview.serialization.CustomFontSourceJs
@@ -126,6 +127,12 @@ class StripeConnectWebViewTest {
         whenever(mockDelegate.getInitialParams(any())).doReturn(params)
         assertThat(webView.stripeJsInterface.fetchInitParams())
             .isEqualTo(ConnectJson.encodeToString(params))
+    }
+
+    @Test
+    fun `JS fetchAppInfo is handled`() {
+        val appInfo = ConnectJson.decodeFromString<AppInfoJs>(webView.stripeJsInterface.fetchAppInfo())
+        assertThat(appInfo.applicationId).startsWith("com.stripe")
     }
 
     @Test


### PR DESCRIPTION
# Summary
Implements (re)opening the app via deep link per the contract outlined in the linked Jira comment.

# Motivation
https://jira.corp.stripe.com/browse/CAX-3633

# Testing
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots

https://github.com/user-attachments/assets/6231fef5-1e76-47a0-a1fc-0beb0b990bbe
