### PR TITLE
Clear keyboard focus on Link primary button press

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -47,6 +48,7 @@ internal fun PaymentMethodBody(
     onPayClicked: () -> Unit,
     onCancelClicked: () -> Unit,
 ) {
+    val focusManager = LocalFocusManager.current
     val uuid = rememberSaveable { UUID.randomUUID().toString() }
 
     ScrollableTopLevelColumn {
@@ -85,7 +87,10 @@ internal fun PaymentMethodBody(
             modifier = Modifier.padding(top = 16.dp, bottom = 8.dp),
             label = state.primaryButtonLabel.resolve(),
             state = state.primaryButtonState,
-            onButtonClick = onPayClicked,
+            onButtonClick = {
+                focusManager.clearFocus()
+                onPayClicked()
+            },
             iconEnd = PaymentsUiCoreR.drawable.stripe_ic_lock
         )
 

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/updatecard/UpdateCardScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/updatecard/UpdateCardScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -54,6 +55,8 @@ internal fun UpdateCardScreenBody(
     onUpdateClicked: () -> Unit,
     onCancelClicked: () -> Unit,
 ) {
+    val focusManager = LocalFocusManager.current
+
     ScrollableTopLevelColumn {
         Text(
             modifier = Modifier
@@ -91,7 +94,10 @@ internal fun UpdateCardScreenBody(
             modifier = Modifier.padding(top = 16.dp, bottom = 8.dp),
             label = stringResource(R.string.stripe_link_update_card_confirm_cta),
             state = state.primaryButtonState,
-            onButtonClick = onUpdateClicked
+            onButtonClick = {
+                focusManager.clearFocus()
+                onUpdateClicked()
+            }
         )
 
         SecondaryButton(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where the keyboard wasn't dismissed on Link primary button presses in the payment method screens, which could cause the keyboard to pop back up on return to MPE.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

[RUN_LINK_MOBILE-8](https://jira.corp.stripe.com/browse/RUN_LINK_MOBILE-8)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
