### PR TITLE
Replace embedded component builders with component factories.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
@@ -568,11 +568,11 @@ class EmbeddedPaymentElement @Inject internal constructor(
                 modelClass = EmbeddedPaymentElementViewModel::class.java,
             )
 
-            val embeddedPaymentElementSubcomponent = viewModel.embeddedPaymentElementSubcomponentBuilder
-                .resultCallback(resultCallback)
-                .activityResultCaller(activityResultCaller)
-                .lifecycleOwner(lifecycleOwner)
-                .build()
+            val embeddedPaymentElementSubcomponent = viewModel.embeddedPaymentElementSubcomponentFactory.build(
+                activityResultCaller = activityResultCaller,
+                lifecycleOwner = lifecycleOwner,
+                resultCallback = resultCallback,
+            )
 
             embeddedPaymentElementSubcomponent.initializer.initialize(activity.applicationIsTaskOwner())
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementSubcomponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementSubcomponent.kt
@@ -23,18 +23,13 @@ internal interface EmbeddedPaymentElementSubcomponent {
     val embeddedPaymentElement: EmbeddedPaymentElement
     val initializer: EmbeddedPaymentElementInitializer
 
-    @Subcomponent.Builder
-    interface Builder {
-        @BindsInstance
-        fun activityResultCaller(activityResultCaller: ActivityResultCaller): Builder
-
-        @BindsInstance
-        fun lifecycleOwner(lifecycleOwner: LifecycleOwner): Builder
-
-        @BindsInstance
-        fun resultCallback(resultCallback: EmbeddedPaymentElement.ResultCallback): Builder
-
-        fun build(): EmbeddedPaymentElementSubcomponent
+    @Subcomponent.Factory
+    interface Factory {
+        fun build(
+            @BindsInstance activityResultCaller: ActivityResultCaller,
+            @BindsInstance lifecycleOwner: LifecycleOwner,
+            @BindsInstance resultCallback: EmbeddedPaymentElement.ResultCallback,
+        ): EmbeddedPaymentElementSubcomponent
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModel.kt
@@ -16,7 +16,7 @@ import kotlin.reflect.KClass
 @Singleton
 @OptIn(ExperimentalEmbeddedPaymentElementApi::class)
 internal class EmbeddedPaymentElementViewModel @Inject constructor(
-    val embeddedPaymentElementSubcomponentBuilder: EmbeddedPaymentElementSubcomponent.Builder,
+    val embeddedPaymentElementSubcomponentFactory: EmbeddedPaymentElementSubcomponent.Factory,
     @ViewModelScope private val customViewModelScope: CoroutineScope,
 ) : ViewModel() {
     override fun onCleared() {
@@ -28,12 +28,12 @@ internal class EmbeddedPaymentElementViewModel @Inject constructor(
         private val statusBarColor: Int?,
     ) : ViewModelProvider.Factory {
         override fun <T : ViewModel> create(modelClass: KClass<T>, extras: CreationExtras): T {
-            val component = DaggerEmbeddedPaymentElementViewModelComponent.builder()
-                .savedStateHandle(extras.createSavedStateHandle())
-                .application(extras.requireApplication())
-                .paymentElementCallbackIdentifier(paymentElementCallbackIdentifier)
-                .statusBarColor(statusBarColor)
-                .build()
+            val component = DaggerEmbeddedPaymentElementViewModelComponent.factory().build(
+                savedStateHandle = extras.createSavedStateHandle(),
+                application = extras.requireApplication(),
+                paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
+                statusBarColor = statusBarColor,
+            )
             @Suppress("UNCHECKED_CAST")
             return component.viewModel as T
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModelComponent.kt
@@ -59,23 +59,17 @@ import kotlin.coroutines.CoroutineContext
 internal interface EmbeddedPaymentElementViewModelComponent {
     val viewModel: EmbeddedPaymentElementViewModel
 
-    @Component.Builder
-    interface Builder {
-        @BindsInstance
-        fun savedStateHandle(savedStateHandle: SavedStateHandle): Builder
-
-        @BindsInstance
-        fun application(application: Application): Builder
-
-        @BindsInstance
-        fun paymentElementCallbackIdentifier(
-            @PaymentElementCallbackIdentifier paymentElementCallbackIdentifier: String,
-        ): Builder
-
-        @BindsInstance
-        fun statusBarColor(@Named(STATUS_BAR_COLOR) statusBarColor: Int?): Builder
-
-        fun build(): EmbeddedPaymentElementViewModelComponent
+    @Component.Factory
+    interface Factory {
+        fun build(
+            @BindsInstance savedStateHandle: SavedStateHandle,
+            @BindsInstance application: Application,
+            @BindsInstance @PaymentElementCallbackIdentifier
+            paymentElementCallbackIdentifier: String,
+            @BindsInstance
+            @Named(STATUS_BAR_COLOR)
+            statusBarColor: Int?,
+        ): EmbeddedPaymentElementViewModelComponent
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivity.kt
@@ -51,11 +51,10 @@ internal class FormActivity : AppCompatActivity() {
 
         renderEdgeToEdge()
 
-        viewModel.component.subcomponentBuilder
-            .activityResultCaller(this)
-            .lifecycleOwner(this)
-            .build()
-            .inject(this)
+        viewModel.component.subcomponentFactory.build(
+            activityResultCaller = this,
+            lifecycleOwner = this,
+        ).inject(this)
 
         setContent {
             StripeTheme {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityViewModel.kt
@@ -26,17 +26,17 @@ internal class FormActivityViewModel @Inject constructor(
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
             val args = argSupplier()
-            val component = DaggerFormActivityViewModelComponent.builder()
-                .paymentMethodMetadata(args.paymentMethodMetadata)
-                .selectedPaymentMethodCode(args.selectedPaymentMethodCode)
-                .hasSavedPaymentMethods(args.hasSavedPaymentMethods)
-                .configuration(args.configuration)
-                .initializationMode(args.initializationMode)
-                .statusBarColor(args.statusBarColor)
-                .application(extras.requireApplication())
-                .paymentElementCallbackIdentifier(args.paymentElementCallbackIdentifier)
-                .savedStateHandle(extras.createSavedStateHandle())
-                .build()
+            val component = DaggerFormActivityViewModelComponent.factory().build(
+                paymentMethodMetadata = args.paymentMethodMetadata,
+                selectedPaymentMethodCode = args.selectedPaymentMethodCode,
+                hasSavedPaymentMethods = args.hasSavedPaymentMethods,
+                configuration = args.configuration,
+                initializationMode = args.initializationMode,
+                statusBarColor = args.statusBarColor,
+                application = extras.requireApplication(),
+                paymentElementCallbackIdentifier = args.paymentElementCallbackIdentifier,
+                savedStateHandle = extras.createSavedStateHandle(),
+            )
 
             return component.viewModel as T
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityViewModelComponent.kt
@@ -53,40 +53,25 @@ import kotlin.coroutines.CoroutineContext
 @OptIn(ExperimentalEmbeddedPaymentElementApi::class)
 internal interface FormActivityViewModelComponent {
     val viewModel: FormActivityViewModel
-    val subcomponentBuilder: FormActivitySubcomponent.Builder
+    val subcomponentFactory: FormActivitySubcomponent.Factory
 
-    @Component.Builder
-    interface Builder {
-        @BindsInstance
-        fun paymentMethodMetadata(paymentMethodMetadata: PaymentMethodMetadata): Builder
-
-        @BindsInstance
-        fun selectedPaymentMethodCode(selectedPaymentMethodCode: PaymentMethodCode): Builder
-
-        @BindsInstance
-        fun hasSavedPaymentMethods(hasSavedPaymentMethods: Boolean): Builder
-
-        @BindsInstance
-        fun statusBarColor(@Named(STATUS_BAR_COLOR) statusBarColor: Int?): Builder
-
-        @BindsInstance
-        fun configuration(configuration: EmbeddedPaymentElement.Configuration): Builder
-
-        @BindsInstance
-        fun initializationMode(initializationMode: PaymentElementLoader.InitializationMode): Builder
-
-        @BindsInstance
-        fun paymentElementCallbackIdentifier(
-            @PaymentElementCallbackIdentifier paymentElementCallbackIdentifier: String,
-        ): Builder
-
-        @BindsInstance
-        fun application(application: Application): Builder
-
-        @BindsInstance
-        fun savedStateHandle(savedStateHandle: SavedStateHandle): Builder
-
-        fun build(): FormActivityViewModelComponent
+    @Component.Factory
+    interface Factory {
+        fun build(
+            @BindsInstance paymentMethodMetadata: PaymentMethodMetadata,
+            @BindsInstance selectedPaymentMethodCode: PaymentMethodCode,
+            @BindsInstance hasSavedPaymentMethods: Boolean,
+            @BindsInstance
+            @Named(STATUS_BAR_COLOR)
+            statusBarColor: Int?,
+            @BindsInstance configuration: EmbeddedPaymentElement.Configuration,
+            @BindsInstance initializationMode: PaymentElementLoader.InitializationMode,
+            @BindsInstance
+            @PaymentElementCallbackIdentifier
+            paymentElementCallbackIdentifier: String,
+            @BindsInstance application: Application,
+            @BindsInstance savedStateHandle: SavedStateHandle,
+        ): FormActivityViewModelComponent
     }
 }
 
@@ -157,15 +142,12 @@ internal interface FormActivityViewModelModule {
 internal interface FormActivitySubcomponent {
     fun inject(activity: FormActivity)
 
-    @Subcomponent.Builder
-    interface Builder {
-        @BindsInstance
-        fun activityResultCaller(activityResultCaller: ActivityResultCaller): Builder
-
-        @BindsInstance
-        fun lifecycleOwner(lifecycleOwner: LifecycleOwner): Builder
-
-        fun build(): FormActivitySubcomponent
+    @Subcomponent.Factory
+    interface Factory {
+        fun build(
+            @BindsInstance activityResultCaller: ActivityResultCaller,
+            @BindsInstance lifecycleOwner: LifecycleOwner,
+        ): FormActivitySubcomponent
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/ManageComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/ManageComponent.kt
@@ -12,7 +12,6 @@ import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.SavedPaymentMethodMutator
 import com.stripe.android.paymentsheet.analytics.EventReporter
-import com.stripe.android.paymentsheet.injection.PaymentSheetLauncherComponent.Builder
 import com.stripe.android.ui.core.di.CardScanModule
 import dagger.Binds
 import dagger.BindsInstance
@@ -37,23 +36,15 @@ internal interface ManageComponent {
     val selectionHolder: EmbeddedSelectionHolder
     fun inject(activity: ManageActivity)
 
-    @Component.Builder
-    interface Builder {
-        @BindsInstance
-        fun savedStateHandle(savedStateHandle: SavedStateHandle): Builder
-
-        @BindsInstance
-        fun paymentMethodMetadata(paymentMethodMetadata: PaymentMethodMetadata): Builder
-
-        @BindsInstance
-        fun context(context: Context): Builder
-
-        @BindsInstance
-        fun paymentElementCallbackIdentifier(
-            @PaymentElementCallbackIdentifier paymentElementCallbackIdentifier: String
-        ): Builder
-
-        fun build(): ManageComponent
+    @Component.Factory
+    interface Factory {
+        fun build(
+            @BindsInstance savedStateHandle: SavedStateHandle,
+            @BindsInstance paymentMethodMetadata: PaymentMethodMetadata,
+            @BindsInstance context: Context,
+            @BindsInstance @PaymentElementCallbackIdentifier
+            paymentElementCallbackIdentifier: String,
+        ): ManageComponent
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/ManageViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/ManageViewModel.kt
@@ -27,12 +27,12 @@ internal class ManageViewModel @Inject constructor(
 
             val args = argsSupplier()
 
-            val component = DaggerManageComponent.builder()
-                .savedStateHandle(savedStateHandle)
-                .paymentElementCallbackIdentifier(args.paymentElementCallbackIdentifier)
-                .paymentMethodMetadata(args.paymentMethodMetadata)
-                .context(extras.requireApplication())
-                .build()
+            val component = DaggerManageComponent.factory().build(
+                savedStateHandle = savedStateHandle,
+                paymentElementCallbackIdentifier = args.paymentElementCallbackIdentifier,
+                paymentMethodMetadata = args.paymentMethodMetadata,
+                context = extras.requireApplication(),
+            )
 
             component.customerStateHolder.setCustomerState(args.customerState)
             component.selectionHolder.set(args.selection)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Replaces `@Component.Builder` with `@Componenet.Factory` (and similar with subcomponents). 

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
It's possible to forget a builder method call (we've seen this in the past), but the compiler will ensure you pass everything to the factory method!
