### PR TITLE
Update UI to collect on the main thread to avoid compose crashes.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -16,6 +16,7 @@ import com.stripe.android.paymentsheet.utils.applicationIsTaskOwner
 import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.elements.bottomsheet.rememberStripeBottomSheetState
 import com.stripe.android.uicore.utils.collectAsState
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.filterNotNull
 
 /**
@@ -50,7 +51,7 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
 
         setContent {
             StripeTheme {
-                val isProcessing by viewModel.processing.collectAsState()
+                val isProcessing by viewModel.processing.collectAsState(Dispatchers.Main)
 
                 val bottomSheetState = rememberStripeBottomSheetState(
                     confirmValueChange = { !isProcessing },

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -18,6 +18,7 @@ import com.stripe.android.paymentsheet.utils.applicationIsTaskOwner
 import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.elements.bottomsheet.rememberStripeBottomSheetState
 import com.stripe.android.uicore.utils.collectAsState
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.filterNotNull
 
 internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
@@ -55,7 +56,7 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
 
         setContent {
             StripeTheme {
-                val isProcessing by viewModel.processing.collectAsState()
+                val isProcessing by viewModel.processing.collectAsState(Dispatchers.Main)
 
                 val bottomSheetState = rememberStripeBottomSheetState(
                     confirmValueChange = { !isProcessing },

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
@@ -118,9 +118,9 @@ private fun PaymentSheetScreen(
     scrollState: ScrollState,
     content: @Composable () -> Unit,
 ) {
-    val processing by viewModel.processing.collectAsState()
+    val processing by viewModel.processing.collectAsState(Dispatchers.Main)
 
-    val walletsProcessingState by viewModel.walletsProcessingState.collectAsState()
+    val walletsProcessingState by viewModel.walletsProcessingState.collectAsState(Dispatchers.Main)
 
     val density = LocalDensity.current
     var contentHeight by remember { mutableStateOf(0.dp) }
@@ -129,7 +129,7 @@ private fun PaymentSheetScreen(
 
     BottomSheetScaffold(
         topBar = {
-            val currentScreen by viewModel.navigationHandler.currentScreen.collectAsState()
+            val currentScreen by viewModel.navigationHandler.currentScreen.collectAsState(Dispatchers.Main)
             val topBarState by remember(currentScreen) {
                 currentScreen.topBarState()
             }.collectAsState()
@@ -423,7 +423,7 @@ internal fun Wallet(
 
 @Composable
 private fun PrimaryButton(viewModel: BaseSheetViewModel) {
-    val uiState = viewModel.primaryButtonUiState.collectAsState()
+    val uiState = viewModel.primaryButtonUiState.collectAsState(Dispatchers.Main)
 
     val modifier = Modifier
         .testTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenUI.kt
@@ -14,6 +14,7 @@ import com.stripe.android.paymentelement.ExperimentalEmbeddedPaymentElementApi
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.uicore.utils.collectAsState
+import kotlinx.coroutines.Dispatchers
 
 @OptIn(ExperimentalEmbeddedPaymentElementApi::class)
 @Composable
@@ -22,7 +23,7 @@ internal fun ManageScreenUI(interactor: ManageScreenInteractor) {
         id = R.dimen.stripe_paymentsheet_outer_spacing_horizontal
     )
 
-    val state by interactor.state.collectAsState()
+    val state by interactor.state.collectAsState(Dispatchers.Main)
 
     Column(
         modifier = Modifier

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodEmbeddedLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodEmbeddedLayoutUI.kt
@@ -24,6 +24,7 @@ import com.stripe.android.ui.core.elements.Mandate
 import com.stripe.android.uicore.image.StripeImageLoader
 import com.stripe.android.uicore.strings.resolve
 import com.stripe.android.uicore.utils.collectAsState
+import kotlinx.coroutines.Dispatchers
 import org.jetbrains.annotations.VisibleForTesting
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -44,7 +45,7 @@ internal fun ColumnScope.PaymentMethodEmbeddedLayoutUI(
         StripeImageLoader(context.applicationContext)
     }
 
-    val state by interactor.state.collectAsState()
+    val state by interactor.state.collectAsState(Dispatchers.Main)
 
     PaymentMethodEmbeddedLayoutUI(
         paymentMethods = state.displayablePaymentMethods,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUI.kt
@@ -28,6 +28,7 @@ import com.stripe.android.paymentsheet.ui.PromoBadge
 import com.stripe.android.uicore.image.StripeImageLoader
 import com.stripe.android.uicore.strings.resolve
 import com.stripe.android.uicore.utils.collectAsState
+import kotlinx.coroutines.Dispatchers
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 const val TEST_TAG_HEADER_TITLE = "TEST_TAG_HEADER_TITLE"
@@ -43,7 +44,7 @@ internal fun VerticalModeFormUI(
     )
 
     var hasSentInteractionEvent by remember { mutableStateOf(false) }
-    val state by interactor.state.collectAsState()
+    val state by interactor.state.collectAsState(Dispatchers.Main)
 
     Column(modifier) {
         val headerInformation = state.headerInformation


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
These states emit on non UI thread (not always), which can cause compose crashes. 

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fix flakey tests, and prevent crashes in the wild.
