### PR TITLE
Add E2E tests for Custom Payment Methods

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCustomPaymentMethod.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCustomPaymentMethod.kt
@@ -1,0 +1,51 @@
+package com.stripe.android.lpm
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.stripe.android.BasePlaygroundTest
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentsheet.example.playground.settings.Country
+import com.stripe.android.paymentsheet.example.playground.settings.CountrySettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.Currency
+import com.stripe.android.paymentsheet.example.playground.settings.CurrencySettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.CustomPaymentMethodPlaygroundType
+import com.stripe.android.paymentsheet.example.playground.settings.CustomPaymentMethodsSettingDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.CustomerSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.CustomerType
+import com.stripe.android.paymentsheet.example.playground.settings.DEFAULT_CUSTOM_PAYMENT_METHOD_ID
+import com.stripe.android.paymentsheet.example.playground.settings.PaymentMethodOrderSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.SupportedPaymentMethodsSettingsDefinition
+import com.stripe.android.test.core.TestParameters
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+internal class TestCustomPaymentMethod : BasePlaygroundTest() {
+    private val testParameters = TestParameters.create(
+        paymentMethodCode = DEFAULT_CUSTOM_PAYMENT_METHOD_ID,
+        executeInNightlyRun = true,
+    ) { settings ->
+        settings[CustomerSettingsDefinition] = CustomerType.GUEST
+        settings[CountrySettingsDefinition] = Country.US
+        settings[CurrencySettingsDefinition] = Currency.USD
+        settings[CustomPaymentMethodsSettingDefinition] = CustomPaymentMethodPlaygroundType.On
+        settings[PaymentMethodOrderSettingsDefinition] = DEFAULT_CUSTOM_PAYMENT_METHOD_ID
+        settings[SupportedPaymentMethodsSettingsDefinition] = listOf(
+            PaymentMethod.Type.Card,
+        ).joinToString(",")
+    }
+
+    @Test
+    fun testCustomPaymentMethod_Success() {
+        testDriver.confirmCustomPaymentMethodSuccess(testParameters)
+    }
+
+    @Test
+    fun testCustomPaymentMethod_Cancel() {
+        testDriver.confirmCustomPaymentMethodCanceled(testParameters)
+    }
+
+    @Test
+    fun testCustomPaymentMethod_Fail() {
+        testDriver.confirmCustomPaymentMethodFailed(testParameters)
+    }
+}

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -40,6 +40,7 @@ import com.stripe.android.paymentsheet.example.BuildConfig
 import com.stripe.android.paymentsheet.example.playground.PaymentSheetPlaygroundActivity
 import com.stripe.android.paymentsheet.example.playground.PlaygroundState
 import com.stripe.android.paymentsheet.example.playground.SUCCESS_RESULT
+import com.stripe.android.paymentsheet.example.playground.activity.CustomPaymentMethodActivity
 import com.stripe.android.paymentsheet.example.playground.activity.FawryActivity
 import com.stripe.android.paymentsheet.example.playground.settings.CheckoutMode
 import com.stripe.android.paymentsheet.example.playground.settings.CheckoutModeSettingsDefinition
@@ -825,7 +826,7 @@ internal class PlaygroundTestDriver(
         setup(testParameters)
         launchComplete()
 
-        confirmExternalPaymentMethod(
+        confirmExternalOrCustomPaymentMethod(
             selectors.externalPaymentMethodSucceedButton,
         )
 
@@ -842,7 +843,7 @@ internal class PlaygroundTestDriver(
         setup(testParameters)
         launchComplete()
 
-        confirmExternalPaymentMethod(
+        confirmExternalOrCustomPaymentMethod(
             selectors.externalPaymentMethodCancelButton,
         )
 
@@ -858,7 +859,7 @@ internal class PlaygroundTestDriver(
         setup(testParameters)
         launchComplete()
 
-        confirmExternalPaymentMethod(
+        confirmExternalOrCustomPaymentMethod(
             selectors.externalPaymentMethodFailButton,
         )
 
@@ -869,7 +870,57 @@ internal class PlaygroundTestDriver(
         teardown()
     }
 
-    private fun confirmExternalPaymentMethod(
+    fun confirmCustomPaymentMethodSuccess(
+        testParameters: TestParameters,
+    ) {
+        setup(testParameters)
+        launchComplete()
+
+        confirmExternalOrCustomPaymentMethod(
+            selectors.customPaymentMethodSucceedButton,
+        )
+
+        waitForPlaygroundActivity()
+
+        assertThat(resultValue).isEqualTo(SUCCESS_RESULT)
+
+        teardown()
+    }
+
+    fun confirmCustomPaymentMethodCanceled(
+        testParameters: TestParameters,
+    ) {
+        setup(testParameters)
+        launchComplete()
+
+        confirmExternalOrCustomPaymentMethod(
+            selectors.customPaymentMethodCancelButton,
+        )
+
+        isSelectPaymentMethodScreen()
+        selectors.buyButton.isEnabled()
+
+        teardown()
+    }
+
+    fun confirmCustomPaymentMethodFailed(
+        testParameters: TestParameters,
+    ) {
+        setup(testParameters)
+        launchComplete()
+
+        confirmExternalOrCustomPaymentMethod(
+            selectors.customPaymentMethodFailButton,
+        )
+
+        composeTestRule.onNode(hasTestTag(PAYMENT_SHEET_ERROR_TEXT_TEST_TAG))
+            .assertIsDisplayed()
+            .assertTextEquals(CustomPaymentMethodActivity.FAILED_DISPLAY_MESSAGE)
+
+        teardown()
+    }
+
+    private fun confirmExternalOrCustomPaymentMethod(
         button: ComposeButton,
     ) {
         clickPaymentSelection()

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/Selectors.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/Selectors.kt
@@ -25,6 +25,7 @@ import com.stripe.android.model.PaymentMethod.Type.Blik
 import com.stripe.android.model.PaymentMethod.Type.CashAppPay
 import com.stripe.android.paymentelement.embedded.form.EMBEDDED_FORM_ACTIVITY_PRIMARY_BUTTON
 import com.stripe.android.paymentsheet.example.playground.RELOAD_TEST_TAG
+import com.stripe.android.paymentsheet.example.playground.activity.CustomPaymentMethodActivity
 import com.stripe.android.paymentsheet.example.playground.activity.FawryActivity
 import com.stripe.android.paymentsheet.example.samples.ui.shared.CHECKOUT_TEST_TAG
 import com.stripe.android.paymentsheet.example.samples.ui.shared.PAYMENT_METHOD_SELECTOR_TEST_TAG
@@ -109,6 +110,21 @@ internal class Selectors(
     val externalPaymentMethodFailButton = ComposeButton(
         composeTestRule,
         hasTestTag(FawryActivity.FAILED_BUTTON_TEST_TAG)
+    )
+
+    val customPaymentMethodSucceedButton = ComposeButton(
+        composeTestRule,
+        hasTestTag(CustomPaymentMethodActivity.COMPLETED_BUTTON_TEST_TAG)
+    )
+
+    val customPaymentMethodCancelButton = ComposeButton(
+        composeTestRule,
+        hasTestTag(CustomPaymentMethodActivity.CANCELED_BUTTON_TEST_TAG)
+    )
+
+    val customPaymentMethodFailButton = ComposeButton(
+        composeTestRule,
+        hasTestTag(CustomPaymentMethodActivity.FAILED_BUTTON_TEST_TAG)
     )
 
     val googlePayButton = ComposeButton(

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/CustomPaymentMethodActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/CustomPaymentMethodActivity.kt
@@ -115,6 +115,6 @@ class CustomPaymentMethodActivity : AppCompatActivity() {
         const val COMPLETED_BUTTON_TEST_TAG = "cpm_complete"
         const val CANCELED_BUTTON_TEST_TAG = "cpm_canceled"
         const val FAILED_BUTTON_TEST_TAG = "cpm_failed"
-        const val FAILED_DISPLAY_MESSAGE = "Payment failed!"
+        const val FAILED_DISPLAY_MESSAGE = "Custom payment failed!"
     }
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomPaymentMethodsSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomPaymentMethodsSettingsDefinition.kt
@@ -64,11 +64,13 @@ enum class CustomPaymentMethodPlaygroundType(
         get() = name
 }
 
+internal const val DEFAULT_CUSTOM_PAYMENT_METHOD_ID = "cpmt_1QpIMNLu5o3P18Zpwln1Sm6I"
+
 @OptIn(ExperimentalCustomPaymentMethodsApi::class)
 private fun createCustomPaymentMethods(disableBillingDetails: Boolean): List<PaymentSheet.CustomPaymentMethod> {
     return listOf(
         PaymentSheet.CustomPaymentMethod(
-            id = "cpmt_1QpIMNLu5o3P18Zpwln1Sm6I",
+            id = DEFAULT_CUSTOM_PAYMENT_METHOD_ID,
             subtitle = "Pay now with BufoPay",
             disableBillingDetailCollection = disableBillingDetails,
         )


### PR DESCRIPTION
# Summary
Add E2E tests for Custom Payment Methods

# Motivation
Ensure CPMs is well-tested.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified