### PR TITLE
[Link in MPE] Fix: Pass CVC to `/share` on passthrough on recollection

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
@@ -269,6 +269,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
     override suspend fun sharePaymentDetails(
         paymentDetailsId: String,
         expectedPaymentMethodType: String,
+        cvc: String?,
     ): Result<SharePaymentDetails> {
         return runCatching {
             requireNotNull(linkAccountHolder.linkAccount.value)
@@ -277,6 +278,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
                 paymentDetailsId = paymentDetailsId,
                 consumerSessionClientSecret = account.clientSecret,
                 expectedPaymentMethodType = expectedPaymentMethodType,
+                cvc = cvc,
             ).getOrThrow()
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
@@ -97,6 +97,7 @@ internal interface LinkAccountManager {
     suspend fun sharePaymentDetails(
         paymentDetailsId: String,
         expectedPaymentMethodType: String,
+        cvc: String?,
     ): Result<SharePaymentDetails>
 
     suspend fun setLinkAccountFromLookupResult(

--- a/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
@@ -119,6 +119,7 @@ internal class DefaultLinkConfirmationHandler @Inject constructor(
             LinkPassthroughConfirmationOption(
                 paymentDetailsId = paymentDetails.id,
                 expectedPaymentMethodType = computeExpectedPaymentMethodType(paymentDetails),
+                cvc = cvc
             )
         } else {
             PaymentMethodConfirmationOption.New(

--- a/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
@@ -238,9 +238,13 @@ internal class LinkApiRepository @Inject constructor(
         consumerSessionClientSecret: String,
         paymentDetailsId: String,
         expectedPaymentMethodType: String,
+        cvc: String?,
     ): Result<SharePaymentDetails> = withContext(workContext) {
         val fraudParams = fraudDetectionDataRepository.getCached()?.params.orEmpty()
         val paymentMethodParams = mapOf("expand" to listOf("payment_method"))
+        val optionsParams = cvc?.let {
+            mapOf("payment_method_options" to mapOf("card" to mapOf("cvc" to it)))
+        } ?: emptyMap()
 
         consumersApiService.sharePaymentDetails(
             consumerSessionClientSecret = consumerSessionClientSecret,
@@ -248,7 +252,7 @@ internal class LinkApiRepository @Inject constructor(
             expectedPaymentMethodType = expectedPaymentMethodType,
             requestOptions = buildRequestOptions(),
             requestSurface = REQUEST_SURFACE,
-            extraParams = paymentMethodParams + fraudParams,
+            extraParams = paymentMethodParams + fraudParams + optionsParams,
             billingPhone = null,
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
@@ -92,6 +92,7 @@ internal interface LinkRepository {
         consumerSessionClientSecret: String,
         paymentDetailsId: String,
         expectedPaymentMethodType: String,
+        cvc: String?,
     ): Result<SharePaymentDetails>
 
     suspend fun logOut(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkPassthroughConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkPassthroughConfirmationDefinition.kt
@@ -85,6 +85,7 @@ internal class LinkPassthroughConfirmationDefinition @Inject constructor(
         return linkAccountManager.sharePaymentDetails(
             paymentDetailsId = confirmationOption.paymentDetailsId,
             expectedPaymentMethodType = confirmationOption.expectedPaymentMethodType,
+            cvc = confirmationOption.cvc,
         ).mapCatching {
             requireNotNull(it.encodedPaymentMethod.parsePaymentMethod())
         }.map { paymentMethod ->

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkPassthroughConfirmationOption.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkPassthroughConfirmationOption.kt
@@ -7,4 +7,5 @@ import kotlinx.parcelize.Parcelize
 internal data class LinkPassthroughConfirmationOption(
     val paymentDetailsId: String,
     val expectedPaymentMethodType: String,
+    val cvc: String?
 ) : ConfirmationHandler.Option

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/FakeLinkAccountManager.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/FakeLinkAccountManager.kt
@@ -165,7 +165,8 @@ internal open class FakeLinkAccountManager(
 
     override suspend fun sharePaymentDetails(
         paymentDetailsId: String,
-        expectedPaymentMethodType: String
+        expectedPaymentMethodType: String,
+        cvc: String?
     ): Result<SharePaymentDetails> {
         return sharePaymentDetails
     }

--- a/paymentsheet/src/test/java/com/stripe/android/link/repositories/FakeLinkRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/repositories/FakeLinkRepository.kt
@@ -128,7 +128,8 @@ internal open class FakeLinkRepository : LinkRepository {
     override suspend fun sharePaymentDetails(
         consumerSessionClientSecret: String,
         paymentDetailsId: String,
-        expectedPaymentMethodType: String
+        expectedPaymentMethodType: String,
+        cvc: String?
     ) = sharePaymentDetails
 
     override suspend fun logOut(


### PR DESCRIPTION
# Summary
- When recollecting on passthrough, the `cvc` is not passed to the `share` call. Recollection always fails with `you must provide a CVC`.
- This ensures collected CVC gets passed as `payment_method_options[card][cvc]`, as iOS does.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
