### PR TITLE
Remove PMO SFU RestricTo annotations

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -2011,6 +2011,17 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$IntentConfigurat
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$Mode$Payment$PaymentMethodOptions : android/os/Parcelable {
+	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Ljava/util/Map;)V
+	public final fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public final fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
 public final class com/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$Mode$Payment$PaymentMethodOptions$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$Mode$Payment$PaymentMethodOptions;
@@ -2043,6 +2054,7 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$IntentConfigurat
 }
 
 public final class com/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$SetupFutureUse : java/lang/Enum {
+	public static final field None Lcom/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$SetupFutureUse;
 	public static final field OffSession Lcom/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$SetupFutureUse;
 	public static final field OnSession Lcom/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$SetupFutureUse;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -429,7 +429,6 @@ class PaymentSheet internal constructor(
                 @Parcelize
                 @Poko
                 @PaymentMethodOptionsSetupFutureUsagePreview
-                @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
                 class PaymentMethodOptions(
                     internal val setupFutureUsageValues: Map<PaymentMethod.Type, SetupFutureUse>
                 ) : Parcelable
@@ -476,7 +475,6 @@ class PaymentSheet internal constructor(
              * Use none if you do not intend to reuse this payment method and want to override the top-level
              * setup_future_usage value for this payment method.
              */
-            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
             None
         }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Remove `RestrictTo` annotations on `IntentConfiguration.Mode.Payment.PaymentMethodOptions` and `IntentConfiguration.SetupFutureUse.None`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Prepare for release

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
