### PR TITLE
Stop automated localization pulls for Financial Connections

### DIFF
--- a/scripts/localization_vars.sh
+++ b/scripts/localization_vars.sh
@@ -8,7 +8,8 @@ MODULES=(
   "stripe-ui-core"
   "stripe-core"
   "identity"
-  "financial-connections"
+  # Add back financial-connections when we're ready to release the localized SDK!
+  # "financial-connections"
   "stripecardscan"
 )
 


### PR DESCRIPTION
# Summary
Stops automated localization pulls for Financial Connections. New text strings will still be uploaded to Lokalise based on this list: https://github.com/stripe/stripe-android/blob/ce1228f11807d1ea8ba631eacd90f01e13f68cce/scripts/lokalise/string_resources.rb#L9-L21

# Motivation
Prevent localization from being released why we're still testing and QA-ing localized content!

# Testing
Build is sufficient!