### PR TITLE
Add exposure logging for Link AB test

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/ElementsSession.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ElementsSession.kt
@@ -177,6 +177,7 @@ data class ElementsSession(
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     enum class ExperimentAssignment(val experimentValue: String) {
         LINK_GLOBAL_HOLD_BACK("link_global_holdback"),
+        LINK_AB_TEST("link_ab_test"),
     }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/paymentsheet/src/main/java/com/stripe/android/common/analytics/experiment/LoggableExperiment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/analytics/experiment/LoggableExperiment.kt
@@ -12,9 +12,10 @@ internal sealed class LoggableExperiment(
     open val group: String,
     open val dimensions: Map<String, String>
 ) {
-    data class LinkGlobalHoldback(
+    data class LinkHoldback(
         override val arbId: String,
         override val group: String,
+        override val experiment: ExperimentAssignment,
         val isReturningLinkUser: Boolean,
         val useLinkNative: Boolean,
         val emailRecognitionSource: EmailRecognitionSource?,
@@ -25,7 +26,7 @@ internal sealed class LoggableExperiment(
     ) : LoggableExperiment(
         arbId = arbId,
         group = group,
-        experiment = ExperimentAssignment.LINK_GLOBAL_HOLD_BACK,
+        experiment = experiment,
         dimensions = mapOf(
             "integration_type" to "mpe_android",
             "is_returning_link_user" to isReturningLinkUser.toString(),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/LinkHoldbackExposureModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/LinkHoldbackExposureModule.kt
@@ -2,8 +2,8 @@ package com.stripe.android.paymentsheet.injection
 
 import android.app.Application
 import com.stripe.android.Stripe
-import com.stripe.android.common.analytics.experiment.DefaultLogLinkGlobalHoldbackExposure
-import com.stripe.android.common.analytics.experiment.LogLinkGlobalHoldbackExposure
+import com.stripe.android.common.analytics.experiment.DefaultLogLinkHoldbackExperiment
+import com.stripe.android.common.analytics.experiment.LogLinkHoldbackExperiment
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
@@ -42,8 +42,8 @@ internal class LinkHoldbackExposureModule {
 
     @Provides
     fun providesLogLinkGlobalHoldbackExposure(
-        default: DefaultLogLinkGlobalHoldbackExposure
-    ): LogLinkGlobalHoldbackExposure {
+        default: DefaultLogLinkHoldbackExperiment
+    ): LogLinkHoldbackExperiment {
         return default
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/common/analytics/experiment/LogLinkGlobalHoldbackExposureTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/analytics/experiment/LogLinkGlobalHoldbackExposureTest.kt
@@ -2,7 +2,7 @@ package com.stripe.android.common.analytics.experiment
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.common.analytics.experiment.LoggableExperiment.LinkGlobalHoldback.EmailRecognitionSource
+import com.stripe.android.common.analytics.experiment.LoggableExperiment.LinkHoldback.EmailRecognitionSource
 import com.stripe.android.common.model.CommonConfigurationFactory
 import com.stripe.android.link.TestFactory
 import com.stripe.android.link.TestFactory.CONSUMER_SESSION
@@ -41,7 +41,7 @@ class LogLinkGlobalHoldbackExposureTest {
     private lateinit var eventReporter: FakeEventReporter
     private lateinit var logger: FakeLogger
     private lateinit var linkRepository: FakeLinkRepository
-    private lateinit var logLinkGlobalHoldbackExposure: LogLinkGlobalHoldbackExposure
+    private lateinit var logLinkHoldbackExperiment: LogLinkHoldbackExperiment
     private lateinit var customerRepository: FakeCustomerRepository
     private lateinit var retrieveCustomerEmail: RetrieveCustomerEmail
     private lateinit var linkConfigurationCoordinator: FakeLinkConfigurationCoordinator
@@ -60,7 +60,7 @@ class LogLinkGlobalHoldbackExposureTest {
         retrieveCustomerEmail = DefaultRetrieveCustomerEmail(customerRepository)
         linkConfigurationCoordinator = FakeLinkConfigurationCoordinator()
 
-        logLinkGlobalHoldbackExposure = DefaultLogLinkGlobalHoldbackExposure(
+        logLinkHoldbackExperiment = DefaultLogLinkHoldbackExperiment(
             linkDisabledApiRepository = linkRepository,
             eventReporter = eventReporter,
             logger = logger,
@@ -83,11 +83,11 @@ class LogLinkGlobalHoldbackExposureTest {
         )
         val state = createElementsState(PaymentMethodMetadataFactory.create())
 
-        logLinkGlobalHoldbackExposure(elementsSession, state)
+        logLinkHoldbackExperiment(elementsSession, state)
 
         val exposureCall = eventReporter.experimentExposureCalls.awaitItem()
 
-        assertTrue(exposureCall.experiment is LoggableExperiment.LinkGlobalHoldback)
+        assertTrue(exposureCall.experiment is LoggableExperiment.LinkHoldback)
         assertEquals(exposureCall.experiment.group, "holdback")
     }
 
@@ -103,11 +103,11 @@ class LogLinkGlobalHoldbackExposureTest {
         )
         val state = createElementsState(PaymentMethodMetadataFactory.create())
 
-        logLinkGlobalHoldbackExposure(elementsSession, state)
+        logLinkHoldbackExperiment(elementsSession, state)
 
         val exposureCall = eventReporter.experimentExposureCalls.awaitItem()
 
-        assertTrue(exposureCall.experiment is LoggableExperiment.LinkGlobalHoldback)
+        assertTrue(exposureCall.experiment is LoggableExperiment.LinkHoldback)
         assertEquals(exposureCall.experiment.group, "control")
     }
 
@@ -125,7 +125,7 @@ class LogLinkGlobalHoldbackExposureTest {
         )
         val state = createElementsState(PaymentMethodMetadataFactory.create())
 
-        logLinkGlobalHoldbackExposure(elementsSession, state)
+        logLinkHoldbackExperiment(elementsSession, state)
 
         eventReporter.experimentExposureCalls.expectNoEvents()
     }
@@ -135,7 +135,7 @@ class LogLinkGlobalHoldbackExposureTest {
         val elementsSession = createElementsSession()
         val state = createElementsState(PaymentMethodMetadataFactory.create())
 
-        logLinkGlobalHoldbackExposure(elementsSession, state)
+        logLinkHoldbackExperiment(elementsSession, state)
 
         val loggedError = logger.errorLogs.first()
         assertEquals(
@@ -174,14 +174,14 @@ class LogLinkGlobalHoldbackExposureTest {
             )
         )
 
-        logLinkGlobalHoldbackExposure(elementsSession, state)
+        logLinkHoldbackExperiment(elementsSession, state)
 
         val lookupCall = linkRepository.awaitLookupWithoutBackendLogging()
         assertEquals(lookupCall.email, TestFactory.LINK_CONFIGURATION.customerInfo.email!!)
 
         val exposureCall = eventReporter.experimentExposureCalls.awaitItem()
         val experiment = exposureCall.experiment
-        assertTrue(experiment is LoggableExperiment.LinkGlobalHoldback)
+        assertTrue(experiment is LoggableExperiment.LinkHoldback)
         assertThat(experiment.group).isEqualTo("holdback")
         assertThat(experiment.isReturningLinkUser).isTrue()
     }
@@ -211,7 +211,7 @@ class LogLinkGlobalHoldbackExposureTest {
             IllegalArgumentException("Test exception")
         )
 
-        logLinkGlobalHoldbackExposure(elementsSession, state)
+        logLinkHoldbackExperiment(elementsSession, state)
 
         eventReporter.experimentExposureCalls.expectNoEvents()
         assertThat(logger.errorLogs.last().first).isEqualTo("Failed to log Global holdback exposure")
@@ -248,13 +248,13 @@ class LogLinkGlobalHoldbackExposureTest {
             )
         )
 
-        logLinkGlobalHoldbackExposure(elementsSession, state)
+        logLinkHoldbackExperiment(elementsSession, state)
 
         val lookupCall = linkRepository.awaitLookupWithoutBackendLogging()
         assertEquals(lookupCall.email, TestFactory.LINK_CONFIGURATION.customerInfo.email!!)
 
         val exposureCall = eventReporter.experimentExposureCalls.awaitItem()
-        assertTrue(exposureCall.experiment is LoggableExperiment.LinkGlobalHoldback)
+        assertTrue(exposureCall.experiment is LoggableExperiment.LinkHoldback)
         assertThat(exposureCall.experiment.group).isEqualTo("holdback")
         assertThat(exposureCall.experiment.isReturningLinkUser).isFalse()
     }
@@ -279,10 +279,10 @@ class LogLinkGlobalHoldbackExposureTest {
             )
         )
 
-        logLinkGlobalHoldbackExposure(elementsSession, state)
+        logLinkHoldbackExperiment(elementsSession, state)
 
         val exposureCall = eventReporter.experimentExposureCalls.awaitItem()
-        assertTrue(exposureCall.experiment is LoggableExperiment.LinkGlobalHoldback)
+        assertTrue(exposureCall.experiment is LoggableExperiment.LinkHoldback)
         assertThat(exposureCall.experiment.useLinkNative).isTrue()
     }
 
@@ -308,10 +308,10 @@ class LogLinkGlobalHoldbackExposureTest {
             )
         )
 
-        logLinkGlobalHoldbackExposure(elementsSession, state)
+        logLinkHoldbackExperiment(elementsSession, state)
 
         val exposureCall = eventReporter.experimentExposureCalls.awaitItem()
-        assertTrue(exposureCall.experiment is LoggableExperiment.LinkGlobalHoldback)
+        assertTrue(exposureCall.experiment is LoggableExperiment.LinkHoldback)
         assertThat(exposureCall.experiment.emailRecognitionSource).isEqualTo(EmailRecognitionSource.EMAIL)
     }
 
@@ -337,10 +337,10 @@ class LogLinkGlobalHoldbackExposureTest {
 
         val state = createElementsState(PaymentMethodMetadataFactory.create())
 
-        logLinkGlobalHoldbackExposure(elementsSession, state)
+        logLinkHoldbackExperiment(elementsSession, state)
 
         val exposureCall = eventReporter.experimentExposureCalls.awaitItem()
-        assertTrue(exposureCall.experiment is LoggableExperiment.LinkGlobalHoldback)
+        assertTrue(exposureCall.experiment is LoggableExperiment.LinkHoldback)
         assertThat(exposureCall.experiment.spmEnabled).isTrue()
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/common/analytics/experiment/LogLinkGlobalHoldbackExposureTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/analytics/experiment/LogLinkGlobalHoldbackExposureTest.kt
@@ -83,7 +83,11 @@ class LogLinkGlobalHoldbackExposureTest {
         )
         val state = createElementsState(PaymentMethodMetadataFactory.create())
 
-        logLinkHoldbackExperiment(elementsSession, state)
+        logLinkHoldbackExperiment(
+            experimentAssignment = LINK_GLOBAL_HOLD_BACK,
+            elementsSession = elementsSession,
+            state = state
+        )
 
         val exposureCall = eventReporter.experimentExposureCalls.awaitItem()
 
@@ -103,7 +107,11 @@ class LogLinkGlobalHoldbackExposureTest {
         )
         val state = createElementsState(PaymentMethodMetadataFactory.create())
 
-        logLinkHoldbackExperiment(elementsSession, state)
+        logLinkHoldbackExperiment(
+            experimentAssignment = LINK_GLOBAL_HOLD_BACK,
+            elementsSession = elementsSession,
+            state = state
+        )
 
         val exposureCall = eventReporter.experimentExposureCalls.awaitItem()
 
@@ -125,7 +133,11 @@ class LogLinkGlobalHoldbackExposureTest {
         )
         val state = createElementsState(PaymentMethodMetadataFactory.create())
 
-        logLinkHoldbackExperiment(elementsSession, state)
+        logLinkHoldbackExperiment(
+            experimentAssignment = LINK_GLOBAL_HOLD_BACK,
+            elementsSession = elementsSession,
+            state = state
+        )
 
         eventReporter.experimentExposureCalls.expectNoEvents()
     }
@@ -135,7 +147,11 @@ class LogLinkGlobalHoldbackExposureTest {
         val elementsSession = createElementsSession()
         val state = createElementsState(PaymentMethodMetadataFactory.create())
 
-        logLinkHoldbackExperiment(elementsSession, state)
+        logLinkHoldbackExperiment(
+            experimentAssignment = LINK_GLOBAL_HOLD_BACK,
+            elementsSession = elementsSession,
+            state = state
+        )
 
         val loggedError = logger.errorLogs.first()
         assertEquals(
@@ -174,7 +190,11 @@ class LogLinkGlobalHoldbackExposureTest {
             )
         )
 
-        logLinkHoldbackExperiment(elementsSession, state)
+        logLinkHoldbackExperiment(
+            experimentAssignment = LINK_GLOBAL_HOLD_BACK,
+            elementsSession = elementsSession,
+            state = state
+        )
 
         val lookupCall = linkRepository.awaitLookupWithoutBackendLogging()
         assertEquals(lookupCall.email, TestFactory.LINK_CONFIGURATION.customerInfo.email!!)
@@ -211,7 +231,11 @@ class LogLinkGlobalHoldbackExposureTest {
             IllegalArgumentException("Test exception")
         )
 
-        logLinkHoldbackExperiment(elementsSession, state)
+        logLinkHoldbackExperiment(
+            experimentAssignment = LINK_GLOBAL_HOLD_BACK,
+            elementsSession = elementsSession,
+            state = state
+        )
 
         eventReporter.experimentExposureCalls.expectNoEvents()
         assertThat(logger.errorLogs.last().first).isEqualTo("Failed to log Global holdback exposure")
@@ -248,7 +272,11 @@ class LogLinkGlobalHoldbackExposureTest {
             )
         )
 
-        logLinkHoldbackExperiment(elementsSession, state)
+        logLinkHoldbackExperiment(
+            experimentAssignment = LINK_GLOBAL_HOLD_BACK,
+            elementsSession = elementsSession,
+            state = state
+        )
 
         val lookupCall = linkRepository.awaitLookupWithoutBackendLogging()
         assertEquals(lookupCall.email, TestFactory.LINK_CONFIGURATION.customerInfo.email!!)
@@ -279,7 +307,11 @@ class LogLinkGlobalHoldbackExposureTest {
             )
         )
 
-        logLinkHoldbackExperiment(elementsSession, state)
+        logLinkHoldbackExperiment(
+            experimentAssignment = LINK_GLOBAL_HOLD_BACK,
+            elementsSession = elementsSession,
+            state = state
+        )
 
         val exposureCall = eventReporter.experimentExposureCalls.awaitItem()
         assertTrue(exposureCall.experiment is LoggableExperiment.LinkHoldback)
@@ -308,7 +340,11 @@ class LogLinkGlobalHoldbackExposureTest {
             )
         )
 
-        logLinkHoldbackExperiment(elementsSession, state)
+        logLinkHoldbackExperiment(
+            experimentAssignment = LINK_GLOBAL_HOLD_BACK,
+            elementsSession = elementsSession,
+            state = state
+        )
 
         val exposureCall = eventReporter.experimentExposureCalls.awaitItem()
         assertTrue(exposureCall.experiment is LoggableExperiment.LinkHoldback)
@@ -337,7 +373,11 @@ class LogLinkGlobalHoldbackExposureTest {
 
         val state = createElementsState(PaymentMethodMetadataFactory.create())
 
-        logLinkHoldbackExperiment(elementsSession, state)
+        logLinkHoldbackExperiment(
+            experimentAssignment = LINK_GLOBAL_HOLD_BACK,
+            elementsSession = elementsSession,
+            state = state
+        )
 
         val exposureCall = eventReporter.experimentExposureCalls.awaitItem()
         assertTrue(exposureCall.experiment is LoggableExperiment.LinkHoldback)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -16,6 +16,7 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.core.utils.DurationProvider
 import com.stripe.android.core.utils.UserFacingLogger
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.ElementsSession.ExperimentAssignment.LINK_GLOBAL_HOLD_BACK
 import com.stripe.android.model.LinkMode
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
@@ -665,6 +666,7 @@ class DefaultEventReporterTest {
             }
 
             val experiment = LoggableExperiment.LinkHoldback(
+                experiment = LINK_GLOBAL_HOLD_BACK,
                 arbId = "random_arb_id",
                 isReturningLinkUser = false,
                 group = "holdback",

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -6,7 +6,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.analytics.experiment.LoggableExperiment
-import com.stripe.android.common.analytics.experiment.LoggableExperiment.LinkGlobalHoldback.EmailRecognitionSource
+import com.stripe.android.common.analytics.experiment.LoggableExperiment.LinkHoldback.EmailRecognitionSource
 import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.core.exception.APIException
 import com.stripe.android.core.networking.AnalyticsRequest
@@ -664,13 +664,13 @@ class DefaultEventReporterTest {
                 simulateSuccessfulSetup()
             }
 
-            val experiment = LoggableExperiment.LinkGlobalHoldback(
+            val experiment = LoggableExperiment.LinkHoldback(
                 arbId = "random_arb_id",
                 isReturningLinkUser = false,
                 group = "holdback",
                 useLinkNative = true,
                 emailRecognitionSource = EmailRecognitionSource.EMAIL,
-                providedDefaultValues = LoggableExperiment.LinkGlobalHoldback.ProvidedDefaultValues(
+                providedDefaultValues = LoggableExperiment.LinkHoldback.ProvidedDefaultValues(
                     email = true,
                     name = false,
                     phone = true,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeLogLinkHoldbackExperiment.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeLogLinkHoldbackExperiment.kt
@@ -12,6 +12,7 @@ internal class FakeLogLinkHoldbackExperiment : LogLinkHoldbackExperiment {
     val calls: ReceiveTurbine<Unit> = _calls
 
     override fun invoke(
+        experiment: ElementsSession.ExperimentAssignment,
         elementsSession: ElementsSession,
         state: PaymentElementLoader.State
     ) {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeLogLinkHoldbackExperiment.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeLogLinkHoldbackExperiment.kt
@@ -2,11 +2,11 @@ package com.stripe.android.paymentsheet.analytics
 
 import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
-import com.stripe.android.common.analytics.experiment.LogLinkGlobalHoldbackExposure
+import com.stripe.android.common.analytics.experiment.LogLinkHoldbackExperiment
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 
-internal class FakeLogLinkGlobalHoldbackExposure : LogLinkGlobalHoldbackExposure {
+internal class FakeLogLinkHoldbackExperiment : LogLinkHoldbackExperiment {
 
     private val _calls = Turbine<Unit>()
     val calls: ReceiveTurbine<Unit> = _calls

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeLogLinkHoldbackExperiment.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeLogLinkHoldbackExperiment.kt
@@ -8,14 +8,22 @@ import com.stripe.android.paymentsheet.state.PaymentElementLoader
 
 internal class FakeLogLinkHoldbackExperiment : LogLinkHoldbackExperiment {
 
-    private val _calls = Turbine<Unit>()
-    val calls: ReceiveTurbine<Unit> = _calls
+    private val _calls = Turbine<ExperimentCall>()
+    val calls: ReceiveTurbine<ExperimentCall> = _calls
 
     override fun invoke(
         experiment: ElementsSession.ExperimentAssignment,
         elementsSession: ElementsSession,
         state: PaymentElementLoader.State
     ) {
-        _calls.add(Unit)
+        _calls.add(
+            ExperimentCall(
+                experiment = experiment
+            )
+        )
     }
 }
+
+data class ExperimentCall(
+    val experiment: ElementsSession.ExperimentAssignment
+)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -42,7 +42,7 @@ import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.PaymentSheetFixtures.MERCHANT_DISPLAY_NAME
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.analytics.EventReporter
-import com.stripe.android.paymentsheet.analytics.FakeLogLinkGlobalHoldbackExposure
+import com.stripe.android.paymentsheet.analytics.FakeLogLinkHoldbackExperiment
 import com.stripe.android.paymentsheet.cvcrecollection.CvcRecollectionHandlerImpl
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
@@ -3172,7 +3172,7 @@ internal class DefaultPaymentElementLoaderTest {
             externalPaymentMethodsRepository = ExternalPaymentMethodsRepository(errorReporter = FakeErrorReporter()),
             userFacingLogger = userFacingLogger,
             cvcRecollectionHandler = CvcRecollectionHandlerImpl(),
-            logLinkGlobalHoldbackExposure = FakeLogLinkGlobalHoldbackExposure(),
+            logLinkHoldbackExperiment = FakeLogLinkHoldbackExperiment(),
             retrieveCustomerEmail = DefaultRetrieveCustomerEmail(customerRepo)
         )
     }


### PR DESCRIPTION
# Summary

- Adds exposure logging for a new experiment, `link_ab_test`. It has the same dimensions as `link_global_holdback`.
- For that now `LogLinkExposure` accepts an experiment name, and `PaymentElementLoader` attempts to log both the global holdback and the ab test, if assignment took place.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
