### PR TITLE
[connect] Init first E2E test in CI

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -88,6 +88,23 @@ workflows:
           timeout: 1200
           inputs:
             - content: ./scripts/retry.sh 3 ./gradlew testDebugUnitTest verifyPaparazziDebug -x :stripe-test-e2e:testDebugUnitTest --continue
+  build-connect-debug:
+    envs:
+      - BUILD_VARIANT: debug
+    before_run:
+      - _build-connect
+  _build-connect:
+    before_run:
+      - prepare_all
+    steps:
+      - android-build@1:
+          inputs:
+            - module: connect-example
+            - variant: $BUILD_VARIANT
+            - build_type: apk
+      - deploy-to-bitrise-io@2:
+          inputs:
+            - pipeline_intermediate_files: "$BITRISE_APK_PATH:BITRISE_APK_PATH"
   build-connections-debug:
     envs:
       - BUILD_VARIANT: debug
@@ -168,6 +185,7 @@ workflows:
       - _run-connections-e2e-tests
   _run-connect-e2e-tests:
     before_run:
+      - build-connect-debug
       - start_connections_emulator
       - prepare_all
     after_run:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -28,19 +28,20 @@ pipelines:
 stages:
   stage-trigger-run-all:
     workflows:
-      - check: { }
-      - test: { }
-      - run-instrumentation-tests: { }
-      - run-paymentsheet-instrumentation-tests: { }
-      - run-example-instrumentation-tests: { }
-      - run-financial-connections-instrumentation-tests: { }
-      - run-connections-e2e-payments-tests-on-push: { }
-      - run-connections-e2e-token-tests-on-push: { }
-      - run-connections-e2e-data-tests-on-push: { }
-      - run-cardscan-instrumentation-tests: { }
-      - run-paymentsheet-end-to-end-tests: { }
-      - run-paymentsheet-screenshot-tests: { }
-      - check-dependencies: { }
+      # - check: { }
+      # - test: { }
+      # - run-instrumentation-tests: { }
+      # - run-paymentsheet-instrumentation-tests: { }
+      # - run-example-instrumentation-tests: { }
+      # - run-financial-connections-instrumentation-tests: { }
+      # - run-connections-e2e-payments-tests-on-push: { }
+      - run-connect-e2e-tests: { }
+      # - run-connections-e2e-token-tests-on-push: { }
+      # - run-connections-e2e-data-tests-on-push: { }
+      # - run-cardscan-instrumentation-tests: { }
+      # - run-paymentsheet-end-to-end-tests: { }
+      # - run-paymentsheet-screenshot-tests: { }
+      # - check-dependencies: { }
   stage-build-connections-debug:
     workflows:
       - build-connections-debug: { }
@@ -110,6 +111,11 @@ workflows:
       - deploy-to-bitrise-io@2:
           inputs:
             - pipeline_intermediate_files: "$BITRISE_APK_PATH:BITRISE_APK_PATH"
+  run-connect-e2e-tests:
+    envs:
+      - MAESTRO_TAGS: all
+    before_run:
+      - _run-connect-e2e-tests
   run-connections-e2e-payments-tests:
     envs:
       - MAESTRO_TAGS: testmode-payments
@@ -160,6 +166,25 @@ workflows:
       - MAESTRO_TAGS: livemode-data
     before_run:
       - _run-connections-e2e-tests
+  _run-connect-e2e-tests:
+    before_run:
+      - start_connections_emulator
+      - prepare_all
+    after_run:
+      - conclude_all
+    steps:
+      - wait-for-android-emulator@1:
+          inputs:
+            - boot_timeout: 600
+      - pull-intermediate-files@1:
+          inputs:
+            - artifact_sources: .*
+      - script@1:
+          title: Execute Maestro tests
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                bash ./scripts/execute_maestro_tests.sh -m connect -t $MAESTRO_TAGS
   _run-connections-e2e-tests:
     before_run:
       - start_connections_emulator
@@ -178,7 +203,7 @@ workflows:
           inputs:
             - content: |-
                 #!/usr/bin/env bash
-                bash ./scripts/execute_maestro_tests.sh -t $MAESTRO_TAGS
+                bash ./scripts/execute_maestro_tests.sh -m financial-connections -t $MAESTRO_TAGS
   notify-connections-e2e-failure:
     steps:
       # Notify all executions.

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -6,7 +6,8 @@ trigger_map:
   - push_branch: 'master'
     pipeline: main-trigger-pipeline
   - pull_request_source_branch: '*'
-    pipeline: main-trigger-pipeline
+    # pipeline: main-trigger-pipeline
+    pipeline: pipeline-connect-e2e-debug-tests
 app:
   envs:
     - GRADLE_OPTS: -Dkotlin.incremental=false

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -6,8 +6,7 @@ trigger_map:
   - push_branch: 'master'
     pipeline: main-trigger-pipeline
   - pull_request_source_branch: '*'
-    # pipeline: main-trigger-pipeline
-    pipeline: pipeline-connect-e2e-debug-tests
+    pipeline: main-trigger-pipeline
 app:
   envs:
     - GRADLE_OPTS: -Dkotlin.incremental=false

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -15,6 +15,10 @@ pipelines:
   main-trigger-pipeline:
     stages:
       - stage-trigger-run-all: { }
+  pipeline-connect-e2e-debug-tests:
+    stages:
+      - stage-run-connect-e2e-tests: { }
+      # TODO: notify failure
   pipeline-connections-e2e-debug-tests:
     stages:
       - stage-build-connections-debug: { }
@@ -28,20 +32,22 @@ pipelines:
 stages:
   stage-trigger-run-all:
     workflows:
-      # - check: { }
-      # - test: { }
-      # - run-instrumentation-tests: { }
-      # - run-paymentsheet-instrumentation-tests: { }
-      # - run-example-instrumentation-tests: { }
-      # - run-financial-connections-instrumentation-tests: { }
-      # - run-connections-e2e-payments-tests-on-push: { }
+      - check: { }
+      - test: { }
+      - run-instrumentation-tests: { }
+      - run-paymentsheet-instrumentation-tests: { }
+      - run-example-instrumentation-tests: { }
+      - run-financial-connections-instrumentation-tests: { }
+      - run-connections-e2e-payments-tests-on-push: { }
+      - run-connections-e2e-token-tests-on-push: { }
+      - run-connections-e2e-data-tests-on-push: { }
+      - run-cardscan-instrumentation-tests: { }
+      - run-paymentsheet-end-to-end-tests: { }
+      - run-paymentsheet-screenshot-tests: { }
+      - check-dependencies: { }
+  stage-run-connect-e2e-tests:
+    workflows:
       - run-connect-e2e-tests: { }
-      # - run-connections-e2e-token-tests-on-push: { }
-      # - run-connections-e2e-data-tests-on-push: { }
-      # - run-cardscan-instrumentation-tests: { }
-      # - run-paymentsheet-end-to-end-tests: { }
-      # - run-paymentsheet-screenshot-tests: { }
-      # - check-dependencies: { }
   stage-build-connections-debug:
     workflows:
       - build-connections-debug: { }

--- a/connect-example/src/main/java/com/stripe/android/connect/example/ui/common/ConnectExampleScaffold.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/ui/common/ConnectExampleScaffold.kt
@@ -11,11 +11,15 @@ import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun ConnectExampleScaffold(
     title: String,
@@ -25,7 +29,9 @@ fun ConnectExampleScaffold(
 ) {
     Scaffold(
         contentWindowInsets = WindowInsets.systemBars,
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .semantics { testTagsAsResourceId = true }
+            .fillMaxSize(),
         topBar = {
             TopAppBar(
                 windowInsets = WindowInsets.statusBars,

--- a/connect-example/src/main/java/com/stripe/android/connect/example/ui/componentpicker/ComponentPickerScreen.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/ui/componentpicker/ComponentPickerScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyItemScope
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.Divider
-import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.ModalBottomSheetLayout
@@ -33,6 +32,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -57,7 +57,7 @@ import com.stripe.android.connect.example.ui.settings.SettingsViewModel
 import kotlinx.coroutines.launch
 
 @Suppress("LongMethod")
-@OptIn(PrivateBetaConnectSDK::class, ExperimentalMaterialApi::class)
+@OptIn(PrivateBetaConnectSDK::class)
 @Composable
 fun ComponentPickerContent(
     viewModel: EmbeddedComponentLoaderViewModel,
@@ -90,7 +90,10 @@ fun ComponentPickerContent(
             title = stringResource(R.string.connect_sdk_example),
             actions = (embeddedComponentAsync is Success).then {
                 {
-                    IconButton(onClick = openSettings) {
+                    IconButton(
+                        modifier = Modifier.testTag("settings_button"),
+                        onClick = openSettings
+                    ) {
                         Icon(
                             imageVector = Icons.Default.Settings,
                             contentDescription = stringResource(R.string.settings),

--- a/connect-example/src/main/java/com/stripe/android/connect/example/ui/settings/SettingsView.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/ui/settings/SettingsView.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.stripe.android.connect.example.R
@@ -33,6 +34,7 @@ import com.stripe.android.connect.example.ui.common.ConnectExampleScaffold
 import com.stripe.android.connect.example.ui.settings.SettingsViewModel.SettingsState.DemoMerchant
 
 @Composable
+@Suppress("LongMethod")
 fun SettingsView(
     viewModel: SettingsViewModel,
     onDismiss: () -> Unit,
@@ -56,6 +58,7 @@ fun SettingsView(
         },
         actions = {
             IconButton(
+                modifier = Modifier.testTag("save_button"),
                 enabled = state.saveEnabled,
                 onClick = {
                     viewModel.saveSettings()
@@ -144,11 +147,13 @@ private fun SelectAnAccount(
                             onClick = null, // onClick handled by row
                         )
                         OutlinedTextField(
+                            modifier = Modifier
+                                .testTag("other_account_input")
+                                .fillMaxWidth(),
                             value = merchant.merchantId,
                             onValueChange = onOtherAccountInputChanged,
                             label = { Text(stringResource(R.string.other)) },
                             placeholder = { Text(stringResource(R.string.account_id_placeholder)) },
-                            modifier = Modifier.fillMaxWidth()
                         )
                     }
                 }

--- a/maestro/connect/TestAccountOnboardingLoads.yaml
+++ b/maestro/connect/TestAccountOnboardingLoads.yaml
@@ -14,6 +14,8 @@ tags:
 - scrollUntilVisible:
     element:
       id: "other_account_input"
+    speed: 80
+    timeout: 60_000
 - tapOn:
     id: "other_account_input"
 - inputText: "acct_1RKLk9PwPtoT2bUJ"

--- a/maestro/connect/TestAccountOnboardingLoads.yaml
+++ b/maestro/connect/TestAccountOnboardingLoads.yaml
@@ -2,6 +2,7 @@ appId: com.stripe.android.connect.example
 tags:
   - all
 ---
+- startRecording: ${'/tmp/test_results/connect-testaccountonboardingloads-' + new Date().getTime()}
 - clearState
 - launchApp
 - extendedWaitUntil:
@@ -23,3 +24,4 @@ tags:
 - extendedWaitUntil:
     visible: "Review and confirm"
     timeout: 30_000
+- stopRecording

--- a/maestro/connect/TestAccountOnboardingLoads.yaml
+++ b/maestro/connect/TestAccountOnboardingLoads.yaml
@@ -1,4 +1,6 @@
 appId: com.stripe.android.connect.example
+tags:
+  - all
 ---
 - clearState
 - launchApp

--- a/maestro/connect/TestAccountOnboardingLoads.yaml
+++ b/maestro/connect/TestAccountOnboardingLoads.yaml
@@ -1,0 +1,23 @@
+appId: com.stripe.android.connect.example
+---
+- clearState
+- launchApp
+- extendedWaitUntil:
+    visible:
+      id: "settings_button"
+    timeout: 30_000
+- tapOn:
+    id: "settings_button"
+- scrollUntilVisible:
+    element:
+      id: "other_account_input"
+- tapOn:
+    id: "other_account_input"
+- inputText: "acct_1RKLk9PwPtoT2bUJ"
+- "hideKeyboard"
+- tapOn:
+    id: "save_button"
+- tapOn: "Account Onboarding"
+- extendedWaitUntil:
+    visible: "Review and confirm"
+    timeout: 30_000

--- a/maestro/connect/TestAccountOnboardingLoads.yaml
+++ b/maestro/connect/TestAccountOnboardingLoads.yaml
@@ -8,7 +8,7 @@ tags:
 - extendedWaitUntil:
     visible:
       id: "settings_button"
-    timeout: 30_000
+    timeout: 60_000
 - tapOn:
     id: "settings_button"
 - scrollUntilVisible:
@@ -23,5 +23,5 @@ tags:
 - tapOn: "Account Onboarding"
 - extendedWaitUntil:
     visible: "Review and confirm"
-    timeout: 30_000
+    timeout: 60_000
 - stopRecording


### PR DESCRIPTION
# Summary
Add a Connect Example E2E test using Maestro, based on the FC setup. The test opens the Connect Example app, sets a custom account ID, opens Account Onboarding, and awaits expected text from the webview.

Once this is merged, we'll have to configure Bitrise to run regularly. 

# Motivation
https://jira.corp.stripe.com/browse/CAX-4044

# Testing
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

Ran locally and on Bitrise by altering the configuration file ([example](https://github.com/stripe/stripe-android/runs/41561774423)).

Example recording pulled from the Bitrise run:

https://github.com/user-attachments/assets/77ff11b8-cbe5-47d1-b280-e3e78aa2bad6

