### PR TITLE
Add PMO SFU logic for Link

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/serialization/PopupPayload.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/serialization/PopupPayload.kt
@@ -4,8 +4,10 @@ import android.content.Context
 import android.os.Build
 import android.util.Base64
 import com.stripe.android.core.networking.AnalyticsRequestFactory
+import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
 import kotlinx.serialization.SerialName
@@ -168,7 +170,7 @@ internal data class PopupPayload(
                 paymentUserAgent = paymentUserAgent,
                 paymentObject = paymentObject(),
                 intentMode = stripeIntent.toIntentMode().type,
-                setupFutureUsage = stripeIntent.isSetupForFutureUsage(),
+                setupFutureUsage = stripeIntent.isSetupForFutureUsage(passthroughModeEnabled),
                 flags = flags,
                 linkFundingSources = stripeIntent.linkFundingSources.map { it.uppercase() },
             )
@@ -201,9 +203,19 @@ internal data class PopupPayload(
             }
         }
 
-        private fun StripeIntent.isSetupForFutureUsage(): Boolean {
+        private fun StripeIntent.isSetupForFutureUsage(passthroughModeEnabled: Boolean): Boolean {
             return when (this) {
-                is PaymentIntent -> setupFutureUsage.isSetupForFutureUsage()
+                is PaymentIntent -> {
+                    if (FeatureFlags.enablePaymentMethodOptionsSetupFutureUsage.isEnabled) {
+                        if (passthroughModeEnabled) {
+                            isSetupFutureUsageSet(PaymentMethod.Type.Card.code)
+                        } else {
+                            isSetupFutureUsageSet(PaymentMethod.Type.Link.code)
+                        }
+                    } else {
+                        setupFutureUsage.isSetupForFutureUsage()
+                    }
+                }
                 is SetupIntent -> true
             }
         }

--- a/paymentsheet/src/test/java/com/stripe/android/link/serialization/PopupPayloadTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/serialization/PopupPayloadTest.kt
@@ -5,11 +5,16 @@ import android.os.LocaleList
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.networking.AnalyticsRequestFactory
+import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.TestFactory
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.testing.FeatureFlagTestRule
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.SetupIntentFactory
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -19,6 +24,13 @@ import java.util.UUID
 @RunWith(RobolectricTestRunner::class)
 @Suppress("MaxLineLength")
 internal class PopupPayloadTest {
+
+    @get:Rule
+    val featureFlagTestRule = FeatureFlagTestRule(
+        featureFlag = FeatureFlags.enablePaymentMethodOptionsSetupFutureUsage,
+        isEnabled = false
+    )
+
     @Test
     fun testJsonSerialization() {
         val currentSessionId = AnalyticsRequestFactory.sessionId
@@ -184,6 +196,140 @@ internal class PopupPayloadTest {
     }
 
     @Test
+    fun `on 'create' with link PMO SFU on session usage, 'setupForFutureUsage' should be true`() {
+        featureFlagTestRule.setEnabled(true)
+        val payload = PopupPayload.create(
+            configuration = createLinkConfiguration(
+                customerCountryCode = null,
+                intent = PaymentIntentFactory.create(
+                    paymentMethodOptionsJsonString = PaymentIntentFixtures.getPaymentMethodOptionsJsonString(
+                        code = PaymentMethod.Type.Link.code,
+                        sfuValue = "on_session"
+                    )
+                )
+            ),
+            context = getContext(Locale.CANADA),
+            paymentUserAgent = "Android",
+            publishableKey = "pk_123",
+            stripeAccount = "str_123"
+        )
+
+        assertThat(payload.setupFutureUsage).isTrue()
+    }
+
+    @Test
+    fun `on 'create' with link PMO SFU off session usage, 'setupForFutureUsage' should be true`() {
+        featureFlagTestRule.setEnabled(true)
+        val payload = PopupPayload.create(
+            configuration = createLinkConfiguration(
+                customerCountryCode = null,
+                intent = PaymentIntentFactory.create(
+                    paymentMethodOptionsJsonString = PaymentIntentFixtures.getPaymentMethodOptionsJsonString(
+                        code = PaymentMethod.Type.Link.code,
+                        sfuValue = "off_session"
+                    )
+                )
+            ),
+            context = getContext(Locale.CANADA),
+            paymentUserAgent = "Android",
+            publishableKey = "pk_123",
+            stripeAccount = "str_123"
+        )
+
+        assertThat(payload.setupFutureUsage).isTrue()
+    }
+
+    @Test
+    fun `on 'create' with card PMO SFU with on session usage, 'setupForFutureUsage' should be true`() {
+        featureFlagTestRule.setEnabled(true)
+        val payload = PopupPayload.create(
+            configuration = createLinkConfiguration(
+                customerCountryCode = null,
+                intent = PaymentIntentFactory.create(
+                    paymentMethodOptionsJsonString = PaymentIntentFixtures.getPaymentMethodOptionsJsonString(
+                        code = PaymentMethod.Type.Card.code,
+                        sfuValue = "on_session"
+                    )
+                ),
+                passthroughModeEnabled = true
+            ),
+            context = getContext(Locale.CANADA),
+            paymentUserAgent = "Android",
+            publishableKey = "pk_123",
+            stripeAccount = "str_123"
+        )
+
+        assertThat(payload.setupFutureUsage).isTrue()
+    }
+
+    @Test
+    fun `on 'create' with card PMO SFU with off session usage, 'setupForFutureUsage' should be true`() {
+        featureFlagTestRule.setEnabled(true)
+        val payload = PopupPayload.create(
+            configuration = createLinkConfiguration(
+                customerCountryCode = null,
+                intent = PaymentIntentFactory.create(
+                    paymentMethodOptionsJsonString = PaymentIntentFixtures.getPaymentMethodOptionsJsonString(
+                        code = PaymentMethod.Type.Card.code,
+                        sfuValue = "off_session"
+                    )
+                ),
+                passthroughModeEnabled = true
+            ),
+            context = getContext(Locale.CANADA),
+            paymentUserAgent = "Android",
+            publishableKey = "pk_123",
+            stripeAccount = "str_123"
+        )
+
+        assertThat(payload.setupFutureUsage).isTrue()
+    }
+
+    @Test
+    fun `on 'create' with card PMO SFU in payment method mode, 'setupForFutureUsage' should be false`() {
+        featureFlagTestRule.setEnabled(true)
+        val payload = PopupPayload.create(
+            configuration = createLinkConfiguration(
+                customerCountryCode = null,
+                intent = PaymentIntentFactory.create(
+                    paymentMethodOptionsJsonString = PaymentIntentFixtures.getPaymentMethodOptionsJsonString(
+                        code = PaymentMethod.Type.Card.code,
+                        sfuValue = "on_session"
+                    )
+                )
+            ),
+            context = getContext(Locale.CANADA),
+            paymentUserAgent = "Android",
+            publishableKey = "pk_123",
+            stripeAccount = "str_123"
+        )
+
+        assertThat(payload.setupFutureUsage).isFalse()
+    }
+
+    @Test
+    fun `on 'create' with link PMO SFU in payment method mode, 'setupForFutureUsage' should be true`() {
+        featureFlagTestRule.setEnabled(true)
+        val payload = PopupPayload.create(
+            configuration = createLinkConfiguration(
+                customerCountryCode = null,
+                intent = PaymentIntentFactory.create(
+                    paymentMethodOptionsJsonString = PaymentIntentFixtures.getPaymentMethodOptionsJsonString(
+                        code = PaymentMethod.Type.Link.code,
+                        sfuValue = "off_session"
+                    )
+                )
+            ),
+            context = getContext(Locale.CANADA),
+            paymentUserAgent = "Android",
+            publishableKey = "pk_123",
+            stripeAccount = "str_123"
+        )
+
+        assertThat(payload.setupFutureUsage).isTrue()
+    }
+
+    @Test
     fun `on 'create' with card brand choice, should contain expected card brand choice values`() {
         val payload = PopupPayload.create(
             configuration = createLinkConfiguration(
@@ -245,14 +391,16 @@ internal class PopupPayloadTest {
     private fun createLinkConfiguration(
         customerCountryCode: String?,
         cardBrandChoice: LinkConfiguration.CardBrandChoice? = null,
-        intent: StripeIntent = PaymentIntentFactory.create()
+        intent: StripeIntent = PaymentIntentFactory.create(),
+        passthroughModeEnabled: Boolean = false
     ): LinkConfiguration {
         return TestFactory.LINK_CONFIGURATION.copy(
             customerInfo = TestFactory.LINK_CONFIGURATION.customerInfo.copy(
                 billingCountryCode = customerCountryCode
             ),
             cardBrandChoice = cardBrandChoice,
-            stripeIntent = intent
+            stripeIntent = intent,
+            passthroughModeEnabled = passthroughModeEnabled
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/model/PaymentIntentFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/model/PaymentIntentFixtures.kt
@@ -519,4 +519,14 @@ internal object PaymentIntentFixtures {
             }
         }
     """.trimIndent()
+
+    fun getPaymentMethodOptionsJsonString(code: String, sfuValue: String): String {
+        return """
+            {
+                "$code": {
+                    "setup_future_usage": "$sfuValue"
+                }
+            }
+        """.trimIndent()
+    }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add logic to check `payment_method_options.setup_future_usage` for `card` when in Passthrough Mode and `link` when in Payment Method Mode to `PopupPayload` and `WalletViewmodel`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-3399

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified


https://github.com/user-attachments/assets/667a0f17-2427-4233-b5f4-29377b53f411


