### PR TITLE
Fix: Clear link account after successful payment in FlowController

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
@@ -260,7 +260,9 @@ internal class WalletViewModel @Inject constructor(
             LinkConfirmationResult.Succeeded -> {
                 dismissWithResult(
                     LinkActivityResult.Completed(
-                        linkAccountUpdate = LinkAccountUpdate.Value(linkAccount),
+                        // After confirmation, clear the link account state so further launches
+                        // require authenticating again.
+                        linkAccountUpdate = LinkAccountUpdate.Value(null),
                         collectedCvc = cvc
                     )
                 )

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
@@ -356,7 +356,7 @@ class WalletViewModelTest {
         assertThat(result)
             .isEqualTo(
                 LinkActivityResult.Completed(
-                    linkAccountUpdate = LinkAccountUpdate.Value(account),
+                    linkAccountUpdate = LinkAccountUpdate.Value(null),
                     collectedCvc = null
                 )
             )


### PR DESCRIPTION
# Summary
- Issue: turns out that we were intentionally clearing the account after succesfully paying with Link, but [this PR](https://github.com/stripe/stripe-android/pull/10813) mistakenly removes that logic
- But we [logout](https://github.com/stripe/stripe-android/blob/03924f055e211ba4e5f965546d044b5ddfb1ea19/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt#L525) after completing in FlowController
- That means subsequent FlowController launches, if any, would preserve LinkAccount info of a logged out account, resulting in a failure.
- Also adds a clarifying comment to prevent this from happening in the future.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
