### PR TITLE
CardDetailsUI should use number keyboard for expiry date

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/CommonTextField.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/CommonTextField.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.ui
 
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.shape.ZeroCornerSize
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.ContentAlpha
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -24,6 +25,7 @@ internal fun CommonTextField(
     shouldShowError: Boolean = false,
     enabled: Boolean = false,
     visualTransformation: VisualTransformation = VisualTransformation.None,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     shape: Shape =
         MaterialTheme.shapes.small.copy(bottomEnd = ZeroCornerSize, bottomStart = ZeroCornerSize),
     colors: TextFieldColors = TextFieldColors(
@@ -42,6 +44,7 @@ internal fun CommonTextField(
         trailingIcon = trailingIcon,
         shape = shape,
         colors = colors,
+        keyboardOptions = keyboardOptions,
         visualTransformation = visualTransformation,
         onValueChange = onValueChange,
     )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/ExpiryTextField.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/ExpiryTextField.kt
@@ -54,7 +54,7 @@ internal fun ExpiryTextField(
         ),
         shouldShowError = isError,
         keyboardOptions = KeyboardOptions.Default.copy(
-            keyboardType = KeyboardType.Number
+            keyboardType = KeyboardType.NumberPassword
         ),
         visualTransformation = ExpiryDateVisualTransformation(CARD_EDIT_UI_FALLBACK_EXPIRY_DATE),
         colors = colors

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/ExpiryTextField.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/ExpiryTextField.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.ui
 
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.shape.ZeroCornerSize
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.TextFieldDefaults.indicatorLine
@@ -11,6 +12,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
 import com.stripe.android.uicore.elements.ExpiryDateVisualTransformation
 import com.stripe.android.uicore.elements.TextFieldColors
 import com.stripe.android.uicore.elements.compat.errorSemanticsWithDefault
@@ -51,6 +53,9 @@ internal fun ExpiryTextField(
             bottomEnd = ZeroCornerSize,
         ),
         shouldShowError = isError,
+        keyboardOptions = KeyboardOptions.Default.copy(
+            keyboardType = KeyboardType.Number
+        ),
         visualTransformation = ExpiryDateVisualTransformation(CARD_EDIT_UI_FALLBACK_EXPIRY_DATE),
         colors = colors
     )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
CardDetailsUI should use number keyboard for expiry date

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots

https://github.com/user-attachments/assets/e095c415-a543-46fe-bf9e-4f2f3040e0b2



# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
