### PR TITLE
Use builders in Payment Element emulator tests

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/DefaultPaymentMethodsConfirmationTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/DefaultPaymentMethodsConfirmationTest.kt
@@ -48,7 +48,11 @@ internal class DefaultPaymentMethodsConfirmationTest {
     @Test
     fun setNewPMAsDefault_withSavedPaymentMethods_sendsSetAsDefaultParamInConfirmCall() = runProductIntegrationTest(
         networkRule = networkRule,
-        createIntentCallback = confirmationType.createIntentCallback,
+        builder = {
+            confirmationType.createIntentCallback?.let {
+                createIntentCallback(it)
+            }
+        },
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
     ) { testContext ->
@@ -94,7 +98,11 @@ internal class DefaultPaymentMethodsConfirmationTest {
     fun setNewPMAsDefault_withSavedPaymentMethods_uncheckSetAsDefault_doesNotSendSetAsDefaultParamInConfirmCall() =
         runProductIntegrationTest(
             networkRule = networkRule,
-            createIntentCallback = confirmationType.createIntentCallback,
+            builder = {
+                confirmationType.createIntentCallback?.let {
+                    createIntentCallback(it)
+                }
+            },
             integrationType = integrationType,
             resultCallback = ::assertCompleted,
         ) { testContext ->
@@ -137,7 +145,11 @@ internal class DefaultPaymentMethodsConfirmationTest {
     fun setNewPMAsDefault_withSavedPaymentMethods_uncheckSaveForFuture_doesNotSendSetAsDefaultParamInConfirmCall() =
         runProductIntegrationTest(
             networkRule = networkRule,
-            createIntentCallback = confirmationType.createIntentCallback,
+            builder = {
+                confirmationType.createIntentCallback?.let {
+                    createIntentCallback(it)
+                }
+            },
             integrationType = integrationType,
             resultCallback = ::assertCompleted,
         ) { testContext ->
@@ -180,7 +192,11 @@ internal class DefaultPaymentMethodsConfirmationTest {
     @Test
     fun payWithNewPM_savePM_sendsSetAsDefaultInConfirmCall() = runProductIntegrationTest(
         networkRule = networkRule,
-        createIntentCallback = confirmationType.createIntentCallback,
+        builder = {
+            confirmationType.createIntentCallback?.let {
+                createIntentCallback(it)
+            }
+        },
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
     ) { testContext ->
@@ -217,7 +233,11 @@ internal class DefaultPaymentMethodsConfirmationTest {
     @Test
     fun payWithNewPM_doNotSaveCard_doesNotSetAsDefault() = runProductIntegrationTest(
         networkRule = networkRule,
-        createIntentCallback = confirmationType.createIntentCallback,
+        builder = {
+            confirmationType.createIntentCallback?.let {
+                createIntentCallback(it)
+            }
+        },
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
     ) { testContext ->

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/DefaultPaymentMethodsDeferredServerSideConfirmationTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/DefaultPaymentMethodsDeferredServerSideConfirmationTest.kt
@@ -33,8 +33,10 @@ internal class DefaultPaymentMethodsDeferredServerSideConfirmationTest {
     @Test
     fun setNewCardAsDefault_withSavedPaymentMethods_failsInTestMode() = runProductIntegrationTest(
         networkRule = networkRule,
-        createIntentCallback = { _, _ ->
-            CreateIntentResult.Success(clientSecret = "pi_example_secret_example")
+        builder = {
+            createIntentCallback { _, _ ->
+                CreateIntentResult.Success(clientSecret = "pi_example_secret_example")
+            }
         },
         integrationType = integrationType,
         resultCallback = integrationType.expectedDeferredSSCResultCallback,
@@ -95,8 +97,10 @@ internal class DefaultPaymentMethodsDeferredServerSideConfirmationTest {
     @Test
     fun addFirstCardForUser_failsInTestMode() = runProductIntegrationTest(
         networkRule = networkRule,
-        createIntentCallback = { _, _ ->
-            CreateIntentResult.Success(clientSecret = "pi_example_secret_example")
+        builder = {
+            createIntentCallback { _, _ ->
+                CreateIntentResult.Success(clientSecret = "pi_example_secret_example")
+            }
         },
         integrationType = integrationType,
         resultCallback = integrationType.expectedDeferredSSCResultCallback,

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/DefaultPaymentMethodsFlowControllerConfirmationTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/DefaultPaymentMethodsFlowControllerConfirmationTest.kt
@@ -88,7 +88,11 @@ internal class DefaultPaymentMethodsFlowControllerConfirmationTest {
     ) {
         runFlowControllerTest(
             networkRule = networkRule,
-            createIntentCallback = confirmationType.createIntentCallback,
+            builder = {
+                confirmationType.createIntentCallback?.let {
+                    createIntentCallback(it)
+                }
+            },
             callConfirmOnPaymentOptionCallback = false,
             integrationType = IntegrationType.Compose,
             resultCallback = ::assertCompleted,

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
@@ -459,7 +459,11 @@ internal class FlowControllerTest {
     ) = runFlowControllerTest(
         networkRule = networkRule,
         integrationType = integrationType,
-        createIntentCallback = { _, _ -> CreateIntentResult.Success("pi_example_secret_example") },
+        builder = {
+            createIntentCallback { _, _ ->
+                CreateIntentResult.Success("pi_example_secret_example")
+            }
+        },
         resultCallback = ::assertCompleted,
     ) { testContext ->
         networkRule.enqueue(
@@ -588,11 +592,13 @@ internal class FlowControllerTest {
     ) = runFlowControllerTest(
         networkRule = networkRule,
         integrationType = integrationType,
-        createIntentCallback = { _, _ ->
-            CreateIntentResult.Failure(
-                cause = Exception("We don't accept visa"),
-                displayMessage = "We don't accept visa"
-            )
+        builder = {
+            createIntentCallback { _, _ ->
+                CreateIntentResult.Failure(
+                    cause = Exception("We don't accept visa"),
+                    displayMessage = "We don't accept visa"
+                )
+            }
         },
         resultCallback = { result ->
             assertThat(result).isInstanceOf(PaymentSheetResult.Failed::class.java)
@@ -647,8 +653,10 @@ internal class FlowControllerTest {
     ) = runFlowControllerTest(
         networkRule = networkRule,
         integrationType = integrationType,
-        createIntentCallback = { _, _ ->
-            CreateIntentResult.Success(PaymentSheet.IntentConfiguration.COMPLETE_WITHOUT_CONFIRMING_INTENT)
+        builder = {
+            createIntentCallback { _, _ ->
+                CreateIntentResult.Success(PaymentSheet.IntentConfiguration.COMPLETE_WITHOUT_CONFIRMING_INTENT)
+            }
         },
         resultCallback = ::assertCompleted,
     ) { testContext ->
@@ -698,7 +706,11 @@ internal class FlowControllerTest {
     ) = runFlowControllerTest(
         networkRule = networkRule,
         integrationType = integrationType,
-        createIntentCallback = { _, _ -> CreateIntentResult.Success("pi_example_secret_example") },
+        builder = {
+            createIntentCallback { _, _ ->
+                CreateIntentResult.Success("pi_example_secret_example")
+            }
+        },
         resultCallback = { result ->
             val failureResult = result as? PaymentSheetResult.Failed
             assertThat(failureResult?.error?.message).isEqualTo(

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAnalyticsTest.kt
@@ -83,7 +83,9 @@ internal class PaymentSheetAnalyticsTest {
     @Test
     fun testSuccessfulCardPayment() = runPaymentSheetTest(
         networkRule = networkRule,
-        analyticEventCallback = analyticEventRule,
+        builder = {
+            analyticEventCallback(analyticEventRule)
+        },
         resultCallback = ::assertCompleted,
     ) { testContext ->
         networkRule.enqueue(
@@ -151,7 +153,9 @@ internal class PaymentSheetAnalyticsTest {
     @Test
     fun testSuccessfulCardPaymentInFlowController() = runFlowControllerTest(
         networkRule = networkRule,
-        analyticEventCallback = analyticEventRule,
+        builder = {
+            analyticEventCallback(analyticEventRule)
+        },
         resultCallback = ::assertCompleted,
     ) { testContext ->
         networkRule.enqueue(
@@ -225,7 +229,9 @@ internal class PaymentSheetAnalyticsTest {
     @Test
     fun testSuccessfulCardPaymentInVerticalMode() = runPaymentSheetTest(
         networkRule = networkRule,
-        analyticEventCallback = analyticEventRule,
+        builder = {
+            analyticEventCallback(analyticEventRule)
+        },
         resultCallback = ::assertCompleted,
     ) { testContext ->
         networkRule.enqueue(
@@ -297,7 +303,9 @@ internal class PaymentSheetAnalyticsTest {
     @Test
     fun testSuccessfulCardPaymentInFlowControllerInVerticalMode() = runFlowControllerTest(
         networkRule = networkRule,
-        analyticEventCallback = analyticEventRule,
+        builder = {
+            analyticEventCallback(analyticEventRule)
+        },
         resultCallback = ::assertCompleted,
     ) { testContext ->
         networkRule.enqueue(
@@ -374,7 +382,9 @@ internal class PaymentSheetAnalyticsTest {
     @Test
     fun testSavedPaymentMethod() = runPaymentSheetTest(
         networkRule = networkRule,
-        analyticEventCallback = analyticEventRule,
+        builder = {
+            analyticEventCallback(analyticEventRule)
+        },
         resultCallback = ::assertCompleted,
     ) { testContext ->
         networkRule.enqueue(
@@ -427,7 +437,9 @@ internal class PaymentSheetAnalyticsTest {
     @Test
     fun testSavedPaymentMethodInFlowController() = runFlowControllerTest(
         networkRule = networkRule,
-        analyticEventCallback = analyticEventRule,
+        builder = {
+            analyticEventCallback(analyticEventRule)
+        },
         resultCallback = ::assertCompleted,
     ) { testContext ->
         networkRule.enqueue(

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetDeferredTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetDeferredTest.kt
@@ -43,9 +43,11 @@ internal class PaymentSheetDeferredTest {
     fun testDeferredIntentCardPayment() = runPaymentSheetTest(
         networkRule = networkRule,
         integrationType = integrationType,
-        createIntentCallback = { _, shouldSavePaymentMethod ->
-            assertThat(shouldSavePaymentMethod).isFalse()
-            CreateIntentResult.Success("pi_example_secret_example")
+        builder = {
+            createIntentCallback { _, shouldSavePaymentMethod ->
+                assertThat(shouldSavePaymentMethod).isFalse()
+                CreateIntentResult.Success("pi_example_secret_example")
+            }
         },
         resultCallback = ::assertCompleted,
     ) { testContext ->
@@ -114,9 +116,11 @@ internal class PaymentSheetDeferredTest {
     fun testDeferredIntentCardPayment_forSetup() = runPaymentSheetTest(
         networkRule = networkRule,
         integrationType = integrationType,
-        createIntentCallback = { _, shouldSavePaymentMethod ->
-            assertThat(shouldSavePaymentMethod).isFalse()
-            CreateIntentResult.Success("seti_example_secret_example")
+        builder = {
+            createIntentCallback { _, shouldSavePaymentMethod ->
+                assertThat(shouldSavePaymentMethod).isFalse()
+                CreateIntentResult.Success("seti_example_secret_example")
+            }
         },
         resultCallback = ::assertCompleted,
     ) { testContext ->
@@ -166,9 +170,11 @@ internal class PaymentSheetDeferredTest {
     fun testDeferredIntentCardPaymentWithCustomer() = runPaymentSheetTest(
         networkRule = networkRule,
         integrationType = integrationType,
-        createIntentCallback = { _, shouldSavePaymentMethod ->
-            assertThat(shouldSavePaymentMethod).isFalse()
-            CreateIntentResult.Success("pi_example_secret_example")
+        builder = {
+            createIntentCallback { _, shouldSavePaymentMethod ->
+                assertThat(shouldSavePaymentMethod).isFalse()
+                CreateIntentResult.Success("pi_example_secret_example")
+            }
         },
         resultCallback = ::assertCompleted,
     ) { testContext ->
@@ -249,9 +255,11 @@ internal class PaymentSheetDeferredTest {
     fun testDeferredIntentCardPaymentWithSaveFor() = runPaymentSheetTest(
         networkRule = networkRule,
         integrationType = integrationType,
-        createIntentCallback = { _, shouldSavePaymentMethod ->
-            assertThat(shouldSavePaymentMethod).isTrue()
-            CreateIntentResult.Success("pi_example_secret_example")
+        builder = {
+            createIntentCallback { _, shouldSavePaymentMethod ->
+                assertThat(shouldSavePaymentMethod).isTrue()
+                CreateIntentResult.Success("pi_example_secret_example")
+            }
         },
         resultCallback = ::assertCompleted,
     ) { testContext ->
@@ -331,11 +339,13 @@ internal class PaymentSheetDeferredTest {
     fun testDeferredIntentFailedCardPayment() = runPaymentSheetTest(
         networkRule = networkRule,
         integrationType = integrationType,
-        createIntentCallback = { _, _ ->
-            CreateIntentResult.Failure(
-                cause = Exception("We don't accept visa"),
-                displayMessage = "We don't accept visa"
-            )
+        builder = {
+            createIntentCallback { _, _ ->
+                CreateIntentResult.Failure(
+                    cause = Exception("We don't accept visa"),
+                    displayMessage = "We don't accept visa"
+                )
+            }
         },
         resultCallback = ::expectNoResult,
     ) { testContext ->
@@ -382,8 +392,10 @@ internal class PaymentSheetDeferredTest {
     fun testDeferredIntentCardPaymentWithForcedSuccess() = runPaymentSheetTest(
         networkRule = networkRule,
         integrationType = integrationType,
-        createIntentCallback = { _, _ ->
-            CreateIntentResult.Success(PaymentSheet.IntentConfiguration.COMPLETE_WITHOUT_CONFIRMING_INTENT)
+        builder = {
+            createIntentCallback { _, _ ->
+                CreateIntentResult.Success(PaymentSheet.IntentConfiguration.COMPLETE_WITHOUT_CONFIRMING_INTENT)
+            }
         },
         resultCallback = ::assertCompleted,
     ) { testContext ->
@@ -426,9 +438,11 @@ internal class PaymentSheetDeferredTest {
     fun testDeferredIntentKonbiniPayment() = runPaymentSheetTest(
         networkRule = networkRule,
         integrationType = integrationType,
-        createIntentCallback = { _, shouldSavePaymentMethod ->
-            assertThat(shouldSavePaymentMethod).isFalse()
-            CreateIntentResult.Success("pi_example_secret_example")
+        builder = {
+            createIntentCallback { _, shouldSavePaymentMethod ->
+                assertThat(shouldSavePaymentMethod).isFalse()
+                CreateIntentResult.Success("pi_example_secret_example")
+            }
         },
         resultCallback = ::assertCompleted,
     ) { testContext ->
@@ -504,9 +518,11 @@ internal class PaymentSheetDeferredTest {
     fun testDeferredPaymentIntent_withElementsSessionFailure() = runPaymentSheetTest(
         networkRule = networkRule,
         integrationType = integrationType,
-        createIntentCallback = { _, shouldSavePaymentMethod ->
-            assertThat(shouldSavePaymentMethod).isFalse()
-            CreateIntentResult.Success("pi_example_secret_example")
+        builder = {
+            createIntentCallback { _, shouldSavePaymentMethod ->
+                assertThat(shouldSavePaymentMethod).isFalse()
+                CreateIntentResult.Success("pi_example_secret_example")
+            }
         },
         resultCallback = ::assertCompleted,
     ) { testContext ->
@@ -575,9 +591,11 @@ internal class PaymentSheetDeferredTest {
     fun testDeferredSetupIntent_withElementsSessionFailure() = runPaymentSheetTest(
         networkRule = networkRule,
         integrationType = integrationType,
-        createIntentCallback = { _, shouldSavePaymentMethod ->
-            assertThat(shouldSavePaymentMethod).isFalse()
-            CreateIntentResult.Success("seti_example_secret_example")
+        builder = {
+            createIntentCallback { _, shouldSavePaymentMethod ->
+                assertThat(shouldSavePaymentMethod).isFalse()
+                CreateIntentResult.Success("seti_example_secret_example")
+            }
         },
         resultCallback = ::assertCompleted,
     ) { testContext ->

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/FlowControllerTestFactory.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/FlowControllerTestFactory.kt
@@ -3,34 +3,16 @@ package com.stripe.android.paymentsheet.utils
 import androidx.activity.ComponentActivity
 import androidx.compose.runtime.Composable
 import app.cash.turbine.Turbine
-import com.stripe.android.paymentelement.AnalyticEventCallback
-import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
-import com.stripe.android.paymentsheet.CreateIntentCallback
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetResultCallback
 import com.stripe.android.paymentsheet.model.PaymentOption
 
-@OptIn(ExperimentalAnalyticEventCallbackApi::class)
 internal class FlowControllerTestFactory(
     callConfirmOnPaymentOptionCallback: Boolean,
-    createIntentCallback: CreateIntentCallback? = null,
-    analyticEventCallback: AnalyticEventCallback? = null,
+    builder: PaymentSheet.FlowController.Builder.() -> Unit,
     configureCallbackTurbine: Turbine<PaymentOption?>,
     resultCallback: PaymentSheetResultCallback,
 ) {
-    constructor(
-        callConfirmOnPaymentOptionCallback: Boolean,
-        createIntentCallback: CreateIntentCallback? = null,
-        configureCallbackTurbine: Turbine<PaymentOption?>,
-        resultCallback: PaymentSheetResultCallback,
-    ) : this(
-        callConfirmOnPaymentOptionCallback = callConfirmOnPaymentOptionCallback,
-        createIntentCallback = createIntentCallback,
-        analyticEventCallback = null,
-        configureCallbackTurbine = configureCallbackTurbine,
-        resultCallback = resultCallback,
-    )
-
     // Needs to be lateinit in order to reference in `paymentOptionCallback`
     private lateinit var flowController: PaymentSheet.FlowController
     private val flowControllerBuilder = PaymentSheet.FlowController.Builder(
@@ -42,8 +24,7 @@ internal class FlowControllerTestFactory(
                 }
             },
         ).apply {
-            createIntentCallback?.let { createIntentCallback(it) }
-            analyticEventCallback?.let { analyticEventCallback(it) }
+            builder()
         }
 
     fun make(activity: ComponentActivity): PaymentSheet.FlowController {

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/PaymentSheetTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/PaymentSheetTestRunner.kt
@@ -7,8 +7,6 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.link.account.LinkStore
 import com.stripe.android.networktesting.NetworkRule
-import com.stripe.android.paymentelement.AnalyticEventCallback
-import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
 import com.stripe.android.paymentsheet.CreateIntentCallback
 import com.stripe.android.paymentsheet.MainActivity
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -48,29 +46,7 @@ internal class PaymentSheetTestRunnerContext(
 internal fun runPaymentSheetTest(
     networkRule: NetworkRule,
     integrationType: IntegrationType = IntegrationType.Compose,
-    createIntentCallback: CreateIntentCallback? = null,
-    successTimeoutSeconds: Long = 5L,
-    resultCallback: PaymentSheetResultCallback,
-    block: suspend (PaymentSheetTestRunnerContext) -> Unit,
-) {
-    @OptIn(ExperimentalAnalyticEventCallbackApi::class)
-    runPaymentSheetTest(
-        networkRule = networkRule,
-        integrationType = integrationType,
-        createIntentCallback = createIntentCallback,
-        analyticEventCallback = null,
-        successTimeoutSeconds = successTimeoutSeconds,
-        resultCallback = resultCallback,
-        block = block
-    )
-}
-
-@OptIn(ExperimentalAnalyticEventCallbackApi::class)
-internal fun runPaymentSheetTest(
-    networkRule: NetworkRule,
-    integrationType: IntegrationType = IntegrationType.Compose,
-    createIntentCallback: CreateIntentCallback? = null,
-    analyticEventCallback: AnalyticEventCallback? = null,
+    builder: PaymentSheet.Builder.() -> Unit = {},
     successTimeoutSeconds: Long = 5L,
     resultCallback: PaymentSheetResultCallback,
     block: suspend (PaymentSheetTestRunnerContext) -> Unit,
@@ -81,8 +57,7 @@ internal fun runPaymentSheetTest(
         resultCallback.onPaymentSheetResult(result)
         countDownLatch.countDown()
     }.apply {
-        createIntentCallback?.let { createIntentCallback(it) }
-        analyticEventCallback?.let { analyticEventCallback(it) }
+        builder()
     }
 
     ActivityScenario.launch(MainActivity::class.java).use { scenario ->


### PR DESCRIPTION
# Summary
Use builders in Payment Element emulator tests

# Motivation
We have more and more callbacks being added to Payment Element. We should be able to build our emulator tests with callback builders rather than add a new test method every time.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified