### PR TITLE
Pull out Card Details UI

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/CardDetailsUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/CardDetailsUI.kt
@@ -1,0 +1,200 @@
+package com.stripe.android.paymentsheet.ui
+
+import android.content.res.Resources
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.ZeroCornerSize
+import androidx.compose.material.Card
+import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.stripe.android.CardBrandFilter
+import com.stripe.android.R
+import com.stripe.android.model.CardBrand
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.uicore.getBorderStroke
+import com.stripe.android.uicore.stripeColors
+import com.stripe.android.uicore.stripeShapes
+
+@Composable
+internal fun CardDetailsEditUI(
+    shouldShowCardBrandDropdown: Boolean,
+    selectedBrand: CardBrandChoice,
+    card: PaymentMethod.Card,
+    isExpired: Boolean,
+    cardBrandFilter: CardBrandFilter,
+    @DrawableRes paymentMethodIcon: Int,
+    onBrandChoiceChanged: (CardBrandChoice) -> Unit
+) {
+    val dividerHeight = remember { mutableStateOf(0.dp) }
+
+    Card(
+        border = MaterialTheme.getBorderStroke(false),
+        elevation = 0.dp,
+        modifier = Modifier.testTag(UPDATE_PM_CARD_TEST_TAG),
+    ) {
+        Column {
+            CardNumberField(
+                card = card,
+                selectedBrand = selectedBrand,
+                shouldShowCardBrandDropdown = shouldShowCardBrandDropdown,
+                cardBrandFilter = cardBrandFilter,
+                savedPaymentMethodIcon = paymentMethodIcon,
+                onBrandChoiceChanged = onBrandChoiceChanged,
+            )
+            Divider(
+                color = MaterialTheme.stripeColors.componentDivider,
+                thickness = MaterialTheme.stripeShapes.borderStrokeWidth.dp,
+            )
+            Row(modifier = Modifier.fillMaxWidth()) {
+                ExpiryField(
+                    expiryMonth = card.expiryMonth,
+                    expiryYear = card.expiryYear,
+                    isExpired = isExpired,
+                    modifier = Modifier
+                        .weight(1F)
+                        .onSizeChanged {
+                            dividerHeight.value =
+                                (it.height / Resources.getSystem().displayMetrics.density).dp
+                        },
+                )
+                Divider(
+                    modifier = Modifier
+                        .height(dividerHeight.value)
+                        .width(MaterialTheme.stripeShapes.borderStrokeWidth.dp),
+                    color = MaterialTheme.stripeColors.componentDivider,
+                )
+                CvcField(cardBrand = card.brand, modifier = Modifier.weight(1F))
+            }
+        }
+    }
+}
+
+@Composable
+private fun CardNumberField(
+    card: PaymentMethod.Card,
+    selectedBrand: CardBrandChoice,
+    cardBrandFilter: CardBrandFilter,
+    shouldShowCardBrandDropdown: Boolean,
+    savedPaymentMethodIcon: Int,
+    onBrandChoiceChanged: (CardBrandChoice) -> Unit,
+) {
+    CommonTextField(
+        value = "•••• •••• •••• ${card.last4}",
+        label = stringResource(id = R.string.stripe_acc_label_card_number),
+        trailingIcon = {
+            if (shouldShowCardBrandDropdown) {
+                CardBrandDropdown(
+                    selectedBrand = selectedBrand,
+                    availableBrands = card.getAvailableNetworks(cardBrandFilter),
+                    onBrandChoiceChanged = onBrandChoiceChanged,
+                )
+            } else {
+                PaymentMethodIconFromResource(
+                    iconRes = savedPaymentMethodIcon,
+                    colorFilter = null,
+                    alignment = Alignment.Center,
+                    modifier = Modifier,
+                )
+            }
+        },
+    )
+}
+
+@Composable
+private fun ExpiryField(
+    expiryMonth: Int?,
+    expiryYear: Int?,
+    isExpired: Boolean,
+    modifier: Modifier
+) {
+    CommonTextField(
+        modifier = modifier.testTag(UPDATE_PM_EXPIRY_FIELD_TEST_TAG),
+        value = formattedExpiryDate(expiryMonth = expiryMonth, expiryYear = expiryYear),
+        label = stringResource(id = com.stripe.android.uicore.R.string.stripe_expiration_date_hint),
+        shape = MaterialTheme.shapes.small.copy(
+            topStart = ZeroCornerSize,
+            topEnd = ZeroCornerSize,
+            bottomEnd = ZeroCornerSize,
+        ),
+        shouldShowError = isExpired,
+    )
+}
+
+private fun formattedExpiryDate(expiryMonth: Int?, expiryYear: Int?): String {
+    @Suppress("ComplexCondition")
+    if (
+        expiryMonth == null ||
+        monthIsInvalid(expiryMonth) ||
+        expiryYear == null ||
+        yearIsInvalid(expiryYear)
+    ) {
+        return "••/••"
+    }
+
+    val formattedExpiryMonth = if (expiryMonth < OCTOBER) {
+        "0$expiryMonth"
+    } else {
+        expiryMonth.toString()
+    }
+
+    @Suppress("MagicNumber")
+    val formattedExpiryYear = expiryYear.toString().substring(2, 4)
+
+    return "$formattedExpiryMonth/$formattedExpiryYear"
+}
+
+private fun monthIsInvalid(expiryMonth: Int): Boolean {
+    return expiryMonth < JANUARY || expiryMonth > DECEMBER
+}
+
+private fun yearIsInvalid(expiryYear: Int): Boolean {
+    // Since we use 2-digit years to represent the expiration year, we should keep dates to
+    // this century.
+    return expiryYear < YEAR_2000 || expiryYear > YEAR_2100
+}
+
+@Composable
+private fun CvcField(cardBrand: CardBrand, modifier: Modifier) {
+    val cvc = buildString {
+        repeat(cardBrand.maxCvcLength) {
+            append("•")
+        }
+    }
+    CommonTextField(
+        modifier = modifier.testTag(UPDATE_PM_CVC_FIELD_TEST_TAG),
+        value = cvc,
+        label = stringResource(id = R.string.stripe_cvc_number_hint),
+        shape = MaterialTheme.shapes.small.copy(
+            topStart = ZeroCornerSize,
+            topEnd = ZeroCornerSize,
+            bottomStart = ZeroCornerSize
+        ),
+        trailingIcon = {
+            Image(
+                painter = painterResource(cardBrand.cvcIcon),
+                contentDescription = null,
+            )
+        },
+    )
+}
+
+private const val JANUARY = 1
+private const val OCTOBER = 10
+private const val DECEMBER = 12
+private const val YEAR_2000 = 2000
+private const val YEAR_2100 = 2100

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/CommonTextField.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/CommonTextField.kt
@@ -1,0 +1,52 @@
+package com.stripe.android.paymentsheet.ui
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.shape.ZeroCornerSize
+import androidx.compose.material.ContentAlpha
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
+import com.stripe.android.uicore.elements.TextFieldColors
+import com.stripe.android.uicore.stripeColors
+
+@Composable
+internal fun CommonTextField(
+    value: String,
+    label: String,
+    modifier: Modifier = Modifier,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    shouldShowError: Boolean = false,
+    shape: Shape =
+        MaterialTheme.shapes.small.copy(bottomEnd = ZeroCornerSize, bottomStart = ZeroCornerSize),
+) {
+    TextField(
+        modifier = modifier.fillMaxWidth(),
+        value = value,
+        enabled = false,
+        label = {
+            Label(
+                text = label,
+            )
+        },
+        trailingIcon = trailingIcon,
+        shape = shape,
+        colors = TextFieldColors(
+            shouldShowError = shouldShowError,
+        ),
+        onValueChange = {},
+    )
+}
+
+@Composable
+private fun Label(
+    text: String,
+) {
+    Text(
+        text = text,
+        color = MaterialTheme.stripeColors.placeholderText.copy(alpha = ContentAlpha.disabled),
+        style = MaterialTheme.typography.subtitle1
+    )
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
@@ -1,42 +1,26 @@
 package com.stripe.android.paymentsheet.ui
 
 import android.content.Context
-import android.content.res.Resources
 import androidx.annotation.RestrictTo
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeight
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.ZeroCornerSize
 import androidx.compose.material.Card
-import androidx.compose.material.ContentAlpha
-import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
-import androidx.compose.material.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.dimensionResource
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.stripe.android.CardBrandFilter
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.R
 import com.stripe.android.core.strings.ResolvableString
@@ -47,11 +31,9 @@ import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.SavedPaymentMethod
 import com.stripe.android.paymentsheet.utils.testMetadata
 import com.stripe.android.uicore.elements.CheckboxElementUI
-import com.stripe.android.uicore.elements.TextFieldColors
 import com.stripe.android.uicore.getBorderStroke
 import com.stripe.android.uicore.strings.resolve
 import com.stripe.android.uicore.stripeColors
-import com.stripe.android.uicore.stripeShapes
 import com.stripe.android.uicore.utils.collectAsState
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import com.stripe.android.common.ui.PrimaryButton as PrimaryButton
@@ -187,52 +169,19 @@ private fun CardDetailsUI(
     card: PaymentMethod.Card,
     interactor: UpdatePaymentMethodInteractor,
 ) {
-    val dividerHeight = remember { mutableStateOf(0.dp) }
-
-    Card(
-        border = MaterialTheme.getBorderStroke(false),
-        elevation = 0.dp,
-        modifier = Modifier.testTag(UPDATE_PM_CARD_TEST_TAG),
-    ) {
-        Column {
-            CardNumberField(
-                card = card,
-                selectedBrand = selectedBrand,
-                shouldShowCardBrandDropdown = shouldShowCardBrandDropdown,
-                cardBrandFilter = interactor.cardBrandFilter,
-                savedPaymentMethodIcon = displayableSavedPaymentMethod
-                    .paymentMethod
-                    .getSavedPaymentMethodIcon(forVerticalMode = true),
-                onBrandChoiceChanged = {
-                    interactor.handleViewAction(UpdatePaymentMethodInteractor.ViewAction.BrandChoiceChanged(it))
-                },
-            )
-            Divider(
-                color = MaterialTheme.stripeColors.componentDivider,
-                thickness = MaterialTheme.stripeShapes.borderStrokeWidth.dp,
-            )
-            Row(modifier = Modifier.fillMaxWidth()) {
-                ExpiryField(
-                    expiryMonth = card.expiryMonth,
-                    expiryYear = card.expiryYear,
-                    isExpired = interactor.isExpiredCard,
-                    modifier = Modifier
-                        .weight(1F)
-                        .onSizeChanged {
-                            dividerHeight.value =
-                                (it.height / Resources.getSystem().displayMetrics.density).dp
-                        },
-                )
-                Divider(
-                    modifier = Modifier
-                        .height(dividerHeight.value)
-                        .width(MaterialTheme.stripeShapes.borderStrokeWidth.dp),
-                    color = MaterialTheme.stripeColors.componentDivider,
-                )
-                CvcField(cardBrand = card.brand, modifier = Modifier.weight(1F))
-            }
+    CardDetailsEditUI(
+        shouldShowCardBrandDropdown = shouldShowCardBrandDropdown,
+        selectedBrand = selectedBrand,
+        card = card,
+        isExpired = interactor.isExpiredCard,
+        cardBrandFilter = interactor.cardBrandFilter,
+        paymentMethodIcon = displayableSavedPaymentMethod
+            .paymentMethod
+            .getSavedPaymentMethodIcon(forVerticalMode = true),
+        onBrandChoiceChanged = {
+            interactor.handleViewAction(UpdatePaymentMethodInteractor.ViewAction.BrandChoiceChanged(it))
         }
-    }
+    )
 }
 
 @Composable
@@ -359,154 +308,6 @@ private fun DeletePaymentMethodUi(interactor: UpdatePaymentMethodInteractor) {
     }
 }
 
-@Composable
-private fun CardNumberField(
-    card: PaymentMethod.Card,
-    selectedBrand: CardBrandChoice,
-    cardBrandFilter: CardBrandFilter,
-    shouldShowCardBrandDropdown: Boolean,
-    savedPaymentMethodIcon: Int,
-    onBrandChoiceChanged: (CardBrandChoice) -> Unit,
-) {
-    CommonTextField(
-        value = "•••• •••• •••• ${card.last4}",
-        label = stringResource(id = R.string.stripe_acc_label_card_number),
-        trailingIcon = {
-            if (shouldShowCardBrandDropdown) {
-                CardBrandDropdown(
-                    selectedBrand = selectedBrand,
-                    availableBrands = card.getAvailableNetworks(cardBrandFilter),
-                    onBrandChoiceChanged = onBrandChoiceChanged,
-                )
-            } else {
-                PaymentMethodIconFromResource(
-                    iconRes = savedPaymentMethodIcon,
-                    colorFilter = null,
-                    alignment = Alignment.Center,
-                    modifier = Modifier,
-                )
-            }
-        },
-    )
-}
-
-@Composable
-private fun ExpiryField(
-    expiryMonth: Int?,
-    expiryYear: Int?,
-    isExpired: Boolean,
-    modifier: Modifier
-) {
-    CommonTextField(
-        modifier = modifier.testTag(UPDATE_PM_EXPIRY_FIELD_TEST_TAG),
-        value = formattedExpiryDate(expiryMonth = expiryMonth, expiryYear = expiryYear),
-        label = stringResource(id = com.stripe.android.uicore.R.string.stripe_expiration_date_hint),
-        shape = MaterialTheme.shapes.small.copy(
-            topStart = ZeroCornerSize,
-            topEnd = ZeroCornerSize,
-            bottomEnd = ZeroCornerSize,
-        ),
-        shouldShowError = isExpired,
-    )
-}
-
-private fun formattedExpiryDate(expiryMonth: Int?, expiryYear: Int?): String {
-    @Suppress("ComplexCondition")
-    if (
-        expiryMonth == null ||
-        monthIsInvalid(expiryMonth) ||
-        expiryYear == null ||
-        yearIsInvalid(expiryYear)
-    ) {
-        return "••/••"
-    }
-
-    val formattedExpiryMonth = if (expiryMonth < OCTOBER) {
-        "0$expiryMonth"
-    } else {
-        expiryMonth.toString()
-    }
-
-    @Suppress("MagicNumber")
-    val formattedExpiryYear = expiryYear.toString().substring(2, 4)
-
-    return "$formattedExpiryMonth/$formattedExpiryYear"
-}
-
-private fun monthIsInvalid(expiryMonth: Int): Boolean {
-    return expiryMonth < JANUARY || expiryMonth > DECEMBER
-}
-
-private fun yearIsInvalid(expiryYear: Int): Boolean {
-    // Since we use 2-digit years to represent the expiration year, we should keep dates to
-    // this century.
-    return expiryYear < YEAR_2000 || expiryYear > YEAR_2100
-}
-
-@Composable
-private fun CvcField(cardBrand: CardBrand, modifier: Modifier) {
-    val cvc = buildString {
-        repeat(cardBrand.maxCvcLength) {
-            append("•")
-        }
-    }
-    CommonTextField(
-        modifier = modifier.testTag(UPDATE_PM_CVC_FIELD_TEST_TAG),
-        value = cvc,
-        label = stringResource(id = R.string.stripe_cvc_number_hint),
-        shape = MaterialTheme.shapes.small.copy(
-            topStart = ZeroCornerSize,
-            topEnd = ZeroCornerSize,
-            bottomStart = ZeroCornerSize
-        ),
-        trailingIcon = {
-            Image(
-                painter = painterResource(cardBrand.cvcIcon),
-                contentDescription = null,
-            )
-        },
-    )
-}
-
-@Composable
-private fun CommonTextField(
-    value: String,
-    label: String,
-    modifier: Modifier = Modifier,
-    trailingIcon: @Composable (() -> Unit)? = null,
-    shouldShowError: Boolean = false,
-    shape: Shape =
-        MaterialTheme.shapes.small.copy(bottomEnd = ZeroCornerSize, bottomStart = ZeroCornerSize),
-) {
-    TextField(
-        modifier = modifier.fillMaxWidth(),
-        value = value,
-        enabled = false,
-        label = {
-            Label(
-                text = label,
-            )
-        },
-        trailingIcon = trailingIcon,
-        shape = shape,
-        colors = TextFieldColors(
-            shouldShowError = shouldShowError,
-        ),
-        onValueChange = {},
-    )
-}
-
-@Composable
-private fun Label(
-    text: String,
-) {
-    Text(
-        text = text,
-        color = MaterialTheme.stripeColors.placeholderText.copy(alpha = ContentAlpha.disabled),
-        style = MaterialTheme.typography.subtitle1
-    )
-}
-
 @Preview
 @Composable
 private fun PreviewUpdatePaymentMethodUI() {
@@ -558,12 +359,6 @@ private fun DisplayableSavedPaymentMethod.getDetailsCannotBeChangedText(
         }
         )?.resolvableString
 }
