### PR TITLE
Enable `Custom Payment Methods` for private beta.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## XX.XX.XX - 20XX-XX-XX
 
 ### PaymentSheet
+* [ADDED][10733](https://github.com/stripe/stripe-android/pull/10733) Added support for [custom payment methods](https://docs.stripe.com/payments/payment-methods/custom-payment-methods).
 * [ADDED][10720](https://github.com/stripe/stripe-android/pull/10720) `EmbeddedPaymentElement` now supports customizing `FormSheetAction` and a 2 step flow (similar to `PaymentSheet.FlowController`).
 
 ## 21.11.1 - 2025-04-22

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -557,12 +557,33 @@ public final class com/stripe/android/lpmfoundations/paymentmethod/link/LinkInli
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public abstract interface class com/stripe/android/paymentelement/ConfirmCustomPaymentMethodCallback {
+	public abstract fun onConfirmCustomPaymentMethod (Lcom/stripe/android/paymentsheet/PaymentSheet$CustomPaymentMethod;Lcom/stripe/android/model/PaymentMethod$BillingDetails;)V
+}
+
+public abstract class com/stripe/android/paymentelement/CustomPaymentMethodResult : android/os/Parcelable {
+	public static final field $stable I
+	public static final field Companion Lcom/stripe/android/paymentelement/CustomPaymentMethodResult$Companion;
+	public static final fun canceled ()Lcom/stripe/android/paymentelement/CustomPaymentMethodResult;
+	public static final fun completed ()Lcom/stripe/android/paymentelement/CustomPaymentMethodResult;
+	public static final fun failed ()Lcom/stripe/android/paymentelement/CustomPaymentMethodResult;
+	public static final fun failed (Ljava/lang/String;)Lcom/stripe/android/paymentelement/CustomPaymentMethodResult;
+}
+
 public final class com/stripe/android/paymentelement/CustomPaymentMethodResult$Canceled$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentelement/CustomPaymentMethodResult$Canceled;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/paymentelement/CustomPaymentMethodResult$Canceled;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentelement/CustomPaymentMethodResult$Companion {
+	public final fun canceled ()Lcom/stripe/android/paymentelement/CustomPaymentMethodResult;
+	public final fun completed ()Lcom/stripe/android/paymentelement/CustomPaymentMethodResult;
+	public final fun failed ()Lcom/stripe/android/paymentelement/CustomPaymentMethodResult;
+	public final fun failed (Ljava/lang/String;)Lcom/stripe/android/paymentelement/CustomPaymentMethodResult;
+	public static synthetic fun failed$default (Lcom/stripe/android/paymentelement/CustomPaymentMethodResult$Companion;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/paymentelement/CustomPaymentMethodResult;
 }
 
 public final class com/stripe/android/paymentelement/CustomPaymentMethodResult$Completed$Creator : android/os/Parcelable$Creator {
@@ -581,6 +602,12 @@ public final class com/stripe/android/paymentelement/CustomPaymentMethodResult$F
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/paymentelement/CustomPaymentMethodResultHandler {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/stripe/android/paymentelement/CustomPaymentMethodResultHandler;
+	public static final fun handleCustomPaymentMethodResult (Landroid/content/Context;Lcom/stripe/android/paymentelement/CustomPaymentMethodResult;)V
+}
+
 public final class com/stripe/android/paymentelement/EmbeddedPaymentElement {
 	public static final field $stable I
 	public final fun Content (Landroidx/compose/runtime/Composer;I)V
@@ -595,6 +622,7 @@ public final class com/stripe/android/paymentelement/EmbeddedPaymentElement {
 public final class com/stripe/android/paymentelement/EmbeddedPaymentElement$Builder {
 	public static final field $stable I
 	public fun <init> (Lcom/stripe/android/paymentsheet/CreateIntentCallback;Lcom/stripe/android/paymentelement/EmbeddedPaymentElement$ResultCallback;)V
+	public final fun confirmCustomPaymentMethodCallback (Lcom/stripe/android/paymentelement/ConfirmCustomPaymentMethodCallback;)Lcom/stripe/android/paymentelement/EmbeddedPaymentElement$Builder;
 	public final fun externalPaymentMethodConfirmHandler (Lcom/stripe/android/paymentsheet/ExternalPaymentMethodConfirmHandler;)Lcom/stripe/android/paymentelement/EmbeddedPaymentElement$Builder;
 }
 
@@ -618,6 +646,7 @@ public final class com/stripe/android/paymentelement/EmbeddedPaymentElement$Conf
 	public final fun billingDetailsCollectionConfiguration (Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;)Lcom/stripe/android/paymentelement/EmbeddedPaymentElement$Configuration$Builder;
 	public final fun build ()Lcom/stripe/android/paymentelement/EmbeddedPaymentElement$Configuration;
 	public final fun cardBrandAcceptance (Lcom/stripe/android/paymentsheet/PaymentSheet$CardBrandAcceptance;)Lcom/stripe/android/paymentelement/EmbeddedPaymentElement$Configuration$Builder;
+	public final fun customPaymentMethods (Ljava/util/List;)Lcom/stripe/android/paymentelement/EmbeddedPaymentElement$Configuration$Builder;
 	public final fun customer (Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;)Lcom/stripe/android/paymentelement/EmbeddedPaymentElement$Configuration$Builder;
 	public final fun defaultBillingDetails (Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;)Lcom/stripe/android/paymentelement/EmbeddedPaymentElement$Configuration$Builder;
 	public final fun embeddedViewDisplaysMandateText (Z)Lcom/stripe/android/paymentelement/EmbeddedPaymentElement$Configuration$Builder;
@@ -1419,6 +1448,7 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$Builder {
 	public final fun build (Landroidx/activity/ComponentActivity;)Lcom/stripe/android/paymentsheet/PaymentSheet;
 	public final fun build (Landroidx/compose/runtime/Composer;I)Lcom/stripe/android/paymentsheet/PaymentSheet;
 	public final fun build (Landroidx/fragment/app/Fragment;)Lcom/stripe/android/paymentsheet/PaymentSheet;
+	public final fun confirmCustomPaymentMethodCallback (Lcom/stripe/android/paymentelement/ConfirmCustomPaymentMethodCallback;)Lcom/stripe/android/paymentsheet/PaymentSheet$Builder;
 	public final fun createIntentCallback (Lcom/stripe/android/paymentsheet/CreateIntentCallback;)Lcom/stripe/android/paymentsheet/PaymentSheet$Builder;
 	public final fun externalPaymentMethodConfirmHandler (Lcom/stripe/android/paymentsheet/ExternalPaymentMethodConfirmHandler;)Lcom/stripe/android/paymentsheet/PaymentSheet$Builder;
 }
@@ -1593,6 +1623,7 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$Configuration$Bu
 	public final fun billingDetailsCollectionConfiguration (Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun build ()Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;
 	public final fun cardBrandAcceptance (Lcom/stripe/android/paymentsheet/PaymentSheet$CardBrandAcceptance;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
+	public final fun customPaymentMethods (Ljava/util/List;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun customer (Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun defaultBillingDetails (Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun externalPaymentMethods (Ljava/util/List;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
@@ -1693,6 +1724,7 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$FlowController$B
 	public final fun build (Landroidx/activity/ComponentActivity;)Lcom/stripe/android/paymentsheet/PaymentSheet$FlowController;
 	public final fun build (Landroidx/compose/runtime/Composer;I)Lcom/stripe/android/paymentsheet/PaymentSheet$FlowController;
 	public final fun build (Landroidx/fragment/app/Fragment;)Lcom/stripe/android/paymentsheet/PaymentSheet$FlowController;
+	public final fun confirmCustomPaymentMethodCallback (Lcom/stripe/android/paymentelement/ConfirmCustomPaymentMethodCallback;)Lcom/stripe/android/paymentsheet/PaymentSheet$FlowController$Builder;
 	public final fun createIntentCallback (Lcom/stripe/android/paymentsheet/CreateIntentCallback;)Lcom/stripe/android/paymentsheet/PaymentSheet$FlowController$Builder;
 	public final fun externalPaymentMethodConfirmHandler (Lcom/stripe/android/paymentsheet/ExternalPaymentMethodConfirmHandler;)Lcom/stripe/android/paymentsheet/PaymentSheet$FlowController$Builder;
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/ConfirmCustomPaymentMethodCallback.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/ConfirmCustomPaymentMethodCallback.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentelement
 
-import androidx.annotation.RestrictTo
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet
 
@@ -10,7 +9,6 @@ import com.stripe.android.paymentsheet.PaymentSheet
  * To learn more about custom payment methods, see "docs_url"
  */
 @ExperimentalCustomPaymentMethodsApi
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun interface ConfirmCustomPaymentMethodCallback {
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/CustomPaymentMethodResultHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/CustomPaymentMethodResultHandler.kt
@@ -3,7 +3,6 @@ package com.stripe.android.paymentelement
 import android.content.Context
 import android.content.Intent
 import android.os.Parcelable
-import androidx.annotation.RestrictTo
 import com.stripe.android.paymentelement.confirmation.cpms.CustomPaymentMethodProxyActivity
 import kotlinx.parcelize.Parcelize
 
@@ -11,7 +10,6 @@ import kotlinx.parcelize.Parcelize
  * Handler used to respond to custom payment method confirm results.
  */
 @ExperimentalCustomPaymentMethodsApi
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 object CustomPaymentMethodResultHandler {
 
     /**
@@ -45,7 +43,6 @@ object CustomPaymentMethodResultHandler {
 /**
  * The result of an attempt to confirm a custom payment method.
  */
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 sealed class CustomPaymentMethodResult : Parcelable {
     @Parcelize
     internal data object Completed : CustomPaymentMethodResult()
@@ -58,7 +55,6 @@ sealed class CustomPaymentMethodResult : Parcelable {
         val displayMessage: String?,
     ) : CustomPaymentMethodResult()
 
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     companion object {
 
         /**
@@ -66,7 +62,6 @@ sealed class CustomPaymentMethodResult : Parcelable {
          */
         @JvmStatic
         @ExperimentalCustomPaymentMethodsApi
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         fun completed(): CustomPaymentMethodResult {
             return Completed
         }
@@ -76,7 +71,6 @@ sealed class CustomPaymentMethodResult : Parcelable {
          */
         @JvmStatic
         @ExperimentalCustomPaymentMethodsApi
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         fun canceled(): CustomPaymentMethodResult {
             return Canceled
         }
@@ -90,7 +84,6 @@ sealed class CustomPaymentMethodResult : Parcelable {
         @JvmStatic
         @JvmOverloads
         @ExperimentalCustomPaymentMethodsApi
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         fun failed(displayMessage: String? = null): CustomPaymentMethodResult {
             return Failed(displayMessage)
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
@@ -143,7 +143,6 @@ class EmbeddedPaymentElement @Inject internal constructor(
          * Called when a user confirms payment for a custom payment method.
          */
         @ExperimentalCustomPaymentMethodsApi
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         fun confirmCustomPaymentMethodCallback(callback: ConfirmCustomPaymentMethodCallback) = apply {
             this.confirmCustomPaymentMethodCallback = callback
         }
@@ -376,7 +375,6 @@ class EmbeddedPaymentElement @Inject internal constructor(
              * If set, Embedded Payment Element will display the defined list of custom payment methods in the UI.
              */
             @ExperimentalCustomPaymentMethodsApi
-            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
             fun customPaymentMethods(
                 customPaymentMethods: List<PaymentSheet.CustomPaymentMethod>,
             ) = apply {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -237,7 +237,6 @@ class PaymentSheet internal constructor(
          * [Configuration.Builder.customPaymentMethods] to specify custom payment methods.
          */
         @ExperimentalCustomPaymentMethodsApi
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         fun confirmCustomPaymentMethodCallback(callback: ConfirmCustomPaymentMethodCallback) = apply {
             callbacksBuilder.confirmCustomPaymentMethodCallback(callback)
         }
@@ -895,7 +894,6 @@ class PaymentSheet internal constructor(
              * If set, Payment Sheet will display the defined list of custom payment methods in the UI.
              */
             @ExperimentalCustomPaymentMethodsApi
-            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
             fun customPaymentMethods(
                 customPaymentMethods: List<CustomPaymentMethod>,
             ) = apply {
@@ -1998,7 +1996,6 @@ class PaymentSheet internal constructor(
         internal val disableBillingDetailCollection: Boolean,
     ) : Parcelable {
         @ExperimentalCustomPaymentMethodsApi
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         constructor(
             /**
              * The unique identifier for this custom payment method type in the format of "cmpt_...".
@@ -2027,7 +2024,6 @@ class PaymentSheet internal constructor(
         )
 
         @ExperimentalCustomPaymentMethodsApi
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         constructor(
             /**
              * The unique identifier for this custom payment method type in the format of "cmpt_...".
@@ -2317,7 +2313,6 @@ class PaymentSheet internal constructor(
              * @param callback Called when a user confirms payment for a custom payment method.
              */
             @ExperimentalCustomPaymentMethodsApi
-            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
             fun confirmCustomPaymentMethodCallback(callback: ConfirmCustomPaymentMethodCallback) = apply {
                 callbacksBuilder.confirmCustomPaymentMethodCallback(callback)
             }


### PR DESCRIPTION
# Summary
Enable `Custom Payment Methods` for private beta.

# Motivation
Allow custom payment methods to be used by select merchants.

[Custom Payment Methods approvals](https://home.corp.stripe.com/compass/projects/custom-payment-methods-on-mobile-cpms/launch_readiness?milestoneToken=milestone_RsifuN0ageWYlM)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified