### PR TITLE
[Link Prominence] Link Account consistency improvements.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityResult.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityResult.kt
@@ -6,12 +6,15 @@ import com.stripe.android.model.PaymentMethod
 import kotlinx.parcelize.Parcelize
 
 internal sealed class LinkActivityResult : Parcelable {
+
+    abstract val linkAccountUpdate: LinkAccountUpdate?
+
     /**
      * Indicates that the flow was completed successfully.
      */
     @Parcelize
     internal data class Completed(
-        val linkAccountUpdate: LinkAccountUpdate,
+        override val linkAccountUpdate: LinkAccountUpdate,
         val selectedPayment: LinkPaymentMethod? = null,
     ) : LinkActivityResult()
 
@@ -21,7 +24,11 @@ internal sealed class LinkActivityResult : Parcelable {
     @Parcelize
     internal data class PaymentMethodObtained(
         val paymentMethod: PaymentMethod
-    ) : LinkActivityResult()
+    ) : LinkActivityResult() {
+
+        override val linkAccountUpdate: LinkAccountUpdate?
+            get() = null
+    }
 
     /**
      * The user cancelled the Link flow without completing it.
@@ -29,7 +36,7 @@ internal sealed class LinkActivityResult : Parcelable {
     @Parcelize
     internal data class Canceled(
         val reason: Reason = Reason.BackPressed,
-        val linkAccountUpdate: LinkAccountUpdate
+        override val linkAccountUpdate: LinkAccountUpdate
     ) : LinkActivityResult() {
         enum class Reason {
             BackPressed,
@@ -44,7 +51,7 @@ internal sealed class LinkActivityResult : Parcelable {
     @Parcelize
     internal data class Failed(
         val error: Throwable,
-        val linkAccountUpdate: LinkAccountUpdate
+        override val linkAccountUpdate: LinkAccountUpdate
     ) : LinkActivityResult()
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAccountUtil.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAccountUtil.kt
@@ -4,3 +4,12 @@ import com.stripe.android.link.LinkAccountUpdate
 
 internal val LinkAccountManager.linkAccountUpdate: LinkAccountUpdate
     get() = LinkAccountUpdate.Value(linkAccount.value)
+
+internal fun LinkAccountUpdate.updateLinkAccount(linkAccountHolder: LinkAccountHolder) {
+    when (this) {
+        is LinkAccountUpdate.Value -> {
+            linkAccountHolder.set(linkAccount)
+        }
+        LinkAccountUpdate.None -> Unit
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/LinkHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/LinkHandler.kt
@@ -29,6 +29,10 @@ internal class LinkHandler @Inject constructor(
         if (state == null) return
 
         _linkConfiguration.value = state.configuration
+
+        // trigger component creation on Link handler setup so that it gets
+        // cached in the coordinator.
+        linkConfigurationCoordinator.getComponent(state.configuration)
     }
 
     suspend fun setupLinkWithEagerLaunch(state: LinkState?): Boolean {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionContract.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet
 import android.content.Context
 import android.content.Intent
 import androidx.activity.result.contract.ActivityResultContract
+import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.paymentsheet.state.PaymentSheetState
 import com.stripe.android.view.ActivityStarter
 import kotlinx.parcelize.Parcelize
@@ -28,6 +29,7 @@ internal class PaymentOptionContract :
     internal data class Args(
         val state: PaymentSheetState.Full,
         val configuration: PaymentSheet.Configuration,
+        val linkAccount: LinkAccount?,
         val enableLogging: Boolean,
         val productUsage: Set<String>,
         val paymentElementCallbackIdentifier: String,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -39,7 +39,6 @@ import com.stripe.android.paymentsheet.verticalmode.VerticalModeInitialScreenFac
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.paymentsheet.viewmodels.PrimaryButtonUiStateMapper
 import com.stripe.android.uicore.utils.combineAsStateFlow
-import com.stripe.android.uicore.utils.mapAsStateFlow
 import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -97,7 +96,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
 
     override val walletsState: StateFlow<WalletsState?> = combineAsStateFlow(
         linkHandler.isLinkEnabled,
-        linkAccountHolder.linkAccount.mapAsStateFlow { it?.email },
+        linkHandler.linkConfigurationCoordinator.emailFlow,
         buttonsEnabled,
     ) { isLinkAvailable, linkEmail, buttonsEnabled ->
         val paymentMethodMetadata = args.state.paymentMethodMetadata
@@ -135,8 +134,8 @@ internal class PaymentOptionsViewModel @Inject constructor(
     init {
         SessionSavedStateHandler.attachTo(this, savedStateHandle)
 
-        linkHandler.setupLink(args.state.paymentMethodMetadata.linkState)
         linkAccountHolder.set(args.linkAccount)
+        linkHandler.setupLink(args.state.paymentMethodMetadata.linkState)
         // After recovering from don't keep activities the paymentMethodMetadata will be saved,
         // calling setPaymentMethodMetadata would require the repository be initialized, which
         // would not be the case.

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -276,7 +276,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
         linkAccount: LinkAccount?
     ): Boolean {
         return paymentSelection is Link &&
-            linkAccount != null && linkAccount.isVerified.not() &&
+            linkAccount != null &&
             linkProminenceFeatureProvider.shouldShowEarlyVerificationInFlowController(linkConfiguration)
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -12,6 +12,7 @@ import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.utils.requireApplication
 import com.stripe.android.link.LinkActivityResult
+import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkLaunchMode
 import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.account.LinkAccountHolder
@@ -30,7 +31,6 @@ import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.AddFirstPaymentMethod
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.SelectSavedPaymentMethods
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
-import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.WalletsProcessingState
 import com.stripe.android.paymentsheet.state.WalletsState
 import com.stripe.android.paymentsheet.ui.DefaultAddPaymentMethodInteractor
@@ -229,7 +229,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
             val linkAccount = linkAccountHolder.linkAccount.value
             val shouldShowLinkConfiguration = linkState != null && shouldShowLinkVerification(
                 paymentSelection = paymentSelection,
-                linkState = linkState,
+                linkConfiguration = linkState.configuration,
                 linkAccount = linkAccount
             )
             if (shouldShowLinkConfiguration) {
@@ -272,12 +272,12 @@ internal class PaymentOptionsViewModel @Inject constructor(
 
     private fun shouldShowLinkVerification(
         paymentSelection: PaymentSelection,
-        linkState: LinkState,
+        linkConfiguration: LinkConfiguration,
         linkAccount: LinkAccount?
     ): Boolean {
         return paymentSelection is Link &&
             linkAccount != null && linkAccount.isVerified.not() &&
-            linkProminenceFeatureProvider.shouldShowEarlyVerificationInFlowController(linkState.configuration)
+            linkProminenceFeatureProvider.shouldShowEarlyVerificationInFlowController(linkConfiguration)
     }
 
     override fun handlePaymentMethodSelected(selection: PaymentSelection?) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -497,24 +497,23 @@ internal class DefaultFlowController @Inject internal constructor(
             )
         }
         when (result) {
-            is PaymentOptionResult.Succeeded -> onPaymentSelection(
-                paymentSelection = result.paymentSelection.also { it.hasAcknowledgedSepaMandate = true },
-                updateCurrent = true
-            )
+            is PaymentOptionResult.Succeeded -> {
+                viewModel.paymentSelection = result.paymentSelection.also { it.hasAcknowledgedSepaMandate = true }
+                onPaymentSelection()
+            }
             null,
-            is PaymentOptionResult.Canceled -> onPaymentSelection(
-                paymentSelection = result?.paymentSelection,
-                updateCurrent = true
-            )
-            is PaymentOptionResult.Failed -> onPaymentSelection(
-                paymentSelection = viewModel.paymentSelection,
-                updateCurrent = false
-            )
+            is PaymentOptionResult.Canceled -> {
+                viewModel.paymentSelection = result?.paymentSelection
+                onPaymentSelection()
+            }
+            is PaymentOptionResult.Failed -> {
+                onPaymentSelection()
+            }
         }
     }
 
-    private fun onPaymentSelection(paymentSelection: PaymentSelection?, updateCurrent: Boolean = true) {
-        if (updateCurrent) viewModel.paymentSelection = paymentSelection
+    private fun onPaymentSelection() {
+        val paymentSelection = viewModel.paymentSelection
         // update the current Link account state if the selected Link payment method includes an account update.
         if (paymentSelection is Link) {
             LinkAccountUpdate.Value(paymentSelection.linkAccount).updateLinkAccount()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.test.performScrollTo
 import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.SavedStateHandle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso
@@ -27,6 +28,7 @@ import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.link.FakeLinkProminenceFeatureProvider
+import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
@@ -457,6 +459,7 @@ internal class PaymentOptionsActivityTest {
                 linkHandler = linkHandler,
                 cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
                 linkProminenceFeatureProvider = FakeLinkProminenceFeatureProvider(),
+                linkAccountHolder = LinkAccountHolder(SavedStateHandle()),
                 linkPaymentLauncher = mock(),
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
@@ -167,6 +167,7 @@ internal object PaymentSheetFixtures {
         enableLogging = false,
         productUsage = mock(),
         paymentElementCallbackIdentifier = PAYMENT_SHEET_CALLBACK_TEST_IDENTIFIER,
+        linkAccount = null
     )
 
     internal fun PaymentOptionContract.Args.updateState(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -489,6 +489,7 @@ internal class DefaultFlowControllerTest {
             configuration = PaymentSheet.Configuration("com.stripe.android.paymentsheet.test"),
             enableLogging = ENABLE_LOGGING,
             productUsage = PRODUCT_USAGE,
+            linkAccount = null,
             paymentElementCallbackIdentifier = FLOW_CONTROLLER_CALLBACK_TEST_IDENTIFIER
         )
 
@@ -1297,7 +1298,7 @@ internal class DefaultFlowControllerTest {
         val previousPaymentSelection = NEW_CARD_PAYMENT_SELECTION
 
         flowController.onPaymentOptionResult(
-            paymentOptionResult = PaymentOptionResult.Succeeded(previousPaymentSelection),
+            result = PaymentOptionResult.Succeeded(previousPaymentSelection),
         )
 
         flowController.presentPaymentOptions()


### PR DESCRIPTION
# Summary
- Ensures LinkActivity's returned `LinkAccountUpdate` is applied in both `FlowController` and `PaymentOptionsActivity`
- Allows 2FA to be launched again on dismissal
- Ensures `linkConfigurationCoordinator`'s componentFlow gets created when calling `LinkHandler.setupLink`, so that `emailFlow` starts emitting values. 

https://github.com/user-attachments/assets/90a8da3b-90c3-44b7-9c39-368cce34acd6

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
