### PR TITLE
Add retries to instrumentation tests.

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -281,7 +281,7 @@ workflows:
           title: Execute instrumentation tests
           timeout: 1200
           inputs:
-            - content: ./gradlew :example:connectedAndroidTest
+            - content: ./scripts/retry.sh 3 ./gradlew :example:connectedAndroidTest
   run-financial-connections-instrumentation-tests:
     before_run:
       - start_emulator


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
These have started flaking more recently. Adding retries to avoid disruption. 

Example failure:
```
com.stripe.example.activity.CreateCardTokenActivityTest > createCardToken[emulator(AVD) - 13] FAILED 
	androidx.test.espresso.base.RootViewPicker$RootViewWithoutFocusException: Waited for the root of the view hierarchy to have window focus and not request layout for 10 seconds. If you specified a non default root matcher, it may be picking a root that never takes focus. Root:
	Root{application-window-token=android.view.ViewRootImpl$W@89fe7bd, window-token=android.view.ViewRootImpl$W@89fe7bd, has-window-focus=false, layout-params-type=1, layout-params-string={(0,0)(fillxfill) sim={forwardNavigation} ty=BASE_APPLICATION wanim=0x10302fd
```