### PR TITLE
Add E2E Test for Cashapp with PMO SFU

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCashApp.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCashApp.kt
@@ -3,6 +3,7 @@ package com.stripe.android.lpm
 import androidx.compose.ui.test.hasTestTag
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.BasePlaygroundTest
+import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.example.playground.settings.CheckoutMode
 import com.stripe.android.paymentsheet.example.playground.settings.CheckoutModeSettingsDefinition
@@ -10,8 +11,10 @@ import com.stripe.android.paymentsheet.example.playground.settings.Country
 import com.stripe.android.paymentsheet.example.playground.settings.CountrySettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.Currency
 import com.stripe.android.paymentsheet.example.playground.settings.CurrencySettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.FeatureFlagSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.InitializationType
 import com.stripe.android.paymentsheet.example.playground.settings.InitializationTypeSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.PaymentMethodOptionsSetupFutureUsageOverrideSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.SupportedPaymentMethodsSettingsDefinition
 import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_ERROR_TEXT_TEST_TAG
 import com.stripe.android.test.core.AuthorizeAction
@@ -75,6 +78,20 @@ internal class TestCashApp : BasePlaygroundTest() {
     }
 
     @Test
+    fun testCashAppPayWithPmoSfu() {
+        testDriver.confirmNewOrGuestComplete(
+            testParameters = testParameters.copyPlaygroundSettings { settings ->
+                settings[FeatureFlagSettingsDefinition(FeatureFlags.enablePaymentMethodOptionsSetupFutureUsage)] = true
+                settings[PaymentMethodOptionsSetupFutureUsageOverrideSettingsDefinition] = "cashapp:off_session"
+                settings[CheckoutModeSettingsDefinition] = CheckoutMode.PAYMENT
+            },
+            populateCustomLpmFields = {
+                verifyMandateFieldExists()
+            }
+        )
+    }
+
+    @Test
     fun testCashAppPayWithSetupIntent() {
         testDriver.confirmNewOrGuestComplete(
             testParameters = testParameters.copyPlaygroundSettings { settings ->
@@ -97,6 +114,18 @@ internal class TestCashApp : BasePlaygroundTest() {
                 settings[InitializationTypeSettingsDefinition] = InitializationType.DeferredClientSideConfirmation
                 settings[CheckoutModeSettingsDefinition] = CheckoutMode.PAYMENT_WITH_SETUP
             },
+        )
+    }
+
+    @Test
+    fun testCashAppPayDeferredCscWithPmoSfu() {
+        testDriver.confirmNewOrGuestComplete(
+            testParameters = testParameters.copyPlaygroundSettings { settings ->
+                settings[FeatureFlagSettingsDefinition(FeatureFlags.enablePaymentMethodOptionsSetupFutureUsage)] = true
+                settings[PaymentMethodOptionsSetupFutureUsageOverrideSettingsDefinition] = "cashapp:off_session"
+                settings[InitializationTypeSettingsDefinition] = InitializationType.DeferredClientSideConfirmation
+                settings[CheckoutModeSettingsDefinition] = CheckoutMode.PAYMENT
+            }
         )
     }
 }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCashApp.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCashApp.kt
@@ -84,9 +84,6 @@ internal class TestCashApp : BasePlaygroundTest() {
                 settings[FeatureFlagSettingsDefinition(FeatureFlags.enablePaymentMethodOptionsSetupFutureUsage)] = true
                 settings[PaymentMethodOptionsSetupFutureUsageOverrideSettingsDefinition] = "cashapp:off_session"
                 settings[CheckoutModeSettingsDefinition] = CheckoutMode.PAYMENT
-            },
-            populateCustomLpmFields = {
-                verifyMandateFieldExists()
             }
         )
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add tests for Cashapp with PMO SFU

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-3566
Primary motivation is to test that MandateData is being sent for LPMs that require it, such as Cashapp, when SFU is set through PMO

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified
