### PR TITLE
Add additional PaymentMethodMetadata.requiresMandate test

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -1661,7 +1661,7 @@ internal class PaymentMethodMetadataTest {
     }
 
     @Test
-    fun `requiresMandate respects PMO SFU if set`() {
+    fun `requiresMandate returns true for PMO SFU`() {
         featureFlagTestRule.setEnabled(true)
         val metadata = PaymentMethodMetadataFactory.create(
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
@@ -1669,6 +1669,21 @@ internal class PaymentMethodMetadataTest {
             ),
         )
         assertThat(metadata.requiresMandate(PaymentMethod.Type.AmazonPay.code)).isTrue()
+    }
+
+    @Test
+    fun `requiresMandate returns false for PMO SFU none override`() {
+        featureFlagTestRule.setEnabled(true)
+        val metadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                setupFutureUsage = StripeIntent.Usage.OffSession,
+                paymentMethodOptionsJsonString = PaymentIntentFixtures.getPaymentMethodOptionsJsonString(
+                    code = "amazon_pay",
+                    sfuValue = "none"
+                )
+            ),
+        )
+        assertThat(metadata.requiresMandate(PaymentMethod.Type.AmazonPay.code)).isFalse()
     }
 
     fun `Passes CBF along to Link`() {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add test to verify `PaymentMethodMetadata.requiresMandate` respects PMO SFU `none` override
Rename `requiresMandate respects PMO SFU if set` to `requiresMandate returns true for PMO SFU`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Coverage

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified
