### PR TITLE
Add spacing unit and fix pixels conversion

### DIFF
--- a/connect-example/src/main/java/com/stripe/android/connect/example/ui/appearance/AppearanceInfo.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/ui/appearance/AppearanceInfo.kt
@@ -187,7 +187,7 @@ data class AppearanceInfo(
                         .base(5f)
                         .build()
                 )
-                .spacingUnit(9f)
+                .spacingUnit(11f)
                 .build()
         )
 

--- a/connect-example/src/main/java/com/stripe/android/connect/example/ui/appearance/AppearanceInfo.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/ui/appearance/AppearanceInfo.kt
@@ -257,6 +257,7 @@ data class AppearanceInfo(
                 .typography(
                     Typography.Builder()
                         .fontFamily("doto")
+                        .fontSizeBase(24f)
                         .build()
                 )
                 .build()

--- a/connect-example/src/main/java/com/stripe/android/connect/example/ui/appearance/AppearanceInfo.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/ui/appearance/AppearanceInfo.kt
@@ -187,6 +187,7 @@ data class AppearanceInfo(
                         .base(5f)
                         .build()
                 )
+                .spacingUnit(9f)
                 .build()
         )
 

--- a/connect-example/src/main/java/com/stripe/android/connect/example/ui/appearance/AppearanceInfo.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/ui/appearance/AppearanceInfo.kt
@@ -187,7 +187,10 @@ data class AppearanceInfo(
                         .base(5f)
                         .build()
                 )
-                .spacingUnit(11f)
+                .spacingUnit(
+                    @Suppress("MagicNumber")
+                    11f
+                )
                 .build()
         )
 
