### PR TITLE
Fix for PaymentSelection state in FlowController after card update

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -164,8 +164,10 @@ internal class PaymentOptionsViewModel @Inject constructor(
 
     private fun PaymentSelection.Saved.takeIfStillValid(): PaymentSelection.Saved? {
         val paymentMethods = customerStateHolder.paymentMethods.value
-        val isStillAround = paymentMethods.any { it.id == paymentMethod.id }
-        return this.takeIf { isStillAround }
+        val paymentMethod = paymentMethods.firstOrNull { it.id == paymentMethod.id }
+        return paymentMethod?.let {
+            this.copy(paymentMethod = it)
+        }
     }
 
     override fun onError(error: ResolvableString?) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -303,6 +303,9 @@ internal class SavedPaymentMethodMutator(
                         }
                     )
                 )
+                if (isSelectedPaymentMethod(updatedMethod)) {
+                    setSelection(PaymentSelection.Saved(updatedMethod))
+                }
 
                 onSuccess(updatedMethod)
             }
@@ -316,6 +319,11 @@ internal class SavedPaymentMethodMutator(
                 error = error,
             )
         }
+    }
+
+    private fun isSelectedPaymentMethod(paymentMethod: PaymentMethod): Boolean {
+        val currentSelection = selection.value as? PaymentSelection.Saved
+        return currentSelection?.paymentMethod?.id == paymentMethod.id
     }
 
     companion object {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Payment Selection for FlowController is not updated after CBC is changed. This PR fixes that by updating the current selection is updated if it is the same as the updated card.

For the cancellation scenario,`PaymentOptionsViewModel` uses an older copy of the updated payment method. This PR fixes that issue as well.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-3496

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
## BEFORE
### CANCELLATION

https://github.com/user-attachments/assets/71d91115-e39d-4eae-aaf7-53ddf734562e

### CONTINUE

https://github.com/user-attachments/assets/b3fa2ceb-b9e9-4f5b-a41a-10ed51120491



## AFTER
### CANCELLATION

https://github.com/user-attachments/assets/5643cdb3-375c-4b96-b1e0-e8ed1cac1fb1

### CONTINUE
https://github.com/user-attachments/assets/a5cd2b02-3605-4692-babf-cb7df773ce0c



# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
