### PR TITLE
Fix for postal code changed state in CardEditUI

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BillingDetailsEntry.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BillingDetailsEntry.kt
@@ -48,6 +48,7 @@ internal data class BillingDetailsEntry(
         get() = this?.isComplete ?: true
 
     private infix fun String?.nullableNeq(other: FormFieldEntry?): Boolean {
-        return this.orEmpty() != other?.value.orEmpty()
+        if (other == null) return false
+        return this.orEmpty() != other.value.orEmpty()
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/BillingDetailsEntryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/BillingDetailsEntryTest.kt
@@ -248,6 +248,24 @@ internal class BillingDetailsEntryTest {
         assertThat(hasChanged).isFalse()
     }
 
+    @Test
+    fun `hasChanged() returns false when comparing String against null FormFieldEntry`() {
+        val state = billingDetailsEntry(
+            billingDetailsFormState = billingDetailsFormState(
+                line1 = null,
+                line2 = null,
+                city = null,
+                state = null,
+            )
+        )
+
+        val hasChanged = state.hasChanged(
+            billingDetails = BILLING_DETAILS_FORM_DETAILS,
+            addressCollectionMode = AddressCollectionMode.Automatic
+        )
+        assertThat(hasChanged).isFalse()
+    }
+
     private fun billingDetailsEntry(
         billingDetailsFormState: BillingDetailsFormState = billingDetailsFormState()
     ): BillingDetailsEntry {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Save button is always enabled after changing from a country requiring postal code to one that doesn't.

https://drive.google.com/file/d/1B5x7Bl1ekFxb9xEOElL_5N12NLYhLoSz/view?usp=sharing

This PR fixes that issue.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-3495

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots

https://github.com/user-attachments/assets/af66a154-6deb-49ef-b960-fe4de0bafc2b



# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
