### PR TITLE
Refactor PaymentMethodVerticalLayoutInteractor.selection to temporarySelection

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodEmbeddedLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodEmbeddedLayoutUI.kt
@@ -52,7 +52,7 @@ internal fun ColumnScope.PaymentMethodEmbeddedLayoutUI(
         paymentMethods = state.displayablePaymentMethods,
         displayedSavedPaymentMethod = state.displayedSavedPaymentMethod,
         savedPaymentMethodAction = state.availableSavedPaymentMethodAction,
-        selection = state.selection,
+        selection = state.temporarySelection,
         isEnabled = !state.isProcessing,
         onViewMorePaymentMethods = {
             interactor.handleViewAction(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -157,7 +157,8 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
             ).also { interactor ->
                 viewModel.viewModelScope.launch {
                     interactor.state.collect { state ->
-                        val newSelection = state.temporarySelection as? PaymentMethodVerticalLayoutInteractor.Selection.New
+                        val newSelection =
+                            state.temporarySelection as? PaymentMethodVerticalLayoutInteractor.Selection.New
                         newSelection?.code?.let { code ->
                             val formType = formHelper.formTypeForCode(code)
                             if (formType is FormType.MandateOnly) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -45,7 +45,7 @@ internal interface PaymentMethodVerticalLayoutInteractor {
     data class State(
         val displayablePaymentMethods: List<DisplayablePaymentMethod>,
         val isProcessing: Boolean,
-        val selection: Selection?,
+        val temporarySelection: Selection?,
         val displayedSavedPaymentMethod: DisplayableSavedPaymentMethod?,
         val availableSavedPaymentMethodAction: SavedPaymentMethodAction,
         val mandate: ResolvableString?,
@@ -157,7 +157,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
             ).also { interactor ->
                 viewModel.viewModelScope.launch {
                     interactor.state.collect { state ->
-                        val newSelection = state.selection as? PaymentMethodVerticalLayoutInteractor.Selection.New
+                        val newSelection = state.temporarySelection as? PaymentMethodVerticalLayoutInteractor.Selection.New
                         newSelection?.code?.let { code ->
                             val formType = formHelper.formTypeForCode(code)
                             if (formType is FormType.MandateOnly) {
@@ -230,7 +230,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
         PaymentMethodVerticalLayoutInteractor.State(
             displayablePaymentMethods = displayablePaymentMethods,
             isProcessing = isProcessing,
-            selection = temporarySelection ?: mostRecentSelection?.asVerticalSelection(),
+            temporarySelection = temporarySelection ?: mostRecentSelection?.asVerticalSelection(),
             displayedSavedPaymentMethod = displayedSavedPaymentMethod,
             availableSavedPaymentMethodAction = action,
             mandate = getMandate(temporarySelectionCode, mostRecentSelection),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUI.kt
@@ -59,7 +59,7 @@ internal fun PaymentMethodVerticalLayoutUI(
         paymentMethods = state.displayablePaymentMethods,
         displayedSavedPaymentMethod = state.displayedSavedPaymentMethod,
         savedPaymentMethodAction = state.availableSavedPaymentMethodAction,
-        selection = state.selection,
+        selection = state.temporarySelection,
         isEnabled = !state.isProcessing,
         onViewMorePaymentMethods = {
             interactor.handleViewAction(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -60,7 +60,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
             interactor.state.test {
                 awaitItem().run {
                     assertThat(displayablePaymentMethods).isNotEmpty()
-                    assertThat(selection).isNull()
+                    assertThat(temporarySelection).isNull()
                 }
             }
             selectionSource.value = PaymentSelection.New.GenericPaymentMethod(
@@ -75,7 +75,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
             interactor.state.test {
                 awaitItem().run {
                     assertThat(displayablePaymentMethods).isNotEmpty()
-                    assertThat((selection as PaymentMethodVerticalLayoutInteractor.Selection.New).code)
+                    assertThat((temporarySelection as PaymentMethodVerticalLayoutInteractor.Selection.New).code)
                         .isEqualTo("cashapp")
                 }
             }
@@ -96,7 +96,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
         interactor.state.test {
             awaitItem().run {
                 assertThat(displayablePaymentMethods).isNotEmpty()
-                assertThat(selection).isEqualTo(PaymentMethodVerticalLayoutInteractor.Selection.Saved)
+                assertThat(temporarySelection).isEqualTo(PaymentMethodVerticalLayoutInteractor.Selection.Saved)
             }
         }
     }
@@ -890,7 +890,8 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
 
             interactor.state.test {
                 awaitItem().run {
-                    assertThat(selection).isEqualTo(PaymentMethodVerticalLayoutInteractor.Selection.New("link"))
+                    assertThat(temporarySelection)
+                        .isEqualTo(PaymentMethodVerticalLayoutInteractor.Selection.New("link"))
                 }
             }
         }
@@ -905,12 +906,13 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
         ) {
             interactor.state.test {
                 awaitItem().run {
-                    assertThat(selection).isEqualTo(PaymentMethodVerticalLayoutInteractor.Selection.New("link"))
+                    assertThat(temporarySelection)
+                        .isEqualTo(PaymentMethodVerticalLayoutInteractor.Selection.New("link"))
                 }
                 isCurrentScreenSource.value = true
                 selectionSource.value = null
                 awaitItem().run {
-                    assertThat(selection).isNull()
+                    assertThat(temporarySelection).isNull()
                 }
             }
         }
@@ -928,7 +930,8 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
 
             interactor.state.test {
                 awaitItem().run {
-                    assertThat(selection).isEqualTo(PaymentMethodVerticalLayoutInteractor.Selection.New("link"))
+                    assertThat(temporarySelection)
+                        .isEqualTo(PaymentMethodVerticalLayoutInteractor.Selection.New("link"))
                 }
             }
         }
@@ -944,7 +947,8 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
         ) {
             interactor.state.test {
                 assertThat(verticalModeSelection).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
-                assertThat(awaitItem().selection).isEqualTo(PaymentMethodVerticalLayoutInteractor.Selection.New("card"))
+                assertThat(awaitItem().temporarySelection)
+                    .isEqualTo(PaymentMethodVerticalLayoutInteractor.Selection.New("card"))
             }
         }
     }
@@ -962,7 +966,8 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
 
             interactor.state.test {
                 awaitItem().run {
-                    assertThat(selection).isEqualTo(PaymentMethodVerticalLayoutInteractor.Selection.New("card"))
+                    assertThat(temporarySelection)
+                        .isEqualTo(PaymentMethodVerticalLayoutInteractor.Selection.New("card"))
                 }
             }
         }
@@ -983,7 +988,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
 
             interactor.state.test {
                 awaitItem().run {
-                    assertThat(selection)
+                    assertThat(temporarySelection)
                         .isEqualTo(PaymentMethodVerticalLayoutInteractor.Selection.New("external_paypal"))
                 }
             }
@@ -1005,7 +1010,8 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
 
             interactor.state.test {
                 awaitItem().run {
-                    assertThat(selection).isEqualTo(PaymentMethodVerticalLayoutInteractor.Selection.Saved)
+                    assertThat(temporarySelection)
+                        .isEqualTo(PaymentMethodVerticalLayoutInteractor.Selection.Saved)
                 }
             }
         }
@@ -1024,7 +1030,8 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
 
             interactor.state.test {
                 awaitItem().run {
-                    assertThat(selection).isEqualTo(PaymentMethodVerticalLayoutInteractor.Selection.New("link"))
+                    assertThat(temporarySelection)
+                        .isEqualTo(PaymentMethodVerticalLayoutInteractor.Selection.New("link"))
                 }
             }
         }
@@ -1043,7 +1050,8 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
 
             interactor.state.test {
                 awaitItem().run {
-                    assertThat(selection).isEqualTo(PaymentMethodVerticalLayoutInteractor.Selection.New("google_pay"))
+                    assertThat(temporarySelection)
+                        .isEqualTo(PaymentMethodVerticalLayoutInteractor.Selection.New("google_pay"))
                 }
             }
         }
@@ -1059,15 +1067,15 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
         ) {
             interactor.state.test {
                 awaitItem().run {
-                    assertThat(selection).isEqualTo(PaymentMethodVerticalLayoutInteractor.Selection.New("link"))
+                    assertThat(temporarySelection).isEqualTo(PaymentMethodVerticalLayoutInteractor.Selection.New("link"))
                 }
                 temporarySelectionSource.value = "card"
                 awaitItem().run {
-                    assertThat(selection).isEqualTo(PaymentMethodVerticalLayoutInteractor.Selection.New("card"))
+                    assertThat(temporarySelection).isEqualTo(PaymentMethodVerticalLayoutInteractor.Selection.New("card"))
                 }
                 temporarySelectionSource.value = null
                 awaitItem().run {
-                    assertThat(selection).isEqualTo(PaymentMethodVerticalLayoutInteractor.Selection.New("link"))
+                    assertThat(temporarySelection).isEqualTo(PaymentMethodVerticalLayoutInteractor.Selection.New("link"))
                 }
             }
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -1067,15 +1067,18 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
         ) {
             interactor.state.test {
                 awaitItem().run {
-                    assertThat(temporarySelection).isEqualTo(PaymentMethodVerticalLayoutInteractor.Selection.New("link"))
+                    assertThat(temporarySelection)
+                        .isEqualTo(PaymentMethodVerticalLayoutInteractor.Selection.New("link"))
                 }
                 temporarySelectionSource.value = "card"
                 awaitItem().run {
-                    assertThat(temporarySelection).isEqualTo(PaymentMethodVerticalLayoutInteractor.Selection.New("card"))
+                    assertThat(temporarySelection)
+                        .isEqualTo(PaymentMethodVerticalLayoutInteractor.Selection.New("card"))
                 }
                 temporarySelectionSource.value = null
                 awaitItem().run {
-                    assertThat(temporarySelection).isEqualTo(PaymentMethodVerticalLayoutInteractor.Selection.New("link"))
+                    assertThat(temporarySelection)
+                        .isEqualTo(PaymentMethodVerticalLayoutInteractor.Selection.New("link"))
                 }
             }
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakePaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakePaymentMethodVerticalLayoutInteractor.kt
@@ -32,7 +32,7 @@ internal class FakePaymentMethodVerticalLayoutInteractor(
             val initialState = PaymentMethodVerticalLayoutInteractor.State(
                 displayablePaymentMethods = displayablePaymentMethods,
                 isProcessing = false,
-                selection = selection,
+                temporarySelection = selection,
                 displayedSavedPaymentMethod = null,
                 availableSavedPaymentMethodAction =
                 PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction.MANAGE_ALL,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodLayoutUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodLayoutUITest.kt
@@ -301,7 +301,7 @@ internal class PaymentMethodLayoutUITest(
         ): PaymentMethodVerticalLayoutInteractor.State = PaymentMethodVerticalLayoutInteractor.State(
             displayablePaymentMethods = displayablePaymentMethods,
             isProcessing = isProcessing,
-            selection = selection,
+            temporarySelection = selection,
             displayedSavedPaymentMethod = displayedSavedPaymentMethod,
             availableSavedPaymentMethodAction = availableSavedPaymentMethodAction,
             mandate = mandate,


### PR DESCRIPTION
# Summary
Renamed selection to temporarySelection

# Motivation
We will be adding paymentSelection too so it will be confusing to keep this named as selection.

I am open to a better name, but going off of what EmbeddedSelectionHolder calls this

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [ ] Manually verified

# Screenshots
N.A.

# Changelog
N.A.