### PR TITLE
Fix 3DS2 Whitelisting Encoding Issue

### DIFF
--- a/3ds2sdk/src/main/kotlin/com/stripe/android/stripe3ds2/transaction/ChallengeAction.kt
+++ b/3ds2sdk/src/main/kotlin/com/stripe/android/stripe3ds2/transaction/ChallengeAction.kt
@@ -7,7 +7,7 @@ internal sealed class ChallengeAction : Parcelable {
     @Parcelize
     data class NativeForm(
         internal val userEntry: String,
-        internal val whitelistingValue: Boolean
+        internal val whitelistingValue: Boolean?
     ) : ChallengeAction()
 
     @Parcelize
@@ -17,7 +17,7 @@ internal sealed class ChallengeAction : Parcelable {
 
     @Parcelize
     data class Oob(
-        internal val whitelistingValue: Boolean
+        internal val whitelistingValue: Boolean?
     ) : ChallengeAction()
 
     @Parcelize

--- a/3ds2sdk/src/main/kotlin/com/stripe/android/stripe3ds2/views/ChallengeFragment.kt
+++ b/3ds2sdk/src/main/kotlin/com/stripe/android/stripe3ds2/views/ChallengeFragment.kt
@@ -102,7 +102,8 @@ internal class ChallengeFragment(
 
     private val challengeAction: ChallengeAction
         get() {
-            val whitelistingSelection = if (cresData.whitelistingInfoText.isNullOrEmpty()) null else challengeZoneView.whitelistingSelection
+            val whitelistingSelection = if (cresData.whitelistingInfoText.isNullOrEmpty()) null
+            else challengeZoneView.whitelistingSelection
 
             return when (cresData.uiType) {
                 UiType.OutOfBand -> ChallengeAction.Oob(whitelistingSelection)

--- a/3ds2sdk/src/main/kotlin/com/stripe/android/stripe3ds2/views/ChallengeFragment.kt
+++ b/3ds2sdk/src/main/kotlin/com/stripe/android/stripe3ds2/views/ChallengeFragment.kt
@@ -102,10 +102,12 @@ internal class ChallengeFragment(
 
     private val challengeAction: ChallengeAction
         get() {
+            val whitelistingSelection = if (cresData.whitelistingInfoText.isNullOrEmpty()) null else challengeZoneView.whitelistingSelection
+
             return when (cresData.uiType) {
-                UiType.OutOfBand -> ChallengeAction.Oob(challengeZoneView.whitelistingSelection)
+                UiType.OutOfBand -> ChallengeAction.Oob(whitelistingSelection)
                 UiType.Html -> ChallengeAction.HtmlForm(userEntry)
-                else -> ChallengeAction.NativeForm(userEntry, challengeZoneView.whitelistingSelection)
+                else -> ChallengeAction.NativeForm(userEntry, whitelistingSelection)
             }
         }
 


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Fixes an issue where we send a whitelisting value, even if no text is present. Some ACSs seem to validate that this value should *NOT* exist when the whitelisting text is not present.

## Motivation
An ACS reported failures when trying to validate challenges that did not contain whitelist text.

## Testing
Using the PaymentSheet Example to test cards that did not contain whitelist text to ensure that the field was no longer sent, and then validating that it was still sent when text did exist.