### PR TITLE
Fix change details logic when a saved card is currently selected.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -247,7 +247,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
             PaymentMethodVerticalLayoutInteractor.Selection.New(
                 code = temporarySelectionCode,
                 changeDetails = changeDetails,
-                canBeChanged = temporarySelectionCode == mostRecentSelection.code(),
+                canBeChanged = temporarySelectionCode == (mostRecentSelection as? PaymentSelection.New?).code(),
             )
         } else {
             null

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -1333,6 +1333,38 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
     }
 
     @Test
+    fun temporarySelection_doesNotAllowChangeDetails_whenSavedCardIsSelected() = runScenario(
+        formTypeForCode = {
+            FormHelper.FormType.UserInteractionRequired
+        },
+        updateSelection = {},
+        shouldUpdateVerticalModeSelection = { true }
+    ) {
+        selectionSource.value = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+        interactor.state.test {
+            assertThat(awaitItem().selection).isEqualTo(
+                PaymentMethodVerticalLayoutInteractor.Selection.Saved
+            )
+
+            // Mimic user pressing on the new card row button.
+            temporarySelectionSource.value = "card"
+            assertThat(awaitItem().selection).isEqualTo(
+                PaymentMethodVerticalLayoutInteractor.Selection.New(
+                    code = "card",
+                    changeDetails = null,
+                    canBeChanged = false,
+                )
+            )
+
+            // Mimic user cancelling form sheet.
+            temporarySelectionSource.value = null
+            assertThat(awaitItem().selection).isEqualTo(
+                PaymentMethodVerticalLayoutInteractor.Selection.Saved
+            )
+        }
+    }
+
+    @Test
     fun savedSelectionUpdatesMandate() {
         val paymentMethodTypes = listOf("card", "sepa_debit")
         val paymentMethodMetadata = PaymentMethodMetadataFactory.create(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Fix an issue where selecting a new card while a saved card was actively selected caused the change UI to be displayed when it shouldn't be.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://docs.google.com/document/d/139z-4FGygfBXBFTtrtecPWnHka8uFfJw4DkRodtYmdw/edit?tab=t.0
https://www.google.com/url?q=https://drive.google.com/file/d/1lybJeUMeFWjMKajZRZsDD7-YuZ_PTCZl/view?usp%3Ddrive_link&sa=D&source=docs&ust=1745604372696070&usg=AOvVaw3L9kT4HrTfCp3bvOkZvkyh

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
