### PR TITLE
[Link-FlowController] Prefer Link over regular payment selection on more scenarios

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -256,22 +256,23 @@ internal class DefaultFlowController @Inject internal constructor(
 
     override fun presentPaymentOptions() {
         withCurrentState { state ->
-            // If the user previously selected Link and authenticated,
-            // show the link wallet instead of the payment option list.
             val linkConfiguration = state.paymentSheetState.linkConfiguration
             val paymentSelection = viewModel.paymentSelection
             val linkAccountInfo = linkAccountHolder.linkAccountInfo.value
 
             val shouldPresentLinkInsteadOfPaymentOptions = linkProminenceInFlowController.isEnabled &&
+                // The current payment selection is Link
                 paymentSelection?.isLink == true &&
+                // Link is enabled and available
                 linkConfiguration != null &&
-                linkAccountInfo?.account != null
+                // The current user has a Link account (not necessarily logged in)
+                linkAccountInfo.account != null
 
             if (shouldPresentLinkInsteadOfPaymentOptions) {
                 linkPaymentLauncher.present(
                     configuration = linkConfiguration,
                     linkAccountInfo = linkAccountInfo,
-                    useLinkExpress = false,
+                    useLinkExpress = true,
                     launchMode = LinkLaunchMode.PaymentMethodSelection(
                         selectedPayment = (paymentSelection as? Link)?.selectedPayment?.details
                     )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -20,6 +20,7 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContractV2
+import com.stripe.android.link.FakeLinkProminenceFeatureProvider
 import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.LinkActivityContract
 import com.stripe.android.link.LinkPaymentLauncher
@@ -174,6 +175,8 @@ internal class DefaultFlowControllerTest {
     private val activityResultCaller: ActivityResultCaller = mock()
 
     private val fakeIntentConfirmationInterceptor = FakeIntentConfirmationInterceptor()
+
+    private val linkProminenceFeatureProvider = FakeLinkProminenceFeatureProvider()
 
     private var paymentLauncherResultCallback: ((InternalPaymentResult) -> Unit)? = null
     private var googlePayLauncherResultCallback: ((GooglePayPaymentMethodLauncher.Result) -> Unit)? = null
@@ -531,7 +534,7 @@ internal class DefaultFlowControllerTest {
 
     @Test
     fun `presentPaymentOptions shows Link picker when a Link payment method is already selected`() = runTest {
-        linkProminenceFeatureRule.setEnabled(true)
+        linkProminenceFeatureProvider.shouldShowEarlyVerificationInFlowController = true
 
         val verifiedLinkAccount = TestFactory.LINK_ACCOUNT
         val flowController = createFlowController(
@@ -2483,6 +2486,7 @@ internal class DefaultFlowControllerTest {
             linkAccountHolder = linkAccountHolder,
             linkPaymentLauncher = linkPaymentLauncher,
             activityResultRegistryOwner = mock(),
+            linkProminenceFeatureProvider = linkProminenceFeatureProvider,
             confirmationHandler = createTestConfirmationHandlerFactory(
                 paymentElementCallbackIdentifier = FLOW_CONTROLLER_CALLBACK_TEST_IDENTIFIER,
                 bacsMandateConfirmationLauncherFactory = bacsMandateConfirmationLauncherFactory,


### PR DESCRIPTION
# Summary

While in flow controller,  Show the Link OTP instead of regular payment selection if:

- PaymentSelection is Link, consumer not logged in, but we have a return user email
- PaymentSelection is saved payment method of type Link, consumer not logged in, but we have a return user email

If the user verifies, show the Link wallet. If they don’t verify, show payment options.

https://github.com/user-attachments/assets/e212794a-c9c7-4c1a-8cb5-58f1f94f1b2c

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
