### PR TITLE
Fix selection chooser to work with FormSheetAction.Continue.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedSelectionChooser.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedSelectionChooser.kt
@@ -37,6 +37,10 @@ internal class DefaultEmbeddedSelectionChooser @Inject constructor(
         get() = savedStateHandle[PREVIOUS_CONFIGURATION_KEY]
         set(value) = savedStateHandle.set(PREVIOUS_CONFIGURATION_KEY, value)
 
+    private var previousPaymentMethodMetadata: PaymentMethodMetadata?
+        get() = savedStateHandle[PREVIOUS_PAYMENT_METHOD_METADATA_KEY]
+        set(value) = savedStateHandle.set(PREVIOUS_PAYMENT_METHOD_METADATA_KEY, value)
+
     override fun choose(
         paymentMethodMetadata: PaymentMethodMetadata,
         paymentMethods: List<PaymentMethod>?,
@@ -53,6 +57,7 @@ internal class DefaultEmbeddedSelectionChooser @Inject constructor(
         } ?: newSelection
 
         previousConfiguration = newConfiguration
+        previousPaymentMethodMetadata = paymentMethodMetadata
 
         return result
     }
@@ -97,16 +102,30 @@ internal class DefaultEmbeddedSelectionChooser @Inject constructor(
         previousSelection: PaymentSelection.New,
         paymentMethodMetadata: PaymentMethodMetadata,
     ): Boolean {
-        val newFormType = formHelperFactory.create(
+        val newFormHelper = formHelperFactory.create(
             coroutineScope = coroutineScope,
             paymentMethodMetadata = paymentMethodMetadata,
             eventReporter = eventReporter,
         ) {}
-            .formTypeForCode(previousSelection.paymentMethodType)
-        return newFormType != FormHelper.FormType.UserInteractionRequired
+        val newFormType = newFormHelper.formTypeForCode(previousSelection.paymentMethodType)
+        if (newFormType != FormHelper.FormType.UserInteractionRequired) {
+            return true
+        }
+        return previousPaymentMethodMetadata?.let { previousPaymentMethodMetadata ->
+            val previousFormHelper = formHelperFactory.create(
+                coroutineScope = coroutineScope,
+                paymentMethodMetadata = previousPaymentMethodMetadata,
+                eventReporter = eventReporter,
+            ) {}
+            val previousFormElements = previousFormHelper.formElementsForCode(previousSelection.paymentMethodType)
+            val newFormElements = newFormHelper.formElementsForCode(previousSelection.paymentMethodType)
+            previousFormElements.size >= newFormElements.size
+        } == true
     }
 
     companion object {
         const val PREVIOUS_CONFIGURATION_KEY = "DefaultEmbeddedSelectionChooser_PREVIOUS_CONFIGURATION_KEY"
+        const val PREVIOUS_PAYMENT_METHOD_METADATA_KEY =
+            "DefaultEmbeddedSelectionChooser_PREVIOUS_PAYMENT_METHOD_METADATA_KEY"
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSelectionChooserTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSelectionChooserTest.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.common.model.asCommonConfiguration
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethodFixtures
@@ -13,19 +14,25 @@ import com.stripe.android.paymentelement.ExperimentalEmbeddedPaymentElementApi
 import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedSelectionChooser.Companion.PREVIOUS_CONFIGURATION_KEY
+import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedSelectionChooser.Companion.PREVIOUS_PAYMENT_METHOD_METADATA_KEY
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
+import org.junit.Rule
 import org.junit.Test
 
 @OptIn(ExperimentalEmbeddedPaymentElementApi::class)
 internal class DefaultEmbeddedSelectionChooserTest {
+    @get:Rule
+    val coroutineTestRule = CoroutineTestRule()
+
     private val defaultConfiguration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.")
         .build()
         .asCommonConfiguration()
@@ -297,6 +304,48 @@ internal class DefaultEmbeddedSelectionChooserTest {
     }
 
     @Test
+    fun `PaymentSelection is preserved when form type remains user interaction required`() = runScenario {
+        val previousSelection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION
+
+        storePreviousChooseState(
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
+            ),
+        )
+        val selection = chooser.choose(
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            ),
+            paymentMethods = emptyList(),
+            previousSelection = previousSelection,
+            newSelection = null,
+            newConfiguration = defaultConfiguration,
+        )
+        assertThat(selection).isEqualTo(previousSelection)
+    }
+
+    @Test
+    fun `PaymentSelection is reset when new form has extra mandate field`() = runScenario {
+        val previousSelection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION
+
+        storePreviousChooseState(
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            ),
+        )
+        val selection = chooser.choose(
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
+            ),
+            paymentMethods = emptyList(),
+            previousSelection = previousSelection,
+            newSelection = null,
+            newConfiguration = defaultConfiguration,
+        )
+        assertThat(selection).isNull()
+    }
+
+    @Test
     fun `previousConfig is set when calling choose`() = runScenario {
         val previousSelection = PaymentSelection.GooglePay
         val paymentMethod = PaymentMethodFixtures.createCard()
@@ -339,8 +388,10 @@ internal class DefaultEmbeddedSelectionChooserTest {
 
     private fun Scenario.storePreviousChooseState(
         configuration: CommonConfiguration = defaultConfiguration,
+        paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
     ) {
         savedStateHandle[PREVIOUS_CONFIGURATION_KEY] = configuration
+        savedStateHandle[PREVIOUS_PAYMENT_METHOD_METADATA_KEY] = paymentMethodMetadata
     }
 
     private class Scenario(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Since we added FormSheetAction.Continue, we needed to update selection updating when a reconfigure happens to preserve form inputs when applicable too.

Forms selections should be preserved when they have the same form fields, or less (ie, we lost a mandate). But should be cleared when more form fields are added (ie, we added a mandate).

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://docs.google.com/document/d/139z-4FGygfBXBFTtrtecPWnHka8uFfJw4DkRodtYmdw/edit?tab=t.0#heading=h.cz1xkpga7giy

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
