### PR TITLE
Fix CBC display brand in Link edit screen

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/EditCardDetailsInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/EditCardDetailsInteractor.kt
@@ -65,7 +65,7 @@ internal data class EditCardPayload(
                 expiryMonth = card.expiryMonth,
                 expiryYear = card.expiryYear,
                 brand = card.brand,
-                displayBrand = null,
+                displayBrand = card.brand.code,
                 networks = card.networks.toSet().takeIf { it.size > 1 },
                 billingDetails = PaymentMethod.BillingDetails(
                     address = card.billingAddress?.let {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where a co-branded card wouldn't show the current card brand in the edit screen.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

[RUN_LINK_MOBILE-8](https://jira.corp.stripe.com/browse/RUN_LINK_MOBILE-8)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
