### PR TITLE
Move DefaultUpdatePaymentMethodInteractor to factory

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -545,7 +545,7 @@ internal class CustomerSheetViewModel(
 
         transition(
             to = CustomerSheetViewState.UpdatePaymentMethod(
-                updatePaymentMethodInteractor = DefaultUpdatePaymentMethodInteractor(
+                updatePaymentMethodInteractor = DefaultUpdatePaymentMethodInteractor.factory(
                     isLiveMode = isLiveModeProvider(),
                     canRemove = customerState.canRemove,
                     displayableSavedPaymentMethod = paymentMethod,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
@@ -29,7 +29,7 @@ internal class DefaultEmbeddedUpdateScreenInteractorFactory @Inject constructor(
     override fun createUpdateScreenInteractor(
         displayableSavedPaymentMethod: DisplayableSavedPaymentMethod
     ): UpdatePaymentMethodInteractor {
-        return DefaultUpdatePaymentMethodInteractor(
+        return DefaultUpdatePaymentMethodInteractor.factory(
             isLiveMode = paymentMethodMetadata.stripeIntent.isLiveMode,
             canRemove = customerStateHolder.canRemove.value,
             displayableSavedPaymentMethod = displayableSavedPaymentMethod,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -361,10 +361,10 @@ internal class SavedPaymentMethodMutator(
                 val isLiveMode = requireNotNull(viewModel.paymentMethodMetadata.value).stripeIntent.isLiveMode
                 viewModel.navigationHandler.transitionTo(
                     PaymentSheetScreen.UpdatePaymentMethod(
-                        DefaultUpdatePaymentMethodInteractor(
+                        DefaultUpdatePaymentMethodInteractor.factory(
                             isLiveMode = isLiveMode,
                             canRemove = canRemove,
-                            displayableSavedPaymentMethod,
+                            displayableSavedPaymentMethod = displayableSavedPaymentMethod,
                             cardBrandFilter = PaymentSheetCardBrandFilter(viewModel.config.cardBrandAcceptance),
                             removeExecutor = { method ->
                                 performRemove()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
@@ -313,6 +313,36 @@ internal class DefaultUpdatePaymentMethodInteractor(
         @VisibleForTesting
         internal val updatesFailedErrorMessage =
             R.string.stripe_paymentsheet_card_updates_failed_error_message.resolvableString
+
+        fun factory(
+            isLiveMode: Boolean,
+            canRemove: Boolean,
+            isDefaultPaymentMethod: Boolean,
+            displayableSavedPaymentMethod: DisplayableSavedPaymentMethod,
+            cardBrandFilter: CardBrandFilter,
+            shouldShowSetAsDefaultCheckbox: Boolean,
+            removeExecutor: PaymentMethodRemoveOperation,
+            updatePaymentMethodExecutor: UpdateCardPaymentMethodOperation,
+            setDefaultPaymentMethodExecutor: PaymentMethodSetAsDefaultOperation,
+            onBrandChoiceSelected: (CardBrand) -> Unit,
+            onUpdateSuccess: () -> Unit,
+            workContext: CoroutineContext = Dispatchers.Default,
+        ): DefaultUpdatePaymentMethodInteractor {
+            return DefaultUpdatePaymentMethodInteractor(
+                isLiveMode = isLiveMode,
+                canRemove = canRemove,
+                displayableSavedPaymentMethod = displayableSavedPaymentMethod,
+                cardBrandFilter = cardBrandFilter,
+                shouldShowSetAsDefaultCheckbox = shouldShowSetAsDefaultCheckbox,
+                removeExecutor = removeExecutor,
+                updatePaymentMethodExecutor = updatePaymentMethodExecutor,
+                setDefaultPaymentMethodExecutor = setDefaultPaymentMethodExecutor,
+                onUpdateSuccess = onUpdateSuccess,
+                onBrandChoiceSelected = onBrandChoiceSelected,
+                workContext = workContext,
+                isDefaultPaymentMethod = isDefaultPaymentMethod
+            )
+        }
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
@@ -522,7 +522,7 @@ private fun PreviewUpdatePaymentMethodUI() {
         )
     )
     UpdatePaymentMethodUI(
-        interactor = DefaultUpdatePaymentMethodInteractor(
+        interactor = DefaultUpdatePaymentMethodInteractor.factory(
             isLiveMode = false,
             canRemove = true,
             displayableSavedPaymentMethod = exampleCard,

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -350,7 +350,7 @@ internal class CustomerSheetScreenshotTest {
         canRemove: Boolean,
     ): CustomerSheetViewState {
         return CustomerSheetViewState.UpdatePaymentMethod(
-            updatePaymentMethodInteractor = DefaultUpdatePaymentMethodInteractor(
+            updatePaymentMethodInteractor = DefaultUpdatePaymentMethodInteractor.factory(
                 displayableSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
                 removeExecutor = { null },
                 updatePaymentMethodExecutor = { paymentMethod, _ -> Result.success(paymentMethod) },

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultUpdatePaymentMethodInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultUpdatePaymentMethodInteractorTest.kt
@@ -713,7 +713,7 @@ class DefaultUpdatePaymentMethodInteractorTest {
         testBlock: suspend TestParams.() -> Unit
     ) {
         editSavedCardPaymentMethodEnabledFeatureFlagTestRule.setEnabled(editSavedCardPaymentMethodEnabled)
-        val interactor = DefaultUpdatePaymentMethodInteractor(
+        val interactor = DefaultUpdatePaymentMethodInteractor.factory(
             isLiveMode = isLiveMode,
             canRemove = canRemove,
             displayableSavedPaymentMethod = displayableSavedPaymentMethod,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
https://github.com/stripe/stripe-android/pull/10453/files#r2020389541

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Break up [this PR](https://github.com/stripe/stripe-android/pull/10453/files#r2020389541)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
