### PR TITLE
Enable canUpdateFullPaymentMethodDetails by default for CustomerSession

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -423,7 +423,6 @@ internal class PlaygroundSettings private constructor(
             CustomerSessionRedisplaySettingsDefinition,
             CustomerSessionRedisplayFiltersSettingsDefinition,
             CustomerSessionOverrideRedisplaySettingsDefinition,
-            FeatureFlagSettingsDefinition(FeatureFlags.editSavedCardPaymentMethodEnabled),
             CustomerSettingsDefinition,
             CheckoutModeSettingsDefinition,
             LinkSettingsDefinition,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionInitializationDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionInitializationDataSource.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.customersheet.data
 
 import com.stripe.android.core.injection.IOContext
-import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.customersheet.CustomerPermissions
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
@@ -58,7 +57,8 @@ internal class CustomerSessionInitializationDataSource @Inject constructor(
                                 component.isPaymentMethodRemoveEnabled
                             is ElementsSession.Customer.Components.CustomerSheet.Disabled -> false
                         },
-                        canUpdateFullPaymentMethodDetails = FeatureFlags.editSavedCardPaymentMethodEnabled.isEnabled
+                        // Should always be enabled when using `customer_session`
+                        canUpdateFullPaymentMethodDetails = true
                     ),
                     defaultPaymentMethodId = customer.defaultPaymentMethod,
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CustomerState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CustomerState.kt
@@ -2,7 +2,6 @@ package com.stripe.android.paymentsheet.state
 
 import android.os.Parcelable
 import com.stripe.android.common.model.CommonConfiguration
-import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -76,7 +75,8 @@ internal data class CustomerState(
                     canRemoveLastPaymentMethod = canRemoveLastPaymentMethod,
                     // Should always remove duplicates when using `customer_session`
                     canRemoveDuplicates = true,
-                    canUpdateFullPaymentMethodDetails = FeatureFlags.editSavedCardPaymentMethodEnabled.isEnabled,
+                    // Should always be enabled when using `customer_session`
+                    canUpdateFullPaymentMethodDetails = true,
                 ),
                 defaultPaymentMethodId = customer.defaultPaymentMethod
             )

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionInitializationDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionInitializationDataSourceTest.kt
@@ -2,7 +2,6 @@ package com.stripe.android.customersheet.data
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ExperimentalAllowsRemovalOfLastSavedPaymentMethodApi
-import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.customersheet.CustomerSheetFixtures
 import com.stripe.android.isInstanceOf
@@ -10,20 +9,13 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentB
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.model.SavedSelection
-import com.stripe.android.testing.FeatureFlagTestRule
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.testing.SetupIntentFactory
 import kotlinx.coroutines.test.runTest
-import org.junit.Rule
 import org.junit.Test
 import kotlin.coroutines.coroutineContext
 
 class CustomerSessionInitializationDataSourceTest {
-    @get:Rule
-    val editSavedCardPaymentMethodEnabledFeatureFlagTestRule = FeatureFlagTestRule(
-        featureFlag = FeatureFlags.editSavedCardPaymentMethodEnabled,
-        isEnabled = false
-    )
 
     @Test
     fun `on load, should return expected successful state`() = runTest {
@@ -105,8 +97,7 @@ class CustomerSessionInitializationDataSourceTest {
     }
 
     @Test
-    fun `on load, canUpdateFullPaymentMethodDetails should enabled when feature flag is enabled`() = runTest {
-        editSavedCardPaymentMethodEnabledFeatureFlagTestRule.setEnabled(true)
+    fun `on load, canUpdateFullPaymentMethodDetails should be enabled`() = runTest {
         val dataSource = createInitializationDataSource(
             elementsSessionManager = FakeCustomerSessionElementsSessionManager(
                 customerSheetComponent = ElementsSession.Customer.Components.CustomerSheet.Disabled,
@@ -117,21 +108,6 @@ class CustomerSessionInitializationDataSourceTest {
         val customerSheetSession = result.asSuccess().value
 
         assertThat(customerSheetSession.permissions.canUpdateFullPaymentMethodDetails).isTrue()
-    }
-
-    @Test
-    fun `on load, canUpdateFullPaymentMethodDetails should enabled when feature flag is disabled`() = runTest {
-        editSavedCardPaymentMethodEnabledFeatureFlagTestRule.setEnabled(false)
-        val dataSource = createInitializationDataSource(
-            elementsSessionManager = FakeCustomerSessionElementsSessionManager(
-                customerSheetComponent = ElementsSession.Customer.Components.CustomerSheet.Disabled,
-            ),
-        )
-
-        val result = dataSource.loadCustomerSheetSession(createConfiguration())
-        val customerSheetSession = result.asSuccess().value
-
-        assertThat(customerSheetSession.permissions.canUpdateFullPaymentMethodDetails).isFalse()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/CustomerSessionPaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/CustomerSessionPaymentSheetActivityTest.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.hasAnyAncestor
 import androidx.compose.ui.test.hasAnyDescendant
@@ -78,11 +79,11 @@ internal class CustomerSessionPaymentSheetActivityTest {
         ) {
             composeTestRule.onEditButton().performClick()
 
-            composeTestRule.onSavedPaymentMethod(last4 = "4242").assertIsEnabled()
+            composeTestRule.onSavedPaymentMethod(last4 = "4242").assertIsDisplayed()
         }
 
     @Test
-    fun `When single PM with remove permissions and cannot remove last PM from server, edit should not be shown`() =
+    fun `When single PM with remove permissions and cannot remove last PM from server, edit should be shown`() =
         runTest(
             cards = listOf(
                 PaymentMethodFactory.card(last4 = "4242"),
@@ -91,11 +92,11 @@ internal class CustomerSessionPaymentSheetActivityTest {
             canRemoveLastPaymentMethodConfig = true,
             canRemoveLastPaymentMethodServer = false,
         ) {
-            composeTestRule.onEditButton().assertDoesNotExist()
+            composeTestRule.onEditButton().assertIsDisplayed()
         }
 
     @Test
-    fun `When single PM with remove permissions & cannot remove last PM from config, edit should not be shown`() =
+    fun `When single PM with remove permissions & cannot remove last PM from config, edit should be shown`() =
         runTest(
             cards = listOf(
                 PaymentMethodFactory.card(last4 = "4242"),
@@ -104,11 +105,11 @@ internal class CustomerSessionPaymentSheetActivityTest {
             canRemoveLastPaymentMethodConfig = false,
             canRemoveLastPaymentMethodServer = true,
         ) {
-            composeTestRule.onEditButton().assertDoesNotExist()
+            composeTestRule.onEditButton().assertIsDisplayed()
         }
 
     @Test
-    fun `When single PM with remove permissions but cannot remove last PM, edit button should not be displayed`() =
+    fun `When single PM with remove permissions but cannot remove last PM, edit button should be displayed`() =
         runTest(
             cards = listOf(
                 PaymentMethodFactory.card(last4 = "4242"),
@@ -117,11 +118,11 @@ internal class CustomerSessionPaymentSheetActivityTest {
             canRemoveLastPaymentMethodConfig = false,
             canRemoveLastPaymentMethodServer = false,
         ) {
-            composeTestRule.onEditButton().assertDoesNotExist()
+            composeTestRule.onEditButton().assertExists()
         }
 
     @Test
-    fun `When multiple PMs but no remove permissions, edit button should not be displayed`() =
+    fun `When multiple PMs but no remove permissions, edit button should be displayed`() =
         runTest(
             cards = listOf(
                 PaymentMethodFactory.card(last4 = "4242"),
@@ -131,7 +132,7 @@ internal class CustomerSessionPaymentSheetActivityTest {
             canRemoveLastPaymentMethodConfig = true,
             canRemoveLastPaymentMethodServer = false,
         ) {
-            composeTestRule.onEditButton().assertDoesNotExist()
+            composeTestRule.onEditButton().assertIsDisplayed()
         }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -6,7 +6,6 @@ import com.stripe.android.core.Logger
 import com.stripe.android.core.exception.APIConnectionException
 import com.stripe.android.core.model.CountryCode
 import com.stripe.android.core.strings.resolvableString
-import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.googlepaylauncher.GooglePayRepository
 import com.stripe.android.isInstanceOf
 import com.stripe.android.link.LinkConfiguration
@@ -48,7 +47,6 @@ import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
 import com.stripe.android.paymentsheet.state.PaymentSheetLoadingException.PaymentIntentInTerminalState
 import com.stripe.android.paymentsheet.utils.FakeUserFacingLogger
 import com.stripe.android.testing.FakeErrorReporter
-import com.stripe.android.testing.FeatureFlagTestRule
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.testing.PaymentMethodFactory.update
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
@@ -58,7 +56,6 @@ import com.stripe.android.utils.FakeElementsSessionRepository
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
-import org.junit.Rule
 import org.mockito.ArgumentCaptor
 import org.mockito.Captor
 import org.mockito.MockitoAnnotations
@@ -76,12 +73,6 @@ import kotlin.test.Test
 
 @OptIn(ExperimentalCustomPaymentMethodsApi::class)
 internal class DefaultPaymentElementLoaderTest {
-
-    @get:Rule
-    val editSavedCardPaymentMethodEnabledFeatureFlagTestRule = FeatureFlagTestRule(
-        featureFlag = FeatureFlags.editSavedCardPaymentMethodEnabled,
-        isEnabled = false
-    )
 
     private val testDispatcher = UnconfinedTestDispatcher()
     private val eventReporter = mock<EventReporter>()
@@ -1611,7 +1602,7 @@ internal class DefaultPaymentElementLoaderTest {
                     canRemovePaymentMethods = true,
                     canRemoveLastPaymentMethod = true,
                     canRemoveDuplicates = true,
-                    canUpdateFullPaymentMethodDetails = false
+                    canUpdateFullPaymentMethodDetails = true
                 )
             )
         }
@@ -1654,7 +1645,7 @@ internal class DefaultPaymentElementLoaderTest {
                     canRemovePaymentMethods = false,
                     canRemoveLastPaymentMethod = true,
                     canRemoveDuplicates = true,
-                    canUpdateFullPaymentMethodDetails = false
+                    canUpdateFullPaymentMethodDetails = true
                 )
             )
         }
@@ -1697,16 +1688,15 @@ internal class DefaultPaymentElementLoaderTest {
                     canRemovePaymentMethods = false,
                     canRemoveLastPaymentMethod = true,
                     canRemoveDuplicates = true,
-                    canUpdateFullPaymentMethodDetails = false
+                    canUpdateFullPaymentMethodDetails = true
                 )
             )
         }
 
     @OptIn(ExperimentalCustomerSessionApi::class)
     @Test
-    fun `customer session with edit saved payment method enabled, should enable canUpdateFullPaymentMethodDetails permission`() =
+    fun `customer session should have canUpdateFullPaymentMethodDetails permission enabled`() =
         runTest {
-            editSavedCardPaymentMethodEnabledFeatureFlagTestRule.setEnabled(true)
             val loader = createPaymentElementLoader(
                 customer = ElementsSession.Customer(
                     paymentMethods = PaymentMethodFactory.cards(4),

--- a/stripe-core/src/main/java/com/stripe/android/core/utils/FeatureFlags.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/FeatureFlags.kt
@@ -9,7 +9,6 @@ object FeatureFlags {
     val nativeLinkEnabled = FeatureFlag("Native Link")
     val nativeLinkAttestationEnabled = FeatureFlag("Native Link Attestation")
     val instantDebitsIncentives = FeatureFlag("Instant Bank Payments Incentives")
-    val editSavedCardPaymentMethodEnabled = FeatureFlag("Edit Saved Card Payment Method")
     val financialConnectionsFullSdkUnavailable = FeatureFlag("FC Full SDK Unavailable")
     val enableCardEditInLinkNative = FeatureFlag("Enable Card Edit In Link Native")
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Removes client side flag for payment method update. This means that any user who opts-into customerSessions will automatically get payment method update.


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
[Decision to remove client side flag](https://stripe.slack.com/archives/C07RF1UM08M/p1744754307752529?thread_ts=1744745534.538099&cid=C07RF1UM08M)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
