### PR TITLE
Ensure updating edit happens on the main thread.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.paymentsheet
 
 import androidx.lifecycle.viewModelScope
+import com.stripe.android.core.mainthread.MainThreadOnlyMutableStateFlow
+import com.stripe.android.core.mainthread.update
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.orEmpty
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
@@ -22,9 +24,7 @@ import com.stripe.android.uicore.utils.mapAsStateFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
@@ -98,7 +98,7 @@ internal class SavedPaymentMethodMutator(
         }
     }
 
-    private val _editing = MutableStateFlow(false)
+    private val _editing = MainThreadOnlyMutableStateFlow(false)
     internal val editing: StateFlow<Boolean> = _editing
 
     init {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Enforcing main thread changes for isEditing, and moving a bunch more state updates to the main thread.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fix flakey tests, and reduce crashes in production.
