### PR TITLE
Enable default opt-in for Link inline signup

### DIFF
--- a/payments-model/src/main/java/com/stripe/android/model/ConsumerSignUpConsentAction.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/ConsumerSignUpConsentAction.kt
@@ -11,6 +11,8 @@ enum class ConsumerSignUpConsentAction(val value: String) {
     Implied("implied_consent_withspm_mobile_v0"),
     ImpliedWithPrefilledEmail("implied_consent_withspm_mobile_v0_0"),
     PrecheckedOptInBoxPrefilledAll("prechecked_opt_in_box_prefilled_all"),
+    PrecheckedOptInBoxPrefilledSome("prechecked_opt_in_box_prefilled_some"),
+    PrecheckedOptInBoxPrefilledNone("prechecked_opt_in_box_prefilled_none"),
 
     // Financial Connections
     EnteredPhoneNumberClickedSaveToLink("entered_phone_number_clicked_save_to_link"),

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -452,7 +452,6 @@ internal class PlaygroundSettings private constructor(
             CardBrandAcceptanceSettingsDefinition,
             FeatureFlagSettingsDefinition(FeatureFlags.instantDebitsIncentives),
             FeatureFlagSettingsDefinition(FeatureFlags.financialConnectionsFullSdkUnavailable),
-            FeatureFlagSettingsDefinition(FeatureFlags.linkDefaultOptIn),
             EmbeddedViewDisplaysMandateSettingDefinition,
             EmbeddedFormSheetActionSettingDefinition,
             EmbeddedTwoStepSettingsDefinition,

--- a/paymentsheet/src/androidTest/resources/elements-sessions-requires_payment_method.json
+++ b/paymentsheet/src/androidTest/resources/elements-sessions-requires_payment_method.json
@@ -41,6 +41,7 @@
     "link_financial_incentives_experiment_enabled": false,
     "link_funding_sources": ["CARD"],
     "link_local_storage_login_enabled": false,
+    "link_mobile_disable_default_opt_in": true,
     "link_m2_default_integration_enabled": true,
     "link_only_for_payment_method_types_enabled": false,
     "link_passthrough_mode_enabled": false,

--- a/paymentsheet/src/androidTest/resources/elements-sessions-requires_pm_with_link_ps_mode.json
+++ b/paymentsheet/src/androidTest/resources/elements-sessions-requires_pm_with_link_ps_mode.json
@@ -41,6 +41,7 @@
     "link_financial_incentives_experiment_enabled": false,
     "link_funding_sources": ["CARD"],
     "link_local_storage_login_enabled": false,
+    "link_mobile_disable_default_opt_in": true,
     "link_m2_default_integration_enabled": true,
     "link_only_for_payment_method_types_enabled": false,
     "link_passthrough_mode_enabled": true,

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
@@ -465,7 +465,11 @@ internal class DefaultLinkAccountManager @Inject constructor(
                 ConsumerSignUpConsentAction.Implied
             SignUpConsentAction.ImpliedWithPrefilledEmail ->
                 ConsumerSignUpConsentAction.ImpliedWithPrefilledEmail
-            SignUpConsentAction.DefaultOptIn ->
+            SignUpConsentAction.DefaultOptInWithAllPrefilled ->
                 ConsumerSignUpConsentAction.PrecheckedOptInBoxPrefilledAll
+            SignUpConsentAction.DefaultOptInWithSomePrefilled ->
+                ConsumerSignUpConsentAction.PrecheckedOptInBoxPrefilledSome
+            SignUpConsentAction.DefaultOptInWithNonePrefilled ->
+                ConsumerSignUpConsentAction.PrecheckedOptInBoxPrefilledNone
         }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/inline/InlineSignupViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/inline/InlineSignupViewModel.kt
@@ -333,8 +333,15 @@ internal class InlineSignupViewModel(
             }
             LinkSignupMode.InsteadOfSaveForFutureUse -> {
                 when {
-                    defaultOptIn ->
-                        SignUpConsentAction.DefaultOptIn
+                    defaultOptIn -> {
+                        if (hasPrefilledEmail && hasPrefilledPhone) {
+                            SignUpConsentAction.DefaultOptInWithAllPrefilled
+                        } else if (hasPrefilledEmail || hasPrefilledPhone) {
+                            SignUpConsentAction.DefaultOptInWithSomePrefilled
+                        } else {
+                            SignUpConsentAction.DefaultOptInWithNonePrefilled
+                        }
+                    }
                     hasPrefilledEmail && hasPrefilledPhone ->
                         SignUpConsentAction.CheckboxWithPrefilledEmailAndPhone
                     hasPrefilledEmail ->

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/inline/InlineSignupViewState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/inline/InlineSignupViewState.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.link.ui.inline
 
 import androidx.annotation.VisibleForTesting
-import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.ui.signup.SignUpState
 import com.stripe.android.link.ui.signup.requiresNameCollection
@@ -100,9 +99,8 @@ constructor(
                 }
             }
 
-            val allowsDefaultOptIn = FeatureFlags.linkDefaultOptIn.isEnabled &&
+            val allowsDefaultOptIn = config.allowDefaultOptIn &&
                 config.stripeIntent.countryCode == "US" &&
-                config.allowDefaultOptIn &&
                 signupMode == LinkSignupMode.InsteadOfSaveForFutureUse
 
             val missingDataForDefaultOptIn = initialEmail.isNullOrBlank() || initialPhone.isNullOrBlank()

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/inline/SignUpConsentAction.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/inline/SignUpConsentAction.kt
@@ -6,5 +6,7 @@ internal enum class SignUpConsentAction {
     CheckboxWithPrefilledEmailAndPhone,
     Implied,
     ImpliedWithPrefilledEmail,
-    DefaultOptIn,
+    DefaultOptInWithAllPrefilled,
+    DefaultOptInWithSomePrefilled,
+    DefaultOptInWithNonePrefilled,
 }

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/inline/InlineSignupViewStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/inline/InlineSignupViewStateTest.kt
@@ -1,21 +1,12 @@
 package com.stripe.android.link.ui.inline
 
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.TestFactory
-import com.stripe.android.testing.FeatureFlagTestRule
 import com.stripe.android.testing.PaymentIntentFactory
-import org.junit.Rule
 import org.junit.Test
 
 class InlineSignupViewStateTest {
-
-    @get:Rule
-    val defaultOptInRule = FeatureFlagTestRule(
-        featureFlag = FeatureFlags.linkDefaultOptIn,
-        isEnabled = false,
-    )
 
     @Test
     fun `Allows full prefill if showing instead of save-for-future-use for US customers`() {
@@ -88,10 +79,9 @@ class InlineSignupViewStateTest {
     }
 
     @Test
-    fun `Allows default opt-in for eligible users if feature flag is turned on`() {
+    fun `Allows default opt-in for eligible users`() {
         testDefaultOptInAllowed(
             countryCode = "US",
-            featureFlagEnabled = true,
             signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
             merchantEligible = true,
             expectedResult = true
@@ -102,7 +92,6 @@ class InlineSignupViewStateTest {
     fun `Disables default opt-in if showing the save-future-use checkbox`() {
         testDefaultOptInAllowed(
             countryCode = "US",
-            featureFlagEnabled = false,
             signupMode = LinkSignupMode.AlongsideSaveForFutureUse,
             merchantEligible = true,
             expectedResult = false
@@ -113,7 +102,6 @@ class InlineSignupViewStateTest {
     fun `Disables default opt-in if outside US`() {
         testDefaultOptInAllowed(
             countryCode = "CA",
-            featureFlagEnabled = true,
             signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
             merchantEligible = true,
             expectedResult = false
@@ -124,7 +112,6 @@ class InlineSignupViewStateTest {
     fun `Disables default opt-in if merchant is not eligible`() {
         testDefaultOptInAllowed(
             countryCode = "US",
-            featureFlagEnabled = false,
             signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
             merchantEligible = false,
             expectedResult = false
@@ -132,20 +119,7 @@ class InlineSignupViewStateTest {
     }
 
     @Test
-    fun `Disables default opt-in for eligible users if feature flag is turned off`() {
-        testDefaultOptInAllowed(
-            countryCode = "US",
-            featureFlagEnabled = false,
-            signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
-            merchantEligible = true,
-            expectedResult = false
-        )
-    }
-
-    @Test
     fun `Uses Link if using default opt-in and all fields filled out`() {
-        defaultOptInRule.setEnabled(true)
-
         val linkConfig = createLinkConfig(
             countryCode = "US",
             allowsDefaultOptIn = true,
@@ -160,7 +134,7 @@ class InlineSignupViewStateTest {
                 phone = "5555555555",
                 name = null,
                 country = "US",
-                consentAction = SignUpConsentAction.DefaultOptIn,
+                consentAction = SignUpConsentAction.DefaultOptInWithAllPrefilled,
             )
         )
 
@@ -169,8 +143,6 @@ class InlineSignupViewStateTest {
 
     @Test
     fun `Does not use Link if using default opt-in but not filling out all fields`() {
-        defaultOptInRule.setEnabled(true)
-
         val linkConfig = createLinkConfig(
             countryCode = "US",
             allowsDefaultOptIn = true,
@@ -188,13 +160,10 @@ class InlineSignupViewStateTest {
 
     private fun testDefaultOptInAllowed(
         countryCode: String,
-        featureFlagEnabled: Boolean,
         signupMode: LinkSignupMode,
         merchantEligible: Boolean,
         expectedResult: Boolean,
     ) {
-        defaultOptInRule.setEnabled(featureFlagEnabled)
-
         val linkConfig = createLinkConfig(
             countryCode = countryCode,
             allowsDefaultOptIn = merchantEligible,

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/inline/LinkInlineSignupScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/inline/LinkInlineSignupScreenshotTest.kt
@@ -4,12 +4,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.link.ui.signup.SignUpState
 import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
 import com.stripe.android.screenshottesting.SystemAppearance
-import com.stripe.android.testing.FeatureFlagTestRule
 import com.stripe.android.testing.LocaleTestRule
 import com.stripe.android.uicore.elements.EmailConfig
 import com.stripe.android.uicore.elements.NameConfig
@@ -30,12 +28,6 @@ class LinkInlineSignupScreenshotTest {
 
     @get:Rule
     val localeRule = LocaleTestRule(Locale.US)
-
-    @get:Rule
-    val defaultOptInRule = FeatureFlagTestRule(
-        featureFlag = FeatureFlags.linkDefaultOptIn,
-        isEnabled = false,
-    )
 
     @Test
     fun testCollapsed() {
@@ -144,8 +136,6 @@ class LinkInlineSignupScreenshotTest {
 
     @Test
     fun testDefaultOptIn() {
-        defaultOptInRule.setEnabled(true)
-
         val emailController = EmailConfig.createController("email@email.com", showOptionalLabel = true)
         val phoneNumberController = PhoneNumberController.createPhoneNumberController(initialValue = "5555555555")
         val nameController = NameConfig.createController(initialValue = null)
@@ -181,8 +171,6 @@ class LinkInlineSignupScreenshotTest {
 
     @Test
     fun testDefaultOptInWithPartialValues() {
-        defaultOptInRule.setEnabled(true)
-
         val emailController = EmailConfig.createController("email@email.com", showOptionalLabel = true)
         val phoneNumberController = PhoneNumberController.createPhoneNumberController(initialValue = "")
         val nameController = NameConfig.createController(initialValue = null)
@@ -218,8 +206,6 @@ class LinkInlineSignupScreenshotTest {
 
     @Test
     fun testDefaultOptInAfterChangingSignupData() {
-        defaultOptInRule.setEnabled(true)
-
         val emailController = EmailConfig.createController("email@email.com", showOptionalLabel = true)
         val phoneNumberController = PhoneNumberController.createPhoneNumberController(initialValue = "5555555555")
         val nameController = NameConfig.createController(initialValue = null)

--- a/stripe-core/src/main/java/com/stripe/android/core/utils/FeatureFlags.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/FeatureFlags.kt
@@ -11,7 +11,6 @@ object FeatureFlags {
     val instantDebitsIncentives = FeatureFlag("Instant Bank Payments Incentives")
     val financialConnectionsFullSdkUnavailable = FeatureFlag("FC Full SDK Unavailable")
     val linkProminenceInFlowController = FeatureFlag("Link Prominence in FlowController")
-    val linkDefaultOptIn = FeatureFlag("Link Default Opt-In")
 }
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request enables default opt-in for Link inline signup in production.



# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
