### PR TITLE
Update selection logic for formSheetAction=continue.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
@@ -69,13 +69,11 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
             sheetStateHolder.sheetIsOpen = false
             selectionHolder.setTemporary(null)
             if (result is FormResult.Complete) {
+                selectionHolder.set(result.selection)
                 if (result.hasBeenConfirmed) {
                     embeddedResultCallbackHelper.setResult(
                         EmbeddedPaymentElement.Result.Completed()
                     )
-                } else {
-                    selectionHolder.setTemporary(result.selection?.paymentMethodType)
-                    selectionHolder.set(result.selection)
                 }
             }
         }
@@ -107,6 +105,7 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
         if (sheetStateHolder.sheetIsOpen) return
         sheetStateHolder.sheetIsOpen = true
         selectionHolder.setTemporary(code)
+        val currentSelection = selectionHolder.selection.value as? PaymentSelection.New?
         val args = FormContract.Args(
             selectedPaymentMethodCode = code,
             paymentMethodMetadata = paymentMethodMetadata,
@@ -115,6 +114,7 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
             initializationMode = embeddedConfirmationState.initializationMode,
             paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
             statusBarColor = statusBarColor,
+            paymentSelection = currentSelection.takeIf { it?.paymentMethodType == code },
         )
         formActivityLauncher.launch(args)
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
@@ -7,11 +7,13 @@ import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.core.mainthread.MainThreadOnlyMutableStateFlow
 import com.stripe.android.core.mainthread.MainThreadSavedStateHandle
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.ExperimentalEmbeddedPaymentElementApi
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentsheet.CustomerStateHolder
+import com.stripe.android.paymentsheet.FormHelper.FormType
 import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded
 import com.stripe.android.paymentsheet.SavedPaymentMethodMutator
 import com.stripe.android.paymentsheet.analytics.EventReporter
@@ -190,6 +192,17 @@ internal class DefaultEmbeddedContentHelper @Inject constructor(
             reportPaymentMethodTypeSelected = eventReporter::onSelectPaymentMethod,
             reportFormShown = eventReporter::onPaymentMethodFormShown,
             onUpdatePaymentMethod = savedPaymentMethodMutator::updatePaymentMethod,
+            shouldUpdateVerticalModeSelection = { paymentMethodCode ->
+                val isConfirmFlow = confirmationStateHolder.state?.configuration?.formSheetAction ==
+                    EmbeddedPaymentElement.FormSheetAction.Confirm
+                if (isConfirmFlow) {
+                    val requiresFormScreen = paymentMethodCode != null &&
+                        formHelper.formTypeForCode(paymentMethodCode) == FormType.UserInteractionRequired
+                    !requiresFormScreen
+                } else {
+                    true
+                }
+            }
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityViewModel.kt
@@ -38,6 +38,8 @@ internal class FormActivityViewModel @Inject constructor(
                 savedStateHandle = extras.createSavedStateHandle(),
             )
 
+            component.selectionHolder.set(args.paymentSelection)
+
             return component.viewModel as T
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityViewModelComponent.kt
@@ -22,6 +22,7 @@ import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.injection.ExtendedPaymentElementConfirmationModule
 import com.stripe.android.paymentelement.embedded.EmbeddedCommonModule
 import com.stripe.android.paymentelement.embedded.EmbeddedLinkExtrasModule
+import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.paymentsheet.verticalmode.DefaultVerticalModeFormInteractor
@@ -53,6 +54,7 @@ import kotlin.coroutines.CoroutineContext
 @OptIn(ExperimentalEmbeddedPaymentElementApi::class)
 internal interface FormActivityViewModelComponent {
     val viewModel: FormActivityViewModel
+    val selectionHolder: EmbeddedSelectionHolder
     val subcomponentFactory: FormActivitySubcomponent.Factory
 
     @Component.Factory

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormContract.kt
@@ -63,6 +63,7 @@ internal object FormContract : ActivityResultContract<FormContract.Args, FormRes
         val initializationMode: PaymentElementLoader.InitializationMode,
         val paymentElementCallbackIdentifier: String,
         val statusBarColor: Int?,
+        val paymentSelection: PaymentSelection?,
     ) : Parcelable {
         companion object {
             fun fromIntent(intent: Intent): Args? {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -95,6 +95,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
     private val reportPaymentMethodTypeSelected: (PaymentMethodCode) -> Unit,
     private val reportFormShown: (PaymentMethodCode) -> Unit,
     private val onUpdatePaymentMethod: (DisplayableSavedPaymentMethod) -> Unit,
+    private val shouldUpdateVerticalModeSelection: (String?) -> Boolean,
     dispatcher: CoroutineContext = Dispatchers.Default,
     mainDispatcher: CoroutineContext = Dispatchers.Main.immediate,
 ) : PaymentMethodVerticalLayoutInteractor {
@@ -155,6 +156,11 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
                 },
                 reportPaymentMethodTypeSelected = viewModel.eventReporter::onSelectPaymentMethod,
                 reportFormShown = viewModel.eventReporter::onPaymentMethodFormShown,
+                shouldUpdateVerticalModeSelection = { paymentMethodCode ->
+                    val requiresFormScreen = paymentMethodCode != null &&
+                        formHelper.formTypeForCode(paymentMethodCode) == FormType.UserInteractionRequired
+                    !requiresFormScreen
+                }
             ).also { interactor ->
                 viewModel.viewModelScope.launch {
                     interactor.state.collect { state ->
@@ -256,10 +262,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
                     else -> null
                 }
 
-                val requiresFormScreen = paymentMethodCode != null &&
-                    formTypeForCode(paymentMethodCode) == FormType.UserInteractionRequired
-
-                if (!requiresFormScreen) {
+                if (shouldUpdateVerticalModeSelection(paymentMethodCode)) {
                     _verticalModeScreenSelection.value = currentSelection
                 }
             }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityTest.kt
@@ -104,6 +104,7 @@ internal class FormActivityTest {
                     initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(intentConfiguration),
                     statusBarColor = null,
                     paymentElementCallbackIdentifier = "EmbeddedFormTestIdentifier",
+                    paymentSelection = null,
                 ),
             )
         ).use { scenario ->

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -918,6 +918,25 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
     }
 
     @Test
+    fun verticalModeScreenSelection_isUpdatedToNewPmWithFormFields_withCustomShouldUpdateVerticalModeSelection() {
+        val initialPaymentSelection = PaymentSelection.Link()
+        runScenario(
+            initialSelection = initialPaymentSelection,
+            formTypeForCode = { FormHelper.FormType.UserInteractionRequired },
+            updateSelection = {},
+            shouldUpdateVerticalModeSelection = { true }
+        ) {
+            selectionSource.value = PaymentMethodFixtures.CARD_PAYMENT_SELECTION
+
+            interactor.state.test {
+                awaitItem().run {
+                    assertThat(selection).isEqualTo(PaymentMethodVerticalLayoutInteractor.Selection.New("card"))
+                }
+            }
+        }
+    }
+
+    @Test
     fun verticalModeSelectionIsNotCleared_whenInitializing() {
         var verticalModeSelection: PaymentSelection? = PaymentMethodFixtures.CARD_PAYMENT_SELECTION
         runScenario(
@@ -1182,6 +1201,11 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
         updateSelection: (PaymentSelection?) -> Unit = { notImplemented() },
         reportPaymentMethodTypeSelected: (PaymentMethodCode) -> Unit = { notImplemented() },
         reportFormShown: (PaymentMethodCode) -> Unit = { notImplemented() },
+        shouldUpdateVerticalModeSelection: (String?) -> Boolean = { paymentMethodCode ->
+            val requiresFormScreen = paymentMethodCode != null &&
+                formTypeForCode(paymentMethodCode) == FormHelper.FormType.UserInteractionRequired
+            !requiresFormScreen
+        },
         testBlock: suspend TestParams.() -> Unit
     ) {
         val processing: MutableStateFlow<Boolean> = MutableStateFlow(initialProcessing)
@@ -1221,6 +1245,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
             reportPaymentMethodTypeSelected = reportPaymentMethodTypeSelected,
             reportFormShown = reportFormShown,
             onUpdatePaymentMethod = onUpdatePaymentMethod,
+            shouldUpdateVerticalModeSelection = shouldUpdateVerticalModeSelection,
             dispatcher = UnconfinedTestDispatcher(),
             mainDispatcher = UnconfinedTestDispatcher(),
         )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Makes selection work correctly when navigating back and forth in embedded when formSheetAction=continue.

