### PR TITLE
Fix `validate_version_number` script

### DIFF
--- a/scripts/deploy/validate_version_number.rb
+++ b/scripts/deploy/validate_version_number.rb
@@ -19,10 +19,10 @@ def validate_version_number_format(version_number)
 end
 
 def target_version_is_newer(target_version, current_version)
-  target_major, target_minor, target_patch = target_version.split('.')
+  target_major, target_minor, target_patch = target_version.split('.').map(&:to_i)
   # We tag version numbers to start with "v", so we need to remove that before comparing to the
   # target version.
-  current_major, current_minor, current_patch = current_version[1..].split('.')
+  current_major, current_minor, current_patch = current_version[1..].split('.').map(&:to_i)
 
   if target_major < current_major
     false


### PR DESCRIPTION
# Summary

iOS equivalent: https://github.com/stripe/stripe-ios/pull/4759

Fixes an issue in how we compared version numbers that was flagging `24.10.0` as not newer than `24.9.0`. Switching from string comparison to integer comparison fixes the issue!

# Motivation

Fixes our CI script

# Testing

On `master`:

<img width="1277" alt="Screenshot 2025-03-31 at 4 07 57 PM" src="https://github.com/user-attachments/assets/18bde8bc-c9d4-4713-8773-ccbace22e734" />

On this branch:

<img width="296" alt="Screenshot 2025-03-31 at 4 11 22 PM" src="https://github.com/user-attachments/assets/34c88e43-b9ac-4fa0-9db0-7eb1cd0556b7" />

# Changelog

N/a
