### PR TITLE
[fc] Stop sending `forced_authflow_version` param

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsManifestRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsManifestRepository.kt
@@ -248,8 +248,6 @@ private class FinancialConnectionsManifestRepositoryImpl(
                 "emit_events" to true,
                 "locale" to locale.toLanguageTag(),
                 "mobile" to mapOf(
-                    // This ensures backend returns v3 responses.
-                    "forced_authflow_version" to "v3",
                     PARAMS_FULLSCREEN to true,
                     PARAMS_HIDE_CLOSE_BUTTON to true,
                     PARAMS_SUPPORT_APP_VERIFICATION to supportsAppVerification,


### PR DESCRIPTION
# Summary
Stop sending parameter `mobile.forced_authflow_version` in `POST /v1/financial_connections/sessions/synchronize`.

# Motivation
https://jira.corp.stripe.com/browse/LINK_MOBILE-60

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

Ran through the FC example app with no issues.