### PR TITLE
Remember PaymentSheet/FlowController in playground

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
@@ -118,20 +118,24 @@ internal class PaymentSheetPlaygroundActivity :
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 window.isNavigationBarContrastEnforced = false
             }
-            val paymentSheet = PaymentSheet.Builder(viewModel::onPaymentSheetResult)
-                .externalPaymentMethodConfirmHandler(this)
-                .confirmCustomPaymentMethodCallback(this)
-                .createIntentCallback(viewModel::createIntentCallback)
-                .analyticEventCallback(viewModel::analyticCallback)
+            val paymentSheet = remember {
+                PaymentSheet.Builder(viewModel::onPaymentSheetResult)
+                    .externalPaymentMethodConfirmHandler(this)
+                    .confirmCustomPaymentMethodCallback(this)
+                    .createIntentCallback(viewModel::createIntentCallback)
+                    .analyticEventCallback(viewModel::analyticCallback)
+            }
                 .build()
-            val flowController = PaymentSheet.FlowController.Builder(
-                viewModel::onPaymentSheetResult,
-                viewModel::onPaymentOptionSelected
-            )
-                .externalPaymentMethodConfirmHandler(this)
-                .confirmCustomPaymentMethodCallback(this)
-                .createIntentCallback(viewModel::createIntentCallback)
-                .analyticEventCallback(viewModel::analyticCallback)
+            val flowController = remember {
+                PaymentSheet.FlowController.Builder(
+                    viewModel::onPaymentSheetResult,
+                    viewModel::onPaymentOptionSelected
+                )
+                    .externalPaymentMethodConfirmHandler(this)
+                    .confirmCustomPaymentMethodCallback(this)
+                    .createIntentCallback(viewModel::createIntentCallback)
+                    .analyticEventCallback(viewModel::analyticCallback)
+            }
                 .build()
             val embeddedPaymentElementBuilder = remember {
                 EmbeddedPaymentElement.Builder(


### PR DESCRIPTION

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
While working on #10833, I noticed that we should remember the Builder. This aligns with `EmbeddedPaymentElement`
```
val embeddedPaymentElementBuilder = remember {
    EmbeddedPaymentElement.Builder(
        viewModel::createIntentCallback,
        viewModel::onEmbeddedResult,
     )
}
embeddedPaymentElement = rememberEmbeddedPaymentElement(embeddedPaymentElementBuilder)
 ```