### PR TITLE
Fix collectAsState does not correctly reset initial values

### DIFF
--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/utils/StateFlowsCompose.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/utils/StateFlowsCompose.kt
@@ -35,7 +35,7 @@ private fun <T> produceState(
     key: Any?,
     producer: suspend ProduceStateScope<T>.() -> Unit
 ): State<T> {
-    val result = remember { mutableStateOf(produceInitialValue()) }
+    val result = remember(produceInitialValue) { mutableStateOf(produceInitialValue()) }
     LaunchedEffect(key) {
         DefaultProduceStateScope(result, coroutineContext).producer()
     }
@@ -59,7 +59,7 @@ fun <T> StateFlow<T>.collectAsState(
         }
     }
     return produceState(
-        produceInitialValue = remember { { value } },
+        produceInitialValue = remember(this) { { value } },
         key = this
     ) {
         if (context == EmptyCoroutineContext) {

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/utils/StateFlowsCompose.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/utils/StateFlowsCompose.kt
@@ -35,7 +35,7 @@ private fun <T> produceState(
     key: Any?,
     producer: suspend ProduceStateScope<T>.() -> Unit
 ): State<T> {
-    val result = remember(produceInitialValue) { mutableStateOf(produceInitialValue()) }
+    val result = remember(key) { mutableStateOf(produceInitialValue()) }
     LaunchedEffect(key) {
         DefaultProduceStateScope(result, coroutineContext).producer()
     }

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/utils/StateFlowsComposeTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/utils/StateFlowsComposeTest.kt
@@ -95,4 +95,23 @@ class StateFlowsComposeTest {
         testStateFlow.value = "John"
         composeTestRule.waitUntilExactlyOneExists(hasText("John"))
     }
+
+    @Test
+    fun `Custom 'collectAsState' collects initial values when sources are changed`() {
+        val countFlow = MutableStateFlow(0)
+        composeTestRule.setContent {
+            val count by countFlow.collectAsState()
+            val testStateFlow = remember(count) {
+                MutableStateFlow(count)
+            }
+            val testState by testStateFlow.collectAsState()
+
+            assertThat(testStateFlow.value).isEqualTo(testState)
+        }
+
+        for (i in 1..3) {
+            countFlow.value = i
+            composeTestRule.waitForIdle()
+        }
+    }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Set keys when remembering the initial value of a `StateFlow`. If not set, 

```
val states by remember(key1) { key1.someStateFlow() }.collectAsState()
```
will get a wrong initial value when the returned state flow is changed.


This is because the remember function still holds the old `produceInitialValue`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
[MOBILESDK-2857](https://jira.corp.stripe.com/browse/MOBILESDK-2857)

When investigating the janky animation, I noticed that `showsWalletsHeader` and `headerText` do not correctly fetch the initial value. With break points set for `result` in `produceState()` and `value` in `collectAsState()`, we can see the inconsistency.

Stepping through the break points is kind of annoying. #10685 shows an easy way to verified this by replacing `collectAsState()` with `value`, and commenting out `PrimaryButton()` (this is another issue that should be fixed separately in #10714). By doing so, the animation is not janky anymore!


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
