### PR TITLE
Add PMO SFU validation to DeferredIntentValidator

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DeferredIntentValidatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DeferredIntentValidatorTest.kt
@@ -1,12 +1,17 @@
+@file:OptIn(PaymentMethodOptionsSetupFutureUsagePreview::class)
+
 package com.stripe.android.paymentsheet
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.isInstanceOf
 import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.paymentelement.PaymentMethodOptionsSetupFutureUsagePreview
 import com.stripe.android.paymentsheet.PaymentSheet.IntentConfiguration
+import com.stripe.android.paymentsheet.paymentmethodoptions.setupfutureusage.toJsonObjectString
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.testing.PaymentMethodFactory.update
@@ -347,6 +352,94 @@ internal class DeferredIntentValidatorTest {
             }
         }
 
+    @Test
+    fun `PMO validation succeeds if intent and config PMO match`() {
+        val paymentIntent = PaymentIntentFactory.create(
+            paymentMethodOptionsJsonString = PaymentIntentFixtures.PMO_SETUP_FUTURE_USAGE
+        )
+        val paymentMethodOptions = IntentConfiguration.Mode.Payment.PaymentMethodOptions(
+            setupFutureUsageValues = mapOf(
+                PaymentMethod.Type.Card to IntentConfiguration.SetupFutureUse.OffSession,
+                PaymentMethod.Type.Affirm to IntentConfiguration.SetupFutureUse.None,
+                PaymentMethod.Type.AmazonPay to IntentConfiguration.SetupFutureUse.OffSession,
+            )
+        )
+        paymentMethodOptionsSetupFutureUsageTest(
+            intent = paymentIntent,
+            paymentMethodOptions = paymentMethodOptions,
+            shouldValidateSucceed = true
+        )
+    }
+
+    @Test
+    fun `PMO validation fails if Config PMO does not contain entry from Intent PMO`() {
+        val paymentIntent = PaymentIntentFactory.create(
+            paymentMethodOptionsJsonString = PaymentIntentFixtures.PMO_SETUP_FUTURE_USAGE
+        )
+
+        val paymentMethodOptions = IntentConfiguration.Mode.Payment.PaymentMethodOptions(
+            setupFutureUsageValues = mapOf(
+                PaymentMethod.Type.Card to IntentConfiguration.SetupFutureUse.OnSession,
+                PaymentMethod.Type.Affirm to IntentConfiguration.SetupFutureUse.None,
+            )
+        )
+        paymentMethodOptionsSetupFutureUsageTest(
+            intent = paymentIntent,
+            paymentMethodOptions = paymentMethodOptions,
+            shouldValidateSucceed = false
+        )
+    }
+
+    @Test
+    fun `PMO validation fails if SFU values are not the same`() {
+        val paymentIntent = PaymentIntentFactory.create(
+            paymentMethodOptionsJsonString = PaymentIntentFixtures.PMO_SETUP_FUTURE_USAGE
+        )
+
+        val paymentMethodOptions = IntentConfiguration.Mode.Payment.PaymentMethodOptions(
+            setupFutureUsageValues = mapOf(
+                PaymentMethod.Type.Card to IntentConfiguration.SetupFutureUse.OnSession,
+                PaymentMethod.Type.Affirm to IntentConfiguration.SetupFutureUse.None,
+                PaymentMethod.Type.AmazonPay to IntentConfiguration.SetupFutureUse.OffSession,
+            )
+        )
+
+        paymentMethodOptionsSetupFutureUsageTest(
+            intent = paymentIntent,
+            paymentMethodOptions = paymentMethodOptions,
+            shouldValidateSucceed = false
+        )
+    }
+
+    @Test
+    fun `PMO validation succeeds if intent PMO does not contain entry in Config PMO`() {
+        val paymentIntent = PaymentIntentFactory.create(
+            paymentMethodOptionsJsonString = """
+                {
+                    "card": {
+                        "setup_future_usage": "off_session"
+                    },
+                    "affirm": {
+                        "setup_future_usage": "none"
+                    }
+                }
+            """.trimIndent()
+        )
+
+        val paymentMethodOptions = IntentConfiguration.Mode.Payment.PaymentMethodOptions(
+            setupFutureUsageValues = mapOf(
+                PaymentMethod.Type.Card to IntentConfiguration.SetupFutureUse.OffSession,
+                PaymentMethod.Type.Affirm to IntentConfiguration.SetupFutureUse.None,
+                PaymentMethod.Type.AmazonPay to IntentConfiguration.SetupFutureUse.OffSession,
+            )
+        )
+        paymentMethodOptionsSetupFutureUsageTest(
+            intent = paymentIntent,
+            paymentMethodOptions = paymentMethodOptions,
+            shouldValidateSucceed = true
+        )
+    }
+
     private fun sameFingerprintTest(
         createPaymentMethod: (id: String, fingerprint: String) -> PaymentMethod,
     ) {
@@ -385,6 +478,7 @@ internal class DeferredIntentValidatorTest {
         currency: String = "usd",
         setupFutureUse: IntentConfiguration.SetupFutureUse? = null,
         captureMethod: IntentConfiguration.CaptureMethod = IntentConfiguration.CaptureMethod.Automatic,
+        paymentMethodOptions: IntentConfiguration.Mode.Payment.PaymentMethodOptions? = null
     ): IntentConfiguration {
         return IntentConfiguration(
             mode = IntentConfiguration.Mode.Payment(
@@ -392,6 +486,7 @@ internal class DeferredIntentValidatorTest {
                 currency = currency,
                 setupFutureUse = setupFutureUse,
                 captureMethod = captureMethod,
+                paymentMethodOptions = paymentMethodOptions
             ),
         )
     }
@@ -404,5 +499,40 @@ internal class DeferredIntentValidatorTest {
                 setupFutureUse = usage,
             ),
         )
+    }
+
+    private fun paymentMethodOptionsSetupFutureUsageTest(
+        intent: StripeIntent,
+        paymentMethodOptions: IntentConfiguration.Mode.Payment.PaymentMethodOptions,
+        shouldValidateSucceed: Boolean
+    ) {
+        val configuration = makeIntentConfigurationForPayment(
+            paymentMethodOptions = paymentMethodOptions
+        )
+
+        if (shouldValidateSucceed) {
+            val result = DeferredIntentValidator.validate(
+                stripeIntent = intent,
+                intentConfiguration = configuration,
+                allowsManualConfirmation = false,
+            )
+
+            assertThat(result).isNotNull()
+        } else {
+            val failure = assertFailsWith<IllegalArgumentException> {
+                DeferredIntentValidator.validate(
+                    stripeIntent = intent,
+                    intentConfiguration = configuration,
+                    allowsManualConfirmation = false,
+                )
+            }
+
+            assertThat(failure).hasMessageThat().isEqualTo(
+                "Your PaymentIntent payment_method_options setup_future_usage values " +
+                    "(${intent.getPaymentMethodOptions()} do not match the values provided in " +
+                    "PaymentSheet.IntentConfiguration.Mode.Payment.PaymentMethodOptions " +
+                    "(${paymentMethodOptions.toJsonObjectString()})"
+            )
+        }
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add PMO SFU validation to DeferredIntentValidator

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
If the merchant provides a setup future usage value in the intent but not the configuration, mandates will not be shown/sent where required. Validation should fail in this case.

If the merchant supplies a setup future usage value in the configuration but not the intent, the SDK will display and send mandates but the payment method will not actually be set up. This is an integration error but non-breaking and doesn't violate legal requirements. We don't want to fail in this case because merchants using automatic PMs could have certain PMs filtered or PMs that don't support a certain currency will not be included in the payment method options of the intent.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified

