### PR TITLE
[MOBILESDK-3379] Fix Save and Continue button both visible in Manage Page

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/PrimaryButtonUiStateMapper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/PrimaryButtonUiStateMapper.kt
@@ -64,7 +64,8 @@ internal class PrimaryButtonUiStateMapper(
                 enabled = buttonsEnabled && selection != null,
                 lockVisible = false,
             ).takeIf {
-                screen.showsContinueButton || selection?.requiresConfirmation == true
+                screen.showsContinueButton ||
+                    (selection?.requiresConfirmation == true && screen.showsMandates)
             }
         }
     }


### PR DESCRIPTION
# Summary
Modify PrimaryButton uiState logic that determines if primary button should be shown.

If PrimaryButton.uiState is null, then primary button is not shown

From
```
takeIf { screen.showsContinueButton || selection?.requiresConfirmation == true}
```

To
```
takeIf { screen.showsContinueButton || (selection?.requiresConfirmation == true && screen.showsMandates)}
```

# Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-3379

Fixing a bug where it was possible for users to show the continue button when editing a payment method. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [X] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
|![1000000169](https://github.com/user-attachments/assets/79ff7174-c9b8-49c9-8fdc-6c7ae9139b12)|![1000000224_trimmed](https://github.com/user-attachments/assets/95e29727-9ba0-48f1-a46e-20fd412c97c9)|

# Changelog
N.A.