### PR TITLE
[Link Prominence] Confirm newly created Link PMs in FlowController

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -384,11 +384,19 @@ public final class com/stripe/android/link/LinkPaymentDetails$Saved$Creator : an
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/stripe/android/link/LinkPaymentMethod$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/link/LinkPaymentMethod$Consumer$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
-	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/link/LinkPaymentMethod;
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/link/LinkPaymentMethod$Consumer;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
-	public final fun newArray (I)[Lcom/stripe/android/link/LinkPaymentMethod;
+	public final fun newArray (I)[Lcom/stripe/android/link/LinkPaymentMethod$Consumer;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/link/LinkPaymentMethod$Link$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/link/LinkPaymentMethod$Link;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/link/LinkPaymentMethod$Link;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -384,19 +384,19 @@ public final class com/stripe/android/link/LinkPaymentDetails$Saved$Creator : an
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/stripe/android/link/LinkPaymentMethod$Consumer$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/link/LinkPaymentMethod$ConsumerPaymentDetails$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
-	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/link/LinkPaymentMethod$Consumer;
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/link/LinkPaymentMethod$ConsumerPaymentDetails;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
-	public final fun newArray (I)[Lcom/stripe/android/link/LinkPaymentMethod$Consumer;
+	public final fun newArray (I)[Lcom/stripe/android/link/LinkPaymentMethod$ConsumerPaymentDetails;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/stripe/android/link/LinkPaymentMethod$Link$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/link/LinkPaymentMethod$LinkPaymentDetails$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
-	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/link/LinkPaymentMethod$Link;
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/link/LinkPaymentMethod$LinkPaymentDetails;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
-	public final fun newArray (I)[Lcom/stripe/android/link/LinkPaymentMethod$Link;
+	public final fun newArray (I)[Lcom/stripe/android/link/LinkPaymentMethod$LinkPaymentDetails;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
@@ -232,12 +232,12 @@ internal class LinkActivityViewModel @Inject constructor(
         require(selectedPayment.readyForConfirmation()) { "LinkPaymentMethod must be ready for confirmation" }
         val linkAccount = requireNotNull(linkAccount) { "LinkAccount must not be null for confirmation" }
         when (selectedPayment) {
-            is LinkPaymentMethod.Consumer -> linkConfirmationHandler.confirm(
+            is LinkPaymentMethod.ConsumerPaymentDetails -> linkConfirmationHandler.confirm(
                 paymentDetails = selectedPayment.details,
                 cvc = selectedPayment.collectedCvc,
                 linkAccount = linkAccount,
             )
-            is LinkPaymentMethod.Link -> linkConfirmationHandler.confirm(
+            is LinkPaymentMethod.LinkPaymentDetails -> linkConfirmationHandler.confirm(
                 paymentDetails = selectedPayment.linkPaymentDetails,
                 cvc = selectedPayment.collectedCvc,
                 linkAccount = linkAccount,

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
@@ -230,11 +230,19 @@ internal class LinkActivityViewModel @Inject constructor(
      */
     private suspend fun confirmLinkPayment(selectedPayment: LinkPaymentMethod) = runCatching {
         require(selectedPayment.readyForConfirmation()) { "LinkPaymentMethod must be ready for confirmation" }
-        linkConfirmationHandler.confirm(
-            paymentDetails = selectedPayment.details,
-            cvc = selectedPayment.collectedCvc,
-            linkAccount = requireNotNull(linkAccount) { "LinkAccount must not be null for confirmation" },
-        )
+        val linkAccount = requireNotNull(linkAccount) { "LinkAccount must not be null for confirmation" }
+        when (selectedPayment) {
+            is LinkPaymentMethod.Consumer -> linkConfirmationHandler.confirm(
+                paymentDetails = selectedPayment.details,
+                cvc = selectedPayment.collectedCvc,
+                linkAccount = linkAccount,
+            )
+            is LinkPaymentMethod.Link -> linkConfirmationHandler.confirm(
+                paymentDetails = selectedPayment.linkPaymentDetails,
+                cvc = selectedPayment.collectedCvc,
+                linkAccount = linkAccount,
+            )
+        }
     }.onSuccess { confirmResult ->
         dismissWithResult(
             when (confirmResult) {

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkPaymentMethod.kt
@@ -8,17 +8,37 @@ import kotlinx.parcelize.Parcelize
  * Link payment method payload needed to confirm the payment.
  */
 @Parcelize
-internal data class LinkPaymentMethod(
-    val details: ConsumerPaymentDetails.PaymentDetails,
-    val collectedCvc: String?
+internal sealed class LinkPaymentMethod(
+    open val collectedCvc: String?,
 ) : Parcelable {
 
-    fun readyForConfirmation(): Boolean = when (details) {
+    internal abstract val details: ConsumerPaymentDetails.PaymentDetails
+
+    internal fun readyForConfirmation(): Boolean = when (val currentDetails = details) {
         is ConsumerPaymentDetails.BankAccount -> true
         is ConsumerPaymentDetails.Card -> {
-            val cvcReady = !details.cvcCheck.requiresRecollection || collectedCvc?.isNotEmpty() == true
-            !details.isExpired && cvcReady
+            val cvcReady = !currentDetails.cvcCheck.requiresRecollection || collectedCvc?.isNotEmpty() == true
+            !currentDetails.isExpired && cvcReady
         }
         is ConsumerPaymentDetails.Passthrough -> true
+    }
+
+    @Parcelize
+    internal data class Consumer(
+        val paymentDetails: ConsumerPaymentDetails.PaymentDetails,
+        override val collectedCvc: String?
+    ) : LinkPaymentMethod(collectedCvc) {
+        override val details
+            get() = paymentDetails
+    }
+
+    @Parcelize
+    internal data class Link(
+        val linkPaymentDetails: LinkPaymentDetails,
+        override val collectedCvc: String?
+    ) : LinkPaymentMethod(collectedCvc) {
+
+        override val details
+            get() = linkPaymentDetails.paymentDetails
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
@@ -145,7 +145,7 @@ internal class PaymentMethodViewModel @Inject constructor(
             is LinkLaunchMode.PaymentMethodSelection -> dismissWithResult(
                 LinkActivityResult.Completed(
                     linkAccountUpdate = linkAccountManager.linkAccountUpdate,
-                    selectedPayment = LinkPaymentMethod.Link(
+                    selectedPayment = LinkPaymentMethod.LinkPaymentDetails(
                         linkPaymentDetails = paymentDetails,
                         collectedCvc = cvc,
                     )

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
@@ -239,8 +239,8 @@ internal class WalletViewModel @Inject constructor(
                 is LinkLaunchMode.PaymentMethodSelection -> dismissWithResult(
                     LinkActivityResult.Completed(
                         linkAccountUpdate = LinkAccountUpdate.Value(linkAccount),
-                        selectedPayment = LinkPaymentMethod(
-                            details = selectedPaymentDetails,
+                        selectedPayment = LinkPaymentMethod.Consumer(
+                            paymentDetails = selectedPaymentDetails,
                             collectedCvc = cvc
                         ),
                     )

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
@@ -239,8 +239,8 @@ internal class WalletViewModel @Inject constructor(
                 is LinkLaunchMode.PaymentMethodSelection -> dismissWithResult(
                     LinkActivityResult.Completed(
                         linkAccountUpdate = LinkAccountUpdate.Value(linkAccount),
-                        selectedPayment = LinkPaymentMethod.Consumer(
-                            paymentDetails = selectedPaymentDetails,
+                        selectedPayment = LinkPaymentMethod.ConsumerPaymentDetails(
+                            details = selectedPaymentDetails,
                             collectedCvc = cvc
                         ),
                     )

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
@@ -194,8 +194,8 @@ internal class LinkActivityViewModelTest {
 
     @Test
     fun `onCreate does not confirm when linkAccount is null`() = runTest {
-        val selectedPayment = LinkPaymentMethod(
-            details = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD,
+        val selectedPayment = LinkPaymentMethod.Consumer(
+            paymentDetails = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD,
             collectedCvc = null
         )
 
@@ -217,8 +217,8 @@ internal class LinkActivityViewModelTest {
 
     @Test
     fun `onCreate confirms preselected Link payment when provided and emits Completed`() = runTest {
-        val selectedPayment = LinkPaymentMethod(
-            details = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD,
+        val selectedPayment = LinkPaymentMethod.Consumer(
+            paymentDetails = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD,
             collectedCvc = null
         )
 
@@ -242,8 +242,8 @@ internal class LinkActivityViewModelTest {
 
     @Test
     fun `onCreate does not emit Completed when confirmation is failed`() = runTest {
-        val selectedPayment = LinkPaymentMethod(
-            details = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD,
+        val selectedPayment = LinkPaymentMethod.Consumer(
+            paymentDetails = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD,
             collectedCvc = null
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
@@ -194,8 +194,8 @@ internal class LinkActivityViewModelTest {
 
     @Test
     fun `onCreate does not confirm when linkAccount is null`() = runTest {
-        val selectedPayment = LinkPaymentMethod.Consumer(
-            paymentDetails = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD,
+        val selectedPayment = LinkPaymentMethod.ConsumerPaymentDetails(
+            details = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD,
             collectedCvc = null
         )
 
@@ -217,8 +217,8 @@ internal class LinkActivityViewModelTest {
 
     @Test
     fun `onCreate confirms preselected Link payment when provided and emits Completed`() = runTest {
-        val selectedPayment = LinkPaymentMethod.Consumer(
-            paymentDetails = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD,
+        val selectedPayment = LinkPaymentMethod.ConsumerPaymentDetails(
+            details = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD,
             collectedCvc = null
         )
 
@@ -242,8 +242,8 @@ internal class LinkActivityViewModelTest {
 
     @Test
     fun `onCreate does not emit Completed when confirmation is failed`() = runTest {
-        val selectedPayment = LinkPaymentMethod.Consumer(
-            paymentDetails = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD,
+        val selectedPayment = LinkPaymentMethod.ConsumerPaymentDetails(
+            details = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD,
             collectedCvc = null
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkPaymentMethodTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkPaymentMethodTest.kt
@@ -12,14 +12,14 @@ class LinkPaymentMethodTest {
     @Test
     fun `readyForConfirmation returns true for BankAccount`() {
         val bankAccount = CONSUMER_PAYMENT_DETAILS_BANK_ACCOUNT
-        val paymentMethod = LinkPaymentMethod.Consumer(bankAccount, collectedCvc = null)
+        val paymentMethod = LinkPaymentMethod.ConsumerPaymentDetails(bankAccount, collectedCvc = null)
         assertThat(paymentMethod.readyForConfirmation()).isTrue()
     }
 
     @Test
     fun `readyForConfirmation returns true for Passthrough`() {
         val passthrough = CONSUMER_PAYMENT_DETAILS_PASSTHROUGH
-        val paymentMethod = LinkPaymentMethod.Consumer(passthrough, collectedCvc = null)
+        val paymentMethod = LinkPaymentMethod.ConsumerPaymentDetails(passthrough, collectedCvc = null)
         assertThat(paymentMethod.readyForConfirmation()).isTrue()
     }
 
@@ -30,7 +30,7 @@ class LinkPaymentMethodTest {
             expiryMonth = 12,
             cvcCheck = CvcCheck.Pass
         )
-        val paymentMethod = LinkPaymentMethod.Consumer(card, collectedCvc = "123")
+        val paymentMethod = LinkPaymentMethod.ConsumerPaymentDetails(card, collectedCvc = "123")
         assertThat(paymentMethod.readyForConfirmation()).isFalse()
     }
 
@@ -41,7 +41,7 @@ class LinkPaymentMethodTest {
             expiryMonth = 12,
             cvcCheck = CvcCheck.Fail
         )
-        val paymentMethod = LinkPaymentMethod.Consumer(card, collectedCvc = "")
+        val paymentMethod = LinkPaymentMethod.ConsumerPaymentDetails(card, collectedCvc = "")
         assertThat(paymentMethod.readyForConfirmation()).isFalse()
     }
 
@@ -52,7 +52,7 @@ class LinkPaymentMethodTest {
             expiryMonth = 12,
             cvcCheck = CvcCheck.Fail
         )
-        val paymentMethod = LinkPaymentMethod.Consumer(card, collectedCvc = "123")
+        val paymentMethod = LinkPaymentMethod.ConsumerPaymentDetails(card, collectedCvc = "123")
         assertThat(paymentMethod.readyForConfirmation()).isTrue()
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkPaymentMethodTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkPaymentMethodTest.kt
@@ -12,14 +12,14 @@ class LinkPaymentMethodTest {
     @Test
     fun `readyForConfirmation returns true for BankAccount`() {
         val bankAccount = CONSUMER_PAYMENT_DETAILS_BANK_ACCOUNT
-        val paymentMethod = LinkPaymentMethod(bankAccount, collectedCvc = null)
+        val paymentMethod = LinkPaymentMethod.Consumer(bankAccount, collectedCvc = null)
         assertThat(paymentMethod.readyForConfirmation()).isTrue()
     }
 
     @Test
     fun `readyForConfirmation returns true for Passthrough`() {
         val passthrough = CONSUMER_PAYMENT_DETAILS_PASSTHROUGH
-        val paymentMethod = LinkPaymentMethod(passthrough, collectedCvc = null)
+        val paymentMethod = LinkPaymentMethod.Consumer(passthrough, collectedCvc = null)
         assertThat(paymentMethod.readyForConfirmation()).isTrue()
     }
 
@@ -30,7 +30,7 @@ class LinkPaymentMethodTest {
             expiryMonth = 12,
             cvcCheck = CvcCheck.Pass
         )
-        val paymentMethod = LinkPaymentMethod(card, collectedCvc = "123")
+        val paymentMethod = LinkPaymentMethod.Consumer(card, collectedCvc = "123")
         assertThat(paymentMethod.readyForConfirmation()).isFalse()
     }
 
@@ -41,7 +41,7 @@ class LinkPaymentMethodTest {
             expiryMonth = 12,
             cvcCheck = CvcCheck.Fail
         )
-        val paymentMethod = LinkPaymentMethod(card, collectedCvc = "")
+        val paymentMethod = LinkPaymentMethod.Consumer(card, collectedCvc = "")
         assertThat(paymentMethod.readyForConfirmation()).isFalse()
     }
 
@@ -52,7 +52,7 @@ class LinkPaymentMethodTest {
             expiryMonth = 12,
             cvcCheck = CvcCheck.Fail
         )
-        val paymentMethod = LinkPaymentMethod(card, collectedCvc = "123")
+        val paymentMethod = LinkPaymentMethod.Consumer(card, collectedCvc = "123")
         assertThat(paymentMethod.readyForConfirmation()).isTrue()
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -535,7 +535,7 @@ internal class DefaultFlowControllerTest {
             paymentSelection = PaymentSelection.Link(
                 linkAccount = verifiedLinkAccount,
                 selectedPayment = LinkPaymentMethod.ConsumerPaymentDetails(
-                    paymentDetails = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD,
+                    details = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD,
                     collectedCvc = null
                 )
             )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -534,8 +534,8 @@ internal class DefaultFlowControllerTest {
         val flowController = createFlowController(
             paymentSelection = PaymentSelection.Link(
                 linkAccount = verifiedLinkAccount,
-                selectedPayment = LinkPaymentMethod(
-                    details = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD,
+                selectedPayment = LinkPaymentMethod.Consumer(
+                    paymentDetails = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD,
                     collectedCvc = null
                 )
             )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -534,7 +534,7 @@ internal class DefaultFlowControllerTest {
         val flowController = createFlowController(
             paymentSelection = PaymentSelection.Link(
                 linkAccount = verifiedLinkAccount,
-                selectedPayment = LinkPaymentMethod.Consumer(
+                selectedPayment = LinkPaymentMethod.ConsumerPaymentDetails(
                     paymentDetails = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD,
                     collectedCvc = null
                 )


### PR DESCRIPTION
# Summary
Adds support for passing `LinkPaymentDetails` from `LinkActivity -> PaymentOptions -> FlowController` for posterior confirmation.

https://github.com/user-attachments/assets/56be3dae-6542-46fc-b06c-c56fed25d6bc

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [ ] Manually verified

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
