### PR TITLE
Setup AnalyticEventCallbackRule for DefaultEventReporterTest

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/AnalyticEventRule.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/AnalyticEventRule.kt
@@ -24,7 +24,7 @@ class AnalyticEventRule : TestRule, AnalyticEventCallback {
                 events = Turbine()
                 try {
                     base.evaluate()
-                    events.expectNoEvents()
+                    events.ensureAllEventsConsumed()
                 } finally {
                     events.close()
                 }

--- a/paymentsheet/src/test/java/com/stripe/android/utils/AnalyticEventCallbackRule.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/AnalyticEventCallbackRule.kt
@@ -1,0 +1,45 @@
+package com.stripe.android.utils
+
+import app.cash.turbine.Turbine
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.paymentelement.AnalyticEvent
+import com.stripe.android.paymentelement.AnalyticEventCallback
+import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+import javax.inject.Provider
+
+@OptIn(ExperimentalAnalyticEventCallbackApi::class)
+class AnalyticEventCallbackRule : TestWatcher(), AnalyticEventCallback, Provider<AnalyticEventCallback?> {
+    private lateinit var analyticEventCall: Turbine<AnalyticEvent>
+    private var callback: AnalyticEventCallback? = null
+
+    override fun get(): AnalyticEventCallback? = callback
+    override fun onEvent(event: AnalyticEvent) {
+        analyticEventCall.add(event)
+    }
+
+    fun setCallback(callback: AnalyticEventCallback?) {
+        this.callback = callback
+    }
+
+    suspend fun assertMatchesExpectedEvent(event: AnalyticEvent) {
+        assertThat(analyticEventCall.awaitItem()).isEqualTo(event)
+    }
+
+    override fun starting(description: Description) {
+        super.starting(description)
+        analyticEventCall = Turbine()
+        setCallback(this)
+    }
+
+    override fun finished(description: Description) {
+        try {
+            analyticEventCall.ensureAllEventsConsumed()
+        } finally {
+            setCallback(null)
+            analyticEventCall.close()
+        }
+        super.finished(description)
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Use a `TestWatcher` to wrap up the callback provider initialization and the turbine clean up.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
To prevent duplicate callback initializing when adding more tests

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified
