### PR TITLE
Fix onRemoveSavedPaymentMethod does not correctly send when no PM is selected

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -159,9 +159,6 @@ internal class SavedPaymentMethodMutator(
             withContext(uiContext) {
                 setSelection(null)
             }
-            currentSelection?.type?.code?.let {
-                eventReporter.onRemoveSavedPaymentMethod(it)
-            }
         }
 
         return customerRepository.detachPaymentMethod(
@@ -178,6 +175,9 @@ internal class SavedPaymentMethodMutator(
     private suspend fun removeDeletedPaymentMethodFromState(paymentMethodId: String) {
         val currentCustomer = customerStateHolder.customer.value ?: return
 
+        currentCustomer.paymentMethods.find { it.id == paymentMethodId }?.type?.code?.let {
+            eventReporter.onRemoveSavedPaymentMethod(it)
+        }
         customerStateHolder.setCustomerState(
             currentCustomer.copy(
                 paymentMethods = currentCustomer.paymentMethods.filter {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
@@ -164,6 +164,7 @@ class SavedPaymentMethodMutatorTest {
             }
 
             assertThat(postPaymentMethodRemovedTurbine.awaitItem()).isEqualTo(Unit)
+            assertThat(eventReporter.removePaymentMethodCalls.awaitItem().code).isEqualTo("card")
 
             assertThat(calledDetach).isTrue()
         }
@@ -202,6 +203,7 @@ class SavedPaymentMethodMutatorTest {
         }
 
         assertThat(postPaymentMethodRemovedTurbine.awaitItem()).isEqualTo(Unit)
+        assertThat(eventReporter.removePaymentMethodCalls.awaitItem().code).isEqualTo("card")
     }
 
     @Test
@@ -264,6 +266,18 @@ class SavedPaymentMethodMutatorTest {
     }
 
     @Test
+    fun `Removing payment methods without any PM selected should correctly send analytic events`() = runScenario {
+        val cards = PaymentMethodFixtures.createCards(3)
+        customerStateHolder.setCustomerState(EMPTY_CUSTOMER_STATE.copy(paymentMethods = cards))
+
+        for (card in cards) {
+            savedPaymentMethodMutator.removePaymentMethod(card)
+            assertThat(postPaymentMethodRemovedTurbine.awaitItem()).isEqualTo(Unit)
+            assertThat(eventReporter.removePaymentMethodCalls.awaitItem().code).isEqualTo("card")
+        }
+    }
+
+    @Test
     fun `On detach without remove duplicate permissions, should not attempt to remove duplicates in repository`() {
         removeDuplicatesTest(shouldRemoveDuplicates = false)
     }
@@ -313,6 +327,7 @@ class SavedPaymentMethodMutatorTest {
 
             assertThat(calledDetach.awaitItem()).isTrue()
             assertThat(prePaymentMethodRemovedTurbine.awaitItem()).isNotNull()
+            assertThat(eventReporter.removePaymentMethodCalls.awaitItem().code).isEqualTo("card")
             assertThat(postPaymentMethodRemovedTurbine.awaitItem()).isNotNull()
 
             assertThat(customerStateHolder.paymentMethods.value).isEmpty()
@@ -346,6 +361,7 @@ class SavedPaymentMethodMutatorTest {
 
             assertThat(calledDetach.awaitItem()).isTrue()
             assertThat(prePaymentMethodRemovedTurbine.awaitItem()).isNotNull()
+            assertThat(eventReporter.removePaymentMethodCalls.awaitItem().code).isEqualTo("card")
             assertThat(postPaymentMethodRemovedTurbine.awaitItem()).isNotNull()
 
             assertThat(customerStateHolder.paymentMethods.value).isEmpty()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Originally, if we remove card1 and then remove card2, only removal of card1 is logged.
This is because `selection` is set to null after removing card1, thus the condition for logging `didRemoveSelectedItem` can not be satisfied.

The fix moves logging into function `removeDeletedPaymentMethodFromState` where:
1. It only executes after successful `removePaymentMethodInternal` (or say `detachPaymentMethod`) operations
2. Tests and production code follow identical paths, enabling accurate behavior verification

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
