### PR TITLE
Show indicator in row of payment method being removed

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
@@ -280,21 +280,24 @@ internal class WalletViewModel @Inject constructor(
 
     fun onRemoveClicked(item: ConsumerPaymentDetails.PaymentDetails) {
         _uiState.update {
-            it.setProcessing()
+            it.copy(cardBeingUpdated = item.id)
         }
         viewModelScope.launch {
-            linkAccountManager.deletePaymentDetails(item.id)
-                .fold(
-                    onSuccess = {
-                        loadPaymentDetails(selectedItemId = uiState.value.selectedItem?.id)
-                    },
-                    onFailure = { error ->
-                        updateErrorMessageAndStopProcessing(
-                            error = error,
-                            loggerMessage = "Failed to delete payment method"
-                        )
-                    }
-                )
+            linkAccountManager.deletePaymentDetails(item.id).fold(
+                onSuccess = {
+                    loadPaymentDetails(selectedItemId = uiState.value.selectedItem?.id)
+                },
+                onFailure = { error ->
+                    updateErrorMessageAndStopProcessing(
+                        error = error,
+                        loggerMessage = "Failed to delete payment method"
+                    )
+                }
+            )
+
+            _uiState.update {
+                it.copy(cardBeingUpdated = null)
+            }
         }
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where removing a payment method in the Link wallet would show a progress indicator in the primary button. It now shows an inline indicator in place of the options menu.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

[RUN_LINK_MOBILE-8](https://jira.corp.stripe.com/browse/RUN_LINK_MOBILE-8)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
