### PR TITLE
Move `Google Pay` button type conversion out of `PaymentSheet`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -36,7 +36,6 @@ import com.stripe.android.paymentsheet.analytics.primaryButtonColorUsage
 import com.stripe.android.paymentsheet.cvcrecollection.CvcRecollectionHandler
 import com.stripe.android.paymentsheet.injection.DaggerPaymentSheetLauncherComponent
 import com.stripe.android.paymentsheet.injection.PaymentSheetViewModelModule
-import com.stripe.android.paymentsheet.model.GooglePayButtonType
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.PaymentSheetViewState
 import com.stripe.android.paymentsheet.model.isLink
@@ -51,6 +50,7 @@ import com.stripe.android.paymentsheet.state.WalletsProcessingState
 import com.stripe.android.paymentsheet.state.WalletsState
 import com.stripe.android.paymentsheet.ui.DefaultAddPaymentMethodInteractor
 import com.stripe.android.paymentsheet.ui.DefaultSelectSavedPaymentMethodsInteractor
+import com.stripe.android.paymentsheet.utils.asGooglePayButtonType
 import com.stripe.android.paymentsheet.utils.canSave
 import com.stripe.android.paymentsheet.utils.toConfirmationError
 import com.stripe.android.paymentsheet.verticalmode.VerticalModeInitialScreenFactory
@@ -139,19 +139,6 @@ internal class PaymentSheetViewModel @Inject internal constructor(
 
     override var newPaymentSelection: NewPaymentOptionSelection? = null
 
-    private val googlePayButtonType: GooglePayButtonType =
-        when (args.config.googlePay?.buttonType) {
-            PaymentSheet.GooglePayConfiguration.ButtonType.Buy -> GooglePayButtonType.Buy
-            PaymentSheet.GooglePayConfiguration.ButtonType.Book -> GooglePayButtonType.Book
-            PaymentSheet.GooglePayConfiguration.ButtonType.Checkout -> GooglePayButtonType.Checkout
-            PaymentSheet.GooglePayConfiguration.ButtonType.Donate -> GooglePayButtonType.Donate
-            PaymentSheet.GooglePayConfiguration.ButtonType.Order -> GooglePayButtonType.Order
-            PaymentSheet.GooglePayConfiguration.ButtonType.Subscribe -> GooglePayButtonType.Subscribe
-            PaymentSheet.GooglePayConfiguration.ButtonType.Plain -> GooglePayButtonType.Plain
-            PaymentSheet.GooglePayConfiguration.ButtonType.Pay,
-            null -> GooglePayButtonType.Pay
-        }
-
     @VisibleForTesting
     internal val googlePayLauncherConfig: GooglePayPaymentMethodLauncher.Config? =
         args.googlePayConfig?.let { config ->
@@ -194,7 +181,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
             buttonsEnabled = buttonsEnabled,
             paymentMethodTypes = paymentMethodMetadata?.supportedPaymentMethodTypes().orEmpty(),
             googlePayLauncherConfig = googlePayLauncherConfig,
-            googlePayButtonType = googlePayButtonType,
+            googlePayButtonType = args.googlePayConfig?.buttonType.asGooglePayButtonType,
             onGooglePayPressed = this::checkoutWithGooglePay,
             onLinkPressed = this::checkoutWithLink,
             isSetupIntent = paymentMethodMetadata?.stripeIntent is SetupIntent

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/utils/GooglePayUtils.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/utils/GooglePayUtils.kt
@@ -1,0 +1,17 @@
+package com.stripe.android.paymentsheet.utils
+
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.model.GooglePayButtonType
+
+internal val PaymentSheet.GooglePayConfiguration.ButtonType?.asGooglePayButtonType: GooglePayButtonType
+    get() = when (this) {
+        PaymentSheet.GooglePayConfiguration.ButtonType.Buy -> GooglePayButtonType.Buy
+        PaymentSheet.GooglePayConfiguration.ButtonType.Book -> GooglePayButtonType.Book
+        PaymentSheet.GooglePayConfiguration.ButtonType.Checkout -> GooglePayButtonType.Checkout
+        PaymentSheet.GooglePayConfiguration.ButtonType.Donate -> GooglePayButtonType.Donate
+        PaymentSheet.GooglePayConfiguration.ButtonType.Order -> GooglePayButtonType.Order
+        PaymentSheet.GooglePayConfiguration.ButtonType.Subscribe -> GooglePayButtonType.Subscribe
+        PaymentSheet.GooglePayConfiguration.ButtonType.Plain -> GooglePayButtonType.Plain
+        PaymentSheet.GooglePayConfiguration.ButtonType.Pay,
+        null -> GooglePayButtonType.Pay
+    }


### PR DESCRIPTION
# Summary
Move `Google Pay` button type conversion out of `PaymentSheet`

# Motivation
Will be requiring this functionality in a separate component.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified