### PR TITLE
[MOBILESDK-3282][MOBILESDK-3307] Fix incorrect payment selection behavior in FlowController

### DIFF
--- a/payments-core-testing/src/main/java/com/stripe/android/testing/PaymentMethodFactory.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/PaymentMethodFactory.kt
@@ -82,6 +82,14 @@ object PaymentMethodFactory {
         )
     }
 
+    fun amexCard(): PaymentMethod {
+        return card(random = false).update(
+            last4 = "0005",
+            addCbcNetworks = false,
+            brand = CardBrand.AmericanExpress,
+        )
+    }
+
     fun cashAppPay(): PaymentMethod {
         return PaymentMethod(
             id = "pm_1234",

--- a/payments-core-testing/src/main/java/com/stripe/android/testing/PaymentMethodFactory.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/PaymentMethodFactory.kt
@@ -82,14 +82,6 @@ object PaymentMethodFactory {
         )
     }
 
-    fun amexCard(): PaymentMethod {
-        return card(random = false).update(
-            last4 = "0005",
-            addCbcNetworks = false,
-            brand = CardBrand.AmericanExpress,
-        )
-    }
-
     fun cashAppPay(): PaymentMethod {
         return PaymentMethod(
             id = "pm_1234",

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdater.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdater.kt
@@ -25,10 +25,11 @@ internal class DefaultPaymentSelectionUpdater @Inject constructor() : PaymentSel
         newState: PaymentSheetState.Full,
         newConfig: PaymentSheet.Configuration,
     ): PaymentSelection? {
-        return newState.paymentSelection?.takeIf { canUseSelection(it, newState) } ?:
-        currentSelection?.takeIf { selection ->
-            canUseSelection(selection, newState) && previousConfig?.let { previousConfig ->
-                !previousConfig.asCommonConfiguration().containsVolatileDifferences(newConfig.asCommonConfiguration())
+        return newState.paymentSelection?.takeIf {
+            canUseSelection(it, newState)
+        } ?: currentSelection?.takeIf { selection ->
+            canUseSelection(selection, newState) && previousConfig?.let {
+                !it.asCommonConfiguration().containsVolatileDifferences(newConfig.asCommonConfiguration())
             } != false
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdater.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdater.kt
@@ -25,11 +25,12 @@ internal class DefaultPaymentSelectionUpdater @Inject constructor() : PaymentSel
         newState: PaymentSheetState.Full,
         newConfig: PaymentSheet.Configuration,
     ): PaymentSelection? {
-        return currentSelection?.takeIf { selection ->
+        return newState.paymentSelection?.takeIf { canUseSelection(it, newState) } ?:
+        currentSelection?.takeIf { selection ->
             canUseSelection(selection, newState) && previousConfig?.let { previousConfig ->
                 !previousConfig.asCommonConfiguration().containsVolatileDifferences(newConfig.asCommonConfiguration())
             } != false
-        } ?: newState.paymentSelection
+        }
     }
 
     private fun canUseSelection(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdaterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdaterTest.kt
@@ -100,16 +100,11 @@ class PaymentSelectionUpdaterTest {
             PaymentMethodFactory.card(id = "pm_1234")
         )
 
-        val newConfig = PaymentSheet.Configuration(
-            merchantDisplayName = "Example, Inc.",
-            allowsDelayedPaymentMethods = true,
-        )
         val newState = mockPaymentSheetStateWithPaymentIntent(
             paymentMethodTypes = listOf("card", "sofort"),
             customerPaymentMethods = listOf(
                 existingSelection.paymentMethod,
             ),
-            config = newConfig
         )
 
         val updater = createUpdater()
@@ -127,10 +122,6 @@ class PaymentSelectionUpdaterTest {
         val existingSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
         val newSelection = PaymentSelection.Saved(PaymentMethodFixtures.SEPA_DEBIT_PAYMENT_METHOD)
 
-        val newConfig = PaymentSheet.Configuration(
-            merchantDisplayName = "Example, Inc.",
-            allowsDelayedPaymentMethods = true,
-        )
         val newState = mockPaymentSheetStateWithPaymentIntent(
             paymentSelection = newSelection,
             customerPaymentMethods = listOf(
@@ -138,7 +129,6 @@ class PaymentSelectionUpdaterTest {
                 newSelection.paymentMethod,
             ),
             paymentMethodTypes = listOf("card", "sofort"),
-            config = newConfig
         )
 
         val updater = createUpdater()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdaterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdaterTest.kt
@@ -71,7 +71,7 @@ class PaymentSelectionUpdaterTest {
         val newSelection = PaymentSelection.Saved(
             PaymentMethodFactory.card(id = "pm_abcd").update(
                 brand = CardBrand.AmericanExpress,
-                last4 ="0005",
+                last4 = "0005",
                 addCbcNetworks = false
             )
         )


### PR DESCRIPTION
# Summary
Use newState.paymentSelection over current selection

# Motivation
Fix incorrect payment selection behavior in FlowController.

Fixed issue where buying with a new card, and reopening payment element, redirected to add card flow
Fixed issue where deleting a saved card but still seeing it as the payment selection

https://jira.corp.stripe.com/browse/MOBILESDK-3307
https://jira.corp.stripe.com/browse/MOBILESDK-3282

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified

# Screenshots
<image src="https://github.com/user-attachments/assets/303e6b4d-80bf-4641-abfb-2266e3513e75" height = 400px/>

# Changelog
N.A.
