### PR TITLE
Remove Group Restriction Annotation on Analytic Event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### PaymentSheet
 * [ADDED][10733](https://github.com/stripe/stripe-android/pull/10733) Added support for [custom payment methods](https://docs.stripe.com/payments/payment-methods/custom-payment-methods).
 * [ADDED][10720](https://github.com/stripe/stripe-android/pull/10720) `EmbeddedPaymentElement` now supports customizing `FormSheetAction` and a 2 step flow (similar to `PaymentSheet.FlowController`).
+* [ADDED][10651](https://github.com/stripe/stripe-android/pull/10651) Analytic Event launches for alpha.
 
 ## 21.11.1 - 2025-04-22
 

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -563,6 +563,77 @@ public final class com/stripe/android/lpmfoundations/paymentmethod/link/LinkInli
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public abstract class com/stripe/android/paymentelement/AnalyticEvent {
+	public static final field $stable I
+}
+
+public final class com/stripe/android/paymentelement/AnalyticEvent$CompletedPaymentMethodForm : com/stripe/android/paymentelement/AnalyticEvent {
+	public static final field $stable I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPaymentMethodType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/paymentelement/AnalyticEvent$DisplayedPaymentMethodForm : com/stripe/android/paymentelement/AnalyticEvent {
+	public static final field $stable I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPaymentMethodType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/paymentelement/AnalyticEvent$PresentedSheet : com/stripe/android/paymentelement/AnalyticEvent {
+	public static final field $stable I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/paymentelement/AnalyticEvent$RemovedSavedPaymentMethod : com/stripe/android/paymentelement/AnalyticEvent {
+	public static final field $stable I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPaymentMethodType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/paymentelement/AnalyticEvent$SelectedPaymentMethodType : com/stripe/android/paymentelement/AnalyticEvent {
+	public static final field $stable I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPaymentMethodType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/paymentelement/AnalyticEvent$SelectedSavedPaymentMethod : com/stripe/android/paymentelement/AnalyticEvent {
+	public static final field $stable I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPaymentMethodType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/paymentelement/AnalyticEvent$StartedInteractionWithPaymentMethodForm : com/stripe/android/paymentelement/AnalyticEvent {
+	public static final field $stable I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPaymentMethodType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/paymentelement/AnalyticEvent$TappedConfirmButton : com/stripe/android/paymentelement/AnalyticEvent {
+	public static final field $stable I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPaymentMethodType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/stripe/android/paymentelement/AnalyticEventCallback {
+	public abstract fun onEvent (Lcom/stripe/android/paymentelement/AnalyticEvent;)V
+}
+
 public abstract interface class com/stripe/android/paymentelement/ConfirmCustomPaymentMethodCallback {
 	public abstract fun onConfirmCustomPaymentMethod (Lcom/stripe/android/paymentsheet/PaymentSheet$CustomPaymentMethod;Lcom/stripe/android/model/PaymentMethod$BillingDetails;)V
 }
@@ -628,6 +699,7 @@ public final class com/stripe/android/paymentelement/EmbeddedPaymentElement {
 public final class com/stripe/android/paymentelement/EmbeddedPaymentElement$Builder {
 	public static final field $stable I
 	public fun <init> (Lcom/stripe/android/paymentsheet/CreateIntentCallback;Lcom/stripe/android/paymentelement/EmbeddedPaymentElement$ResultCallback;)V
+	public final fun analyticEventCallback (Lcom/stripe/android/paymentelement/AnalyticEventCallback;)Lcom/stripe/android/paymentelement/EmbeddedPaymentElement$Builder;
 	public final fun confirmCustomPaymentMethodCallback (Lcom/stripe/android/paymentelement/ConfirmCustomPaymentMethodCallback;)Lcom/stripe/android/paymentelement/EmbeddedPaymentElement$Builder;
 	public final fun externalPaymentMethodConfirmHandler (Lcom/stripe/android/paymentsheet/ExternalPaymentMethodConfirmHandler;)Lcom/stripe/android/paymentelement/EmbeddedPaymentElement$Builder;
 }
@@ -752,6 +824,9 @@ public final class com/stripe/android/paymentelement/EmbeddedPaymentElement$Stat
 
 public final class com/stripe/android/paymentelement/EmbeddedPaymentElementKtxKt {
 	public static final fun rememberEmbeddedPaymentElement (Lcom/stripe/android/paymentelement/EmbeddedPaymentElement$Builder;Landroidx/compose/runtime/Composer;I)Lcom/stripe/android/paymentelement/EmbeddedPaymentElement;
+}
+
+public abstract interface annotation class com/stripe/android/paymentelement/ExperimentalAnalyticEventCallbackApi : java/lang/annotation/Annotation {
 }
 
 public abstract interface annotation class com/stripe/android/paymentelement/ExperimentalEmbeddedPaymentElementApi : java/lang/annotation/Annotation {
@@ -1451,6 +1526,7 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCo
 public final class com/stripe/android/paymentsheet/PaymentSheet$Builder {
 	public static final field $stable I
 	public fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheetResultCallback;)V
+	public final fun analyticEventCallback (Lcom/stripe/android/paymentelement/AnalyticEventCallback;)Lcom/stripe/android/paymentsheet/PaymentSheet$Builder;
 	public final fun build (Landroidx/activity/ComponentActivity;)Lcom/stripe/android/paymentsheet/PaymentSheet;
 	public final fun build (Landroidx/compose/runtime/Composer;I)Lcom/stripe/android/paymentsheet/PaymentSheet;
 	public final fun build (Landroidx/fragment/app/Fragment;)Lcom/stripe/android/paymentsheet/PaymentSheet;
@@ -1727,6 +1803,7 @@ public abstract interface class com/stripe/android/paymentsheet/PaymentSheet$Flo
 public final class com/stripe/android/paymentsheet/PaymentSheet$FlowController$Builder {
 	public static final field $stable I
 	public fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheetResultCallback;Lcom/stripe/android/paymentsheet/PaymentOptionCallback;)V
+	public final fun analyticEventCallback (Lcom/stripe/android/paymentelement/AnalyticEventCallback;)Lcom/stripe/android/paymentsheet/PaymentSheet$FlowController$Builder;
 	public final fun build (Landroidx/activity/ComponentActivity;)Lcom/stripe/android/paymentsheet/PaymentSheet$FlowController;
 	public final fun build (Landroidx/compose/runtime/Composer;I)Lcom/stripe/android/paymentsheet/PaymentSheet$FlowController;
 	public final fun build (Landroidx/fragment/app/Fragment;)Lcom/stripe/android/paymentsheet/PaymentSheet$FlowController;

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/AnalyticEventCallback.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/AnalyticEventCallback.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentelement
 
-import androidx.annotation.RestrictTo
 import dev.drewhamilton.poko.Poko
 
 /**
@@ -21,7 +20,6 @@ abstract class AnalyticEvent internal constructor() {
     /**
      * User viewed the payment sheet
      */
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     class PresentedSheet internal constructor() : AnalyticEvent() {
         override fun toString(): String =
             javaClass.simpleName
@@ -37,48 +35,41 @@ abstract class AnalyticEvent internal constructor() {
      * User selected a payment method type
      */
     @Poko
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     class SelectedPaymentMethodType internal constructor(val paymentMethodType: String) : AnalyticEvent()
 
     /**
      * User viewed a payment method form
      */
     @Poko
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     class DisplayedPaymentMethodForm internal constructor(val paymentMethodType: String) : AnalyticEvent()
 
     /**
      * User interacted with a payment method form
      */
     @Poko
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     class StartedInteractionWithPaymentMethodForm internal constructor(val paymentMethodType: String) : AnalyticEvent()
 
     /**
      * User completed all required payment form fields
      */
     @Poko
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     class CompletedPaymentMethodForm internal constructor(val paymentMethodType: String) : AnalyticEvent()
 
     /**
      * User tapped on the confirm button
      */
     @Poko
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     class TappedConfirmButton internal constructor(val paymentMethodType: String) : AnalyticEvent()
 
     /**
      * User selected a saved payment method
      */
     @Poko
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     class SelectedSavedPaymentMethod internal constructor(val paymentMethodType: String) : AnalyticEvent()
 
     /**
      * User removed a saved payment method
      */
     @Poko
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     class RemovedSavedPaymentMethod internal constructor(val paymentMethodType: String) : AnalyticEvent()
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/AnalyticEventCallback.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/AnalyticEventCallback.kt
@@ -10,13 +10,11 @@ import dev.drewhamilton.poko.Poko
  *
  * @param event the [AnalyticEvent] that was emitted
  */
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @ExperimentalAnalyticEventCallbackApi
 fun interface AnalyticEventCallback {
     fun onEvent(event: AnalyticEvent)
 }
 
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @ExperimentalAnalyticEventCallbackApi
 abstract class AnalyticEvent internal constructor() {
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
@@ -4,7 +4,6 @@ import android.app.Activity
 import android.graphics.drawable.Drawable
 import android.os.Parcelable
 import androidx.activity.result.ActivityResultCaller
-import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.graphics.painter.Painter

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
@@ -151,7 +151,6 @@ class EmbeddedPaymentElement @Inject internal constructor(
          * Called when an analytic event is emitted.
          */
         @ExperimentalAnalyticEventCallbackApi
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         fun analyticEventCallback(callback: AnalyticEventCallback) = apply {
             this.analyticEventCallback = callback
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/ExperimentalAnalyticEventCallbackApi.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/ExperimentalAnalyticEventCallbackApi.kt
@@ -1,11 +1,8 @@
 package com.stripe.android.paymentelement
 
-import androidx.annotation.RestrictTo
-
 @RequiresOptIn(
     level = RequiresOptIn.Level.ERROR,
     message = "This API is under construction. It can be changed or removed at any time (use at your own risk)."
 )
 @Retention(AnnotationRetention.BINARY)
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 annotation class ExperimentalAnalyticEventCallbackApi

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -252,7 +252,6 @@ class PaymentSheet internal constructor(
         /**
          * @param callback Called when an analytic event occurs.
          */
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         @ExperimentalAnalyticEventCallbackApi
         fun analyticEventCallback(callback: AnalyticEventCallback) = apply {
             callbacksBuilder.analyticEventCallback(callback)
@@ -2327,7 +2326,6 @@ class PaymentSheet internal constructor(
             /**
              * @param callback If specified, called when an analytic event occurs.
              */
-            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
             @ExperimentalAnalyticEventCallbackApi
             fun analyticEventCallback(callback: AnalyticEventCallback) = apply {
                 callbacksBuilder.analyticEventCallback(callback)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Remove the annotation so the users can adopt these APIs.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://home.corp.stripe.com/compass/projects/mpe-events/docs
[MOBILESDK-3474](https://jira.corp.stripe.com/browse/MOBILESDK-3474)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
    - [ADDED][10651](https://github.com/stripe/stripe-android/pull/10651) Analytic Event launches for alpha.