### PR TITLE
Release FC lite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Dependencies updated in [10579](https://github.com/stripe/stripe-android/pull/10
 * Bumped Compose from 1.6.8 to 1.7.8.
 * Bumped Androidx Navigation from 2.7.7 to 2.8.5.
 
+### PaymentSheet
+[Added] Bank payments are now available in the PaymentSheet without requiring a dependency on `:financial-connections`.
+
 ## 21.10.0 - 2025-04-11
 
 ### Payments

--- a/payments-core/src/main/java/com/stripe/android/payments/financialconnections/GetFinancialConnectionsAvailability.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/financialconnections/GetFinancialConnectionsAvailability.kt
@@ -2,7 +2,6 @@ package com.stripe.android.payments.financialconnections
 
 import androidx.annotation.RestrictTo
 import com.stripe.android.core.utils.FeatureFlags.financialConnectionsFullSdkUnavailable
-import com.stripe.android.core.utils.FeatureFlags.financialConnectionsLiteEnabled
 import com.stripe.android.model.ElementsSession
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -16,7 +15,7 @@ object GetFinancialConnectionsAvailability {
             isFullSdkAvailable() && financialConnectionsFullSdkUnavailable.isEnabled.not() -> {
                 FinancialConnectionsAvailability.Full
             }
-            elementsSession.fcLiteKillSwitchEnabled().not() && financialConnectionsLiteEnabled.isEnabled -> {
+            elementsSession.fcLiteKillSwitchEnabled().not() -> {
                 FinancialConnectionsAvailability.Lite
             }
             else -> {

--- a/payments-core/src/test/java/com/stripe/android/payments/financialconnections/GetFinancialConnectionsAvailabilityTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/financialconnections/GetFinancialConnectionsAvailabilityTest.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.payments.financialconnections
 
 import com.stripe.android.core.utils.FeatureFlags.financialConnectionsFullSdkUnavailable
-import com.stripe.android.core.utils.FeatureFlags.financialConnectionsLiteEnabled
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.ElementsSession.Flag.ELEMENTS_DISABLE_FC_LITE
 import com.stripe.android.testing.FeatureFlagTestRule
@@ -16,12 +15,6 @@ class GetFinancialConnectionsAvailabilityTest {
     @get:Rule
     val financialConnectionsFullSdkUnavailableFeatureFlagTestRule = FeatureFlagTestRule(
         featureFlag = financialConnectionsFullSdkUnavailable,
-        isEnabled = false
-    )
-
-    @get:Rule
-    val financialConnectionsLiteEnabledFeatureFlagTestRule = FeatureFlagTestRule(
-        featureFlag = financialConnectionsLiteEnabled,
         isEnabled = false
     )
 
@@ -53,7 +46,6 @@ class GetFinancialConnectionsAvailabilityTest {
 
     @Test
     fun `when full not available and killswitch not enabled, should return Lite`() {
-        financialConnectionsLiteEnabled.setEnabled(true)
         val elementsSession = createSession(flags = emptyMap())
         assertEquals(
             FinancialConnectionsAvailability.Lite,
@@ -67,7 +59,6 @@ class GetFinancialConnectionsAvailabilityTest {
     @Test
     fun `when full client flag on and killswitch not enabled, should return Lite`() {
         financialConnectionsFullSdkUnavailableFeatureFlagTestRule.setEnabled(true)
-        financialConnectionsLiteEnabled.setEnabled(true)
         val elementsSession = createSession(flags = emptyMap())
         assertEquals(
             FinancialConnectionsAvailability.Lite,

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestUSBankAccount.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestUSBankAccount.kt
@@ -64,7 +64,6 @@ internal class TestUSBankAccount : BasePlaygroundTest() {
             testParameters = testParameters
                 .copyPlaygroundSettings {
                     it[DefaultBillingAddressSettingsDefinition] = DefaultBillingAddress.OnWithRandomEmail
-                    it[FeatureFlagSettingsDefinition(FeatureFlags.financialConnectionsLiteEnabled)] = true
                     it[FeatureFlagSettingsDefinition(FeatureFlags.financialConnectionsFullSdkUnavailable)] = true
                 }
                 .copy(executeInNightlyRun = false),
@@ -146,7 +145,6 @@ internal class TestUSBankAccount : BasePlaygroundTest() {
             financialConnectionsLiteEnabled = true,
             testParameters = testParameters
                 .copyPlaygroundSettings {
-                    it[FeatureFlagSettingsDefinition(FeatureFlags.financialConnectionsLiteEnabled)] = true
                     it[FeatureFlagSettingsDefinition(FeatureFlags.financialConnectionsFullSdkUnavailable)] = true
                 }.copy(
                     authorizationAction = AuthorizeAction.Cancel,

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestUsBankAccountInCustomerSheet.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestUsBankAccountInCustomerSheet.kt
@@ -51,7 +51,6 @@ internal class TestUsBankAccountInCustomerSheet : BasePlaygroundTest() {
                 authorizationAction = AuthorizeAction.Cancel,
             ).copyPlaygroundSettings {
                 it[DefaultBillingAddressSettingsDefinition] = DefaultBillingAddress.OnWithRandomEmail
-                it[FeatureFlagSettingsDefinition(FeatureFlags.financialConnectionsLiteEnabled)] = true
                 it[FeatureFlagSettingsDefinition(FeatureFlags.financialConnectionsFullSdkUnavailable)] = true
             }
         )
@@ -79,7 +78,6 @@ internal class TestUsBankAccountInCustomerSheet : BasePlaygroundTest() {
             ).copyPlaygroundSettings { settings ->
                 settings[CustomerSessionSettingsDefinition] = true
                 settings[DefaultBillingAddressSettingsDefinition] = DefaultBillingAddress.OnWithRandomEmail
-                settings[FeatureFlagSettingsDefinition(FeatureFlags.financialConnectionsLiteEnabled)] = true
                 settings[FeatureFlagSettingsDefinition(FeatureFlags.financialConnectionsFullSdkUnavailable)] = true
             }
         )

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -452,7 +452,6 @@ internal class PlaygroundSettings private constructor(
             LayoutSettingsDefinition,
             CardBrandAcceptanceSettingsDefinition,
             FeatureFlagSettingsDefinition(FeatureFlags.instantDebitsIncentives),
-            FeatureFlagSettingsDefinition(FeatureFlags.financialConnectionsLiteEnabled),
             FeatureFlagSettingsDefinition(FeatureFlags.financialConnectionsFullSdkUnavailable),
             EmbeddedViewDisplaysMandateSettingDefinition,
             EmbeddedFormSheetActionSettingDefinition,

--- a/stripe-core/src/main/java/com/stripe/android/core/utils/FeatureFlags.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/FeatureFlags.kt
@@ -10,7 +10,6 @@ object FeatureFlags {
     val nativeLinkAttestationEnabled = FeatureFlag("Native Link Attestation")
     val instantDebitsIncentives = FeatureFlag("Instant Bank Payments Incentives")
     val editSavedCardPaymentMethodEnabled = FeatureFlag("Edit Saved Card Payment Method")
-    val financialConnectionsLiteEnabled = FeatureFlag("FC Lite enabled")
     val financialConnectionsFullSdkUnavailable = FeatureFlag("FC Full SDK Unavailable")
 }
 


### PR DESCRIPTION
# Summary
- Removes "disable FC Lite" flag. It can still be disabled via the backend killswitch.
- Adds release notes.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [ ] Manually verified