### PR TITLE
Fix bitrise deprecation.

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -77,7 +77,7 @@ workflows:
     meta:
       bitrise.io:
         stack: osx-xcode-16.2.x    # Specify Mac stack just for this workflow
-        machine_type_id: g2.mac.large # Appropriate Mac instance
+        machine_type_id: g2.mac.4large # Appropriate Mac instance
     before_run:
       - prepare_all
     after_run:


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
<img width="1254" alt="Screenshot 2025-04-29 at 10 29 01 AM" src="https://github.com/user-attachments/assets/ee7567b6-3f56-45f6-8833-07373a66aaaa" />

This is the M4 variant that matches the config of our previous generation.

