### PR TITLE
Fetch payment methods with Link details in loader

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -2758,6 +2758,14 @@ public final class com/stripe/android/model/KlarnaSourceParams$PaymentPageOption
 	public static fun values ()[Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions$PurchaseType;
 }
 
+public final class com/stripe/android/model/LinkPaymentDetails$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/LinkPaymentDetails;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/LinkPaymentDetails;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/model/ListPaymentMethodsParams$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/ListPaymentMethodsParams;
@@ -3073,16 +3081,17 @@ public final class com/stripe/android/model/PaymentMethod : com/stripe/android/c
 	public final fun component16 ()Lcom/stripe/android/model/PaymentMethod$Upi;
 	public final fun component17 ()Lcom/stripe/android/model/PaymentMethod$Netbanking;
 	public final fun component18 ()Lcom/stripe/android/model/PaymentMethod$USBankAccount;
-	public final fun component19 ()Lcom/stripe/android/model/PaymentMethod$AllowRedisplay;
+	public final fun component19 ()Lcom/stripe/android/model/LinkPaymentDetails;
 	public final fun component2 ()Ljava/lang/Long;
+	public final fun component20 ()Lcom/stripe/android/model/PaymentMethod$AllowRedisplay;
 	public final fun component3 ()Z
 	public final fun component5 ()Lcom/stripe/android/model/PaymentMethod$Type;
 	public final fun component6 ()Lcom/stripe/android/model/PaymentMethod$BillingDetails;
 	public final fun component7 ()Ljava/lang/String;
 	public final fun component8 ()Lcom/stripe/android/model/PaymentMethod$Card;
 	public final fun component9 ()Lcom/stripe/android/model/PaymentMethod$CardPresent;
-	public final fun copy (Ljava/lang/String;Ljava/lang/Long;ZLjava/lang/String;Lcom/stripe/android/model/PaymentMethod$Type;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$Card;Lcom/stripe/android/model/PaymentMethod$CardPresent;Lcom/stripe/android/model/PaymentMethod$Fpx;Lcom/stripe/android/model/PaymentMethod$Ideal;Lcom/stripe/android/model/PaymentMethod$SepaDebit;Lcom/stripe/android/model/PaymentMethod$AuBecsDebit;Lcom/stripe/android/model/PaymentMethod$BacsDebit;Lcom/stripe/android/model/PaymentMethod$Sofort;Lcom/stripe/android/model/PaymentMethod$Upi;Lcom/stripe/android/model/PaymentMethod$Netbanking;Lcom/stripe/android/model/PaymentMethod$USBankAccount;Lcom/stripe/android/model/PaymentMethod$AllowRedisplay;)Lcom/stripe/android/model/PaymentMethod;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethod;Ljava/lang/String;Ljava/lang/Long;ZLjava/lang/String;Lcom/stripe/android/model/PaymentMethod$Type;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$Card;Lcom/stripe/android/model/PaymentMethod$CardPresent;Lcom/stripe/android/model/PaymentMethod$Fpx;Lcom/stripe/android/model/PaymentMethod$Ideal;Lcom/stripe/android/model/PaymentMethod$SepaDebit;Lcom/stripe/android/model/PaymentMethod$AuBecsDebit;Lcom/stripe/android/model/PaymentMethod$BacsDebit;Lcom/stripe/android/model/PaymentMethod$Sofort;Lcom/stripe/android/model/PaymentMethod$Upi;Lcom/stripe/android/model/PaymentMethod$Netbanking;Lcom/stripe/android/model/PaymentMethod$USBankAccount;Lcom/stripe/android/model/PaymentMethod$AllowRedisplay;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethod;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Long;ZLjava/lang/String;Lcom/stripe/android/model/PaymentMethod$Type;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$Card;Lcom/stripe/android/model/PaymentMethod$CardPresent;Lcom/stripe/android/model/PaymentMethod$Fpx;Lcom/stripe/android/model/PaymentMethod$Ideal;Lcom/stripe/android/model/PaymentMethod$SepaDebit;Lcom/stripe/android/model/PaymentMethod$AuBecsDebit;Lcom/stripe/android/model/PaymentMethod$BacsDebit;Lcom/stripe/android/model/PaymentMethod$Sofort;Lcom/stripe/android/model/PaymentMethod$Upi;Lcom/stripe/android/model/PaymentMethod$Netbanking;Lcom/stripe/android/model/PaymentMethod$USBankAccount;Lcom/stripe/android/model/LinkPaymentDetails;Lcom/stripe/android/model/PaymentMethod$AllowRedisplay;)Lcom/stripe/android/model/PaymentMethod;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethod;Ljava/lang/String;Ljava/lang/Long;ZLjava/lang/String;Lcom/stripe/android/model/PaymentMethod$Type;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$Card;Lcom/stripe/android/model/PaymentMethod$CardPresent;Lcom/stripe/android/model/PaymentMethod$Fpx;Lcom/stripe/android/model/PaymentMethod$Ideal;Lcom/stripe/android/model/PaymentMethod$SepaDebit;Lcom/stripe/android/model/PaymentMethod$AuBecsDebit;Lcom/stripe/android/model/PaymentMethod$BacsDebit;Lcom/stripe/android/model/PaymentMethod$Sofort;Lcom/stripe/android/model/PaymentMethod$Upi;Lcom/stripe/android/model/PaymentMethod$Netbanking;Lcom/stripe/android/model/PaymentMethod$USBankAccount;Lcom/stripe/android/model/LinkPaymentDetails;Lcom/stripe/android/model/PaymentMethod$AllowRedisplay;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethod;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Lorg/json/JSONObject;)Lcom/stripe/android/model/PaymentMethod;

--- a/payments-core/detekt-baseline.xml
+++ b/payments-core/detekt-baseline.xml
@@ -35,6 +35,7 @@
     <ID>LongMethod:CardInputWidget.kt$CardInputWidget$private fun initView(attrs: AttributeSet?)</ID>
     <ID>LongMethod:CollectBankAccountViewModel.kt$CollectBankAccountViewModel$private suspend fun createFinancialConnectionsSession()</ID>
     <ID>LongMethod:ElementsSessionFixtures.kt$ElementsSessionFixtures$fun createWithCustomPaymentMethods( customPaymentMethodData: String, ): JSONObject</ID>
+    <ID>LongMethod:ElementsSessionJsonParser.kt$ElementsSessionJsonParser$override fun parse(json: JSONObject): ElementsSession?</ID>
     <ID>LongMethod:ElementsSessionJsonParserTest.kt$ElementsSessionJsonParserTest$@Test fun `ElementsSession has expected customer session information in the response`()</ID>
     <ID>LongMethod:GooglePayJsonFactoryTest.kt$GooglePayJsonFactoryTest$@Test fun testCreatePaymentMethodRequestJson()</ID>
     <ID>LongMethod:PaymentAuthConfigTest.kt$PaymentAuthConfigTest$@Test fun testUiCustomizationWrapper()</ID>

--- a/payments-core/src/main/java/com/stripe/android/model/ElementsSession.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ElementsSession.kt
@@ -48,6 +48,9 @@ data class ElementsSession(
     val suppressLink2faModal: Boolean
         get() = linkSettings?.suppress2faModal ?: false
 
+    val enableLinkInSpm: Boolean
+        get() = flags[Flag.ELEMENTS_ENABLE_LINK_SPM] == true
+
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Parcelize
     data class LinkSettings(

--- a/payments-core/src/main/java/com/stripe/android/model/LinkPaymentDetails.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/LinkPaymentDetails.kt
@@ -1,0 +1,14 @@
+package com.stripe.android.model
+
+import android.os.Parcelable
+import androidx.annotation.RestrictTo
+import kotlinx.parcelize.Parcelize
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Parcelize
+data class LinkPaymentDetails(
+    val expMonth: Int,
+    val expYear: Int,
+    val last4: String,
+    val brand: CardBrand,
+) : Parcelable

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
@@ -145,6 +145,8 @@ constructor(
      */
     @JvmField val usBankAccount: USBankAccount? = null,
 
+    @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val linkPaymentDetails: LinkPaymentDetails? = null,
+
     /**
      * Indicates whether this payment method can be shown again to its customer in a checkout flow. Stripe products
      * such as Checkout and Elements use this field to determine whether a payment method can be shown as a saved

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/PaymentMethodWithLinkDetailsJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/PaymentMethodWithLinkDetailsJsonParser.kt
@@ -1,0 +1,40 @@
+package com.stripe.android.model.parsers
+
+import com.stripe.android.core.model.parsers.ModelJsonParser
+import com.stripe.android.core.utils.FeatureFlags
+import com.stripe.android.model.ConsumerPaymentDetails
+import com.stripe.android.model.LinkPaymentDetails
+import com.stripe.android.model.PaymentMethod
+import org.json.JSONObject
+
+internal object PaymentMethodWithLinkDetailsJsonParser : ModelJsonParser<PaymentMethod> {
+
+    override fun parse(json: JSONObject): PaymentMethod? {
+        val paymentMethod = PaymentMethodJsonParser().parse(json.getJSONObject("payment_method"))
+
+        val consumerPaymentDetails = if (FeatureFlags.linkPMsInSPM.isEnabled) {
+            json.optJSONObject("link_payment_details")?.let {
+                ConsumerPaymentDetailsJsonParser.parsePaymentDetails(it)
+            }
+        } else {
+            null
+        }
+
+        val cardDetails = consumerPaymentDetails as? ConsumerPaymentDetails.Card
+
+        val linkDetails = cardDetails?.let {
+            LinkPaymentDetails(
+                expMonth = it.expiryMonth,
+                expYear = it.expiryYear,
+                last4 = it.last4,
+                brand = it.brand,
+            )
+        }
+
+        // TODO(tillh-stripe): This is a short-term solution. We plan to create a new type that
+        //  contains payment method and Link information, but we can't easily do that right now.
+        return paymentMethod.copy(
+            linkPaymentDetails = linkDetails,
+        )
+    }
+}

--- a/payments-core/src/test/java/com/stripe/android/model/ElementsSessionFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/ElementsSessionFixtures.kt
@@ -451,6 +451,8 @@ internal object ElementsSessionFixtures {
         paymentMethodRemoveLastFeature: String? = "enabled",
         paymentMethodSetAsDefaultFeature: String = "disabled",
         paymentMethodSyncDefaultFeature: String = "disabled",
+        enableLinkSpm: Boolean = false,
+        paymentMethodsWithLinkDetails: String = "",
     ): JSONObject {
         return JSONObject(
             """
@@ -459,6 +461,9 @@ internal object ElementsSessionFixtures {
               "link_settings": {
                 "link_bank_enabled": false,
                 "link_bank_onboarding_enabled": false
+              },
+              "flags": {
+                "elements_enable_link_spm": $enableLinkSpm
               },
               "merchant_country": "US",
               "payment_method_preference": {
@@ -582,7 +587,9 @@ internal object ElementsSessionFixtures {
                     }
                   }
                 ],
-                "payment_methods_with_link_details": []
+                "payment_methods_with_link_details": [
+                  $paymentMethodsWithLinkDetails
+                ]
               }
             }
             """.trimIndent()
@@ -2166,4 +2173,138 @@ internal object ElementsSessionFixtures {
             """.trimIndent()
         )
     }
+
+    val PAYMENT_METHODS_WITH_LINK_DETAILS = """
+      {
+        "link_payment_details": {
+          "id": "csmrpd_test_61S4AzLQgLW0RABmO41L7cNqHDkf19Am",
+          "backup_ids": [],
+          "balance_details": null,
+          "bank_account_details": null,
+          "billing_address": {
+            "administrative_area": null,
+            "country_code": "US",
+            "dependent_locality": null,
+            "line_1": null,
+            "line_2": null,
+            "locality": null,
+            "name": null,
+            "postal_code": "11234",
+            "sorting_code": null
+          },
+          "billing_email_address": "david.estes+12302193@gmail.com",
+          "card_details": {
+            "brand": "MASTERCARD",
+            "brand_enum": "mastercard",
+            "checks": {
+              "address_line1_check": "UNAVAILABLE",
+              "address_postal_code_check": "PASS",
+              "cvc_check": "PASS"
+            },
+            "country": "COUNTRY_US",
+            "exp_month": 12,
+            "exp_year": 2025,
+            "funding": "CREDIT",
+            "last4": "4444",
+            "networks": [
+              "MASTERCARD"
+            ],
+            "preferred_network": null,
+            "program_details": {
+              "background_color": null,
+              "card_art_network_id": null,
+              "card_art_url": null,
+              "foreground_color": null,
+              "height": null,
+              "program_name": null,
+              "width": null
+            }
+          },
+          "is_default": false,
+          "is_us_debit_prepaid_or_bank_payment": false,
+          "klarna_details": null,
+          "nickname": "",
+          "type": "CARD"
+        },
+        "payment_method": {
+          "id": "pm_1Qun1zEsh8quxL21pDqJeSWF",
+          "object": "payment_method",
+          "allow_redisplay": "always",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": "US",
+              "line1": null,
+              "line2": null,
+              "postal_code": "11234",
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "created": 1740108963,
+          "customer": "cus_Qurj8RK03RchBB",
+          "link": {
+            "email": "david.estes+12302193@gmail.com"
+          },
+          "livemode": false,
+          "type": "link"
+        }
+      },
+      {
+        "link_payment_details": null,
+        "payment_method": {
+          "id": "pm_1QoYo1Esh8quxL21bpIFTRrP",
+          "object": "payment_method",
+          "allow_redisplay": "always",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": "US",
+              "line1": null,
+              "line2": null,
+              "postal_code": "12345",
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null,
+            "tax_id": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": null
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 4,
+            "exp_year": 2026,
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "4242",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1738624313,
+          "customer": "cus_Qurj8RK03RchBB",
+          "livemode": false,
+          "radar_options": {},
+          "type": "card"
+        }
+      }
+    """.trimIndent()
 }

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
@@ -8,6 +8,7 @@ import com.stripe.android.model.CardBrand
 import com.stripe.android.model.DeferredIntentParams
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.ElementsSessionFixtures
+import com.stripe.android.model.ElementsSessionFixtures.PAYMENT_METHODS_WITH_LINK_DETAILS
 import com.stripe.android.model.ElementsSessionFixtures.createPaymentIntentWithCustomerSession
 import com.stripe.android.model.ElementsSessionFixtures.createWithCustomPaymentMethods
 import com.stripe.android.model.ElementsSessionParams
@@ -27,6 +28,12 @@ class ElementsSessionJsonParserTest {
     @get:Rule
     val incentivesFeatureFlagRule = FeatureFlagTestRule(
         featureFlag = FeatureFlags.instantDebitsIncentives,
+        isEnabled = false,
+    )
+
+    @get:Rule
+    val linkInSpmFeatureFlagRule = FeatureFlagTestRule(
+        featureFlag = FeatureFlags.linkPMsInSPM,
         isEnabled = false,
     )
 
@@ -1134,6 +1141,65 @@ class ElementsSessionJsonParserTest {
 
         assertThat(elementsSession?.linkSettings?.useAttestationEndpoints).isFalse()
         assertThat(elementsSession?.linkSettings?.suppress2faModal).isFalse()
+    }
+
+    @Test
+    fun `Parses payment_methods_with_link_details if feature is enabled locally and for merchant`() {
+        testPaymentMethodsAndLinkDetails(
+            featureEnabled = true,
+            merchantEnabled = true,
+            expectedPaymentMethods = 2,
+            expectLinkPaymentDetails = true,
+        )
+    }
+
+    @Test
+    fun `Does not parse payment_methods_with_link_details if feature is enabled locally but disabled for merchant`() {
+        testPaymentMethodsAndLinkDetails(
+            featureEnabled = true,
+            merchantEnabled = false,
+            expectedPaymentMethods = 1,
+            expectLinkPaymentDetails = false,
+        )
+    }
+
+    @Test
+    fun `Does not parse payment_methods_with_link_details if feature is enabled for merchant but disabled locally`() {
+        testPaymentMethodsAndLinkDetails(
+            featureEnabled = false,
+            merchantEnabled = true,
+            expectedPaymentMethods = 1,
+            expectLinkPaymentDetails = false,
+        )
+    }
+
+    private fun testPaymentMethodsAndLinkDetails(
+        featureEnabled: Boolean,
+        merchantEnabled: Boolean,
+        expectedPaymentMethods: Int,
+        expectLinkPaymentDetails: Boolean,
+    ) {
+        linkInSpmFeatureFlagRule.setEnabled(featureEnabled)
+
+        val parser = ElementsSessionJsonParser(
+            ElementsSessionParams.PaymentIntentType(
+                clientSecret = "secret",
+                externalPaymentMethods = listOf(),
+                customPaymentMethods = listOf(),
+                appId = APP_ID
+            ),
+            isLiveMode = false,
+        )
+
+        val intent = createPaymentIntentWithCustomerSession(
+            enableLinkSpm = merchantEnabled,
+            paymentMethodsWithLinkDetails = PAYMENT_METHODS_WITH_LINK_DETAILS,
+        )
+        val session = parser.parse(intent)
+        val paymentMethods = session!!.customer!!.paymentMethods
+
+        assertThat(paymentMethods).hasSize(expectedPaymentMethods)
+        assertThat(paymentMethods.first().linkPaymentDetails != null).isEqualTo(expectLinkPaymentDetails)
     }
 
     private fun allowRedisplayTest(

--- a/payments-model/src/main/java/com/stripe/android/model/parsers/ConsumerPaymentDetailsJsonParser.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/parsers/ConsumerPaymentDetailsJsonParser.kt
@@ -57,7 +57,8 @@ object ConsumerPaymentDetailsJsonParser : ModelJsonParser<ConsumerPaymentDetails
         return ConsumerPaymentDetails(paymentDetails)
     }
 
-    private fun parsePaymentDetails(json: JSONObject): ConsumerPaymentDetails.PaymentDetails? =
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    fun parsePaymentDetails(json: JSONObject): ConsumerPaymentDetails.PaymentDetails? =
         optString(json, FIELD_TYPE)?.let { type ->
             val id = json.getString(FIELD_ID)
             val isDefault = json.optBoolean(FIELD_IS_DEFAULT)

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -453,6 +453,7 @@ internal class PlaygroundSettings private constructor(
             CardBrandAcceptanceSettingsDefinition,
             FeatureFlagSettingsDefinition(FeatureFlags.instantDebitsIncentives),
             FeatureFlagSettingsDefinition(FeatureFlags.financialConnectionsFullSdkUnavailable),
+            FeatureFlagSettingsDefinition(FeatureFlags.linkPMsInSPM),
             EmbeddedViewDisplaysMandateSettingDefinition,
             EmbeddedFormSheetActionSettingDefinition,
             EmbeddedTwoStepSettingsDefinition,

--- a/stripe-core/src/main/java/com/stripe/android/core/utils/FeatureFlags.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/FeatureFlags.kt
@@ -12,6 +12,7 @@ object FeatureFlags {
     val instantDebitsIncentives = FeatureFlag("Instant Bank Payments Incentives")
     val financialConnectionsFullSdkUnavailable = FeatureFlag("FC Full SDK Unavailable")
     val enablePaymentMethodOptionsSetupFutureUsage = FeatureFlag("Enable PaymentMethodOptions SetupFutureUse")
+    val linkPMsInSPM = FeatureFlag("Link PMs in SPM")
 }
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds the ability to fetch payment method with Link details. This functionality is hidden behind a local feature flag and a server-side one, and will be used in https://github.com/stripe/stripe-android/pull/10765.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
