### PR TITLE
[Link holdback] Uses space separator on `dvs-provided` dimension.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/analytics/experiment/LoggableExperiment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/analytics/experiment/LoggableExperiment.kt
@@ -50,7 +50,7 @@ internal sealed class LoggableExperiment(
                 if (email) "email" else null,
                 if (name) "name" else null,
                 if (phone) "phone" else null
-            ).joinToString(",")
+            ).joinToString(" ")
         }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -661,6 +661,7 @@ class DefaultEventReporterTest {
             assertEquals(params["dimensions-is_returning_link_user"], "false")
             assertEquals(params["dimensions-recognition_type"], "email")
             assertEquals(params["dimensions-link_displayed"], "true")
+            assertEquals(params["dimensions-dvs_provided"], "email phone")
             assertEquals(params["dimensions-integration_shape"], "embedded")
             assertEquals(params["sdk_platform"], "android")
             assertEquals(params["plugin_type"], "native")


### PR DESCRIPTION
# Summary
- We're currently using commas as separators, but we should be using spaces.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [ ] Manually verified
