### PR TITLE
Update UsBankAccount and Card PaymentMethodOptionsParams

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -39,6 +39,7 @@ import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.addresselement.toIdentifierMap
 import com.stripe.android.paymentsheet.model.PaymentMethodIncentive
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.model.getSetupFutureUseValue
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.BankFormScreenState.ResultIdentifier
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormViewModel.AnalyticsEvent.Finished
@@ -692,7 +693,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
 
         val paymentMethodOptionsParams = if (resultIdentifier is ResultIdentifier.Session) {
             PaymentMethodOptionsParams.USBankAccount(
-                setupFutureUsage = customerRequestedSave.setupFutureUsage
+                setupFutureUsage = customerRequestedSave.getSetupFutureUseValue(args.formArgs.hasIntentToSetup)
             )
         } else {
             null

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -9,7 +9,6 @@ import androidx.compose.ui.platform.testTag
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.CardBrand
-import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.PaymentMethodCreateParams

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.platform.testTag
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.PaymentMethodCreateParams
@@ -16,6 +17,7 @@ import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.model.getSetupFutureUseValue
 import com.stripe.android.ui.core.FieldValuesToParamsMapConverter
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.utils.collectAsState
@@ -101,7 +103,9 @@ internal fun FormFieldValues.transformToPaymentSelection(
     return if (paymentMethod.code == PaymentMethod.Type.Card.code) {
         PaymentSelection.New.Card(
             paymentMethodOptionsParams = PaymentMethodOptionsParams.Card(
-                setupFutureUsage = userRequestedReuse.setupFutureUsage
+                setupFutureUsage = userRequestedReuse.getSetupFutureUseValue(
+                    paymentMethodMetadata.hasIntentToSetup(PaymentMethod.Type.Card.code)
+                )
             ),
             paymentMethodCreateParams = params,
             paymentMethodExtraParams = extras,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentSelectionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentSelectionTest.kt
@@ -5,6 +5,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountTextBuilder
 import com.stripe.android.testing.FeatureFlagTestRule
@@ -182,5 +183,43 @@ class PaymentSelectionTest {
                 isSetupFlow = true
             )
         )
+    }
+
+    @Test
+    fun `getSetupFutureUseValue returns correct value when hasIntentToSetup is true`() {
+        featureFlagTestRule.setEnabled(true)
+        val noRequestSfu = PaymentSelection.CustomerRequestedSave.NoRequest.getSetupFutureUseValue(
+            hasIntentToSetup = true
+        )
+        assertThat(noRequestSfu).isNull()
+
+        val noReuseSfu = PaymentSelection.CustomerRequestedSave.RequestNoReuse.getSetupFutureUseValue(
+            hasIntentToSetup = true
+        )
+        assertThat(noReuseSfu).isNull()
+
+        val reuseSfu = PaymentSelection.CustomerRequestedSave.RequestReuse.getSetupFutureUseValue(
+            hasIntentToSetup = true
+        )
+        assertThat(reuseSfu).isEqualTo(ConfirmPaymentIntentParams.SetupFutureUsage.OffSession)
+    }
+
+    @Test
+    fun `getSetupFutureUseValue returns correct value when hasIntentToSetup is false`() {
+        featureFlagTestRule.setEnabled(true)
+        val noRequestSfu = PaymentSelection.CustomerRequestedSave.NoRequest.getSetupFutureUseValue(
+            hasIntentToSetup = false
+        )
+        assertThat(noRequestSfu).isNull()
+
+        val noReuseSfu = PaymentSelection.CustomerRequestedSave.RequestNoReuse.getSetupFutureUseValue(
+            hasIntentToSetup = false
+        )
+        assertThat(noReuseSfu).isEqualTo(ConfirmPaymentIntentParams.SetupFutureUsage.Blank)
+
+        val reuseSfu = PaymentSelection.CustomerRequestedSave.RequestReuse.getSetupFutureUseValue(
+            hasIntentToSetup = false
+        )
+        assertThat(reuseSfu).isEqualTo(ConfirmPaymentIntentParams.SetupFutureUsage.OffSession)
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Update UsBankAccount and Card PaymentMethodOptionsParams creation to only send `setup_future_usage` if it is equal to `off_session` when SFU is set at either the top level or PMO level

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
- If SFU is set at the top level, sending `SetupFutureUsage.Blank` or `null` has no effect as the PM will inherit the top level value.
- If SFU is set to `on_session` at the top level or PMO level, it can only be changed to `off_session`
- If SFU is set to `off_session` at the PMO level, it cannot be changed


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified
