### PR TITLE
Show legal mandate in Link wallet

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -489,12 +489,6 @@ public final class com/stripe/android/link/ui/wallet/ComposableSingletons$Paymen
 	public final fun getLambda-2$paymentsheet_release ()Lkotlin/jvm/functions/Function2;
 }
 
-public final class com/stripe/android/link/ui/wallet/ComposableSingletons$WalletScreenKt {
-	public static final field INSTANCE Lcom/stripe/android/link/ui/wallet/ComposableSingletons$WalletScreenKt;
-	public fun <init> ()V
-	public final fun getLambda-1$paymentsheet_release ()Lkotlin/jvm/functions/Function3;
-}
-
 public final class com/stripe/android/lpmfoundations/paymentmethod/CustomerMetadata$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/lpmfoundations/paymentmethod/CustomerMetadata;

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
@@ -191,8 +191,10 @@ private fun PaymentDetailsSection(
             hideBottomSheetContent = hideBottomSheetContent
         )
 
-        AnimatedVisibility(state.showBankAccountTerms) {
-            BankAccountTerms()
+        AnimatedVisibility(visible = state.mandate != null) {
+            state.mandate?.let { mandate ->
+                LinkMandate(mandate.resolve())
+            }
         }
 
         ErrorSection(state.errorMessage)
@@ -577,9 +579,9 @@ private fun AddPaymentMethodRow(
 }
 
 @Composable
-private fun BankAccountTerms() {
+private fun LinkMandate(text: String) {
     Html(
-        html = stringResource(R.string.stripe_wallet_bank_account_terms).replaceHyperlinks(),
+        html = text.replaceHyperlinks(),
         color = LinkTheme.colors.textSecondary,
         style = LinkTheme.typography.caption.copy(
             textAlign = TextAlign.Center,

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletUiState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletUiState.kt
@@ -3,9 +3,11 @@ package com.stripe.android.link.ui.wallet
 import androidx.compose.runtime.Immutable
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.link.ui.PrimaryButtonState
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.ConsumerPaymentDetails.Card
+import com.stripe.android.paymentsheet.R
 import com.stripe.android.uicore.forms.FormFieldEntry
 
 @Immutable
@@ -15,6 +17,8 @@ internal data class WalletUiState(
     val cardBrandFilter: CardBrandFilter,
     val selectedItemId: String?,
     val isProcessing: Boolean,
+    val isSettingUp: Boolean,
+    val merchantName: String,
     val primaryButtonLabel: ResolvableString,
     val hasCompleted: Boolean,
     val canAddNewPaymentMethod: Boolean,
@@ -36,8 +40,8 @@ internal data class WalletUiState(
     val selectedCard: Card?
         get() = selectedItem as? Card
 
-    val showBankAccountTerms: Boolean
-        get() = selectedItem is ConsumerPaymentDetails.BankAccount
+    val mandate: ResolvableString?
+        get() = selectedItem?.makeMandateText(isSettingUp, merchantName)
 
     val isExpanded: Boolean
         get() = userSetIsExpanded ?: (selectedItem?.let { isItemAvailable(it) } != true)
@@ -89,5 +93,24 @@ internal data class WalletUiState(
             isProcessing = false,
             cardBeingUpdated = null
         )
+    }
+}
+
+private fun ConsumerPaymentDetails.PaymentDetails.makeMandateText(
+    isSettingUp: Boolean,
+    merchantName: String,
+): ResolvableString? {
+    return when (this) {
+        is ConsumerPaymentDetails.BankAccount -> {
+            resolvableString(R.string.stripe_wallet_bank_account_terms)
+        }
+        is Card,
+        is ConsumerPaymentDetails.Passthrough -> {
+            if (isSettingUp) {
+                resolvableString(R.string.stripe_paymentsheet_card_mandate, merchantName)
+            } else {
+                null
+            }
+        }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
@@ -23,8 +23,11 @@ import com.stripe.android.link.withDismissalDisabled
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.ConsumerPaymentDetailsUpdateParams
+import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod.Type.Card
 import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.model.SetupIntent
+import com.stripe.android.model.StripeIntent
 import com.stripe.android.ui.core.FieldValuesToParamsMapConverter
 import com.stripe.android.ui.core.elements.CardDetailsUtil.createExpiryDateFormFieldValues
 import com.stripe.android.ui.core.elements.CvcController
@@ -59,6 +62,8 @@ internal class WalletViewModel @Inject constructor(
         value = WalletUiState(
             paymentDetailsList = emptyList(),
             email = linkAccount.email,
+            isSettingUp = stripeIntent.hasIntentToSetup(),
+            merchantName = configuration.merchantName,
             selectedItemId = null,
             cardBrandFilter = configuration.cardBrandFilter,
             isProcessing = false,
@@ -399,4 +404,11 @@ private fun WalletUiState.toPaymentMethodCreateParams(): PaymentMethodCreatePara
         code = Card.code,
         requiresMandate = false
     )
+}
+
+private fun StripeIntent.hasIntentToSetup(): Boolean {
+    return when (this) {
+        is PaymentIntent -> setupFutureUsage != null
+        is SetupIntent -> true
+    }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletScreenScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletScreenScreenshotTest.kt
@@ -195,6 +195,8 @@ internal class WalletScreenScreenshotTest {
             alertMessage = alertMessage,
             canAddNewPaymentMethod = canAddNewPaymentMethod,
             userSetIsExpanded = userSetIsExpanded,
+            isSettingUp = false,
+            merchantName = "Example Inc.",
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletScreenTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletScreenTest.kt
@@ -695,6 +695,8 @@ internal class WalletScreenTest {
                 primaryButtonLabel = "Buy".resolvableString,
                 canAddNewPaymentMethod = true,
                 userSetIsExpanded = true,
+                isSettingUp = false,
+                merchantName = "Example Inc.",
             ),
             onItemSelected = {},
             onExpandedChanged = {},

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletUiStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletUiStateTest.kt
@@ -3,12 +3,14 @@ package com.stripe.android.link.ui.wallet
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.link.TestFactory
 import com.stripe.android.link.TestFactory.LINK_WALLET_PRIMARY_BUTTON_LABEL
 import com.stripe.android.link.ui.PrimaryButtonState
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.CvcCheck
+import com.stripe.android.paymentsheet.R
 import com.stripe.android.uicore.forms.FormFieldEntry
 import org.junit.Test
 
@@ -68,19 +70,42 @@ class WalletUiStateTest {
     }
 
     @Test
-    fun testShowBankAccountTermsForSelectedBankPaymentMethod() {
+    fun testShowTermsForSelectedBankPaymentMethodIfNotReusing() {
         val state = walletUiState(
             selectedItem = TestFactory.CONSUMER_PAYMENT_DETAILS_BANK_ACCOUNT
         )
 
-        assertThat(state.showBankAccountTerms).isTrue()
+        assertThat(state.mandate).isEqualTo(
+            resolvableString(R.string.stripe_wallet_bank_account_terms)
+        )
     }
 
     @Test
-    fun testNoBankAccountTermsForSelectedNonBankPaymentMethod() {
-        val state = walletUiState()
+    fun testShowTermsForSelectedBankPaymentMethodIfReusing() {
+        val state = walletUiState(
+            selectedItem = TestFactory.CONSUMER_PAYMENT_DETAILS_BANK_ACCOUNT,
+            isSettingUp = true,
+        )
 
-        assertThat(state.showBankAccountTerms).isFalse()
+        assertThat(state.mandate).isEqualTo(
+            resolvableString(R.string.stripe_wallet_bank_account_terms)
+        )
+    }
+
+    @Test
+    fun testShowNoTermsForSelectedCardIfNotReusing() {
+        val state = walletUiState(isSettingUp = false)
+
+        assertThat(state.mandate).isNull()
+    }
+
+    @Test
+    fun testShowTermsForSelectedCardIfReusing() {
+        val state = walletUiState(isSettingUp = true)
+
+        assertThat(state.mandate).isEqualTo(
+            resolvableString(R.string.stripe_paymentsheet_card_mandate, "Example Inc.")
+        )
     }
 
     @Test
@@ -217,7 +242,9 @@ class WalletUiStateTest {
         expiryDateInput: FormFieldEntry = FormFieldEntry(null),
         cvcInput: FormFieldEntry = FormFieldEntry(null),
         canAddNewPaymentMethod: Boolean = true,
-        cardBeingUpdated: String? = null
+        cardBeingUpdated: String? = null,
+        isSettingUp: Boolean = false,
+        merchantName: String = "Example Inc.",
     ): WalletUiState {
         return WalletUiState(
             paymentDetailsList = paymentDetailsList,
@@ -230,7 +257,9 @@ class WalletUiStateTest {
             expiryDateInput = expiryDateInput,
             cvcInput = cvcInput,
             canAddNewPaymentMethod = canAddNewPaymentMethod,
-            cardBeingUpdated = cardBeingUpdated
+            cardBeingUpdated = cardBeingUpdated,
+            isSettingUp = isSettingUp,
+            merchantName = merchantName,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
@@ -66,6 +66,8 @@ class WalletViewModelTest {
                 expiryDateInput = FormFieldEntry(""),
                 cvcInput = FormFieldEntry(""),
                 canAddNewPaymentMethod = true,
+                isSettingUp = false,
+                merchantName = "merchantName",
             )
         )
         assertThat(state.selectedItem).isEqualTo(TestFactory.CONSUMER_PAYMENT_DETAILS.paymentDetails.firstOrNull())


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request updates the native Link UI to show the legal mandate if the payment method is saved for future use. This aligns it with the current Web experience.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
