### PR TITLE
Allow samsung a15s to go through selfie verification

### DIFF
--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebView.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebView.kt
@@ -101,6 +101,10 @@ internal class StripeConnectWebView private constructor(
             loadWithOverviewMode = true
             useWideViewPort = true
             userAgentString = "$userAgentString - stripe-android/${StripeSdkVersion.VERSION_NAME}"
+
+            // Fixes front camera "paused" issue on Samsung devices with Gelato selfie verification
+            // by allowing camera activation without requiring explicit user interaction first
+            mediaPlaybackRequiresUserGesture = false
         }
 
         setDownloadListener(StripeDownloadListener(context))


### PR DESCRIPTION
# Summary
We noticed on a physical Samsung A15 that selfie verification (front camera ID verification via Gelato) wasn't working. 

This was quite odd because:
- It works on ALL other physical + virtual devices we tried
- It works on the A15 when using the selfie verification flow on mobile web browser
- We can see that the camera permissions are correct, and that a green icon is shown that the camera is in use
- The web says that the camera is "paused"

Asking go/llm finally revealed a simple fix which was to set `mediaPlaybackRequiresUserGesture = false`. LLM claims that this is because Samsung's implementation of Webviews has higher privacy controls for the selfie camera which sounds plausible, but I did not find explicit documentation confirming this. It also does not explain why this flow works on a Galaxy Fold we tried. 

Regardless, our problem is fixed and the fix seems sensible.

# Motivation
https://jira.corp.stripe.com/browse/CAX-3996

# Testing

Tested on Simulator to make sure nothing was affected on Pixel-like devices

- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
|![Screenshot_20250408_152036_Connect Example](https://github.com/user-attachments/assets/a6d68349-eb90-432c-b462-dc4ab95ceb92) | ![Screenshot_20250408_150907_Connect Example](https://github.com/user-attachments/assets/48d90ba1-973d-44b7-94a0-02212a35bcf6)  |


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
