### PR TITLE
Add assert function TestType interface

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/BaseLpmNetworkTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/BaseLpmNetworkTest.kt
@@ -51,7 +51,6 @@ internal open class BaseLpmNetworkTest(
         shippingDetails: AddressDetails? = null,
         customerRequestedSave: Boolean = false,
         allowsManualConfirmation: Boolean = false,
-        assertion: suspend (LpmNetworkTestActivity, LpmAssertionParams) -> Unit,
     ) = runLpmNetworkTest(country = country, allowsManualConfirmation = allowsManualConfirmation) {
         val factory = CreateIntentFactory(
             paymentElementCallbackIdentifier = LPM_NETWORK_PAYMENT_ELEMENT_CALLBACK_TEST_IDENTIFIER,
@@ -62,7 +61,7 @@ internal open class BaseLpmNetworkTest(
         val createIntentData = testType.createIntent(country, factory)
 
         createIntentData.onSuccess { data ->
-            assertion(
+            testType.assert(
                 this,
                 LpmAssertionParams(
                     intent = data.intent,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/CardLpmTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/CardLpmTest.kt
@@ -3,7 +3,6 @@ package com.stripe.android.paymentelement.confirmation.lpms
 import com.stripe.android.model.CardParams
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
-import com.stripe.android.paymentelement.confirmation.lpms.foundations.assertIntentConfirmed
 import com.stripe.android.paymentelement.confirmation.lpms.foundations.network.MerchantCountry
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -25,7 +24,6 @@ internal class CardLpmTest(
                 cvc = "454",
             )
         ),
-        assertion = ::assertIntentConfirmed
     )
 
     @Test
@@ -40,7 +38,6 @@ internal class CardLpmTest(
                 cvc = "454",
             )
         ),
-        assertion = ::assertIntentConfirmed
     )
 
     companion object {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/CashAppLpmTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/CashAppLpmTest.kt
@@ -2,7 +2,6 @@ package com.stripe.android.paymentelement.confirmation.lpms
 
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
-import com.stripe.android.paymentelement.confirmation.lpms.foundations.assertIntentConfirmed
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
@@ -15,7 +14,6 @@ internal class CashAppLpmTest(
     fun `Confirm Cash App LPM`() = test(
         testType = testType,
         createParams = PaymentMethodCreateParams.createCashAppPay(),
-        assertion = ::assertIntentConfirmed
     )
 
     companion object {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/TestType.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/TestType.kt
@@ -1,6 +1,9 @@
 package com.stripe.android.paymentelement.confirmation.lpms
 
 import com.stripe.android.paymentelement.confirmation.lpms.foundations.CreateIntentFactory
+import com.stripe.android.paymentelement.confirmation.lpms.foundations.LpmAssertionParams
+import com.stripe.android.paymentelement.confirmation.lpms.foundations.LpmNetworkTestActivity
+import com.stripe.android.paymentelement.confirmation.lpms.foundations.assertIntentConfirmed
 import com.stripe.android.paymentelement.confirmation.lpms.foundations.network.MerchantCountry
 
 internal interface TestType {
@@ -8,6 +11,11 @@ internal interface TestType {
         country: MerchantCountry,
         factory: CreateIntentFactory
     ): Result<CreateIntentFactory.CreateIntentData>
+
+    suspend fun assert(
+        activity: LpmNetworkTestActivity,
+        params: LpmAssertionParams
+    )
 
     companion object {
         fun all(
@@ -60,6 +68,10 @@ internal data class PaymentIntentTestType(
             createWithSetupFutureUsage = createWithSetupFutureUsage,
         )
     }
+
+    override suspend fun assert(activity: LpmNetworkTestActivity, params: LpmAssertionParams) {
+        assertIntentConfirmed(activity, params)
+    }
 }
 
 internal data object SetupIntentTestType : TestType {
@@ -70,6 +82,10 @@ internal data object SetupIntentTestType : TestType {
         return factory.createSetupIntent(
             country = country,
         )
+    }
+
+    override suspend fun assert(activity: LpmNetworkTestActivity, params: LpmAssertionParams) {
+        assertIntentConfirmed(activity, params)
     }
 }
 
@@ -89,6 +105,10 @@ internal data class DeferredPaymentIntentTestType(
             createWithSetupFutureUsage = createWithSetupFutureUsage,
         )
     }
+
+    override suspend fun assert(activity: LpmNetworkTestActivity, params: LpmAssertionParams) {
+        assertIntentConfirmed(activity, params)
+    }
 }
 
 internal data object DeferredSetupIntentTestType : TestType {
@@ -99,5 +119,9 @@ internal data object DeferredSetupIntentTestType : TestType {
         return factory.createDeferredSetupIntent(
             country = country,
         )
+    }
+
+    override suspend fun assert(activity: LpmNetworkTestActivity, params: LpmAssertionParams) {
+        assertIntentConfirmed(activity, params)
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/foundations/LpmTestAssertions.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/foundations/LpmTestAssertions.kt
@@ -28,7 +28,7 @@ import kotlin.test.fail
 internal suspend fun assertIntentConfirmed(
     activity: LpmNetworkTestActivity,
     params: LpmAssertionParams
-) {
+): Intent {
     intendingPaymentConfirmationToBeLaunched(params.intent)
 
     val option = PaymentMethodConfirmationOption.New(
@@ -73,6 +73,8 @@ internal suspend fun assertIntentConfirmed(
     val arguments = recordedIntent.assertPaymentLauncherArgs()
 
     assertConfirmed(activity, arguments.confirmStripeIntentParams)
+
+    return recordedIntent
 }
 
 private fun intendingPaymentConfirmationToBeLaunched(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add `assert` function to `TestType` interface
Return `Intent` from `assertIntentConfirmed` so the intent can be used for extra verification after confirmation

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Allow test types to implement assert for more flexibility in test configurations

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [ ] Manually verified
