### PR TITLE
Make several signup tweaks for Link in MPE

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
@@ -62,7 +63,7 @@ internal class LinkActivityViewModel @Inject constructor(
             email = null,
         )
     )
-    val linkAppBarState: StateFlow<LinkAppBarState> = _linkAppBarState
+    val linkAppBarState: StateFlow<LinkAppBarState> = _linkAppBarState.asStateFlow()
 
     private val _linkScreenState = MutableStateFlow<ScreenState>(ScreenState.Loading)
     val linkScreenState: StateFlow<ScreenState> = _linkScreenState
@@ -117,12 +118,13 @@ internal class LinkActivityViewModel @Inject constructor(
         navController ?: return
         navListenerJob = viewModelScope.launch {
             navController.currentBackStackEntryFlow.collectLatest { entry ->
+                val previousEntry = navController.previousBackStackEntry
                 val route = entry.destination.route
                 _linkAppBarState.update {
                     it.copy(
                         showHeader = showHeaderRoutes.contains(route),
                         showOverflowMenu = route == LinkScreen.Wallet.route,
-                        navigationIcon = if (route == LinkScreen.PaymentMethod.route) {
+                        navigationIcon = if (previousEntry != null) {
                             R.drawable.stripe_link_back
                         } else {
                             R.drawable.stripe_link_close

--- a/paymentsheet/src/main/java/com/stripe/android/link/model/LinkAccount.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/model/LinkAccount.kt
@@ -25,6 +25,9 @@ internal class LinkAccount(private val consumerSession: ConsumerSession) : Parce
         consumerSession.isVerifiedForSignup()
 
     @IgnoredOnParcel
+    val completedSignup: Boolean = consumerSession.isVerifiedForSignup()
+
+    @IgnoredOnParcel
     val accountStatus = when {
         isVerified -> {
             AccountStatus.Verified

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/LinkAppBarState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/LinkAppBarState.kt
@@ -1,10 +1,63 @@
 package com.stripe.android.link.ui
 
 import androidx.annotation.DrawableRes
+import com.stripe.android.link.LinkScreen
+import com.stripe.android.paymentsheet.R
 
 internal data class LinkAppBarState(
     @DrawableRes val navigationIcon: Int,
     val showHeader: Boolean,
     val showOverflowMenu: Boolean,
     val email: String?,
-)
+) {
+
+    internal companion object {
+
+        fun initial(): LinkAppBarState {
+            return LinkAppBarState(
+                navigationIcon = R.drawable.stripe_link_close,
+                showHeader = true,
+                showOverflowMenu = false,
+                email = null,
+            )
+        }
+
+        fun create(
+            route: String?,
+            email: String?,
+            previousEntryRoute: String?,
+            consumerIsSigningUp: Boolean,
+        ): LinkAppBarState {
+            val showHeaderRoutes = mutableSetOf(
+                LinkScreen.Loading.route,
+                LinkScreen.SignUp.route,
+                LinkScreen.Wallet.route,
+                LinkScreen.Verification.route,
+            )
+
+            val showEmailRoutes = mutableSetOf(
+                LinkScreen.Wallet.route,
+            )
+
+            if (consumerIsSigningUp) {
+                // If the consumer is just signing up, we show the Link logo and the email address used for signup
+                // on the payment method screen.
+                showHeaderRoutes.add(LinkScreen.PaymentMethod.route)
+                showEmailRoutes.add(LinkScreen.PaymentMethod.route)
+            }
+
+            return LinkAppBarState(
+                showHeader = route in showHeaderRoutes,
+                showOverflowMenu = route == LinkScreen.Wallet.route,
+                navigationIcon = if (previousEntryRoute != null) {
+                    R.drawable.stripe_link_back
+                } else {
+                    R.drawable.stripe_link_close
+                },
+                email = email?.takeIf {
+                    route in showEmailRoutes
+                },
+            )
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/inline/InlineSignupViewState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/inline/InlineSignupViewState.kt
@@ -1,9 +1,9 @@
 package com.stripe.android.link.ui.inline
 
 import androidx.annotation.VisibleForTesting
-import com.stripe.android.core.model.CountryCode
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.ui.signup.SignUpState
+import com.stripe.android.link.ui.signup.requiresNameCollection
 
 /**
  * The LinkInlineSignup view state.
@@ -67,8 +67,7 @@ constructor(
                     add(LinkSignupField.Phone)
                 }
 
-                val requiresNameCollection = config.stripeIntent.countryCode != CountryCode.US.value
-                if (requiresNameCollection) {
+                if (config.requiresNameCollection) {
                     add(LinkSignupField.Name)
                 }
             }

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/signup/SignUpScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/signup/SignUpScreen.kt
@@ -78,7 +78,7 @@ internal fun SignUpBody(
     var didFocusField by rememberSaveable { mutableStateOf(false) }
     val emailFocusRequester = remember { FocusRequester() }
 
-    if (!didFocusField && signUpScreenState.showKeyboardOnOpen) {
+    if (!didFocusField && signUpScreenState.signUpState == SignUpState.InputtingPrimaryField) {
         LaunchedEffect(Unit) {
             delay(LINK_DEFAULT_ANIMATION_DELAY_MILLIS)
             emailFocusRequester.requestFocus()
@@ -274,7 +274,6 @@ private fun SignUpScreenPreview() {
                     signUpEnabled = false,
                     signUpState = SignUpState.InputtingRemainingFields,
                     requiresNameCollection = true,
-                    showKeyboardOnOpen = false,
                 ),
                 onSignUpClick = {}
             )

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/signup/SignUpScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/signup/SignUpScreen.kt
@@ -42,6 +42,7 @@ import com.stripe.android.link.ui.PrimaryButtonState
 import com.stripe.android.link.ui.ProgressIndicatorTestTag
 import com.stripe.android.link.utils.LINK_DEFAULT_ANIMATION_DELAY_MILLIS
 import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.addresselement.ScrollableColumn
 import com.stripe.android.uicore.elements.EmailConfig
 import com.stripe.android.uicore.elements.NameConfig
 import com.stripe.android.uicore.elements.PhoneNumberCollectionSection
@@ -86,11 +87,11 @@ internal fun SignUpBody(
         }
     }
 
-    Column(
+    ScrollableColumn(
         modifier = Modifier
             .fillMaxWidth()
             .padding(20.dp),
-        horizontalAlignment = Alignment.CenterHorizontally
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Text(
             text = stringResource(R.string.stripe_link_sign_up_header),

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/signup/SignUpScreenState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/signup/SignUpScreenState.kt
@@ -1,18 +1,58 @@
 package com.stripe.android.link.ui.signup
 
 import androidx.compose.runtime.Immutable
+import com.stripe.android.core.model.CountryCode
 import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.link.LinkConfiguration
+import com.stripe.android.link.ui.signup.SignUpState.InputtingPrimaryField
+import com.stripe.android.link.ui.signup.SignUpState.InputtingRemainingFields
+import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.SetupIntent
 
 @Immutable
 internal data class SignUpScreenState(
     val merchantName: String,
     val signUpEnabled: Boolean,
     val requiresNameCollection: Boolean,
-    val showKeyboardOnOpen: Boolean,
-    val signUpState: SignUpState = SignUpState.InputtingPrimaryField,
+    val signUpState: SignUpState = InputtingPrimaryField,
     val isSubmitting: Boolean = false,
-    val errorMessage: ResolvableString? = null
+    val errorMessage: ResolvableString? = null,
 ) {
     val canEditForm: Boolean
         get() = !isSubmitting
+
+    companion object {
+
+        fun create(
+            configuration: LinkConfiguration,
+            customerInfo: LinkConfiguration.CustomerInfo?,
+        ): SignUpScreenState {
+            val showKeyboardOnOpen = customerInfo == null || customerInfo.showKeyboardOnOpen
+            val signUpState = if (showKeyboardOnOpen) InputtingPrimaryField else InputtingRemainingFields
+            val signupEnabled = customerInfo != null && customerInfo.isComplete(configuration.requiresNameCollection)
+
+            return SignUpScreenState(
+                signUpEnabled = signupEnabled,
+                merchantName = configuration.merchantName,
+                requiresNameCollection = configuration.requiresNameCollection,
+                signUpState = signUpState,
+            )
+        }
+    }
+}
+
+private val LinkConfiguration.requiresNameCollection: Boolean
+    get() {
+        val countryCode = when (stripeIntent) {
+            is PaymentIntent -> stripeIntent.countryCode
+            is SetupIntent -> stripeIntent.countryCode
+        }
+        return countryCode != CountryCode.US.value
+    }
+
+private val LinkConfiguration.CustomerInfo.showKeyboardOnOpen: Boolean
+    get() = email.isNullOrBlank()
+
+private fun LinkConfiguration.CustomerInfo.isComplete(requiresNameCollection: Boolean): Boolean {
+    return !email.isNullOrBlank() && !phone.isNullOrBlank() && (!requiresNameCollection || !name.isNullOrBlank())
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/signup/SignUpScreenState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/signup/SignUpScreenState.kt
@@ -21,7 +21,7 @@ internal data class SignUpScreenState(
     val canEditForm: Boolean
         get() = !isSubmitting
 
-    companion object {
+    internal companion object {
 
         fun create(
             configuration: LinkConfiguration,

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/signup/SignUpViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/signup/SignUpViewModel.kt
@@ -192,7 +192,9 @@ internal class SignUpViewModel @Inject constructor(
     }
 
     private fun onAccountFetched(linkAccount: LinkAccount?) {
-        if (linkAccount?.isVerified == true) {
+        if (linkAccount?.completedSignup == true) {
+            navigateAndClearStack(LinkScreen.PaymentMethod)
+        } else if (linkAccount?.isVerified == true) {
             navigateAndClearStack(LinkScreen.Wallet)
         } else {
             navigateAndClearStack(LinkScreen.Verification)

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/signup/SignUpViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/signup/SignUpViewModel.kt
@@ -8,7 +8,6 @@ import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.core.Logger
-import com.stripe.android.core.model.CountryCode
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.link.LinkConfiguration
@@ -21,8 +20,6 @@ import com.stripe.android.link.injection.NativeLinkComponent
 import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.link.ui.inline.SignUpConsentAction
 import com.stripe.android.model.EmailSource
-import com.stripe.android.model.PaymentIntent
-import com.stripe.android.model.SetupIntent
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.uicore.elements.EmailConfig
 import com.stripe.android.uicore.elements.NameConfig
@@ -30,6 +27,7 @@ import com.stripe.android.uicore.elements.PhoneNumberController
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
@@ -62,22 +60,10 @@ internal class SignUpViewModel @Inject constructor(
     val nameController = NameConfig.createController(
         initialValue = customerInfo?.name
     )
-    private val _state = MutableStateFlow(
-        value = SignUpScreenState(
-            signUpEnabled = false,
-            merchantName = configuration.merchantName,
-            requiresNameCollection = kotlin.run {
-                val countryCode = when (val stripeIntent = configuration.stripeIntent) {
-                    is PaymentIntent -> stripeIntent.countryCode
-                    is SetupIntent -> stripeIntent.countryCode
-                }
-                countryCode != CountryCode.US.value
-            },
-            showKeyboardOnOpen = customerInfo?.email == null,
-        )
-    )
 
-    val state: StateFlow<SignUpScreenState> = _state
+    private val _state = MutableStateFlow(SignUpScreenState.create(configuration, customerInfo))
+    val state: StateFlow<SignUpScreenState> = _state.asStateFlow()
+
     private var emailHasChanged = false
 
     init {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressUtils.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressUtils.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import kotlin.math.min
 
@@ -58,6 +59,7 @@ internal fun AddressDetails.editDistance(otherAddress: AddressDetails?): Int {
 @Composable
 internal fun ScrollableColumn(
     modifier: Modifier = Modifier,
+    horizontalAlignment: Alignment.Horizontal = Alignment.Start,
     content: @Composable ColumnScope.() -> Unit
 ) {
     Box(
@@ -65,6 +67,7 @@ internal fun ScrollableColumn(
     ) {
         Column(
             modifier = modifier,
+            horizontalAlignment = horizontalAlignment,
             content = content
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
@@ -554,7 +554,7 @@ internal class LinkActivityViewModelTest {
         assertThat(appBarState.email).isNull()
         assertThat(appBarState.showHeader).isFalse()
         assertThat(appBarState.showOverflowMenu).isFalse()
-        assertThat(appBarState.navigationIcon).isEqualTo(R.drawable.stripe_link_back)
+        assertThat(appBarState.navigationIcon).isEqualTo(R.drawable.stripe_link_close)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpBodyTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpBodyTest.kt
@@ -136,7 +136,6 @@ internal class SignUpBodyTest {
                     requiresNameCollection = requiresNameCollection,
                     errorMessage = errorMessage,
                     signUpState = signUpState,
-                    showKeyboardOnOpen = false,
                 ),
                 onSignUpClick = {}
             )

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenStateTest.kt
@@ -1,0 +1,109 @@
+package com.stripe.android.link.ui.signup
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.link.LinkConfiguration
+import com.stripe.android.model.LinkMode
+import com.stripe.android.paymentsheet.state.PaymentElementLoader
+import com.stripe.android.testing.PaymentIntentFactory
+import org.junit.Test
+
+class SignUpScreenStateTest {
+
+    @Test
+    fun `Produces correct initial state if no customer info is passed in`() {
+        val customerInfo = makeCustomerInfo()
+
+        val result = SignUpScreenState.create(
+            configuration = makeLinkConfiguration(customerInfo),
+            customerInfo = customerInfo,
+        )
+
+        assertThat(result.signUpEnabled).isFalse()
+        assertThat(result.signUpState).isEqualTo(SignUpState.InputtingPrimaryField)
+    }
+
+    @Test
+    fun `Produces correct initial state if only email is passed in`() {
+        val customerInfo = makeCustomerInfo(
+            email = "email@email.com",
+        )
+
+        val result = SignUpScreenState.create(
+            configuration = makeLinkConfiguration(customerInfo),
+            customerInfo = customerInfo,
+        )
+
+        assertThat(result.signUpEnabled).isFalse()
+        assertThat(result.signUpState).isEqualTo(SignUpState.InputtingRemainingFields)
+    }
+
+    @Test
+    fun `Produces correct initial state if everything but email is passed in`() {
+        val customerInfo = makeCustomerInfo(
+            email = null,
+            phone = "5555555555",
+            name = "John Doe",
+            billingCountryCode = "US",
+        )
+
+        val result = SignUpScreenState.create(
+            configuration = makeLinkConfiguration(customerInfo),
+            customerInfo = customerInfo,
+        )
+
+        assertThat(result.signUpEnabled).isFalse()
+        assertThat(result.signUpState).isEqualTo(SignUpState.InputtingPrimaryField)
+    }
+
+    @Test
+    fun `Produces correct initial state if all required details are passed in`() {
+        val customerInfo = makeCustomerInfo(
+            email = "email@email.com",
+            phone = "5555555555",
+            name = "John Doe",
+            billingCountryCode = "US",
+        )
+
+        val result = SignUpScreenState.create(
+            configuration = makeLinkConfiguration(customerInfo),
+            customerInfo = customerInfo,
+        )
+
+        assertThat(result.signUpEnabled).isTrue()
+        assertThat(result.signUpState).isEqualTo(SignUpState.InputtingRemainingFields)
+    }
+
+    private fun makeLinkConfiguration(
+        customerInfo: LinkConfiguration.CustomerInfo,
+    ): LinkConfiguration {
+        return LinkConfiguration(
+            stripeIntent = PaymentIntentFactory.create(),
+            merchantName = "Merchant, Inc.",
+            merchantCountryCode = "US",
+            customerInfo = customerInfo,
+            shippingDetails = null,
+            passthroughModeEnabled = true,
+            flags = emptyMap(),
+            cardBrandChoice = null,
+            useAttestationEndpointsForLink = true,
+            suppress2faModal = false,
+            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent("pi_123_secret_456"),
+            elementsSessionId = "elements_session_id_123",
+            linkMode = LinkMode.Passthrough,
+        )
+    }
+
+    private fun makeCustomerInfo(
+        email: String? = null,
+        phone: String? = null,
+        name: String? = null,
+        billingCountryCode: String? = null,
+    ): LinkConfiguration.CustomerInfo {
+        return LinkConfiguration.CustomerInfo(
+            email = email,
+            phone = phone,
+            name = name,
+            billingCountryCode = billingCountryCode,
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenTest.kt
@@ -46,7 +46,14 @@ internal class SignUpScreenTest {
 
     @Test
     fun `only email field displayed when controllers are empty`() = runTest(dispatcher) {
-        val viewModel = viewModel()
+        val viewModel = viewModel(
+            customerInfo = LinkConfiguration.CustomerInfo(
+                email = null,
+                phone = null,
+                name = null,
+                billingCountryCode = null,
+            )
+        )
 
         composeTestRule.setContent {
             SignUpScreen(viewModel = viewModel)

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenshotTest.kt
@@ -75,7 +75,6 @@ internal class SignUpScreenshotTest(
                                         requiresNameCollection = requiresNameCollection,
                                         signUpState = signUpState,
                                         errorMessage = errorMessage,
-                                        showKeyboardOnOpen = false,
                                         isSubmitting = isSubmitting,
                                     )
                                 )

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpViewModelTest.kt
@@ -229,7 +229,7 @@ internal class SignUpViewModelTest {
         val linkAuth = FakeLinkAuth()
         val viewModel = createViewModel(prefilledEmail = CUSTOMER_EMAIL, linkAuth = linkAuth)
 
-        assertThat(viewModel.contentState.signUpState).isEqualTo(SignUpState.InputtingPrimaryField)
+        assertThat(viewModel.contentState.signUpState).isEqualTo(SignUpState.InputtingRemainingFields)
         linkAuth.ensureAllItemsConsumed()
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes some issues around signup in Link in MPE.

This includes:
- Directly displaying all fields in the signup screen, instead of just showing the email field initially (including unit tests!).
- Using the backstack instead of manual logic to display the back or clear button in the top bar.
- Navigating from the signup screen to the payment method screen, instead of opening the (empty) wallet.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
