### PR TITLE
Exclude FC lite tests from nightlies.

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestUSBankAccount.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestUSBankAccount.kt
@@ -61,11 +61,13 @@ internal class TestUSBankAccount : BasePlaygroundTest() {
     fun testUSBankAccountLiteSuccess() {
         testDriver.confirmUSBankAccount(
             financialConnectionsLiteEnabled = true,
-            testParameters = testParameters.copyPlaygroundSettings {
-                it[DefaultBillingAddressSettingsDefinition] = DefaultBillingAddress.OnWithRandomEmail
-                it[FeatureFlagSettingsDefinition(FeatureFlags.financialConnectionsLiteEnabled)] = true
-                it[FeatureFlagSettingsDefinition(FeatureFlags.financialConnectionsFullSdkUnavailable)] = true
-            },
+            testParameters = testParameters
+                .copyPlaygroundSettings {
+                    it[DefaultBillingAddressSettingsDefinition] = DefaultBillingAddress.OnWithRandomEmail
+                    it[FeatureFlagSettingsDefinition(FeatureFlags.financialConnectionsLiteEnabled)] = true
+                    it[FeatureFlagSettingsDefinition(FeatureFlags.financialConnectionsFullSdkUnavailable)] = true
+                }
+                .copy(executeInNightlyRun = false),
             afterAuthorization = { _, _ ->
                 ComposeButton(rules.compose, hasTestTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG))
                     .waitFor(isEnabled())
@@ -142,12 +144,14 @@ internal class TestUSBankAccount : BasePlaygroundTest() {
     fun testUSBankAccountLiteCancelAllowsUserToContinue() {
         testDriver.confirmUSBankAccount(
             financialConnectionsLiteEnabled = true,
-            testParameters = testParameters.copyPlaygroundSettings {
-                it[FeatureFlagSettingsDefinition(FeatureFlags.financialConnectionsLiteEnabled)] = true
-                it[FeatureFlagSettingsDefinition(FeatureFlags.financialConnectionsFullSdkUnavailable)] = true
-            }.copy(
-                authorizationAction = AuthorizeAction.Cancel,
-            ),
+            testParameters = testParameters
+                .copyPlaygroundSettings {
+                    it[FeatureFlagSettingsDefinition(FeatureFlags.financialConnectionsLiteEnabled)] = true
+                    it[FeatureFlagSettingsDefinition(FeatureFlags.financialConnectionsFullSdkUnavailable)] = true
+                }.copy(
+                    authorizationAction = AuthorizeAction.Cancel,
+                    executeInNightlyRun = false
+                ),
             afterAuthorization = { _, _ ->
                 ComposeButton(rules.compose, hasTestTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG))
                     .waitFor(isEnabled())

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestUsBankAccountInCustomerSheet.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestUsBankAccountInCustomerSheet.kt
@@ -47,6 +47,7 @@ internal class TestUsBankAccountInCustomerSheet : BasePlaygroundTest() {
         testDriver.saveUsBankAccountInCustomerSheet(
             financialConnectionsLiteEnabled = true,
             testParameters = testParameters.copy(
+                executeInNightlyRun = false,
                 authorizationAction = AuthorizeAction.Cancel,
             ).copyPlaygroundSettings {
                 it[DefaultBillingAddressSettingsDefinition] = DefaultBillingAddress.OnWithRandomEmail
@@ -73,6 +74,7 @@ internal class TestUsBankAccountInCustomerSheet : BasePlaygroundTest() {
         testDriver.saveUsBankAccountInCustomerSheet(
             financialConnectionsLiteEnabled = true,
             testParameters = testParameters.copy(
+                executeInNightlyRun = false,
                 authorizationAction = AuthorizeAction.Cancel,
             ).copyPlaygroundSettings { settings ->
                 settings[CustomerSessionSettingsDefinition] = true


### PR DESCRIPTION
# Summary

- Webview based tests on FC seem to be flaky when executed on the nightly job, that targets a wider range of devices.
- This PR excludes lite tests from the nightly execution while keeping the full SDK tests running.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
