### PR TITLE
Fix bug with phone number prefix not populated properly if only input in `PhoneNumberController`

### DIFF
--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/PhoneNumberControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/PhoneNumberControllerTest.kt
@@ -180,4 +180,31 @@ internal class PhoneNumberControllerTest {
             assertThat(awaitItem().value).isEqualTo("+11222525252")
         }
     }
+
+    @Test
+    fun `when only prefix is received as initial phone number, should filter out properly`() = runTest {
+        val usPhoneNumberController = PhoneNumberController.createPhoneNumberController(
+            initialValue = "+1",
+        )
+
+        usPhoneNumberController.countryDropdownController.formFieldValue.test {
+            assertThat(awaitItem().value).isEqualTo("US")
+        }
+
+        usPhoneNumberController.fieldValue.test {
+            assertThat(awaitItem()).isEmpty()
+        }
+
+        val lsPhoneNumberController = PhoneNumberController.createPhoneNumberController(
+            initialValue = "+266"
+        )
+
+        lsPhoneNumberController.countryDropdownController.formFieldValue.test {
+            assertThat(awaitItem().value).isEqualTo("LS")
+        }
+
+        lsPhoneNumberController.fieldValue.test {
+            assertThat(awaitItem()).isEmpty()
+        }
+    }
 }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberFormatter.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberFormatter.kt
@@ -213,7 +213,7 @@ internal sealed class PhoneNumberFormatter {
 
             // Find the regions that match the phone number prefix, then pick the top match from the
             // device's locales
-            while (charIndex < phoneNumber.lastIndex && charIndex < COUNTRY_PREFIX_MAX_LENGTH - 1) {
+            while (charIndex <= phoneNumber.lastIndex && charIndex < COUNTRY_PREFIX_MAX_LENGTH - 1) {
                 charIndex++
 
                 val country = findBestCountryForPrefix(


### PR DESCRIPTION
# Summary
Fix bug with phone number prefix not populated properly if only input in `PhoneNumberController`

# Motivation
Ensures the prefix isn't applied to the phone number input.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified