### PR TITLE
Fix issue where CVC recollection is not enabled for saved cards created with Link passthrough mode.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/PaymentMethodConfirmationOption.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/PaymentMethodConfirmationOption.kt
@@ -10,6 +10,7 @@ internal sealed interface PaymentMethodConfirmationOption : ConfirmationHandler.
     data class Saved(
         val paymentMethod: com.stripe.android.model.PaymentMethod,
         val optionsParams: PaymentMethodOptionsParams?,
+        val originatedFromWallet: Boolean = false,
     ) : PaymentMethodConfirmationOption
 
     @Parcelize

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationDefinition.kt
@@ -37,7 +37,7 @@ internal class CvcRecollectionConfirmationDefinition @Inject constructor(
             initializationMode = confirmationParameters.initializationMode,
             paymentMethod = confirmationOption.paymentMethod,
             optionsParams = confirmationOption.optionsParams,
-        )
+        ) && !confirmationOption.originatedFromWallet
     }
 
     override suspend fun action(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinition.kt
@@ -112,6 +112,7 @@ internal class GooglePayConfirmationDefinition @Inject constructor(
                 val nextConfirmationOption = PaymentMethodConfirmationOption.Saved(
                     paymentMethod = result.paymentMethod,
                     optionsParams = null,
+                    originatedFromWallet = true,
                 )
 
                 ConfirmationDefinition.Result.NextStep(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinition.kt
@@ -80,6 +80,7 @@ internal class LinkConfirmationDefinition @Inject constructor(
                     confirmationOption = PaymentMethodConfirmationOption.Saved(
                         paymentMethod = result.paymentMethod,
                         optionsParams = null,
+                        originatedFromWallet = true,
                     ),
                     parameters = confirmationParameters,
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkPassthroughConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkPassthroughConfirmationDefinition.kt
@@ -91,6 +91,7 @@ internal class LinkPassthroughConfirmationDefinition @Inject constructor(
             PaymentMethodConfirmationOption.Saved(
                 paymentMethod = paymentMethod,
                 optionsParams = null,
+                originatedFromWallet = true,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinition.kt
@@ -164,6 +164,7 @@ internal class LinkInlineSignupConfirmationDefinition(
                     saveOption.shouldSave()
                 } ?: ConfirmPaymentIntentParams.SetupFutureUsage.Blank
             ),
+            originatedFromWallet = true,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/cvcrecollection/CvcRecollectionHandlerImpl.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/cvcrecollection/CvcRecollectionHandlerImpl.kt
@@ -40,16 +40,11 @@ internal class CvcRecollectionHandlerImpl : CvcRecollectionHandler {
         initializationMode: PaymentElementLoader.InitializationMode,
     ): Boolean {
         return paymentMethod.isCard() &&
-            paymentMethod.hasNoWallet() &&
             cvcRecollectionEnabled(stripeIntent, initializationMode)
     }
 
     private fun PaymentMethod.isCard(): Boolean {
         return type == PaymentMethod.Type.Card
-    }
-
-    private fun PaymentMethod.hasNoWallet(): Boolean {
-        return card?.wallet == null
     }
 
     private fun StripeIntent.supportsCvcRecollection(): Boolean {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationDefinitionTest.kt
@@ -61,6 +61,22 @@ class CvcRecollectionConfirmationDefinitionTest {
     }
 
     @Test
+    fun `'canConfirm' returns 'false' if payment method originated from wallet`() = test(
+        handler = FakeCvcRecollectionHandler().apply {
+            requiresCVCRecollection = true
+        }
+    ) {
+        assertThat(
+            definition.canConfirm(
+                confirmationOption = createSavedConfirmationOption(
+                    originatedFromWallet = true,
+                ),
+                confirmationParameters = CONFIRMATION_PARAMETERS,
+            )
+        ).isFalse()
+    }
+
+    @Test
     fun `'canConfirm' returns 'false' if CVC recollection is not required`() = test(
         handler = FakeCvcRecollectionHandler().apply {
             requiresCVCRecollection = false
@@ -273,11 +289,13 @@ class CvcRecollectionConfirmationDefinitionTest {
     }
 
     private fun createSavedConfirmationOption(
-        optionsParams: PaymentMethodOptionsParams? = null
+        optionsParams: PaymentMethodOptionsParams? = null,
+        originatedFromWallet: Boolean = false,
     ): PaymentMethodConfirmationOption.Saved {
         return PaymentMethodConfirmationOption.Saved(
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             optionsParams = optionsParams,
+            originatedFromWallet = originatedFromWallet,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationActivityTest.kt
@@ -82,6 +82,7 @@ internal class GooglePayConfirmationActivityTest {
                     PaymentMethodConfirmationOption.Saved(
                         paymentMethod = paymentMethod,
                         optionsParams = null,
+                        originatedFromWallet = true,
                     )
                 )
 
@@ -269,7 +270,11 @@ internal class GooglePayConfirmationActivityTest {
     }
 
     private companion object {
-        val PAYMENT_INTENT = PaymentIntentFactory.create().copy(
+        val PAYMENT_INTENT = PaymentIntentFactory.create(
+            paymentMethodOptionsJsonString = """
+                {"card": {"require_cvc_recollection": true}}
+            """.trimIndent()
+        ).copy(
             id = "pm_1",
             amount = 5000,
             currency = "CAD",

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinitionTest.kt
@@ -23,6 +23,7 @@ import com.stripe.android.paymentelement.confirmation.asFail
 import com.stripe.android.paymentelement.confirmation.asFailed
 import com.stripe.android.paymentelement.confirmation.asLaunch
 import com.stripe.android.paymentelement.confirmation.asNextStep
+import com.stripe.android.paymentelement.confirmation.asSaved
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
@@ -115,7 +116,14 @@ class GooglePayConfirmationDefinitionTest {
         val successResult = result.asNextStep()
 
         assertThat(successResult.parameters).isEqualTo(CONFIRMATION_PARAMETERS)
+
         assertThat(successResult.confirmationOption).isInstanceOf<PaymentMethodConfirmationOption.Saved>()
+
+        val savedOption = successResult.confirmationOption.asSaved()
+
+        assertThat(savedOption.paymentMethod).isEqualTo(savedOption.paymentMethod)
+        assertThat(savedOption.optionsParams).isNull()
+        assertThat(savedOption.originatedFromWallet).isTrue()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationFlowTest.kt
@@ -90,6 +90,7 @@ class GooglePayConfirmationFlowTest {
             confirmationOption = PaymentMethodConfirmationOption.Saved(
                 paymentMethod = PAYMENT_METHOD,
                 optionsParams = null,
+                originatedFromWallet = true,
             ),
             parameters = CONFIRMATION_PARAMETERS,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationActivityTest.kt
@@ -121,6 +121,7 @@ internal class LinkConfirmationActivityTest(private val nativeLinkEnabled: Boole
                     PaymentMethodConfirmationOption.Saved(
                         paymentMethod = paymentMethod,
                         optionsParams = null,
+                        originatedFromWallet = true,
                     )
                 )
 
@@ -224,7 +225,11 @@ internal class LinkConfirmationActivityTest(private val nativeLinkEnabled: Boole
             arrayOf(false),
         )
 
-        val PAYMENT_INTENT = PaymentIntentFactory.create().copy(
+        val PAYMENT_INTENT = PaymentIntentFactory.create(
+            paymentMethodOptionsJsonString = """
+                {"card": {"require_cvc_recollection": true}}
+            """.trimIndent()
+        ).copy(
             id = "pm_1",
             amount = 5000,
             currency = "CAD",

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinitionTest.kt
@@ -189,6 +189,7 @@ internal class LinkConfirmationDefinitionTest {
         val savedOption = nextStepResult.confirmationOption.asSaved()
 
         assertThat(savedOption.paymentMethod).isEqualTo(paymentMethod)
+        assertThat(savedOption.originatedFromWallet).isTrue()
         assertThat(savedOption.optionsParams).isNull()
 
         assertThat(storeScenario.markAsUsedCalls.awaitItem()).isNotNull()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationFlowTest.kt
@@ -120,6 +120,7 @@ class LinkConfirmationFlowTest {
                 confirmationOption = PaymentMethodConfirmationOption.Saved(
                     paymentMethod = PAYMENT_METHOD,
                     optionsParams = null,
+                    originatedFromWallet = true,
                 ),
                 parameters = CONFIRMATION_PARAMETERS,
             )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentelement.confirmation.linkinline
 
-import androidx.compose.material.Card
 import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
@@ -505,6 +504,8 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
                     setupFutureUsage = expectedSetupForFutureUsage,
                 )
             )
+
+            assertThat(savedConfirmationOption.originatedFromWallet).isTrue()
 
             val paymentMethod = savedConfirmationOption.paymentMethod
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/cvcrecollection/CvcRecollectionHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/cvcrecollection/CvcRecollectionHandlerTest.kt
@@ -61,7 +61,7 @@ class CvcRecollectionHandlerTest {
     }
 
     @Test
-    fun `card & intent requiring cvc recollection should return false if card is from a wallet`() {
+    fun `card & intent requiring cvc recollection should return true if card is from a wallet`() {
         val paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_CVC_RECOLLECTION
         val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD.run {
             copy(card = card?.copy(wallet = Wallet.GooglePayWallet(dynamicLast4 = null)))
@@ -72,7 +72,7 @@ class CvcRecollectionHandlerTest {
             optionsParams = null,
             initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent("")
         )
-        assertThat(response).isFalse()
+        assertThat(response).isTrue()
     }
 
     @Test
@@ -128,7 +128,7 @@ class CvcRecollectionHandlerTest {
     }
 
     @Test
-    fun `card & valid deferred intent should return false if card is from a wallet`() {
+    fun `card & valid deferred intent should return true if card is from a wallet`() {
         val paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD
         val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD.run {
             copy(card = card?.copy(wallet = Wallet.GooglePayWallet(dynamicLast4 = null)))
@@ -147,7 +147,7 @@ class CvcRecollectionHandlerTest {
                 )
             )
         )
-        assertThat(response).isFalse()
+        assertThat(response).isTrue()
     }
 
     @Test


### PR DESCRIPTION
# Summary
Fix issue where CVC recollection is not enabled for saved cards created with Link passthrough mode.

# Motivation
#ir-sulfur-forest

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified