### PR TITLE
Only support Link cards in SPM

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/parsers/PaymentMethodWithLinkDetailsJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/PaymentMethodWithLinkDetailsJsonParser.kt
@@ -2,7 +2,6 @@ package com.stripe.android.model.parsers
 
 import com.stripe.android.core.model.StripeJsonUtils.optString
 import com.stripe.android.core.model.parsers.ModelJsonParser
-import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.LinkPaymentDetails
 import com.stripe.android.model.PaymentMethod
@@ -19,12 +18,8 @@ internal object PaymentMethodWithLinkDetailsJsonParser : ModelJsonParser<Payment
             return null
         }
 
-        val consumerPaymentDetails = if (FeatureFlags.linkPMsInSPM.isEnabled) {
-            linkPaymentDetailsJson?.let {
-                ConsumerPaymentDetailsJsonParser.parsePaymentDetails(it)
-            }
-        } else {
-            null
+        val consumerPaymentDetails = linkPaymentDetailsJson?.let {
+            ConsumerPaymentDetailsJsonParser.parsePaymentDetails(it)
         }
 
         val linkDetails = when (consumerPaymentDetails) {

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/PaymentMethodWithLinkDetailsJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/PaymentMethodWithLinkDetailsJsonParserTest.kt
@@ -1,0 +1,47 @@
+package com.stripe.android.model.parsers
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.ConsumerFixtures.CONSUMER_PAYMENT_DETAILS_JSON
+import com.stripe.android.model.PaymentMethodFixtures.ALLOW_REDISPLAY_UNSPECIFIED_JSON
+import org.json.JSONObject
+import org.junit.Test
+
+class PaymentMethodWithLinkDetailsJsonParserTest {
+
+    @Test
+    fun `Supports payment method that has no Link payment details`() {
+        val json = JSONObject().apply {
+            put("payment_method", ALLOW_REDISPLAY_UNSPECIFIED_JSON)
+            // No "link_payment_details" value
+        }
+        val paymentMethod = PaymentMethodWithLinkDetailsJsonParser.parse(json)
+
+        assertThat(paymentMethod).isNotNull()
+        assertThat(paymentMethod?.linkPaymentDetails).isNull()
+    }
+
+    @Test
+    fun `Supports payment method that has Link payment details of type CARD`() {
+        val linkPaymentDetails = CONSUMER_PAYMENT_DETAILS_JSON.getJSONArray("redacted_payment_details").getJSONObject(0)
+        val json = JSONObject().apply {
+            put("payment_method", ALLOW_REDISPLAY_UNSPECIFIED_JSON)
+            put("link_payment_details", linkPaymentDetails)
+        }
+        val paymentMethod = PaymentMethodWithLinkDetailsJsonParser.parse(json)
+
+        assertThat(paymentMethod).isNotNull()
+        assertThat(paymentMethod?.linkPaymentDetails).isNotNull()
+    }
+
+    @Test
+    fun `Does not support method that has Link payment details of type other than CARD`() {
+        val linkPaymentDetails = CONSUMER_PAYMENT_DETAILS_JSON.getJSONArray("redacted_payment_details").getJSONObject(2)
+        val json = JSONObject().apply {
+            put("payment_method", ALLOW_REDISPLAY_UNSPECIFIED_JSON)
+            put("link_payment_details", linkPaymentDetails)
+        }
+        val paymentMethod = PaymentMethodWithLinkDetailsJsonParser.parse(json)
+
+        assertThat(paymentMethod).isNull()
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request updates the `PaymentMethodWithLinkDetailsJsonParser` to ignore Link payment methods that aren't cards, as we don't support those yet.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
