### PR TITLE
Deprecate PaymentSheet Constructors and FlowController.create()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### PaymentSheet
 * [ADDED][10919](https://github.com/stripe/stripe-android/pull/10919) Add `formInsetValues` to `PaymentSheet.Appearance`.
+* [DEPRECATED][10833](https://github.com/stripe/stripe-android/pull/10833) Deprecated PaymentSheet/FlowController constructors, create methods, and Compose remember functions in favor of new Builder pattern APIs.
 
 ## 21.16.0 - 2025-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@
 
 ### PaymentSheet
 * [ADDED][10935](https://github.com/stripe/stripe-android/pull/10935) Add `formInsetValues` method to `PaymentSheet.Appearance.Builder`.
+* [DEPRECATED][10833](https://github.com/stripe/stripe-android/pull/10833) Deprecated PaymentSheet/FlowController constructors, create methods, and Compose remember functions in favor of new Builder pattern APIs.
 
 ## 21.17.0 - 2025-06-09
 
 ### PaymentSheet
 * [ADDED][10919](https://github.com/stripe/stripe-android/pull/10919) Add `formInsetValues` to `PaymentSheet.Appearance`.
-* [DEPRECATED][10833](https://github.com/stripe/stripe-android/pull/10833) Deprecated PaymentSheet/FlowController constructors, create methods, and Compose remember functions in favor of new Builder pattern APIs.
 
 ## 21.16.0 - 2025-06-02
 

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -2,13 +2,13 @@
 
 ## Migrating from versions < 21.18.0
 - Changes to `PaymentSheet`:
-  * The constructors have been deprecated and will be removed in a future release. Use the `PaymentSheet.Builder` method instead.
+  * The constructors have been deprecated and will be removed in a future release. Use `PaymentSheet.Builder` method instead.
 - Changes to `PaymentSheet.FlowController`:
-  * `FlowController.create()` has been deprecated and will be removed in a future release. Use the `FlowController.Builder` method instead.
+  * `FlowController.create()` has been deprecated and will be removed in a future release. Use `FlowController.Builder` instead.
 - Changes to `rememberPaymentSheet`:
   * The functions have been deprecated and will be removed in a future release. Use `PaymentSheet.Builder` with `remember` instead.
 - Changes to `rememberPaymentSheetFlowController`:
-  * The functions have been deprecated and will be removed in a future release. Use the `FlowController.Builder` with `remember` instead.
+  * The functions have been deprecated and will be removed in a future release. Use `FlowController.Builder` with `remember` instead.
 
 ## Migrating from versions < 21.0.0
 - Basic Integration has been removed. [Please use Mobile Payment Element instead](https://docs.stripe.com/payments/mobile/migrating-to-mobile-payment-element-from-basic-integration).

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -4,7 +4,7 @@
 - Changes to `PaymentSheet`:
   * The constructors have been deprecated and will be removed in a future release. Use the `Builder()` or the `rememberPaymentSheet()` method instead.
 - Changes to `PaymentSheet.FlowController`:
-  * The constructors have been deprecated and will be removed in a future release. Use the `Builder()` or the `rememberPaymentSheetFlowController()` method instead.
+  * `FlowController.create()` has been deprecated and will be removed in a future release. Use the `Builder()` or the `rememberPaymentSheetFlowController()` method instead.
 
 ## Migrating from versions < 21.0.0
 - Basic Integration has been removed. [Please use Mobile Payment Element instead](https://docs.stripe.com/payments/mobile/migrating-to-mobile-payment-element-from-basic-integration).

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,5 +1,11 @@
 # Migration Guide
 
+## Migrating from versions < 21.15.0
+- Changes to `PaymentSheet`:
+  * The constructors have been deprecated and will be removed in a future release. Use the `Builder()` or the `rememberPaymentSheet()` method instead.
+- Changes to `PaymentSheet.FlowController`:
+  * The constructors have been deprecated and will be removed in a future release. Use the `Builder()` or the `rememberPaymentSheetFlowController()` method instead.
+
 ## Migrating from versions < 21.0.0
 - Basic Integration has been removed. [Please use Mobile Payment Element instead](https://docs.stripe.com/payments/mobile/migrating-to-mobile-payment-element-from-basic-integration).
 - Card image verification has been removed. [Please use card OCR instead](https://github.com/stripe/stripe-android/tree/master/stripecardscan#credit-card-ocr).

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,14 +1,14 @@
 # Migration Guide
 
-## Migrating from versions < 21.15.0
+## Migrating from versions < 21.18.0
 - Changes to `PaymentSheet`:
   * The constructors have been deprecated and will be removed in a future release. Use the `PaymentSheet.Builder` method instead.
 - Changes to `PaymentSheet.FlowController`:
   * `FlowController.create()` has been deprecated and will be removed in a future release. Use the `FlowController.Builder` method instead.
-- Changes to `PaymentSheetCompose`:
-  * `rememberPaymentSheet` has been deprecated and will be removed in a future release. Use `PaymentSheet.Builder` instead.
-- Changes to `FlowControllerCompose`:
-  * `rememberPaymentSheetFlowController` has been deprecated and will be removed in a future release. Use the `FlowController.Builder` instead.
+- Changes to `rememberPaymentSheet`:
+  * The functions have been deprecated and will be removed in a future release. Use `PaymentSheet.Builder` with `remember` instead.
+- Changes to `rememberPaymentSheetFlowController`:
+  * The functions have been deprecated and will be removed in a future release. Use the `FlowController.Builder` with `remember` instead.
 
 ## Migrating from versions < 21.0.0
 - Basic Integration has been removed. [Please use Mobile Payment Element instead](https://docs.stripe.com/payments/mobile/migrating-to-mobile-payment-element-from-basic-integration).

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -2,9 +2,13 @@
 
 ## Migrating from versions < 21.15.0
 - Changes to `PaymentSheet`:
-  * The constructors have been deprecated and will be removed in a future release. Use the `Builder()` or the `rememberPaymentSheet()` method instead.
+  * The constructors have been deprecated and will be removed in a future release. Use the `PaymentSheet.Builder` method instead.
 - Changes to `PaymentSheet.FlowController`:
-  * `FlowController.create()` has been deprecated and will be removed in a future release. Use the `Builder()` or the `rememberPaymentSheetFlowController()` method instead.
+  * `FlowController.create()` has been deprecated and will be removed in a future release. Use the `FlowController.Builder` method instead.
+- Changes to `PaymentSheetCompose`:
+  * `rememberPaymentSheet` has been deprecated and will be removed in a future release. Use `PaymentSheet.Builder` instead.
+- Changes to `FlowControllerCompose`:
+  * `rememberPaymentSheetFlowController` has been deprecated and will be removed in a future release. Use the `FlowController.Builder` instead.
 
 ## Migrating from versions < 21.0.0
 - Basic Integration has been removed. [Please use Mobile Payment Element instead](https://docs.stripe.com/payments/mobile/migrating-to-mobile-payment-element-from-basic-integration).

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -2,7 +2,7 @@
 
 ## Migrating from versions < 21.18.0
 - Changes to `PaymentSheet`:
-  * The constructors have been deprecated and will be removed in a future release. Use `PaymentSheet.Builder` method instead.
+  * The constructors have been deprecated and will be removed in a future release. Use `PaymentSheet.Builder` instead.
 - Changes to `PaymentSheet.FlowController`:
   * `FlowController.create()` has been deprecated and will be removed in a future release. Use `FlowController.Builder` instead.
 - Changes to `rememberPaymentSheet`:

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
@@ -338,6 +338,7 @@ internal class FlowControllerTest {
             scenario.onActivity {
                 PaymentConfiguration.init(it, "pk_test_123")
 
+                @Suppress("Deprecation")
                 val unsynchronizedController = PaymentSheet.FlowController.create(
                     activity = it,
                     paymentOptionCallback = { paymentOption ->
@@ -404,6 +405,7 @@ internal class FlowControllerTest {
         scenario.moveToState(Lifecycle.State.CREATED)
         scenario.onActivity {
             PaymentConfiguration.init(it, "pk_test_123")
+            @Suppress("Deprecation")
             flowController = PaymentSheet.FlowController.create(
                 activity = it,
                 paymentOptionCallback = {

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetBillingConfigurationTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetBillingConfigurationTest.kt
@@ -12,6 +12,7 @@ import com.stripe.android.networktesting.RequestMatchers.method
 import com.stripe.android.networktesting.RequestMatchers.not
 import com.stripe.android.networktesting.RequestMatchers.path
 import com.stripe.android.networktesting.testBodyFromFile
+import com.stripe.android.paymentsheet.PaymentSheet.Builder
 import com.stripe.android.paymentsheet.utils.IntegrationType
 import com.stripe.android.paymentsheet.utils.PaymentSheetLayoutType
 import com.stripe.android.paymentsheet.utils.PaymentSheetLayoutTypeProvider
@@ -53,10 +54,10 @@ internal class PaymentSheetBillingConfigurationTest {
         lateinit var paymentSheet: PaymentSheet
         scenario.onActivity {
             PaymentConfiguration.init(it, "pk_test_123")
-            paymentSheet = PaymentSheet(it) { result ->
+            paymentSheet = Builder { result ->
                 assertThat(result).isInstanceOf(PaymentSheetResult.Completed::class.java)
                 countDownLatch.countDown()
-            }
+            }.build(it)
         }
         scenario.moveToState(Lifecycle.State.RESUMED)
         scenario.onActivity {
@@ -130,10 +131,10 @@ internal class PaymentSheetBillingConfigurationTest {
         lateinit var paymentSheet: PaymentSheet
         scenario.onActivity {
             PaymentConfiguration.init(it, "pk_test_123")
-            paymentSheet = PaymentSheet(it) { result ->
+            paymentSheet = Builder { result ->
                 assertThat(result).isInstanceOf(PaymentSheetResult.Completed::class.java)
                 countDownLatch.countDown()
-            }
+            }.build(it)
         }
         scenario.moveToState(Lifecycle.State.RESUMED)
         scenario.onActivity {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/FlowControllerCompose.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/FlowControllerCompose.kt
@@ -21,7 +21,14 @@ import java.util.UUID
  * @param paymentResultCallback Called when a [PaymentSheetResult] is available.
  */
 @Composable
-@Deprecated(message = "This will be removed in a future release. Use FlowController.Builder instead.")
+@Deprecated(
+    message = "This will be removed in a future release. Use FlowController.Builder instead.",
+    replaceWith = ReplaceWith(
+        "remember(paymentOptionCallback, paymentResultCallback) { " +
+            "PaymentSheet.FlowController.Builder(paymentResultCallback, paymentOptionCallback) " +
+        "}.build()"
+    )
+)
 fun rememberPaymentSheetFlowController(
     paymentOptionCallback: PaymentOptionCallback,
     paymentResultCallback: PaymentSheetResultCallback,
@@ -50,7 +57,15 @@ fun rememberPaymentSheetFlowController(
  * @param paymentResultCallback Called when a [PaymentSheetResult] is available.
  */
 @Composable
-@Deprecated(message = "This will be removed in a future release. Use FlowController.Builder instead.")
+@Deprecated(
+    message = "This will be removed in a future release. Use FlowController.Builder instead.",
+    replaceWith = ReplaceWith(
+        "remember(createIntentCallback, paymentOptionCallback, paymentResultCallback) { " +
+            "PaymentSheet.FlowController.Builder(paymentResultCallback, paymentOptionCallback)" +
+                ".createIntentCallback(createIntentCallback) " +
+        "}.build()"
+    )
+)
 fun rememberPaymentSheetFlowController(
     createIntentCallback: CreateIntentCallback,
     paymentOptionCallback: PaymentOptionCallback,
@@ -84,7 +99,16 @@ fun rememberPaymentSheetFlowController(
  * @param paymentResultCallback Called when a [PaymentSheetResult] is available.
  */
 @Composable
-@Deprecated(message = "This will be removed in a future release. Use FlowController.Builder instead.")
+@Deprecated(
+    message = "This will be removed in a future release. Use FlowController.Builder instead.",
+    replaceWith = ReplaceWith(
+        "remember(createIntentCallback, externalPaymentMethodConfirmHandler, paymentOptionCallback, paymentResultCallback) { " +
+            "PaymentSheet.FlowController.Builder(paymentResultCallback, paymentOptionCallback)" +
+                ".createIntentCallback(createIntentCallback)" +
+                ".externalPaymentMethodConfirmHandler(externalPaymentMethodConfirmHandler) " +
+        "}.build()"
+    )
+)
 fun rememberPaymentSheetFlowController(
     createIntentCallback: CreateIntentCallback? = null,
     externalPaymentMethodConfirmHandler: ExternalPaymentMethodConfirmHandler,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/FlowControllerCompose.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/FlowControllerCompose.kt
@@ -21,6 +21,7 @@ import java.util.UUID
  * @param paymentResultCallback Called when a [PaymentSheetResult] is available.
  */
 @Composable
+@Deprecated(message = "This will be removed in a future release. Use FlowController.Builder instead.")
 fun rememberPaymentSheetFlowController(
     paymentOptionCallback: PaymentOptionCallback,
     paymentResultCallback: PaymentSheetResultCallback,
@@ -49,6 +50,7 @@ fun rememberPaymentSheetFlowController(
  * @param paymentResultCallback Called when a [PaymentSheetResult] is available.
  */
 @Composable
+@Deprecated(message = "This will be removed in a future release. Use FlowController.Builder instead.")
 fun rememberPaymentSheetFlowController(
     createIntentCallback: CreateIntentCallback,
     paymentOptionCallback: PaymentOptionCallback,
@@ -82,6 +84,7 @@ fun rememberPaymentSheetFlowController(
  * @param paymentResultCallback Called when a [PaymentSheetResult] is available.
  */
 @Composable
+@Deprecated(message = "This will be removed in a future release. Use FlowController.Builder instead.")
 fun rememberPaymentSheetFlowController(
     createIntentCallback: CreateIntentCallback? = null,
     externalPaymentMethodConfirmHandler: ExternalPaymentMethodConfirmHandler,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/FlowControllerCompose.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/FlowControllerCompose.kt
@@ -26,7 +26,7 @@ import java.util.UUID
     replaceWith = ReplaceWith(
         "remember(paymentOptionCallback, paymentResultCallback) { " +
             "PaymentSheet.FlowController.Builder(paymentResultCallback, paymentOptionCallback) " +
-        "}.build()"
+            "}.build()"
     )
 )
 fun rememberPaymentSheetFlowController(
@@ -62,8 +62,8 @@ fun rememberPaymentSheetFlowController(
     replaceWith = ReplaceWith(
         "remember(createIntentCallback, paymentOptionCallback, paymentResultCallback) { " +
             "PaymentSheet.FlowController.Builder(paymentResultCallback, paymentOptionCallback)" +
-                ".createIntentCallback(createIntentCallback) " +
-        "}.build()"
+            ".createIntentCallback(createIntentCallback) " +
+            "}.build()"
     )
 )
 fun rememberPaymentSheetFlowController(
@@ -102,11 +102,16 @@ fun rememberPaymentSheetFlowController(
 @Deprecated(
     message = "This will be removed in a future release. Use FlowController.Builder instead.",
     replaceWith = ReplaceWith(
-        "remember(createIntentCallback, externalPaymentMethodConfirmHandler, paymentOptionCallback, paymentResultCallback) { " +
+        "remember(" +
+            "createIntentCallback, " +
+            "externalPaymentMethodConfirmHandler, " +
+            "paymentOptionCallback, " +
+            "paymentResultCallback" +
+            ") { " +
             "PaymentSheet.FlowController.Builder(paymentResultCallback, paymentOptionCallback)" +
-                ".createIntentCallback(createIntentCallback)" +
-                ".externalPaymentMethodConfirmHandler(externalPaymentMethodConfirmHandler) " +
-        "}.build()"
+            ".createIntentCallback(createIntentCallback)" +
+            ".externalPaymentMethodConfirmHandler(externalPaymentMethodConfirmHandler) " +
+            "}.build()"
     )
 )
 fun rememberPaymentSheetFlowController(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -2706,6 +2706,12 @@ class PaymentSheet internal constructor(
              * [PaymentSheet] is dismissed.
              */
             @JvmStatic
+            @Deprecated(
+                message = "This will be removed in a future release.",
+                replaceWith = ReplaceWith(
+                    "FlowController.Builder(paymentResultCallback, paymentOptionCallback).build(activity)"
+                )
+            )
             fun create(
                 activity: ComponentActivity,
                 paymentOptionCallback: PaymentOptionCallback,
@@ -2733,6 +2739,14 @@ class PaymentSheet internal constructor(
              * [PaymentSheet] is dismissed.
              */
             @JvmStatic
+            @Deprecated(
+                message = "This will be removed in a future release.",
+                replaceWith = ReplaceWith(
+                    "FlowController.Builder(paymentResultCallback, paymentOptionCallback)" +
+                        ".externalPaymentMethodConfirmHandler(externalPaymentMethodConfirmHandler)" +
+                        ".build(activity)"
+                )
+            )
             fun create(
                 activity: ComponentActivity,
                 externalPaymentMethodConfirmHandler: ExternalPaymentMethodConfirmHandler,
@@ -2763,6 +2777,14 @@ class PaymentSheet internal constructor(
              * [PaymentSheet] is dismissed.
              */
             @JvmStatic
+            @Deprecated(
+                message = "This will be removed in a future release.",
+                replaceWith = ReplaceWith(
+                    "FlowController.Builder(paymentResultCallback, paymentOptionCallback)" +
+                        ".createIntentCallback(createIntentCallback)" +
+                        ".build(activity)"
+                )
+            )
             fun create(
                 activity: ComponentActivity,
                 paymentOptionCallback: PaymentOptionCallback,
@@ -2797,6 +2819,15 @@ class PaymentSheet internal constructor(
              * [PaymentSheet] is dismissed.
              */
             @JvmStatic
+            @Deprecated(
+                message = "This will be removed in a future release.",
+                replaceWith = ReplaceWith(
+                    "FlowController.Builder(paymentResultCallback, paymentOptionCallback)" +
+                        ".createIntentCallback(createIntentCallback)" +
+                        ".externalPaymentMethodConfirmHandler(externalPaymentMethodConfirmHandler)" +
+                        ".build(activity)"
+                )
+            )
             fun create(
                 activity: ComponentActivity,
                 paymentOptionCallback: PaymentOptionCallback,
@@ -2826,6 +2857,12 @@ class PaymentSheet internal constructor(
              * @param paymentResultCallback called when a [PaymentSheetResult] is available.
              */
             @JvmStatic
+            @Deprecated(
+                message = "This will be removed in a future release.",
+                replaceWith = ReplaceWith(
+                    "FlowController.Builder(paymentResultCallback, paymentOptionCallback).build(fragment)"
+                )
+            )
             fun create(
                 fragment: Fragment,
                 paymentOptionCallback: PaymentOptionCallback,
@@ -2851,6 +2888,14 @@ class PaymentSheet internal constructor(
              * @param paymentResultCallback called when a [PaymentSheetResult] is available.
              */
             @JvmStatic
+            @Deprecated(
+                message = "This will be removed in a future release.",
+                replaceWith = ReplaceWith(
+                    "FlowController.Builder(paymentResultCallback, paymentOptionCallback)" +
+                        ".externalPaymentMethodConfirmHandler(externalPaymentMethodConfirmHandler)" +
+                        ".build(fragment)"
+                )
+            )
             fun create(
                 fragment: Fragment,
                 externalPaymentMethodConfirmHandler: ExternalPaymentMethodConfirmHandler,
@@ -2881,6 +2926,14 @@ class PaymentSheet internal constructor(
              * [PaymentSheet] is dismissed.
              */
             @JvmStatic
+            @Deprecated(
+                message = "This will be removed in a future release.",
+                replaceWith = ReplaceWith(
+                    "FlowController.Builder(paymentResultCallback, paymentOptionCallback)" +
+                        ".createIntentCallback(createIntentCallback)" +
+                        ".build(fragment)"
+                )
+            )
             fun create(
                 fragment: Fragment,
                 paymentOptionCallback: PaymentOptionCallback,
@@ -2915,6 +2968,15 @@ class PaymentSheet internal constructor(
              * [PaymentSheet] is dismissed.
              */
             @JvmStatic
+            @Deprecated(
+                message = "This will be removed in a future release.",
+                replaceWith = ReplaceWith(
+                    "FlowController.Builder(paymentResultCallback, paymentOptionCallback)" +
+                        ".createIntentCallback(createIntentCallback)" +
+                        ".externalPaymentMethodConfirmHandler(externalPaymentMethodConfirmHandler)" +
+                        ".build(fragment)"
+                )
+            )
             fun create(
                 fragment: Fragment,
                 paymentOptionCallback: PaymentOptionCallback,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -58,6 +58,10 @@ class PaymentSheet internal constructor(
      * @param activity The Activity that is presenting [PaymentSheet].
      * @param callback Called with the result of the payment after [PaymentSheet] is dismissed.
      */
+    @Deprecated(
+        message = "This will be removed in a future release.",
+        replaceWith = ReplaceWith("Builder(callback).build(activity)")
+    )
     constructor(
         activity: ComponentActivity,
         callback: PaymentSheetResultCallback
@@ -73,6 +77,14 @@ class PaymentSheet internal constructor(
      * @param externalPaymentMethodConfirmHandler Called when a user confirms payment with an external payment method.
      * @param callback Called with the result of the payment after [PaymentSheet] is dismissed.
      */
+    @Deprecated(
+        message = "This will be removed in a future release.",
+        replaceWith = ReplaceWith(
+            "Builder(callback)" +
+                ".externalPaymentMethodConfirmHandler(externalPaymentMethodConfirmHandler)" +
+                ".build(activity)"
+        )
+    )
     constructor(
         activity: ComponentActivity,
         externalPaymentMethodConfirmHandler: ExternalPaymentMethodConfirmHandler,
@@ -96,6 +108,14 @@ class PaymentSheet internal constructor(
      * @param paymentResultCallback Called with the result of the payment or setup after
      * [PaymentSheet] is dismissed.
      */
+    @Deprecated(
+        message = "This will be removed in a future release.",
+        replaceWith = ReplaceWith(
+            "Builder(paymentResultCallback)" +
+                ".createIntentCallback(createIntentCallback)" +
+                ".build(activity)"
+        )
+    )
     constructor(
         activity: ComponentActivity,
         createIntentCallback: CreateIntentCallback,
@@ -121,6 +141,15 @@ class PaymentSheet internal constructor(
      * @param paymentResultCallback Called with the result of the payment or setup after
      * [PaymentSheet] is dismissed.
      */
+    @Deprecated(
+        message = "This will be removed in a future release.",
+        replaceWith = ReplaceWith(
+            "Builder(paymentResultCallback)" +
+                ".createIntentCallback(createIntentCallback)" +
+                ".externalPaymentMethodConfirmHandler(externalPaymentMethodConfirmHandler)" +
+                ".build(activity)"
+        )
+    )
     constructor(
         activity: ComponentActivity,
         createIntentCallback: CreateIntentCallback,
@@ -143,6 +172,10 @@ class PaymentSheet internal constructor(
      * @param fragment the Fragment that is presenting the payment sheet.
      * @param callback called with the result of the payment after the payment sheet is dismissed.
      */
+    @Deprecated(
+        message = "This will be removed in a future release.",
+        replaceWith = ReplaceWith("Builder(callback).build(fragment)")
+    )
     constructor(
         fragment: Fragment,
         callback: PaymentSheetResultCallback
@@ -158,6 +191,14 @@ class PaymentSheet internal constructor(
      * @param externalPaymentMethodConfirmHandler Called when a user confirms payment with an external payment method.
      * @param callback called with the result of the payment after the payment sheet is dismissed.
      */
+    @Deprecated(
+        message = "This will be removed in a future release.",
+        replaceWith = ReplaceWith(
+            "Builder(callback)" +
+                ".externalPaymentMethodConfirmHandler(externalPaymentMethodConfirmHandler)" +
+                ".build(fragment)"
+        )
+    )
     constructor(
         fragment: Fragment,
         externalPaymentMethodConfirmHandler: ExternalPaymentMethodConfirmHandler,
@@ -181,6 +222,14 @@ class PaymentSheet internal constructor(
      * @param paymentResultCallback Called with the result of the payment or setup after
      * [PaymentSheet] is dismissed.
      */
+    @Deprecated(
+        message = "This will be removed in a future release.",
+        replaceWith = ReplaceWith(
+            "Builder(paymentResultCallback)" +
+                ".createIntentCallback(createIntentCallback)" +
+                ".build(fragment)"
+        )
+    )
     constructor(
         fragment: Fragment,
         createIntentCallback: CreateIntentCallback,
@@ -206,6 +255,15 @@ class PaymentSheet internal constructor(
      * @param paymentResultCallback Called with the result of the payment or setup after
      * [PaymentSheet] is dismissed.
      */
+    @Deprecated(
+        message = "This will be removed in a future release.",
+        replaceWith = ReplaceWith(
+            "Builder(paymentResultCallback)" +
+                ".createIntentCallback(createIntentCallback)" +
+                ".externalPaymentMethodConfirmHandler(externalPaymentMethodConfirmHandler)" +
+                ".build(fragment)"
+        )
+    )
     constructor(
         fragment: Fragment,
         createIntentCallback: CreateIntentCallback,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -60,7 +60,7 @@ class PaymentSheet internal constructor(
      */
     @Deprecated(
         message = "This will be removed in a future release.",
-        replaceWith = ReplaceWith("Builder(callback).build(activity)")
+        replaceWith = ReplaceWith("PaymentSheet.Builder(callback).build(activity)")
     )
     constructor(
         activity: ComponentActivity,
@@ -80,7 +80,7 @@ class PaymentSheet internal constructor(
     @Deprecated(
         message = "This will be removed in a future release.",
         replaceWith = ReplaceWith(
-            "Builder(callback)" +
+            "PaymentSheet.Builder(callback)" +
                 ".externalPaymentMethodConfirmHandler(externalPaymentMethodConfirmHandler)" +
                 ".build(activity)"
         )
@@ -111,7 +111,7 @@ class PaymentSheet internal constructor(
     @Deprecated(
         message = "This will be removed in a future release.",
         replaceWith = ReplaceWith(
-            "Builder(paymentResultCallback)" +
+            "PaymentSheet.Builder(paymentResultCallback)" +
                 ".createIntentCallback(createIntentCallback)" +
                 ".build(activity)"
         )
@@ -144,7 +144,7 @@ class PaymentSheet internal constructor(
     @Deprecated(
         message = "This will be removed in a future release.",
         replaceWith = ReplaceWith(
-            "Builder(paymentResultCallback)" +
+            "PaymentSheet.Builder(paymentResultCallback)" +
                 ".createIntentCallback(createIntentCallback)" +
                 ".externalPaymentMethodConfirmHandler(externalPaymentMethodConfirmHandler)" +
                 ".build(activity)"
@@ -174,7 +174,7 @@ class PaymentSheet internal constructor(
      */
     @Deprecated(
         message = "This will be removed in a future release.",
-        replaceWith = ReplaceWith("Builder(callback).build(fragment)")
+        replaceWith = ReplaceWith("PaymentSheet.Builder(callback).build(fragment)")
     )
     constructor(
         fragment: Fragment,
@@ -194,7 +194,7 @@ class PaymentSheet internal constructor(
     @Deprecated(
         message = "This will be removed in a future release.",
         replaceWith = ReplaceWith(
-            "Builder(callback)" +
+            "PaymentSheet.Builder(callback)" +
                 ".externalPaymentMethodConfirmHandler(externalPaymentMethodConfirmHandler)" +
                 ".build(fragment)"
         )
@@ -225,7 +225,7 @@ class PaymentSheet internal constructor(
     @Deprecated(
         message = "This will be removed in a future release.",
         replaceWith = ReplaceWith(
-            "Builder(paymentResultCallback)" +
+            "PaymentSheet.Builder(paymentResultCallback)" +
                 ".createIntentCallback(createIntentCallback)" +
                 ".build(fragment)"
         )
@@ -258,7 +258,7 @@ class PaymentSheet internal constructor(
     @Deprecated(
         message = "This will be removed in a future release.",
         replaceWith = ReplaceWith(
-            "Builder(paymentResultCallback)" +
+            "PaymentSheet.Builder(paymentResultCallback)" +
                 ".createIntentCallback(createIntentCallback)" +
                 ".externalPaymentMethodConfirmHandler(externalPaymentMethodConfirmHandler)" +
                 ".build(fragment)"

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetCompose.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetCompose.kt
@@ -58,7 +58,7 @@ fun rememberPaymentSheet(
     replaceWith = ReplaceWith(
         "remember(createIntentCallback, paymentResultCallback) { " +
             "PaymentSheet.Builder(paymentResultCallback).createIntentCallback(createIntentCallback) " +
-        "}.build()"
+            "}.build()"
     )
 )
 fun rememberPaymentSheet(
@@ -96,9 +96,9 @@ fun rememberPaymentSheet(
     replaceWith = ReplaceWith(
         "remember(createIntentCallback, externalPaymentMethodConfirmHandler, paymentResultCallback) { " +
             "PaymentSheet.Builder(paymentResultCallback)" +
-                ".createIntentCallback(createIntentCallback)" +
-                ".externalPaymentMethodConfirmHandler(externalPaymentMethodConfirmHandler) " +
-        "}.build()"
+            ".createIntentCallback(createIntentCallback)" +
+            ".externalPaymentMethodConfirmHandler(externalPaymentMethodConfirmHandler) " +
+            "}.build()"
     )
 )
 fun rememberPaymentSheet(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetCompose.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetCompose.kt
@@ -22,6 +22,7 @@ import java.util.UUID
  * @param paymentResultCallback Called with the result of the payment after [PaymentSheet] is dismissed.
  */
 @Composable
+@Deprecated(message = "This will be removed in a future release. Use PaymentSheet.Builder instead.")
 fun rememberPaymentSheet(
     paymentResultCallback: PaymentSheetResultCallback,
 ): PaymentSheet {
@@ -47,6 +48,7 @@ fun rememberPaymentSheet(
  * @param paymentResultCallback Called with the result of the payment after [PaymentSheet] is dismissed.
  */
 @Composable
+@Deprecated(message = "This will be removed in a future release. Use PaymentSheet.Builder instead.")
 fun rememberPaymentSheet(
     createIntentCallback: CreateIntentCallback,
     paymentResultCallback: PaymentSheetResultCallback,
@@ -77,6 +79,7 @@ fun rememberPaymentSheet(
  * @param externalPaymentMethodConfirmHandler Called when a user confirms payment for an external payment method.
  */
 @Composable
+@Deprecated(message = "This will be removed in a future release. Use PaymentSheet.Builder instead.")
 fun rememberPaymentSheet(
     createIntentCallback: CreateIntentCallback? = null,
     externalPaymentMethodConfirmHandler: ExternalPaymentMethodConfirmHandler,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetCompose.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetCompose.kt
@@ -22,7 +22,12 @@ import java.util.UUID
  * @param paymentResultCallback Called with the result of the payment after [PaymentSheet] is dismissed.
  */
 @Composable
-@Deprecated(message = "This will be removed in a future release. Use PaymentSheet.Builder instead.")
+@Deprecated(
+    message = "This will be removed in a future release. Use PaymentSheet.Builder instead.",
+    replaceWith = ReplaceWith(
+        "remember(paymentResultCallback) { PaymentSheet.Builder(paymentResultCallback) }.build()"
+    )
+)
 fun rememberPaymentSheet(
     paymentResultCallback: PaymentSheetResultCallback,
 ): PaymentSheet {
@@ -48,7 +53,14 @@ fun rememberPaymentSheet(
  * @param paymentResultCallback Called with the result of the payment after [PaymentSheet] is dismissed.
  */
 @Composable
-@Deprecated(message = "This will be removed in a future release. Use PaymentSheet.Builder instead.")
+@Deprecated(
+    message = "This will be removed in a future release. Use PaymentSheet.Builder instead.",
+    replaceWith = ReplaceWith(
+        "remember(createIntentCallback, paymentResultCallback) { " +
+            "PaymentSheet.Builder(paymentResultCallback).createIntentCallback(createIntentCallback) " +
+        "}.build()"
+    )
+)
 fun rememberPaymentSheet(
     createIntentCallback: CreateIntentCallback,
     paymentResultCallback: PaymentSheetResultCallback,
@@ -79,7 +91,16 @@ fun rememberPaymentSheet(
  * @param externalPaymentMethodConfirmHandler Called when a user confirms payment for an external payment method.
  */
 @Composable
-@Deprecated(message = "This will be removed in a future release. Use PaymentSheet.Builder instead.")
+@Deprecated(
+    message = "This will be removed in a future release. Use PaymentSheet.Builder instead.",
+    replaceWith = ReplaceWith(
+        "remember(createIntentCallback, externalPaymentMethodConfirmHandler, paymentResultCallback) { " +
+            "PaymentSheet.Builder(paymentResultCallback)" +
+                ".createIntentCallback(createIntentCallback)" +
+                ".externalPaymentMethodConfirmHandler(externalPaymentMethodConfirmHandler) " +
+        "}.build()"
+    )
+)
 fun rememberPaymentSheet(
     createIntentCallback: CreateIntentCallback? = null,
     externalPaymentMethodConfirmHandler: ExternalPaymentMethodConfirmHandler,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentElementBuilderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentElementBuilderTest.kt
@@ -26,6 +26,7 @@ internal class PaymentElementBuilderTest {
         testWithActivity { activity ->
             val createIntentCallback = newCreateIntentCallback()
 
+            @Suppress("Deprecation")
             val paymentSheet = PaymentSheet(activity, createIntentCallback, newPaymentSheetResultCallback())
 
             assertThat(paymentSheet).isNotNull()
@@ -40,6 +41,7 @@ internal class PaymentElementBuilderTest {
         testWithFragment { fragment ->
             val createIntentCallback = newCreateIntentCallback()
 
+            @Suppress("Deprecation")
             val paymentSheet = PaymentSheet(fragment, createIntentCallback, newPaymentSheetResultCallback())
 
             assertThat(paymentSheet).isNotNull()
@@ -54,6 +56,7 @@ internal class PaymentElementBuilderTest {
         testWithActivity { activity ->
             val externalPaymentMethodConfirmHandler = newExternalPaymentMethodConfirmHandler()
 
+            @Suppress("Deprecation")
             val paymentSheet = PaymentSheet(
                 activity = activity,
                 externalPaymentMethodConfirmHandler = externalPaymentMethodConfirmHandler,
@@ -73,6 +76,7 @@ internal class PaymentElementBuilderTest {
         testWithFragment { fragment ->
             val externalPaymentMethodConfirmHandler = newExternalPaymentMethodConfirmHandler()
 
+            @Suppress("Deprecation")
             val paymentSheet = PaymentSheet(
                 fragment = fragment,
                 externalPaymentMethodConfirmHandler = externalPaymentMethodConfirmHandler,
@@ -93,6 +97,7 @@ internal class PaymentElementBuilderTest {
             val createIntentCallback = newCreateIntentCallback()
             val externalPaymentMethodConfirmHandler = newExternalPaymentMethodConfirmHandler()
 
+            @Suppress("Deprecation")
             val paymentSheet = PaymentSheet(
                 activity = activity,
                 createIntentCallback = createIntentCallback,
@@ -115,6 +120,7 @@ internal class PaymentElementBuilderTest {
             val createIntentCallback = newCreateIntentCallback()
             val externalPaymentMethodConfirmHandler = newExternalPaymentMethodConfirmHandler()
 
+            @Suppress("Deprecation")
             val paymentSheet = PaymentSheet(
                 fragment = fragment,
                 createIntentCallback = createIntentCallback,
@@ -135,6 +141,7 @@ internal class PaymentElementBuilderTest {
         testWithActivity { activity ->
             val createIntentCallback = newCreateIntentCallback()
 
+            @Suppress("Deprecation")
             val paymentSheet = PaymentSheet.FlowController.create(
                 activity = activity,
                 createIntentCallback = createIntentCallback,
@@ -154,6 +161,7 @@ internal class PaymentElementBuilderTest {
         testWithFragment { fragment ->
             val createIntentCallback = newCreateIntentCallback()
 
+            @Suppress("Deprecation")
             val paymentSheet = PaymentSheet.FlowController.create(
                 fragment = fragment,
                 createIntentCallback = createIntentCallback,
@@ -173,6 +181,7 @@ internal class PaymentElementBuilderTest {
         testWithActivity { activity ->
             val externalPaymentMethodConfirmHandler = newExternalPaymentMethodConfirmHandler()
 
+            @Suppress("Deprecation")
             val paymentSheet = PaymentSheet.FlowController.create(
                 activity = activity,
                 externalPaymentMethodConfirmHandler = externalPaymentMethodConfirmHandler,
@@ -193,6 +202,7 @@ internal class PaymentElementBuilderTest {
         testWithFragment { fragment ->
             val externalPaymentMethodConfirmHandler = newExternalPaymentMethodConfirmHandler()
 
+            @Suppress("Deprecation")
             val paymentSheet = PaymentSheet.FlowController.create(
                 fragment = fragment,
                 externalPaymentMethodConfirmHandler = externalPaymentMethodConfirmHandler,
@@ -214,6 +224,7 @@ internal class PaymentElementBuilderTest {
             val createIntentCallback = newCreateIntentCallback()
             val externalPaymentMethodConfirmHandler = newExternalPaymentMethodConfirmHandler()
 
+            @Suppress("Deprecation")
             val paymentSheet = PaymentSheet.FlowController.create(
                 activity = activity,
                 createIntentCallback = createIntentCallback,
@@ -237,6 +248,7 @@ internal class PaymentElementBuilderTest {
             val createIntentCallback = newCreateIntentCallback()
             val externalPaymentMethodConfirmHandler = newExternalPaymentMethodConfirmHandler()
 
+            @Suppress("Deprecation")
             val paymentSheet = PaymentSheet.FlowController.create(
                 fragment = fragment,
                 createIntentCallback = createIntentCallback,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
1. Deprecate `PaymentSheet` constructors
2. Deprecate `PaymentSheet.FlowController.create()`
3. Deprecate `rememberPaymentSheet` and `rememberPaymentSheetFlowController`
4. Document the change in `MIGRATING.md`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
We have several new features, e.g. `AnalyticCallback`, `confirmCustomPaymentMethodCallback`, that can only be set to a `PaymentSheet`/`FlowController` by our new Builder pattern. While the old constructor and factory pattern are still in support for backward compatibility, new features would not be added to this legacy initialization. We are deprecating the old constructors to avoid confusion and point the merchants to our new APIs with migration guide.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
[DEPRECATED][10833](https://github.com/stripe/stripe-android/pull/10833) Deprecated PaymentSheet/FlowController constructors, create methods, and Compose remember functions in favor of new Builder pattern APIs.