### PR TITLE
Fix `product_usage` not being populated across Payment Element.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryFactory.kt
@@ -39,6 +39,7 @@ class DefaultCardAccountRangeRepositoryFactory @Inject constructor(
         )
     }
 
+    @JvmOverloads
     constructor(
         context: Context,
         productUsageTokens: Set<String> = emptySet()

--- a/payments-core/src/main/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryFactory.kt
@@ -39,9 +39,12 @@ class DefaultCardAccountRangeRepositoryFactory @Inject constructor(
         )
     }
 
-    constructor(context: Context) : this(
+    constructor(
+        context: Context,
+        productUsageTokens: Set<String> = emptySet()
+    ) : this(
         context,
-        emptySet(),
+        productUsageTokens,
         DefaultAnalyticsRequestExecutor(),
     )
 

--- a/payments-core/src/main/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryFactory.kt
@@ -11,9 +11,11 @@ import com.stripe.android.networking.PaymentAnalyticsEvent
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.networking.StripeApiRepository
 import com.stripe.android.networking.StripeRepository
+import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
+import javax.inject.Named
 
 /**
  * A [CardAccountRangeRepository.Factory] that returns a [DefaultCardAccountRangeRepositoryFactory].
@@ -23,7 +25,8 @@ import javax.inject.Inject
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class DefaultCardAccountRangeRepositoryFactory @Inject constructor(
     context: Context,
-    private val analyticsRequestExecutor: AnalyticsRequestExecutor
+    @Named(PRODUCT_USAGE) private val productUsageTokens: Set<String>,
+    private val analyticsRequestExecutor: AnalyticsRequestExecutor,
 ) : CardAccountRangeRepository.Factory {
     private val appContext = context.applicationContext
     private val cardAccountRangeRepository = lazy {
@@ -38,7 +41,8 @@ class DefaultCardAccountRangeRepositoryFactory @Inject constructor(
 
     constructor(context: Context) : this(
         context,
-        DefaultAnalyticsRequestExecutor()
+        emptySet(),
+        DefaultAnalyticsRequestExecutor(),
     )
 
     @Throws(IllegalStateException::class)
@@ -60,7 +64,7 @@ class DefaultCardAccountRangeRepositoryFactory @Inject constructor(
                 ),
                 store,
                 DefaultAnalyticsRequestExecutor(),
-                PaymentAnalyticsRequestFactory(appContext, publishableKey)
+                PaymentAnalyticsRequestFactory(appContext, publishableKey, productUsageTokens)
             ),
             staticSource = StaticCardAccountRangeSource(),
             store = store
@@ -96,7 +100,7 @@ class DefaultCardAccountRangeRepositoryFactory @Inject constructor(
                     ),
                     store,
                     DefaultAnalyticsRequestExecutor(),
-                    PaymentAnalyticsRequestFactory(appContext, publishableKey)
+                    PaymentAnalyticsRequestFactory(appContext, publishableKey, productUsageTokens)
                 )
             },
             onFailure = {
@@ -112,7 +116,8 @@ class DefaultCardAccountRangeRepositoryFactory @Inject constructor(
         analyticsRequestExecutor.executeAsync(
             PaymentAnalyticsRequestFactory(
                 appContext,
-                publishableKey
+                publishableKey,
+                productUsageTokens,
             ).createRequest(event)
         )
     }

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -132,7 +132,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
     private val fraudDetectionDataRepository: FraudDetectionDataRepository =
         DefaultFraudDetectionDataRepository(context, workContext),
     private val cardAccountRangeRepositoryFactory: CardAccountRangeRepository.Factory =
-        DefaultCardAccountRangeRepositoryFactory(context, analyticsRequestExecutor),
+        DefaultCardAccountRangeRepositoryFactory(context, productUsageTokens, analyticsRequestExecutor),
     private val paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory =
         PaymentAnalyticsRequestFactory(context, publishableKeyProvider, productUsageTokens),
     private val fraudDetectionDataParamsUtils: FraudDetectionDataParamsUtils = FraudDetectionDataParamsUtils(),

--- a/payments-core/src/test/java/com/stripe/android/PaymentAnalyticsRequestFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/PaymentAnalyticsRequestFactoryTest.kt
@@ -118,7 +118,7 @@ class PaymentAnalyticsRequestFactoryTest {
                 "bindings_version" to StripeSdkVersion.VERSION_NAME,
                 "app_name" to "com.stripe.android.test",
                 "app_version" to 0,
-                "product_usage" to ATTRIBUTION.toList(),
+                "product_usage" to ATTRIBUTION.joinToString(","),
                 "source_type" to "card",
                 "is_development" to true,
                 "session_id" to AnalyticsRequestFactory.sessionId,
@@ -148,7 +148,7 @@ class PaymentAnalyticsRequestFactoryTest {
                 "bindings_version" to StripeSdkVersion.VERSION_NAME,
                 "app_name" to "com.stripe.android.test",
                 "app_version" to 0,
-                "product_usage" to ATTRIBUTION.toList(),
+                "product_usage" to ATTRIBUTION.joinToString(","),
                 "source_type" to "card",
                 "is_development" to true,
                 "session_id" to AnalyticsRequestFactory.sessionId,
@@ -271,7 +271,7 @@ class PaymentAnalyticsRequestFactoryTest {
         assertThat(params)
             .hasSize(VALID_PARAM_FIELDS.size - 2)
         assertEquals(API_KEY, params[AnalyticsFields.PUBLISHABLE_KEY])
-        assertEquals(ATTRIBUTION.toList(), params[PaymentAnalyticsRequestFactory.FIELD_PRODUCT_USAGE])
+        assertEquals(ATTRIBUTION.joinToString(","), params[PaymentAnalyticsRequestFactory.FIELD_PRODUCT_USAGE])
         assertEquals(Token.Type.Card.code, params[PaymentAnalyticsRequestFactory.FIELD_TOKEN_TYPE])
         assertEquals(Build.VERSION.SDK_INT, params[AnalyticsFields.OS_VERSION])
         assertNotNull(params[AnalyticsFields.OS_RELEASE])
@@ -390,7 +390,7 @@ class PaymentAnalyticsRequestFactoryTest {
 
         val productUsage = analyticsRequest.params["product_usage"]
         assertThat(productUsage)
-            .isEqualTo(listOf("Hello", "World"))
+            .isEqualTo("Hello,World")
     }
 
     @Test
@@ -407,7 +407,7 @@ class PaymentAnalyticsRequestFactoryTest {
         )
 
         assertThat(analyticsRequest.params["product_usage"])
-            .isEqualTo(listOf("Hello"))
+            .isEqualTo("Hello")
     }
 
     @Test
@@ -423,8 +423,7 @@ class PaymentAnalyticsRequestFactoryTest {
         )
 
         val productUsage = analyticsRequest.params["product_usage"]
-        assertThat(productUsage)
-            .isEqualTo(listOf("Hello"))
+        assertThat(productUsage).isEqualTo("Hello")
     }
 
     private companion object {

--- a/payments-core/src/test/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryFactoryTest.kt
@@ -16,7 +16,8 @@ class DefaultCardAccountRangeRepositoryFactoryTest {
     private val analyticsRequests = mutableListOf<AnalyticsRequest>()
     private val context: Context = ApplicationProvider.getApplicationContext()
     private val factory = DefaultCardAccountRangeRepositoryFactory(
-        context
+        context = context,
+        productUsageTokens = setOf("SomeProduct"),
     ) {
         analyticsRequests.add(it)
     }
@@ -32,8 +33,11 @@ class DefaultCardAccountRangeRepositoryFactoryTest {
             .isNotNull()
         assertThat(analyticsRequests)
             .hasSize(1)
-        assertThat(analyticsRequests.first().params["event"])
-            .isEqualTo("stripe_android.card_metadata_pk_unavailable")
+
+        val event = analyticsRequests.first()
+
+        assertThat(event.params["event"]).isEqualTo("stripe_android.card_metadata_pk_unavailable")
+        assertThat(event.params["product_usage"]).isEqualTo("SomeProduct")
     }
 
     @Test
@@ -43,7 +47,10 @@ class DefaultCardAccountRangeRepositoryFactoryTest {
             .isNotNull()
         assertThat(analyticsRequests)
             .hasSize(1)
-        assertThat(analyticsRequests.first().params["event"])
-            .isEqualTo("stripe_android.card_metadata_pk_available")
+
+        val event = analyticsRequests.first()
+
+        assertThat(event.params["event"]).isEqualTo("stripe_android.card_metadata_pk_available")
+        assertThat(event.params["product_usage"]).isEqualTo("SomeProduct")
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -371,7 +371,7 @@ internal class StripeApiRepositoryTest {
 
             verifyFraudDetectionDataAndAnalyticsRequests(
                 PaymentAnalyticsEvent.SourceCreate,
-                productUsage = listOf("CardInputView")
+                productUsage = "CardInputView"
             )
         }
 
@@ -616,7 +616,7 @@ internal class StripeApiRepositoryTest {
 
             verifyAnalyticsRequest(
                 event = PaymentAnalyticsEvent.PaymentIntentConfirm,
-                productUsage = listOf(productUsage),
+                productUsage = productUsage,
             )
         }
 
@@ -646,7 +646,7 @@ internal class StripeApiRepositoryTest {
 
             verifyAnalyticsRequest(
                 event = PaymentAnalyticsEvent.PaymentIntentConfirm,
-                productUsage = listOf(productUsage),
+                productUsage = productUsage,
                 errorMessage = "ioException",
             )
         }
@@ -680,7 +680,7 @@ internal class StripeApiRepositoryTest {
 
             verifyAnalyticsRequest(
                 event = PaymentAnalyticsEvent.PaymentIntentConfirm,
-                productUsage = listOf(productUsage),
+                productUsage = productUsage,
                 errorMessage = "apiError",
             )
         }
@@ -839,7 +839,7 @@ internal class StripeApiRepositoryTest {
 
             verifyAnalyticsRequest(
                 event = PaymentAnalyticsEvent.SetupIntentConfirm,
-                productUsage = listOf(productUsage),
+                productUsage = productUsage,
             )
         }
 
@@ -871,7 +871,7 @@ internal class StripeApiRepositoryTest {
 
             verifyAnalyticsRequest(
                 event = PaymentAnalyticsEvent.SetupIntentConfirm,
-                productUsage = listOf(productUsage),
+                productUsage = productUsage,
                 errorMessage = "ioException",
             )
         }
@@ -907,7 +907,7 @@ internal class StripeApiRepositoryTest {
 
             verifyAnalyticsRequest(
                 event = PaymentAnalyticsEvent.SetupIntentConfirm,
-                productUsage = listOf(productUsage),
+                productUsage = productUsage,
                 errorMessage = "apiError",
             )
         }
@@ -1479,7 +1479,7 @@ internal class StripeApiRepositoryTest {
 
             verifyFraudDetectionDataAndAnalyticsRequests(
                 PaymentAnalyticsEvent.TokenCreate,
-                listOf("CardInputView")
+                productUsage = "CardInputView",
             )
         }
 
@@ -1619,7 +1619,7 @@ internal class StripeApiRepositoryTest {
 
             verifyFraudDetectionDataAndAnalyticsRequests(
                 PaymentAnalyticsEvent.PaymentMethodCreate,
-                productUsage = listOf("CardInputView")
+                productUsage = "CardInputView",
             )
         }
 
@@ -1659,7 +1659,7 @@ internal class StripeApiRepositoryTest {
 
             verifyFraudDetectionDataAndAnalyticsRequests(
                 PaymentAnalyticsEvent.PaymentMethodCreate,
-                productUsage = listOf("PaymentSheet")
+                productUsage = "PaymentSheet",
             )
         }
 
@@ -3000,7 +3000,7 @@ internal class StripeApiRepositoryTest {
 
     private fun verifyFraudDetectionDataAndAnalyticsRequests(
         event: PaymentAnalyticsEvent,
-        productUsage: List<String>? = null
+        productUsage: String? = null
     ) {
         verify(fraudDetectionDataRepository, times(2))
             .refresh()
@@ -3010,7 +3010,7 @@ internal class StripeApiRepositoryTest {
 
     private fun verifyAnalyticsRequest(
         event: PaymentAnalyticsEvent,
-        productUsage: List<String>? = null,
+        productUsage: String? = null,
         errorMessage: String? = null
     ) {
         verify(analyticsRequestExecutor)

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverter.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverter.kt
@@ -44,7 +44,7 @@ class FieldValuesToParamsMapConverter {
                         requiresMandate = requiresMandate,
                         billingDetails = createBillingDetails(fieldValuePairsForCreateParams),
                         overrideParamMap = this,
-                        productUsage = setOf("PaymentSheet"),
+                        productUsage = emptySet(),
                         allowRedisplay = allowRedisplay,
                     )
                 }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementAnalyticsTest.kt
@@ -126,7 +126,10 @@ internal class EmbeddedPaymentElementAnalyticsTest {
             response.testBodyFromFile("payment-intent-confirm.json")
         }
 
-        validateAnalyticsRequest(eventName = "stripe_android.payment_method_creation")
+        validateAnalyticsRequest(
+            eventName = "stripe_android.payment_method_creation",
+            additionalProductUsage = setOf("deferred-intent", "autopm"),
+        )
         validateAnalyticsRequest(eventName = "stripe_android.payment_intent_retrieval")
         validateAnalyticsRequest(
             eventName = "stripe_android.paymenthandler.confirm.started",
@@ -316,8 +319,13 @@ internal class EmbeddedPaymentElementAnalyticsTest {
     private fun validateAnalyticsRequest(
         eventName: String,
         vararg requestMatchers: RequestMatcher,
+        additionalProductUsage: Set<String> = emptySet(),
     ) {
-        networkRule.validateAnalyticsRequest(eventName, *requestMatchers)
+        networkRule.validateAnalyticsRequest(
+            eventName = eventName,
+            productUsage = setOf("EmbeddedPaymentElement").plus(additionalProductUsage),
+            *requestMatchers
+        )
     }
 
     private fun createFakeGooglePayAvailabilityClient(): GooglePayAvailabilityClient.Factory {

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetAnalyticsTest.kt
@@ -1,0 +1,137 @@
+package com.stripe.android.paymentsheet
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.Stripe
+import com.stripe.android.core.networking.AnalyticsRequest
+import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.customersheet.CustomerSheetResult
+import com.stripe.android.networktesting.NetworkRule
+import com.stripe.android.networktesting.RequestMatcher
+import com.stripe.android.networktesting.RequestMatchers.query
+import com.stripe.android.networktesting.testBodyFromFile
+import com.stripe.android.paymentsheet.utils.CustomerSheetTestType
+import com.stripe.android.paymentsheet.utils.CustomerSheetUtils
+import com.stripe.android.paymentsheet.utils.IntegrationType
+import com.stripe.android.paymentsheet.utils.TestRules
+import com.stripe.android.paymentsheet.utils.runCustomerSheetTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import kotlin.time.Duration.Companion.seconds
+
+internal class CustomerSheetAnalyticsTest {
+    private val networkRule = NetworkRule(
+        hostsToTrack = listOf(ApiRequest.API_HOST, AnalyticsRequest.HOST),
+        validationTimeout = 1.seconds, // Analytics requests happen async.
+    )
+
+    @get:Rule
+    val testRules: TestRules = TestRules.create(networkRule = networkRule)
+
+    private val composeTestRule = testRules.compose
+
+    private val page: CustomerSheetPage = CustomerSheetPage(composeTestRule)
+
+    @Before
+    fun setup() {
+        Stripe.advancedFraudSignalsEnabled = false
+    }
+
+    @After
+    fun teardown() {
+        Stripe.advancedFraudSignalsEnabled = true
+    }
+
+    @Test
+    fun testSuccessfulCardSave() = runCustomerSheetTest(
+        networkRule = networkRule,
+        integrationType = IntegrationType.Compose,
+        customerSheetTestType = CustomerSheetTestType.AttachToSetupIntent,
+        resultCallback = { result ->
+            assertThat(result).isInstanceOf(CustomerSheetResult.Selected::class.java)
+        }
+    ) { context ->
+        networkRule.enqueue(
+            CustomerSheetUtils.retrieveElementsSessionRequest(),
+        ) { response ->
+            response.testBodyFromFile("elements-sessions-requires_payment_method.json")
+        }
+
+        CustomerSheetUtils.enqueueFetchRequests(networkRule = networkRule, withCards = false)
+
+        validateAnalyticsRequest(eventName = "cs_init_with_customer_adapter")
+
+        // These are all fired twice, once for cards & once for US bank account
+        validateAnalyticsRequest(eventName = "stripe_android.retrieve_payment_methods")
+        validateAnalyticsRequest(eventName = "stripe_android.retrieve_payment_methods")
+        validateAnalyticsRequest(eventName = "elements.customer_repository.get_saved_payment_methods_success")
+        validateAnalyticsRequest(eventName = "elements.customer_repository.get_saved_payment_methods_success")
+
+        validateAnalyticsRequest(eventName = "elements.customer_sheet.elements_session.load_success")
+        validateAnalyticsRequest(eventName = "elements.customer_sheet.payment_methods.load_success")
+
+        validateAnalyticsRequest(eventName = "stripe_android.card_metadata_pk_available")
+        validateAnalyticsRequest(eventName = "cs_add_payment_method_screen_presented")
+
+        context.presentCustomerSheet()
+
+        validateAnalyticsRequest(eventName = "cs_card_number_completed")
+
+        page.fillOutCardDetails()
+
+        networkRule.enqueue(
+            createPaymentMethodsRequest(),
+            cardDetailsParams(),
+            billingDetailsParams(),
+        ) { response ->
+            response.testBodyFromFile("payment-methods-create.json")
+        }
+
+        CustomerSheetUtils.enqueueFetchRequests(networkRule = networkRule, withCards = true)
+        CustomerSheetUtils.enqueueAttachRequests(
+            networkRule = networkRule,
+            customerSheetTestType = CustomerSheetTestType.AttachToSetupIntent,
+        )
+
+        validateAnalyticsRequest(eventName = "stripe_android.payment_method_creation")
+        validateAnalyticsRequest(eventName = "stripe_android.setup_intent_retrieval")
+        validateAnalyticsRequest(
+            eventName = "stripe_android.paymenthandler.confirm.started",
+            query("intent_id", "seti_12345"),
+        )
+        validateAnalyticsRequest(eventName = "stripe_android.confirm_returnurl_null")
+        validateAnalyticsRequest(eventName = "stripe_android.setup_intent_confirmation")
+        validateAnalyticsRequest(
+            eventName = "stripe_android.paymenthandler.confirm.finished",
+            query("intent_id", "seti_12345"),
+        )
+        validateAnalyticsRequest(eventName = "cs_add_payment_method_via_setup_intent_success")
+
+        // These are all fired twice, once for cards & once for US bank account
+        validateAnalyticsRequest(eventName = "stripe_android.retrieve_payment_methods")
+        validateAnalyticsRequest(eventName = "stripe_android.retrieve_payment_methods")
+        validateAnalyticsRequest(eventName = "elements.customer_repository.get_saved_payment_methods_success")
+        validateAnalyticsRequest(eventName = "elements.customer_repository.get_saved_payment_methods_success")
+
+        validateAnalyticsRequest(eventName = "elements.customer_sheet.payment_methods.refresh_success")
+        validateAnalyticsRequest(eventName = "cs_select_payment_method_screen_presented")
+
+        page.clickSaveButton()
+
+        validateAnalyticsRequest(eventName = "cs_select_payment_method_screen_confirmed_savedpm_success")
+
+        page.clickConfirmButton()
+    }
+
+    private fun validateAnalyticsRequest(
+        eventName: String,
+        vararg requestMatchers: RequestMatcher,
+    ) {
+        networkRule.validateAnalyticsRequest(
+            eventName = eventName,
+            productUsage = setOf("CustomerSheet"),
+            requestMatchers = requestMatchers,
+        )
+    }
+}

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetTest.kt
@@ -7,16 +7,10 @@ import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.customersheet.CustomerSheetResult
 import com.stripe.android.customersheet.PaymentOptionSelection
 import com.stripe.android.model.CardBrand
-import com.stripe.android.networktesting.NetworkRule
-import com.stripe.android.networktesting.RequestMatcher
-import com.stripe.android.networktesting.RequestMatchers
-import com.stripe.android.networktesting.RequestMatchers.host
-import com.stripe.android.networktesting.RequestMatchers.method
-import com.stripe.android.networktesting.RequestMatchers.path
-import com.stripe.android.networktesting.RequestMatchers.query
 import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentsheet.utils.CustomerSheetTestType
 import com.stripe.android.paymentsheet.utils.CustomerSheetTestTypeProvider
+import com.stripe.android.paymentsheet.utils.CustomerSheetUtils
 import com.stripe.android.paymentsheet.utils.IntegrationType
 import com.stripe.android.paymentsheet.utils.IntegrationTypeProvider
 import com.stripe.android.paymentsheet.utils.PrefsTestStore
@@ -52,12 +46,12 @@ internal class CustomerSheetTest {
         }
     ) { context ->
         networkRule.enqueue(
-            retrieveElementsSessionRequest(),
+            CustomerSheetUtils.retrieveElementsSessionRequest(),
         ) { response ->
             response.testBodyFromFile("elements-sessions-requires_payment_method.json")
         }
 
-        networkRule.enqueueFetchRequests(withCards = false)
+        CustomerSheetUtils.enqueueFetchRequests(networkRule = networkRule, withCards = false)
 
         context.presentCustomerSheet()
 
@@ -71,8 +65,11 @@ internal class CustomerSheetTest {
             response.testBodyFromFile("payment-methods-create.json")
         }
 
-        networkRule.enqueueFetchRequests(withCards = true)
-        networkRule.enqueueAttachRequests(customerSheetTestType)
+        CustomerSheetUtils.enqueueFetchRequests(networkRule = networkRule, withCards = true)
+        CustomerSheetUtils.enqueueAttachRequests(
+            networkRule = networkRule,
+            customerSheetTestType = customerSheetTestType
+        )
 
         page.clickSaveButton()
         page.clickConfirmButton()
@@ -103,12 +100,12 @@ internal class CustomerSheetTest {
         }
 
         networkRule.enqueue(
-            retrieveElementsSessionRequest(),
+            CustomerSheetUtils.retrieveElementsSessionRequest(),
         ) { response ->
             response.testBodyFromFile("elements-sessions-requires_payment_method.json")
         }
 
-        networkRule.enqueueFetchRequests(withCards = true)
+        CustomerSheetUtils.enqueueFetchRequests(networkRule = networkRule, withCards = true)
 
         context.presentCustomerSheet()
 
@@ -141,17 +138,17 @@ internal class CustomerSheetTest {
         }
 
         networkRule.enqueue(
-            retrieveElementsSessionRequest(),
+            CustomerSheetUtils.retrieveElementsSessionRequest(),
         ) { response ->
             response.testBodyFromFile("elements-sessions-requires_payment_method.json")
         }
 
-        networkRule.enqueueFetchRequests(withCards = true)
+        CustomerSheetUtils.enqueueFetchRequests(networkRule = networkRule, withCards = true)
 
         context.presentCustomerSheet()
 
         networkRule.enqueue(
-            detachRequest(),
+            CustomerSheetUtils.detachRequest(),
         ) { response ->
             response.testBodyFromFile("payment-methods-detach.json")
         }
@@ -189,12 +186,12 @@ internal class CustomerSheetTest {
         }
     ) { context ->
         networkRule.enqueue(
-            retrieveElementsSessionRequest(),
+            CustomerSheetUtils.retrieveElementsSessionRequest(),
         ) { response ->
             response.testBodyFromFile("elements-sessions-requires_payment_method.json")
         }
 
-        networkRule.enqueueFetchRequests(withCards = false)
+        CustomerSheetUtils.enqueueFetchRequests(networkRule = networkRule, withCards = false)
 
         context.presentCustomerSheet()
 
@@ -212,8 +209,11 @@ internal class CustomerSheetTest {
             response.testBodyFromFile("payment-methods-create.json")
         }
 
-        networkRule.enqueueFetchRequests(withCards = true)
-        networkRule.enqueueAttachRequests(customerSheetTestType)
+        CustomerSheetUtils.enqueueFetchRequests(networkRule = networkRule, withCards = true)
+        CustomerSheetUtils.enqueueAttachRequests(
+            networkRule = networkRule,
+            customerSheetTestType = customerSheetTestType
+        )
 
         page.clickSaveButton()
         page.clickConfirmButton()
@@ -232,12 +232,12 @@ internal class CustomerSheetTest {
         }
     ) { context ->
         networkRule.enqueue(
-            retrieveElementsSessionRequest(),
+            CustomerSheetUtils.retrieveElementsSessionRequest(),
         ) { response ->
             response.testBodyFromFile("elements-sessions-requires_payment_method_with_cbc.json")
         }
 
-        networkRule.enqueueFetchRequests(withCards = false)
+        CustomerSheetUtils.enqueueFetchRequests(networkRule = networkRule, withCards = false)
 
         context.presentCustomerSheet()
 
@@ -259,8 +259,11 @@ internal class CustomerSheetTest {
             response.testBodyFromFile("payment-methods-create.json")
         }
 
-        networkRule.enqueueFetchRequests(withCards = true)
-        networkRule.enqueueAttachRequests(customerSheetTestType)
+        CustomerSheetUtils.enqueueFetchRequests(networkRule = networkRule, withCards = true)
+        CustomerSheetUtils.enqueueAttachRequests(
+            networkRule = networkRule,
+            customerSheetTestType = customerSheetTestType
+        )
 
         page.clickSaveButton()
         page.clickConfirmButton()
@@ -276,12 +279,12 @@ internal class CustomerSheetTest {
         }
     ) { context ->
         networkRule.enqueue(
-            retrieveElementsSessionRequest(),
+            CustomerSheetUtils.retrieveElementsSessionRequest(),
         ) { response ->
             response.testBodyFromFile("elements-sessions-requires_payment_method.json")
         }
 
-        networkRule.enqueueFetchRequests(withCards = false)
+        CustomerSheetUtils.enqueueFetchRequests(networkRule = networkRule, withCards = false)
 
         context.presentCustomerSheet()
 
@@ -315,99 +318,5 @@ internal class CustomerSheetTest {
         page.waitForText("Your card's security code is incorrect.")
 
         context.markTestSucceeded()
-    }
-
-    private fun NetworkRule.enqueueFetchRequests(withCards: Boolean) {
-        enqueue(
-            retrievePaymentMethodsRequest(),
-            cardPaymentMethodsParams(),
-        ) { response ->
-            val file = if (withCards) {
-                "payment-methods-get-success.json"
-            } else {
-                "payment-methods-get-success-empty.json"
-            }
-
-            response.testBodyFromFile(file)
-        }
-
-        enqueue(
-            retrievePaymentMethodsRequest(),
-            usBankAccountPaymentMethodsParams(),
-        ) { response ->
-            response.testBodyFromFile("payment-methods-get-success-empty.json")
-        }
-    }
-
-    private fun NetworkRule.enqueueAttachRequests(customerSheetTestType: CustomerSheetTestType) {
-        when (customerSheetTestType) {
-            CustomerSheetTestType.AttachToCustomer -> {
-                enqueue(
-                    attachPaymentMethodRequest(),
-                ) { response ->
-                    response.testBodyFromFile("payment-methods-create.json")
-                }
-            }
-            CustomerSheetTestType.AttachToSetupIntent -> {
-                enqueue(
-                    retrieveSetupIntentRequest(),
-                    retrieveSetupIntentParams(),
-                ) { response ->
-                    response.testBodyFromFile("setup-intent-get.json")
-                }
-
-                enqueue(
-                    confirmSetupIntentRequest(),
-                    confirmSetupIntentParams()
-                ) { response ->
-                    response.testBodyFromFile("setup-intent-confirm.json")
-                }
-            }
-            CustomerSheetTestType.CustomerSession -> Unit
-        }
-    }
-
-    private fun retrieveElementsSessionRequest(): RequestMatcher {
-        return RequestMatchers.composite(
-            host("api.stripe.com"),
-            method("GET"),
-            path("/v1/elements/sessions"),
-        )
-    }
-
-    private fun retrievePaymentMethodsRequest(): RequestMatcher {
-        return RequestMatchers.composite(
-            host("api.stripe.com"),
-            method("GET"),
-            path("/v1/payment_methods"),
-        )
-    }
-
-    private fun attachPaymentMethodRequest(): RequestMatcher {
-        return RequestMatchers.composite(
-            host("api.stripe.com"),
-            method("POST"),
-            path("/v1/payment_methods/pm_12345/attach"),
-        )
-    }
-
-    private fun detachRequest(): RequestMatcher {
-        return RequestMatchers.composite(
-            host("api.stripe.com"),
-            method("POST"),
-            path("/v1/payment_methods/pm_67890/detach")
-        )
-    }
-
-    private fun cardPaymentMethodsParams(): RequestMatcher {
-        return RequestMatchers.composite(
-            query("type", "card"),
-        )
-    }
-
-    private fun usBankAccountPaymentMethodsParams(): RequestMatcher {
-        return RequestMatchers.composite(
-            query("type", "us_bank_account"),
-        )
     }
 }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
@@ -493,7 +493,7 @@ internal class FlowControllerTest {
             path("/v1/payment_methods"),
             bodyPart(
                 "payment_user_agent",
-                Regex("stripe-android%2F\\d*.\\d*.\\d*%3BPaymentSheet.FlowController%3BPaymentSheet%3Bdeferred-intent%3Bautopm")
+                Regex("stripe-android%2F\\d*.\\d*.\\d*%3BPaymentSheet.FlowController%3Bdeferred-intent%3Bautopm")
             ),
         ) { response ->
             response.testBodyFromFile("payment-methods-create.json")
@@ -512,7 +512,7 @@ internal class FlowControllerTest {
             not(
                 bodyPart(
                     urlEncode("payment_method_data[payment_user_agent]"),
-                    Regex("stripe-android%2F\\d*.\\d*.\\d*%3BPaymentSheet.FlowController%3BPaymentSheet%3Bdeferred-intent%3Bautopm")
+                    Regex("stripe-android%2F\\d*.\\d*.\\d*%3BPaymentSheet.FlowController%3Bdeferred-intent%3Bautopm")
                 )
             ),
         ) { response ->
@@ -631,7 +631,7 @@ internal class FlowControllerTest {
             path("/v1/payment_methods"),
             bodyPart(
                 "payment_user_agent",
-                Regex("stripe-android%2F\\d*.\\d*.\\d*%3BPaymentSheet.FlowController%3BPaymentSheet%3Bdeferred-intent%3Bautopm")
+                Regex("stripe-android%2F\\d*.\\d*.\\d*%3BPaymentSheet.FlowController%3Bdeferred-intent%3Bautopm")
             ),
         ) { response ->
             response.testBodyFromFile("payment-methods-create.json")
@@ -683,7 +683,7 @@ internal class FlowControllerTest {
             path("/v1/payment_methods"),
             bodyPart(
                 "payment_user_agent",
-                Regex("stripe-android%2F\\d*.\\d*.\\d*%3BPaymentSheet.FlowController%3BPaymentSheet%3Bdeferred-intent%3Bautopm")
+                Regex("stripe-android%2F\\d*.\\d*.\\d*%3BPaymentSheet.FlowController%3Bdeferred-intent%3Bautopm")
             ),
         ) { response ->
             response.testBodyFromFile("payment-methods-create.json")
@@ -740,7 +740,7 @@ internal class FlowControllerTest {
             path("/v1/payment_methods"),
             bodyPart(
                 "payment_user_agent",
-                Regex("stripe-android%2F\\d*.\\d*.\\d*%3BPaymentSheet.FlowController%3BPaymentSheet%3Bdeferred-intent%3Bautopm")
+                Regex("stripe-android%2F\\d*.\\d*.\\d*%3BPaymentSheet.FlowController%3Bdeferred-intent%3Bautopm")
             ),
         ) { response ->
             response.testBodyFromFile("payment-methods-create.json")

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/NetworkRuleExtensions.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/NetworkRuleExtensions.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet
 
+import com.stripe.android.core.utils.urlEncode
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatcher
 import com.stripe.android.networktesting.RequestMatchers.host
@@ -8,12 +9,14 @@ import com.stripe.android.networktesting.RequestMatchers.query
 
 internal fun NetworkRule.validateAnalyticsRequest(
     eventName: String,
+    productUsage: Set<String>,
     vararg requestMatchers: RequestMatcher,
 ) {
     enqueue(
         host("q.stripe.com"),
         method("GET"),
         query("event", eventName),
+        query("product_usage", urlEncode(productUsage.joinToString(","))),
         *requestMatchers,
     ) { response ->
         response.status = "HTTP/1.1 200 OK"

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAnalyticsTest.kt
@@ -20,6 +20,8 @@ import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentelement.AnalyticEvent
 import com.stripe.android.paymentelement.AnalyticEventRule
 import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
+import com.stripe.android.paymentsheet.utils.FlowControllerTestRunnerContext
+import com.stripe.android.paymentsheet.utils.PaymentSheetTestRunnerContext
 import com.stripe.android.paymentsheet.utils.TestRules
 import com.stripe.android.paymentsheet.utils.assertCompleted
 import com.stripe.android.paymentsheet.utils.runFlowControllerTest
@@ -84,11 +86,11 @@ internal class PaymentSheetAnalyticsTest {
             response.testBodyFromFile("elements-sessions-requires_payment_method.json")
         }
 
-        validateAnalyticsRequest(eventName = "mc_complete_init_default")
-        validateAnalyticsRequest(eventName = "mc_load_started")
-        validateAnalyticsRequest(eventName = "mc_load_succeeded")
-        validateAnalyticsRequest(eventName = "mc_complete_sheet_newpm_show")
-        validateAnalyticsRequest(eventName = "mc_form_shown")
+        testContext.validateAnalyticsRequest(eventName = "mc_complete_init_default")
+        testContext.validateAnalyticsRequest(eventName = "mc_load_started")
+        testContext.validateAnalyticsRequest(eventName = "mc_load_succeeded")
+        testContext.validateAnalyticsRequest(eventName = "mc_complete_sheet_newpm_show")
+        testContext.validateAnalyticsRequest(eventName = "mc_form_shown")
 
         testContext.presentPaymentSheet {
             presentWithPaymentIntent(
@@ -99,9 +101,9 @@ internal class PaymentSheetAnalyticsTest {
 
         analyticEventRule.assertMatchesExpectedEvent(AnalyticEvent.PresentedSheet())
 
-        validateAnalyticsRequest(eventName = "stripe_android.card_metadata_pk_available")
-        validateAnalyticsRequest(eventName = "mc_form_interacted")
-        validateAnalyticsRequest(eventName = "mc_card_number_completed")
+        testContext.validateAnalyticsRequest(eventName = "stripe_android.card_metadata_pk_available")
+        testContext.validateAnalyticsRequest(eventName = "mc_form_interacted")
+        testContext.validateAnalyticsRequest(eventName = "mc_card_number_completed")
 
         page.fillOutCardDetails()
         analyticEventRule.assertMatchesExpectedEvent(AnalyticEvent.CompletedPaymentMethodForm("card"))
@@ -114,20 +116,23 @@ internal class PaymentSheetAnalyticsTest {
             response.testBodyFromFile("payment-intent-confirm.json")
         }
 
-        validateAnalyticsRequest(eventName = "mc_confirm_button_tapped")
-        validateAnalyticsRequest(
+        testContext.validateAnalyticsRequest(eventName = "mc_confirm_button_tapped")
+        testContext.validateAnalyticsRequest(
             eventName = "stripe_android.paymenthandler.confirm.started",
             query("intent_id", "pi_example"),
             query("payment_method_type", "card"),
         )
-        validateAnalyticsRequest(eventName = "stripe_android.confirm_returnurl_null")
-        validateAnalyticsRequest(eventName = "stripe_android.payment_intent_confirmation")
-        validateAnalyticsRequest(
+        testContext.validateAnalyticsRequest(eventName = "stripe_android.confirm_returnurl_null")
+        testContext.validateAnalyticsRequest(eventName = "stripe_android.payment_intent_confirmation")
+        testContext.validateAnalyticsRequest(
             eventName = "stripe_android.paymenthandler.confirm.finished",
             query("intent_id", "pi_example"),
             query("payment_method_type", "card"),
         )
-        validateAnalyticsRequest(eventName = "mc_complete_payment_newpm_success", hasQueryParam("duration"))
+        testContext.validateAnalyticsRequest(
+            eventName = "mc_complete_payment_newpm_success",
+            hasQueryParam("duration")
+        )
 
         page.clickPrimaryButton()
     }
@@ -146,11 +151,11 @@ internal class PaymentSheetAnalyticsTest {
             response.testBodyFromFile("elements-sessions-requires_payment_method.json")
         }
 
-        validateAnalyticsRequest(eventName = "mc_custom_init_default")
-        validateAnalyticsRequest(eventName = "mc_load_started")
-        validateAnalyticsRequest(eventName = "mc_load_succeeded")
-        validateAnalyticsRequest(eventName = "mc_custom_sheet_newpm_show")
-        validateAnalyticsRequest(eventName = "mc_form_shown")
+        testContext.validateAnalyticsRequest(eventName = "mc_custom_init_default")
+        testContext.validateAnalyticsRequest(eventName = "mc_load_started")
+        testContext.validateAnalyticsRequest(eventName = "mc_load_succeeded")
+        testContext.validateAnalyticsRequest(eventName = "mc_custom_sheet_newpm_show")
+        testContext.validateAnalyticsRequest(eventName = "mc_form_shown")
 
         testContext.configureFlowController {
             configureWithPaymentIntent(
@@ -166,10 +171,10 @@ internal class PaymentSheetAnalyticsTest {
 
         analyticEventRule.assertMatchesExpectedEvent(AnalyticEvent.PresentedSheet())
 
-        validateAnalyticsRequest(eventName = "stripe_android.card_metadata_pk_available")
-        validateAnalyticsRequest(eventName = "mc_custom_paymentoption_newpm_select")
-        validateAnalyticsRequest(eventName = "mc_form_interacted")
-        validateAnalyticsRequest(eventName = "mc_card_number_completed")
+        testContext.validateAnalyticsRequest(eventName = "stripe_android.card_metadata_pk_available")
+        testContext.validateAnalyticsRequest(eventName = "mc_custom_paymentoption_newpm_select")
+        testContext.validateAnalyticsRequest(eventName = "mc_form_interacted")
+        testContext.validateAnalyticsRequest(eventName = "mc_card_number_completed")
 
         page.fillOutCardDetails()
         analyticEventRule.assertMatchesExpectedEvent(AnalyticEvent.CompletedPaymentMethodForm("card"))
@@ -182,20 +187,23 @@ internal class PaymentSheetAnalyticsTest {
             response.testBodyFromFile("payment-intent-confirm.json")
         }
 
-        validateAnalyticsRequest(eventName = "mc_confirm_button_tapped")
-        validateAnalyticsRequest(
+        testContext.validateAnalyticsRequest(eventName = "mc_confirm_button_tapped")
+        testContext.validateAnalyticsRequest(
             eventName = "stripe_android.paymenthandler.confirm.started",
             query("intent_id", "pi_example"),
             query("payment_method_type", "card"),
         )
-        validateAnalyticsRequest(eventName = "stripe_android.confirm_returnurl_null")
-        validateAnalyticsRequest(eventName = "stripe_android.payment_intent_confirmation")
-        validateAnalyticsRequest(
+        testContext.validateAnalyticsRequest(eventName = "stripe_android.confirm_returnurl_null")
+        testContext.validateAnalyticsRequest(eventName = "stripe_android.payment_intent_confirmation")
+        testContext.validateAnalyticsRequest(
             eventName = "stripe_android.paymenthandler.confirm.finished",
             query("intent_id", "pi_example"),
             query("payment_method_type", "card"),
         )
-        validateAnalyticsRequest(eventName = "mc_custom_payment_newpm_success", hasQueryParam("duration"))
+        testContext.validateAnalyticsRequest(
+            eventName = "mc_custom_payment_newpm_success",
+            hasQueryParam("duration")
+        )
 
         page.clickPrimaryButton()
     }
@@ -214,12 +222,12 @@ internal class PaymentSheetAnalyticsTest {
             response.testBodyFromFile("elements-sessions-requires_payment_method.json")
         }
 
-        validateAnalyticsRequest(eventName = "mc_complete_init_default")
-        validateAnalyticsRequest(eventName = "mc_load_started")
-        validateAnalyticsRequest(eventName = "mc_load_succeeded")
-        validateAnalyticsRequest(eventName = "mc_complete_sheet_newpm_show")
-        validateAnalyticsRequest(eventName = "mc_carousel_payment_method_tapped")
-        validateAnalyticsRequest(eventName = "mc_form_shown")
+        testContext.validateAnalyticsRequest(eventName = "mc_complete_init_default")
+        testContext.validateAnalyticsRequest(eventName = "mc_load_started")
+        testContext.validateAnalyticsRequest(eventName = "mc_load_succeeded")
+        testContext.validateAnalyticsRequest(eventName = "mc_complete_sheet_newpm_show")
+        testContext.validateAnalyticsRequest(eventName = "mc_carousel_payment_method_tapped")
+        testContext.validateAnalyticsRequest(eventName = "mc_form_shown")
 
         testContext.presentPaymentSheet {
             presentWithPaymentIntent(
@@ -230,9 +238,9 @@ internal class PaymentSheetAnalyticsTest {
 
         analyticEventRule.assertMatchesExpectedEvent(AnalyticEvent.PresentedSheet())
 
-        validateAnalyticsRequest(eventName = "stripe_android.card_metadata_pk_available")
-        validateAnalyticsRequest(eventName = "mc_form_interacted")
-        validateAnalyticsRequest(eventName = "mc_card_number_completed")
+        testContext.validateAnalyticsRequest(eventName = "stripe_android.card_metadata_pk_available")
+        testContext.validateAnalyticsRequest(eventName = "mc_form_interacted")
+        testContext.validateAnalyticsRequest(eventName = "mc_card_number_completed")
 
         page.clickOnLpm("card", forVerticalMode = true)
         page.fillOutCardDetails()
@@ -246,20 +254,23 @@ internal class PaymentSheetAnalyticsTest {
             response.testBodyFromFile("payment-intent-confirm.json")
         }
 
-        validateAnalyticsRequest(eventName = "mc_confirm_button_tapped")
-        validateAnalyticsRequest(
+        testContext.validateAnalyticsRequest(eventName = "mc_confirm_button_tapped")
+        testContext.validateAnalyticsRequest(
             eventName = "stripe_android.paymenthandler.confirm.started",
             query("intent_id", "pi_example"),
             query("payment_method_type", "card"),
         )
-        validateAnalyticsRequest(eventName = "stripe_android.confirm_returnurl_null")
-        validateAnalyticsRequest(eventName = "stripe_android.payment_intent_confirmation")
-        validateAnalyticsRequest(
+        testContext.validateAnalyticsRequest(eventName = "stripe_android.confirm_returnurl_null")
+        testContext.validateAnalyticsRequest(eventName = "stripe_android.payment_intent_confirmation")
+        testContext.validateAnalyticsRequest(
             eventName = "stripe_android.paymenthandler.confirm.finished",
             query("intent_id", "pi_example"),
             query("payment_method_type", "card"),
         )
-        validateAnalyticsRequest(eventName = "mc_complete_payment_newpm_success", hasQueryParam("duration"))
+        testContext.validateAnalyticsRequest(
+            eventName = "mc_complete_payment_newpm_success",
+            hasQueryParam("duration")
+        )
 
         page.clickPrimaryButton()
     }
@@ -278,11 +289,11 @@ internal class PaymentSheetAnalyticsTest {
             response.testBodyFromFile("elements-sessions-requires_payment_method.json")
         }
 
-        validateAnalyticsRequest(eventName = "mc_custom_init_default")
-        validateAnalyticsRequest(eventName = "mc_load_started")
-        validateAnalyticsRequest(eventName = "mc_load_succeeded")
-        validateAnalyticsRequest(eventName = "mc_custom_sheet_newpm_show")
-        validateAnalyticsRequest(eventName = "mc_form_shown")
+        testContext.validateAnalyticsRequest(eventName = "mc_custom_init_default")
+        testContext.validateAnalyticsRequest(eventName = "mc_load_started")
+        testContext.validateAnalyticsRequest(eventName = "mc_load_succeeded")
+        testContext.validateAnalyticsRequest(eventName = "mc_custom_sheet_newpm_show")
+        testContext.validateAnalyticsRequest(eventName = "mc_form_shown")
 
         testContext.configureFlowController {
             configureWithPaymentIntent(
@@ -297,11 +308,11 @@ internal class PaymentSheetAnalyticsTest {
         }
         analyticEventRule.assertMatchesExpectedEvent(AnalyticEvent.PresentedSheet())
 
-        validateAnalyticsRequest(eventName = "stripe_android.card_metadata_pk_available")
-        validateAnalyticsRequest(eventName = "mc_carousel_payment_method_tapped")
-        validateAnalyticsRequest(eventName = "mc_custom_paymentoption_newpm_select")
-        validateAnalyticsRequest(eventName = "mc_form_interacted")
-        validateAnalyticsRequest(eventName = "mc_card_number_completed")
+        testContext.validateAnalyticsRequest(eventName = "stripe_android.card_metadata_pk_available")
+        testContext.validateAnalyticsRequest(eventName = "mc_carousel_payment_method_tapped")
+        testContext.validateAnalyticsRequest(eventName = "mc_custom_paymentoption_newpm_select")
+        testContext.validateAnalyticsRequest(eventName = "mc_form_interacted")
+        testContext.validateAnalyticsRequest(eventName = "mc_card_number_completed")
 
         page.clickOnLpm("card", forVerticalMode = true)
         page.fillOutCardDetails()
@@ -315,29 +326,47 @@ internal class PaymentSheetAnalyticsTest {
             response.testBodyFromFile("payment-intent-confirm.json")
         }
 
-        validateAnalyticsRequest(eventName = "mc_confirm_button_tapped")
-        validateAnalyticsRequest(
+        testContext.validateAnalyticsRequest(eventName = "mc_confirm_button_tapped")
+        testContext.validateAnalyticsRequest(
             eventName = "stripe_android.paymenthandler.confirm.started",
             query("intent_id", "pi_example"),
             query("payment_method_type", "card"),
         )
-        validateAnalyticsRequest(eventName = "stripe_android.confirm_returnurl_null")
-        validateAnalyticsRequest(eventName = "stripe_android.payment_intent_confirmation")
-        validateAnalyticsRequest(
+        testContext.validateAnalyticsRequest(eventName = "stripe_android.confirm_returnurl_null")
+        testContext.validateAnalyticsRequest(eventName = "stripe_android.payment_intent_confirmation")
+        testContext.validateAnalyticsRequest(
             eventName = "stripe_android.paymenthandler.confirm.finished",
             query("intent_id", "pi_example"),
             query("payment_method_type", "card"),
         )
-        validateAnalyticsRequest(eventName = "mc_custom_payment_newpm_success", hasQueryParam("duration"))
+        testContext.validateAnalyticsRequest(
+            eventName = "mc_custom_payment_newpm_success",
+            hasQueryParam("duration")
+        )
 
         page.clickPrimaryButton()
     }
 
-    private fun validateAnalyticsRequest(
+    private fun PaymentSheetTestRunnerContext.validateAnalyticsRequest(
         eventName: String,
         vararg requestMatchers: RequestMatcher,
     ) {
-        networkRule.validateAnalyticsRequest(eventName, *requestMatchers)
+        networkRule.validateAnalyticsRequest(
+            eventName = eventName,
+            productUsage = setOf("PaymentSheet"),
+            *requestMatchers
+        )
+    }
+
+    private fun FlowControllerTestRunnerContext.validateAnalyticsRequest(
+        eventName: String,
+        vararg requestMatchers: RequestMatcher,
+    ) {
+        networkRule.validateAnalyticsRequest(
+            eventName = eventName,
+            productUsage = setOf("PaymentSheet.FlowController"),
+            *requestMatchers
+        )
     }
 
     private fun createFakeGooglePayAvailabilityClient(): GooglePayAvailabilityClient.Factory {

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/CustomerSheetUtils.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/CustomerSheetUtils.kt
@@ -1,0 +1,116 @@
+package com.stripe.android.paymentsheet.utils
+
+import com.stripe.android.networktesting.NetworkRule
+import com.stripe.android.networktesting.RequestMatcher
+import com.stripe.android.networktesting.RequestMatchers
+import com.stripe.android.networktesting.RequestMatchers.host
+import com.stripe.android.networktesting.RequestMatchers.method
+import com.stripe.android.networktesting.RequestMatchers.path
+import com.stripe.android.networktesting.RequestMatchers.query
+import com.stripe.android.networktesting.testBodyFromFile
+import com.stripe.android.paymentsheet.confirmSetupIntentParams
+import com.stripe.android.paymentsheet.confirmSetupIntentRequest
+import com.stripe.android.paymentsheet.retrieveSetupIntentParams
+import com.stripe.android.paymentsheet.retrieveSetupIntentRequest
+
+internal object CustomerSheetUtils {
+    fun enqueueFetchRequests(
+        networkRule: NetworkRule,
+        withCards: Boolean
+    ) = with(networkRule) {
+        enqueue(
+            retrievePaymentMethodsRequest(),
+            cardPaymentMethodsParams(),
+        ) { response ->
+            val file = if (withCards) {
+                "payment-methods-get-success.json"
+            } else {
+                "payment-methods-get-success-empty.json"
+            }
+
+            response.testBodyFromFile(file)
+        }
+
+        enqueue(
+            retrievePaymentMethodsRequest(),
+            usBankAccountPaymentMethodsParams(),
+        ) { response ->
+            response.testBodyFromFile("payment-methods-get-success-empty.json")
+        }
+    }
+
+    internal fun enqueueAttachRequests(
+        networkRule: NetworkRule,
+        customerSheetTestType: CustomerSheetTestType
+    ) = with(networkRule) {
+        when (customerSheetTestType) {
+            CustomerSheetTestType.AttachToCustomer -> {
+                enqueue(
+                    attachPaymentMethodRequest(),
+                ) { response ->
+                    response.testBodyFromFile("payment-methods-create.json")
+                }
+            }
+            CustomerSheetTestType.AttachToSetupIntent -> {
+                enqueue(
+                    retrieveSetupIntentRequest(),
+                    retrieveSetupIntentParams(),
+                ) { response ->
+                    response.testBodyFromFile("setup-intent-get.json")
+                }
+
+                enqueue(
+                    confirmSetupIntentRequest(),
+                    confirmSetupIntentParams()
+                ) { response ->
+                    response.testBodyFromFile("setup-intent-confirm.json")
+                }
+            }
+            CustomerSheetTestType.CustomerSession -> Unit
+        }
+    }
+
+    internal fun retrieveElementsSessionRequest(): RequestMatcher {
+        return RequestMatchers.composite(
+            host("api.stripe.com"),
+            method("GET"),
+            path("/v1/elements/sessions"),
+        )
+    }
+
+    internal fun detachRequest(): RequestMatcher {
+        return RequestMatchers.composite(
+            host("api.stripe.com"),
+            method("POST"),
+            path("/v1/payment_methods/pm_67890/detach")
+        )
+    }
+
+    private fun retrievePaymentMethodsRequest(): RequestMatcher {
+        return RequestMatchers.composite(
+            host("api.stripe.com"),
+            method("GET"),
+            path("/v1/payment_methods"),
+        )
+    }
+
+    private fun attachPaymentMethodRequest(): RequestMatcher {
+        return RequestMatchers.composite(
+            host("api.stripe.com"),
+            method("POST"),
+            path("/v1/payment_methods/pm_12345/attach"),
+        )
+    }
+
+    private fun cardPaymentMethodsParams(): RequestMatcher {
+        return RequestMatchers.composite(
+            query("type", "card"),
+        )
+    }
+
+    private fun usBankAccountPaymentMethodsParams(): RequestMatcher {
+        return RequestMatchers.composite(
+            query("type", "us_bank_account"),
+        )
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -50,6 +50,7 @@ import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.payments.bankaccount.CollectBankAccountLauncher
 import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.payments.financialconnections.GetFinancialConnectionsAvailability
 import com.stripe.android.paymentsheet.CardUpdateParams
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
@@ -101,6 +102,7 @@ internal class CustomerSheetViewModel(
     private val eventReporter: CustomerSheetEventReporter,
     private val workContext: CoroutineContext = Dispatchers.IO,
     @Named(IS_LIVE_MODE) private val isLiveModeProvider: () -> Boolean,
+    private val productUsage: Set<String>,
     confirmationHandlerFactory: ConfirmationHandler.Factory,
     private val customerSheetLoader: CustomerSheetLoader,
     private val errorReporter: ErrorReporter,
@@ -117,6 +119,7 @@ internal class CustomerSheetViewModel(
         eventReporter: CustomerSheetEventReporter,
         workContext: CoroutineContext = Dispatchers.IO,
         @Named(IS_LIVE_MODE) isLiveModeProvider: () -> Boolean,
+        @Named(PRODUCT_USAGE) productUsage: Set<String>,
         confirmationHandlerFactory: ConfirmationHandler.Factory,
         customerSheetLoader: CustomerSheetLoader,
         errorReporter: ErrorReporter,
@@ -133,13 +136,17 @@ internal class CustomerSheetViewModel(
         stripeRepository = stripeRepository,
         eventReporter = eventReporter,
         workContext = workContext,
+        productUsage = productUsage,
         isLiveModeProvider = isLiveModeProvider,
         confirmationHandlerFactory = confirmationHandlerFactory,
         customerSheetLoader = customerSheetLoader,
         errorReporter = errorReporter,
     )
 
-    private val cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(application)
+    private val cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(
+        context = application,
+        productUsageTokens = productUsage,
+    )
 
     private val backStack = MutableStateFlow<List<CustomerSheetViewState>>(
         listOf(

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetDataCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetDataCommonModule.kt
@@ -61,7 +61,7 @@ internal interface CustomerSheetDataCommonModule {
 
         @Provides
         @Named(PRODUCT_USAGE)
-        fun providesProductUsage(): Set<String> = setOf("WalletMode")
+        fun providesProductUsage(): Set<String> = setOf("CustomerSheet")
 
         @Provides
         @Named(ENABLE_LOGGING)

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetDataCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetDataCommonModule.kt
@@ -7,8 +7,7 @@ import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.core.networking.AnalyticsRequestFactory
-import com.stripe.android.core.networking.NetworkTypeDetector
-import com.stripe.android.core.utils.ContextUtils.packageInfo
+import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.analytics.RealErrorReporter
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
@@ -25,6 +24,11 @@ import javax.inject.Provider
 internal interface CustomerSheetDataCommonModule {
     @Binds
     fun bindsCustomerRepository(repository: CustomerApiRepository): CustomerRepository
+
+    @Binds
+    fun bindsAnalyticsRequestFactory(
+        paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory
+    ): AnalyticsRequestFactory
 
     @Binds
     fun bindsErrorReporter(errorReporter: RealErrorReporter): ErrorReporter
@@ -62,18 +66,6 @@ internal interface CustomerSheetDataCommonModule {
         @Provides
         @Named(ENABLE_LOGGING)
         fun providesEnableLogging(): Boolean = BuildConfig.DEBUG
-
-        @Provides
-        fun provideAnalyticsRequestFactory(
-            context: Context,
-            paymentConfiguration: Provider<PaymentConfiguration>
-        ): AnalyticsRequestFactory = AnalyticsRequestFactory(
-            packageManager = context.packageManager,
-            packageName = context.packageName.orEmpty(),
-            packageInfo = context.packageInfo,
-            publishableKeyProvider = { paymentConfiguration.get().publishableKey },
-            networkTypeProvider = NetworkTypeDetector(context)::invoke,
-        )
 
         @Provides
         fun provideTimeProvider(): () -> Long = {

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
@@ -15,13 +15,12 @@ import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.core.injection.UIContext
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.networking.AnalyticsRequestFactory
-import com.stripe.android.core.networking.NetworkTypeDetector
-import com.stripe.android.core.utils.ContextUtils.packageInfo
 import com.stripe.android.core.utils.UserFacingLogger
 import com.stripe.android.customersheet.CustomerSheetLoader
 import com.stripe.android.customersheet.DefaultCustomerSheetLoader
 import com.stripe.android.customersheet.analytics.CustomerSheetEventReporter
 import com.stripe.android.customersheet.analytics.DefaultCustomerSheetEventReporter
+import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.paymentelement.confirmation.ALLOWS_MANUAL_CONFIRMATION
 import com.stripe.android.payments.core.analytics.ErrorReporter
@@ -51,6 +50,11 @@ internal interface CustomerSheetViewModelModule {
     fun bindsCustomerSheetLoader(
         impl: DefaultCustomerSheetLoader
     ): CustomerSheetLoader
+
+    @Binds
+    fun bindsAnalyticsRequestFactory(
+        paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory
+    ): AnalyticsRequestFactory
 
     @Binds
     fun bindsStripeIntentRepository(
@@ -109,18 +113,6 @@ internal interface CustomerSheetViewModelModule {
 
         @Provides
         fun providesUserFacingLogger(): UserFacingLogger? = null
-
-        @Provides
-        internal fun provideAnalyticsRequestFactory(
-            application: Application,
-            paymentConfiguration: Provider<PaymentConfiguration>
-        ): AnalyticsRequestFactory = AnalyticsRequestFactory(
-            packageManager = application.packageManager,
-            packageName = application.packageName.orEmpty(),
-            packageInfo = application.packageInfo,
-            publishableKeyProvider = { paymentConfiguration.get().publishableKey },
-            networkTypeProvider = NetworkTypeDetector(application)::invoke,
-        )
 
         @Provides
         internal fun providesErrorReporter(

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkModule.kt
@@ -12,11 +12,8 @@ import com.stripe.android.cards.DefaultCardAccountRangeRepositoryFactory
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.IOContext
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.core.networking.DefaultStripeNetworkClient
-import com.stripe.android.core.networking.NetworkTypeDetector
-import com.stripe.android.core.utils.ContextUtils.packageInfo
 import com.stripe.android.core.utils.DefaultDurationProvider
 import com.stripe.android.core.utils.DurationProvider
 import com.stripe.android.core.utils.RealUserFacingLogger
@@ -38,6 +35,7 @@ import com.stripe.android.link.gate.LinkGate
 import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.link.repositories.LinkApiRepository
 import com.stripe.android.link.repositories.LinkRepository
+import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.paymentelement.AnalyticEventCallback
 import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
@@ -117,6 +115,9 @@ internal interface NativeLinkModule {
     @Binds
     fun bindsUserFacingLogger(impl: RealUserFacingLogger): UserFacingLogger
 
+    @Binds
+    fun bindsAnalyticsRequestFactory(impl: PaymentAnalyticsRequestFactory): AnalyticsRequestFactory
+
     @SuppressWarnings("TooManyFunctions")
     companion object {
         @Provides
@@ -143,19 +144,6 @@ internal interface NativeLinkModule {
                 logger = logger,
                 workContext = workContext
             )
-        )
-
-        @Provides
-        @NativeLinkScope
-        fun provideAnalyticsRequestFactory(
-            context: Context,
-            @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String
-        ): AnalyticsRequestFactory = AnalyticsRequestFactory(
-            packageManager = context.packageManager,
-            packageName = context.packageName.orEmpty(),
-            packageInfo = context.packageInfo,
-            publishableKeyProvider = publishableKeyProvider,
-            networkTypeProvider = NetworkTypeDetector(context)::invoke,
         )
 
         @Provides

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedCommonModule.kt
@@ -10,10 +10,9 @@ import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.core.injection.UIContext
 import com.stripe.android.core.networking.AnalyticsRequestFactory
-import com.stripe.android.core.networking.NetworkTypeDetector
-import com.stripe.android.core.utils.ContextUtils.packageInfo
 import com.stripe.android.core.utils.DefaultDurationProvider
 import com.stripe.android.core.utils.DurationProvider
+import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.paymentelement.AnalyticEventCallback
 import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
@@ -55,6 +54,11 @@ internal interface EmbeddedCommonModule {
     @Binds
     fun bindsCustomerRepository(repository: CustomerApiRepository): CustomerRepository
 
+    @Binds
+    fun bindsPaymentAnalyticsRequestFactory(
+        paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory
+    ): AnalyticsRequestFactory
+
     companion object {
         @Provides
         @Named(ENABLE_LOGGING)
@@ -79,18 +83,6 @@ internal interface EmbeddedCommonModule {
         fun provideDurationProvider(): DurationProvider {
             return DefaultDurationProvider.instance
         }
-
-        @Provides
-        fun provideAnalyticsRequestFactory(
-            context: Context,
-            paymentConfiguration: Provider<PaymentConfiguration>
-        ): AnalyticsRequestFactory = AnalyticsRequestFactory(
-            packageManager = context.packageManager,
-            packageName = context.packageName.orEmpty(),
-            packageInfo = context.packageInfo,
-            publishableKeyProvider = { paymentConfiguration.get().publishableKey },
-            networkTypeProvider = NetworkTypeDetector(context)::invoke,
-        )
 
         @Provides
         @Singleton

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelModule.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.injection
 import android.content.Context
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.paymentsheet.addresselement.AddressElementActivityContract
 import com.stripe.android.paymentsheet.addresselement.FormControllerSubcomponent
 import com.stripe.android.paymentsheet.addresselement.analytics.AddressLauncherEventReporter
@@ -26,6 +27,11 @@ internal class AddressElementViewModelModule {
     @Provides
     @Singleton
     fun provideEventReporterMode(): EventReporter.Mode = EventReporter.Mode.Custom
+
+    @Provides
+    @Named(PRODUCT_USAGE)
+    @Singleton
+    fun providesProductUsage() = setOf("PaymentSheet.AddressController")
 
     @Provides
     @Named(PUBLISHABLE_KEY)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
@@ -10,8 +10,6 @@ import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.core.networking.AnalyticsRequestFactory
-import com.stripe.android.core.networking.NetworkTypeDetector
-import com.stripe.android.core.utils.ContextUtils.packageInfo
 import com.stripe.android.core.utils.DefaultDurationProvider
 import com.stripe.android.core.utils.DurationProvider
 import com.stripe.android.core.utils.RealUserFacingLogger
@@ -23,6 +21,7 @@ import com.stripe.android.link.gate.DefaultLinkGate
 import com.stripe.android.link.gate.LinkGate
 import com.stripe.android.link.injection.LinkAnalyticsComponent
 import com.stripe.android.link.injection.LinkComponent
+import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.paymentelement.AnalyticEventCallback
 import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
@@ -107,6 +106,11 @@ internal abstract class PaymentSheetCommonModule {
     abstract fun bindsLinkConfigurationCoordinator(impl: RealLinkConfigurationCoordinator): LinkConfigurationCoordinator
 
     @Binds
+    abstract fun bindsAnalyticsRequestFactory(
+        paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory
+    ): AnalyticsRequestFactory
+
+    @Binds
     abstract fun bindLinkGateFactory(linkGateFactory: DefaultLinkGate.Factory): LinkGate.Factory
 
     @Binds
@@ -170,18 +174,6 @@ internal abstract class PaymentSheetCommonModule {
         fun provideDurationProvider(): DurationProvider {
             return DefaultDurationProvider.instance
         }
-
-        @Provides
-        fun provideAnalyticsRequestFactory(
-            context: Context,
-            paymentConfiguration: Provider<PaymentConfiguration>
-        ): AnalyticsRequestFactory = AnalyticsRequestFactory(
-            packageManager = context.packageManager,
-            packageName = context.packageName.orEmpty(),
-            packageInfo = context.packageInfo,
-            publishableKeyProvider = { paymentConfiguration.get().publishableKey },
-            networkTypeProvider = NetworkTypeDetector(context)::invoke,
-        )
 
         @Provides
         fun providesCvcRecollectionInteractorFactory(): CvcRecollectionInteractor.Factory {

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -111,6 +111,7 @@ internal object CustomerSheetTestHelper {
             integrationType = integrationType,
             isLiveModeProvider = { isLiveMode },
             logger = Logger.noop(),
+            productUsage = emptySet(),
             confirmationHandlerFactory = createTestConfirmationHandlerFactory(
                 paymentElementCallbackIdentifier = "CustomerSheetTestIdentifier",
                 intentConfirmationInterceptor = intentConfirmationInterceptor,

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestFactory.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestFactory.kt
@@ -28,7 +28,7 @@ open class AnalyticsRequestFactory(
      * Ensure this common parameters are not already included in [standardParams].
      *
      */
-    fun createRequest(
+    open fun createRequest(
         event: AnalyticsEvent,
         additionalParams: Map<String, Any?>
     ): AnalyticsRequest {


### PR DESCRIPTION
# Summary
Fix `product_usage` not being populated across Payment Element.

# Motivation
We require `product_usage` be populated across Payment Element in order to understand what products a merchant is using as an entry point in a merchant's usage of the Android SDK.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified