### PR TITLE
Fix `PrimaryButton` lock being visible when processing.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButton.kt
@@ -174,6 +174,7 @@ internal class PrimaryButton @JvmOverloads constructor(
     }
 
     private fun onReadyState() {
+        updateLockVisibility(canShow = true)
         isClickable = true
         originalLabel?.let {
             setLabel(it)
@@ -186,7 +187,7 @@ internal class PrimaryButton @JvmOverloads constructor(
     }
 
     private fun onStartProcessing() {
-        viewBinding.lockIcon.isVisible = false
+        updateLockVisibility(canShow = false)
         viewBinding.confirmingIcon.isVisible = true
         isClickable = false
         setLabel(
@@ -195,6 +196,7 @@ internal class PrimaryButton @JvmOverloads constructor(
     }
 
     private fun onFinishProcessing(onAnimationEnd: () -> Unit) {
+        updateLockVisibility(canShow = false)
         isClickable = false
         backgroundTintList = ColorStateList.valueOf(finishedBackgroundColor)
         confirmedIcon.imageTintList = ColorStateList.valueOf(finishedOnBackgroundColor)
@@ -223,14 +225,16 @@ internal class PrimaryButton @JvmOverloads constructor(
         isVisible = uiState != null
 
         if (uiState != null) {
+            lockVisible = uiState.lockVisible
+
             if (state !is State.StartProcessing && state !is State.FinishProcessing) {
                 // If we're processing or finishing, we're not overriding the label
                 setLabel(uiState.label)
+                updateLockVisibility(canShow = true)
             }
 
             isEnabled = uiState.enabled
-            lockVisible = uiState.lockVisible
-            viewBinding.lockIcon.isVisible = lockVisible
+
             setOnClickListener { uiState.onClick() }
 
             contentDescription = uiState.label.resolve(context)
@@ -253,6 +257,10 @@ internal class PrimaryButton @JvmOverloads constructor(
             }
             null -> {}
         }
+    }
+
+    private fun updateLockVisibility(canShow: Boolean) {
+        viewBinding.lockIcon.isVisible = lockVisible && canShow
     }
 
     private fun updateAlpha() {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PrimaryButtonTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PrimaryButtonTest.kt
@@ -180,7 +180,7 @@ class PrimaryButtonTest {
             PrimaryButton.State.FinishProcessing(onComplete = {})
         )
 
-        // Setting lock visible after we start processing should still keep the lock hidden
+        // Setting lock visible after we finish processing should still keep the lock hidden
         primaryButton.updateUiState(
             PrimaryButton.UIState(
                 label = "Pay $50".resolvableString,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PrimaryButtonTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PrimaryButtonTest.kt
@@ -11,6 +11,7 @@ import android.view.View
 import android.view.View.GONE
 import android.widget.LinearLayout
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.isVisible
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
@@ -124,6 +125,74 @@ class PrimaryButtonTest {
         ).isEqualTo(
             "Processing…"
         )
+    }
+
+    @Test
+    fun `onStartProcessing() should hide lock`() {
+        primaryButton.updateUiState(
+            PrimaryButton.UIState(
+                label = "Pay $50".resolvableString,
+                lockVisible = true,
+                enabled = true,
+                onClick = {},
+            )
+        )
+
+        assertThat(
+            primaryButton.viewBinding.lockIcon.isVisible
+        ).isTrue()
+
+        primaryButton.updateState(
+            PrimaryButton.State.StartProcessing
+        )
+
+        // Setting lock visible after we start processing should still keep the lock hidden
+        primaryButton.updateUiState(
+            PrimaryButton.UIState(
+                label = "Pay $50".resolvableString,
+                lockVisible = true,
+                enabled = true,
+                onClick = {},
+            )
+        )
+
+        assertThat(
+            primaryButton.viewBinding.lockIcon.isVisible
+        ).isFalse()
+    }
+
+    @Test
+    fun `onFinishProcessing() should hide lock`() {
+        primaryButton.updateUiState(
+            PrimaryButton.UIState(
+                label = "Pay $50".resolvableString,
+                lockVisible = true,
+                enabled = true,
+                onClick = {},
+            )
+        )
+
+        assertThat(
+            primaryButton.viewBinding.lockIcon.isVisible
+        ).isTrue()
+
+        primaryButton.updateState(
+            PrimaryButton.State.FinishProcessing(onComplete = {})
+        )
+
+        // Setting lock visible after we start processing should still keep the lock hidden
+        primaryButton.updateUiState(
+            PrimaryButton.UIState(
+                label = "Pay $50".resolvableString,
+                lockVisible = true,
+                enabled = true,
+                onClick = {},
+            )
+        )
+
+        assertThat(
+            primaryButton.viewBinding.lockIcon.isVisible
+        ).isFalse()
     }
 
     @Test


### PR DESCRIPTION
# Summary
Fix `PrimaryButton` lock being visible when processing.

# Motivation
Following the `StateFlow` changes in https://github.com/stripe/stripe-android/pull/10506, a race condition issue was exposed in which calling `updateUiState` after `updateState` would cause the lock to be visible even in processing and complete states.

| Before | After |
| - | - |
| <video src="https://github.com/user-attachments/assets/dc9cc711-c872-45e2-9626-e3012d31d8ff" /> | <video src="https://github.com/user-attachments/assets/ab44accb-0fc5-496e-82c7-a93048263f4f" /> |

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified