### PR TITLE
Update 3ds2sdk proguard rules to keep bouncycastle

### DIFF
--- a/3ds2sdk/consumer-rules.pro
+++ b/3ds2sdk/consumer-rules.pro
@@ -13,5 +13,6 @@
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
 
--keep class org.bouncycastle.**
+-keep class org.bouncycastle.jcajce.provider.** { *; }
+-keep class !org.bouncycastle.jce.provider.X509LDAPCertStoreSpi,org.bouncycastle.jce.provider.** { *; }
 -dontwarn com.google.crypto.tink.subtle.XChaCha20Poly1305

--- a/3ds2sdk/consumer-rules.pro
+++ b/3ds2sdk/consumer-rules.pro
@@ -13,5 +13,5 @@
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
 
--dontwarn org.bouncycastle.**
+-keep class org.bouncycastle.**
 -dontwarn com.google.crypto.tink.subtle.XChaCha20Poly1305


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Keep bouncycastle to resolve JWS validation error.
The wide keep rule is a temporary measure for incident mitigation. We will follow up with more narrow rules to only keep the required classes.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
ir-compost-carve

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
