### PR TITLE
Select Saved PM in Horizontal PaymentSheet Should Send Analytic Events

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAnalyticsTest.kt
@@ -416,6 +416,11 @@ internal class PaymentSheetAnalyticsTest {
 
         editPage.clickRemove()
         analyticEventRule.assertMatchesExpectedEvent(AnalyticEvent.RemovedSavedPaymentMethod("card"))
+
+        testContext.validateAnalyticsRequest(eventName = "mc_complete_paymentoption_savedpm_select")
+        page.clickDoneButton()
+        page.clickSavedCard(card2.last4)
+        analyticEventRule.assertMatchesExpectedEvent(AnalyticEvent.SelectedSavedPaymentMethod("card"))
         testContext.markTestSucceeded()
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -371,6 +371,9 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     override fun handlePaymentMethodSelected(selection: PaymentSelection?) {
         if (selection != this.selection.value) {
             updateSelection(selection)
+            selection?.let {
+                eventReporter.onSelectPaymentOption(selection)
+            }
         }
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Calls `eventReporter.onSelectPaymentOption` in `PaymentSheetViewModel::handelPaymentMethodSelected`. 

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-3461

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
