### PR TITLE
Re enable sofort tests.

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestSofort.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestSofort.kt
@@ -12,12 +12,10 @@ import com.stripe.android.paymentsheet.example.playground.settings.DelayedPaymen
 import com.stripe.android.paymentsheet.example.playground.settings.GooglePaySettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.SupportedPaymentMethodsSettingsDefinition
 import com.stripe.android.test.core.TestParameters
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-@Ignore("#ir-agitate-surround")
 internal class TestSofort : BasePlaygroundTest() {
     private val testParameters = TestParameters.create(
         paymentMethodCode = "sofort",


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Sofort is being deprecated, but we want to continue running our tests to ensure the code works. We've added our test merchant to a flag that has sofort enabled.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
ir-agitate-surround

https://support.stripe.com/questions/sofort-is-being-consolidated-into-klarna-and-discontinued-as-a-standalone-payment-method