-
-private const val JANUARY = 1
-private const val OCTOBER = 10
-private const val DECEMBER = 12
-private const val YEAR_2000 = 2000
-private const val YEAR_2100 = 2100
 
 internal const val UPDATE_PM_EXPIRY_FIELD_TEST_TAG = "update_payment_method_expiry_date"
 internal const val UPDATE_PM_CVC_FIELD_TEST_TAG = "update_payment_method_cvc"

--- a/paymentsheet/src/test/java/com/stripe/android/model/PaymentMethodFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/model/PaymentMethodFixtures.kt
@@ -34,7 +34,7 @@ internal object PaymentMethodFixtures {
         wallet = null
     )
 
-    private val CARD_WITH_NETWORKS = CARD.copy(
+    internal val CARD_WITH_NETWORKS = CARD.copy(
         displayBrand = "cartes_bancaires",
         networks = PaymentMethod.Card.Networks(
             available = setOf("visa", "cartes_bancaires"),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/CardDetailsEditUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/CardDetailsEditUITest.kt
@@ -157,7 +157,7 @@ internal class CardDetailsEditUITest {
     @Test
     fun `Card drop down has accessibility label`() {
         runScenario(
-            card = visaCard()
+            card = PaymentMethodFixtures.CARD_WITH_NETWORKS
         ) {
             composeRule.onNodeWithTag(DROPDOWN_MENU_CLICKABLE_TEST_TAG)
                 .assertContentDescriptionEquals("Visa")
@@ -195,15 +195,5 @@ internal class CardDetailsEditUITest {
                 onBrandChoiceChanged = onBrandChoiceChanged,
             )
         }
-    }
-
-    private fun visaCard(): PaymentMethod.Card {
-        return PaymentMethodFixtures.CARD_WITH_NETWORKS.copy(
-            brand = CardBrand.Visa,
-            networks = PaymentMethodFixtures.CARD_WITH_NETWORKS.networks?.copy(
-                preferred = "visa"
-            ),
-            displayBrand = "visa"
-        )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/CardDetailsEditUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/CardDetailsEditUITest.kt
@@ -1,0 +1,209 @@
+package com.stripe.android.paymentsheet.ui
+
+import android.os.Build
+import androidx.compose.ui.test.assertContentDescriptionEquals
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.CardBrandFilter
+import com.stripe.android.DefaultCardBrandFilter
+import com.stripe.android.model.CardBrand
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.uicore.elements.DROPDOWN_MENU_CLICKABLE_TEST_TAG
+import com.stripe.android.uicore.elements.TEST_TAG_DROP_DOWN_CHOICE
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.Q])
+internal class CardDetailsEditUITest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun missingExpiryDate_displaysDots() {
+        runScenario(
+            card = PaymentMethodFixtures.CARD_WITH_NETWORKS.copy(
+                expiryMonth = null
+            )
+        ) {
+            assertExpiryDateEquals(
+                "••/••"
+            )
+        }
+    }
+
+    @Test
+    fun invalidExpiryMonth_displaysDots() {
+        runScenario(
+            card = PaymentMethodFixtures.CARD_WITH_NETWORKS.copy(
+                expiryMonth = -1
+            )
+        ) {
+            assertExpiryDateEquals(
+                "••/••"
+            )
+        }
+    }
+
+    @Test
+    fun invalidExpiryYear_displaysDots() {
+        runScenario(
+            card = PaymentMethodFixtures.CARD_WITH_NETWORKS.copy(
+                expiryMonth = 202
+            )
+        ) {
+            assertExpiryDateEquals(
+                "••/••"
+            )
+        }
+    }
+
+    @Test
+    fun singleDigitExpiryMonth_hasLeadingZero() {
+        runScenario(
+            card = PaymentMethodFixtures.CARD_WITH_NETWORKS.copy(
+                expiryMonth = 8,
+                expiryYear = 2029,
+            )
+        ) {
+            assertExpiryDateEquals(
+                "08/29"
+            )
+        }
+    }
+
+    @Test
+    fun doubleDigitExpiryMonth_doesNotHaveLeadingZero() {
+        runScenario(
+            card = PaymentMethodFixtures.CARD_WITH_NETWORKS.copy(
+                expiryMonth = 11,
+                expiryYear = 2029,
+            )
+        ) {
+            assertExpiryDateEquals(
+                "11/29"
+            )
+        }
+    }
+
+    @Test
+    fun threeDigitCvcCardBrand_displaysThreeDotsForCvc() {
+        runScenario(
+            card = PaymentMethodFixtures.CARD_WITH_NETWORKS.copy(
+                brand = CardBrand.Visa,
+            )
+        ) {
+            assertCvcEquals(
+                "•••"
+            )
+        }
+    }
+
+    @Test
+    fun fourDigitCvcCardBrand_displaysFourDotsForCvc() {
+        runScenario(
+            card = PaymentMethodFixtures.CARD_WITH_NETWORKS.copy(
+                brand = CardBrand.AmericanExpress,
+            )
+        ) {
+            assertCvcEquals(
+                "••••"
+            )
+        }
+    }
+
+    @Test
+    fun modifiableCard_cbcDropdownIsShown() {
+        runScenario(
+            card = PaymentMethodFixtures.CARD_WITH_NETWORKS
+        ) {
+            composeRule.onNodeWithTag(DROPDOWN_MENU_CLICKABLE_TEST_TAG).assertExists()
+        }
+    }
+
+    @Test
+    fun notModifiableCard_cbcDropdownIsNotShown() {
+        runScenario(
+            card = PaymentMethodFixtures.CARD_WITH_NETWORKS
+        ) {
+            composeRule.onNodeWithTag(DROPDOWN_MENU_CLICKABLE_TEST_TAG).assertDoesNotExist()
+        }
+    }
+
+    @Test
+    fun selectingCardBrandDropdown_sendsOnBrandChoiceChangedAction() {
+        var brandChange: CardBrand? = null
+        runScenario(
+            card = PaymentMethodFixtures.CARD_WITH_NETWORKS,
+            onBrandChoiceChanged = {
+                brandChange = it.brand
+            }
+        )
+
+        composeRule.onNodeWithTag(DROPDOWN_MENU_CLICKABLE_TEST_TAG).performClick()
+
+        composeRule.onNodeWithTag("${TEST_TAG_DROP_DOWN_CHOICE}_Visa").performClick()
+
+        assertThat(brandChange).isEqualTo(CardBrand.Visa)
+    }
+
+    @Test
+    fun `Card drop down has accessibility label`() {
+        runScenario(
+            card = visaCard()
+        ) {
+            composeRule.onNodeWithTag(DROPDOWN_MENU_CLICKABLE_TEST_TAG)
+                .assertContentDescriptionEquals("Visa")
+        }
+    }
+
+    private fun assertExpiryDateEquals(text: String) {
+        composeRule.onNodeWithTag(UPDATE_PM_EXPIRY_FIELD_TEST_TAG).assertTextContains(
+            text
+        )
+    }
+
+    private fun assertCvcEquals(text: String) {
+        composeRule.onNodeWithTag(UPDATE_PM_CVC_FIELD_TEST_TAG).assertTextContains(
+            text
+        )
+    }
+
+    private fun runScenario(
+        card: PaymentMethod.Card = PaymentMethodFixtures.CARD_WITH_NETWORKS,
+        selectedCardBrand: CardBrandChoice = CardBrandChoice(CardBrand.Visa, enabled = true),
+        cardBrandFilter: CardBrandFilter = DefaultCardBrandFilter,
+        showCardBrandDropdown: Boolean = true,
+        isExpiredCard: Boolean = false,
+        onBrandChoiceChanged: (CardBrandChoice) -> Unit = {},
+    ) {
+        composeRule.setContent {
+            CardDetailsEditUI(
+                shouldShowCardBrandDropdown = showCardBrandDropdown,
+                selectedBrand = selectedCardBrand,
+                card = card,
+                isExpired = isExpiredCard,
+                cardBrandFilter = cardBrandFilter,
+                paymentMethodIcon = com.stripe.payments.model.R.drawable.stripe_ic_visa_unpadded,
+                onBrandChoiceChanged = onBrandChoiceChanged,
+            )
+        }
+    }
+
+    private fun visaCard(): PaymentMethod.Card {
+        return PaymentMethodFixtures.CARD_WITH_NETWORKS.copy(
+            brand = CardBrand.Visa,
+            networks = PaymentMethodFixtures.CARD_WITH_NETWORKS.networks?.copy(
+                preferred = "visa"
+            ),
+            displayBrand = "visa"
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUITest.kt
@@ -4,11 +4,9 @@ import android.os.Build
 import android.os.Parcel
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertAll
-import androidx.compose.ui.test.assertContentDescriptionEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
-import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.isEnabled
 import androidx.compose.ui.test.isNotEnabled
@@ -42,113 +40,6 @@ class UpdatePaymentMethodUITest {
 
     @get:Rule
     val composeRule = createComposeRule()
-
-    @Test
-    fun missingExpiryDate_displaysDots() {
-        val card = PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(
-            card = PaymentMethodFixtures.CARD_PAYMENT_METHOD.card!!.copy(
-                expiryMonth = null,
-            )
-        )
-
-        runScenario(displayableSavedPaymentMethod = card.toDisplayableSavedPaymentMethod()) {
-            assertExpiryDateEquals(
-                "••/••"
-            )
-        }
-    }
-
-    @Test
-    fun invalidExpiryMonth_displaysDots() {
-        val card = PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(
-            card = PaymentMethodFixtures.CARD_PAYMENT_METHOD.card!!.copy(
-                expiryMonth = -1,
-            )
-        )
-
-        runScenario(displayableSavedPaymentMethod = card.toDisplayableSavedPaymentMethod()) {
-            assertExpiryDateEquals(
-                "••/••"
-            )
-        }
-    }
-
-    @Test
-    fun invalidExpiryYear_displaysDots() {
-        val card = PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(
-            card = PaymentMethodFixtures.CARD_PAYMENT_METHOD.card!!.copy(
-                expiryYear = 202,
-            )
-        )
-
-        runScenario(displayableSavedPaymentMethod = card.toDisplayableSavedPaymentMethod()) {
-            assertExpiryDateEquals(
-                "••/••"
-            )
-        }
-    }
-
-    @Test
-    fun singleDigitExpiryMonth_hasLeadingZero() {
-        val card = PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(
-            card = PaymentMethodFixtures.CARD_PAYMENT_METHOD.card!!.copy(
-                expiryMonth = 8,
-                expiryYear = 2029,
-            )
-        )
-
-        runScenario(displayableSavedPaymentMethod = card.toDisplayableSavedPaymentMethod()) {
-            assertExpiryDateEquals(
-                "08/29"
-            )
-        }
-    }
-
-    @Test
-    fun doubleDigitExpiryMonth_doesNotHaveLeadingZero() {
-        val card = PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(
-            card = PaymentMethodFixtures.CARD_PAYMENT_METHOD.card!!.copy(
-                expiryMonth = 11,
-                expiryYear = 2029,
-            )
-        )
-
-        runScenario(displayableSavedPaymentMethod = card.toDisplayableSavedPaymentMethod()) {
-            assertExpiryDateEquals(
-                "11/29"
-            )
-        }
-    }
-
-    @Test
-    fun threeDigitCvcCardBrand_displaysThreeDotsForCvc() {
-        val card = PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(
-            card = PaymentMethodFixtures.CARD_PAYMENT_METHOD.card!!.copy(
-                brand = CardBrand.Visa
-            )
-        )
-
-        runScenario(displayableSavedPaymentMethod = card.toDisplayableSavedPaymentMethod()) {
-            assertCvcEquals(
-                "•••"
-            )
-        }
-    }
-
-    @Test
-    fun fourDigitCvcCardBrand_displaysFourDotsForCvc() {
-        val card = PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(
-            card = PaymentMethodFixtures.CARD_PAYMENT_METHOD.card!!.copy(
-                brand = CardBrand.AmericanExpress
-            )
-        )
-
-        runScenario(displayableSavedPaymentMethod = card.toDisplayableSavedPaymentMethod()) {
-            assertCvcEquals(
-                "••••"
-            )
-        }
-    }
 
     @Test
     fun canRemoveIsFalse_removeButtonHidden() = runScenario(
@@ -349,43 +240,10 @@ class UpdatePaymentMethodUITest {
     }
 
     @Test
-    fun modifiableCard_cbcDropdownIsShown() {
-        runScenario(
-            displayableSavedPaymentMethod = PaymentMethodFixtures
-                .CARD_WITH_NETWORKS_PAYMENT_METHOD
-                .toDisplayableSavedPaymentMethod()
-        ) {
-            composeRule.onNodeWithTag(DROPDOWN_MENU_CLICKABLE_TEST_TAG).assertExists()
-        }
-    }
-
-    @Test
-    fun notModifiableCard_cbcDropdownIsNotShown() {
-        runScenario(
-            displayableSavedPaymentMethod = PaymentMethodFixtures.displayableCard()
-        ) {
-            composeRule.onNodeWithTag(DROPDOWN_MENU_CLICKABLE_TEST_TAG).assertDoesNotExist()
-        }
-    }
-
-    @Test
     fun bankAccount_cbcDropdownIsNotShown() {
         runScenario(
             displayableSavedPaymentMethod = PaymentMethodFixtures.US_BANK_ACCOUNT.toDisplayableSavedPaymentMethod()
         ) {
-            composeRule.onNodeWithTag(DROPDOWN_MENU_CLICKABLE_TEST_TAG).assertDoesNotExist()
-        }
-    }
-
-    @Test
-    fun isNotModifiablePM_cbcDropdownIsNotShown() {
-        runScenario(
-            displayableSavedPaymentMethod = PaymentMethodFixtures
-                .CARD_WITH_NETWORKS_PAYMENT_METHOD
-                .toDisplayableSavedPaymentMethod(),
-            isModifiablePaymentMethod = false,
-        ) {
-            // Even if the card itself is modifiable, if we set isModifiablePaymentMethod to false, CBC is hidden.
             composeRule.onNodeWithTag(DROPDOWN_MENU_CLICKABLE_TEST_TAG).assertDoesNotExist()
         }
     }
@@ -408,19 +266,6 @@ class UpdatePaymentMethodUITest {
                 )
             )
             assertThat(viewActionRecorder.viewActions).isEmpty()
-        }
-    }
-
-    @Test
-    fun `Card drop down has accessibility label`() {
-        runScenario(
-            displayableSavedPaymentMethod = PaymentMethodFixtures
-                .CARD_WITH_NETWORKS_PAYMENT_METHOD
-                .toDisplayableSavedPaymentMethod(),
-            initialCardBrand = CardBrand.Visa,
-        ) {
-            composeRule.onNodeWithTag(DROPDOWN_MENU_CLICKABLE_TEST_TAG)
-                .assertContentDescriptionEquals("Visa")
         }
     }
 
@@ -477,18 +322,6 @@ class UpdatePaymentMethodUITest {
             )
             assertThat(viewActionRecorder.viewActions).isEmpty()
         }
-    }
-
-    private fun assertExpiryDateEquals(text: String) {
-        composeRule.onNodeWithTag(UPDATE_PM_EXPIRY_FIELD_TEST_TAG).assertTextContains(
-            text
-        )
-    }
-
-    private fun assertCvcEquals(text: String) {
-        composeRule.onNodeWithTag(UPDATE_PM_CVC_FIELD_TEST_TAG).assertTextContains(
-            text
-        )
     }
 
     private fun runScenario(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This change pulls out the composables required to render the card details from `UpdatePaymentMethodUI`.

## Why?
Card details/edits will eventually be controlled by `CardEditUIHandler`

![card_edit_ui_handler](https://github.com/user-attachments/assets/13ba3290-dc4f-4409-b58e-e39e5f7fe030)


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Breaking up [this PR](https://github.com/stripe/stripe-android/pull/10453)
[JIRA](https://jira.corp.stripe.com/browse/MOBILESDK-3357)
[Design Doc](https://docs.google.com/document/d/1mvmApRTfsmQd0A4-b6g8EGuerlF0VE6N2eHr1F19HSk/edit?tab=t.0#heading=h.gl2i202sfdwi)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
