### PR TITLE
Implement 2 step flow for embedded.

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalEmbeddedPaymentElementApi::class)
+
 package com.stripe.android.paymentsheet.example.playground
 
 import android.content.Intent
@@ -30,8 +32,11 @@ import com.stripe.android.customersheet.CustomerSheetResult
 import com.stripe.android.customersheet.rememberCustomerSheet
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentelement.ConfirmCustomPaymentMethodCallback
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
 import com.stripe.android.paymentelement.ExperimentalCustomPaymentMethodsApi
+import com.stripe.android.paymentelement.ExperimentalEmbeddedPaymentElementApi
+import com.stripe.android.paymentelement.rememberEmbeddedPaymentElement
 import com.stripe.android.paymentsheet.ExperimentalCustomerSessionApi
 import com.stripe.android.paymentsheet.ExternalPaymentMethodConfirmHandler
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -44,9 +49,11 @@ import com.stripe.android.paymentsheet.example.playground.activity.CustomPayment
 import com.stripe.android.paymentsheet.example.playground.activity.FawryActivity
 import com.stripe.android.paymentsheet.example.playground.activity.QrCodeActivity
 import com.stripe.android.paymentsheet.example.playground.activity.getEmbeddedAppearance
-import com.stripe.android.paymentsheet.example.playground.embedded.EmbeddedPlaygroundContract
+import com.stripe.android.paymentsheet.example.playground.embedded.EmbeddedPlaygroundOneStepContract
+import com.stripe.android.paymentsheet.example.playground.embedded.EmbeddedPlaygroundTwoStepContract
 import com.stripe.android.paymentsheet.example.playground.settings.CheckoutMode
 import com.stripe.android.paymentsheet.example.playground.settings.EmbeddedAppearanceSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.EmbeddedTwoStepSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.InitializationType
 import com.stripe.android.paymentsheet.example.playground.settings.PlaygroundConfigurationData
 import com.stripe.android.paymentsheet.example.playground.settings.PlaygroundSettings
@@ -81,8 +88,24 @@ internal class PaymentSheetPlaygroundActivity :
         )
     }
 
