### PR TITLE
Add nexus-sonatype-login to add_new_team_member.rb script

### DIFF
--- a/scripts/deploy/add_new_team_member.rb
+++ b/scripts/deploy/add_new_team_member.rb
@@ -15,6 +15,7 @@ required_passwords = [
     "bindings/gnupg/privkey",
     "bindings/gnupg/passphrase",
     "bindings/java-maven-api-token",
+    "nexus-sonatype-login",
 ]
 
 required_passwords.each do |password|


### PR DESCRIPTION
# Summary
Added `nexus-sonatype-login` to the logins that add_new_team_member.rb runs

# Motivation
Fixing a problem I encountered while trying to get onboarded for deploy
