### PR TITLE
Validate json from body

### DIFF
--- a/network-testing/src/main/java/com/stripe/android/networktesting/NetworkRule.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/NetworkRule.kt
@@ -46,21 +46,27 @@ class NetworkRule private constructor(
 
     fun enqueue(
         vararg requestMatcher: RequestMatcher,
+        checkValidJson: Boolean = true,
         responseFactory: (MockResponse) -> Unit
     ) {
         mockWebServer.dispatcher.enqueue(*requestMatcher) { response ->
             responseFactory(response)
-            assertResponseBodyIsValidJson(response)
+            if (checkValidJson) {
+                assertResponseBodyIsValidJson(response)
+            }
         }
     }
 
     fun enqueue(
         vararg requestMatcher: RequestMatcher,
+        checkValidJson: Boolean = true,
         responseFactory: (TestRecordedRequest, MockResponse) -> Unit
     ) {
         mockWebServer.dispatcher.enqueue(*requestMatcher) { request, response ->
             responseFactory(request, response)
-            assertResponseBodyIsValidJson(response)
+            if (checkValidJson) {
+                assertResponseBodyIsValidJson(response)
+            }
         }
     }
 

--- a/network-testing/src/main/java/com/stripe/android/networktesting/NetworkRule.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/NetworkRule.kt
@@ -46,12 +46,12 @@ class NetworkRule private constructor(
 
     fun enqueue(
         vararg requestMatcher: RequestMatcher,
-        checkValidJson: Boolean = true,
+        ensureResponseIsValidJson: Boolean = true,
         responseFactory: (MockResponse) -> Unit
     ) {
         mockWebServer.dispatcher.enqueue(*requestMatcher) { response ->
             responseFactory(response)
-            if (checkValidJson) {
+            if (ensureResponseIsValidJson) {
                 assertResponseBodyIsValidJson(response)
             }
         }
@@ -59,12 +59,12 @@ class NetworkRule private constructor(
 
     fun enqueue(
         vararg requestMatcher: RequestMatcher,
-        checkValidJson: Boolean = true,
+        ensureResponseIsValidJson: Boolean = true,
         responseFactory: (TestRecordedRequest, MockResponse) -> Unit
     ) {
         mockWebServer.dispatcher.enqueue(*requestMatcher) { request, response ->
             responseFactory(request, response)
-            if (checkValidJson) {
+            if (ensureResponseIsValidJson) {
                 assertResponseBodyIsValidJson(response)
             }
         }

--- a/payments-model/src/test/java/com/stripe/android/repository/ConsumersApiServiceImplTest.kt
+++ b/payments-model/src/test/java/com/stripe/android/repository/ConsumersApiServiceImplTest.kt
@@ -123,6 +123,7 @@ class ConsumersApiServiceImplTest {
         networkRule.enqueue(
             method("POST"),
             path("/v1/consumers/sessions/lookup"),
+            checkValidJson = false
         ) { response ->
             response.setResponseCode(400)
             response.setBody("""{"invalid-json"}""")

--- a/payments-model/src/test/java/com/stripe/android/repository/ConsumersApiServiceImplTest.kt
+++ b/payments-model/src/test/java/com/stripe/android/repository/ConsumersApiServiceImplTest.kt
@@ -123,7 +123,7 @@ class ConsumersApiServiceImplTest {
         networkRule.enqueue(
             method("POST"),
             path("/v1/consumers/sessions/lookup"),
-            checkValidJson = false
+            ensureResponseIsValidJson = false
         ) { response ->
             response.setResponseCode(400)
             response.setBody("""{"invalid-json"}""")

--- a/stripe-core/src/test/java/com/stripe/android/core/networking/NetworkCachingTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/networking/NetworkCachingTest.kt
@@ -19,13 +19,13 @@ internal class NetworkCachingTest {
 
     @Test
     fun `request that should cache creates a connection that uses cache`() = runTest {
-        networkRule.enqueue(method("GET")) { response ->
+        networkRule.enqueue(method("GET"), checkValidJson = false) { response ->
             response.setBody("response1")
         }
-        networkRule.enqueue(method("GET")) { response ->
+        networkRule.enqueue(method("GET"), checkValidJson = false) { response ->
             response.setBody("response2")
         }
-        networkRule.enqueue(method("GET")) { response ->
+        networkRule.enqueue(method("GET"), checkValidJson = false) { response ->
             response.setBody("response3")
         }
 

--- a/stripe-core/src/test/java/com/stripe/android/core/networking/NetworkCachingTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/networking/NetworkCachingTest.kt
@@ -19,13 +19,13 @@ internal class NetworkCachingTest {
 
     @Test
     fun `request that should cache creates a connection that uses cache`() = runTest {
-        networkRule.enqueue(method("GET"), checkValidJson = false) { response ->
+        networkRule.enqueue(method("GET"), ensureResponseIsValidJson = false) { response ->
             response.setBody("response1")
         }
-        networkRule.enqueue(method("GET"), checkValidJson = false) { response ->
+        networkRule.enqueue(method("GET"), ensureResponseIsValidJson = false) { response ->
             response.setBody("response2")
         }
-        networkRule.enqueue(method("GET"), checkValidJson = false) { response ->
+        networkRule.enqueue(method("GET"), ensureResponseIsValidJson = false) { response ->
             response.setBody("response3")
         }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
`NetworkRule.enqueue` is the place where all the mock response will go through no matter it is from file or code. This validation is separated from the #10558, because it is beneficial to log the file name which is not achievable in `NetworkRule`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
[MOBILESDK-3446](https://jira.corp.stripe.com/browse/MOBILESDK-3446)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
