### PR TITLE
Update deploy script to update 3DS2 version

### DIFF
--- a/3ds2sdk/src/main/kotlin/com/stripe/android/stripe3ds2/SdkVersion.kt
+++ b/3ds2sdk/src/main/kotlin/com/stripe/android/stripe3ds2/SdkVersion.kt
@@ -1,7 +1,5 @@
 package com.stripe.android.stripe3ds2
 
 internal object SdkVersion {
-    // update these values when publishing a new release
     internal const val VERSION_NAME = "6.2.0"
-    internal const val VERSION_CODE = 26
 }

--- a/3ds2sdk/src/main/kotlin/com/stripe/android/stripe3ds2/observability/DefaultErrorReporter.kt
+++ b/3ds2sdk/src/main/kotlin/com/stripe/android/stripe3ds2/observability/DefaultErrorReporter.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.os.Build
 import androidx.annotation.VisibleForTesting
 import com.stripe.android.stripe3ds2.BuildConfig
-import com.stripe.android.stripe3ds2.SdkVersion.VERSION_CODE
 import com.stripe.android.stripe3ds2.SdkVersion.VERSION_NAME
 import com.stripe.android.stripe3ds2.transaction.Logger
 import kotlinx.coroutines.CoroutineScope
@@ -112,7 +111,7 @@ internal class DefaultErrorReporter(
         t: Throwable
     ): JSONObject {
         return JSONObject()
-            .put("release", "${BuildConfig.LIBRARY_PACKAGE_NAME}@$VERSION_NAME+$VERSION_CODE")
+            .put("release", "${BuildConfig.LIBRARY_PACKAGE_NAME}@$VERSION_NAME")
             .put(
                 "exception",
                 JSONObject()

--- a/scripts/deploy/update_version_numbers.rb
+++ b/scripts/deploy/update_version_numbers.rb
@@ -49,3 +49,11 @@ def update_changelog()
 
     execute_or_fail("git add CHANGELOG.md")
 end
+
+def update_3ds2_version()
+    replace_in_file("3ds2sdk/src/main/kotlin/com/stripe/android/stripe3ds2/SdkVersion.kt",
+      /internal const val VERSION_NAME = "[.\d]+"/,
+      %Q{internal const val VERSION_NAME = "#{@version}"},
+    )
+    execute_or_fail("git add 3ds2sdk/src/main/kotlin/com/stripe/android/stripe3ds2/SdkVersion.kt")
+end

--- a/scripts/deploy/version_bump_pr_steps.rb
+++ b/scripts/deploy/version_bump_pr_steps.rb
@@ -30,6 +30,7 @@ def create_version_bump_pr()
     update_gradle_properties()
     update_changelog()
     update_version()
+    update_3ds2_version()
     execute_or_fail("git commit -m \"Bump version to #{@version}\"")
 
     begin


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Update deploy script to update 3DS2 version number
Removed version code from Sentry call

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
com.stripe.android.stripe3ds2.SdkVersion is used to send events to Sentry

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

Verified deploy updates version number with [dry run](https://github.com/stripe/stripe-android/pull/10849/files)
Verified removed `VERSION_CODE` is not needed for Sentry by sending [test event without](https://sentry.corp.stripe.com/organizations/stripe/releases/com.stripe.android.stripe3ds2%406.2.0/?project=426&statsPeriod=14d)

