### PR TITLE
Keep Link prominence behind feature flag

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -16,6 +16,7 @@ import androidx.lifecycle.lifecycleScope
 import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.ENABLE_LOGGING
+import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkActivityResult.Canceled.Reason
 import com.stripe.android.link.LinkLaunchMode
@@ -243,23 +244,31 @@ internal class DefaultFlowController @Inject internal constructor(
         }
     }
 
-    override fun presentPaymentOptions() = withCurrentState { state: State ->
-        // If the user previously selected Link and authenticated,
-        // show the link wallet instead of the payment option list.
-        val configuration = state.paymentSheetState.linkConfiguration
-        val paymentSelection = viewModel.paymentSelection
-        val linkAccount = linkAccountHolder.linkAccount.value
-        if (paymentSelection is Link && configuration != null && linkAccount?.accountStatus == Verified) {
-            linkPaymentLauncher.present(
-                configuration = configuration,
-                linkAccount = linkAccount,
-                useLinkExpress = false,
-                launchMode = LinkLaunchMode.PaymentMethodSelection(
-                    selectedPayment = paymentSelection.selectedPayment?.details
+    override fun presentPaymentOptions() {
+        withCurrentState { state ->
+            // If the user previously selected Link and authenticated,
+            // show the link wallet instead of the payment option list.
+            val linkConfiguration = state.paymentSheetState.linkConfiguration
+            val paymentSelection = viewModel.paymentSelection
+            val linkAccount = linkAccountHolder.linkAccount.value
+
+            val shouldPresentLinkInsteadOfPaymentOptions = FeatureFlags.linkProminenceInFlowController.isEnabled &&
+                paymentSelection is Link &&
+                linkConfiguration != null &&
+                linkAccount?.accountStatus == Verified
+
+            if (shouldPresentLinkInsteadOfPaymentOptions) {
+                linkPaymentLauncher.present(
+                    configuration = linkConfiguration,
+                    linkAccount = linkAccount,
+                    useLinkExpress = false,
+                    launchMode = LinkLaunchMode.PaymentMethodSelection(
+                        selectedPayment = paymentSelection.selectedPayment?.details
+                    )
                 )
-            )
-        } else {
-            showPaymentOptionList(state, paymentSelection)
+            } else {
+                showPaymentOptionList(state, paymentSelection)
+            }
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -17,6 +17,7 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.core.exception.APIConnectionException
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContractV2
 import com.stripe.android.link.LinkActivityContract
@@ -90,6 +91,7 @@ import com.stripe.android.paymentsheet.ui.SepaMandateResult
 import com.stripe.android.paymentsheet.utils.RecordingGooglePayPaymentMethodLauncherFactory
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FakeErrorReporter
+import com.stripe.android.testing.FeatureFlagTestRule
 import com.stripe.android.uicore.image.StripeImageLoader
 import com.stripe.android.utils.FakeIntentConfirmationInterceptor
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
@@ -179,6 +181,12 @@ internal class DefaultFlowControllerTest {
 
     @get:Rule
     val coroutineTestRule = CoroutineTestRule(testDispatcher)
+
+    @get:Rule
+    val linkProminenceFeatureRule = FeatureFlagTestRule(
+        featureFlag = FeatureFlags.linkProminenceInFlowController,
+        isEnabled = false,
+    )
 
     @Suppress("LongMethod")
     @BeforeTest
@@ -520,6 +528,8 @@ internal class DefaultFlowControllerTest {
 
     @Test
     fun `presentPaymentOptions shows Link picker when a Link payment method is already selected`() = runTest {
+        linkProminenceFeatureRule.setEnabled(true)
+
         val verifiedLinkAccount = TestFactory.LINK_ACCOUNT
         val flowController = createFlowController(
             paymentSelection = PaymentSelection.Link(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request ensures that some of the “Link Prominence in FlowController” work isn't exposed early.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
