### PR TITLE
Update test dispatchers for confirmation tests.

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ExtendedPaymentElementConfirmationTestActivity.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ExtendedPaymentElementConfirmationTestActivity.kt
@@ -13,8 +13,8 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.Logger
+import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.core.injection.ENABLE_LOGGING
-import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
@@ -46,11 +46,9 @@ import dagger.Component
 import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
-import kotlin.coroutines.CoroutineContext
 
 internal class ExtendedPaymentElementConfirmationTestActivity : AppCompatActivity() {
     val viewModel: TestViewModel by viewModels {
@@ -91,6 +89,7 @@ internal class ExtendedPaymentElementConfirmationTestActivity : AppCompatActivit
 @Component(
     modules = [
         ExtendedPaymentElementConfirmationModule::class,
+        CoroutineContextModule::class,
         ExtendedPaymentElementConfirmationTestModule::class,
     ]
 )
@@ -184,10 +183,5 @@ internal interface ExtendedPaymentElementConfirmationTestModule {
         fun providesLinkAccountHolder(savedStateHandle: SavedStateHandle): LinkAccountHolder {
             return LinkAccountHolder(savedStateHandle)
         }
-
-        @Provides
-        @Singleton
-        @IOContext
-        fun provideWorkContext(): CoroutineContext = UnconfinedTestDispatcher()
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/PaymentElementConfirmationTestActivity.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/PaymentElementConfirmationTestActivity.kt
@@ -13,8 +13,8 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.Logger
+import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.core.injection.ENABLE_LOGGING
-import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
@@ -46,11 +46,9 @@ import dagger.Component
 import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
-import kotlin.coroutines.CoroutineContext
 
 internal class PaymentElementConfirmationTestActivity : AppCompatActivity() {
     val viewModel: TestViewModel by viewModels {
@@ -91,6 +89,7 @@ internal class PaymentElementConfirmationTestActivity : AppCompatActivity() {
 @Component(
     modules = [
         PaymentElementConfirmationModule::class,
+        CoroutineContextModule::class,
         PaymentElementConfirmationTestModule::class,
     ]
 )
@@ -184,10 +183,5 @@ internal interface PaymentElementConfirmationTestModule {
         fun providesLinkAccountHolder(savedStateHandle: SavedStateHandle): LinkAccountHolder {
             return LinkAccountHolder(savedStateHandle)
         }
-
-        @Provides
-        @Singleton
-        @IOContext
-        fun provideWorkContext(): CoroutineContext = UnconfinedTestDispatcher()
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationActivityTest.kt
@@ -33,7 +33,7 @@ import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.view.ActivityStarter
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -141,7 +141,7 @@ internal class BacsConfirmationActivityTest {
 
     private fun test(
         test: suspend PaymentElementConfirmationTestActivity.() -> Unit
-    ) = runTest(UnconfinedTestDispatcher()) {
+    ) = runTest(StandardTestDispatcher()) {
         val countDownLatch = CountDownLatch(1)
 
         ActivityScenario.launch<PaymentElementConfirmationTestActivity>(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cpms/CustomPaymentMethodConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cpms/CustomPaymentMethodConfirmationActivityTest.kt
@@ -33,7 +33,7 @@ import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.utils.PaymentElementCallbackTestRule
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
@@ -139,7 +139,7 @@ internal class CustomPaymentMethodConfirmationActivityTest {
 
     private fun test(
         test: suspend PaymentElementConfirmationTestActivity.() -> Unit
-    ) = runTest(UnconfinedTestDispatcher()) {
+    ) = runTest(StandardTestDispatcher()) {
         val countDownLatch = CountDownLatch(1)
 
         ActivityScenario.launch<PaymentElementConfirmationTestActivity>(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationActivityTest.kt
@@ -31,7 +31,7 @@ import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.view.ActivityStarter
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -123,7 +123,7 @@ internal class CvcRecollectionConfirmationActivityTest {
 
     private fun test(
         test: suspend ExtendedPaymentElementConfirmationTestActivity.() -> Unit
-    ) = runTest(UnconfinedTestDispatcher()) {
+    ) = runTest(StandardTestDispatcher()) {
         val countDownLatch = CountDownLatch(1)
 
         ActivityScenario.launch<ExtendedPaymentElementConfirmationTestActivity>(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationActivityTest.kt
@@ -34,7 +34,7 @@ import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.utils.PaymentElementCallbackTestRule
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
@@ -162,7 +162,7 @@ internal class ExternalPaymentMethodConfirmationActivityTest {
 
     private fun test(
         test: suspend PaymentElementConfirmationTestActivity.() -> Unit
-    ) = runTest(UnconfinedTestDispatcher()) {
+    ) = runTest(StandardTestDispatcher()) {
         val countDownLatch = CountDownLatch(1)
 
         ActivityScenario.launch<PaymentElementConfirmationTestActivity>(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationActivityTest.kt
@@ -35,7 +35,7 @@ import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.PaymentMethodFactory
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -225,7 +225,7 @@ internal class GooglePayConfirmationActivityTest {
 
     private fun test(
         test: suspend PaymentElementConfirmationTestActivity.() -> Unit
-    ) = runTest(UnconfinedTestDispatcher()) {
+    ) = runTest(StandardTestDispatcher()) {
         val countDownLatch = CountDownLatch(1)
 
         ActivityScenario.launch<PaymentElementConfirmationTestActivity>(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinitionTest.kt
@@ -23,12 +23,15 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
+import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.utils.DummyActivityResultCaller
 import com.stripe.android.utils.RecordingLinkPaymentLauncher
 import com.stripe.android.utils.RecordingLinkStore
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.any
@@ -36,6 +39,9 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 
 internal class LinkConfirmationDefinitionTest {
+    @get:Rule
+    val coroutineTestRule = CoroutineTestRule()
+
     @Test
     fun `'key' should be 'Link'`() {
         val definition = createLinkConfirmationDefinition()
@@ -300,7 +306,7 @@ internal class LinkConfirmationDefinitionTest {
         verify(linkAccountHolder, times(0)).set(any())
     }
 
-    private fun test(test: suspend Scenario.() -> Unit) = runTest {
+    private fun test(test: suspend Scenario.() -> Unit) = runTest(StandardTestDispatcher()) {
         RecordingLinkPaymentLauncher.test {
             val launcherScenario = this
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
I reverted some previous changes to make all the tests consistent by setting `StandardTestDispatcher`.
