### PR TITLE
Send analytic event logging to sdk_event

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -556,7 +556,16 @@ internal class DefaultEventReporter @Inject internal constructor(
                     logger.logWarningWithoutPii(
                         "AnalyticEventCallback.onEvent() failed for event: $event"
                     )
+                    return@run
                 }
+                fireEvent(
+                    PaymentSheetEvent.EmitAnalyticEvent(
+                        analyticEventName = event.toString(),
+                        isDeferred = isDeferred,
+                        linkEnabled = linkEnabled,
+                        googlePaySupported = googlePaySupported,
+                    )
+                )
             }
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -606,6 +606,18 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         ) + experiment.dimensions.mapKeys { "dimensions-${it.key}" }
     }
 
+    class EmitAnalyticEvent(
+        analyticEventName: String,
+        override val isDeferred: Boolean,
+        override val linkEnabled: Boolean,
+        override val googlePaySupported: Boolean,
+    ) : PaymentSheetEvent() {
+        override val eventName: String = "mc_emit_analytic_event"
+
+        override val additionalParams: Map<String, Any?> = buildMap {
+            put(FIELD_ANALYTIC_EVENT, analyticEventName)
+        }
+    }
     private fun standardParams(
         isDecoupled: Boolean,
         linkEnabled: Boolean,
@@ -683,6 +695,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         const val FIELD_CARD_SCAN_AVAILABLE = "card_scan_available"
         const val FIELD_ANALYTIC_CALLBACK_SET = "analytic_callback_set"
         const val FIELD_LINK_DISPLAY = "link_display"
+        const val FIELD_ANALYTIC_EVENT = "analytic_event"
 
         const val VALUE_EDIT_CBC_EVENT_SOURCE = "edit"
         const val VALUE_ADD_CBC_EVENT_SOURCE = "add"


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Added a new `mc_emit_analytic_event` to monitor the analytic event health broken out by analytic event type.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
[Comments of Key Metrics in Launch Readiness Doc](https://docs.google.com/document/d/1qBoNxlacxVW0bZzFrETgQSjNFSpWExNL69hFErUJgmE/edit?tab=t.0)
I assume we probably want a chart of events over time so we can monitor for dips? And I would assume we want this broken out by event?
Do we have existing health monitoring on the specific events we added?
# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
