### PR TITLE
Pass `Modifier` to all `SectionFieldComposable` elements

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
@@ -135,7 +135,8 @@ internal class CardDetailsController(
             enabled,
             this,
             hiddenIdentifiers,
-            lastTextFieldIdentifier
+            lastTextFieldIdentifier,
+            modifier = modifier,
         )
     }
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElementUI.kt
@@ -17,7 +17,8 @@ internal fun CardDetailsElementUI(
     enabled: Boolean,
     controller: CardDetailsController,
     hiddenIdentifiers: Set<IdentifierSpec>,
-    lastTextFieldIdentifier: IdentifierSpec?
+    lastTextFieldIdentifier: IdentifierSpec?,
+    modifier: Modifier = Modifier,
 ) {
     controller.fields.forEachIndexed { index, field ->
         // We need to adjust the focus direction, because some devices (Samsung, OnePlus) will
@@ -33,6 +34,7 @@ internal fun CardDetailsElementUI(
         SectionFieldElementUI(
             enabled,
             field,
+            modifier = modifier,
             hiddenIdentifiers = hiddenIdentifiers,
             lastTextFieldIdentifier = lastTextFieldIdentifier,
             nextFocusDirection = nextFocusDirection

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressController.kt
@@ -43,7 +43,8 @@ class AddressController(
             enabled,
             this,
             hiddenIdentifiers,
-            lastTextFieldIdentifier
+            lastTextFieldIdentifier,
+            modifier,
         )
     }
 }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressElementUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressElementUI.kt
@@ -19,7 +19,8 @@ fun AddressElementUI(
     enabled: Boolean,
     controller: AddressController,
     hiddenIdentifiers: Set<IdentifierSpec>,
-    lastTextFieldIdentifier: IdentifierSpec?
+    lastTextFieldIdentifier: IdentifierSpec?,
+    modifier: Modifier = Modifier,
 ) {
     val fields by controller.fieldsFlowable.collectAsState()
 
@@ -32,7 +33,8 @@ fun AddressElementUI(
                     enabled,
                     field,
                     hiddenIdentifiers = hiddenIdentifiers,
-                    lastTextFieldIdentifier = lastTextFieldIdentifier
+                    lastTextFieldIdentifier = lastTextFieldIdentifier,
+                    modifier = modifier,
                 )
                 if (index != fieldList.lastIndex) {
                     Divider(

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldController.kt
@@ -118,7 +118,7 @@ class AddressTextFieldController(
         nextFocusDirection: FocusDirection,
         previousFocusDirection: FocusDirection
     ) {
-        AddressTextFieldUI(this)
+        AddressTextFieldUI(this, modifier)
     }
 
     fun launchAutocompleteScreen() {

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldUI.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.text.input.ImeAction
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun AddressTextFieldUI(
     controller: AddressTextFieldController,
+    modifier: Modifier = Modifier,
     onClick: () -> Unit = {
         controller.launchAutocompleteScreen()
     }
@@ -18,7 +19,7 @@ fun AddressTextFieldUI(
         textFieldController = controller,
         imeAction = ImeAction.Next,
         enabled = false,
-        modifier = Modifier.clickable {
+        modifier = modifier.clickable {
             onClick()
         }
     )

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DropdownFieldController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DropdownFieldController.kt
@@ -79,7 +79,8 @@ class DropdownFieldController(
     ) {
         DropDown(
             this,
-            enabled
+            enabled,
+            modifier = modifier,
         )
     }
 }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberController.kt
@@ -188,6 +188,7 @@ class PhoneNumberController private constructor(
         PhoneNumberElementUI(
             enabled,
             this,
+            modifier = modifier,
             imeAction = if (lastTextFieldIdentifier != field.identifier) {
                 ImeAction.Next
             } else {

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/RowController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/RowController.kt
@@ -31,7 +31,8 @@ class RowController(
             enabled,
             this,
             hiddenIdentifiers,
-            lastTextFieldIdentifier
+            lastTextFieldIdentifier,
+            modifier = modifier,
         )
     }
 }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/RowElementUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/RowElementUI.kt
@@ -26,7 +26,8 @@ fun RowElementUI(
     enabled: Boolean,
     controller: RowController,
     hiddenIdentifiers: Set<IdentifierSpec>,
-    lastTextFieldIdentifier: IdentifierSpec?
+    lastTextFieldIdentifier: IdentifierSpec?,
+    modifier: Modifier = Modifier,
 ) {
     val visibleFields = controller.fields.filter { !hiddenIdentifiers.contains(it.identifier) }
     val dividerHeight = remember { mutableStateOf(0.dp) }
@@ -57,7 +58,7 @@ fun RowElementUI(
                     field,
                     hiddenIdentifiers = hiddenIdentifiers,
                     lastTextFieldIdentifier = lastTextFieldIdentifier,
-                    modifier = Modifier
+                    modifier = modifier
                         .weight(1.0f / visibleFields.size.toFloat())
                         .onSizeChanged {
                             dividerHeight.value =


### PR DESCRIPTION
# Summary
Pass `Modifier` to all `SectionFieldComposable` elements

# Motivation
We have a bunch of places where the `Modifier` is not passed through to our elements implementing `SectionFieldComposable`. Any modifications to padding that are expected to be applied are then not. Doing this fixes that.

Need to make this change to better support adding custom insets to elements 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

The tests should catch any changes that occur from passing these modifiers. There shouldn't be any changes now but potentially can happen in the future.