### PR TITLE
[link-in-mpe] you can't signup for link in link native in the US

### DIFF
--- a/payments-core/src/test/java/com/stripe/android/model/SignUpParamsTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/SignUpParamsTest.kt
@@ -42,7 +42,6 @@ class SignUpParamsTest {
         assertEquals("John Doe", paramMap["legal_name"])
         assertEquals("token123", paramMap["android_verification_token"])
         assertEquals("appId123", paramMap["app_id"])
-        assertEquals("incentive_value", paramMap["incentive_key"])
     }
 
     @Test
@@ -68,8 +67,6 @@ class SignUpParamsTest {
         assertEquals("PHONE_NUMBER", paramMap["country_inferring_method"])
         assertEquals("implied_consent_withspm_mobile_v0", paramMap["consent_action"])
         assertEquals("MOBILE", paramMap["request_surface"])
-        assertFalse(paramMap.containsKey("amount"))
-        assertFalse(paramMap.containsKey("currency"))
         assertFalse(paramMap.containsKey("locale"))
         assertFalse(paramMap.containsKey("legal_name"))
         assertFalse(paramMap.containsKey("android_verification_token"))

--- a/payments-core/src/test/java/com/stripe/android/model/SignUpParamsTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/SignUpParamsTest.kt
@@ -5,8 +5,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Test
 import java.util.Locale
-import kotlin.collections.containsKey
-import kotlin.text.get
 
 class SignUpParamsTest {
 

--- a/payments-core/src/test/java/com/stripe/android/model/SignUpParamsTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/SignUpParamsTest.kt
@@ -1,0 +1,102 @@
+import com.stripe.android.model.ConsumerSignUpConsentAction
+import com.stripe.android.model.IncentiveEligibilitySession
+import com.stripe.android.model.SignUpParams
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import java.util.Locale
+import kotlin.collections.containsKey
+import kotlin.text.get
+
+class SignUpParamsTest {
+
+    @Test
+    fun `toParamMap should include all non-null fields`() {
+        val locale = Locale.US
+        val incentiveEligibilitySession = IncentiveEligibilitySession.PaymentIntent("incentive123")
+
+        val signUpParams = SignUpParams(
+            email = "test@example.com",
+            phoneNumber = "1234567890",
+            country = "US",
+            name = "John Doe",
+            locale = locale,
+            amount = 1000L,
+            currency = "USD",
+            incentiveEligibilitySession = incentiveEligibilitySession,
+            requestSurface = "MOBILE",
+            consentAction = ConsumerSignUpConsentAction.Implied,
+            verificationToken = "token123",
+            appId = "appId123"
+        )
+
+        val paramMap = signUpParams.toParamMap()
+
+        assertEquals("test@example.com", paramMap["email_address"])
+        assertEquals("1234567890", paramMap["phone_number"])
+        assertEquals("US", paramMap["country"])
+        assertEquals("PHONE_NUMBER", paramMap["country_inferring_method"])
+        assertEquals(1000L, paramMap["amount"])
+        assertEquals("USD", paramMap["currency"])
+        assertEquals("implied_consent_withspm_mobile_v0", paramMap["consent_action"])
+        assertEquals("MOBILE", paramMap["request_surface"])
+        assertEquals("en-US", paramMap["locale"])
+        assertEquals("John Doe", paramMap["legal_name"])
+        assertEquals("token123", paramMap["android_verification_token"])
+        assertEquals("appId123", paramMap["app_id"])
+        assertEquals("incentive_value", paramMap["incentive_key"])
+    }
+
+    @Test
+    fun `toParamMap should exclude null fields`() {
+        val signUpParams = SignUpParams(
+            email = "test@example.com",
+            phoneNumber = "1234567890",
+            country = "US",
+            name = null,
+            locale = null,
+            amount = null,
+            currency = null,
+            incentiveEligibilitySession = null,
+            requestSurface = "MOBILE",
+            consentAction = ConsumerSignUpConsentAction.Implied
+        )
+
+        val paramMap = signUpParams.toParamMap()
+
+        assertEquals("test@example.com", paramMap["email_address"])
+        assertEquals("1234567890", paramMap["phone_number"])
+        assertEquals("US", paramMap["country"])
+        assertEquals("PHONE_NUMBER", paramMap["country_inferring_method"])
+        assertEquals("implied_consent_withspm_mobile_v0", paramMap["consent_action"])
+        assertEquals("MOBILE", paramMap["request_surface"])
+        assertFalse(paramMap.containsKey("amount"))
+        assertFalse(paramMap.containsKey("currency"))
+        assertFalse(paramMap.containsKey("locale"))
+        assertFalse(paramMap.containsKey("legal_name"))
+        assertFalse(paramMap.containsKey("android_verification_token"))
+        assertFalse(paramMap.containsKey("app_id"))
+    }
+
+    @Test
+    fun `toParamMap should exclude empty name`() {
+        val signUpParams = SignUpParams(
+            email = "test@example.com",
+            phoneNumber = "1234567890",
+            country = "US",
+            name = "",
+            locale = Locale.US,
+            amount = 1000L,
+            currency = "USD",
+            incentiveEligibilitySession = IncentiveEligibilitySession.PaymentIntent("incentive123"),
+            requestSurface = "MOBILE",
+            consentAction = ConsumerSignUpConsentAction.Implied,
+            verificationToken = "token123",
+            appId = "appId123"
+        )
+
+        val paramMap = signUpParams.toParamMap()
+
+        assertFalse(paramMap.containsKey("legal_name"))
+    }
+}

--- a/payments-model/src/main/java/com/stripe/android/model/SignUpParams.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/SignUpParams.kt
@@ -34,7 +34,7 @@ data class SignUpParams(
             params["locale"] = it.toLanguageTag()
         }
 
-        name?.takeIf { it.isNotBlank() }.let {
+        name?.takeIf { it.isNotBlank() }?.let {
             params["legal_name"] = it
         }
 

--- a/payments-model/src/main/java/com/stripe/android/model/SignUpParams.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/SignUpParams.kt
@@ -34,7 +34,7 @@ data class SignUpParams(
             params["locale"] = it.toLanguageTag()
         }
 
-        name?.let {
+        name?.takeIf { it.isNotBlank() }.let {
             params["legal_name"] = it
         }
 


### PR DESCRIPTION
# Summary
- We just require legal name via a field outside of the US
- On these scenarios, we're sending an empty `legal_name` param on `/signup` calls. That makes the request fail.

<img width="508" alt="Screenshot 2025-03-31 at 12 02 21 PM" src="https://github.com/user-attachments/assets/659f2da2-4d2a-477f-898d-b68224b49caf" />

# Motivation
https://jira.corp.stripe.com/browse/LINK_MOBILE-100

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
