### PR TITLE
Add changeDetails to vertical selection.

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/model/PaymentMethodFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/model/PaymentMethodFixtures.kt
@@ -11,7 +11,6 @@ import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.ExternalPaymentMethodSpec
 import com.stripe.android.utils.BankFormScreenStateFactory
 import org.json.JSONObject
-import org.mockito.kotlin.mock
 import java.util.UUID
 import java.util.concurrent.ThreadLocalRandom
 
@@ -482,10 +481,10 @@ internal object PaymentMethodFixtures {
     )
 
     val US_BANK_PAYMENT_SELECTION = PaymentSelection.New.USBankAccount(
-        label = "Test",
+        label = "···· 6789",
         iconResource = 0,
-        paymentMethodCreateParams = mock(),
-        customerRequestedSave = mock(),
+        paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.US_BANK_ACCOUNT,
+        customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest,
         input = PaymentSelection.New.USBankAccount.Input(
             name = "",
             email = null,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -930,8 +930,95 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
 
             interactor.state.test {
                 awaitItem().run {
-                    assertThat(selection).isEqualTo(PaymentMethodVerticalLayoutInteractor.Selection.New("card"))
+                    assertThat(selection).isEqualTo(
+                        PaymentMethodVerticalLayoutInteractor.Selection.New(
+                            code = "card",
+                            changeDetails = "···· 4242",
+                            canBeChanged = true,
+                        )
+                    )
                 }
+            }
+        }
+    }
+
+    @Test
+    fun verticalModeScreenSelection_retainsLast4_whenUpdatingTemporarySelection() {
+        val initialPaymentSelection = PaymentSelection.Link()
+        runScenario(
+            initialSelection = initialPaymentSelection,
+            formTypeForCode = { FormHelper.FormType.UserInteractionRequired },
+            updateSelection = {},
+            shouldUpdateVerticalModeSelection = { true }
+        ) {
+            selectionSource.value = PaymentMethodFixtures.CARD_PAYMENT_SELECTION
+
+            interactor.state.test {
+                awaitItem().run {
+                    assertThat(selection).isEqualTo(
+                        PaymentMethodVerticalLayoutInteractor.Selection.New(
+                            code = "card",
+                            changeDetails = "···· 4242",
+                            canBeChanged = true,
+                        )
+                    )
+                }
+                temporarySelectionSource.value = "card"
+                ensureAllEventsConsumed()
+                temporarySelectionSource.value = null
+                ensureAllEventsConsumed()
+            }
+        }
+    }
+
+    @Test
+    fun verticalModeScreenSelection_retainsCanBeChanged_whenUpdatingTemporarySelection() {
+        runScenario(
+            formTypeForCode = { FormHelper.FormType.UserInteractionRequired },
+            updateSelection = {},
+            shouldUpdateVerticalModeSelection = { true }
+        ) {
+            selectionSource.value = PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION
+
+            interactor.state.test {
+                awaitItem().run {
+                    assertThat(selection).isEqualTo(
+                        PaymentMethodVerticalLayoutInteractor.Selection.New(
+                            code = "cashapp",
+                            changeDetails = null,
+                            canBeChanged = true,
+                        )
+                    )
+                }
+                temporarySelectionSource.value = "cashapp"
+                ensureAllEventsConsumed()
+                temporarySelectionSource.value = null
+                ensureAllEventsConsumed()
+            }
+        }
+    }
+
+    @Test
+    fun verticalModeSelectionIsInitialedAsUsBankAccount() {
+        var verticalModeSelection: PaymentSelection? = PaymentMethodFixtures.US_BANK_PAYMENT_SELECTION
+        runScenario(
+            initialSelection = verticalModeSelection,
+            formTypeForCode = { FormHelper.FormType.UserInteractionRequired },
+            updateSelection = { true },
+        ) {
+            interactor.state.test {
+                assertThat(verticalModeSelection).isEqualTo(PaymentMethodFixtures.US_BANK_PAYMENT_SELECTION)
+                assertThat(awaitItem().selection).isEqualTo(
+                    PaymentMethodVerticalLayoutInteractor.Selection.New(
+                        code = "us_bank_account",
+                        changeDetails = "···· 6789",
+                        canBeChanged = true,
+                    )
+                )
+                temporarySelectionSource.value = "us_bank_account"
+                ensureAllEventsConsumed()
+                temporarySelectionSource.value = null
+                ensureAllEventsConsumed()
             }
         }
     }
@@ -946,7 +1033,13 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
         ) {
             interactor.state.test {
                 assertThat(verticalModeSelection).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
-                assertThat(awaitItem().selection).isEqualTo(PaymentMethodVerticalLayoutInteractor.Selection.New("card"))
+                assertThat(awaitItem().selection).isEqualTo(
+                    PaymentMethodVerticalLayoutInteractor.Selection.New(
+                        code = "card",
+                        changeDetails = "···· 4242",
+                        canBeChanged = true,
+                    )
+                )
             }
         }
     }
@@ -964,7 +1057,13 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
 
             interactor.state.test {
                 awaitItem().run {
-                    assertThat(selection).isEqualTo(PaymentMethodVerticalLayoutInteractor.Selection.New("card"))
+                    assertThat(selection).isEqualTo(
+                        PaymentMethodVerticalLayoutInteractor.Selection.New(
+                            code = "card",
+                            changeDetails = "···· 4242",
+                            canBeChanged = true,
+                        )
+                    )
                 }
             }
         }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This will be used in a follow up PR that adds UI in this case.

We want to show a change button in the case the selection has already been filled out. We also want to show UI displaying details about the selection if it's already been filled out. This PR is the business logic that will later be consumed by the UI to do so.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified
