### PR TITLE
[MOBILESDK-3282][MOBILESDK-3707] Fix incorrect payment selection behavior in FlowController v2

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -277,12 +277,15 @@ internal class DefaultFlowController @Inject internal constructor(
             is PaymentSelection.GooglePay,
             is PaymentSelection.ExternalPaymentMethod,
             is PaymentSelection.New,
-            null -> confirmPaymentSelection(
-                paymentSelection = paymentSelection,
-                state = state.paymentSheetState,
-                appearance = state.config.appearance,
-                initializationMode = initializationMode,
-            )
+            null -> {
+                confirmPaymentSelection(
+                    paymentSelection = paymentSelection,
+                    state = state.paymentSheetState,
+                    appearance = state.config.appearance,
+                    initializationMode = initializationMode,
+                )
+                viewModel.paymentSelection = null
+            }
             is PaymentSelection.Saved -> confirmSavedPaymentMethod(
                 paymentSelection = paymentSelection,
                 state = state.paymentSheetState,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -277,14 +277,12 @@ internal class DefaultFlowController @Inject internal constructor(
             is PaymentSelection.GooglePay,
             is PaymentSelection.ExternalPaymentMethod,
             is PaymentSelection.New,
-            null -> {
-                confirmPaymentSelection(
-                    paymentSelection = paymentSelection,
-                    state = state.paymentSheetState,
-                    appearance = state.config.appearance,
-                    initializationMode = initializationMode,
-                )
-            }
+            null -> confirmPaymentSelection(
+                paymentSelection = paymentSelection,
+                state = state.paymentSheetState,
+                appearance = state.config.appearance,
+                initializationMode = initializationMode,
+            )
             is PaymentSelection.Saved -> confirmSavedPaymentMethod(
                 paymentSelection = paymentSelection,
                 state = state.paymentSheetState,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -501,6 +501,7 @@ internal class DefaultFlowController @Inject internal constructor(
 
         if (paymentResult is PaymentResult.Completed) {
             viewModel.paymentSelection = null
+            viewModel.state = null
         }
 
         viewModelScope.launch {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -284,7 +284,6 @@ internal class DefaultFlowController @Inject internal constructor(
                     appearance = state.config.appearance,
                     initializationMode = initializationMode,
                 )
-                viewModel.paymentSelection = null
             }
             is PaymentSelection.Saved -> confirmSavedPaymentMethod(
                 paymentSelection = paymentSelection,
@@ -500,6 +499,10 @@ internal class DefaultFlowController @Inject internal constructor(
 
         if (paymentResult is PaymentResult.Completed && selection != null && selection.isLink) {
             linkHandler.logOut()
+        }
+
+        if (paymentResult is PaymentResult.Completed) {
+            viewModel.paymentSelection = null
         }
 
         viewModelScope.launch {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -284,6 +284,24 @@ internal class DefaultFlowControllerTest {
     }
 
     @Test
+    fun `successful payment should clear viewmodel paymentSelection`() = runTest {
+        val viewModel = createViewModel()
+        val flowController = createFlowController(viewModel = viewModel)
+
+        flowController.configureExpectingSuccess()
+
+        viewModel.paymentSelection = PaymentSelection.New.Card(
+            PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+            mock(),
+            mock()
+        )
+
+        flowController.onPaymentResult(PaymentResult.Completed)
+
+        assertThat(viewModel.paymentSelection).isNull()
+    }
+
+    @Test
     fun `failed payment should fire analytics event`() = runTest {
         val viewModel = createViewModel()
         val flowController = createFlowController(viewModel = viewModel)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -284,7 +284,7 @@ internal class DefaultFlowControllerTest {
     }
 
     @Test
-    fun `successful payment should clear viewmodel paymentSelection`() = runTest {
+    fun `successful payment should clear viewmodel state`() = runTest {
         val viewModel = createViewModel()
         val flowController = createFlowController(viewModel = viewModel)
 
@@ -299,6 +299,7 @@ internal class DefaultFlowControllerTest {
         flowController.onPaymentResult(PaymentResult.Completed)
 
         assertThat(viewModel.paymentSelection).isNull()
+        assertThat(viewModel.state).isNull()
     }
 
     @Test


### PR DESCRIPTION
# Summary
Set clean up paymentSelection upon successful payment. 

# Motivation
Fix incorrect payment selection behavior in FlowController.

Fixed issue where buying with a new card, and reopening payment element, redirected to add card flow
Fixed issue where deleting a saved card but still seeing it as the payment selection

https://jira.corp.stripe.com/browse/MOBILESDK-3307
https://jira.corp.stripe.com/browse/MOBILESDK-3282

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| ![1000000176](https://github.com/user-attachments/assets/662aba0b-3735-4277-8d35-06da82c75bd1) | ![1000000175](https://github.com/user-attachments/assets/95e14e79-c41d-457d-ad73-4d532ea943a6)|

# Changelog
N.A.