### PR TITLE
Remove FeatureFlag check in CheckoutRequest.Builder for PMO SFU

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentsheet.example.playground.model
 
-import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.paymentsheet.ExperimentalCustomerSessionApi
 import com.stripe.android.paymentsheet.PaymentSheet
 import kotlinx.serialization.SerialName
@@ -194,13 +193,8 @@ class CheckoutRequest private constructor(
                 paymentMethodRedisplayFeature = paymentMethodRedisplayFeature,
                 paymentMethodRedisplayFilters = paymentMethodRedisplayFilters,
                 paymentMethodOverrideRedisplay = paymentMethodOverrideRedisplay,
-                paymentMethodOptionsSetupFutureUsage =
-                if (FeatureFlags.enablePaymentMethodOptionsSetupFutureUsage.isEnabled) {
-                    overridePaymentMethodOptionsSetupFutureUsage
-                        ?: paymentMethodOptionsSetupFutureUsage
-                } else {
-                    null
-                }
+                paymentMethodOptionsSetupFutureUsage = overridePaymentMethodOptionsSetupFutureUsage
+                    ?: paymentMethodOptionsSetupFutureUsage
             )
         }
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Remove Feature Flag check before adding PMO SFU to CheckoutRequest


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
`setValue` is not called before `CheckoutRequest.Builder.build()` is called meaning PMO SFU values will not be sent in initial checkout request.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified
