### PR TITLE
Fix `PaymentSelection` being null on errors for wallets.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -502,7 +502,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         message: ResolvableString
     ) {
         eventReporter.onPaymentFailure(
-            paymentSelection = selection.value,
+            paymentSelection = inProgressSelection,
             error = error,
         )
 


### PR DESCRIPTION
# Summary
Fix `PaymentSelection` being null on errors for wallets.

# Motivation
Forgot this when fixing the payment selection being null for successful payments.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified