### PR TITLE
Fix primary button being enabled in `PaymentSheet` when initial load with `Google Pay` or `Link` selection

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -276,7 +276,11 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         withContext(Dispatchers.Main.immediate) {
             customerStateHolder.setCustomerState(state.customer)
 
-            updateSelection(state.paymentSelection)
+            when (state.paymentSelection) {
+                is PaymentSelection.GooglePay,
+                is PaymentSelection.Link -> Unit
+                else -> updateSelection(state.paymentSelection)
+            }
 
             setPaymentMethodMetadata(state.paymentMethodMetadata)
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -1721,6 +1721,44 @@ internal class PaymentSheetViewModelTest {
     }
 
     @Test
+    fun `On load with initial Google Pay selection, selection should be null & primary button disabled`() = runTest {
+        val viewModel = createViewModel(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            initialPaymentSelection = PaymentSelection.GooglePay,
+        )
+
+        viewModel.selection.test {
+            assertThat(awaitItem()).isNull()
+        }
+
+        viewModel.primaryButtonUiState.test {
+            val uiState = awaitItem()
+
+            assertThat(uiState).isNotNull()
+            assertThat(uiState?.enabled).isFalse()
+        }
+    }
+
+    @Test
+    fun `On load with initial Link selection, selection should be null & primary button disabled`() = runTest {
+        val viewModel = createViewModel(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            initialPaymentSelection = PaymentSelection.GooglePay,
+        )
+
+        viewModel.selection.test {
+            assertThat(awaitItem()).isNull()
+        }
+
+        viewModel.primaryButtonUiState.test {
+            val uiState = awaitItem()
+
+            assertThat(uiState).isNotNull()
+            assertThat(uiState?.enabled).isFalse()
+        }
+    }
+
+    @Test
     fun `Sends correct event when navigating to AddFirstPaymentMethod screen`() = runTest {
         val viewModel = createViewModel(
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,


### PR DESCRIPTION
# Summary
Fix primary button being enabled in `PaymentSheet` when initial load with `Google Pay` or `Link` selection

# Motivation
Better UX for `PaymentSheet`

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Video
| Before  | After |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/880f942b-1550-4c43-8a49-010c4d4657e4" />  | <video src="https://github.com/user-attachments/assets/e629ed48-ae8f-4415-8749-ca21b01021ab" /> |