-    private val embeddedPlaygroundLauncher = registerForActivityResult(EmbeddedPlaygroundContract()) { success ->
+    private lateinit var embeddedPaymentElement: EmbeddedPaymentElement
+
+    private val embeddedPlaygroundOneStepLauncher = registerForActivityResult(
+        EmbeddedPlaygroundOneStepContract()
+    ) { success ->
         viewModel.onEmbeddedResult(success)
+    }
+
+    private val embeddedPlaygroundTwoStepLauncher = registerForActivityResult(
+        EmbeddedPlaygroundTwoStepContract()
+    ) { result ->
+        when (result) {
+            EmbeddedPlaygroundTwoStepContract.Result.Cancelled -> Unit
+            EmbeddedPlaygroundTwoStepContract.Result.Complete -> viewModel.onEmbeddedResult(true)
+            is EmbeddedPlaygroundTwoStepContract.Result.Updated -> {
+                embeddedPaymentElement.state = result.embeddedPaymentElementState
+            }
+        }
     }
 
     @OptIn(ExperimentalCustomerSessionApi::class, ExperimentalAnalyticEventCallbackApi::class)
@@ -110,6 +133,13 @@ internal class PaymentSheetPlaygroundActivity :
                 .createIntentCallback(viewModel::createIntentCallback)
                 .analyticEventCallback(viewModel::analyticCallback)
                 .build()
+            val embeddedPaymentElementBuilder = remember {
+                EmbeddedPaymentElement.Builder(
+                    viewModel::createIntentCallback,
+                    viewModel::onEmbeddedResult,
+                )
+            }
+            embeddedPaymentElement = rememberEmbeddedPaymentElement(embeddedPaymentElementBuilder)
 
             val addressLauncher = rememberAddressLauncher(
                 callback = viewModel::onAddressLauncherResult
@@ -403,10 +433,52 @@ internal class PaymentSheetPlaygroundActivity :
     fun EmbeddedUi(
         playgroundState: PlaygroundState.Payment,
     ) {
+        val isTwoStep = remember(playgroundState) {
+            playgroundState.snapshot[EmbeddedTwoStepSettingsDefinition]
+        }
+        var hasConfigured: Boolean by remember { mutableStateOf(false) }
+
+        LaunchedEffect(playgroundState) {
+            if (isTwoStep) {
+                val configureResult = embeddedPaymentElement.configure(
+                    intentConfiguration = playgroundState.intentConfiguration(),
+                    configuration = playgroundState.embeddedConfiguration(),
+                )
+                hasConfigured = configureResult is EmbeddedPaymentElement.ConfigureResult.Succeeded
+            }
+        }
+
+        if (isTwoStep) {
+            val paymentOption by embeddedPaymentElement.paymentOption.collectAsState()
+
+            PaymentMethodSelector(
+                isEnabled = hasConfigured,
+                paymentMethodLabel = if (hasConfigured) {
+                    paymentOption?.label ?: "Select"
+                } else {
+                    "Loading"
+                },
+                paymentMethodPainter = paymentOption?.iconPainter,
+                onClick = {
+                    embeddedPlaygroundTwoStepLauncher.launch(
+                        EmbeddedPlaygroundTwoStepContract.Args(
+                            playgroundState,
+                            requireNotNull(embeddedPaymentElement.state),
+                        )
+                    )
+                }
+            )
+        }
+
         Button(
             onClick = {
-                embeddedPlaygroundLauncher.launch(playgroundState)
+                if (isTwoStep) {
+                    embeddedPaymentElement.confirm()
+                } else {
+                    embeddedPlaygroundOneStepLauncher.launch(playgroundState)
+                }
             },
+            enabled = if (isTwoStep) hasConfigured else true,
             modifier = Modifier
                 .fillMaxWidth()
                 .testTag(CHECKOUT_TEST_TAG),

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundViewModel.kt
@@ -21,7 +21,9 @@ import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.customersheet.CustomerSheetResult
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentelement.AnalyticEvent
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
+import com.stripe.android.paymentelement.ExperimentalEmbeddedPaymentElementApi
 import com.stripe.android.paymentsheet.CreateIntentResult
 import com.stripe.android.paymentsheet.DelicatePaymentSheetApi
 import com.stripe.android.paymentsheet.ExperimentalCustomerSessionApi
@@ -55,7 +57,7 @@ import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import java.io.IOException
 
-@OptIn(ExperimentalCustomerSessionApi::class)
+@OptIn(ExperimentalCustomerSessionApi::class, ExperimentalEmbeddedPaymentElementApi::class)
 internal class PaymentSheetPlaygroundViewModel(
     application: Application,
     private val savedStateHandle: SavedStateHandle,
@@ -392,6 +394,40 @@ internal class PaymentSheetPlaygroundViewModel(
             setPlaygroundState(null)
             status.value = StatusMessage(SUCCESS_RESULT)
         }
+    }
+
+    fun onEmbeddedResult(result: EmbeddedPaymentElement.Result) {
+        if (result is EmbeddedPaymentElement.Result.Completed) {
+            setPlaygroundState(null)
+        }
+
+        val statusMessage = when (result) {
+            is EmbeddedPaymentElement.Result.Canceled -> {
+                "Canceled"
+            }
+
+            is EmbeddedPaymentElement.Result.Completed -> {
+                SUCCESS_RESULT
+            }
+
+            is EmbeddedPaymentElement.Result.Failed -> {
+                when (result.error) {
+                    is ConfirmIntentEndpointException -> {
+                        "Couldn't process your payment: ${result.error.message}"
+                    }
+
+                    is ConfirmIntentNetworkException -> {
+                        "No internet. Try again later."
+                    }
+
+                    else -> {
+                        "Something went wrong: ${result.error.message}"
+                    }
+                }
+            }
+        }
+
+        status.value = StatusMessage(statusMessage)
     }
 
     fun onCustomerSheetCallback(result: CustomerSheetResult) {

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/embedded/EmbeddedPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/embedded/EmbeddedPlaygroundActivity.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import android.widget.Toast
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -65,11 +66,17 @@ internal class EmbeddedPlaygroundActivity :
     ExternalPaymentMethodConfirmHandler,
     AnalyticEventCallback {
     companion object {
-        const val PLAYGROUND_STATE_KEY = "playgroundState"
+        private const val PLAYGROUND_STATE_KEY = "playgroundState"
+        const val EMBEDDED_PAYMENT_ELEMENT_STATE_KEY = "EMBEDDED_PAYMENT_ELEMENT_STATE_KEY"
 
-        fun create(context: Context, playgroundState: PlaygroundState.Payment): Intent {
+        fun create(
+            context: Context,
+            playgroundState: PlaygroundState.Payment,
+            embeddedPaymentElementState: EmbeddedPaymentElement.State? = null,
+        ): Intent {
             return Intent(context, EmbeddedPlaygroundActivity::class.java).apply {
                 putExtra(PLAYGROUND_STATE_KEY, playgroundState)
+                putExtra(EMBEDDED_PAYMENT_ELEMENT_STATE_KEY, embeddedPaymentElementState)
             }
         }
     }
@@ -77,6 +84,7 @@ internal class EmbeddedPlaygroundActivity :
     private val viewModel: EmbeddedPlaygroundViewModel by viewModels()
     private lateinit var playgroundState: PlaygroundState.Payment
     private lateinit var playgroundSettings: PlaygroundSettings
+    private lateinit var embeddedPaymentElement: EmbeddedPaymentElement
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -110,7 +118,7 @@ internal class EmbeddedPlaygroundActivity :
         val embeddedViewDisplaysMandateText =
             initialPlaygroundState.snapshot[EmbeddedViewDisplaysMandateSettingDefinition]
         setContent {
-            val embeddedPaymentElement = rememberEmbeddedPaymentElement(embeddedBuilder)
+            embeddedPaymentElement = rememberEmbeddedPaymentElement(embeddedBuilder)
 
             var loadingState by remember {
                 mutableStateOf(LoadingState.Loading)
@@ -131,28 +139,64 @@ internal class EmbeddedPlaygroundActivity :
             }
 
             LaunchedEffect(embeddedPaymentElement) {
-                configure()
+                val embeddedPaymentElementState = getEmbeddedPaymentElementState(savedInstanceState)
+                if (embeddedPaymentElementState != null) {
+                    embeddedPaymentElement.state = embeddedPaymentElementState
+                    loadingState = LoadingState.Complete
+                } else {
+                    configure()
+                }
             }
 
-            PlaygroundTheme(
-                content = {
-                    loadingState.Content(embeddedPaymentElement = embeddedPaymentElement, retry = ::configure)
-                },
-                bottomBarContent = {
-                    val selectedPaymentOption by embeddedPaymentElement.paymentOption.collectAsState()
-
-                    selectedPaymentOption?.let { selectedPaymentOption ->
-                        EmbeddedContentWithSelectedPaymentOption(
-                            embeddedPaymentElement = embeddedPaymentElement,
-                            selectedPaymentOption = selectedPaymentOption,
-                            embeddedViewDisplaysMandateText = embeddedViewDisplaysMandateText,
-                        )
-                    }
-
-                    ModeUi(::configure)
-                }
+            BottomSheetContent(
+                loadingState = loadingState,
+                configure = ::configure,
+                embeddedViewDisplaysMandateText = embeddedViewDisplaysMandateText,
             )
         }
+
+        setupBackPressedCallback()
+    }
+
+    @Composable
+    private fun BottomSheetContent(
+        loadingState: LoadingState,
+        configure: () -> Unit,
+        embeddedViewDisplaysMandateText: Boolean,
+    ) {
+        PlaygroundTheme(
+            content = {
+                loadingState.Content(embeddedPaymentElement = embeddedPaymentElement, retry = configure)
+            },
+            bottomBarContent = {
+                val selectedPaymentOption by embeddedPaymentElement.paymentOption.collectAsState()
+
+                selectedPaymentOption?.let { selectedPaymentOption ->
+                    EmbeddedContentWithSelectedPaymentOption(
+                        selectedPaymentOption = selectedPaymentOption,
+                        embeddedViewDisplaysMandateText = embeddedViewDisplaysMandateText,
+                    )
+                }
+
+                ModeUi(configure = configure)
+            }
+        )
+    }
+
+    private fun setupBackPressedCallback() {
+        onBackPressedDispatcher.addCallback(
+            object : OnBackPressedCallback(enabled = true) {
+                override fun handleOnBackPressed() {
+                    setResult(
+                        RESULT_CANCELED,
+                        Intent().apply {
+                            putExtra(EMBEDDED_PAYMENT_ELEMENT_STATE_KEY, embeddedPaymentElement.state)
+                        }
+                    )
+                    finish()
+                }
+            }
+        )
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -186,7 +230,6 @@ internal class EmbeddedPlaygroundActivity :
 
     @Composable
     private fun EmbeddedContentWithSelectedPaymentOption(
-        embeddedPaymentElement: EmbeddedPaymentElement,
         selectedPaymentOption: EmbeddedPaymentElement.PaymentOptionDisplayData,
         embeddedViewDisplaysMandateText: Boolean,
     ) {
@@ -257,6 +300,14 @@ internal class EmbeddedPlaygroundActivity :
     private fun getPlaygroundState(savedInstanceState: Bundle?): PlaygroundState.Payment? {
         return savedInstanceState?.getParcelable<PlaygroundState.Payment?>(PLAYGROUND_STATE_KEY)
             ?: intent.getParcelableExtra<PlaygroundState.Payment?>(PLAYGROUND_STATE_KEY)
+    }
+
+    @Suppress("DEPRECATION")
+    private fun getEmbeddedPaymentElementState(savedInstanceState: Bundle?): EmbeddedPaymentElement.State? {
+        if (savedInstanceState != null) {
+            return null // Only set the state the first time.
+        }
+        return intent.getParcelableExtra<EmbeddedPaymentElement.State?>(EMBEDDED_PAYMENT_ELEMENT_STATE_KEY)
     }
 
     private fun PlaygroundState.Payment?.validate(): PlaygroundState.Payment? {

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/embedded/EmbeddedPlaygroundOneStepContract.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/embedded/EmbeddedPlaygroundOneStepContract.kt
@@ -4,9 +4,11 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import androidx.activity.result.contract.ActivityResultContract
+import com.stripe.android.paymentelement.ExperimentalEmbeddedPaymentElementApi
 import com.stripe.android.paymentsheet.example.playground.PlaygroundState
 
-internal class EmbeddedPlaygroundContract : ActivityResultContract<PlaygroundState.Payment, Boolean>() {
+@OptIn(ExperimentalEmbeddedPaymentElementApi::class)
+internal class EmbeddedPlaygroundOneStepContract : ActivityResultContract<PlaygroundState.Payment, Boolean>() {
     override fun createIntent(context: Context, input: PlaygroundState.Payment): Intent {
         return EmbeddedPlaygroundActivity.create(context, input)
     }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/embedded/EmbeddedPlaygroundTwoStepContract.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/embedded/EmbeddedPlaygroundTwoStepContract.kt
@@ -1,0 +1,48 @@
+package com.stripe.android.paymentsheet.example.playground.embedded
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.os.Parcelable
+import androidx.activity.result.contract.ActivityResultContract
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentelement.ExperimentalEmbeddedPaymentElementApi
+import com.stripe.android.paymentsheet.example.playground.PlaygroundState
+import kotlinx.parcelize.Parcelize
+
+@OptIn(ExperimentalEmbeddedPaymentElementApi::class)
+internal class EmbeddedPlaygroundTwoStepContract :
+    ActivityResultContract<EmbeddedPlaygroundTwoStepContract.Args, EmbeddedPlaygroundTwoStepContract.Result>() {
+    override fun createIntent(context: Context, input: Args): Intent {
+        return EmbeddedPlaygroundActivity.create(context, input.playgroundState, input.embeddedPaymentElementState)
+    }
+
+    override fun parseResult(resultCode: Int, intent: Intent?): Result {
+        return if (resultCode == Activity.RESULT_OK) {
+            Result.Complete
+        } else {
+            val embeddedPlaygroundState = intent?.getParcelableExtra<EmbeddedPaymentElement.State?>(
+                EmbeddedPlaygroundActivity.EMBEDDED_PAYMENT_ELEMENT_STATE_KEY
+            )
+            if (embeddedPlaygroundState != null) {
+                Result.Updated(embeddedPlaygroundState)
+            } else {
+                Result.Cancelled
+            }
+        }
+    }
+
+    @Parcelize
+    class Args(
+        val playgroundState: PlaygroundState.Payment,
+        val embeddedPaymentElementState: EmbeddedPaymentElement.State,
+    ) : Parcelable
+
+    sealed interface Result {
+        object Complete : Result
+
+        class Updated(val embeddedPaymentElementState: EmbeddedPaymentElement.State) : Result
+
+        object Cancelled : Result
+    }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/EmbeddedTwoStepSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/EmbeddedTwoStepSettingsDefinition.kt
@@ -1,0 +1,11 @@
+package com.stripe.android.paymentsheet.example.playground.settings
+
+internal object EmbeddedTwoStepSettingsDefinition : BooleanSettingsDefinition(
+    key = "embedded_2_step",
+    displayName = "Embedded 2 Step Integration",
+    defaultValue = false,
+) {
+    override fun applicable(configurationData: PlaygroundConfigurationData): Boolean {
+        return configurationData.integrationType == PlaygroundConfigurationData.IntegrationType.Embedded
+    }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -456,6 +456,7 @@ internal class PlaygroundSettings private constructor(
             FeatureFlagSettingsDefinition(FeatureFlags.financialConnectionsFullSdkUnavailable),
             EmbeddedViewDisplaysMandateSettingDefinition,
             EmbeddedFormSheetActionSettingDefinition,
+            EmbeddedTwoStepSettingsDefinition,
         )
 
         private val nonUiSettingDefinitions: List<PlaygroundSettingDefinition<*>> = listOf(

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedContentPage.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedContentPage.kt
@@ -17,13 +17,17 @@ import com.stripe.paymentelementtestpages.hasTestMetadata
 internal class EmbeddedContentPage(
     private val composeTestRule: ComposeTestRule,
 ) {
-    fun clickOnLpm(code: String) {
+    fun waitUntilVisible() {
         composeTestRule.waitUntil {
             composeTestRule
                 .onAllNodes(hasTestTag(TEST_TAG_PAYMENT_METHOD_EMBEDDED_LAYOUT))
                 .fetchSemanticsNodes()
                 .isNotEmpty()
         }
+    }
+
+    fun clickOnLpm(code: String) {
+        waitUntilVisible()
 
         composeTestRule.onNode(hasTestTag("${TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON}_$code"))
             .performScrollTo()
@@ -53,6 +57,8 @@ internal class EmbeddedContentPage(
     }
 
     fun clickViewMore() {
+        waitUntilVisible()
+
         composeTestRule.onNodeWithTag(TEST_TAG_VIEW_MORE).performClick()
     }
 }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementTestRunner.kt
@@ -22,7 +22,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 internal class EmbeddedPaymentElementTestRunnerContext(
-    private val embeddedPaymentElement: EmbeddedPaymentElement,
+    val embeddedPaymentElement: EmbeddedPaymentElement,
     private val countDownLatch: CountDownLatch,
 ) {
     suspend fun configure(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
@@ -25,6 +25,7 @@ import com.stripe.android.paymentelement.embedded.content.EmbeddedConfirmationSt
 import com.stripe.android.paymentelement.embedded.content.EmbeddedContentHelper
 import com.stripe.android.paymentelement.embedded.content.EmbeddedPaymentElementScope
 import com.stripe.android.paymentelement.embedded.content.EmbeddedPaymentElementViewModel
+import com.stripe.android.paymentelement.embedded.content.EmbeddedStateHelper
 import com.stripe.android.paymentelement.embedded.content.PaymentOptionDisplayDataHolder
 import com.stripe.android.paymentsheet.CreateIntentCallback
 import com.stripe.android.paymentsheet.ExternalPaymentMethodConfirmHandler
@@ -47,6 +48,7 @@ class EmbeddedPaymentElement @Inject internal constructor(
     private val selectionHolder: EmbeddedSelectionHolder,
     paymentOptionDisplayDataHolder: PaymentOptionDisplayDataHolder,
     private val configurationCoordinator: EmbeddedConfigurationCoordinator,
+    stateHelper: EmbeddedStateHelper,
 ) {
 
     /**
@@ -54,6 +56,15 @@ class EmbeddedPaymentElement @Inject internal constructor(
      * Use this to display the payment option in your own UI.
      */
     val paymentOption: StateFlow<PaymentOptionDisplayData?> = paymentOptionDisplayDataHolder.paymentOption
+
+    /**
+     * The state of an already configured [EmbeddedPaymentElement].
+     *
+     * Use this to instantly configure an [EmbeddedPaymentElement], likely from the state of another Activity.
+     */
+    @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @set:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    var state: State? by stateHelper::state
 
     /**
      * Call this method to configure [EmbeddedPaymentElement] or when the IntentConfiguration values you used to
@@ -560,10 +571,11 @@ class EmbeddedPaymentElement @Inject internal constructor(
     /**
      * A [Parcelable] state used to reconfigure [EmbeddedPaymentElement] across activity boundaries.
      */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @ExperimentalEmbeddedPaymentElementApi
     @Poko
     @Parcelize
-    internal class State internal constructor(
+    class State internal constructor(
         internal val confirmationState: EmbeddedConfirmationStateHolder.State,
         internal val customer: CustomerState?,
     ) : Parcelable


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This implements a 2 step flow -- similar to FlowController. Where a merchant would have a payment method selector on one activity. Clicking on that selector launches a new activity that displays the embedded content. Once the user has selected something, or clicks back - the user is navigated back to the first activity where they can complete the payment, and the payment method selector is updated with the payment details.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-3312

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