@@ -257,7 +260,10 @@ data class AppearanceInfo(
                 .typography(
                     Typography.Builder()
                         .fontFamily("doto")
-                        .fontSizeBase(24f)
+                        .fontSizeBase(
+                            @Suppress("MagicNumber")
+                            24f
+                        )
                         .build()
                 )
                 .build()

--- a/connect/api/connect.api
+++ b/connect/api/connect.api
@@ -156,7 +156,7 @@ public final class com/stripe/android/connect/StripeEmbeddedComponentListener$De
 public final class com/stripe/android/connect/appearance/Appearance : android/os/Parcelable {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public synthetic fun <init> (Lcom/stripe/android/connect/appearance/Colors;Lcom/stripe/android/connect/appearance/CornerRadius;Lcom/stripe/android/connect/appearance/Typography;Lcom/stripe/android/connect/appearance/Button;Lcom/stripe/android/connect/appearance/Button;Lcom/stripe/android/connect/appearance/Badge;Lcom/stripe/android/connect/appearance/Badge;Lcom/stripe/android/connect/appearance/Badge;Lcom/stripe/android/connect/appearance/Badge;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lcom/stripe/android/connect/appearance/Colors;Lcom/stripe/android/connect/appearance/CornerRadius;Lcom/stripe/android/connect/appearance/Typography;Ljava/lang/Float;Lcom/stripe/android/connect/appearance/Button;Lcom/stripe/android/connect/appearance/Button;Lcom/stripe/android/connect/appearance/Badge;Lcom/stripe/android/connect/appearance/Badge;Lcom/stripe/android/connect/appearance/Badge;Lcom/stripe/android/connect/appearance/Badge;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
@@ -176,6 +176,7 @@ public final class com/stripe/android/connect/appearance/Appearance$Builder {
 	public final fun buttonSecondary (Lcom/stripe/android/connect/appearance/Button;)Lcom/stripe/android/connect/appearance/Appearance$Builder;
 	public final fun colors (Lcom/stripe/android/connect/appearance/Colors;)Lcom/stripe/android/connect/appearance/Appearance$Builder;
 	public final fun cornerRadius (Lcom/stripe/android/connect/appearance/CornerRadius;)Lcom/stripe/android/connect/appearance/Appearance$Builder;
+	public final fun spacingUnit (F)Lcom/stripe/android/connect/appearance/Appearance$Builder;
 	public final fun typography (Lcom/stripe/android/connect/appearance/Typography;)Lcom/stripe/android/connect/appearance/Appearance$Builder;
 }
 

--- a/connect/src/main/java/com/stripe/android/connect/appearance/Appearance.kt
+++ b/connect/src/main/java/com/stripe/android/connect/appearance/Appearance.kt
@@ -87,9 +87,6 @@ class Appearance private constructor(
         fun badgeDanger(badgeDanger: Badge): Builder =
             apply { this.badgeDanger = badgeDanger }
 
-        /**
-         * Describes the spacing unit appearance settings.
-         */
         fun spacingUnit(spacingUnit: Float): Builder =
             apply { this.spacingUnit = spacingUnit }
 

--- a/connect/src/main/java/com/stripe/android/connect/appearance/Appearance.kt
+++ b/connect/src/main/java/com/stripe/android/connect/appearance/Appearance.kt
@@ -18,6 +18,7 @@ class Appearance private constructor(
     internal val badgeSuccess: Badge,
     internal val badgeWarning: Badge,
     internal val badgeDanger: Badge,
+    internal val spacingUnit: Float?
 ) : Parcelable {
 
     class Builder {
@@ -30,6 +31,7 @@ class Appearance private constructor(
         private var badgeSuccess: Badge = Badge.default()
         private var badgeWarning: Badge = Badge.default()
         private var badgeDanger: Badge = Badge.default()
+        private var spacingUnit: Float? = null
 
         /**
          * Describes the colors used in embedded components.
@@ -85,6 +87,12 @@ class Appearance private constructor(
         fun badgeDanger(badgeDanger: Badge): Builder =
             apply { this.badgeDanger = badgeDanger }
 
+        /**
+         * Describes the spacing unit appearance settings.
+         */
+        fun spacingUnit(spacingUnit: Float): Builder =
+            apply { this.spacingUnit = spacingUnit }
+
         fun build(): Appearance {
             return Appearance(
                 colors = colors,
@@ -95,7 +103,8 @@ class Appearance private constructor(
                 badgeNeutral = badgeNeutral,
                 badgeSuccess = badgeSuccess,
                 badgeWarning = badgeWarning,
-                badgeDanger = badgeDanger
+                badgeDanger = badgeDanger,
+                spacingUnit = spacingUnit,
             )
         }
     }

--- a/connect/src/main/java/com/stripe/android/connect/appearance/Appearance.kt
+++ b/connect/src/main/java/com/stripe/android/connect/appearance/Appearance.kt
@@ -12,26 +12,26 @@ class Appearance private constructor(
     internal val colors: Colors,
     internal val cornerRadius: CornerRadius,
     internal val typography: Typography,
+    internal val spacingUnit: Float?,
     internal val buttonPrimary: Button,
     internal val buttonSecondary: Button,
     internal val badgeNeutral: Badge,
     internal val badgeSuccess: Badge,
     internal val badgeWarning: Badge,
     internal val badgeDanger: Badge,
-    internal val spacingUnit: Float?
 ) : Parcelable {
 
     class Builder {
         private var colors: Colors = Colors.default()
         private var cornerRadius: CornerRadius = CornerRadius.default()
         private var typography: Typography = Typography.default()
+        private var spacingUnit: Float? = null
         private var buttonPrimary: Button = Button.default()
         private var buttonSecondary: Button = Button.default()
         private var badgeNeutral: Badge = Badge.default()
         private var badgeSuccess: Badge = Badge.default()
         private var badgeWarning: Badge = Badge.default()
         private var badgeDanger: Badge = Badge.default()
-        private var spacingUnit: Float? = null
 
         /**
          * Describes the colors used in embedded components.
@@ -50,6 +50,12 @@ class Appearance private constructor(
          */
         fun typography(typography: Typography): Builder =
             apply { this.typography = typography }
+
+        /**
+         * Describes the spacing unit appearance settings.
+         */
+        fun spacingUnit(spacingUnit: Float): Builder =
+            apply { this.spacingUnit = spacingUnit }
 
         /**
          * Describes the primary button appearance settings.
@@ -87,21 +93,18 @@ class Appearance private constructor(
         fun badgeDanger(badgeDanger: Badge): Builder =
             apply { this.badgeDanger = badgeDanger }
 
-        fun spacingUnit(spacingUnit: Float): Builder =
-            apply { this.spacingUnit = spacingUnit }
-
         fun build(): Appearance {
             return Appearance(
                 colors = colors,
                 cornerRadius = cornerRadius,
                 typography = typography,
+                spacingUnit = spacingUnit,
                 buttonPrimary = buttonPrimary,
                 buttonSecondary = buttonSecondary,
                 badgeNeutral = badgeNeutral,
                 badgeSuccess = badgeSuccess,
                 badgeWarning = badgeWarning,
                 badgeDanger = badgeDanger,
-                spacingUnit = spacingUnit,
             )
         }
     }

--- a/connect/src/main/java/com/stripe/android/connect/appearance/Appearance.kt
+++ b/connect/src/main/java/com/stripe/android/connect/appearance/Appearance.kt
@@ -21,6 +21,7 @@ class Appearance private constructor(
     internal val badgeDanger: Badge,
 ) : Parcelable {
 
+    @SuppressWarnings("TooManyFunctions")
     class Builder {
         private var colors: Colors = Colors.default()
         private var cornerRadius: CornerRadius = CornerRadius.default()

--- a/connect/src/main/java/com/stripe/android/connect/appearance/Appearance.kt
+++ b/connect/src/main/java/com/stripe/android/connect/appearance/Appearance.kt
@@ -52,7 +52,8 @@ class Appearance private constructor(
             apply { this.typography = typography }
 
         /**
-         * Describes the spacing unit appearance settings.
+         * The base spacing unit that derives all spacing values.
+         * Increase or decrease this value to make your layout more or less spacious.
          */
         fun spacingUnit(spacingUnit: Float): Builder =
             apply { this.spacingUnit = spacingUnit }

--- a/connect/src/main/java/com/stripe/android/connect/webview/serialization/AppearanceJs.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/serialization/AppearanceJs.kt
@@ -362,15 +362,19 @@ internal data class AppearanceVariablesJs(
     val labelSmTextTransform: TextTransform?,
 )
 
+private fun Float?.toPx(): String? {
+    return this?.let { "${it.toString().removeSuffix(".0")}px" }
+}
+
 @OptIn(PrivateBetaConnectSDK::class)
 @Suppress("LongMethod")
 internal fun Appearance.toJs(): AppearanceJs {
     return AppearanceJs(
         variables = AppearanceVariablesJs(
             fontFamily = typography.fontFamily,
-            fontSizeBase = typography.fontSizeBase?.let { "${it.toString().removeSuffix(".0")}px" },
-            spacingUnit = spacingUnit?.let { "${it.toString().removeSuffix(".0")}px" },
-            borderRadius = cornerRadius.base?.let { "${it.toString().removeSuffix(".0")}px" },
+            fontSizeBase = typography.fontSizeBase.toPx(),
+            spacingUnit = spacingUnit.toPx(),
+            borderRadius = cornerRadius.base.toPx(),
             colorPrimary = colors.primary,
             colorBackground = colors.background,
             colorText = colors.text,
@@ -403,34 +407,34 @@ internal fun Appearance.toJs(): AppearanceJs {
             colorBorder = colors.border,
             formHighlightColorBorder = colors.formHighlightBorder,
             formAccentColor = colors.formAccent,
-            buttonBorderRadius = cornerRadius.button?.let { "${it.toString().removeSuffix(".0")}px" },
-            formBorderRadius = cornerRadius.form?.let { "${it.toString().removeSuffix(".0")}px" },
-            badgeBorderRadius = cornerRadius.badge?.let { "${it.toString().removeSuffix(".0")}px" },
-            overlayBorderRadius = cornerRadius.overlay?.let { "${it.toString().removeSuffix(".0")}px" },
+            buttonBorderRadius = cornerRadius.button.toPx(),
+            formBorderRadius = cornerRadius.form.toPx(),
+            badgeBorderRadius = cornerRadius.badge.toPx(),
+            overlayBorderRadius = cornerRadius.overlay.toPx(),
             overlayBackdropColor = null,
-            bodyMdFontSize = typography.bodyMd?.fontSize?.let { "${it.toString().removeSuffix(".0")}px" },
+            bodyMdFontSize = typography.bodyMd?.fontSize.toPx(),
             bodyMdFontWeight = typography.bodyMd?.fontWeight,
-            bodySmFontSize = typography.bodySm?.fontSize?.let { "${it.toString().removeSuffix(".0")}px" },
+            bodySmFontSize = typography.bodySm?.fontSize.toPx(),
             bodySmFontWeight = typography.bodySm?.fontWeight,
-            headingXlFontSize = typography.headingXl?.fontSize?.let { "${it.toString().removeSuffix(".0")}px" },
+            headingXlFontSize = typography.headingXl?.fontSize.toPx(),
             headingXlFontWeight = typography.headingXl?.fontWeight,
             headingXlTextTransform = typography.headingXl?.textTransform,
-            headingLgFontSize = typography.headingLg?.fontSize?.let { "${it.toString().removeSuffix(".0")}px" },
+            headingLgFontSize = typography.headingLg?.fontSize.toPx(),
             headingLgFontWeight = typography.headingLg?.fontWeight,
             headingLgTextTransform = typography.headingLg?.textTransform,
-            headingMdFontSize = typography.headingMd?.fontSize?.let { "${it.toString().removeSuffix(".0")}px" },
+            headingMdFontSize = typography.headingMd?.fontSize.toPx(),
             headingMdFontWeight = typography.headingMd?.fontWeight,
             headingMdTextTransform = typography.headingMd?.textTransform,
-            headingSmFontSize = typography.headingSm?.fontSize?.let { "${it.toString().removeSuffix(".0")}px" },
+            headingSmFontSize = typography.headingSm?.fontSize.toPx(),
             headingSmFontWeight = typography.headingSm?.fontWeight,
             headingSmTextTransform = typography.headingSm?.textTransform,
-            headingXsFontSize = typography.headingXs?.fontSize?.let { "${it.toString().removeSuffix(".0")}px" },
+            headingXsFontSize = typography.headingXs?.fontSize.toPx(),
             headingXsFontWeight = typography.headingXs?.fontWeight,
             headingXsTextTransform = typography.headingXs?.textTransform,
-            labelMdFontSize = typography.labelMd?.fontSize?.let { "${it.toString().removeSuffix(".0")}px" },
+            labelMdFontSize = typography.labelMd?.fontSize.toPx(),
             labelMdFontWeight = typography.labelMd?.fontWeight,
             labelMdTextTransform = typography.labelMd?.textTransform,
-            labelSmFontSize = typography.labelSm?.fontSize?.let { "${it.toString().removeSuffix(".0")}px" },
+            labelSmFontSize = typography.labelSm?.fontSize.toPx(),
             labelSmFontWeight = typography.labelSm?.fontWeight,
             labelSmTextTransform = typography.labelSm?.textTransform,
         )

--- a/connect/src/main/java/com/stripe/android/connect/webview/serialization/AppearanceJs.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/serialization/AppearanceJs.kt
@@ -22,7 +22,8 @@ internal data class AppearanceVariablesJs(
     val fontFamily: String?,
 
     /**
-     * The baseline font size in px set on the embedded component root. This scales the value of other font size variables.
+     * The baseline font size in px set on the embedded component root.
+     * This scales the value of other font size variables.
      */
     val fontSizeBase: String?,
 

--- a/connect/src/main/java/com/stripe/android/connect/webview/serialization/AppearanceJs.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/serialization/AppearanceJs.kt
@@ -363,7 +363,7 @@ internal data class AppearanceVariablesJs(
 )
 
 private fun Float?.toPx(): String? {
-    return this?.let { "${it.toString().removeSuffix(".0")}px" }
+    return this?.let { "${roundToInt()}px" }
 }
 
 /**

--- a/connect/src/main/java/com/stripe/android/connect/webview/serialization/AppearanceJs.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/serialization/AppearanceJs.kt
@@ -21,18 +21,18 @@ internal data class AppearanceVariablesJs(
     val fontFamily: String?,
 
     /**
-     * The baseline font size set on the embedded component root. This scales the value of other font size variables.
+     * The baseline font size in px set on the embedded component root. This scales the value of other font size variables.
      */
-    val fontSizeBase: Float?,
+    val fontSizeBase: String?,
 
     /**
-     * The base spacing unit in dp that derives all spacing values. Increase or decrease this value to make your layout
+     * The base spacing unit in px that derives all spacing values. Increase or decrease this value to make your layout
      * more or less spacious.
      */
     val spacingUnit: String?,
 
     /**
-     * The general border radius in dp used in embedded components. This sets the default border radius for all
+     * The general border radius in px used in embedded components. This sets the default border radius for all
      * components.
      */
     val borderRadius: String?,
@@ -205,24 +205,24 @@ internal data class AppearanceVariablesJs(
     @ColorInt val formAccentColor: IntAsRgbHexString?,
 
     /**
-     * The border radius in dp used for buttons.
+     * The border radius in px used for buttons.
      */
-    val buttonBorderRadius: Float?,
+    val buttonBorderRadius: String?,
 
     /**
-     * The border radius in dp used for form elements.
+     * The border radius in px used for form elements.
      */
-    val formBorderRadius: Float?,
+    val formBorderRadius: String?,
 
     /**
-     * The border radius in dp used for badges.
+     * The border radius in px used for badges.
      */
-    val badgeBorderRadius: Float?,
+    val badgeBorderRadius: String?,
 
     /**
-     * The border radius in dp used for overlays.
+     * The border radius in px used for overlays.
      */
-    val overlayBorderRadius: Float?,
+    val overlayBorderRadius: String?,
 
     /**
      * The backdrop color when an overlay is opened.
@@ -230,9 +230,9 @@ internal data class AppearanceVariablesJs(
     @ColorInt val overlayBackdropColor: IntAsRgbHexString?,
 
     /**
-     * The font size in sp for the medium body typography.
+     * The font size in px for the medium body typography.
      */
-    val bodyMdFontSize: Float?,
+    val bodyMdFontSize: String?,
 
     /**
      * The font weight (between 0-1000) for the medium body typography.
@@ -240,9 +240,9 @@ internal data class AppearanceVariablesJs(
     val bodyMdFontWeight: Int?,
 
     /**
-     * The font size in sp for the small body typography.
+     * The font size in px for the small body typography.
      */
-    val bodySmFontSize: Float?,
+    val bodySmFontSize: String?,
 
     /**
      * The font weight (between 0-1000) for the small body typography.
@@ -250,9 +250,9 @@ internal data class AppearanceVariablesJs(
     val bodySmFontWeight: Int?,
 
     /**
-     * The font size in sp for the extra large heading typography.
+     * The font size in px for the extra large heading typography.
      */
-    val headingXlFontSize: Float?,
+    val headingXlFontSize: String?,
 
     /**
      * The font weight (between 0-1000) for the extra large heading typography.
@@ -266,9 +266,9 @@ internal data class AppearanceVariablesJs(
     val headingXlTextTransform: TextTransform?,
 
     /**
-     * The font size in sp for the large heading typography.
+     * The font size in px for the large heading typography.
      */
-    val headingLgFontSize: Float?,
+    val headingLgFontSize: String?,
 
     /**
      * The font weight (between 0-1000) for the large heading typography.
@@ -282,9 +282,9 @@ internal data class AppearanceVariablesJs(
     val headingLgTextTransform: TextTransform?,
 
     /**
-     * The font size in sp for the medium heading typography.
+     * The font size in px for the medium heading typography.
      */
-    val headingMdFontSize: Float?,
+    val headingMdFontSize: String?,
 
     /**
      * The font weight (between 0-1000) for the medium heading typography.
@@ -298,9 +298,9 @@ internal data class AppearanceVariablesJs(
     val headingMdTextTransform: TextTransform?,
 
     /**
-     * The font size in sp for the small heading typography.
+     * The font size in px for the small heading typography.
      */
-    val headingSmFontSize: Float?,
+    val headingSmFontSize: String?,
 
     /**
      * The font weight (between 0-1000) for the small heading typography.
@@ -314,9 +314,9 @@ internal data class AppearanceVariablesJs(
     val headingSmTextTransform: TextTransform?,
 
     /**
-     * The font size in sp for the extra small heading typography.
+     * The font size in px for the extra small heading typography.
      */
-    val headingXsFontSize: Float?,
+    val headingXsFontSize: String?,
 
     /**
      * The font weight (between 0-1000) for the extra small heading typography.
@@ -330,9 +330,9 @@ internal data class AppearanceVariablesJs(
     val headingXsTextTransform: TextTransform?,
 
     /**
-     * The font size in sp for the medium label typography.
+     * The font size in px for the medium label typography.
      */
-    val labelMdFontSize: Float?,
+    val labelMdFontSize: String?,
 
     /**
      * The font weight (between 0-1000) for the medium label typography.
@@ -346,9 +346,9 @@ internal data class AppearanceVariablesJs(
     val labelMdTextTransform: TextTransform?,
 
     /**
-     * The font size in sp for the small label typography.
+     * The font size in px for the small label typography.
      */
-    val labelSmFontSize: Float?,
+    val labelSmFontSize: String?,
 
     /**
      * The font weight (between 0-1000) for the small label typography.
@@ -368,7 +368,7 @@ internal fun Appearance.toJs(): AppearanceJs {
     return AppearanceJs(
         variables = AppearanceVariablesJs(
             fontFamily = typography.fontFamily,
-            fontSizeBase = typography.fontSizeBase,
+            fontSizeBase = typography.fontSizeBase?.let { "${it.toString().removeSuffix(".0")}px" },
             spacingUnit = spacingUnit?.let { "${it.toString().removeSuffix(".0")}px" },
             borderRadius = cornerRadius.base?.let { "${it.toString().removeSuffix(".0")}px" },
             colorPrimary = colors.primary,
@@ -403,34 +403,34 @@ internal fun Appearance.toJs(): AppearanceJs {
             colorBorder = colors.border,
             formHighlightColorBorder = colors.formHighlightBorder,
             formAccentColor = colors.formAccent,
-            buttonBorderRadius = cornerRadius.button,
-            formBorderRadius = cornerRadius.form,
-            badgeBorderRadius = cornerRadius.badge,
-            overlayBorderRadius = cornerRadius.overlay,
+            buttonBorderRadius = cornerRadius.button?.let { "${it.toString().removeSuffix(".0")}px" },
+            formBorderRadius = cornerRadius.form?.let { "${it.toString().removeSuffix(".0")}px" },
+            badgeBorderRadius = cornerRadius.badge?.let { "${it.toString().removeSuffix(".0")}px" },
+            overlayBorderRadius = cornerRadius.overlay?.let { "${it.toString().removeSuffix(".0")}px" },
             overlayBackdropColor = null,
-            bodyMdFontSize = typography.bodyMd?.fontSize,
+            bodyMdFontSize = typography.bodyMd?.fontSize?.let { "${it.toString().removeSuffix(".0")}px" },
             bodyMdFontWeight = typography.bodyMd?.fontWeight,
-            bodySmFontSize = typography.bodySm?.fontSize,
+            bodySmFontSize = typography.bodySm?.fontSize?.let { "${it.toString().removeSuffix(".0")}px" },
             bodySmFontWeight = typography.bodySm?.fontWeight,
-            headingXlFontSize = typography.headingXl?.fontSize,
+            headingXlFontSize = typography.headingXl?.fontSize?.let { "${it.toString().removeSuffix(".0")}px" },
             headingXlFontWeight = typography.headingXl?.fontWeight,
             headingXlTextTransform = typography.headingXl?.textTransform,
-            headingLgFontSize = typography.headingLg?.fontSize,
+            headingLgFontSize = typography.headingLg?.fontSize?.let { "${it.toString().removeSuffix(".0")}px" },
             headingLgFontWeight = typography.headingLg?.fontWeight,
             headingLgTextTransform = typography.headingLg?.textTransform,
-            headingMdFontSize = typography.headingMd?.fontSize,
+            headingMdFontSize = typography.headingMd?.fontSize?.let { "${it.toString().removeSuffix(".0")}px" },
             headingMdFontWeight = typography.headingMd?.fontWeight,
             headingMdTextTransform = typography.headingMd?.textTransform,
-            headingSmFontSize = typography.headingSm?.fontSize,
+            headingSmFontSize = typography.headingSm?.fontSize?.let { "${it.toString().removeSuffix(".0")}px" },
             headingSmFontWeight = typography.headingSm?.fontWeight,
             headingSmTextTransform = typography.headingSm?.textTransform,
-            headingXsFontSize = typography.headingXs?.fontSize,
+            headingXsFontSize = typography.headingXs?.fontSize?.let { "${it.toString().removeSuffix(".0")}px" },
             headingXsFontWeight = typography.headingXs?.fontWeight,
             headingXsTextTransform = typography.headingXs?.textTransform,
-            labelMdFontSize = typography.labelMd?.fontSize,
+            labelMdFontSize = typography.labelMd?.fontSize?.let { "${it.toString().removeSuffix(".0")}px" },
             labelMdFontWeight = typography.labelMd?.fontWeight,
             labelMdTextTransform = typography.labelMd?.textTransform,
-            labelSmFontSize = typography.labelSm?.fontSize,
+            labelSmFontSize = typography.labelSm?.fontSize?.let { "${it.toString().removeSuffix(".0")}px" },
             labelSmFontWeight = typography.labelSm?.fontWeight,
             labelSmTextTransform = typography.labelSm?.textTransform,
         )

--- a/connect/src/main/java/com/stripe/android/connect/webview/serialization/AppearanceJs.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/serialization/AppearanceJs.kt
@@ -5,6 +5,7 @@ import com.stripe.android.connect.PrivateBetaConnectSDK
 import com.stripe.android.connect.appearance.Appearance
 import com.stripe.android.connect.appearance.TextTransform
 import kotlinx.serialization.Serializable
+import kotlin.math.roundToInt
 
 @Serializable
 internal data class AppearanceJs(

--- a/connect/src/main/java/com/stripe/android/connect/webview/serialization/AppearanceJs.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/serialization/AppearanceJs.kt
@@ -368,8 +368,8 @@ private fun Float?.toPx(): String? {
 
 /**
  * We need to send the user's customization options to ConnectJS which is only aware of web.
- * While the integrator specifics font and spacing overrides with unscaled floats, we convert this to pixels
- * and append `px` to that value before sending it to ConnectJS.
+ * Unscaled floats are sent without conversion since browsers will appropriately
+ * scale `px` values.
  */
 @OptIn(PrivateBetaConnectSDK::class)
 @Suppress("LongMethod")

--- a/connect/src/main/java/com/stripe/android/connect/webview/serialization/AppearanceJs.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/serialization/AppearanceJs.kt
@@ -29,13 +29,13 @@ internal data class AppearanceVariablesJs(
      * The base spacing unit in dp that derives all spacing values. Increase or decrease this value to make your layout
      * more or less spacious.
      */
-    val spacingUnit: Float?,
+    val spacingUnit: String?,
 
     /**
      * The general border radius in dp used in embedded components. This sets the default border radius for all
      * components.
      */
-    val borderRadius: Float?,
+    val borderRadius: String?,
 
     /**
      * The primary color used throughout embedded components. Set this to your primary brand color.
@@ -369,8 +369,8 @@ internal fun Appearance.toJs(): AppearanceJs {
         variables = AppearanceVariablesJs(
             fontFamily = typography.fontFamily,
             fontSizeBase = typography.fontSizeBase,
-            spacingUnit = null,
-            borderRadius = cornerRadius.base,
+            spacingUnit = spacingUnit?.let { "${it.toString().removeSuffix(".0")}px" },
+            borderRadius = cornerRadius.base?.let { "${it.toString().removeSuffix(".0")}px" },
             colorPrimary = colors.primary,
             colorBackground = colors.background,
             colorText = colors.text,

--- a/connect/src/main/java/com/stripe/android/connect/webview/serialization/AppearanceJs.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/serialization/AppearanceJs.kt
@@ -366,6 +366,11 @@ private fun Float?.toPx(): String? {
     return this?.let { "${it.toString().removeSuffix(".0")}px" }
 }
 
+/**
+ * We need to send the user's customization options to ConnectJS which is only aware of web.
+ * While the integrator specifics font and spacing overrides with unscaled floats, we convert this to pixels
+ * and append `px` to that value before sending it to ConnectJS.
+ */
 @OptIn(PrivateBetaConnectSDK::class)
 @Suppress("LongMethod")
 internal fun Appearance.toJs(): AppearanceJs {


### PR DESCRIPTION
# Summary
Looks like we had two issues with appearance customizations. 

1: `spacingUnit` was never properly implemented
2. When converting Appearance -> JS compatible appearance options (like [here](https://docs.stripe.com/connect/customize-connect-embedded-components)), we did not convert the values we received as a `float` to `{x}px`. 

I've also updated some of the example appearance options to better show this behavior being correct. 

# Motivation
https://jira.corp.stripe.com/browse/CAX-4059

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Feature | Before  | After |
| ------------- | ------------- | ------------- |
| Border radius | ![CleanShot 2025-04-04 at 14 42 47](https://github.com/user-attachments/assets/badd8416-79c6-47c1-97a6-1beec89f7a16) |  ![CleanShot 2025-04-04 at 14 36 28](https://github.com/user-attachments/assets/9361cd44-7da3-4408-b384-ccfbde022619)
| Spacing unit | ![CleanShot 2025-04-04 at 14 42 13](https://github.com/user-attachments/assets/f5623017-5078-4eae-94a2-0230780a15e6) | ![CleanShot 2025-04-04 at 14 38 33](https://github.com/user-attachments/assets/5b08fa8c-393a-4047-b8de-3fb7b8e14c66)
| Font size | ![CleanShot 2025-04-04 at 14 41 37](https://github.com/user-attachments/assets/82ae5c4d-5779-4936-ae2b-321f46c1fdc9) |  ![CleanShot 2025-04-04 at 14 39 43](https://github.com/user-attachments/assets/1cd2018b-8dee-4b46-9334-400750442fae)


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
