### PR TITLE
PrimaryButton should update its UI with collectAsState

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
@@ -421,16 +421,14 @@ internal fun Wallet(
 
 @Composable
 private fun PrimaryButton(viewModel: BaseSheetViewModel) {
-    val uiState = viewModel.primaryButtonUiState.collectAsState()
+    val uiState by viewModel.primaryButtonUiState.collectAsState()
 
     val modifier = Modifier
         .testTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG)
         .semantics {
             role = Role.Button
 
-            val currentState = uiState.value
-
-            if (currentState == null || !currentState.enabled) {
+            if (uiState?.enabled != true) {
                 disabled()
             }
         }
@@ -455,14 +453,11 @@ private fun PrimaryButton(viewModel: BaseSheetViewModel) {
             )
             binding
         },
+        update = {
+            button?.updateUiState(uiState)
+        },
         modifier = modifier,
     )
-
-    LaunchedEffect(viewModel, button) {
-        viewModel.primaryButtonUiState.collect { uiState ->
-            button?.updateUiState(uiState)
-        }
-    }
 
     LaunchedEffect(viewModel, button) {
         (viewModel as? PaymentSheetViewModel)?.buyButtonState?.collect { state ->

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -519,11 +519,13 @@ internal class PaymentSheetActivityTest {
             viewModel.updateSelection(
                 PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
             )
+            Espresso.onIdle()
             assertThat(activity.buyButton.isVisible).isTrue()
             assertThat(activity.buyButton.isEnabled).isTrue()
 
             // Back to empty/invalid card
             viewModel.updateSelection(null)
+            Espresso.onIdle()
             assertThat(activity.buyButton.isVisible).isTrue()
             assertThat(activity.buyButton.isEnabled).isFalse()
 
@@ -535,6 +537,7 @@ internal class PaymentSheetActivityTest {
                     customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestNoReuse
                 )
             )
+            Espresso.onIdle()
             assertThat(activity.buyButton.isVisible).isTrue()
             assertThat(activity.buyButton.isEnabled).isTrue()
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/VerticalModePaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/VerticalModePaymentSheetActivityTest.kt
@@ -320,6 +320,7 @@ internal class VerticalModePaymentSheetActivityTest {
         verticalModePage.assertPrimaryButton(isEnabled())
 
         verticalModePage.clickOnNewLpm("card")
+        Espresso.onIdle()
         formPage.waitUntilVisible()
         Espresso.pressBack()
 
@@ -331,6 +332,7 @@ internal class VerticalModePaymentSheetActivityTest {
         verticalModePage.assertLpmIsSelected("cashapp")
 
         verticalModePage.clickOnNewLpm("card")
+        Espresso.onIdle()
         formPage.waitUntilVisible()
         Espresso.pressBack()
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Move `button?.updateUiState(uiState)` from `LaunchedEffect` to `update` inside `AndroidViewBinding`. According to the comment of `AndroidViewBinding`:
```
update - The callback to be invoked after the layout is inflated and upon recomposition to update the information and state of the binding
```
The UI state of `PrimaryButton` updates immediately upon inflation rather than remaining in its initial state.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
[MOBILESDK-2857](https://jira.corp.stripe.com/browse/MOBILESDK-2857)
`PrimaryButton` causes janky animation because its visibility was originally `gone` when inflated but is later updated to `visible` through `LaunchedEffect`, vice versa

In `stripe_fragment_primary_button_container.xml`
```
<?xml version="1.0" encoding="utf-8"?>
<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
    android:layout_width="match_parent"
    android:layout_height="wrap_content">
    <!-- Needs to be wrapped in a FrameLayout to prevent layout issues after configuration changes. -->

    <com.stripe.android.paymentsheet.ui.PrimaryButton
        android:id="@+id/primary_button"
        android:layout_width="match_parent"
        android:layout_height="@dimen/stripe_paymentsheet_primary_button_height"
        android:layout_marginTop="@dimen/stripe_paymentsheet_button_container_spacing"
        android:layout_marginStart="@dimen/stripe_paymentsheet_outer_spacing_horizontal"
        android:layout_marginEnd="@dimen/stripe_paymentsheet_outer_spacing_horizontal"
        android:text="@string/stripe_paymentsheet_pay_button_label"
        android:visibility="gone" />
</FrameLayout>
```

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| --| Before  | After |
| --| ------------- | ------------- |
|Slow motion gif by stepping through breakpoints| ![untitled](https://github.com/user-attachments/assets/4e6b550f-1aef-43e1-8b49-8961a9e14ae6)| ![untitled](https://github.com/user-attachments/assets/e9432100-0d23-4597-8bb1-b30018f52b34) |
|mp4|https://github.com/user-attachments/assets/d8413f25-f981-41b6-89d0-006d67160499|https://github.com/user-attachments/assets/548d1bb5-1ee6-4d8c-87f6-72db2167674b|



# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
