### PR TITLE
Un-restrict remaining CustomerSession APIs

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -185,6 +185,7 @@ public final class com/stripe/android/customersheet/CustomerSheet$IntentConfigur
 
 public final class com/stripe/android/customersheet/CustomerSheetComposeKt {
 	public static final fun rememberCustomerSheet (Lcom/stripe/android/customersheet/CustomerAdapter;Lcom/stripe/android/customersheet/CustomerSheetResultCallback;Landroidx/compose/runtime/Composer;I)Lcom/stripe/android/customersheet/CustomerSheet;
+	public static final fun rememberCustomerSheet (Lcom/stripe/android/customersheet/CustomerSheet$CustomerSessionProvider;Lcom/stripe/android/customersheet/CustomerSheetResultCallback;Landroidx/compose/runtime/Composer;I)Lcom/stripe/android/customersheet/CustomerSheet;
 }
 
 public final class com/stripe/android/customersheet/CustomerSheetConfigureRequest$Creator : android/os/Parcelable$Creator {
@@ -959,6 +960,9 @@ public final class com/stripe/android/paymentsheet/CreateIntentResult$Success : 
 }
 
 public abstract interface annotation class com/stripe/android/paymentsheet/DelicatePaymentSheetApi : java/lang/annotation/Annotation {
+}
+
+public abstract interface annotation class com/stripe/android/paymentsheet/ExperimentalCustomerSessionApi : java/lang/annotation/Annotation {
 }
 
 public abstract interface annotation class com/stripe/android/paymentsheet/ExperimentalPaymentSheetDecouplingApi : java/lang/annotation/Annotation {

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetCompose.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetCompose.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.customersheet
 
 import androidx.activity.compose.LocalActivityResultRegistryOwner
-import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -39,7 +38,6 @@ fun rememberCustomerSheet(
 * @param callback Called with the result of the operation after [CustomerSheet] is dismissed
 */
 @ExperimentalCustomerSessionApi
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Composable
 fun rememberCustomerSheet(
     customerSessionProvider: CustomerSheet.CustomerSessionProvider,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ExperimentalCustomerSessionApi.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ExperimentalCustomerSessionApi.kt
@@ -1,7 +1,5 @@
 package com.stripe.android.paymentsheet
 
-import androidx.annotation.RestrictTo
-
 @RequiresOptIn(message = "Customer session support is beta. It may be changed in the future without notice.")
 @Retention(AnnotationRetention.BINARY)
 @Target(
@@ -9,5 +7,4 @@ import androidx.annotation.RestrictTo
     AnnotationTarget.FUNCTION,
     AnnotationTarget.PROPERTY
 )
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 annotation class ExperimentalCustomerSessionApi


### PR DESCRIPTION
# Summary
Un-restrict remaining CustomerSession APIs

# Motivation
These shouldn't be restricted since we announced that `CustomerSession` is available in October 2024.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified