### PR TITLE
Fix cancel button in Link edit screen

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/updatecard/UpdateCardScreenViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/updatecard/UpdateCardScreenViewModel.kt
@@ -103,7 +103,7 @@ internal class UpdateCardScreenViewModel @Inject constructor(
     )
 
     fun onCancelClicked() {
-        logger.info("Cancel button clicked")
+        navigationManager.tryNavigateBack()
     }
 
     private fun initializeInteractor(

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/updatecard/UpdateCardScreenViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/updatecard/UpdateCardScreenViewModelTest.kt
@@ -55,12 +55,14 @@ class UpdateCardScreenViewModelTest {
     @Test
     fun `onUpdateClicked updates payment details successfully`() = runTest(dispatcher) {
         val card = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD
+        val navigationManager = TestNavigationManager()
         val linkAccountManager = FakeLinkAccountManager()
         linkAccountManager.setConsumerPaymentDetails(ConsumerPaymentDetails(listOf(card)))
 
         val viewModel = createViewModel(
             linkAccountManager = linkAccountManager,
-            paymentDetailsId = card.id
+            paymentDetailsId = card.id,
+            navigationManager = navigationManager,
         )
 
         val cardUpdateParams = CardUpdateParams(
@@ -79,16 +81,17 @@ class UpdateCardScreenViewModelTest {
         assertThat(state.error).isNull()
         assertThat(call.id).isEqualTo(state.paymentDetailsId)
         assertThat(call).isNotNull()
+
+        navigationManager.assertNavigatedBack()
     }
 
     @Test
-    fun `onCancelClicked logs cancel action`() = runTest(dispatcher) {
-        val logger = FakeLogger()
-        val viewModel = createViewModel(logger = logger)
+    fun `onCancelClicked navigates back`() = runTest(dispatcher) {
+        val navigationManager = TestNavigationManager()
+        val viewModel = createViewModel(navigationManager = navigationManager)
 
         viewModel.onCancelClicked()
-
-        assertThat(logger.infoLogs).contains("Cancel button clicked")
+        navigationManager.assertNavigatedBack()
     }
 
     private fun createViewModel(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue in the Link edit screen where pressing the cancel button wouldn't do anything.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

[RUN_LINK_MOBILE-8](https://jira.corp.stripe.com/browse/RUN_LINK_MOBILE-8)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
