### PR TITLE
Move canUpdatePaymentMethod permission to Customer Session

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerPermissions.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerPermissions.kt
@@ -3,5 +3,5 @@ package com.stripe.android.customersheet
 internal data class CustomerPermissions(
     val canRemovePaymentMethods: Boolean,
     val canRemoveLastPaymentMethod: Boolean,
-    val canUpdatePaymentMethod: Boolean
+    val canUpdateFullPaymentMethodDetails: Boolean
 )

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerPermissions.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerPermissions.kt
@@ -3,4 +3,5 @@ package com.stripe.android.customersheet
 internal data class CustomerPermissions(
     val canRemovePaymentMethods: Boolean,
     val canRemoveLastPaymentMethod: Boolean,
+    val canUpdatePaymentMethod: Boolean
 )

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -19,7 +19,6 @@ import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.orEmpty
 import com.stripe.android.core.strings.resolvableString
-import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.core.utils.requireApplication
 import com.stripe.android.customersheet.analytics.CustomerSheetEventReporter
 import com.stripe.android.customersheet.data.CustomerSheetDataResult

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -179,7 +179,7 @@ internal class CustomerSheetViewModel(
             permissions = CustomerPermissions(
                 canRemovePaymentMethods = false,
                 canRemoveLastPaymentMethod = false,
-                canUpdatePaymentMethod = false,
+                canUpdateFullPaymentMethodDetails = false,
             ),
             metadata = null,
         )
@@ -556,7 +556,7 @@ internal class CustomerSheetViewModel(
                 updatePaymentMethodInteractor = DefaultUpdatePaymentMethodInteractor(
                     isLiveMode = isLiveModeProvider(),
                     canRemove = customerState.canRemove,
-                    allowCardEdit = customerState.canUpdatePaymentMethod,
+                    allowFullCardDetailsEdit = customerState.canUpdateFullPaymentMethodDetails,
                     displayableSavedPaymentMethod = paymentMethod,
                     addressCollectionMode = configuration.billingDetailsCollectionConfiguration.address,
                     cardBrandFilter = PaymentSheetCardBrandFilter(customerState.configuration.cardBrandAcceptance),
@@ -1266,12 +1266,12 @@ internal class CustomerSheetViewModel(
             else -> permissions.canRemovePaymentMethods
         }
 
-        val canUpdatePaymentMethod = permissions.canUpdatePaymentMethod
+        val canUpdateFullPaymentMethodDetails = permissions.canUpdateFullPaymentMethodDetails
 
         val cbcEligibility = metadata?.cbcEligibility ?: CardBrandChoiceEligibility.Ineligible
 
         val canEdit = canRemove || paymentMethods.any { method ->
-            isModifiable(method, cbcEligibility, canUpdatePaymentMethod)
+            isModifiable(method, cbcEligibility, canUpdateFullPaymentMethodDetails)
         }
 
         val canShowSavedPaymentMethods = paymentMethods.isNotEmpty() || shouldShowGooglePay(metadata)

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewState.kt
@@ -140,23 +140,12 @@ internal sealed class CustomerSheetViewState(
     }
 }
 
-internal fun canEdit(
-    allowsRemovalOfLastSavedPaymentMethod: Boolean,
-    savedPaymentMethods: List<PaymentMethod>,
+internal fun isModifiable(
+    paymentMethod: PaymentMethod,
     cbcEligibility: CardBrandChoiceEligibility,
+    canUpdatePaymentMethod: Boolean
 ): Boolean {
-    return if (allowsRemovalOfLastSavedPaymentMethod) {
-        savedPaymentMethods.isNotEmpty()
-    } else {
-        if (savedPaymentMethods.size == 1) {
-            isModifiable(savedPaymentMethods.first(), cbcEligibility)
-        } else {
-            savedPaymentMethods.size > 1
-        }
-    }
-}
-
-internal fun isModifiable(paymentMethod: PaymentMethod, cbcEligibility: CardBrandChoiceEligibility): Boolean {
+    if (canUpdatePaymentMethod && paymentMethod.card != null) return true
     val hasMultipleNetworks = paymentMethod.card?.networks?.available?.let { available ->
         available.size > 1
     } ?: false

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewState.kt
@@ -143,9 +143,9 @@ internal sealed class CustomerSheetViewState(
 internal fun isModifiable(
     paymentMethod: PaymentMethod,
     cbcEligibility: CardBrandChoiceEligibility,
-    canUpdatePaymentMethod: Boolean
+    canUpdateFullPaymentMethodDetails: Boolean
 ): Boolean {
-    if (canUpdatePaymentMethod && paymentMethod.card != null) return true
+    if (canUpdateFullPaymentMethodDetails && paymentMethod.card != null) return true
     val hasMultipleNetworks = paymentMethod.card?.networks?.available?.let { available ->
         available.size > 1
     } ?: false

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerAdapterDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerAdapterDataSource.kt
@@ -3,7 +3,6 @@ package com.stripe.android.customersheet.data
 import com.stripe.android.common.coroutines.runCatching
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.IOContext
-import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.customersheet.CustomerAdapter
 import com.stripe.android.customersheet.CustomerAdapter.PaymentOption.Companion.toPaymentOption
 import com.stripe.android.customersheet.CustomerPermissions

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerAdapterDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerAdapterDataSource.kt
@@ -3,6 +3,7 @@ package com.stripe.android.customersheet.data
 import com.stripe.android.common.coroutines.runCatching
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.IOContext
+import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.customersheet.CustomerAdapter
 import com.stripe.android.customersheet.CustomerAdapter.PaymentOption.Companion.toPaymentOption
 import com.stripe.android.customersheet.CustomerPermissions
@@ -65,6 +66,8 @@ internal class CustomerAdapterDataSource @Inject constructor(
                     canRemoveLastPaymentMethod = configuration.allowsRemovalOfLastSavedPaymentMethod,
                     // Always `true` for `Adapter` use case
                     canRemovePaymentMethods = true,
+                    // Payment Method Update is customer sessions-only feature, so this value is unused.
+                    canUpdatePaymentMethod = false,
                 ),
                 // Default payment methods are a customer sessions-only feature, so this value is unused.
                 defaultPaymentMethodId = null,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerAdapterDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerAdapterDataSource.kt
@@ -66,7 +66,7 @@ internal class CustomerAdapterDataSource @Inject constructor(
                     // Always `true` for `Adapter` use case
                     canRemovePaymentMethods = true,
                     // Payment Method Update is customer sessions-only feature, so this value is unused.
-                    canUpdatePaymentMethod = false,
+                    canUpdateFullPaymentMethodDetails = false,
                 ),
                 // Default payment methods are a customer sessions-only feature, so this value is unused.
                 defaultPaymentMethodId = null,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionInitializationDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionInitializationDataSource.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.customersheet.data
 
 import com.stripe.android.core.injection.IOContext
+import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.customersheet.CustomerPermissions
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
@@ -56,7 +57,8 @@ internal class CustomerSessionInitializationDataSource @Inject constructor(
                             is ElementsSession.Customer.Components.CustomerSheet.Enabled ->
                                 component.isPaymentMethodRemoveEnabled
                             is ElementsSession.Customer.Components.CustomerSheet.Disabled -> false
-                        }
+                        },
+                        canUpdatePaymentMethod = FeatureFlags.editSavedCardPaymentMethodEnabled.isEnabled
                     ),
                     defaultPaymentMethodId = customer.defaultPaymentMethod,
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionInitializationDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionInitializationDataSource.kt
@@ -58,7 +58,7 @@ internal class CustomerSessionInitializationDataSource @Inject constructor(
                                 component.isPaymentMethodRemoveEnabled
                             is ElementsSession.Customer.Components.CustomerSheet.Disabled -> false
                         },
-                        canUpdatePaymentMethod = FeatureFlags.editSavedCardPaymentMethodEnabled.isEnabled
+                        canUpdateFullPaymentMethodDetails = FeatureFlags.editSavedCardPaymentMethodEnabled.isEnabled
                     ),
                     defaultPaymentMethodId = customer.defaultPaymentMethod,
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
@@ -32,7 +32,7 @@ internal class DefaultEmbeddedUpdateScreenInteractorFactory @Inject constructor(
         return DefaultUpdatePaymentMethodInteractor(
             isLiveMode = paymentMethodMetadata.stripeIntent.isLiveMode,
             canRemove = customerStateHolder.canRemove.value,
-            allowCardEdit = customerStateHolder.updatePaymentMethodEnabled,
+            allowFullCardDetailsEdit = customerStateHolder.updatePaymentMethodEnabled,
             displayableSavedPaymentMethod = displayableSavedPaymentMethod,
             cardBrandFilter = paymentMethodMetadata.cardBrandFilter,
             addressCollectionMode = paymentMethodMetadata.billingDetailsCollectionConfiguration.address,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
@@ -32,6 +32,7 @@ internal class DefaultEmbeddedUpdateScreenInteractorFactory @Inject constructor(
         return DefaultUpdatePaymentMethodInteractor(
             isLiveMode = paymentMethodMetadata.stripeIntent.isLiveMode,
             canRemove = customerStateHolder.canRemove.value,
+            allowCardEdit = customerStateHolder.updatePaymentMethodEnabled,
             displayableSavedPaymentMethod = displayableSavedPaymentMethod,
             cardBrandFilter = paymentMethodMetadata.cardBrandFilter,
             addressCollectionMode = paymentMethodMetadata.billingDetailsCollectionConfiguration.address,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/CustomerStateHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/CustomerStateHolder.kt
@@ -42,6 +42,11 @@ internal class CustomerStateHolder(
         } ?: false
     }
 
+    val updatePaymentMethodEnabled: Boolean
+        get() {
+            return customer.value?.permissions?.canUpdatePaymentMethod ?: false
+        }
+
     fun setCustomerState(customerState: CustomerState?) {
         savedStateHandle[SAVED_CUSTOMER] = customerState
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/CustomerStateHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/CustomerStateHolder.kt
@@ -44,7 +44,7 @@ internal class CustomerStateHolder(
 
     val updatePaymentMethodEnabled: Boolean
         get() {
-            return customer.value?.permissions?.canUpdatePaymentMethod ?: false
+            return customer.value?.permissions?.canUpdateFullPaymentMethodDetails ?: false
         }
 
     fun setCustomerState(customerState: CustomerState?) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -372,7 +372,8 @@ internal class SavedPaymentMethodMutator(
                         DefaultUpdatePaymentMethodInteractor(
                             isLiveMode = isLiveMode,
                             canRemove = canRemove,
-                            displayableSavedPaymentMethod,
+                            allowCardEdit = viewModel.customerStateHolder.updatePaymentMethodEnabled,
+                            displayableSavedPaymentMethod = displayableSavedPaymentMethod,
                             cardBrandFilter = PaymentSheetCardBrandFilter(viewModel.config.cardBrandAcceptance),
                             addressCollectionMode = viewModel.config.asCommonConfiguration()
                                 .billingDetailsCollectionConfiguration.address,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -372,7 +372,7 @@ internal class SavedPaymentMethodMutator(
                         DefaultUpdatePaymentMethodInteractor(
                             isLiveMode = isLiveMode,
                             canRemove = canRemove,
-                            allowCardEdit = viewModel.customerStateHolder.updatePaymentMethodEnabled,
+                            allowFullCardDetailsEdit = viewModel.customerStateHolder.updatePaymentMethodEnabled,
                             displayableSavedPaymentMethod = displayableSavedPaymentMethod,
                             cardBrandFilter = PaymentSheetCardBrandFilter(viewModel.config.cardBrandAcceptance),
                             addressCollectionMode = viewModel.config.asCommonConfiguration()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CustomerState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CustomerState.kt
@@ -22,7 +22,7 @@ internal data class CustomerState(
         val canRemovePaymentMethods: Boolean,
         val canRemoveLastPaymentMethod: Boolean,
         val canRemoveDuplicates: Boolean,
-        val canUpdatePaymentMethod: Boolean,
+        val canUpdateFullPaymentMethodDetails: Boolean,
     ) : Parcelable
 
     @Parcelize
@@ -76,7 +76,7 @@ internal data class CustomerState(
                     canRemoveLastPaymentMethod = canRemoveLastPaymentMethod,
                     // Should always remove duplicates when using `customer_session`
                     canRemoveDuplicates = true,
-                    canUpdatePaymentMethod = FeatureFlags.editSavedCardPaymentMethodEnabled.isEnabled,
+                    canUpdateFullPaymentMethodDetails = FeatureFlags.editSavedCardPaymentMethodEnabled.isEnabled,
                 ),
                 defaultPaymentMethodId = customer.defaultPaymentMethod
             )
@@ -124,7 +124,7 @@ internal data class CustomerState(
                      * Un-scoped legacy ephemeral keys do not have permissions to update payment method. This should
                      * always be set to false.
                      */
-                    canUpdatePaymentMethod = false,
+                    canUpdateFullPaymentMethodDetails = false,
                 ),
                 // This is a customer sessions only feature, so will always be null when using a legacy ephemeral key.
                 defaultPaymentMethodId = null

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CustomerState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CustomerState.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.state
 
 import android.os.Parcelable
 import com.stripe.android.common.model.CommonConfiguration
+import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -21,6 +22,7 @@ internal data class CustomerState(
         val canRemovePaymentMethods: Boolean,
         val canRemoveLastPaymentMethod: Boolean,
         val canRemoveDuplicates: Boolean,
+        val canUpdatePaymentMethod: Boolean,
     ) : Parcelable
 
     @Parcelize
@@ -74,6 +76,7 @@ internal data class CustomerState(
                     canRemoveLastPaymentMethod = canRemoveLastPaymentMethod,
                     // Should always remove duplicates when using `customer_session`
                     canRemoveDuplicates = true,
+                    canUpdatePaymentMethod = FeatureFlags.editSavedCardPaymentMethodEnabled.isEnabled,
                 ),
                 defaultPaymentMethodId = customer.defaultPaymentMethod
             )
@@ -101,7 +104,7 @@ internal data class CustomerState(
                 paymentMethods = paymentMethods,
                 permissions = Permissions(
                     /*
-                     * Un-scoped legacy ephemeral keys have full permissions to remove/save/modify. This should
+                     * Un-scoped legacy ephemeral keys have full permissions to remove/save. This should
                      * always be set to true.
                      */
                     canRemovePaymentMethods = true,
@@ -117,6 +120,11 @@ internal data class CustomerState(
                      * un-scoped ephemeral keys.
                      */
                     canRemoveDuplicates = false,
+                    /*
+                     * Un-scoped legacy ephemeral keys do not have permissions to update payment method. This should
+                     * always be set to false.
+                     */
+                    canUpdatePaymentMethod = false,
                 ),
                 // This is a customer sessions only feature, so will always be null when using a legacy ephemeral key.
                 defaultPaymentMethodId = null

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
@@ -35,7 +35,7 @@ internal interface UpdatePaymentMethodInteractor {
     val shouldShowSetAsDefaultCheckbox: Boolean
     val setAsDefaultCheckboxEnabled: Boolean
     val shouldShowSaveButton: Boolean
-    val allowCardEdit: Boolean
+    val allowFullCardDetailsEdit: Boolean
     val addressCollectionMode: AddressCollectionMode
     val editCardDetailsInteractor: EditCardDetailsInteractor
 
@@ -93,7 +93,7 @@ internal class DefaultUpdatePaymentMethodInteractor(
     override val displayableSavedPaymentMethod: DisplayableSavedPaymentMethod,
     override val cardBrandFilter: CardBrandFilter,
     override val addressCollectionMode: AddressCollectionMode,
-    override val allowCardEdit: Boolean,
+    override val allowFullCardDetailsEdit: Boolean,
     val isDefaultPaymentMethod: Boolean,
     shouldShowSetAsDefaultCheckbox: Boolean,
     private val removeExecutor: PaymentMethodRemoveOperation,
@@ -154,7 +154,7 @@ internal class DefaultUpdatePaymentMethodInteractor(
             isModifiable = displayableSavedPaymentMethod.isModifiable(),
             cardBrandFilter = cardBrandFilter,
             onBrandChoiceChanged = onBrandChoiceSelected,
-            areExpiryDateAndAddressModificationSupported = allowCardEdit,
+            areExpiryDateAndAddressModificationSupported = allowFullCardDetailsEdit,
             billingDetails = savedPaymentMethodCard.billingDetails,
             addressCollectionMode = addressCollectionMode,
         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
@@ -5,7 +5,6 @@ import com.stripe.android.CardBrandFilter
 import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
-import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.CardUpdateParams
@@ -94,6 +93,7 @@ internal class DefaultUpdatePaymentMethodInteractor(
     override val displayableSavedPaymentMethod: DisplayableSavedPaymentMethod,
     override val cardBrandFilter: CardBrandFilter,
     override val addressCollectionMode: AddressCollectionMode,
+    override val allowCardEdit: Boolean,
     val isDefaultPaymentMethod: Boolean,
     shouldShowSetAsDefaultCheckbox: Boolean,
     private val removeExecutor: PaymentMethodRemoveOperation,
@@ -134,7 +134,6 @@ internal class DefaultUpdatePaymentMethodInteractor(
 
     override val shouldShowSaveButton: Boolean = isModifiablePaymentMethod ||
         (shouldShowSetAsDefaultCheckbox && !isDefaultPaymentMethod)
-    override val allowCardEdit = FeatureFlags.editSavedCardPaymentMethodEnabled.isEnabled
 
     private val _setAsDefaultValueChanged = setAsDefaultCheckboxChecked.mapAsStateFlow { setAsDefaultCheckboxChecked ->
         setAsDefaultCheckboxChecked != initialSetAsDefaultCheckedValue

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
@@ -306,6 +306,7 @@ private fun PreviewUpdatePaymentMethodUI() {
         interactor = DefaultUpdatePaymentMethodInteractor(
             isLiveMode = false,
             canRemove = true,
+            allowCardEdit = true,
             displayableSavedPaymentMethod = exampleCard,
             addressCollectionMode = AddressCollectionMode.Automatic,
             removeExecutor = { null },

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
@@ -306,7 +306,7 @@ private fun PreviewUpdatePaymentMethodUI() {
         interactor = DefaultUpdatePaymentMethodInteractor(
             isLiveMode = false,
             canRemove = true,
-            allowCardEdit = true,
+            allowFullCardDetailsEdit = true,
             displayableSavedPaymentMethod = exampleCard,
             addressCollectionMode = AddressCollectionMode.Automatic,
             removeExecutor = { null },

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -353,6 +353,7 @@ internal class CustomerSheetScreenshotTest {
     ): CustomerSheetViewState {
         return CustomerSheetViewState.UpdatePaymentMethod(
             updatePaymentMethodInteractor = DefaultUpdatePaymentMethodInteractor(
+                allowCardEdit = false,
                 displayableSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
                 removeExecutor = { null },
                 updatePaymentMethodExecutor = { paymentMethod, _ -> Result.success(paymentMethod) },

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -353,7 +353,7 @@ internal class CustomerSheetScreenshotTest {
     ): CustomerSheetViewState {
         return CustomerSheetViewState.UpdatePaymentMethod(
             updatePaymentMethodInteractor = DefaultUpdatePaymentMethodInteractor(
-                allowCardEdit = false,
+                allowFullCardDetailsEdit = false,
                 displayableSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
                 removeExecutor = { null },
                 updatePaymentMethodExecutor = { paymentMethod, _ -> Result.success(paymentMethod) },

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -541,7 +541,7 @@ class CustomerSheetViewModelTest {
             customerPermissions = CustomerPermissions(
                 canRemovePaymentMethods = true,
                 canRemoveLastPaymentMethod = false,
-                canUpdatePaymentMethod = false,
+                canUpdateFullPaymentMethodDetails = false,
             )
         )
         viewModel.viewState.test {
@@ -574,14 +574,14 @@ class CustomerSheetViewModelTest {
     }
 
     @Test
-    fun `When canUpdatePaymentMethod=true, showEditMenu should be true`() = runTest(testDispatcher) {
+    fun `When canUpdateFullPaymentMethodDetails=true, showEditMenu should be true`() = runTest(testDispatcher) {
         val viewModel = createViewModel(
             workContext = testDispatcher,
             customerPaymentMethods = listOf(CARD_PAYMENT_METHOD),
             customerPermissions = CustomerPermissions(
                 canRemovePaymentMethods = false,
                 canRemoveLastPaymentMethod = false,
-                canUpdatePaymentMethod = true,
+                canUpdateFullPaymentMethodDetails = true,
             )
         )
         viewModel.viewState.test {
@@ -597,14 +597,14 @@ class CustomerSheetViewModelTest {
     }
 
     @Test
-    fun `When canUpdatePaymentMethod=false, showEditMenu should be false`() = runTest(testDispatcher) {
+    fun `When canUpdateFullPaymentMethodDetails=false, showEditMenu should be false`() = runTest(testDispatcher) {
         val viewModel = createViewModel(
             workContext = testDispatcher,
             customerPaymentMethods = listOf(CARD_PAYMENT_METHOD),
             customerPermissions = CustomerPermissions(
                 canRemovePaymentMethods = false,
                 canRemoveLastPaymentMethod = false,
-                canUpdatePaymentMethod = false,
+                canUpdateFullPaymentMethodDetails = false,
             )
         )
         viewModel.viewState.test {
@@ -619,7 +619,7 @@ class CustomerSheetViewModelTest {
     }
 
     @Test
-    fun `When canUpdatePaymentMethod=false, card is cbc eligible, showEditMenu should be true`() =
+    fun `When canUpdateFullPaymentMethodDetails=false, card is cbc eligible, showEditMenu should be true`() =
         runTest(testDispatcher) {
             val viewModel = createViewModel(
                 workContext = testDispatcher,
@@ -627,7 +627,7 @@ class CustomerSheetViewModelTest {
                 customerPermissions = CustomerPermissions(
                     canRemovePaymentMethods = false,
                     canRemoveLastPaymentMethod = false,
-                    canUpdatePaymentMethod = false,
+                    canUpdateFullPaymentMethodDetails = false,
                 ),
                 cbcEligibility = CardBrandChoiceEligibility.Eligible(
                     preferredNetworks = listOf(CardBrand.CartesBancaires)
@@ -3067,7 +3067,7 @@ class CustomerSheetViewModelTest {
                 permissions = CustomerPermissions(
                     canRemovePaymentMethods = true,
                     canRemoveLastPaymentMethod = false,
-                    canUpdatePaymentMethod = false,
+                    canUpdateFullPaymentMethodDetails = false,
                 )
             )
 
@@ -3253,7 +3253,7 @@ class CustomerSheetViewModelTest {
             customerPermissions = CustomerPermissions(
                 canRemovePaymentMethods = true,
                 canRemoveLastPaymentMethod = true,
-                canUpdatePaymentMethod = true,
+                canUpdateFullPaymentMethodDetails = true,
             ),
         )
 
@@ -3272,7 +3272,7 @@ class CustomerSheetViewModelTest {
             customerPermissions = CustomerPermissions(
                 canRemovePaymentMethods = false,
                 canRemoveLastPaymentMethod = false,
-                canUpdatePaymentMethod = false
+                canUpdateFullPaymentMethodDetails = false
             ),
         )
 
@@ -3295,7 +3295,7 @@ class CustomerSheetViewModelTest {
                 customerPermissions = CustomerPermissions(
                     canRemovePaymentMethods = false,
                     canRemoveLastPaymentMethod = false,
-                    canUpdatePaymentMethod = true,
+                    canUpdateFullPaymentMethodDetails = true,
                 ),
             )
 
@@ -3315,7 +3315,7 @@ class CustomerSheetViewModelTest {
                 customerPermissions = CustomerPermissions(
                     canRemovePaymentMethods = true,
                     canRemoveLastPaymentMethod = false,
-                    canUpdatePaymentMethod = false,
+                    canUpdateFullPaymentMethodDetails = false,
                 ),
             )
 
@@ -3338,7 +3338,7 @@ class CustomerSheetViewModelTest {
                 customerPermissions = CustomerPermissions(
                     canRemovePaymentMethods = true,
                     canRemoveLastPaymentMethod = false,
-                    canUpdatePaymentMethod = true,
+                    canUpdateFullPaymentMethodDetails = true,
                 ),
             )
 
@@ -3583,7 +3583,7 @@ class CustomerSheetViewModelTest {
         permissions: CustomerPermissions = CustomerPermissions(
             canRemovePaymentMethods = true,
             canRemoveLastPaymentMethod = true,
-            canUpdatePaymentMethod = true,
+            canUpdateFullPaymentMethodDetails = true,
         )
     ): CustomerSheetViewModel {
         return createViewModel(

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -541,6 +541,7 @@ class CustomerSheetViewModelTest {
             customerPermissions = CustomerPermissions(
                 canRemovePaymentMethods = true,
                 canRemoveLastPaymentMethod = false,
+                canUpdatePaymentMethod = false,
             )
         )
         viewModel.viewState.test {
@@ -571,6 +572,79 @@ class CustomerSheetViewModelTest {
             assertThat(viewState.topBarState {}.showEditMenu).isFalse()
         }
     }
+
+    @Test
+    fun `When canUpdatePaymentMethod=true, showEditMenu should be true`() = runTest(testDispatcher) {
+        val viewModel = createViewModel(
+            workContext = testDispatcher,
+            customerPaymentMethods = listOf(CARD_PAYMENT_METHOD),
+            customerPermissions = CustomerPermissions(
+                canRemovePaymentMethods = false,
+                canRemoveLastPaymentMethod = false,
+                canUpdatePaymentMethod = true,
+            )
+        )
+        viewModel.viewState.test {
+            var viewState = awaitViewState<SelectPaymentMethod>()
+            assertThat(viewState.topBarState {}.showEditMenu).isTrue()
+
+            viewModel.handleViewAction(CustomerSheetViewAction.OnEditPressed)
+
+            viewState = awaitViewState()
+            assertThat(viewState.isEditing).isTrue()
+            assertThat(viewState.topBarState {}.showEditMenu).isTrue()
+        }
+    }
+
+    @Test
+    fun `When canUpdatePaymentMethod=false, showEditMenu should be false`() = runTest(testDispatcher) {
+        val viewModel = createViewModel(
+            workContext = testDispatcher,
+            customerPaymentMethods = listOf(CARD_PAYMENT_METHOD),
+            customerPermissions = CustomerPermissions(
+                canRemovePaymentMethods = false,
+                canRemoveLastPaymentMethod = false,
+                canUpdatePaymentMethod = false,
+            )
+        )
+        viewModel.viewState.test {
+            val viewState = awaitViewState<SelectPaymentMethod>()
+            assertThat(viewState.isEditing).isFalse()
+            assertThat(viewState.topBarState {}.showEditMenu).isFalse()
+
+            viewModel.handleViewAction(CustomerSheetViewAction.OnEditPressed)
+
+            ensureAllEventsConsumed()
+        }
+    }
+
+    @Test
+    fun `When canUpdatePaymentMethod=false, card is cbc eligible, showEditMenu should be true`() =
+        runTest(testDispatcher) {
+            val viewModel = createViewModel(
+                workContext = testDispatcher,
+                customerPaymentMethods = listOf(CARD_WITH_NETWORKS_PAYMENT_METHOD),
+                customerPermissions = CustomerPermissions(
+                    canRemovePaymentMethods = false,
+                    canRemoveLastPaymentMethod = false,
+                    canUpdatePaymentMethod = false,
+                ),
+                cbcEligibility = CardBrandChoiceEligibility.Eligible(
+                    preferredNetworks = listOf(CardBrand.CartesBancaires)
+                ),
+            )
+            viewModel.viewState.test {
+                var viewState = awaitViewState<SelectPaymentMethod>()
+                assertThat(viewState.isEditing).isFalse()
+                assertThat(viewState.topBarState {}.showEditMenu).isTrue()
+
+                viewModel.handleViewAction(CustomerSheetViewAction.OnEditPressed)
+
+                viewState = awaitViewState()
+                assertThat(viewState.isEditing).isTrue()
+                assertThat(viewState.topBarState {}.showEditMenu).isTrue()
+            }
+        }
 
     @Test
     fun `When removing a payment method, payment method list should be updated`() = runTest(testDispatcher) {
@@ -2993,6 +3067,7 @@ class CustomerSheetViewModelTest {
                 permissions = CustomerPermissions(
                     canRemovePaymentMethods = true,
                     canRemoveLastPaymentMethod = false,
+                    canUpdatePaymentMethod = false,
                 )
             )
 
@@ -3178,6 +3253,7 @@ class CustomerSheetViewModelTest {
             customerPermissions = CustomerPermissions(
                 canRemovePaymentMethods = true,
                 canRemoveLastPaymentMethod = true,
+                canUpdatePaymentMethod = true,
             ),
         )
 
@@ -3196,6 +3272,7 @@ class CustomerSheetViewModelTest {
             customerPermissions = CustomerPermissions(
                 canRemovePaymentMethods = false,
                 canRemoveLastPaymentMethod = false,
+                canUpdatePaymentMethod = false
             ),
         )
 
@@ -3218,6 +3295,7 @@ class CustomerSheetViewModelTest {
                 customerPermissions = CustomerPermissions(
                     canRemovePaymentMethods = false,
                     canRemoveLastPaymentMethod = false,
+                    canUpdatePaymentMethod = true,
                 ),
             )
 
@@ -3237,6 +3315,7 @@ class CustomerSheetViewModelTest {
                 customerPermissions = CustomerPermissions(
                     canRemovePaymentMethods = true,
                     canRemoveLastPaymentMethod = false,
+                    canUpdatePaymentMethod = false,
                 ),
             )
 
@@ -3259,6 +3338,7 @@ class CustomerSheetViewModelTest {
                 customerPermissions = CustomerPermissions(
                     canRemovePaymentMethods = true,
                     canRemoveLastPaymentMethod = false,
+                    canUpdatePaymentMethod = true,
                 ),
             )
 
@@ -3503,6 +3583,7 @@ class CustomerSheetViewModelTest {
         permissions: CustomerPermissions = CustomerPermissions(
             canRemovePaymentMethods = true,
             canRemoveLastPaymentMethod = true,
+            canUpdatePaymentMethod = true,
         )
     ): CustomerSheetViewModel {
         return createViewModel(

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerAdapterDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerAdapterDataSourceTest.kt
@@ -532,7 +532,7 @@ class CustomerAdapterDataSourceTest {
         assertThat(customerSheetSession.paymentMethods).containsExactlyElementsIn(paymentMethods)
         assertThat(customerSheetSession.savedSelection).isEqualTo(SavedSelection.PaymentMethod(id = "pm_1"))
         assertThat(customerSheetSession.permissions.canRemovePaymentMethods).isTrue()
-        assertThat(customerSheetSession.permissions.canUpdatePaymentMethod).isFalse()
+        assertThat(customerSheetSession.permissions.canUpdateFullPaymentMethodDetails).isFalse()
         assertThat(customerSheetSession.paymentMethodSaveConsentBehavior).isEqualTo(
             PaymentMethodSaveConsentBehavior.Legacy
         )

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerAdapterDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerAdapterDataSourceTest.kt
@@ -23,7 +23,9 @@ import kotlinx.coroutines.test.runTest
 import kotlin.coroutines.coroutineContext
 import kotlin.test.Test
 
+@SuppressWarnings("LargeClass")
 class CustomerAdapterDataSourceTest {
+
     @Test
     fun `on retrieve payment methods, should complete successfully from adapter`() = runTest {
         val paymentMethods = PaymentMethodFactory.cards(size = 6)
@@ -530,6 +532,7 @@ class CustomerAdapterDataSourceTest {
         assertThat(customerSheetSession.paymentMethods).containsExactlyElementsIn(paymentMethods)
         assertThat(customerSheetSession.savedSelection).isEqualTo(SavedSelection.PaymentMethod(id = "pm_1"))
         assertThat(customerSheetSession.permissions.canRemovePaymentMethods).isTrue()
+        assertThat(customerSheetSession.permissions.canUpdatePaymentMethod).isFalse()
         assertThat(customerSheetSession.paymentMethodSaveConsentBehavior).isEqualTo(
             PaymentMethodSaveConsentBehavior.Legacy
         )

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionInitializationDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionInitializationDataSourceTest.kt
@@ -105,7 +105,7 @@ class CustomerSessionInitializationDataSourceTest {
     }
 
     @Test
-    fun `on load, canUpdatePaymentMethod should enabled when feature flag is enabled`() = runTest {
+    fun `on load, canUpdateFullPaymentMethodDetails should enabled when feature flag is enabled`() = runTest {
         editSavedCardPaymentMethodEnabledFeatureFlagTestRule.setEnabled(true)
         val dataSource = createInitializationDataSource(
             elementsSessionManager = FakeCustomerSessionElementsSessionManager(
@@ -116,11 +116,11 @@ class CustomerSessionInitializationDataSourceTest {
         val result = dataSource.loadCustomerSheetSession(createConfiguration())
         val customerSheetSession = result.asSuccess().value
 
-        assertThat(customerSheetSession.permissions.canUpdatePaymentMethod).isTrue()
+        assertThat(customerSheetSession.permissions.canUpdateFullPaymentMethodDetails).isTrue()
     }
 
     @Test
-    fun `on load, canUpdatePaymentMethod should enabled when feature flag is disabled`() = runTest {
+    fun `on load, canUpdateFullPaymentMethodDetails should enabled when feature flag is disabled`() = runTest {
         editSavedCardPaymentMethodEnabledFeatureFlagTestRule.setEnabled(false)
         val dataSource = createInitializationDataSource(
             elementsSessionManager = FakeCustomerSessionElementsSessionManager(
@@ -131,7 +131,7 @@ class CustomerSessionInitializationDataSourceTest {
         val result = dataSource.loadCustomerSheetSession(createConfiguration())
         val customerSheetSession = result.asSuccess().value
 
-        assertThat(customerSheetSession.permissions.canUpdatePaymentMethod).isFalse()
+        assertThat(customerSheetSession.permissions.canUpdateFullPaymentMethodDetails).isFalse()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionInitializationDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionInitializationDataSourceTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.customersheet.data
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ExperimentalAllowsRemovalOfLastSavedPaymentMethodApi
+import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.customersheet.CustomerSheetFixtures
 import com.stripe.android.isInstanceOf
@@ -9,13 +10,21 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentB
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.model.SavedSelection
+import com.stripe.android.testing.FeatureFlagTestRule
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.testing.SetupIntentFactory
 import kotlinx.coroutines.test.runTest
+import org.junit.Rule
 import org.junit.Test
 import kotlin.coroutines.coroutineContext
 
 class CustomerSessionInitializationDataSourceTest {
+    @get:Rule
+    val editSavedCardPaymentMethodEnabledFeatureFlagTestRule = FeatureFlagTestRule(
+        featureFlag = FeatureFlags.editSavedCardPaymentMethodEnabled,
+        isEnabled = false
+    )
+
     @Test
     fun `on load, should return expected successful state`() = runTest {
         val paymentMethods = PaymentMethodFactory.cards(size = 6)
@@ -93,6 +102,36 @@ class CustomerSessionInitializationDataSourceTest {
         val customerSheetSession = result.asSuccess().value
 
         assertThat(customerSheetSession.permissions.canRemovePaymentMethods).isFalse()
+    }
+
+    @Test
+    fun `on load, canUpdatePaymentMethod should enabled when feature flag is enabled`() = runTest {
+        editSavedCardPaymentMethodEnabledFeatureFlagTestRule.setEnabled(true)
+        val dataSource = createInitializationDataSource(
+            elementsSessionManager = FakeCustomerSessionElementsSessionManager(
+                customerSheetComponent = ElementsSession.Customer.Components.CustomerSheet.Disabled,
+            ),
+        )
+
+        val result = dataSource.loadCustomerSheetSession(createConfiguration())
+        val customerSheetSession = result.asSuccess().value
+
+        assertThat(customerSheetSession.permissions.canUpdatePaymentMethod).isTrue()
+    }
+
+    @Test
+    fun `on load, canUpdatePaymentMethod should enabled when feature flag is disabled`() = runTest {
+        editSavedCardPaymentMethodEnabledFeatureFlagTestRule.setEnabled(false)
+        val dataSource = createInitializationDataSource(
+            elementsSessionManager = FakeCustomerSessionElementsSessionManager(
+                customerSheetComponent = ElementsSession.Customer.Components.CustomerSheet.Disabled,
+            ),
+        )
+
+        val result = dataSource.loadCustomerSheetSession(createConfiguration())
+        val customerSheetSession = result.asSuccess().value
+
+        assertThat(customerSheetSession.permissions.canUpdatePaymentMethod).isFalse()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -540,6 +540,7 @@ class DefaultCustomerSheetLoaderTest {
                         permissions = CustomerPermissions(
                             canRemovePaymentMethods = true,
                             canRemoveLastPaymentMethod = true,
+                            canUpdatePaymentMethod = true,
                         ),
                         defaultPaymentMethodId = defaultPaymentMethodId,
                     )

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -540,7 +540,7 @@ class DefaultCustomerSheetLoaderTest {
                         permissions = CustomerPermissions(
                             canRemovePaymentMethods = true,
                             canRemoveLastPaymentMethod = true,
-                            canUpdatePaymentMethod = true,
+                            canUpdateFullPaymentMethodDetails = true,
                         ),
                         defaultPaymentMethodId = defaultPaymentMethodId,
                     )

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -63,6 +63,7 @@ internal object CustomerSheetTestHelper {
         customerPermissions: CustomerPermissions = CustomerPermissions(
             canRemovePaymentMethods = true,
             canRemoveLastPaymentMethod = true,
+            canUpdatePaymentMethod = true,
         ),
         cbcEligibility: CardBrandChoiceEligibility = CardBrandChoiceEligibility.Ineligible,
         supportedPaymentMethods: List<SupportedPaymentMethod> = listOf(

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -63,7 +63,7 @@ internal object CustomerSheetTestHelper {
         customerPermissions: CustomerPermissions = CustomerPermissions(
             canRemovePaymentMethods = true,
             canRemoveLastPaymentMethod = true,
-            canUpdatePaymentMethod = true,
+            canUpdateFullPaymentMethodDetails = true,
         ),
         cbcEligibility: CardBrandChoiceEligibility = CardBrandChoiceEligibility.Ineligible,
         supportedPaymentMethods: List<SupportedPaymentMethod> = listOf(

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/FakeCustomerSheetLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/FakeCustomerSheetLoader.kt
@@ -33,7 +33,7 @@ internal class FakeCustomerSheetLoader(
     private val permissions: CustomerPermissions = CustomerPermissions(
         canRemovePaymentMethods = true,
         canRemoveLastPaymentMethod = true,
-        canUpdatePaymentMethod = true,
+        canUpdateFullPaymentMethodDetails = true,
     ),
     private val isPaymentMethodSyncDefaultEnabled: Boolean = false,
 ) : CustomerSheetLoader {

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/FakeCustomerSheetLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/FakeCustomerSheetLoader.kt
@@ -33,6 +33,7 @@ internal class FakeCustomerSheetLoader(
     private val permissions: CustomerPermissions = CustomerPermissions(
         canRemovePaymentMethods = true,
         canRemoveLastPaymentMethod = true,
+        canUpdatePaymentMethod = true,
     ),
     private val isPaymentMethodSyncDefaultEnabled: Boolean = false,
 ) : CustomerSheetLoader {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/CustomerState.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/CustomerState.kt
@@ -7,7 +7,7 @@ internal fun createCustomerState(
     paymentMethods: List<PaymentMethod>,
     isRemoveEnabled: Boolean = true,
     canRemoveLastPaymentMethod: Boolean = true,
-    canUpdatePaymentMethod: Boolean = true,
+    canUpdateFullPaymentMethodDetails: Boolean = true,
     defaultPaymentMethodId: String? = null,
 ): CustomerState {
     return CustomerState(
@@ -19,7 +19,7 @@ internal fun createCustomerState(
             canRemovePaymentMethods = isRemoveEnabled,
             canRemoveDuplicates = true,
             canRemoveLastPaymentMethod = canRemoveLastPaymentMethod,
-            canUpdatePaymentMethod = canUpdatePaymentMethod,
+            canUpdateFullPaymentMethodDetails = canUpdateFullPaymentMethodDetails,
         ),
         defaultPaymentMethodId = defaultPaymentMethodId,
     )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/CustomerState.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/CustomerState.kt
@@ -7,6 +7,7 @@ internal fun createCustomerState(
     paymentMethods: List<PaymentMethod>,
     isRemoveEnabled: Boolean = true,
     canRemoveLastPaymentMethod: Boolean = true,
+    canUpdatePaymentMethod: Boolean = true,
     defaultPaymentMethodId: String? = null,
 ): CustomerState {
     return CustomerState(
@@ -18,6 +19,7 @@ internal fun createCustomerState(
             canRemovePaymentMethods = isRemoveEnabled,
             canRemoveDuplicates = true,
             canRemoveLastPaymentMethod = canRemoveLastPaymentMethod,
+            canUpdatePaymentMethod = canUpdatePaymentMethod,
         ),
         defaultPaymentMethodId = defaultPaymentMethodId,
     )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
@@ -112,6 +112,7 @@ internal object PaymentSheetFixtures {
             canRemovePaymentMethods = true,
             canRemoveLastPaymentMethod = true,
             canRemoveDuplicates = false,
+            canUpdatePaymentMethod = false,
         ),
         defaultPaymentMethodId = null,
     )
@@ -193,6 +194,7 @@ internal object PaymentSheetFixtures {
                         canRemovePaymentMethods = true,
                         canRemoveLastPaymentMethod = true,
                         canRemoveDuplicates = false,
+                        canUpdatePaymentMethod = true
                     ),
                     defaultPaymentMethodId = null,
                 ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
@@ -112,7 +112,7 @@ internal object PaymentSheetFixtures {
             canRemovePaymentMethods = true,
             canRemoveLastPaymentMethod = true,
             canRemoveDuplicates = false,
-            canUpdatePaymentMethod = false,
+            canUpdateFullPaymentMethodDetails = false,
         ),
         defaultPaymentMethodId = null,
     )
@@ -194,7 +194,7 @@ internal object PaymentSheetFixtures {
                         canRemovePaymentMethods = true,
                         canRemoveLastPaymentMethod = true,
                         canRemoveDuplicates = false,
-                        canUpdatePaymentMethod = true
+                        canUpdateFullPaymentMethodDetails = true
                     ),
                     defaultPaymentMethodId = null,
                 ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -269,7 +269,7 @@ internal class PaymentSheetViewModelTest {
                     canRemovePaymentMethods = true,
                     canRemoveLastPaymentMethod = true,
                     canRemoveDuplicates = false,
-                    canUpdatePaymentMethod = true
+                    canUpdateFullPaymentMethodDetails = true
                 ),
                 defaultPaymentMethodId = null,
             ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -269,6 +269,7 @@ internal class PaymentSheetViewModelTest {
                     canRemovePaymentMethods = true,
                     canRemoveLastPaymentMethod = true,
                     canRemoveDuplicates = false,
+                    canUpdatePaymentMethod = true
                 ),
                 defaultPaymentMethodId = null,
             ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
@@ -769,7 +769,7 @@ class SavedPaymentMethodMutatorTest {
                         canRemovePaymentMethods = true,
                         canRemoveLastPaymentMethod = true,
                         canRemoveDuplicates = shouldRemoveDuplicates,
-                        canUpdatePaymentMethod = true
+                        canUpdateFullPaymentMethodDetails = true
                     ),
                     defaultPaymentMethodId = null,
                 )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
@@ -769,6 +769,7 @@ class SavedPaymentMethodMutatorTest {
                         canRemovePaymentMethods = true,
                         canRemoveLastPaymentMethod = true,
                         canRemoveDuplicates = shouldRemoveDuplicates,
+                        canUpdatePaymentMethod = true
                     ),
                     defaultPaymentMethodId = null,
                 )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -146,7 +146,7 @@ internal class DefaultPaymentElementLoaderTest {
                         canRemovePaymentMethods = true,
                         canRemoveLastPaymentMethod = true,
                         canRemoveDuplicates = false,
-                        canUpdatePaymentMethod = false
+                        canUpdateFullPaymentMethodDetails = false
                     ),
                     defaultPaymentMethodId = null,
                 ),
@@ -1609,7 +1609,7 @@ internal class DefaultPaymentElementLoaderTest {
                     canRemovePaymentMethods = true,
                     canRemoveLastPaymentMethod = true,
                     canRemoveDuplicates = true,
-                    canUpdatePaymentMethod = false
+                    canUpdateFullPaymentMethodDetails = false
                 )
             )
         }
@@ -1652,7 +1652,7 @@ internal class DefaultPaymentElementLoaderTest {
                     canRemovePaymentMethods = false,
                     canRemoveLastPaymentMethod = true,
                     canRemoveDuplicates = true,
-                    canUpdatePaymentMethod = false
+                    canUpdateFullPaymentMethodDetails = false
                 )
             )
         }
@@ -1695,14 +1695,14 @@ internal class DefaultPaymentElementLoaderTest {
                     canRemovePaymentMethods = false,
                     canRemoveLastPaymentMethod = true,
                     canRemoveDuplicates = true,
-                    canUpdatePaymentMethod = false
+                    canUpdateFullPaymentMethodDetails = false
                 )
             )
         }
 
     @OptIn(ExperimentalCustomerSessionApi::class)
     @Test
-    fun `customer session with edit saved payment method enabled, should enable canUpdatePaymentMethod permission`() =
+    fun `customer session with edit saved payment method enabled, should enable canUpdateFullPaymentMethodDetails permission`() =
         runTest {
             editSavedCardPaymentMethodEnabledFeatureFlagTestRule.setEnabled(true)
             val loader = createPaymentElementLoader(
@@ -1739,7 +1739,7 @@ internal class DefaultPaymentElementLoaderTest {
                     canRemovePaymentMethods = false,
                     canRemoveLastPaymentMethod = true,
                     canRemoveDuplicates = true,
-                    canUpdatePaymentMethod = true
+                    canUpdateFullPaymentMethodDetails = true
                 )
             )
         }
@@ -1768,7 +1768,7 @@ internal class DefaultPaymentElementLoaderTest {
                     canRemovePaymentMethods = true,
                     canRemoveLastPaymentMethod = true,
                     canRemoveDuplicates = false,
-                    canUpdatePaymentMethod = false
+                    canUpdateFullPaymentMethodDetails = false
                 )
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultUpdatePaymentMethodInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultUpdatePaymentMethodInteractorTest.kt
@@ -633,7 +633,7 @@ class DefaultUpdatePaymentMethodInteractorTest {
         val interactor = DefaultUpdatePaymentMethodInteractor(
             isLiveMode = isLiveMode,
             canRemove = canRemove,
-            allowCardEdit = editSavedCardPaymentMethodEnabled,
+            allowFullCardDetailsEdit = editSavedCardPaymentMethodEnabled,
             displayableSavedPaymentMethod = displayableSavedPaymentMethod,
             addressCollectionMode = AddressCollectionMode.Automatic,
             removeExecutor = onRemovePaymentMethod,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultUpdatePaymentMethodInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultUpdatePaymentMethodInteractorTest.kt
@@ -4,7 +4,6 @@ import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.common.exception.stripeErrorMessage
-import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
@@ -16,7 +15,6 @@ import com.stripe.android.paymentsheet.ui.DefaultUpdatePaymentMethodInteractor.C
 import com.stripe.android.paymentsheet.ui.DefaultUpdatePaymentMethodInteractor.Companion.updateCardBrandErrorMessage
 import com.stripe.android.paymentsheet.ui.DefaultUpdatePaymentMethodInteractor.Companion.updatesFailedErrorMessage
 import com.stripe.android.testing.CoroutineTestRule
-import com.stripe.android.testing.FeatureFlagTestRule
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertThrows
@@ -25,12 +23,6 @@ import org.junit.Test
 
 @Suppress("LargeClass")
 class DefaultUpdatePaymentMethodInteractorTest {
-
-    @get:Rule
-    val editSavedCardPaymentMethodEnabledFeatureFlagTestRule = FeatureFlagTestRule(
-        featureFlag = FeatureFlags.editSavedCardPaymentMethodEnabled,
-        isEnabled = false
-    )
 
     private val testDispatcher = UnconfinedTestDispatcher()
 
@@ -638,10 +630,10 @@ class DefaultUpdatePaymentMethodInteractorTest {
         onBrandChoiceSelected: (CardBrand) -> Unit = {},
         testBlock: suspend TestParams.() -> Unit
     ) {
-        editSavedCardPaymentMethodEnabledFeatureFlagTestRule.setEnabled(editSavedCardPaymentMethodEnabled)
         val interactor = DefaultUpdatePaymentMethodInteractor(
             isLiveMode = isLiveMode,
             canRemove = canRemove,
+            allowCardEdit = editSavedCardPaymentMethodEnabled,
             displayableSavedPaymentMethod = displayableSavedPaymentMethod,
             addressCollectionMode = AddressCollectionMode.Automatic,
             removeExecutor = onRemovePaymentMethod,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeUpdatePaymentMethodInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeUpdatePaymentMethodInteractor.kt
@@ -32,7 +32,7 @@ internal class FakeUpdatePaymentMethodInteractor(
         isSaveButtonEnabled = false,
     ),
     override val setAsDefaultCheckboxEnabled: Boolean = true,
-    override val allowCardEdit: Boolean = false,
+    override val allowFullCardDetailsEdit: Boolean = false,
     private val editCardDetailsInteractorFactory: EditCardDetailsInteractor.Factory = DefaultEditCardDetailsInteractor
         .Factory(),
 ) : UpdatePaymentMethodInteractor {
@@ -48,7 +48,7 @@ internal class FakeUpdatePaymentMethodInteractor(
             card = displayableSavedPaymentMethod.paymentMethod.card!!,
             onBrandChoiceChanged = {},
             onCardUpdateParamsChanged = {},
-            areExpiryDateAndAddressModificationSupported = allowCardEdit,
+            areExpiryDateAndAddressModificationSupported = allowFullCardDetailsEdit,
             billingDetails = PaymentMethodFixtures.BILLING_DETAILS,
             addressCollectionMode = addressCollectionMode,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreenUpdatePaymentMethodScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreenUpdatePaymentMethodScreenshotTest.kt
@@ -127,7 +127,7 @@ internal class PaymentSheetScreenUpdatePaymentMethodScreenshotTest {
                     .toDisplayableSavedPaymentMethod(),
                 canRemove = true,
                 shouldShowSetAsDefaultCheckbox = true,
-                allowCardEdit = true,
+                allowFullCardDetailsEdit = true,
                 addressCollectionMode = AddressCollectionMode.Automatic
             )
         }
@@ -143,7 +143,7 @@ internal class PaymentSheetScreenUpdatePaymentMethodScreenshotTest {
                 isModifiablePaymentMethod = true,
                 canRemove = true,
                 shouldShowSetAsDefaultCheckbox = true,
-                allowCardEdit = true,
+                allowFullCardDetailsEdit = true,
                 addressCollectionMode = AddressCollectionMode.Full,
             )
         }
@@ -159,7 +159,7 @@ internal class PaymentSheetScreenUpdatePaymentMethodScreenshotTest {
                 isModifiablePaymentMethod = true,
                 canRemove = true,
                 shouldShowSetAsDefaultCheckbox = true,
-                allowCardEdit = true,
+                allowFullCardDetailsEdit = true,
                 addressCollectionMode = AddressCollectionMode.Never,
             )
         }
@@ -173,7 +173,7 @@ internal class PaymentSheetScreenUpdatePaymentMethodScreenshotTest {
         isExpiredCard: Boolean = false,
         error: String? = null,
         shouldShowSetAsDefaultCheckbox: Boolean = false,
-        allowCardEdit: Boolean = false,
+        allowFullCardDetailsEdit: Boolean = false,
         addressCollectionMode: AddressCollectionMode = AddressCollectionMode.Never
     ) {
         val interactor = FakeUpdatePaymentMethodInteractor(
@@ -192,7 +192,7 @@ internal class PaymentSheetScreenUpdatePaymentMethodScreenshotTest {
             ),
             shouldShowSaveButton = isModifiablePaymentMethod || shouldShowSetAsDefaultCheckbox,
             addressCollectionMode = addressCollectionMode,
-            allowCardEdit = allowCardEdit
+            allowFullCardDetailsEdit = allowFullCardDetailsEdit
         )
         val screen = com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.UpdatePaymentMethod(interactor)
         val metadata = PaymentMethodMetadataFactory.create()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactoryTest.kt
@@ -78,6 +78,7 @@ class VerticalModeInitialScreenFactoryTest {
                         canRemovePaymentMethods = true,
                         canRemoveLastPaymentMethod = true,
                         canRemoveDuplicates = true,
+                        canUpdatePaymentMethod = false
                     ),
                     defaultPaymentMethodId = null,
                 )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactoryTest.kt
@@ -78,7 +78,7 @@ class VerticalModeInitialScreenFactoryTest {
                         canRemovePaymentMethods = true,
                         canRemoveLastPaymentMethod = true,
                         canRemoveDuplicates = true,
-                        canUpdatePaymentMethod = false
+                        canUpdateFullPaymentMethodDetails = false
                     ),
                     defaultPaymentMethodId = null,
                 )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsItemsMapperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsItemsMapperTest.kt
@@ -179,6 +179,7 @@ class PaymentOptionsItemsMapperTest {
                 canRemovePaymentMethods = true,
                 canRemoveLastPaymentMethod = true,
                 canRemoveDuplicates = false,
+                canUpdatePaymentMethod = true
             ),
             defaultPaymentMethodId = defaultPaymentMethodId,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsItemsMapperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsItemsMapperTest.kt
@@ -179,7 +179,7 @@ class PaymentOptionsItemsMapperTest {
                 canRemovePaymentMethods = true,
                 canRemoveLastPaymentMethod = true,
                 canRemoveDuplicates = false,
-                canUpdatePaymentMethod = true
+                canUpdateFullPaymentMethodDetails = true
             ),
             defaultPaymentMethodId = defaultPaymentMethodId,
         )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
We only want the payment method update feature to be available to users using customer sessions. So, this PR moves payment method update flag to customer session permissions.

The flag is local so it will be obtain the value from `FeatureFlags`. It will be set to true by default for merchants on `CustomerSessions` before release.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://docs.google.com/document/d/1zxwi8vpDFL1CPlDQ3O3G426543zyt5f6AZ_ik3bQcDk/edit?tab=t.0#heading=h.4mulqy85jncd

https://stripe.slack.com/archives/C07RF1UM08M/p1744754307752529?thread_ts=1744745534.538099&cid=C07RF1UM08M

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
