### PR TITLE
Don't set playground state when calling the create intent callback.

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundViewModel.kt
@@ -421,7 +421,6 @@ internal class PaymentSheetPlaygroundViewModel(
         return PlaygroundRequester(playgroundSettingsSnapshot, getApplication()).fetch().fold(
             onSuccess = { state ->
                 playgroundSettingsFlow.value = state.snapshot.playgroundSettings()
-                setPlaygroundState(state)
                 val clientSecret = requireNotNull(state.asPaymentState()).clientSecret
                 CreateIntentResult.Success(clientSecret)
             },


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This causes everything to reload, and configuration to happen during confirmation.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
While building the 2 step flow, I noticed configuration happening during confirmation. This is what was causing it.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

