### PR TITLE
Edit card widget: card info IME action should move to address section

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/CardDetailsUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/CardDetailsUI.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.shape.ZeroCornerSize
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -25,6 +26,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.stripe.android.R
 import com.stripe.android.model.CardBrand
+import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.Section
 import com.stripe.android.uicore.strings.resolve
 import com.stripe.android.uicore.stripeColors
@@ -73,6 +75,10 @@ private fun CardDetailsEditUI(
 ) {
     val dividerHeight = remember { mutableStateOf(0.dp) }
 
+    val hiddenBillingDetailsFields: State<Set<IdentifierSpec>>? = billingDetailsForm
+        ?.hiddenElements
+        ?.collectAsState()
+
     Column {
         Section(
             title = billingDetailsForm?.let {
@@ -95,15 +101,17 @@ private fun CardDetailsEditUI(
                     thickness = MaterialTheme.stripeShapes.borderStrokeWidth.dp,
                 )
                 Row(modifier = Modifier.fillMaxWidth()) {
-                    ExpiryField(
+                    ExpiryTextField(
                         modifier = Modifier
+                            .testTag(UPDATE_PM_EXPIRY_FIELD_TEST_TAG)
                             .weight(1F)
                             .onSizeChanged {
                                 dividerHeight.value =
                                     (it.height / Resources.getSystem().displayMetrics.density).dp
                             },
                         state = expiryDateState,
-                        onValueChanged = onExpDateChanged
+                        hasNextField = hiddenBillingDetailsFields?.value?.hasFocusableFields() == true,
+                        onValueChange = onExpDateChanged,
                     )
                     Divider(
                         modifier = Modifier
@@ -126,6 +134,14 @@ private fun CardDetailsEditUI(
         }
     }
 }
+
+/**
+ * Checks if the billing details form has any fields that are focusable.
+ */
+@Composable
+private fun Set<IdentifierSpec>.hasFocusableFields(): Boolean = listOf(
+    IdentifierSpec.PostalCode
+).none { contains(it) }
 
 @Composable
 private fun CardNumberField(
@@ -154,21 +170,7 @@ private fun CardNumberField(
                     modifier = Modifier,
                 )
             }
-        },
-    )
-}
-
-@Composable
-private fun ExpiryField(
-    modifier: Modifier,
-    state: ExpiryDateState,
-    onValueChanged: (String) -> Unit
-) {
-    ExpiryTextField(
-        modifier = modifier
-            .testTag(UPDATE_PM_EXPIRY_FIELD_TEST_TAG),
-        state = state,
-        onValueChange = onValueChanged,
+        }
     )
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/CommonTextField.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/CommonTextField.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.ui
 
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.shape.ZeroCornerSize
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.ContentAlpha
 import androidx.compose.material.MaterialTheme
@@ -26,6 +27,7 @@ internal fun CommonTextField(
     enabled: Boolean = false,
     visualTransformation: VisualTransformation = VisualTransformation.None,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
     shape: Shape =
         MaterialTheme.shapes.small.copy(bottomEnd = ZeroCornerSize, bottomStart = ZeroCornerSize),
     colors: TextFieldColors = TextFieldColors(
@@ -45,6 +47,7 @@ internal fun CommonTextField(
         shape = shape,
         colors = colors,
         keyboardOptions = keyboardOptions,
+        keyboardActions = keyboardActions,
         visualTransformation = visualTransformation,
         onValueChange = onValueChange,
     )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/ExpiryTextField.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/ExpiryTextField.kt
@@ -2,16 +2,19 @@ package com.stripe.android.paymentsheet.ui
 
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.shape.ZeroCornerSize
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.TextFieldDefaults.indicatorLine
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import com.stripe.android.uicore.elements.ExpiryDateVisualTransformation
 import com.stripe.android.uicore.elements.TextFieldColors
@@ -24,9 +27,12 @@ import com.stripe.android.uicore.strings.resolve
 internal fun ExpiryTextField(
     modifier: Modifier = Modifier,
     state: ExpiryDateState,
+    hasNextField: Boolean,
     onValueChange: (String) -> Unit,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
 ) {
+    val focusManager = LocalFocusManager.current
+    val keyboardController = LocalSoftwareKeyboardController.current
     val isError = state.shouldShowError()
     val colors = TextFieldColors(
         shouldShowError = isError,
@@ -54,9 +60,18 @@ internal fun ExpiryTextField(
         ),
         shouldShowError = isError,
         keyboardOptions = KeyboardOptions.Default.copy(
-            keyboardType = KeyboardType.NumberPassword
+            keyboardType = KeyboardType.NumberPassword,
+            imeAction = if (hasNextField) {
+                ImeAction.Next
+            } else {
+                ImeAction.Done
+            }
         ),
         visualTransformation = ExpiryDateVisualTransformation(CARD_EDIT_UI_FALLBACK_EXPIRY_DATE),
-        colors = colors
+        colors = colors,
+        keyboardActions = KeyboardActions(
+            onNext = { focusManager.moveFocus(FocusDirection.Next) },
+            onDone = { keyboardController?.hide() }
+        )
     )
 }


### PR DESCRIPTION
# Summary
- Adds IME actions to card edit widget;
  - If on expiry and billing address fields are focusable, keyboard action is Next
  - If no billing address focusable (on countries with no postal code collection) keyboard shows Done action and closes keyboard. 

https://github.com/user-attachments/assets/06708002-29fd-49f4-86a4-baa08d23d32e

# Motivation
https://jira.corp.stripe.com/browse/LINK_MOBILE-183

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
