### PR TITLE
Fix issue with Link pre-selection in FlowController

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/SupportedPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/SupportedPaymentMethod.kt
@@ -20,6 +20,8 @@ internal data class SupportedPaymentMethod(
      */
     val code: PaymentMethodCode,
 
+    val syntheticCode: String = code,
+
     /** This describes the name that appears under the selector. */
     val displayName: ResolvableString,
 
@@ -57,6 +59,7 @@ internal data class SupportedPaymentMethod(
 
     constructor(
         code: PaymentMethodCode,
+        syntheticCode: PaymentMethodCode = code,
         @StringRes displayNameResource: Int,
         @DrawableRes iconResource: Int,
         iconRequiresTinting: Boolean = false,
@@ -65,6 +68,7 @@ internal data class SupportedPaymentMethod(
         subtitle: ResolvableString? = null,
     ) : this(
         code = code,
+        syntheticCode = syntheticCode,
         displayName = displayNameResource.resolvableString,
         iconResource = iconResource,
         lightThemeIconUrl = lightThemeIconUrl,
@@ -104,6 +108,7 @@ internal data class SupportedPaymentMethod(
 
         return DisplayablePaymentMethod(
             code = code,
+            syntheticCode = syntheticCode,
             displayName = displayName,
             iconResource = iconResource,
             lightThemeIconUrl = lightThemeIconUrl,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/InstantDebitsDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/InstantDebitsDefinition.kt
@@ -32,6 +32,7 @@ private object InstantDebitsUiDefinitionFactory : UiDefinitionFactory.Simple {
     override fun createSupportedPaymentMethod(): SupportedPaymentMethod {
         return SupportedPaymentMethod(
             code = InstantDebitsDefinition.type.code,
+            syntheticCode = "link_instant_debits",
             displayNameResource = PaymentsUiCoreR.string.stripe_paymentsheet_payment_method_instant_debits,
             iconResource = PaymentsUiCoreR.drawable.stripe_ic_paymentsheet_pm_bank,
             iconRequiresTinting = true,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/LinkCardBrandDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/LinkCardBrandDefinition.kt
@@ -32,6 +32,7 @@ private object LinkCardBrandDefinitionFactory : UiDefinitionFactory.Simple {
     override fun createSupportedPaymentMethod(): SupportedPaymentMethod {
         return SupportedPaymentMethod(
             code = InstantDebitsDefinition.type.code,
+            syntheticCode = "link_card_brand",
             displayNameResource = PaymentsUiCoreR.string.stripe_paymentsheet_payment_method_instant_debits,
             iconResource = PaymentsUiCoreR.drawable.stripe_ic_paymentsheet_pm_bank,
             iconRequiresTinting = true,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/DisplayablePaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/DisplayablePaymentMethod.kt
@@ -6,6 +6,7 @@ import com.stripe.android.model.PaymentMethodCode
 
 internal data class DisplayablePaymentMethod(
     val code: PaymentMethodCode,
+    val syntheticCode: String = code,
     val displayName: ResolvableString,
     @DrawableRes val iconResource: Int,
     val lightThemeIconUrl: String?,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUI.kt
@@ -129,7 +129,7 @@ internal fun PaymentMethodVerticalLayoutUI(
         val selectedIndex = remember(selection, paymentMethods) {
             if (selection is PaymentMethodVerticalLayoutInteractor.Selection.New) {
                 val code = selection.code
-                paymentMethods.indexOfFirst { it.code == code }
+                paymentMethods.indexOfFirst { it.syntheticCode == code }
             } else {
                 -1
             }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where a pre-selection of Link in FlowController caused the bank tab to be selected.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
