### PR TITLE
Shorten loading spinner overlap to 100ms

### DIFF
--- a/connect/src/main/java/com/stripe/android/connect/StripeComponentView.kt
+++ b/connect/src/main/java/com/stripe/android/connect/StripeComponentView.kt
@@ -283,10 +283,8 @@ abstract class StripeComponentView<Listener, Props> internal constructor(
         } else if (progressBar.isVisible) {
             @Suppress("MagicNumber")
             progressBar.animate()
-                // Delay a bit to allow the web spinner to appear.
-                .setStartDelay(200L)
                 // Fade out to reduce visual impact from minor UI discrepancies.
-                .setDuration(200L)
+                .setDuration(100L)
                 .alpha(0f)
                 .withStartAction { progressBar.alpha = 1f }
                 .withEndAction { progressBar.isVisible = false }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

# Motivation
After onLoaderStart is received, currently, we keep the spinner on for a 200ms and decrease its opacity to smooth out the loading transition between the SDK and the webview for account onboarding.

However, when account onboarding is created with a non-custom account, a different UI loads in without a spinner and this 200ms spillover is too long. I didn't want to just delete the fade out entirely because it does look jarring, but reducing this down to 100ms seems to give us a reasonable compromise.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
Before

https://github.com/user-attachments/assets/99ead3aa-3a21-43ad-b475-f37b788abd57 

After

https://github.com/user-attachments/assets/3079ac27-5978-4834-984e-97b3c9e3ea6b  

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
