### PR TITLE
Update tflite to support 16KB page size on Android 16

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -60,7 +60,7 @@ ext.versions = [
         payButtonCompose            : '0.1.3',
         places                      : '3.5.0',
         playServicesCoroutines      : '1.10.1',
-        playServicesTfLite          : '16.0.1',
+        playServicesTfLite          : '16.4.0',
         playServicesWallet          : '19.4.0',
         playIntegrity               : '1.4.0',
         retrofit                    : '2.11.0',

--- a/ml-core:googleplay/dependencies/dependencies.txt
+++ b/ml-core:googleplay/dependencies/dependencies.txt
@@ -4,102 +4,74 @@
 |    \--- androidx.annotation:annotation:1.9.1
 |         \--- androidx.annotation:annotation-jvm:1.9.1
 |              \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.24 -> 2.1.10 (*)
-+--- com.google.android.gms:play-services-tflite-support:16.0.1
-|    +--- com.google.android.gms:play-services-basement:18.1.0
-|    |    +--- androidx.collection:collection:1.0.0
-|    |    |    \--- androidx.annotation:annotation:1.0.0 -> 1.9.1 (*)
++--- com.google.android.gms:play-services-tflite-support:16.4.0
+|    +--- com.google.android.gms:play-services-basement:18.4.0
+|    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0
+|    |    |    \--- androidx.annotation:annotation:1.1.0 -> 1.9.1 (*)
 |    |    +--- androidx.core:core:1.2.0
 |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.9.1 (*)
-|    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.0.0
-|    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.0.0
-|    |    |    |    |    \--- androidx.annotation:annotation:1.0.0 -> 1.9.1 (*)
-|    |    |    |    +--- androidx.arch.core:core-common:2.0.0
-|    |    |    |    |    \--- androidx.annotation:annotation:1.0.0 -> 1.9.1 (*)
-|    |    |    |    \--- androidx.annotation:annotation:1.0.0 -> 1.9.1 (*)
+|    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.0.0 -> 2.1.0
+|    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.1.0
+|    |    |    |    |    \--- androidx.annotation:annotation:1.1.0 -> 1.9.1 (*)
+|    |    |    |    +--- androidx.arch.core:core-common:2.1.0
+|    |    |    |    |    \--- androidx.annotation:annotation:1.1.0 -> 1.9.1 (*)
+|    |    |    |    \--- androidx.annotation:annotation:1.1.0 -> 1.9.1 (*)
 |    |    |    +--- androidx.versionedparcelable:versionedparcelable:1.1.0
 |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.9.1 (*)
-|    |    |    |    \--- androidx.collection:collection:1.0.0 (*)
-|    |    |    \--- androidx.collection:collection:1.0.0 (*)
-|    |    \--- androidx.fragment:fragment:1.0.0
-|    |         +--- androidx.core:core:1.0.0 -> 1.2.0 (*)
-|    |         +--- androidx.legacy:legacy-support-core-ui:1.0.0
+|    |    |    |    \--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    |    \--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
+|    |    \--- androidx.fragment:fragment:1.1.0
+|    |         +--- androidx.annotation:annotation:1.1.0 -> 1.9.1 (*)
+|    |         +--- androidx.core:core:1.1.0 -> 1.2.0 (*)
+|    |         +--- androidx.collection:collection:1.1.0 (*)
+|    |         +--- androidx.viewpager:viewpager:1.0.0
 |    |         |    +--- androidx.annotation:annotation:1.0.0 -> 1.9.1 (*)
 |    |         |    +--- androidx.core:core:1.0.0 -> 1.2.0 (*)
-|    |         |    +--- androidx.legacy:legacy-support-core-utils:1.0.0
-|    |         |    |    +--- androidx.annotation:annotation:1.0.0 -> 1.9.1 (*)
-|    |         |    |    +--- androidx.core:core:1.0.0 -> 1.2.0 (*)
-|    |         |    |    +--- androidx.documentfile:documentfile:1.0.0
-|    |         |    |    |    \--- androidx.annotation:annotation:1.0.0 -> 1.9.1 (*)
-|    |         |    |    +--- androidx.loader:loader:1.0.0
+|    |         |    \--- androidx.customview:customview:1.0.0
+|    |         |         +--- androidx.annotation:annotation:1.0.0 -> 1.9.1 (*)
+|    |         |         \--- androidx.core:core:1.0.0 -> 1.2.0 (*)
+|    |         +--- androidx.loader:loader:1.0.0
+|    |         |    +--- androidx.annotation:annotation:1.0.0 -> 1.9.1 (*)
+|    |         |    +--- androidx.core:core:1.0.0 -> 1.2.0 (*)
+|    |         |    +--- androidx.lifecycle:lifecycle-livedata:2.0.0
+|    |         |    |    +--- androidx.arch.core:core-runtime:2.0.0
 |    |         |    |    |    +--- androidx.annotation:annotation:1.0.0 -> 1.9.1 (*)
-|    |         |    |    |    +--- androidx.core:core:1.0.0 -> 1.2.0 (*)
-|    |         |    |    |    +--- androidx.lifecycle:lifecycle-livedata:2.0.0
-|    |         |    |    |    |    +--- androidx.arch.core:core-runtime:2.0.0
-|    |         |    |    |    |    |    +--- androidx.annotation:annotation:1.0.0 -> 1.9.1 (*)
-|    |         |    |    |    |    |    \--- androidx.arch.core:core-common:2.0.0 (*)
-|    |         |    |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.0.0
-|    |         |    |    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.0.0 (*)
-|    |         |    |    |    |    |    +--- androidx.arch.core:core-common:2.0.0 (*)
-|    |         |    |    |    |    |    \--- androidx.arch.core:core-runtime:2.0.0 (*)
-|    |         |    |    |    |    \--- androidx.arch.core:core-common:2.0.0 (*)
-|    |         |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel:2.0.0
-|    |         |    |    |         \--- androidx.annotation:annotation:1.0.0 -> 1.9.1 (*)
-|    |         |    |    +--- androidx.localbroadcastmanager:localbroadcastmanager:1.0.0
-|    |         |    |    |    \--- androidx.annotation:annotation:1.0.0 -> 1.9.1 (*)
-|    |         |    |    \--- androidx.print:print:1.0.0
-|    |         |    |         \--- androidx.annotation:annotation:1.0.0 -> 1.9.1 (*)
-|    |         |    +--- androidx.customview:customview:1.0.0
-|    |         |    |    +--- androidx.annotation:annotation:1.0.0 -> 1.9.1 (*)
-|    |         |    |    \--- androidx.core:core:1.0.0 -> 1.2.0 (*)
-|    |         |    +--- androidx.viewpager:viewpager:1.0.0
-|    |         |    |    +--- androidx.annotation:annotation:1.0.0 -> 1.9.1 (*)
-|    |         |    |    +--- androidx.core:core:1.0.0 -> 1.2.0 (*)
-|    |         |    |    \--- androidx.customview:customview:1.0.0 (*)
-|    |         |    +--- androidx.coordinatorlayout:coordinatorlayout:1.0.0
-|    |         |    |    +--- androidx.annotation:annotation:1.0.0 -> 1.9.1 (*)
-|    |         |    |    +--- androidx.core:core:1.0.0 -> 1.2.0 (*)
-|    |         |    |    \--- androidx.customview:customview:1.0.0 (*)
-|    |         |    +--- androidx.drawerlayout:drawerlayout:1.0.0
-|    |         |    |    +--- androidx.annotation:annotation:1.0.0 -> 1.9.1 (*)
-|    |         |    |    +--- androidx.core:core:1.0.0 -> 1.2.0 (*)
-|    |         |    |    \--- androidx.customview:customview:1.0.0 (*)
-|    |         |    +--- androidx.slidingpanelayout:slidingpanelayout:1.0.0
-|    |         |    |    +--- androidx.annotation:annotation:1.0.0 -> 1.9.1 (*)
-|    |         |    |    +--- androidx.core:core:1.0.0 -> 1.2.0 (*)
-|    |         |    |    \--- androidx.customview:customview:1.0.0 (*)
-|    |         |    +--- androidx.interpolator:interpolator:1.0.0
-|    |         |    |    \--- androidx.annotation:annotation:1.0.0 -> 1.9.1 (*)
-|    |         |    +--- androidx.swiperefreshlayout:swiperefreshlayout:1.0.0
-|    |         |    |    +--- androidx.annotation:annotation:1.0.0 -> 1.9.1 (*)
-|    |         |    |    +--- androidx.core:core:1.0.0 -> 1.2.0 (*)
-|    |         |    |    \--- androidx.interpolator:interpolator:1.0.0 (*)
-|    |         |    +--- androidx.asynclayoutinflater:asynclayoutinflater:1.0.0
-|    |         |    |    +--- androidx.annotation:annotation:1.0.0 -> 1.9.1 (*)
-|    |         |    |    \--- androidx.core:core:1.0.0 -> 1.2.0 (*)
-|    |         |    \--- androidx.cursoradapter:cursoradapter:1.0.0
-|    |         |         \--- androidx.annotation:annotation:1.0.0 -> 1.9.1 (*)
-|    |         +--- androidx.legacy:legacy-support-core-utils:1.0.0 (*)
-|    |         +--- androidx.annotation:annotation:1.0.0 -> 1.9.1 (*)
-|    |         +--- androidx.loader:loader:1.0.0 (*)
-|    |         \--- androidx.lifecycle:lifecycle-viewmodel:2.0.0 (*)
-|    +--- com.google.android.gms:play-services-tflite-java:16.0.1
-|    |    +--- com.google.android.gms:play-services-base:18.1.0
-|    |    |    +--- androidx.collection:collection:1.0.0 (*)
+|    |         |    |    |    \--- androidx.arch.core:core-common:2.0.0 -> 2.1.0 (*)
+|    |         |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.0.0
+|    |         |    |    |    +--- androidx.lifecycle:lifecycle-common:2.0.0 -> 2.1.0 (*)
+|    |         |    |    |    +--- androidx.arch.core:core-common:2.0.0 -> 2.1.0 (*)
+|    |         |    |    |    \--- androidx.arch.core:core-runtime:2.0.0 (*)
+|    |         |    |    \--- androidx.arch.core:core-common:2.0.0 -> 2.1.0 (*)
+|    |         |    \--- androidx.lifecycle:lifecycle-viewmodel:2.0.0 -> 2.1.0
+|    |         |         \--- androidx.annotation:annotation:1.1.0 -> 1.9.1 (*)
+|    |         +--- androidx.activity:activity:1.0.0
+|    |         |    +--- androidx.annotation:annotation:1.1.0 -> 1.9.1 (*)
+|    |         |    +--- androidx.core:core:1.1.0 -> 1.2.0 (*)
+|    |         |    +--- androidx.lifecycle:lifecycle-runtime:2.1.0 (*)
+|    |         |    +--- androidx.lifecycle:lifecycle-viewmodel:2.1.0 (*)
+|    |         |    \--- androidx.savedstate:savedstate:1.0.0
+|    |         |         +--- androidx.annotation:annotation:1.1.0 -> 1.9.1 (*)
+|    |         |         +--- androidx.arch.core:core-common:2.0.1 -> 2.1.0 (*)
+|    |         |         \--- androidx.lifecycle:lifecycle-common:2.0.0 -> 2.1.0 (*)
+|    |         \--- androidx.lifecycle:lifecycle-viewmodel:2.0.0 -> 2.1.0 (*)
+|    +--- com.google.android.gms:play-services-tflite-java:16.4.0
+|    |    +--- com.google.android.gms:play-services-base:18.5.0
+|    |    |    +--- androidx.collection:collection:1.0.0 -> 1.1.0 (*)
 |    |    |    +--- androidx.core:core:1.2.0 (*)
-|    |    |    +--- androidx.fragment:fragment:1.0.0 (*)
-|    |    |    +--- com.google.android.gms:play-services-basement:18.1.0 (*)
-|    |    |    \--- com.google.android.gms:play-services-tasks:18.0.2
-|    |    |         \--- com.google.android.gms:play-services-basement:18.1.0 (*)
-|    |    +--- com.google.android.gms:play-services-basement:18.1.0 (*)
-|    |    +--- com.google.android.gms:play-services-tasks:18.0.2 (*)
-|    |    +--- com.google.android.gms:play-services-tflite-impl:16.0.1
-|    |    |    +--- com.google.android.gms:play-services-base:18.1.0 (*)
-|    |    |    +--- com.google.android.gms:play-services-basement:18.1.0 (*)
-|    |    |    \--- com.google.android.gms:play-services-tasks:18.0.2 (*)
-|    |    \--- org.tensorflow:tensorflow-lite-api:2.10.0
+|    |    |    +--- androidx.fragment:fragment:1.0.0 -> 1.1.0 (*)
+|    |    |    +--- com.google.android.gms:play-services-basement:18.4.0 (*)
+|    |    |    \--- com.google.android.gms:play-services-tasks:18.2.0
+|    |    |         \--- com.google.android.gms:play-services-basement:18.4.0 (*)
+|    |    +--- com.google.android.gms:play-services-basement:18.4.0 (*)
+|    |    +--- com.google.android.gms:play-services-tasks:18.2.0 (*)
+|    |    +--- com.google.android.gms:play-services-tflite-impl:16.4.0
+|    |    |    +--- com.google.android.gms:play-services-base:18.5.0 (*)
+|    |    |    +--- com.google.android.gms:play-services-basement:18.4.0 (*)
+|    |    |    \--- com.google.android.gms:play-services-tasks:18.2.0 (*)
+|    |    \--- org.tensorflow:tensorflow-lite-api:2.16.1
 |    \--- org.tensorflow:tensorflow-lite-support-api:0.4.2
 |         +--- org.checkerframework:checker-qual:2.5.8
-|         +--- org.tensorflow:tensorflow-lite-api:2.9.0 -> 2.10.0
+|         +--- org.tensorflow:tensorflow-lite-api:2.9.0 -> 2.16.1
 |         \--- com.google.android.odml:image:1.0.0-beta1
 +--- org.jetbrains.kotlin:kotlin-stdlib:2.1.10 (*)
-\--- com.google.android.gms:play-services-tflite-java:16.0.1 (*)
+\--- com.google.android.gms:play-services-tflite-java:16.4.0 (*)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
16KB page size support for Android 16. Our APK is unaligned with the 16KB page size because of the tflite dependency. Upgrading the latest version resolves this for the `arm64-v8a` architecture. Other architectures are still unsupported according to [this issue](https://github.com/google-ai-edge/LiteRT/issues/43) on the tf repo.


### APK Analysis Result

```
// ALIGNED
*/paymentsheet-example-debug_*/lib/arm64-v8a/libtensorflowlite_jni.so: \e[32mALIGNED\e[0m (2**16)

//UNALIGNED
*/paymentsheet-example-debug_out_*/armeabi-v7a/libtensorflowlite_jni.so: \e[31mUNALIGNED\e[0m (2**12)
*/paymentsheet-example-debug_out_*/x86/libtensorflowlite_jni.so: \e[31mUNALIGNED\e[0m (2**12)
*/paymentsheet-example-debug_out_*/x86_64/libtensorflowlite_jni.so: \e[31mUNALIGNED\e[0m (2**12)
```

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

> When your app is running on a device with Android 16 or higher, if Android detects that your app has 4 KB aligned memory pages, it automatically uses compatibility mode and display a notification dialog to the user.

https://developer.android.com/about/versions/16/behavior-changes-all#16-kb-compatibility-mode
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-4211

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
