### PR TITLE
Send customer ephemeral key to backend

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/ElementsSessionParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ElementsSessionParams.kt
@@ -12,6 +12,7 @@ sealed interface ElementsSessionParams : Parcelable {
     val type: String
     val clientSecret: String?
     val customerSessionClientSecret: String?
+    val legacyCustomerEphemeralKey: String?
     val mobileSessionId: String?
     val locale: String?
     val expandFields: List<String>
@@ -26,6 +27,7 @@ sealed interface ElementsSessionParams : Parcelable {
         override val clientSecret: String,
         override val locale: String? = Locale.getDefault().toLanguageTag(),
         override val customerSessionClientSecret: String? = null,
+        override val legacyCustomerEphemeralKey: String? = null,
         override val savedPaymentMethodSelectionId: String? = null,
         override val mobileSessionId: String? = null,
         override val customPaymentMethods: List<String>,
@@ -46,6 +48,7 @@ sealed interface ElementsSessionParams : Parcelable {
         override val clientSecret: String,
         override val locale: String? = Locale.getDefault().toLanguageTag(),
         override val customerSessionClientSecret: String? = null,
+        override val legacyCustomerEphemeralKey: String? = null,
         override val savedPaymentMethodSelectionId: String? = null,
         override val mobileSessionId: String? = null,
         override val customPaymentMethods: List<String>,
@@ -69,6 +72,7 @@ sealed interface ElementsSessionParams : Parcelable {
         override val externalPaymentMethods: List<String>,
         override val savedPaymentMethodSelectionId: String? = null,
         override val customerSessionClientSecret: String? = null,
+        override val legacyCustomerEphemeralKey: String? = null,
         override val mobileSessionId: String? = null,
         override val appId: String,
     ) : ElementsSessionParams {

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -1579,6 +1579,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
             params.clientSecret?.let { this["client_secret"] = it }
             params.locale.let { this["locale"] = it }
             params.customerSessionClientSecret?.let { this["customer_session_client_secret"] = it }
+            params.legacyCustomerEphemeralKey?.let { this["legacy_customer_ephemeral_key"] = it }
             params.externalPaymentMethods.takeIf { it.isNotEmpty() }?.let { this["external_payment_methods"] = it }
             params.customPaymentMethods.takeIf { it.isNotEmpty() }?.let { this["custom_payment_methods"] = it }
             params.mobileSessionId?.takeIf { it.isNotEmpty() }?.let { this["mobile_session_id"] = it }

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -2629,6 +2629,66 @@ internal class StripeApiRepositoryTest {
     }
 
     @Test
+    fun `Verify legacy customer ephemeral key not in params when null`() = runTest {
+        val stripeResponse = StripeResponse(
+            200,
+            ElementsSessionFixtures.EXPANDED_PAYMENT_INTENT_JSON.toString(),
+            emptyMap()
+        )
+
+        whenever(stripeNetworkClient.executeRequest(any<ApiRequest>())).thenReturn(stripeResponse)
+
+        create().retrieveElementsSession(
+            params = ElementsSessionParams.PaymentIntentType(
+                clientSecret = "client_secret",
+                legacyCustomerEphemeralKey = null,
+                externalPaymentMethods = emptyList(),
+                customPaymentMethods = emptyList(),
+                appId = APP_ID
+            ),
+            options = DEFAULT_OPTIONS,
+        )
+
+        verify(stripeNetworkClient).executeRequest(apiRequestArgumentCaptor.capture())
+
+        val request = apiRequestArgumentCaptor.firstValue
+        val params = requireNotNull(request.params)
+
+        assertThat(request.baseUrl).isEqualTo("https://api.stripe.com/v1/elements/sessions")
+        assertThat(params["legacy_customer_ephemeral_key"]).isNull()
+    }
+
+    @Test
+    fun `Verify legacy customer ephemeral key in params when provided`() = runTest {
+        val stripeResponse = StripeResponse(
+            200,
+            ElementsSessionFixtures.EXPANDED_PAYMENT_INTENT_JSON.toString(),
+            emptyMap()
+        )
+
+        whenever(stripeNetworkClient.executeRequest(any<ApiRequest>())).thenReturn(stripeResponse)
+
+        create().retrieveElementsSession(
+            params = ElementsSessionParams.PaymentIntentType(
+                clientSecret = "client_secret",
+                legacyCustomerEphemeralKey = "legacy_customer_ephemeral_key",
+                externalPaymentMethods = emptyList(),
+                customPaymentMethods = emptyList(),
+                appId = APP_ID
+            ),
+            options = DEFAULT_OPTIONS,
+        )
+
+        verify(stripeNetworkClient).executeRequest(apiRequestArgumentCaptor.capture())
+
+        val request = apiRequestArgumentCaptor.firstValue
+        val params = requireNotNull(request.params)
+
+        assertThat(request.baseUrl).isEqualTo("https://api.stripe.com/v1/elements/sessions")
+        assertThat(params["legacy_customer_ephemeral_key"]).isEqualTo("legacy_customer_ephemeral_key")
+    }
+
+    @Test
     fun `Verify mobile session ID in params when provided`() = runTest {
         val stripeResponse = StripeResponse(
             200,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds a `legacy_customer_ephemeral_key` parameter to the Elements session request. This parameter helps us determine if inline signup can be enabled. The related backend work can be found [here](https://git.corp.stripe.com/stripe-internal/pay-server/pull/1084214).

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
