### PR TITLE
Prepare card editing for use in Link UI

### DIFF
--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/ApiKeyFixtures.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/ApiKeyFixtures.kt
@@ -140,6 +140,8 @@ internal object ApiKeyFixtures {
         emailAddress = "test@test.com",
         redactedPhoneNumber = "+1********12",
         redactedFormattedPhoneNumber = "(***) *** **12",
+        unredactedPhoneNumber = null,
+        phoneNumberCountry = null,
         verificationSessions = emptyList(),
     )
 
@@ -154,6 +156,8 @@ internal object ApiKeyFixtures {
         emailAddress = "test@test.com",
         redactedPhoneNumber = "+1********12",
         redactedFormattedPhoneNumber = "(***) *** **12",
+        unredactedPhoneNumber = null,
+        phoneNumberCountry = null,
         verificationSessions = listOf(
             ConsumerSession.VerificationSession(
                 type = ConsumerSession.VerificationSession.SessionType.Sms,

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/RealConsumerSessionRepositoryTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/RealConsumerSessionRepositoryTest.kt
@@ -118,6 +118,8 @@ class RealConsumerSessionRepositoryTest {
             emailAddress = "email@email.com",
             redactedFormattedPhoneNumber = "(***) ***-1234",
             redactedPhoneNumber = "******1234",
+            unredactedPhoneNumber = null,
+            phoneNumberCountry = null,
             verificationSessions = listOf(
                 ConsumerSession.VerificationSession(
                     type = ConsumerSession.VerificationSession.SessionType.Sms,

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/ConsumerPaymentDetailsJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/ConsumerPaymentDetailsJsonParserTest.kt
@@ -26,7 +26,13 @@ class ConsumerPaymentDetailsJsonParserTest {
                         brand = CardBrand.MasterCard,
                         last4 = "4444",
                         cvcCheck = CvcCheck.Pass,
+                        networks = emptyList(),
                         billingAddress = ConsumerPaymentDetails.BillingAddress(
+                            name = null,
+                            line1 = null,
+                            line2 = null,
+                            locality = null,
+                            administrativeArea = null,
                             countryCode = CountryCode.US,
                             postalCode = "12312"
                         )
@@ -51,6 +57,7 @@ class ConsumerPaymentDetailsJsonParserTest {
                         brand = CardBrand.MasterCard,
                         last4 = "4444",
                         cvcCheck = CvcCheck.Unknown,
+                        networks = emptyList(),
                         billingAddress = null
                     )
                 )
@@ -109,7 +116,13 @@ class ConsumerPaymentDetailsJsonParserTest {
                         isDefault = true,
                         brand = CardBrand.MasterCard,
                         cvcCheck = CvcCheck.Pass,
+                        networks = emptyList(),
                         billingAddress = ConsumerPaymentDetails.BillingAddress(
+                            name = null,
+                            line1 = null,
+                            line2 = null,
+                            locality = null,
+                            administrativeArea = null,
                             countryCode = CountryCode.US,
                             postalCode = "12312"
                         )
@@ -122,7 +135,13 @@ class ConsumerPaymentDetailsJsonParserTest {
                         brand = CardBrand.Visa,
                         cvcCheck = CvcCheck.Fail,
                         isDefault = false,
+                        networks = emptyList(),
                         billingAddress = ConsumerPaymentDetails.BillingAddress(
+                            name = null,
+                            line1 = null,
+                            line2 = null,
+                            locality = null,
+                            administrativeArea = null,
                             countryCode = CountryCode.US,
                             postalCode = "42424"
                         )
@@ -223,7 +242,13 @@ class ConsumerPaymentDetailsJsonParserTest {
                         brand = CardBrand.AmericanExpress,
                         cvcCheck = CvcCheck.Pass,
                         isDefault = true,
+                        networks = emptyList(),
                         billingAddress = ConsumerPaymentDetails.BillingAddress(
+                            name = null,
+                            line1 = null,
+                            line2 = null,
+                            locality = null,
+                            administrativeArea = null,
                             countryCode = CountryCode.US,
                             postalCode = "12312"
                         )
@@ -236,7 +261,13 @@ class ConsumerPaymentDetailsJsonParserTest {
                         brand = CardBrand.DinersClub,
                         cvcCheck = CvcCheck.Fail,
                         isDefault = false,
+                        networks = emptyList(),
                         billingAddress = ConsumerPaymentDetails.BillingAddress(
+                            name = null,
+                            line1 = null,
+                            line2 = null,
+                            locality = null,
+                            administrativeArea = null,
                             countryCode = CountryCode.US,
                             postalCode = "42424"
                         )

--- a/payments-model/src/main/java/com/stripe/android/model/ConsumerPaymentDetails.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/ConsumerPaymentDetails.kt
@@ -34,7 +34,8 @@ data class ConsumerPaymentDetails(
         val brand: CardBrand,
         val networks: List<String>,
         val cvcCheck: CvcCheck,
-        val billingAddress: BillingAddress? = null
+        val billingAddress: BillingAddress? = null,
+        val billingEmailAddress: String? = null,
     ) : PaymentDetails(
         id = id,
         isDefault = isDefault,
@@ -108,7 +109,12 @@ data class ConsumerPaymentDetails(
     @Parcelize
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     data class BillingAddress(
+        val name: String?,
+        val line1: String?,
+        val line2: String?,
+        val administrativeArea: String?,
+        val locality: String?,
+        val postalCode: String?,
         val countryCode: CountryCode?,
-        val postalCode: String?
     ) : Parcelable
 }

--- a/payments-model/src/main/java/com/stripe/android/model/ConsumerPaymentDetails.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/ConsumerPaymentDetails.kt
@@ -32,6 +32,7 @@ data class ConsumerPaymentDetails(
         val expiryYear: Int,
         val expiryMonth: Int,
         val brand: CardBrand,
+        val networks: List<String>,
         val cvcCheck: CvcCheck,
         val billingAddress: BillingAddress? = null
     ) : PaymentDetails(

--- a/payments-model/src/main/java/com/stripe/android/model/ConsumerSession.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/ConsumerSession.kt
@@ -20,9 +20,9 @@ data class ConsumerSession(
     @SerialName("redacted_phone_number")
     val redactedPhoneNumber: String,
     @SerialName("unredacted_phone_number")
-    val unredactedPhoneNumber: String?,
+    val unredactedPhoneNumber: String? = null,
     @SerialName("phone_number_country")
-    val phoneNumberCountry: String?,
+    val phoneNumberCountry: String? = null,
     @SerialName("verification_sessions")
     val verificationSessions: List<VerificationSession> = emptyList(),
 ) : StripeModel {

--- a/payments-model/src/main/java/com/stripe/android/model/ConsumerSession.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/ConsumerSession.kt
@@ -19,6 +19,10 @@ data class ConsumerSession(
     val redactedFormattedPhoneNumber: String,
     @SerialName("redacted_phone_number")
     val redactedPhoneNumber: String,
+    @SerialName("unredacted_phone_number")
+    val unredactedPhoneNumber: String?,
+    @SerialName("phone_number_country")
+    val phoneNumberCountry: String?,
     @SerialName("verification_sessions")
     val verificationSessions: List<VerificationSession> = emptyList(),
 ) : StripeModel {

--- a/payments-model/src/main/java/com/stripe/android/model/parsers/ConsumerPaymentDetailsJsonParser.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/parsers/ConsumerPaymentDetailsJsonParser.kt
@@ -19,8 +19,14 @@ private const val FIELD_BANK_ACCOUNT_LAST_4 = "last4"
 private const val FIELD_BANK_ACCOUNT_BANK_NAME = "bank_name"
 
 private const val FIELD_BILLING_ADDRESS = "billing_address"
+private const val FIELD_BILLING_EMAIL_ADDRESS = "billing_email_address"
 private const val FIELD_ADDRESS_COUNTRY_CODE = "country_code"
 private const val FIELD_ADDRESS_POSTAL_CODE = "postal_code"
+private const val FIELD_ADDRESS_NAME = "name"
+private const val FIELD_ADDRESS_LINE_1 = "line1"
+private const val FIELD_ADDRESS_LINE_2 = "line2"
+private const val FIELD_ADDRESS_LOCALITY = "locality"
+private const val FIELD_ADDRESS_ADMINISTRATIVE_AREA = "administrative_area"
 
 private const val FIELD_CARD_EXPIRY_YEAR = "exp_year"
 private const val FIELD_CARD_EXPIRY_MONTH = "exp_month"
@@ -65,6 +71,7 @@ object ConsumerPaymentDetailsJsonParser : ModelJsonParser<ConsumerPaymentDetails
                         last4 = cardDetails.getString(FIELD_CARD_LAST_4),
                         cvcCheck = CvcCheck.fromCode(checks?.getString(FIELD_CARD_CVC_CHECK)),
                         billingAddress = parseBillingAddress(json),
+                        billingEmailAddress = optString(json, FIELD_BILLING_EMAIL_ADDRESS),
                         isDefault = json.optBoolean(FIELD_IS_DEFAULT),
                     )
                 }
@@ -85,8 +92,13 @@ object ConsumerPaymentDetailsJsonParser : ModelJsonParser<ConsumerPaymentDetails
     private fun parseBillingAddress(json: JSONObject) =
         json.optJSONObject(FIELD_BILLING_ADDRESS)?.let { address ->
             ConsumerPaymentDetails.BillingAddress(
-                optString(address, FIELD_ADDRESS_COUNTRY_CODE)?.let { CountryCode(it) },
-                optString(address, FIELD_ADDRESS_POSTAL_CODE)
+                name = optString(address, FIELD_ADDRESS_NAME),
+                line1 = optString(address, FIELD_ADDRESS_LINE_1),
+                line2 = optString(address, FIELD_ADDRESS_LINE_2),
+                locality = optString(address, FIELD_ADDRESS_LOCALITY),
+                postalCode = optString(address, FIELD_ADDRESS_POSTAL_CODE),
+                administrativeArea = optString(address, FIELD_ADDRESS_ADMINISTRATIVE_AREA),
+                countryCode = optString(address, FIELD_ADDRESS_COUNTRY_CODE)?.let { CountryCode(it) },
             )
         }
 

--- a/payments-model/src/main/java/com/stripe/android/model/parsers/ConsumerPaymentDetailsJsonParser.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/parsers/ConsumerPaymentDetailsJsonParser.kt
@@ -4,6 +4,7 @@ import androidx.annotation.RestrictTo
 import com.stripe.android.core.model.CountryCode
 import com.stripe.android.core.model.StripeJsonUtils.optString
 import com.stripe.android.core.model.parsers.ModelJsonParser
+import com.stripe.android.core.model.parsers.ModelJsonParser.Companion.jsonArrayToList
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.CvcCheck
@@ -60,7 +61,7 @@ object ConsumerPaymentDetailsJsonParser : ModelJsonParser<ConsumerPaymentDetails
                 "card" -> {
                     val cardDetails = json.getJSONObject(FIELD_CARD_DETAILS)
                     val checks = cardDetails.optJSONObject(FIELD_CARD_CHECKS)
-                    val networks = ModelJsonParser.jsonArrayToList(cardDetails.optJSONArray(FIELD_CARD_NETWORKS))
+                    val networks = jsonArrayToList(cardDetails.optJSONArray(FIELD_CARD_NETWORKS))
 
                     ConsumerPaymentDetails.Card(
                         id = json.getString(FIELD_ID),

--- a/payments-model/src/main/java/com/stripe/android/model/parsers/ConsumerPaymentDetailsJsonParser.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/parsers/ConsumerPaymentDetailsJsonParser.kt
@@ -25,6 +25,7 @@ private const val FIELD_ADDRESS_POSTAL_CODE = "postal_code"
 private const val FIELD_CARD_EXPIRY_YEAR = "exp_year"
 private const val FIELD_CARD_EXPIRY_MONTH = "exp_month"
 private const val FIELD_CARD_BRAND = "brand"
+private const val FIELD_CARD_NETWORKS = "networks"
 private const val FIELD_CARD_CHECKS = "checks"
 private const val FIELD_CARD_CVC_CHECK = "cvc_check"
 
@@ -53,12 +54,14 @@ object ConsumerPaymentDetailsJsonParser : ModelJsonParser<ConsumerPaymentDetails
                 "card" -> {
                     val cardDetails = json.getJSONObject(FIELD_CARD_DETAILS)
                     val checks = cardDetails.optJSONObject(FIELD_CARD_CHECKS)
+                    val networks = ModelJsonParser.jsonArrayToList(cardDetails.optJSONArray(FIELD_CARD_NETWORKS))
 
                     ConsumerPaymentDetails.Card(
                         id = json.getString(FIELD_ID),
                         expiryYear = cardDetails.getInt(FIELD_CARD_EXPIRY_YEAR),
                         expiryMonth = cardDetails.getInt(FIELD_CARD_EXPIRY_MONTH),
                         brand = CardBrand.fromCode(cardBrandFix(cardDetails.getString(FIELD_CARD_BRAND))),
+                        networks = networks,
                         last4 = cardDetails.getString(FIELD_CARD_LAST_4),
                         cvcCheck = CvcCheck.fromCode(checks?.getString(FIELD_CARD_CVC_CHECK)),
                         billingAddress = parseBillingAddress(json),

--- a/payments-model/src/main/java/com/stripe/android/model/parsers/ConsumerSessionJsonParser.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/parsers/ConsumerSessionJsonParser.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.model.parsers
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.model.StripeJsonUtils.optString
 import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.model.ConsumerSession
 import org.json.JSONObject
@@ -23,8 +24,8 @@ class ConsumerSessionJsonParser : ModelJsonParser<ConsumerSession> {
             emailAddress = consumerSessionJson.getString(FIELD_CONSUMER_SESSION_EMAIL),
             redactedFormattedPhoneNumber = consumerSessionJson.getString(FIELD_CONSUMER_SESSION_FORMATTED_PHONE),
             redactedPhoneNumber = consumerSessionJson.getString(FIELD_CONSUMER_SESSION_PHONE),
-            unredactedPhoneNumber = consumerSessionJson.getString(FIELD_CONSUMER_SESSION_UNREDACTED_PHONE),
-            phoneNumberCountry = consumerSessionJson.optString(FIELD_CONSUMER_SESSION_PHONE_COUNTRY),
+            unredactedPhoneNumber = optString(consumerSessionJson, FIELD_CONSUMER_SESSION_UNREDACTED_PHONE),
+            phoneNumberCountry = optString(consumerSessionJson, FIELD_CONSUMER_SESSION_PHONE_COUNTRY),
             verificationSessions = verificationSession,
         )
     }

--- a/payments-model/src/main/java/com/stripe/android/model/parsers/ConsumerSessionJsonParser.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/parsers/ConsumerSessionJsonParser.kt
@@ -23,6 +23,8 @@ class ConsumerSessionJsonParser : ModelJsonParser<ConsumerSession> {
             emailAddress = consumerSessionJson.getString(FIELD_CONSUMER_SESSION_EMAIL),
             redactedFormattedPhoneNumber = consumerSessionJson.getString(FIELD_CONSUMER_SESSION_FORMATTED_PHONE),
             redactedPhoneNumber = consumerSessionJson.getString(FIELD_CONSUMER_SESSION_PHONE),
+            unredactedPhoneNumber = consumerSessionJson.getString(FIELD_CONSUMER_SESSION_UNREDACTED_PHONE),
+            phoneNumberCountry = consumerSessionJson.optString(FIELD_CONSUMER_SESSION_PHONE_COUNTRY),
             verificationSessions = verificationSession,
         )
     }
@@ -45,6 +47,8 @@ class ConsumerSessionJsonParser : ModelJsonParser<ConsumerSession> {
         private const val FIELD_CONSUMER_SESSION_PHONE = "redacted_phone_number"
         private const val FIELD_CONSUMER_SESSION_FORMATTED_PHONE = "redacted_formatted_phone_number"
         private const val FIELD_CONSUMER_SESSION_VERIFICATION_SESSIONS = "verification_sessions"
+        private const val FIELD_CONSUMER_SESSION_UNREDACTED_PHONE = "unredacted_phone_number"
+        private const val FIELD_CONSUMER_SESSION_PHONE_COUNTRY = "phone_number_country"
 
         private const val FIELD_VERIFICATION_SESSION_TYPE = "type"
         private const val FIELD_VERIFICATION_SESSION_STATE = "state"

--- a/payments-model/src/test/java/com/stripe/android/model/CardPaymentDetailTest.kt
+++ b/payments-model/src/test/java/com/stripe/android/model/CardPaymentDetailTest.kt
@@ -14,7 +14,13 @@ class CardPaymentDetailTest {
         brand = CardBrand.Visa,
         cvcCheck = CvcCheck.Fail,
         isDefault = false,
+        networks = listOf("VISA"),
         billingAddress = ConsumerPaymentDetails.BillingAddress(
+            name = null,
+            line1 = null,
+            line2 = null,
+            locality = null,
+            administrativeArea = null,
             countryCode = CountryCode.US,
             postalCode = "42424"
         )

--- a/payments-model/src/test/java/com/stripe/android/model/parsers/ConsumerSessionJsonParserTest.kt
+++ b/payments-model/src/test/java/com/stripe/android/model/parsers/ConsumerSessionJsonParserTest.kt
@@ -17,6 +17,8 @@ class ConsumerSessionJsonParserTest {
                 emailAddress = "test@stripe.com",
                 redactedPhoneNumber = "+1********56",
                 redactedFormattedPhoneNumber = "(***) *** **56",
+                unredactedPhoneNumber = null,
+                phoneNumberCountry = null,
                 verificationSessions = listOf(
                     ConsumerSession.VerificationSession(
                         type = ConsumerSession.VerificationSession.SessionType.Sms,
@@ -37,6 +39,8 @@ class ConsumerSessionJsonParserTest {
                 emailAddress = "test@stripe.com",
                 redactedPhoneNumber = "+1********56",
                 redactedFormattedPhoneNumber = "(***) *** **56",
+                unredactedPhoneNumber = null,
+                phoneNumberCountry = null,
                 verificationSessions = listOf(
                     ConsumerSession.VerificationSession(
                         type = ConsumerSession.VerificationSession.SessionType.Sms,
@@ -57,6 +61,8 @@ class ConsumerSessionJsonParserTest {
                 emailAddress = "test@stripe.com",
                 redactedPhoneNumber = "+1********23",
                 redactedFormattedPhoneNumber = "(***) *** **23",
+                unredactedPhoneNumber = null,
+                phoneNumberCountry = null,
                 verificationSessions = listOf(
                     ConsumerSession.VerificationSession(
                         type = ConsumerSession.VerificationSession.SessionType.SignUp,

--- a/payments-model/src/test/java/com/stripe/android/model/parsers/ConsumerSessionLookupJsonParserTest.kt
+++ b/payments-model/src/test/java/com/stripe/android/model/parsers/ConsumerSessionLookupJsonParserTest.kt
@@ -31,6 +31,8 @@ class ConsumerSessionLookupJsonParserTest {
                     emailAddress = "email@example.com",
                     redactedPhoneNumber = "+1********68",
                     redactedFormattedPhoneNumber = "(***) *** **68",
+                    unredactedPhoneNumber = null,
+                    phoneNumberCountry = null,
                     verificationSessions = emptyList(),
                 ),
                 errorMessage = null,

--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -84,6 +84,7 @@
     <ID>TooManyFunctions:NativeLinkComponent.kt$NativeLinkComponent$Builder</ID>
     <ID>TooManyFunctions:NativeLinkModule.kt$NativeLinkModule</ID>
     <ID>TooManyFunctions:PaymentMethodMetadata.kt$PaymentMethodMetadata : Parcelable</ID>
+    <ID>TooManyFunctions:PaymentMethodsUiExtension.kt$com.stripe.android.paymentsheet.ui.PaymentMethodsUiExtension.kt</ID>
     <ID>UnusedPrivateClass:PaymentOptionsViewModelTest.kt$PaymentOptionsViewModelTest$MyHostActivity : AppCompatActivity</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/paymentsheet/src/main/java/com/stripe/android/link/model/LinkAccount.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/model/LinkAccount.kt
@@ -2,7 +2,7 @@ package com.stripe.android.link.model
 
 import android.os.Parcelable
 import com.stripe.android.model.ConsumerSession
-import com.stripe.android.uicore.elements.PhoneNumberFormatter
+import com.stripe.android.uicore.elements.convertPhoneNumberToE164
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 
@@ -21,8 +21,7 @@ internal class LinkAccount(private val consumerSession: ConsumerSession) : Parce
             val countryCode = consumerSession.phoneNumberCountry
 
             return if (nationalPhoneNumber != null && countryCode != null) {
-                val formatter = PhoneNumberFormatter.forCountry(countryCode)
-                formatter.toE164Format(nationalPhoneNumber)
+                convertPhoneNumberToE164(nationalPhoneNumber, countryCode)
             } else {
                 null
             }

--- a/paymentsheet/src/main/java/com/stripe/android/link/model/LinkAccount.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/model/LinkAccount.kt
@@ -2,6 +2,7 @@ package com.stripe.android.link.model
 
 import android.os.Parcelable
 import com.stripe.android.model.ConsumerSession
+import com.stripe.android.uicore.elements.PhoneNumberFormatter
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 
@@ -13,6 +14,19 @@ internal class LinkAccount(private val consumerSession: ConsumerSession) : Parce
 
     @IgnoredOnParcel
     val redactedPhoneNumber = consumerSession.redactedFormattedPhoneNumber.replace("*", "•")
+
+    val unredactedPhoneNumber: String?
+        get() {
+            val nationalPhoneNumber = consumerSession.unredactedPhoneNumber
+            val countryCode = consumerSession.phoneNumberCountry
+
+            return if (nationalPhoneNumber != null && countryCode != null) {
+                val formatter = PhoneNumberFormatter.forCountry(countryCode)
+                formatter.toE164Format(nationalPhoneNumber)
+            } else {
+                null
+            }
+        }
 
     @IgnoredOnParcel
     val clientSecret = consumerSession.clientSecret

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/CardDetailsEntry.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/CardDetailsEntry.kt
@@ -20,11 +20,11 @@ internal data class CardDetailsEntry(
      * @return True if any of the card details have changed, false otherwise.
      */
     fun hasChanged(
-        card: PaymentMethod.Card,
+        editCardPayload: EditCardPayload,
         originalCardBrandChoice: CardBrandChoice,
     ): Boolean {
         return originalCardBrandChoice != this.cardBrandChoice ||
-            expiryDateHasChanged(card)
+            expiryDateHasChanged(editCardPayload)
     }
 
     fun isComplete(): Boolean {
@@ -32,8 +32,9 @@ internal data class CardDetailsEntry(
         return expiryDateState.expiryMonth != null && expiryDateState.expiryYear != null
     }
 
-    private fun expiryDateHasChanged(card: PaymentMethod.Card): Boolean {
-        return card.expiryMonth != expiryDateState.expiryMonth || card.expiryYear != expiryDateState.expiryYear
+    private fun expiryDateHasChanged(editCardPayload: EditCardPayload): Boolean {
+        return editCardPayload.expiryMonth != expiryDateState.expiryMonth ||
+            editCardPayload.expiryYear != expiryDateState.expiryYear
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/CardDetailsUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/CardDetailsUI.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.ZeroCornerSize
-import androidx.compose.material.Card
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -26,7 +25,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.stripe.android.R
 import com.stripe.android.model.CardBrand
-import com.stripe.android.model.PaymentMethod
 import com.stripe.android.uicore.elements.Section
 import com.stripe.android.uicore.strings.resolve
 import com.stripe.android.uicore.stripeColors
@@ -43,7 +41,7 @@ internal fun CardDetailsEditUI(
     CardDetailsEditUI(
         shouldShowCardBrandDropdown = state.shouldShowCardBrandDropdown,
         selectedBrand = state.selectedCardBrand,
-        card = state.card,
+        payload = state.payload,
         availableNetworks = state.availableNetworks,
         paymentMethodIcon = state.paymentMethodIcon,
         expiryDateState = state.expiryDateState,
@@ -64,7 +62,7 @@ internal fun CardDetailsEditUI(
 private fun CardDetailsEditUI(
     shouldShowCardBrandDropdown: Boolean,
     selectedBrand: CardBrandChoice,
-    card: PaymentMethod.Card,
+    payload: EditCardPayload,
     expiryDateState: ExpiryDateState,
     billingDetailsForm: BillingDetailsForm?,
     availableNetworks: List<CardBrandChoice>,
@@ -85,7 +83,7 @@ private fun CardDetailsEditUI(
         ) {
             Column {
                 CardNumberField(
-                    card = card,
+                    last4 = payload.last4,
                     selectedBrand = selectedBrand,
                     shouldShowCardBrandDropdown = shouldShowCardBrandDropdown,
                     availableNetworks = availableNetworks,
@@ -113,7 +111,7 @@ private fun CardDetailsEditUI(
                             .width(MaterialTheme.stripeShapes.borderStrokeWidth.dp),
                         color = MaterialTheme.stripeColors.componentDivider,
                     )
-                    CvcField(cardBrand = card.brand, modifier = Modifier.weight(1F))
+                    CvcField(cardBrand = payload.brand, modifier = Modifier.weight(1F))
                 }
             }
         }
@@ -131,7 +129,7 @@ private fun CardDetailsEditUI(
 
 @Composable
 private fun CardNumberField(
-    card: PaymentMethod.Card,
+    last4: String?,
     selectedBrand: CardBrandChoice,
     availableNetworks: List<CardBrandChoice>,
     shouldShowCardBrandDropdown: Boolean,
@@ -139,7 +137,7 @@ private fun CardNumberField(
     onBrandChoiceChanged: (CardBrandChoice) -> Unit,
 ) {
     CommonTextField(
-        value = "•••• •••• •••• ${card.last4}",
+        value = "•••• •••• •••• $last4",
         label = stringResource(id = R.string.stripe_acc_label_card_number),
         trailingIcon = {
             if (shouldShowCardBrandDropdown) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/CardDetailsUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/CardDetailsUI.kt
@@ -137,7 +137,7 @@ private fun CardNumberField(
     onBrandChoiceChanged: (CardBrandChoice) -> Unit,
 ) {
     CommonTextField(
-        value = "•••• •••• •••• $last4",
+        value = "•••• •••• •••• ${last4 ?: "••••"}",
         label = stringResource(id = R.string.stripe_acc_label_card_number),
         trailingIcon = {
             if (shouldShowCardBrandDropdown) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/EditCardDetailsInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/EditCardDetailsInteractor.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Immutable
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.model.Address
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.CardBrand.Unknown
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.CardUpdateParams
@@ -28,13 +29,14 @@ internal data class EditCardPayload(
     val last4: String?,
     val expiryMonth: Int?,
     val expiryYear: Int?,
+    val brand: CardBrand,
     val displayBrand: String?,
     val networks: Set<String>?,
     val billingDetails: PaymentMethod.BillingDetails?,
 ) {
 
-    val brand: CardBrand
-        get() = CardBrand.fromCode(displayBrand)
+    val cardBrand: CardBrand
+        get() = CardBrand.fromCode(displayBrand).takeIf { it != Unknown } ?: brand
 
     internal companion object {
 
@@ -46,6 +48,7 @@ internal data class EditCardPayload(
                 last4 = card.last4,
                 expiryMonth = card.expiryMonth,
                 expiryYear = card.expiryYear,
+                brand = card.brand,
                 displayBrand = card.displayBrand,
                 networks = card.networks?.available,
                 billingDetails = billingDetails,
@@ -60,8 +63,8 @@ internal data class EditCardPayload(
                 last4 = card.last4,
                 expiryMonth = card.expiryMonth,
                 expiryYear = card.expiryYear,
-                displayBrand = card.brand.code,
-                // TODO: This still shows the dropdown somehow…
+                brand = card.brand,
+                displayBrand = null,
                 networks = card.networks.toSet().takeIf { it.size > 1 },
                 billingDetails = PaymentMethod.BillingDetails(
                     address = card.billingAddress?.let {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/ExpiryDateState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/ExpiryDateState.kt
@@ -100,6 +100,21 @@ internal data class ExpiryDateState(
                 enabled = enabled
             )
         }
+
+        fun create(
+            editPayload: EditCardPayload,
+            enabled: Boolean
+        ): ExpiryDateState {
+            val text = formattedExpiryDate(
+                expiryMonth = editPayload.expiryMonth,
+                expiryYear = editPayload.expiryYear,
+                enabled = enabled
+            )
+            return ExpiryDateState(
+                text = text,
+                enabled = enabled
+            )
+        }
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/ExpiryDateState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/ExpiryDateState.kt
@@ -3,7 +3,6 @@ package com.stripe.android.paymentsheet.ui
 import androidx.compose.runtime.Immutable
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
-import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.elements.CardDetailsUtil
 import com.stripe.android.uicore.elements.DateConfig
 import com.stripe.android.uicore.elements.IdentifierSpec
@@ -86,21 +85,6 @@ internal data class ExpiryDateState(
     }
 
     companion object {
-        fun create(
-            card: PaymentMethod.Card,
-            enabled: Boolean
-        ): ExpiryDateState {
-            val text = formattedExpiryDate(
-                expiryMonth = card.expiryMonth,
-                expiryYear = card.expiryYear,
-                enabled = enabled
-            )
-            return ExpiryDateState(
-                text = text,
-                enabled = enabled
-            )
-        }
-
         fun create(
             editPayload: EditCardPayload,
             enabled: Boolean

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodCardKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodCardKtx.kt
@@ -2,14 +2,13 @@ package com.stripe.android.paymentsheet.ui
 
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.model.CardBrand
-import com.stripe.android.model.PaymentMethod
 
-internal fun PaymentMethod.Card.getPreferredChoice(cardBrandFilter: CardBrandFilter): CardBrandChoice {
+internal fun EditCardPayload.getPreferredChoice(cardBrandFilter: CardBrandFilter): CardBrandChoice {
     return CardBrand.fromCode(displayBrand).toChoice(cardBrandFilter)
 }
 
-internal fun PaymentMethod.Card.getAvailableNetworks(cardBrandFilter: CardBrandFilter): List<CardBrandChoice> {
-    return networks?.available?.let { brandCodes ->
+internal fun EditCardPayload.getAvailableNetworks(cardBrandFilter: CardBrandFilter): List<CardBrandChoice> {
+    return networks?.let { brandCodes ->
         brandCodes.map { code ->
             CardBrand.fromCode(code).toChoice(cardBrandFilter)
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodsUiExtension.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodsUiExtension.kt
@@ -53,13 +53,11 @@ internal fun EditCardPayload.getSavedPaymentMethodIcon(
     forVerticalMode: Boolean = false,
     showNightIcon: Boolean? = null,
 ): Int {
-    val brand = CardBrand.fromCode(displayBrand)
-
     // Vertical mode icons are the same for light & dark
     return if (forVerticalMode) {
-        brand.getCardBrandIconForVerticalMode()
+        cardBrand.getCardBrandIconForVerticalMode()
     } else {
-        brand.getCardBrandIconForHorizontalMode(
+        cardBrand.getCardBrandIconForHorizontalMode(
             showNightIcon = showNightIcon,
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodsUiExtension.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodsUiExtension.kt
@@ -49,6 +49,23 @@ internal fun PaymentMethod.Card?.getSavedPaymentMethodIcon(
 }
 
 @DrawableRes
+internal fun EditCardPayload.getSavedPaymentMethodIcon(
+    forVerticalMode: Boolean = false,
+    showNightIcon: Boolean? = null,
+): Int {
+    val brand = CardBrand.fromCode(displayBrand)
+
+    // Vertical mode icons are the same for light & dark
+    return if (forVerticalMode) {
+        brand.getCardBrandIconForVerticalMode()
+    } else {
+        brand.getCardBrandIconForHorizontalMode(
+            showNightIcon = showNightIcon,
+        )
+    }
+}
+
+@DrawableRes
 internal fun CardBrand.getCardBrandIcon(): Int {
     return this.getCardBrandIconRef()
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
@@ -142,8 +142,9 @@ internal class DefaultUpdatePaymentMethodInteractor(
             "Card payment method required for creating EditCardDetailsInteractor"
         }
         val isModifiable = displayableSavedPaymentMethod.isModifiable(canUpdateFullPaymentMethodDetails)
+        val payload = EditCardPayload.create(savedPaymentMethodCard.card)
         editCardDetailsInteractorFactory.create(
-            card = savedPaymentMethodCard.card,
+            payload = payload,
             onCardUpdateParamsChanged = { cardUpdateParams ->
                 onCardUpdateParamsChanged(cardUpdateParams)
             },

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
@@ -142,7 +142,7 @@ internal class DefaultUpdatePaymentMethodInteractor(
             "Card payment method required for creating EditCardDetailsInteractor"
         }
         val isModifiable = displayableSavedPaymentMethod.isModifiable(canUpdateFullPaymentMethodDetails)
-        val payload = EditCardPayload.create(savedPaymentMethodCard.card)
+        val payload = EditCardPayload.create(savedPaymentMethodCard.card, savedPaymentMethodCard.billingDetails)
         editCardDetailsInteractorFactory.create(
             payload = payload,
             onCardUpdateParamsChanged = { cardUpdateParams ->
@@ -153,7 +153,6 @@ internal class DefaultUpdatePaymentMethodInteractor(
             cardBrandFilter = cardBrandFilter,
             onBrandChoiceChanged = onBrandChoiceSelected,
             areExpiryDateAndAddressModificationSupported = isModifiable && canUpdateFullPaymentMethodDetails,
-            billingDetails = savedPaymentMethodCard.billingDetails,
             addressCollectionMode = addressCollectionMode,
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
@@ -93,7 +93,13 @@ internal object TestFactory {
         brand = CardBrand.Visa,
         cvcCheck = CvcCheck.Pass,
         isDefault = true,
+        networks = emptyList(),
         billingAddress = ConsumerPaymentDetails.BillingAddress(
+            name = null,
+            line1 = null,
+            line2 = null,
+            locality = null,
+            administrativeArea = null,
             countryCode = CountryCode.US,
             postalCode = "12312"
         )

--- a/paymentsheet/src/test/java/com/stripe/android/link/model/LinkAccountTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/model/LinkAccountTest.kt
@@ -1,0 +1,52 @@
+package com.stripe.android.link.model
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.ConsumerSession
+import org.junit.Test
+
+class LinkAccountTest {
+
+    @Test
+    fun `Returns unredacted E164 phone number if unredacted local number and country are available`() {
+        val linkAccount = makeLinkAccount(
+            unredactedPhoneNumber = "(555) 555-0007",
+            phoneNumberCountry = "US",
+        )
+        assertThat(linkAccount.unredactedPhoneNumber).isEqualTo("+15555550007")
+    }
+
+    @Test
+    fun `Returns no unredacted E164 phone number if unredacted local number is missing`() {
+        val linkAccount = makeLinkAccount(
+            unredactedPhoneNumber = null,
+            phoneNumberCountry = "US",
+        )
+        assertThat(linkAccount.unredactedPhoneNumber).isNull()
+    }
+
+    @Test
+    fun `Returns no unredacted E164 phone number if country is missing`() {
+        val linkAccount = makeLinkAccount(
+            unredactedPhoneNumber = "(555) 555-0007",
+            phoneNumberCountry = null,
+        )
+        assertThat(linkAccount.unredactedPhoneNumber).isNull()
+    }
+
+    private fun makeLinkAccount(
+        unredactedPhoneNumber: String?,
+        phoneNumberCountry: String?,
+    ): LinkAccount {
+        val consumerSession = ConsumerSession(
+            clientSecret = "consumer_session_007",
+            emailAddress = "John Doe",
+            redactedPhoneNumber = "+1********07",
+            redactedFormattedPhoneNumber = "(***) *** **07",
+            unredactedPhoneNumber = unredactedPhoneNumber,
+            phoneNumberCountry = phoneNumberCountry,
+            verificationSessions = emptyList(),
+        )
+
+        return LinkAccount(consumerSession)
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/PaymentDetailsListItemScreenShotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/PaymentDetailsListItemScreenShotTest.kt
@@ -37,7 +37,13 @@ internal class PaymentDetailsListItemScreenShotTest {
                     brand = CardBrand.MasterCard,
                     last4 = "4444",
                     cvcCheck = CvcCheck.Pass,
+                    networks = emptyList(),
                     billingAddress = ConsumerPaymentDetails.BillingAddress(
+                        name = null,
+                        line1 = null,
+                        line2 = null,
+                        locality = null,
+                        administrativeArea = null,
                         countryCode = CountryCode.US,
                         postalCode = "12312"
                     )
@@ -61,7 +67,13 @@ internal class PaymentDetailsListItemScreenShotTest {
                     brand = CardBrand.MasterCard,
                     last4 = "4444",
                     cvcCheck = CvcCheck.Pass,
+                    networks = emptyList(),
                     billingAddress = ConsumerPaymentDetails.BillingAddress(
+                        name = null,
+                        line1 = null,
+                        line2 = null,
+                        locality = null,
+                        administrativeArea = null,
                         countryCode = CountryCode.US,
                         postalCode = "12312"
                     )
@@ -85,7 +97,13 @@ internal class PaymentDetailsListItemScreenShotTest {
                     brand = CardBrand.MasterCard,
                     last4 = "4444",
                     cvcCheck = CvcCheck.Pass,
+                    networks = emptyList(),
                     billingAddress = ConsumerPaymentDetails.BillingAddress(
+                        name = null,
+                        line1 = null,
+                        line2 = null,
+                        locality = null,
+                        administrativeArea = null,
                         countryCode = CountryCode.US,
                         postalCode = "12312"
                     )
@@ -109,7 +127,13 @@ internal class PaymentDetailsListItemScreenShotTest {
                     brand = CardBrand.MasterCard,
                     last4 = "4444",
                     cvcCheck = CvcCheck.Pass,
+                    networks = emptyList(),
                     billingAddress = ConsumerPaymentDetails.BillingAddress(
+                        name = null,
+                        line1 = null,
+                        line2 = null,
+                        locality = null,
+                        administrativeArea = null,
                         countryCode = CountryCode.US,
                         postalCode = "12312"
                     )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
@@ -226,6 +226,7 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
                     expiryMonth = 4,
                     brand = CardBrand.Visa,
                     cvcCheck = CvcCheck.Pass,
+                    networks = emptyList(),
                     billingAddress = null,
                 ),
                 paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
@@ -412,6 +413,7 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
                         expiryMonth = 4,
                         brand = CardBrand.Visa,
                         cvcCheck = CvcCheck.Pass,
+                        networks = emptyList(),
                         billingAddress = null,
                     ),
                     paymentMethodCreateParams = expectedCreateParams,
@@ -468,6 +470,7 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
                         expiryMonth = 4,
                         brand = CardBrand.Visa,
                         cvcCheck = CvcCheck.Pass,
+                        networks = emptyList(),
                         billingAddress = null,
                     ),
                     paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
@@ -565,7 +568,13 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
                     brand = CardBrand.DinersClub,
                     cvcCheck = CvcCheck.Fail,
                     isDefault = false,
+                    networks = emptyList(),
                     billingAddress = ConsumerPaymentDetails.BillingAddress(
+                        name = null,
+                        line1 = null,
+                        line2 = null,
+                        locality = null,
+                        administrativeArea = null,
                         countryCode = CountryCode.US,
                         postalCode = "42424"
                     )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/CardDetailsEditUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/CardDetailsEditUITest.kt
@@ -276,6 +276,7 @@ internal class CardDetailsEditUITest {
         runScenario(
             card = PaymentMethodFixtures.CARD_WITH_NETWORKS.copy(
                 brand = CardBrand.AmericanExpress,
+                displayBrand = null,
             )
         ) {
             assertCvcEquals(
@@ -427,10 +428,9 @@ internal class CardDetailsEditUITest {
                 isCbcModifiable = showCardBrandDropdown,
                 areExpiryDateAndAddressModificationSupported = expiryDateEditEnabled,
                 cardBrandFilter = DefaultCardBrandFilter,
-                card = card,
+                payload = EditCardPayload.create(card, PaymentMethodFixtures.BILLING_DETAILS),
                 onBrandChoiceChanged = {},
                 onCardUpdateParamsChanged = {},
-                billingDetails = PaymentMethodFixtures.BILLING_DETAILS,
                 addressCollectionMode = addressCollectionMode
             )
         composeRule.setContent {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/CardDetailsEntryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/CardDetailsEntryTest.kt
@@ -2,7 +2,6 @@ package com.stripe.android.paymentsheet.ui
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.CardBrand
-import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.PaymentSheetFixtures.BILLING_DETAILS_FORM_DETAILS
 import com.stripe.android.paymentsheet.PaymentSheetFixtures.billingDetailsFormState
@@ -226,7 +225,7 @@ internal class CardDetailsEntryTest {
     ) = CardDetailsEntry(
         cardBrandChoice = cardBrandChoice,
         expiryDateState = ExpiryDateState.create(
-            card = createCard(expiryMonth = expMonth, expiryYear = expYear),
+            editPayload = createCard(expiryMonth = expMonth, expiryYear = expYear),
             enabled = expiryDateEditable
         ),
     )
@@ -240,10 +239,14 @@ internal class CardDetailsEntryTest {
     private fun createCard(
         expiryMonth: Int? = 12,
         expiryYear: Int? = 2030
-    ): PaymentMethod.Card = PaymentMethodFixtures.CARD_WITH_NETWORKS.copy(
-        brand = CardBrand.Visa,
-        expiryMonth = expiryMonth,
-        expiryYear = expiryYear,
-        last4 = "4242"
-    )
+    ): EditCardPayload {
+        val card = PaymentMethodFixtures.CARD_WITH_NETWORKS.copy(
+            brand = CardBrand.Visa,
+            expiryMonth = expiryMonth,
+            expiryYear = expiryYear,
+            last4 = "4242"
+        )
+
+        return EditCardPayload.create(card, null)
+    }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultEditCardDetailsInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultEditCardDetailsInteractorTest.kt
@@ -27,19 +27,41 @@ internal class DefaultEditCardDetailsInteractorTest {
 
     @Test
     fun testInitialStateForCardWithNetworks() {
+        val card = PaymentMethodFixtures.CARD_WITH_NETWORKS
         val handler = handler()
 
         val state = handler.uiState
-        assertThat(state.card).isEqualTo(PaymentMethodFixtures.CARD_WITH_NETWORKS)
+        assertThat(state.payload).isEqualTo(
+            EditCardPayload(
+                last4 = card.last4,
+                expiryMonth = card.expiryMonth,
+                expiryYear = card.expiryYear,
+                brand = card.brand,
+                displayBrand = card.displayBrand,
+                networks = card.networks?.available,
+                billingDetails = PaymentMethodFixtures.BILLING_DETAILS,
+            )
+        )
         assertThat(state.selectedCardBrand.brand).isEqualTo(CardBrand.CartesBancaires)
     }
 
     @Test
     fun testInitialStateForCardWithNoNetworks() {
-        val handler = handler(card = PaymentMethodFixtures.CARD)
+        val card = PaymentMethodFixtures.CARD
+        val handler = handler(card = card)
 
         val state = handler.uiState
-        assertThat(state.card).isEqualTo(PaymentMethodFixtures.CARD)
+        assertThat(state.payload).isEqualTo(
+            EditCardPayload(
+                last4 = card.last4,
+                expiryMonth = card.expiryMonth,
+                expiryYear = card.expiryYear,
+                brand = card.brand,
+                displayBrand = card.displayBrand,
+                networks = card.networks?.available,
+                billingDetails = PaymentMethodFixtures.BILLING_DETAILS,
+            )
+        )
         assertThat(state.selectedCardBrand.brand).isEqualTo(CardBrand.Unknown)
     }
 
@@ -433,10 +455,9 @@ internal class DefaultEditCardDetailsInteractorTest {
             onBrandChoiceChanged = onBrandChoiceChanged,
             coroutineScope = TestScope(testDispatcher),
             isCbcModifiable = isCbcModifiable,
-            card = card,
+            payload = EditCardPayload.create(card, billingDetails),
             onCardUpdateParamsChanged = onCardUpdateParamsChanged,
             areExpiryDateAndAddressModificationSupported = areExpiryDateAndAddressModificationSupported,
-            billingDetails = billingDetails,
             addressCollectionMode = addressCollectionMode,
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/ExpiryDateStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/ExpiryDateStateTest.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentsheet.ui
 
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import org.junit.Test
 
@@ -139,11 +138,12 @@ internal class ExpiryDateStateTest {
         assertThat(state.expiryYear).isEqualTo(2025)
     }
 
-    private fun createCard(expiryMonth: Int?, expiryYear: Int?): PaymentMethod.Card {
-        return PaymentMethodFixtures.CARD_WITH_NETWORKS.copy(
+    private fun createCard(expiryMonth: Int?, expiryYear: Int?): EditCardPayload {
+        val card = PaymentMethodFixtures.CARD_WITH_NETWORKS.copy(
             expiryMonth = expiryMonth,
             expiryYear = expiryYear
         )
+        return EditCardPayload.create(card, null)
     }
 }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeEditCardDetailsInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeEditCardDetailsInteractor.kt
@@ -2,28 +2,27 @@ package com.stripe.android.paymentsheet.ui
 
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.model.CardBrand
-import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.ViewActionRecorder
 import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.flow.StateFlow
 
 internal class FakeEditCardDetailsInteractor(
-    private val card: PaymentMethod.Card = PaymentMethodFixtures.CARD_WITH_NETWORKS,
+    private val payload: EditCardPayload = EditCardPayload.create(PaymentMethodFixtures.CARD_WITH_NETWORKS, null),
     private val shouldShowCardBrandDropdown: Boolean = true,
     private val expiryDateEditEnabled: Boolean = true,
     override val state: StateFlow<EditCardDetailsInteractor.State> = stateFlowOf(
         EditCardDetailsInteractor.State(
-            card = card,
-            selectedCardBrand = card.getPreferredChoice(DefaultCardBrandFilter),
-            paymentMethodIcon = card.getSavedPaymentMethodIcon(forVerticalMode = true),
+            payload = payload,
+            selectedCardBrand = payload.getPreferredChoice(DefaultCardBrandFilter),
+            paymentMethodIcon = payload.getSavedPaymentMethodIcon(forVerticalMode = true),
             shouldShowCardBrandDropdown = shouldShowCardBrandDropdown,
             availableNetworks = listOf(
                 CardBrandChoice(CardBrand.CartesBancaires, enabled = true),
                 CardBrandChoice(CardBrand.Visa, enabled = true),
             ),
             expiryDateState = ExpiryDateState.create(
-                card = card,
+                editPayload = payload,
                 enabled = expiryDateEditEnabled,
             ),
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeEditCardDetailsInteractorFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeEditCardDetailsInteractorFactory.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentsheet.ui
 
 import com.stripe.android.CardBrandFilter
-import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet
 import kotlinx.coroutines.CoroutineScope
 
@@ -14,15 +13,14 @@ internal class FakeEditCardDetailsInteractorFactory : EditCardDetailsInteractor.
         isModifiable: Boolean,
         areExpiryDateAndAddressModificationSupported: Boolean,
         cardBrandFilter: CardBrandFilter,
-        card: PaymentMethod.Card,
-        billingDetails: PaymentMethod.BillingDetails?,
+        payload: EditCardPayload,
         addressCollectionMode: PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode,
         onBrandChoiceChanged: CardBrandCallback,
         onCardUpdateParamsChanged: CardUpdateParamsCallback
     ): EditCardDetailsInteractor {
         this.onCardUpdateParamsChanged = onCardUpdateParamsChanged
         return FakeEditCardDetailsInteractor(
-            card = card,
+            payload = payload,
             shouldShowCardBrandDropdown = isModifiable,
             expiryDateEditEnabled = areExpiryDateAndAddressModificationSupported,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeUpdatePaymentMethodInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeUpdatePaymentMethodInteractor.kt
@@ -46,11 +46,13 @@ internal class FakeUpdatePaymentMethodInteractor(
             coroutineScope = TestScope(),
             isCbcModifiable = isModifiable && displayableSavedPaymentMethod.canChangeCbc(),
             cardBrandFilter = cardBrandFilter,
-            card = displayableSavedPaymentMethod.paymentMethod.card!!,
+            payload = EditCardPayload.create(
+                card = displayableSavedPaymentMethod.paymentMethod.card!!,
+                billingDetails = PaymentMethodFixtures.BILLING_DETAILS,
+            ),
             onBrandChoiceChanged = {},
             onCardUpdateParamsChanged = {},
             areExpiryDateAndAddressModificationSupported = isModifiable && canUpdateFullPaymentMethodDetails,
-            billingDetails = PaymentMethodFixtures.BILLING_DETAILS,
             addressCollectionMode = addressCollectionMode,
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
@@ -22,7 +22,13 @@ internal object LinkTestUtils {
             brand = CardBrand.DinersClub,
             cvcCheck = CvcCheck.Fail,
             isDefault = false,
+            networks = emptyList(),
             billingAddress = ConsumerPaymentDetails.BillingAddress(
+                name = null,
+                line1 = null,
+                line2 = null,
+                locality = null,
+                administrativeArea = null,
                 countryCode = CountryCode.US,
                 postalCode = "42424"
             )
@@ -39,7 +45,13 @@ internal object LinkTestUtils {
             brand = CardBrand.DinersClub,
             cvcCheck = CvcCheck.Fail,
             isDefault = false,
+            networks = emptyList(),
             billingAddress = ConsumerPaymentDetails.BillingAddress(
+                name = null,
+                line1 = null,
+                line2 = null,
+                locality = null,
+                administrativeArea = null,
                 countryCode = CountryCode.US,
                 postalCode = "42424"
             )

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeLinkConfigurationCoordinator.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeLinkConfigurationCoordinator.kt
@@ -33,7 +33,13 @@ internal class FakeLinkConfigurationCoordinator(
                 brand = CardBrand.DinersClub,
                 cvcCheck = CvcCheck.Fail,
                 isDefault = false,
+                networks = emptyList(),
                 billingAddress = ConsumerPaymentDetails.BillingAddress(
+                    name = null,
+                    line1 = null,
+                    line2 = null,
+                    locality = null,
+                    administrativeArea = null,
                     countryCode = CountryCode.US,
                     postalCode = "42424"
                 )

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberFormatter.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberFormatter.kt
@@ -15,8 +15,7 @@ import kotlin.math.min
  * characters. The resulting value should be shown in a TextField that uses [visualTransformation],
  * which will display it in the domestic format (e.g. "(555) 555-5555" for "US" locale).
  */
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-sealed class PhoneNumberFormatter {
+internal sealed class PhoneNumberFormatter {
     /**
      * Region prefix, like "+1" for US.
      */
@@ -496,4 +495,13 @@ sealed class PhoneNumberFormatter {
             "UZ" to Metadata(prefix = "+998", regionCode = "UZ", pattern = "## ### ## ##")
         )
     }
+}
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun convertPhoneNumberToE164(
+    nationalPhoneNumber: String,
+    countryCode: String,
+): String? {
+    val formatter = PhoneNumberFormatter.forCountry(countryCode)
+    return formatter.toE164Format(nationalPhoneNumber)
 }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberFormatter.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberFormatter.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.uicore.elements
 
+import androidx.annotation.RestrictTo
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.input.OffsetMapping
 import androidx.compose.ui.text.input.TransformedText
@@ -14,7 +15,8 @@ import kotlin.math.min
  * characters. The resulting value should be shown in a TextField that uses [visualTransformation],
  * which will display it in the domestic format (e.g. "(555) 555-5555" for "US" locale).
  */
-internal sealed class PhoneNumberFormatter {
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+sealed class PhoneNumberFormatter {
     /**
      * Region prefix, like "+1" for US.
      */


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request prepares the card editing functionality for use in the Link UI.

Instead of relying on `PaymentMethod.Card`, we introduce a new `EditCardPayload` that contains all the relevant information. This data class can be created from both `PaymentMethod.Card` and `ConsumerPaymentDetails.Card`.

I'm also adding new fields to `ConsumerPaymentDetails.Card`, so that all fields in `EditCardPayload` can be properly populated.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Reuse the card editing functionality in the Link UI.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
