### PR TITLE
[Link prominence] No-UI confirm if Link PM available in FlowController.

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -376,6 +376,14 @@ public final class com/stripe/android/link/LinkPaymentDetails$Saved$Creator : an
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/link/LinkPaymentMethod$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/link/LinkPaymentMethod;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/link/LinkPaymentMethod;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/link/NativeLinkArgs$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/link/NativeLinkArgs;

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivity.kt
@@ -134,10 +134,6 @@ internal class LinkActivity : ComponentActivity() {
                 .putExtra(EXTRA_ARGS, args)
         }
 
-        internal fun getArgs(intent: Intent): NativeLinkArgs? {
-            return intent.getParcelableExtra<NativeLinkArgs>(EXTRA_ARGS)
-        }
-
         internal fun getArgs(savedStateHandle: SavedStateHandle): NativeLinkArgs? {
             return savedStateHandle.get<NativeLinkArgs>(EXTRA_ARGS)
         }

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivity.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.core.os.bundleOf
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModelProvider
+import com.stripe.android.R
 import com.stripe.android.core.Logger
 import com.stripe.android.paymentsheet.BuildConfig
 import com.stripe.android.paymentsheet.utils.renderEdgeToEdge
@@ -28,7 +29,6 @@ internal class LinkActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        renderEdgeToEdge()
 
         try {
             viewModel = ViewModelProvider(this, viewModelFactory)[LinkActivityViewModel::class.java]
@@ -39,6 +39,9 @@ internal class LinkActivity : ComponentActivity() {
         }
 
         val vm = viewModel ?: return
+
+        vm.linkLaunchMode.setTheme()
+
         vm.registerActivityForConfirmation(
             activityResultCaller = this,
             lifecycleOwner = this,
@@ -69,6 +72,18 @@ internal class LinkActivity : ComponentActivity() {
                 bottomSheetState = bottomSheetState,
             )
         }
+    }
+
+    /**
+     * Set the theme to transparent if [LinkActivity] launches in confirmation mode.
+     */
+    private fun LinkLaunchMode.setTheme() {
+        if ((this as? LinkLaunchMode.Full)?.selectedPayment?.readyForConfirmation() == true) {
+            setTheme(R.style.StripeTransparentTheme)
+        } else {
+            setTheme(R.style.StripePaymentSheetDefaultTheme)
+        }
+        renderEdgeToEdge()
     }
 
     private fun observeBackPress() {
@@ -117,6 +132,10 @@ internal class LinkActivity : ComponentActivity() {
         ): Intent {
             return Intent(context, LinkActivity::class.java)
                 .putExtra(EXTRA_ARGS, args)
+        }
+
+        internal fun getArgs(intent: Intent): NativeLinkArgs? {
+            return intent.getParcelableExtra<NativeLinkArgs>(EXTRA_ARGS)
         }
 
         internal fun getArgs(savedStateHandle: SavedStateHandle): NativeLinkArgs? {

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivity.kt
@@ -102,7 +102,7 @@ internal class LinkActivity : ComponentActivity() {
                 configuration = configuration,
                 startWithVerificationDialog = false,
                 linkAccount = null,
-                launchMode = LinkLaunchMode.Full
+                launchMode = LinkLaunchMode.Full()
             )
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityResult.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityResult.kt
@@ -2,7 +2,6 @@ package com.stripe.android.link
 
 import android.os.Parcelable
 import com.stripe.android.link.model.LinkAccount
-import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.PaymentMethod
 import kotlinx.parcelize.Parcelize
 
@@ -11,17 +10,16 @@ internal sealed class LinkActivityResult : Parcelable {
      * Indicates that the flow was completed successfully.
      */
     @Parcelize
-    data class Completed(
+    internal data class Completed(
         val linkAccountUpdate: LinkAccountUpdate,
-        val selectedPaymentDetails: ConsumerPaymentDetails.PaymentDetails? = null,
-        val collectedCvc: String?,
+        val selectedPayment: LinkPaymentMethod? = null,
     ) : LinkActivityResult()
 
     /**
      * Indicates that the user selected a payment method. This payment method has not yet been confirmed.
      */
     @Parcelize
-    data class PaymentMethodObtained(
+    internal data class PaymentMethodObtained(
         val paymentMethod: PaymentMethod
     ) : LinkActivityResult()
 
@@ -29,7 +27,7 @@ internal sealed class LinkActivityResult : Parcelable {
      * The user cancelled the Link flow without completing it.
      */
     @Parcelize
-    data class Canceled(
+    internal data class Canceled(
         val reason: Reason = Reason.BackPressed,
         val linkAccountUpdate: LinkAccountUpdate
     ) : LinkActivityResult() {
@@ -44,7 +42,7 @@ internal sealed class LinkActivityResult : Parcelable {
      * Something went wrong. See [error] for more information.
      */
     @Parcelize
-    data class Failed(
+    internal data class Failed(
         val error: Throwable,
         val linkAccountUpdate: LinkAccountUpdate
     ) : LinkActivityResult()

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
@@ -18,6 +18,7 @@ import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.link.account.LinkAccountManager
 import com.stripe.android.link.account.linkAccountUpdate
 import com.stripe.android.link.attestation.LinkAttestationCheck
+import com.stripe.android.link.confirmation.LinkConfirmationHandler
 import com.stripe.android.link.injection.DaggerNativeLinkComponent
 import com.stripe.android.link.injection.NativeLinkComponent
 import com.stripe.android.link.model.AccountStatus
@@ -25,6 +26,7 @@ import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.link.ui.LinkAppBarState
 import com.stripe.android.link.ui.signup.SignUpViewModel
 import com.stripe.android.link.utils.LINK_DEFAULT_ANIMATION_DELAY_MILLIS
+import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.uicore.navigation.NavBackStackEntryUpdate
@@ -43,11 +45,13 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import com.stripe.android.link.confirmation.Result as LinkConfirmationResult
 
 @SuppressWarnings("TooManyFunctions")
 internal class LinkActivityViewModel @Inject constructor(
     val activityRetainedComponent: NativeLinkComponent,
     confirmationHandlerFactory: ConfirmationHandler.Factory,
+    linkConfirmationHandlerFactory: LinkConfirmationHandler.Factory,
     private val linkAccountManager: LinkAccountManager,
     private val linkAccountHolder: LinkAccountHolder,
     val eventReporter: EventReporter,
@@ -55,9 +59,11 @@ internal class LinkActivityViewModel @Inject constructor(
     private val linkAttestationCheck: LinkAttestationCheck,
     val savedStateHandle: SavedStateHandle,
     private val startWithVerificationDialog: Boolean,
-    private val navigationManager: NavigationManager
+    private val navigationManager: NavigationManager,
+    private val linkLaunchMode: LinkLaunchMode,
 ) : ViewModel(), DefaultLifecycleObserver {
     val confirmationHandler = confirmationHandlerFactory.create(viewModelScope)
+    val linkConfirmationHandler = linkConfirmationHandlerFactory.create(confirmationHandler)
 
     private val _linkAppBarState = MutableStateFlow(LinkAppBarState.initial())
     val linkAppBarState: StateFlow<LinkAppBarState> = _linkAppBarState.asStateFlow()
@@ -192,7 +198,24 @@ internal class LinkActivityViewModel @Inject constructor(
     override fun onCreate(owner: LifecycleOwner) {
         super.onCreate(owner)
         viewModelScope.launch {
-            if (startWithVerificationDialog) return@launch updateScreenState()
+            val confirmResult = confirmPreselectedLinkPaymentIfAvailable()
+            when (confirmResult) {
+                // if no confirmation required or something fails confirming, render Link normally.
+                null,
+                is LinkConfirmationResult.Canceled,
+                is LinkConfirmationResult.Failed -> loadLink()
+                // if successfully confirmed the preselected payment, complete before rendering.
+                is LinkConfirmationResult.Succeeded -> dismissWithResult(
+                    LinkActivityResult.Completed(linkAccountUpdate = LinkAccountUpdate.Value(null))
+                )
+            }
+        }
+    }
+
+    private suspend fun loadLink() {
+        if (startWithVerificationDialog) {
+            updateScreenState()
+        } else {
             val attestationCheckResult = linkAttestationCheck.invoke()
             when (attestationCheckResult) {
                 is LinkAttestationCheck.Result.AttestationFailed -> {
@@ -206,6 +229,27 @@ internal class LinkActivityViewModel @Inject constructor(
                     handleAccountError()
                 }
             }
+        }
+    }
+
+    /**
+     * Attempts to confirm payment eagerly if the Link flow was launched with an authenticated user and a preselected
+     * Link payment method.
+     * @return The result of the confirmation attempt, or null if no confirmation was attempted.
+     */
+    private suspend fun confirmPreselectedLinkPaymentIfAvailable(): LinkConfirmationResult? {
+        val selectedPayment = (linkLaunchMode as? LinkLaunchMode.Full)?.selectedPayment
+        val requiresRecollection = selectedPayment?.details is ConsumerPaymentDetails.Card &&
+            selectedPayment.details.requiresCardDetailsRecollection == true
+        val paymentReadyForConfirmation = selectedPayment.takeIf { requiresRecollection.not() }
+        val account = linkAccount ?: return null
+
+        return paymentReadyForConfirmation?.let {
+            linkConfirmationHandler.confirm(
+                paymentDetails = it.details,
+                cvc = it.collectedCvc,
+                linkAccount = account,
+            )
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkLaunchMode.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkLaunchMode.kt
@@ -18,5 +18,10 @@ internal sealed interface LinkLaunchMode : Parcelable {
      * to payment,
      */
     @Parcelize
-    data object Full : LinkLaunchMode
+    data class Full(
+        /**
+         * The selected Link payment method to be used for confirmation.
+         */
+        val selectedPayment: LinkPaymentMethod? = null
+    ) : LinkLaunchMode
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkPaymentMethod.kt
@@ -11,4 +11,14 @@ import kotlinx.parcelize.Parcelize
 internal data class LinkPaymentMethod(
     val details: ConsumerPaymentDetails.PaymentDetails,
     val collectedCvc: String?
-) : Parcelable
+) : Parcelable {
+
+    fun readyForConfirmation(): Boolean = when (details) {
+        is ConsumerPaymentDetails.BankAccount -> true
+        is ConsumerPaymentDetails.Card -> {
+            val cvcReady = !details.cvcCheck.requiresRecollection || collectedCvc?.isNotEmpty() == true
+            !details.isExpired && cvcReady
+        }
+        is ConsumerPaymentDetails.Passthrough -> true
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkPaymentMethod.kt
@@ -1,0 +1,14 @@
+package com.stripe.android.link
+
+import android.os.Parcelable
+import com.stripe.android.model.ConsumerPaymentDetails
+import kotlinx.parcelize.Parcelize
+
+/**
+ * Link payment method payload needed to confirm the payment.
+ */
+@Parcelize
+internal data class LinkPaymentMethod(
+    val details: ConsumerPaymentDetails.PaymentDetails,
+    val collectedCvc: String?
+) : Parcelable

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkViewModelModule.kt
@@ -3,9 +3,11 @@ package com.stripe.android.link.injection
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.link.LinkActivityViewModel
 import com.stripe.android.link.LinkConfiguration
+import com.stripe.android.link.LinkLaunchMode
 import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.link.account.LinkAccountManager
 import com.stripe.android.link.attestation.LinkAttestationCheck
+import com.stripe.android.link.confirmation.LinkConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.DefaultConfirmationHandler
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.uicore.navigation.NavigationManager
@@ -25,8 +27,10 @@ internal object LinkViewModelModule {
         eventReporter: EventReporter,
         linkConfiguration: LinkConfiguration,
         linkAttestationCheck: LinkAttestationCheck,
+        linkConfirmationHandlerFactory: LinkConfirmationHandler.Factory,
         navigationManager: NavigationManager,
         savedStateHandle: SavedStateHandle,
+        linkLaunchMode: LinkLaunchMode,
         @Named(START_WITH_VERIFICATION_DIALOG) startWithVerificationDialog: Boolean
     ): LinkActivityViewModel {
         return LinkActivityViewModel(
@@ -39,7 +43,9 @@ internal object LinkViewModelModule {
             linkAttestationCheck = linkAttestationCheck,
             savedStateHandle = savedStateHandle,
             navigationManager = navigationManager,
-            startWithVerificationDialog = startWithVerificationDialog
+            startWithVerificationDialog = startWithVerificationDialog,
+            linkConfirmationHandlerFactory = linkConfirmationHandlerFactory,
+            linkLaunchMode = linkLaunchMode
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/PrimaryButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/PrimaryButton.kt
@@ -148,7 +148,7 @@ internal fun completePaymentButtonLabel(
     stripeIntent: StripeIntent,
     linkLaunchMode: LinkLaunchMode,
 ): ResolvableString = when (linkLaunchMode) {
-    LinkLaunchMode.Full -> when (stripeIntent) {
+    is LinkLaunchMode.Full -> when (stripeIntent) {
         is PaymentIntent -> {
             Amount(
                 requireNotNull(stripeIntent.amount),
@@ -159,7 +159,7 @@ internal fun completePaymentButtonLabel(
             uiCoreR.string.stripe_continue_button_label.resolvableString
         }
     }
-    LinkLaunchMode.PaymentMethodSelection -> uiCoreR.string.stripe_continue_button_label.resolvableString
+    is LinkLaunchMode.PaymentMethodSelection -> uiCoreR.string.stripe_continue_button_label.resolvableString
 }
 
 private val PrimaryButtonIconWidth = 13.dp

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
@@ -131,7 +131,7 @@ internal class PaymentMethodViewModel @Inject constructor(
                 dismissWithResult(
                     LinkActivityResult.Completed(
                         linkAccountUpdate = LinkAccountUpdate.Value(null),
-                        collectedCvc = cvc
+                        selectedPayment = null
                     )
                 )
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationOptionKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationOptionKtx.kt
@@ -123,7 +123,8 @@ private fun PaymentSelection.Link.toConfirmationOption(
     return linkConfiguration?.let {
         LinkConfirmationOption(
             configuration = linkConfiguration,
-            useLinkExpress = useLinkExpress
+            useLinkExpress = useLinkExpress,
+            selectedLinkPayment = selectedPayment
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinition.kt
@@ -59,7 +59,9 @@ internal class LinkConfirmationDefinition @Inject constructor(
             configuration = confirmationOption.configuration,
             linkAccount = linkAccountHolder.linkAccount.value,
             useLinkExpress = confirmationOption.useLinkExpress,
-            launchMode = LinkLaunchMode.Full
+            launchMode = LinkLaunchMode.Full(
+                confirmationOption.selectedLinkPayment
+            )
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationOption.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationOption.kt
@@ -1,11 +1,13 @@
 package com.stripe.android.paymentelement.confirmation.link
 
 import com.stripe.android.link.LinkConfiguration
+import com.stripe.android.link.LinkPaymentMethod
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
 internal data class LinkConfirmationOption(
     val configuration: LinkConfiguration,
+    val selectedLinkPayment: LinkPaymentMethod?,
     val useLinkExpress: Boolean
 ) : ConfirmationHandler.Option

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -167,7 +167,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
                     PaymentOptionResult.Succeeded(
                         paymentSelection = Link(
                             linkAccount = (result.linkAccountUpdate as? LinkAccountUpdate.Value)?.linkAccount,
-                            selectedLinkPayment = result.selectedPaymentDetails
+                            selectedPayment = result.selectedPayment
                         ),
                         paymentMethods = customerStateHolder.paymentMethods.value
                     )
@@ -247,8 +247,8 @@ internal class PaymentOptionsViewModel @Inject constructor(
      */
     private fun PaymentSelection.preserveLinkPaymentIfNeeded(): PaymentSelection {
         return if (this is Link) {
-            val previousLinkPayment = (args.state.paymentSelection as? Link)?.selectedLinkPayment
-            copy(selectedLinkPayment = selectedLinkPayment ?: previousLinkPayment)
+            val previousLinkPayment = (args.state.paymentSelection as? Link)?.selectedPayment
+            copy(selectedPayment = selectedPayment ?: previousLinkPayment)
         } else {
             this
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -12,6 +12,7 @@ import androidx.core.content.res.ResourcesCompat
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.orEmpty
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.link.LinkPaymentMethod
 import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.link.ui.wallet.displayName
@@ -19,7 +20,6 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.Address
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConfirmPaymentIntentParams
-import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.LinkMode
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethod.Type.USBankAccount
@@ -71,14 +71,14 @@ internal sealed class PaymentSelection : Parcelable {
     data class Link(
         val useLinkExpress: Boolean = false,
         val linkAccount: LinkAccount? = null,
-        val selectedLinkPayment: ConsumerPaymentDetails.PaymentDetails? = null,
+        val selectedPayment: LinkPaymentMethod? = null,
     ) : PaymentSelection() {
 
         override val requiresConfirmation: Boolean
             get() = false
 
         val label: ResolvableString
-            get() = selectedLinkPayment?.displayName ?: StripeR.string.stripe_link.resolvableString
+            get() = selectedPayment?.details?.displayName ?: StripeR.string.stripe_link.resolvableString
 
         override fun mandateText(
             merchantName: String,

--- a/paymentsheet/src/test/java/com/stripe/android/link/FakeNativeLinkComponent.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/FakeNativeLinkComponent.kt
@@ -40,5 +40,5 @@ internal class FakeNativeLinkComponent(
     override val eventReporter: EventReporter = FakeEventReporter(),
     override val navigationManager: NavigationManager = TestNavigationManager(),
     override val dismissalCoordinator: LinkDismissalCoordinator = RealLinkDismissalCoordinator(),
-    override val linkLaunchMode: LinkLaunchMode = LinkLaunchMode.Full,
+    override val linkLaunchMode: LinkLaunchMode = LinkLaunchMode.Full(),
 ) : NativeLinkComponent

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityContractTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityContractTest.kt
@@ -23,7 +23,7 @@ class LinkActivityContractTest {
         configuration = TestFactory.LINK_CONFIGURATION,
         startWithVerificationDialog = false,
         linkAccount = null,
-        launchMode = LinkLaunchMode.Full
+        launchMode = LinkLaunchMode.Full()
     )
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityTest.kt
@@ -20,6 +20,7 @@ import com.stripe.android.link.account.FakeLinkAccountManager
 import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.link.account.LinkAccountManager
 import com.stripe.android.link.attestation.FakeLinkAttestationCheck
+import com.stripe.android.link.confirmation.FakeLinkConfirmationHandler
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.utils.TestNavigationManager
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
@@ -152,7 +153,9 @@ internal class LinkActivityTest {
                 savedStateHandle = SavedStateHandle(),
                 linkConfiguration = TestFactory.LINK_CONFIGURATION,
                 startWithVerificationDialog = use2faDialog,
-                navigationManager = TestNavigationManager()
+                navigationManager = TestNavigationManager(),
+                linkLaunchMode = LinkLaunchMode.Full(),
+                linkConfirmationHandlerFactory = { FakeLinkConfirmationHandler() }
             )
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkPaymentLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkPaymentLauncherTest.kt
@@ -91,7 +91,7 @@ internal class LinkPaymentLauncherTest {
                 configuration = TestFactory.LINK_CONFIGURATION,
                 linkAccount = TestFactory.LINK_ACCOUNT,
                 useLinkExpress = true,
-                launchMode = LinkLaunchMode.Full
+                launchMode = LinkLaunchMode.Full()
             )
 
             val launchCall = awaitLaunchCall()
@@ -102,7 +102,7 @@ internal class LinkPaymentLauncherTest {
                         configuration = TestFactory.LINK_CONFIGURATION,
                         startWithVerificationDialog = true,
                         linkAccount = TestFactory.LINK_ACCOUNT,
-                        launchMode = LinkLaunchMode.Full
+                        launchMode = LinkLaunchMode.Full()
                     )
                 )
 
@@ -124,7 +124,7 @@ internal class LinkPaymentLauncherTest {
                 configuration = TestFactory.LINK_CONFIGURATION,
                 linkAccount = TestFactory.LINK_ACCOUNT,
                 useLinkExpress = false,
-                launchMode = LinkLaunchMode.Full
+                launchMode = LinkLaunchMode.Full()
             )
 
             val launchCall = awaitLaunchCall() as? LinkActivityContract.Args
@@ -138,7 +138,7 @@ internal class LinkPaymentLauncherTest {
         testActivityResultCallbackWithActivityResultRegistry(
             linkActivityResult = LinkActivityResult.Completed(
                 linkAccountUpdate = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
-                collectedCvc = null
+                selectedPayment = null,
             ),
             expectedMarkAsUsedCalls = 1,
         )
@@ -178,7 +178,7 @@ internal class LinkPaymentLauncherTest {
         testActivityResultCallbackWithResultCaller(
             linkActivityResult = LinkActivityResult.Completed(
                 linkAccountUpdate = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
-                collectedCvc = null
+                selectedPayment = null
             ),
             expectedMarkAsUsedCalls = 1,
         )
@@ -233,7 +233,7 @@ internal class LinkPaymentLauncherTest {
                 configuration = TestFactory.LINK_CONFIGURATION,
                 linkAccount = TestFactory.LINK_ACCOUNT,
                 useLinkExpress = true,
-                launchMode = LinkLaunchMode.Full
+                launchMode = LinkLaunchMode.Full()
             )
 
             verifyActivityResultCallback(
@@ -265,7 +265,7 @@ internal class LinkPaymentLauncherTest {
                     configuration = TestFactory.LINK_CONFIGURATION,
                     linkAccount = TestFactory.LINK_ACCOUNT,
                     useLinkExpress = true,
-                    launchMode = LinkLaunchMode.Full
+                    launchMode = LinkLaunchMode.Full()
                 )
 
                 val registerCall = awaitRegisterCall()

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkPaymentMethodTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkPaymentMethodTest.kt
@@ -1,0 +1,58 @@
+package com.stripe.android.link
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.link.TestFactory.CONSUMER_PAYMENT_DETAILS_BANK_ACCOUNT
+import com.stripe.android.link.TestFactory.CONSUMER_PAYMENT_DETAILS_CARD
+import com.stripe.android.link.TestFactory.CONSUMER_PAYMENT_DETAILS_PASSTHROUGH
+import com.stripe.android.model.CvcCheck
+import org.junit.Test
+
+class LinkPaymentMethodTest {
+
+    @Test
+    fun `readyForConfirmation returns true for BankAccount`() {
+        val bankAccount = CONSUMER_PAYMENT_DETAILS_BANK_ACCOUNT
+        val paymentMethod = LinkPaymentMethod(bankAccount, collectedCvc = null)
+        assertThat(paymentMethod.readyForConfirmation()).isTrue()
+    }
+
+    @Test
+    fun `readyForConfirmation returns true for Passthrough`() {
+        val passthrough = CONSUMER_PAYMENT_DETAILS_PASSTHROUGH
+        val paymentMethod = LinkPaymentMethod(passthrough, collectedCvc = null)
+        assertThat(paymentMethod.readyForConfirmation()).isTrue()
+    }
+
+    @Test
+    fun `readyForConfirmation returns false for expired card`() {
+        val card = CONSUMER_PAYMENT_DETAILS_CARD.copy(
+            expiryYear = 1990,
+            expiryMonth = 12,
+            cvcCheck = CvcCheck.Pass
+        )
+        val paymentMethod = LinkPaymentMethod(card, collectedCvc = "123")
+        assertThat(paymentMethod.readyForConfirmation()).isFalse()
+    }
+
+    @Test
+    fun `readyForConfirmation returns false when cvc recollection required and cvc is empty`() {
+        val card = CONSUMER_PAYMENT_DETAILS_CARD.copy(
+            expiryYear = 2100,
+            expiryMonth = 12,
+            cvcCheck = CvcCheck.Fail
+        )
+        val paymentMethod = LinkPaymentMethod(card, collectedCvc = "")
+        assertThat(paymentMethod.readyForConfirmation()).isFalse()
+    }
+
+    @Test
+    fun `readyForConfirmation returns true when cvc recollection required and cvc is provided`() {
+        val card = CONSUMER_PAYMENT_DETAILS_CARD.copy(
+            expiryYear = 2100,
+            expiryMonth = 12,
+            cvcCheck = CvcCheck.Fail
+        )
+        val paymentMethod = LinkPaymentMethod(card, collectedCvc = "123")
+        assertThat(paymentMethod.readyForConfirmation()).isTrue()
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/link/NativeLinkActivityContractTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/NativeLinkActivityContractTest.kt
@@ -37,7 +37,7 @@ class NativeLinkActivityContractTest {
             configuration = TestFactory.LINK_CONFIGURATION,
             startWithVerificationDialog = false,
             linkAccount = TestFactory.LINK_ACCOUNT,
-            launchMode = LinkLaunchMode.Full
+            launchMode = LinkLaunchMode.Full()
         )
 
         val intent = contract.createIntent(ApplicationProvider.getApplicationContext(), args)
@@ -55,7 +55,7 @@ class NativeLinkActivityContractTest {
                 startWithVerificationDialog = false,
                 linkAccount = TestFactory.LINK_ACCOUNT,
                 paymentElementCallbackIdentifier = LINK_CALLBACK_TEST_IDENTIFIER,
-                launchMode = LinkLaunchMode.Full
+                launchMode = LinkLaunchMode.Full()
             )
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
@@ -209,6 +209,6 @@ internal object TestFactory {
         startWithVerificationDialog = false,
         linkAccount = LINK_ACCOUNT,
         paymentElementCallbackIdentifier = "LinkNativeTestIdentifier",
-        launchMode = LinkLaunchMode.Full
+        launchMode = LinkLaunchMode.Full()
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/link/WebLinkActivityContractTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/WebLinkActivityContractTest.kt
@@ -43,7 +43,7 @@ class WebLinkActivityContractTest {
             configuration = TestFactory.LINK_CONFIGURATION,
             startWithVerificationDialog = false,
             linkAccount = TestFactory.LINK_ACCOUNT,
-            launchMode = LinkLaunchMode.Full
+            launchMode = LinkLaunchMode.Full()
         )
 
         val intent = contract.createIntent(ApplicationProvider.getApplicationContext(), args)

--- a/paymentsheet/src/test/java/com/stripe/android/link/analytics/DefaultLinkAnalyticsHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/analytics/DefaultLinkAnalyticsHelperTest.kt
@@ -51,8 +51,7 @@ internal class DefaultLinkAnalyticsHelperTest {
         val analyticsHelper = DefaultLinkAnalyticsHelper(eventReporter)
         analyticsHelper.onLinkResult(
             LinkActivityResult.Completed(
-                linkAccountUpdate = LinkAccountUpdate.None,
-                collectedCvc = null
+                linkAccountUpdate = LinkAccountUpdate.None
             )
         )
         assertThat(eventReporter.calledCount).isEqualTo(1)

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodScreenTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodScreenTest.kt
@@ -182,7 +182,7 @@ internal class PaymentMethodScreenTest {
             logger = FakeLogger(),
             formHelper = formHelper,
             dismissalCoordinator = dismissalCoordinator,
-            linkLaunchMode = LinkLaunchMode.Full,
+            linkLaunchMode = LinkLaunchMode.Full(),
             dismissWithResult = {}
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModelTest.kt
@@ -63,7 +63,7 @@ class PaymentMethodViewModelTest {
                 primaryButtonState = PrimaryButtonState.Disabled,
                 primaryButtonLabel = completePaymentButtonLabel(
                     TestFactory.LINK_CONFIGURATION.stripeIntent,
-                    LinkLaunchMode.Full
+                    LinkLaunchMode.Full()
                 )
             )
         )
@@ -123,14 +123,14 @@ class PaymentMethodViewModelTest {
 
         assertThat(linkConfirmationHandler.confirmWithLinkPaymentDetailsCall).hasSize(1)
         val call = linkConfirmationHandler.confirmWithLinkPaymentDetailsCall.first()
-        assertThat(call.paymentDetails)
-            .isEqualTo(TestFactory.LINK_NEW_PAYMENT_DETAILS)
+        val paymentDetails = TestFactory.LINK_NEW_PAYMENT_DETAILS
+        assertThat(call.paymentDetails).isEqualTo(paymentDetails)
         assertThat(call.cvc).isEqualTo("111")
         assertThat(result)
             .isEqualTo(
                 LinkActivityResult.Completed(
                     linkAccountUpdate = LinkAccountUpdate.Value(null),
-                    collectedCvc = "111"
+                    selectedPayment = null,
                 )
             )
         assertThat(viewModel.state.value.primaryButtonState).isEqualTo(PrimaryButtonState.Enabled)
@@ -242,7 +242,7 @@ class PaymentMethodViewModelTest {
             logger = logger,
             dismissalCoordinator = dismissalCoordinator,
             linkAccountManager = linkAccountManager,
-            linkLaunchMode = LinkLaunchMode.Full
+            linkLaunchMode = LinkLaunchMode.Full()
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletScreenTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletScreenTest.kt
@@ -722,7 +722,7 @@ internal class WalletScreenTest {
         linkConfirmationHandler: LinkConfirmationHandler = FakeLinkConfirmationHandler(),
         navigationManager: TestNavigationManager = TestNavigationManager(),
         dismissalCoordinator: LinkDismissalCoordinator = RealLinkDismissalCoordinator(),
-        linkLaunchMode: LinkLaunchMode = LinkLaunchMode.Full
+        linkLaunchMode: LinkLaunchMode = LinkLaunchMode.Full()
     ): WalletViewModel {
         return WalletViewModel(
             configuration = TestFactory.LINK_CONFIGURATION,

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
@@ -357,7 +357,7 @@ class WalletViewModelTest {
             .isEqualTo(
                 LinkActivityResult.Completed(
                     linkAccountUpdate = LinkAccountUpdate.Value(null),
-                    collectedCvc = null
+                    selectedPayment = null
                 )
             )
     }
@@ -687,7 +687,7 @@ class WalletViewModelTest {
         navigateAndClearStack: (route: LinkScreen) -> Unit = {},
         dismissWithResult: (LinkActivityResult) -> Unit = {},
         configuration: LinkConfiguration = TestFactory.LINK_CONFIGURATION,
-        linkLaunchMode: LinkLaunchMode = LinkLaunchMode.Full
+        linkLaunchMode: LinkLaunchMode = LinkLaunchMode.Full()
     ): WalletViewModel {
         return WalletViewModel(
             configuration = configuration,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
@@ -272,6 +272,7 @@ class ConfirmationHandlerOptionKtxTest {
         ).isEqualTo(
             LinkConfirmationOption(
                 configuration = LINK_CONFIGURATION,
+                selectedLinkPayment = null,
                 useLinkExpress = false
             )
         )
@@ -289,6 +290,7 @@ class ConfirmationHandlerOptionKtxTest {
         ).isEqualTo(
             LinkConfirmationOption(
                 configuration = LINK_CONFIGURATION,
+                selectedLinkPayment = null,
                 useLinkExpress = true
             )
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationActivityTest.kt
@@ -205,7 +205,7 @@ internal class LinkConfirmationActivityTest(private val nativeLinkEnabled: Boole
                             startWithVerificationDialog = true,
                             linkAccount = null,
                             paymentElementCallbackIdentifier = "ConfirmationTestIdentifier",
-                            launchMode = LinkLaunchMode.Full
+                            launchMode = LinkLaunchMode.Full()
                         )
                     )
                 )
@@ -239,7 +239,8 @@ internal class LinkConfirmationActivityTest(private val nativeLinkEnabled: Boole
 
         val LINK_CONFIRMATION_OPTION = LinkConfirmationOption(
             configuration = TestFactory.LINK_CONFIGURATION,
-            useLinkExpress = true
+            useLinkExpress = true,
+            selectedLinkPayment = null
         )
 
         val CONFIRMATION_PARAMETERS = ConfirmationDefinition.Parameters(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinitionTest.kt
@@ -203,8 +203,7 @@ internal class LinkConfirmationDefinitionTest {
             confirmationOption = LINK_CONFIRMATION_OPTION,
             confirmationParameters = CONFIRMATION_PARAMETERS,
             result = LinkActivityResult.Completed(
-                linkAccountUpdate = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
-                collectedCvc = null
+                linkAccountUpdate = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT)
             ),
             deferredIntentConfirmationType = null,
         )
@@ -356,7 +355,8 @@ internal class LinkConfirmationDefinitionTest {
 
         private val LINK_CONFIRMATION_OPTION = LinkConfirmationOption(
             configuration = TestFactory.LINK_CONFIGURATION,
-            useLinkExpress = true
+            useLinkExpress = true,
+            selectedLinkPayment = null
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationFlowTest.kt
@@ -151,7 +151,8 @@ class LinkConfirmationFlowTest {
 
         private val LINK_CONFIRMATION_OPTION = LinkConfirmationOption(
             configuration = TestFactory.LINK_CONFIGURATION,
-            useLinkExpress = true
+            useLinkExpress = true,
+            selectedLinkPayment = null
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -891,7 +891,7 @@ internal class PaymentOptionsViewModelTest {
         val linkAccountUpdate = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT)
         val result = LinkActivityResult.Completed(
             linkAccountUpdate = linkAccountUpdate,
-            collectedCvc = null
+            selectedPayment = null
         )
         val viewModel = createViewModel()
         viewModel.paymentOptionResult.test {


### PR DESCRIPTION
# Summary
- If `LinkActivity` receives a preselected payment method, attempts to confirm it using the received details and CVC.
- Wraps Link payment method info ready for confirmation (consumer payment details + cvc, if collected) into `LinkPaymentMethod`.

# Motivation
https://jira.corp.stripe.com/browse/LINK_MOBILE-196

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots

https://github.com/user-attachments/assets/00367ec8-9ec8-4e6e-af42-5b894d9c537d

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
