### PR TITLE
Remove should not clear current selection.

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedContentPage.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedContentPage.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import com.stripe.android.paymentsheet.ui.TEST_TAG_ICON_FROM_RES
+import com.stripe.android.paymentsheet.verticalmode.TEST_TAG_EDIT_SAVED_CARD
 import com.stripe.android.paymentsheet.verticalmode.TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON
 import com.stripe.android.paymentsheet.verticalmode.TEST_TAG_PAYMENT_METHOD_EMBEDDED_LAYOUT
 import com.stripe.android.paymentsheet.verticalmode.TEST_TAG_SAVED_PAYMENT_METHOD_ROW_BUTTON
@@ -68,5 +69,11 @@ internal class EmbeddedContentPage(
         waitUntilVisible()
 
         composeTestRule.onNodeWithTag(TEST_TAG_VIEW_MORE).performClick()
+    }
+
+    fun clickEdit() {
+        waitUntilVisible()
+
+        composeTestRule.onNodeWithTag(TEST_TAG_EDIT_SAVED_CARD).performClick()
     }
 }

--- a/paymentsheet/src/androidTest/resources/elements-sessions-deferred_payment_intent_no_link.json
+++ b/paymentsheet/src/androidTest/resources/elements-sessions-deferred_payment_intent_no_link.json
@@ -15,14 +15,16 @@
   "order": null,
   "ordered_payment_method_types_and_wallets": [
     "card",
-    "konbini"
+    "konbini",
+    "cashapp"
   ],
   "payment_method_preference": {
     "object": "payment_method_preference",
     "country_code": "US",
     "ordered_payment_method_types": [
       "card",
-      "konbini"
+      "konbini",
+      "cashapp"
     ],
     "type": "deferred_intent"
   },

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/ManageSavedPaymentMethodMutatorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/ManageSavedPaymentMethodMutatorFactory.kt
@@ -63,7 +63,6 @@ internal class ManageSavedPaymentMethodMutatorFactory @Inject constructor(
     private fun onPaymentMethodRemoved() {
         val shouldCloseSheet = customerStateHolder.paymentMethods.value.isEmpty()
         if (shouldCloseSheet) {
-            selectionHolder.set(null)
             manageNavigatorProvider.get().performAction(ManageNavigator.Action.Close)
         }
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Removing a saved PM that's not selected shouldn't clear the selection. 

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://docs.google.com/document/d/139z-4FGygfBXBFTtrtecPWnHka8uFfJw4DkRodtYmdw/edit?tab=t.0

