### PR TITLE
Add mc_*_paymentoption_removed and mc_form_completed to sdk_event

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementAnalyticsTest.kt
@@ -94,8 +94,8 @@ internal class EmbeddedPaymentElementAnalyticsTest {
         analyticEventRule.assertMatchesExpectedEvent(AnalyticEvent.SelectedPaymentMethodType("card"))
         analyticEventRule.assertMatchesExpectedEvent(AnalyticEvent.DisplayedPaymentMethodForm("card"))
 
-        formPage.fillOutCardDetails()
         validateAnalyticsRequest(eventName = "mc_form_completed")
+        formPage.fillOutCardDetails()
         analyticEventRule.assertMatchesExpectedEvent(AnalyticEvent.StartedInteractionWithPaymentMethodForm("card"))
         analyticEventRule.assertMatchesExpectedEvent(AnalyticEvent.CompletedPaymentMethodForm("card"))
 
@@ -309,8 +309,8 @@ internal class EmbeddedPaymentElementAnalyticsTest {
         validateAnalyticsRequest(eventName = "stripe_android.detach_payment_method")
         validateAnalyticsRequest(eventName = "mc_cancel_edit_screen")
 
+        validateAnalyticsRequest(eventName = "mc_embedded_paymentoption_removed")
         editPage.clickRemove()
-        validateAnalyticsRequest(eventName = "mc_saved_payment_method_removed")
         analyticEventRule.assertMatchesExpectedEvent(AnalyticEvent.RemovedSavedPaymentMethod("card"))
 
         managePage.waitUntilVisible()

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementAnalyticsTest.kt
@@ -95,6 +95,7 @@ internal class EmbeddedPaymentElementAnalyticsTest {
         analyticEventRule.assertMatchesExpectedEvent(AnalyticEvent.DisplayedPaymentMethodForm("card"))
 
         formPage.fillOutCardDetails()
+        validateAnalyticsRequest(eventName = "mc_form_completed")
         analyticEventRule.assertMatchesExpectedEvent(AnalyticEvent.StartedInteractionWithPaymentMethodForm("card"))
         analyticEventRule.assertMatchesExpectedEvent(AnalyticEvent.CompletedPaymentMethodForm("card"))
 
@@ -309,6 +310,7 @@ internal class EmbeddedPaymentElementAnalyticsTest {
         validateAnalyticsRequest(eventName = "mc_cancel_edit_screen")
 
         editPage.clickRemove()
+        validateAnalyticsRequest(eventName = "mc_saved_payment_method_removed")
         analyticEventRule.assertMatchesExpectedEvent(AnalyticEvent.RemovedSavedPaymentMethod("card"))
 
         managePage.waitUntilVisible()

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAnalyticsTest.kt
@@ -105,6 +105,7 @@ internal class PaymentSheetAnalyticsTest {
         testContext.validateAnalyticsRequest(eventName = "mc_form_interacted")
         testContext.validateAnalyticsRequest(eventName = "mc_card_number_completed")
 
+        testContext.validateAnalyticsRequest(eventName = "mc_form_completed")
         page.fillOutCardDetails()
         analyticEventRule.assertMatchesExpectedEvent(AnalyticEvent.StartedInteractionWithPaymentMethodForm("card"))
         analyticEventRule.assertMatchesExpectedEvent(AnalyticEvent.CompletedPaymentMethodForm("card"))
@@ -184,6 +185,7 @@ internal class PaymentSheetAnalyticsTest {
         testContext.validateAnalyticsRequest(eventName = "mc_form_interacted")
         testContext.validateAnalyticsRequest(eventName = "mc_card_number_completed")
 
+        testContext.validateAnalyticsRequest(eventName = "mc_form_completed")
         page.fillOutCardDetails()
         analyticEventRule.assertMatchesExpectedEvent(AnalyticEvent.StartedInteractionWithPaymentMethodForm("card"))
         analyticEventRule.assertMatchesExpectedEvent(AnalyticEvent.CompletedPaymentMethodForm("card"))
@@ -258,6 +260,7 @@ internal class PaymentSheetAnalyticsTest {
         analyticEventRule.assertMatchesExpectedEvent(AnalyticEvent.SelectedPaymentMethodType("card"))
         analyticEventRule.assertMatchesExpectedEvent(AnalyticEvent.DisplayedPaymentMethodForm("card"))
 
+        testContext.validateAnalyticsRequest(eventName = "mc_form_completed")
         page.fillOutCardDetails()
         analyticEventRule.assertMatchesExpectedEvent(AnalyticEvent.StartedInteractionWithPaymentMethodForm("card"))
         analyticEventRule.assertMatchesExpectedEvent(AnalyticEvent.CompletedPaymentMethodForm("card"))
@@ -337,6 +340,7 @@ internal class PaymentSheetAnalyticsTest {
         analyticEventRule.assertMatchesExpectedEvent(AnalyticEvent.SelectedPaymentMethodType("card"))
         analyticEventRule.assertMatchesExpectedEvent(AnalyticEvent.DisplayedPaymentMethodForm("card"))
 
+        testContext.validateAnalyticsRequest(eventName = "mc_form_completed")
         page.fillOutCardDetails()
         analyticEventRule.assertMatchesExpectedEvent(AnalyticEvent.StartedInteractionWithPaymentMethodForm("card"))
         analyticEventRule.assertMatchesExpectedEvent(AnalyticEvent.CompletedPaymentMethodForm("card"))
@@ -416,6 +420,7 @@ internal class PaymentSheetAnalyticsTest {
         testContext.validateAnalyticsRequest(eventName = "stripe_android.detach_payment_method")
         testContext.validateAnalyticsRequest(eventName = "mc_cancel_edit_screen")
 
+        testContext.validateAnalyticsRequest(eventName = "mc_complete_paymentoption_removed")
         editPage.clickRemove()
         analyticEventRule.assertMatchesExpectedEvent(AnalyticEvent.RemovedSavedPaymentMethod("card"))
 
@@ -478,6 +483,7 @@ internal class PaymentSheetAnalyticsTest {
         testContext.validateAnalyticsRequest(eventName = "stripe_android.detach_payment_method")
         testContext.validateAnalyticsRequest(eventName = "mc_cancel_edit_screen")
 
+        testContext.validateAnalyticsRequest(eventName = "mc_custom_paymentoption_removed")
         editPage.clickRemove()
         analyticEventRule.assertMatchesExpectedEvent(AnalyticEvent.RemovedSavedPaymentMethod("card"))
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -225,6 +225,15 @@ internal class DefaultEventReporter @Inject internal constructor(
 
     override fun onRemoveSavedPaymentMethod(code: PaymentMethodCode) {
         fireAnalyticEvent(AnalyticEvent.RemovedSavedPaymentMethod(code))
+        fireEvent(
+            PaymentSheetEvent.RemoveSavedPaymentMethod(
+                code = code,
+                currency = currency,
+                isDeferred = isDeferred,
+                linkEnabled = linkEnabled,
+                googlePaySupported = googlePaySupported,
+            )
+        )
     }
 
     override fun onPaymentMethodFormShown(code: PaymentMethodCode) {
@@ -257,6 +266,14 @@ internal class DefaultEventReporter @Inject internal constructor(
         fireAnalyticEvent(
             AnalyticEvent.CompletedPaymentMethodForm(
                 paymentMethodType = code,
+            )
+        )
+        fireEvent(
+            PaymentSheetEvent.PaymentMethodFormCompleted(
+                code = code,
+                isDeferred = isDeferred,
+                linkEnabled = linkEnabled,
+                googlePaySupported = googlePaySupported,
             )
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -226,7 +226,8 @@ internal class DefaultEventReporter @Inject internal constructor(
     override fun onRemoveSavedPaymentMethod(code: PaymentMethodCode) {
         fireAnalyticEvent(AnalyticEvent.RemovedSavedPaymentMethod(code))
         fireEvent(
-            PaymentSheetEvent.RemoveSavedPaymentMethod(
+            PaymentSheetEvent.RemovePaymentOption(
+                mode = mode,
                 code = code,
                 currency = currency,
                 isDeferred = isDeferred,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -282,14 +282,16 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         )
     }
 
-    class RemoveSavedPaymentMethod(
+    class RemovePaymentOption(
+        mode: EventReporter.Mode,
         code: String,
         currency: String?,
         override val isDeferred: Boolean,
         override val linkEnabled: Boolean,
         override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
-        override val eventName: String = "mc_saved_payment_method_removed"
+        override val eventName: String =
+            formatEventName(mode, "paymentoption_removed")
         override val additionalParams: Map<String, Any?> = mapOf(
             FIELD_CURRENCY to currency,
             FIELD_SELECTED_LPM to code,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -282,6 +282,20 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         )
     }
 
+    class RemoveSavedPaymentMethod(
+        code: String,
+        currency: String?,
+        override val isDeferred: Boolean,
+        override val linkEnabled: Boolean,
+        override val googlePaySupported: Boolean,
+    ) : PaymentSheetEvent() {
+        override val eventName: String = "mc_saved_payment_method_removed"
+        override val additionalParams: Map<String, Any?> = mapOf(
+            FIELD_CURRENCY to currency,
+            FIELD_SELECTED_LPM to code,
+        )
+    }
+
     class SelectPaymentOption(
         mode: EventReporter.Mode,
         paymentSelection: PaymentSelection?,
@@ -316,6 +330,18 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
         override val eventName: String = "mc_form_interacted"
+        override val additionalParams: Map<String, Any?> = mapOf(
+            FIELD_SELECTED_LPM to code
+        )
+    }
+
+    class PaymentMethodFormCompleted(
+        code: String,
+        override val isDeferred: Boolean,
+        override val linkEnabled: Boolean,
+        override val googlePaySupported: Boolean,
+    ) : PaymentSheetEvent() {
+        override val eventName: String = "mc_form_completed"
         override val additionalParams: Map<String, Any?> = mapOf(
             FIELD_SELECTED_LPM to code
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
@@ -1023,6 +1023,33 @@ class PaymentSheetEventTest {
     }
 
     @Test
+    fun `RemoveSavedPaymentMethod event should return expected toString()`() {
+        val event = PaymentSheetEvent.RemoveSavedPaymentMethod(
+            code = "card",
+            currency = "usd",
+            isDeferred = false,
+            linkEnabled = false,
+            googlePaySupported = false,
+        )
+        assertThat(
+            event.eventName
+        ).isEqualTo(
+            "mc_saved_payment_method_removed"
+        )
+        assertThat(
+            event.params
+        ).isEqualTo(
+            mapOf(
+                "selected_lpm" to "card",
+                "currency" to "usd",
+                "is_decoupled" to false,
+                "link_enabled" to false,
+                "google_pay_enabled" to false,
+            )
+        )
+    }
+
+    @Test
     fun `SelectPaymentOption event should return expected toString()`() {
         val event = PaymentSheetEvent.SelectPaymentOption(
             mode = EventReporter.Mode.Custom,
@@ -1086,6 +1113,31 @@ class PaymentSheetEventTest {
             event.eventName
         ).isEqualTo(
             "mc_form_interacted"
+        )
+        assertThat(
+            event.params
+        ).isEqualTo(
+            mapOf(
+                "selected_lpm" to "card",
+                "is_decoupled" to false,
+                "link_enabled" to false,
+                "google_pay_enabled" to false,
+            )
+        )
+    }
+
+    @Test
+    fun `PaymentMethodFormCompleted event should return expected toString()`() {
+        val event = PaymentSheetEvent.PaymentMethodFormCompleted(
+            code = "card",
+            isDeferred = false,
+            linkEnabled = false,
+            googlePaySupported = false,
+        )
+        assertThat(
+            event.eventName
+        ).isEqualTo(
+            "mc_form_completed"
         )
         assertThat(
             event.params

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
@@ -1024,7 +1024,8 @@ class PaymentSheetEventTest {
 
     @Test
     fun `RemoveSavedPaymentMethod event should return expected toString()`() {
-        val event = PaymentSheetEvent.RemoveSavedPaymentMethod(
+        val event = PaymentSheetEvent.RemovePaymentOption(
+            mode = EventReporter.Mode.Custom,
             code = "card",
             currency = "usd",
             isDeferred = false,
@@ -1034,7 +1035,7 @@ class PaymentSheetEventTest {
         assertThat(
             event.eventName
         ).isEqualTo(
-            "mc_saved_payment_method_removed"
+            "mc_custom_paymentoption_removed"
         )
         assertThat(
             event.params


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Adding two sdk_events so every `AnalyticEvent` has its corresponding sdk_event to be monitored on Hubble.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
[Comments of Key Metrics in Launch Readiness Doc](https://docs.google.com/document/d/1qBoNxlacxVW0bZzFrETgQSjNFSpWExNL69hFErUJgmE/edit?tab=t.0)
The purpose is to monitor the analytic event health broken out by analytic event type.

I was trying to add a new sdk_event `mc_emit_analytic_event` for each MPE event emission in #10724 , but this would introduce duplicates with twice as many analytics events being emitted.

What we could do instead is to only add new sdk_event for  `RemovedSavedPaymentMethod` and `CompletedPaymentMethodForm`, which do not have existing sdk_event correspondingly. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
