### PR TITLE
Add title to `PaymentLauncherConfirmationActivity` for better `Talkback` support

### DIFF
--- a/payments-core/res/values/strings.xml
+++ b/payments-core/res/values/strings.xml
@@ -118,6 +118,8 @@
   <string name="stripe_card_with_last_4">%1$s ····%2$s</string>
   <!-- Text for close button -->
   <string name="stripe_close">Close</string>
+  <!-- Accessibility title used during Talkback to indicate to users that a transaction is being confirmed -->
+  <string name="stripe_confirming_transaction_status">Confirming transaction</string>
   <!-- Accessibility action for deleting a payment method -->
   <string name="stripe_delete_payment_method">Delete Payment Method</string>
   <string name="stripe_delete_payment_method_prompt_title">Delete payment method?</string>

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivity.kt
@@ -9,6 +9,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
+import com.stripe.android.R
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.uicore.utils.fadeOut
@@ -35,6 +36,8 @@ internal class PaymentLauncherConfirmationActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        title = resources.getString(R.string.stripe_confirming_transaction_status)
 
         val args = runCatching {
             requireNotNull(starterArgs) {

--- a/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivityTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivityTest.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
+import com.stripe.android.R
 import com.stripe.android.model.ConfirmStripeIntentParams
 import com.stripe.android.utils.InjectableActivityScenario
 import com.stripe.android.utils.TestUtils
@@ -27,6 +28,32 @@ class PaymentLauncherConfirmationActivityTest {
         on { it.internalPaymentResult } doReturn MutableStateFlow(null)
     }
     private val testFactory = TestUtils.viewModelFactoryFor(viewModel)
+
+    @Test
+    fun `Ensure title is 'Confirming transaction'`() {
+        mockViewModelActivityScenario().launch(
+            Intent(
+                ApplicationProvider.getApplicationContext(),
+                PaymentLauncherConfirmationActivity::class.java
+            ).putExtras(
+                PaymentLauncherContract.Args.IntentConfirmationArgs(
+                    publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+                    stripeAccountId = TEST_STRIPE_ACCOUNT_ID,
+                    enableLogging = false,
+                    productUsage = PRODUCT_USAGE,
+                    includePaymentSheetNextHandlers = false,
+                    confirmStripeIntentParams = mock(),
+                    statusBarColor = Color.CYAN
+                ).toBundle()
+            )
+        ).use {
+            it.onActivity { activity ->
+                assertThat(activity.title).isEqualTo(
+                    activity.resources.getString(R.string.stripe_confirming_transaction_status)
+                )
+            }
+        }
+    }
 
     @Test
     fun `statusBarColor is set to transparent on window`() {


### PR DESCRIPTION
# Summary
Add title to `PaymentLauncherConfirmationActivity` for better `Talkback` support

# Motivation
[MOBILESDK-2970](https://jira.corp.stripe.com/browse/MOBILESDK-2970)

This is to better support `Talkback` during confirmation. I don't think this is the ideal solution. The ideal solution is to retain focus on the primary button. In order to do that, we have to avoid launching a transparent foreground activity (`PaymentLauncherConfirmationActivity`).

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Video
[TalkbackFix.webm](https://github.com/user-attachments/assets/c765c13f-22b8-430c-8fc0-b8fedf59c432)