### PR TITLE
Update PaymentElement horizontal padding

### DIFF
--- a/paymentsheet/res/layout/stripe_fragment_primary_button_container.xml
+++ b/paymentsheet/res/layout/stripe_fragment_primary_button_container.xml
@@ -9,8 +9,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/stripe_paymentsheet_button_container_spacing"
-        android:layout_marginStart="@dimen/stripe_paymentsheet_outer_spacing_horizontal"
-        android:layout_marginEnd="@dimen/stripe_paymentsheet_outer_spacing_horizontal"
         android:text="@string/stripe_paymentsheet_pay_button_label"
         android:visibility="gone" />
 </FrameLayout>

--- a/paymentsheet/res/values/dimens.xml
+++ b/paymentsheet/res/values/dimens.xml
@@ -6,7 +6,6 @@
     <dimen name="stripe_paymentsheet_paymentmethod_icon_height">64dp</dimen>
     <dimen name="stripe_paymentsheet_paymentmethod_icon_width">100dp</dimen>
     <dimen name="stripe_paymentsheet_outer_spacing_top">10dp</dimen>
-    <dimen name="stripe_paymentsheet_outer_spacing_horizontal">20dp</dimen>
     <dimen name="stripe_paymentsheet_button_container_spacing">10dp</dimen>
     <dimen name="stripe_paymentsheet_button_container_spacing_bottom">40dp</dimen>
     <dimen name="stripe_paymentsheet_primary_button_padding">4dp</dimen>

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
@@ -39,7 +39,7 @@ import com.stripe.android.ui.core.elements.events.CardNumberCompletedEventReport
 import com.stripe.android.ui.core.elements.events.LocalCardBrandDisallowedReporter
 import com.stripe.android.ui.core.elements.events.LocalCardNumberCompletedEventReporter
 import com.stripe.android.uicore.StripeTheme
-import com.stripe.android.uicore.getHorizontalPaddingValues
+import com.stripe.android.uicore.getOuterFormInsets
 import com.stripe.android.uicore.strings.resolve
 import com.stripe.android.uicore.utils.collectAsState
 import com.stripe.android.R as PaymentsCoreR
@@ -122,7 +122,7 @@ internal fun SelectPaymentMethod(
     paymentMethodNameProvider: (PaymentMethodCode?) -> ResolvableString,
     modifier: Modifier = Modifier,
 ) {
-    val horizontalPadding = StripeTheme.getHorizontalPaddingValues()
+    val horizontalPadding = StripeTheme.getOuterFormInsets()
 
     Column(
         modifier = modifier
@@ -198,7 +198,7 @@ internal fun AddPaymentMethod(
     viewActionHandler: (CustomerSheetViewAction) -> Unit,
     displayForm: Boolean,
 ) {
-    val horizontalPadding = StripeTheme.getHorizontalPaddingValues()
+    val horizontalPadding = StripeTheme.getOuterFormInsets()
 
     if (viewState.displayDismissConfirmationModal) {
         SimpleDialogElementUI(
@@ -310,7 +310,7 @@ private fun UpdatePaymentMethod(
     viewState: CustomerSheetViewState.UpdatePaymentMethod,
     modifier: Modifier = Modifier,
 ) {
-    val horizontalPadding = StripeTheme.getHorizontalPaddingValues()
+    val horizontalPadding = StripeTheme.getOuterFormInsets()
 
     Column(modifier) {
         viewState.updatePaymentMethodInteractor.screenTitle?.let {

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
@@ -300,6 +300,7 @@ internal fun AddPaymentMethod(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(top = 8.dp)
+                .padding(horizontalPadding)
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.stripe.android.common.ui.BottomSheetLoadingIndicator
@@ -39,6 +38,8 @@ import com.stripe.android.ui.core.elements.events.CardBrandDisallowedReporter
 import com.stripe.android.ui.core.elements.events.CardNumberCompletedEventReporter
 import com.stripe.android.ui.core.elements.events.LocalCardBrandDisallowedReporter
 import com.stripe.android.ui.core.elements.events.LocalCardNumberCompletedEventReporter
+import com.stripe.android.uicore.StripeTheme
+import com.stripe.android.uicore.getHorizontalPaddingValues
 import com.stripe.android.uicore.strings.resolve
 import com.stripe.android.uicore.utils.collectAsState
 import com.stripe.android.R as PaymentsCoreR
@@ -121,7 +122,7 @@ internal fun SelectPaymentMethod(
     paymentMethodNameProvider: (PaymentMethodCode?) -> ResolvableString,
     modifier: Modifier = Modifier,
 ) {
-    val horizontalPadding = dimensionResource(R.dimen.stripe_paymentsheet_outer_spacing_horizontal)
+    val horizontalPadding = StripeTheme.getHorizontalPaddingValues()
 
     Column(
         modifier = modifier
@@ -132,7 +133,7 @@ internal fun SelectPaymentMethod(
             ),
             modifier = Modifier
                 .padding(bottom = 20.dp)
-                .padding(horizontal = horizontalPadding)
+                .padding(horizontalPadding)
         )
 
         val paymentOptionsState = PaymentOptionsStateFactory.create(
@@ -161,7 +162,7 @@ internal fun SelectPaymentMethod(
                 error = error,
                 modifier = Modifier
                     .padding(vertical = 2.dp)
-                    .padding(horizontal = horizontalPadding),
+                    .padding(horizontalPadding),
             )
         }
 
@@ -176,7 +177,7 @@ internal fun SelectPaymentMethod(
                 modifier = Modifier
                     .testTag(CUSTOMER_SHEET_CONFIRM_BUTTON_TEST_TAG)
                     .padding(top = 20.dp)
-                    .padding(horizontal = horizontalPadding),
+                    .padding(horizontalPadding),
             )
         }
 
@@ -185,7 +186,7 @@ internal fun SelectPaymentMethod(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(top = 8.dp)
-                .padding(horizontal = horizontalPadding),
+                .padding(horizontalPadding),
         )
     }
 }
@@ -197,7 +198,7 @@ internal fun AddPaymentMethod(
     viewActionHandler: (CustomerSheetViewAction) -> Unit,
     displayForm: Boolean,
 ) {
-    val horizontalPadding = dimensionResource(R.dimen.stripe_paymentsheet_outer_spacing_horizontal)
+    val horizontalPadding = StripeTheme.getHorizontalPaddingValues()
 
     if (viewState.displayDismissConfirmationModal) {
         SimpleDialogElementUI(
@@ -220,7 +221,7 @@ internal fun AddPaymentMethod(
         text = stringResource(id = R.string.stripe_paymentsheet_save_a_new_payment_method),
         modifier = Modifier
             .padding(bottom = 4.dp)
-            .padding(horizontal = horizontalPadding)
+            .padding(horizontalPadding)
     )
 
     val eventReporter = remember(viewActionHandler) {
@@ -261,7 +262,7 @@ internal fun AddPaymentMethod(
     viewState.errorMessage?.let { error ->
         ErrorMessage(
             error = error.resolve(),
-            modifier = Modifier.padding(horizontal = horizontalPadding)
+            modifier = Modifier.padding(horizontalPadding)
         )
     }
 
@@ -275,7 +276,7 @@ internal fun AddPaymentMethod(
                         8.dp
                     } ?: 0.dp
                 )
-                .padding(horizontal = horizontalPadding),
+                .padding(horizontalPadding),
         )
     }
 
@@ -290,7 +291,7 @@ internal fun AddPaymentMethod(
         modifier = Modifier
             .testTag(CUSTOMER_SHEET_SAVE_BUTTON_TEST_TAG)
             .padding(top = 10.dp)
-            .padding(horizontal = horizontalPadding),
+            .padding(horizontalPadding),
     )
 
     if (!viewState.showMandateAbovePrimaryButton) {
@@ -299,7 +300,6 @@ internal fun AddPaymentMethod(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(top = 8.dp)
-                .padding(horizontal = horizontalPadding),
         )
     }
 }
@@ -309,7 +309,7 @@ private fun UpdatePaymentMethod(
     viewState: CustomerSheetViewState.UpdatePaymentMethod,
     modifier: Modifier = Modifier,
 ) {
-    val horizontalPadding = dimensionResource(R.dimen.stripe_paymentsheet_outer_spacing_horizontal)
+    val horizontalPadding = StripeTheme.getHorizontalPaddingValues()
 
     Column(modifier) {
         viewState.updatePaymentMethodInteractor.screenTitle?.let {
@@ -317,7 +317,7 @@ private fun UpdatePaymentMethod(
                 text = it.resolve(),
                 modifier = Modifier
                     .padding(bottom = 20.dp)
-                    .padding(horizontal = horizontalPadding)
+                    .padding(horizontalPadding)
             )
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityUI.kt
@@ -3,7 +3,6 @@ package com.stripe.android.paymentelement.embedded.form
 import androidx.annotation.RestrictTo
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.Icon

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityUI.kt
@@ -135,7 +135,7 @@ internal fun FormActivityTopBar(
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(StripeTheme.getHorizontalPaddingValues()),
+            .padding(start = StripeTheme.formInsets.start.dp),
         contentAlignment = Alignment.CenterStart
     ) {
         if (!isLiveMode) {
@@ -144,7 +144,7 @@ internal fun FormActivityTopBar(
         IconButton(
             enabled = true,
             onClick = onDismissed,
-            modifier = Modifier.align(Alignment.CenterEnd).offset(16.dp)
+            modifier = Modifier.align(Alignment.CenterEnd)
         ) {
             Icon(
                 painter = painterResource(R.drawable.stripe_ic_paymentsheet_close),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityUI.kt
@@ -29,7 +29,7 @@ import com.stripe.android.paymentsheet.verticalmode.DefaultVerticalModeFormInter
 import com.stripe.android.paymentsheet.verticalmode.VerticalModeFormUI
 import com.stripe.android.ui.core.elements.Mandate
 import com.stripe.android.uicore.StripeTheme
-import com.stripe.android.uicore.getHorizontalPaddingValues
+import com.stripe.android.uicore.getOuterFormInsets
 import com.stripe.android.uicore.strings.resolve
 import com.stripe.android.uicore.stripeColors
 import com.stripe.android.uicore.utils.collectAsState
@@ -85,7 +85,7 @@ internal fun USBankAccountMandate(
             mandateText = it.resolve(),
             modifier = Modifier
                 .padding(vertical = 8.dp)
-                .padding(StripeTheme.getHorizontalPaddingValues())
+                .padding(StripeTheme.getOuterFormInsets())
         )
     }
 }
@@ -99,7 +99,7 @@ internal fun FormActivityError(
             error = it.resolve(),
             modifier = Modifier
                 .padding(vertical = 8.dp)
-                .padding(StripeTheme.getHorizontalPaddingValues())
+                .padding(StripeTheme.getOuterFormInsets())
         )
     }
 }
@@ -111,7 +111,7 @@ internal fun FormActivityPrimaryButton(
     onClick: () -> Unit,
 ) {
     Box(
-        modifier = Modifier.padding(StripeTheme.getHorizontalPaddingValues())
+        modifier = Modifier.padding(StripeTheme.getOuterFormInsets())
     ) {
         PrimaryButton(
             modifier = Modifier.testTag(EMBEDDED_FORM_ACTIVITY_PRIMARY_BUTTON),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityUI.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentelement.embedded.form
 import androidx.annotation.RestrictTo
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.Icon
@@ -143,7 +144,7 @@ internal fun FormActivityTopBar(
         IconButton(
             enabled = true,
             onClick = onDismissed,
-            modifier = Modifier.align(Alignment.CenterEnd)
+            modifier = Modifier.align(Alignment.CenterEnd).offset(16.dp)
         ) {
             Icon(
                 painter = painterResource(R.drawable.stripe_ic_paymentsheet_close),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityUI.kt
@@ -13,7 +13,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -29,6 +28,8 @@ import com.stripe.android.paymentsheet.utils.PaymentSheetContentPadding
 import com.stripe.android.paymentsheet.verticalmode.DefaultVerticalModeFormInteractor
 import com.stripe.android.paymentsheet.verticalmode.VerticalModeFormUI
 import com.stripe.android.ui.core.elements.Mandate
+import com.stripe.android.uicore.StripeTheme
+import com.stripe.android.uicore.getHorizontalPaddingValues
 import com.stripe.android.uicore.strings.resolve
 import com.stripe.android.uicore.stripeColors
 import com.stripe.android.uicore.utils.collectAsState
@@ -83,12 +84,8 @@ internal fun USBankAccountMandate(
         Mandate(
             mandateText = it.resolve(),
             modifier = Modifier
-                .padding(
-                    horizontal = dimensionResource(
-                        id = R.dimen.stripe_paymentsheet_outer_spacing_horizontal
-                    ),
-                    vertical = 8.dp
-                )
+                .padding(vertical = 8.dp)
+                .padding(StripeTheme.getHorizontalPaddingValues())
         )
     }
 }
@@ -101,12 +98,8 @@ internal fun FormActivityError(
         ErrorMessage(
             error = it.resolve(),
             modifier = Modifier
-                .padding(
-                    horizontal = dimensionResource(
-                        id = R.dimen.stripe_paymentsheet_outer_spacing_horizontal
-                    ),
-                    vertical = 8.dp
-                )
+                .padding(vertical = 8.dp)
+                .padding(StripeTheme.getHorizontalPaddingValues())
         )
     }
 }
@@ -118,10 +111,7 @@ internal fun FormActivityPrimaryButton(
     onClick: () -> Unit,
 ) {
     Box(
-        modifier = Modifier
-            .padding(
-                horizontal = dimensionResource(id = R.dimen.stripe_paymentsheet_outer_spacing_horizontal),
-            )
+        modifier = Modifier.padding(StripeTheme.getHorizontalPaddingValues())
     ) {
         PrimaryButton(
             modifier = Modifier.testTag(EMBEDDED_FORM_ACTIVITY_PRIMARY_BUTTON),
@@ -144,9 +134,7 @@ internal fun FormActivityTopBar(
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(
-                start = dimensionResource(id = R.dimen.stripe_paymentsheet_outer_spacing_horizontal)
-            ),
+            .padding(StripeTheme.getHorizontalPaddingValues()),
         contentAlignment = Alignment.CenterStart
     ) {
         if (!isLiveMode) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/ManageActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/ManageActivity.kt
@@ -19,18 +19,17 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.unit.dp
 import com.stripe.android.common.ui.BottomSheetScaffold
 import com.stripe.android.common.ui.ElementsBottomSheetLayout
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentsheet.CustomerStateHolder
-import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.ui.PaymentSheetTopBar
 import com.stripe.android.paymentsheet.utils.renderEdgeToEdge
 import com.stripe.android.ui.core.elements.H4Text
 import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.elements.bottomsheet.rememberStripeBottomSheetState
+import com.stripe.android.uicore.getHorizontalPaddingValues
 import com.stripe.android.uicore.strings.resolve
 import com.stripe.android.uicore.utils.collectAsState
 import com.stripe.android.uicore.utils.fadeOut
@@ -128,7 +127,7 @@ internal class ManageActivity : AppCompatActivity() {
                 )
             },
             content = {
-                val horizontalPadding = dimensionResource(R.dimen.stripe_paymentsheet_outer_spacing_horizontal)
+                val horizontalPadding = StripeTheme.getHorizontalPaddingValues()
                 val headerText by remember(screen) {
                     screen.title()
                 }.collectAsState()
@@ -137,7 +136,7 @@ internal class ManageActivity : AppCompatActivity() {
                         text = text.resolve(),
                         modifier = Modifier
                             .padding(bottom = 16.dp)
-                            .padding(horizontal = horizontalPadding),
+                            .padding(horizontalPadding),
                     )
                 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/ManageActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/ManageActivity.kt
@@ -29,7 +29,7 @@ import com.stripe.android.paymentsheet.utils.renderEdgeToEdge
 import com.stripe.android.ui.core.elements.H4Text
 import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.elements.bottomsheet.rememberStripeBottomSheetState
-import com.stripe.android.uicore.getHorizontalPaddingValues
+import com.stripe.android.uicore.getOuterFormInsets
 import com.stripe.android.uicore.strings.resolve
 import com.stripe.android.uicore.utils.collectAsState
 import com.stripe.android.uicore.utils.fadeOut
@@ -127,7 +127,7 @@ internal class ManageActivity : AppCompatActivity() {
                 )
             },
             content = {
-                val horizontalPadding = StripeTheme.getHorizontalPaddingValues()
+                val horizontalPadding = StripeTheme.getOuterFormInsets()
                 val headerText by remember(screen) {
                     screen.title()
                 }.collectAsState()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
@@ -22,7 +22,9 @@ import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.injection.InputAddressViewModelSubcomponent
 import com.stripe.android.paymentsheet.ui.AddressOptionsAppBar
 import com.stripe.android.ui.core.FormUI
+import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.elements.CheckboxElementUI
+import com.stripe.android.uicore.getHorizontalPaddingValues
 import com.stripe.android.uicore.utils.collectAsState
 import javax.inject.Provider
 
@@ -56,7 +58,7 @@ internal fun InputAddressScreen(
             modifier = Modifier.padding(it)
         ) {
             Column(
-                Modifier.padding(horizontal = 20.dp)
+                Modifier.padding(StripeTheme.getHorizontalPaddingValues())
             ) {
                 Text(
                     title,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
@@ -24,7 +24,7 @@ import com.stripe.android.paymentsheet.ui.AddressOptionsAppBar
 import com.stripe.android.ui.core.FormUI
 import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.elements.CheckboxElementUI
-import com.stripe.android.uicore.getHorizontalPaddingValues
+import com.stripe.android.uicore.getOuterFormInsets
 import com.stripe.android.uicore.utils.collectAsState
 import javax.inject.Provider
 
@@ -58,7 +58,7 @@ internal fun InputAddressScreen(
             modifier = Modifier.padding(it)
         ) {
             Column(
-                Modifier.padding(StripeTheme.getHorizontalPaddingValues())
+                Modifier.padding(StripeTheme.getOuterFormInsets())
             ) {
                 Text(
                     title,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
@@ -30,7 +30,7 @@ import com.stripe.android.paymentsheet.verticalmode.VerticalModeFormInteractor
 import com.stripe.android.paymentsheet.verticalmode.VerticalModeFormUI
 import com.stripe.android.ui.core.elements.CvcController
 import com.stripe.android.uicore.StripeTheme
-import com.stripe.android.uicore.getHorizontalPaddingValues
+import com.stripe.android.uicore.getOuterFormInsets
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.flow.StateFlow
@@ -321,7 +321,7 @@ internal sealed interface PaymentSheetScreen {
         override fun Content(modifier: Modifier) {
             PaymentMethodVerticalLayoutUI(
                 interactor,
-                modifier.padding(StripeTheme.getHorizontalPaddingValues())
+                modifier.padding(StripeTheme.getOuterFormInsets())
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
@@ -29,6 +29,8 @@ import com.stripe.android.paymentsheet.verticalmode.PaymentMethodVerticalLayoutU
 import com.stripe.android.paymentsheet.verticalmode.VerticalModeFormInteractor
 import com.stripe.android.paymentsheet.verticalmode.VerticalModeFormUI
 import com.stripe.android.ui.core.elements.CvcController
+import com.stripe.android.uicore.StripeTheme
+import com.stripe.android.uicore.getHorizontalPaddingValues
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.flow.StateFlow
@@ -317,7 +319,10 @@ internal sealed interface PaymentSheetScreen {
 
         @Composable
         override fun Content(modifier: Modifier) {
-            PaymentMethodVerticalLayoutUI(interactor, modifier.padding(horizontal = 20.dp))
+            PaymentMethodVerticalLayoutUI(
+                interactor,
+                modifier.padding(StripeTheme.getHorizontalPaddingValues())
+            )
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateConfirmationForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateConfirmationForm.kt
@@ -32,7 +32,7 @@ import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.utils.PaymentSheetContentPadding
 import com.stripe.android.ui.core.elements.H4Text
 import com.stripe.android.uicore.StripeTheme
-import com.stripe.android.uicore.getHorizontalPaddingValues
+import com.stripe.android.uicore.getOuterFormInsets
 import com.stripe.android.uicore.shouldUseDarkDynamicColor
 import com.stripe.android.uicore.strings.resolve
 import com.stripe.android.uicore.stripeColors
@@ -59,7 +59,7 @@ internal fun BacsMandateConfirmationFormView(
     viewActionHandler: (action: BacsMandateConfirmationViewAction) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val horizontalPadding = StripeTheme.getHorizontalPaddingValues()
+    val horizontalPadding = StripeTheme.getOuterFormInsets()
 
     return Column(
         modifier = modifier

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateConfirmationForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateConfirmationForm.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
@@ -33,6 +32,7 @@ import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.utils.PaymentSheetContentPadding
 import com.stripe.android.ui.core.elements.H4Text
 import com.stripe.android.uicore.StripeTheme
+import com.stripe.android.uicore.getHorizontalPaddingValues
 import com.stripe.android.uicore.shouldUseDarkDynamicColor
 import com.stripe.android.uicore.strings.resolve
 import com.stripe.android.uicore.stripeColors
@@ -59,12 +59,12 @@ internal fun BacsMandateConfirmationFormView(
     viewActionHandler: (action: BacsMandateConfirmationViewAction) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val padding = dimensionResource(id = R.dimen.stripe_paymentsheet_outer_spacing_horizontal)
+    val horizontalPadding = StripeTheme.getHorizontalPaddingValues()
 
     return Column(
         modifier = modifier
             .background(MaterialTheme.colors.surface)
-            .padding(horizontal = padding),
+            .padding(horizontalPadding),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
         H4Text(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/CvcRecollectionScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/CvcRecollectionScreen.kt
@@ -52,7 +52,7 @@ import com.stripe.android.uicore.elements.Placeholder
 import com.stripe.android.uicore.elements.SectionCard
 import com.stripe.android.uicore.elements.TextFieldColors
 import com.stripe.android.uicore.elements.TrailingIcon
-import com.stripe.android.uicore.getHorizontalPaddingValues
+import com.stripe.android.uicore.getOuterFormInsets
 import com.stripe.android.uicore.stripeColors
 import com.stripe.android.uicore.text.autofill
 import com.stripe.android.uicore.utils.collectAsState
@@ -68,7 +68,7 @@ internal fun CvcRecollectionScreen(
         Column(
             Modifier
                 .background(MaterialTheme.stripeColors.materialColors.surface)
-                .padding(StripeTheme.getHorizontalPaddingValues())
+                .padding(StripeTheme.getOuterFormInsets())
         ) {
             CvcRecollectionTopBar(isTestMode) {
                 viewActionHandler.invoke(CvcRecollectionViewAction.OnBackPressed)
@@ -99,7 +99,7 @@ internal fun CvcRecollectionPaymentSheetScreen(
         Column(
             Modifier
                 .background(MaterialTheme.stripeColors.materialColors.surface)
-                .padding(StripeTheme.getHorizontalPaddingValues())
+                .padding(StripeTheme.getOuterFormInsets())
         ) {
             CvcRecollectionTitle()
             CvcRecollectionField(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/CvcRecollectionScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/CvcRecollectionScreen.kt
@@ -52,6 +52,7 @@ import com.stripe.android.uicore.elements.Placeholder
 import com.stripe.android.uicore.elements.SectionCard
 import com.stripe.android.uicore.elements.TextFieldColors
 import com.stripe.android.uicore.elements.TrailingIcon
+import com.stripe.android.uicore.getHorizontalPaddingValues
 import com.stripe.android.uicore.stripeColors
 import com.stripe.android.uicore.text.autofill
 import com.stripe.android.uicore.utils.collectAsState
@@ -67,7 +68,7 @@ internal fun CvcRecollectionScreen(
         Column(
             Modifier
                 .background(MaterialTheme.stripeColors.materialColors.surface)
-                .padding(horizontal = 20.dp)
+                .padding(StripeTheme.getHorizontalPaddingValues())
         ) {
             CvcRecollectionTopBar(isTestMode) {
                 viewActionHandler.invoke(CvcRecollectionViewAction.OnBackPressed)
@@ -98,7 +99,7 @@ internal fun CvcRecollectionPaymentSheetScreen(
         Column(
             Modifier
                 .background(MaterialTheme.stripeColors.materialColors.surface)
-                .padding(horizontal = 20.dp)
+                .padding(StripeTheme.getHorizontalPaddingValues())
         ) {
             CvcRecollectionTitle()
             CvcRecollectionField(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingScreen.kt
@@ -36,7 +36,7 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.stripe.android.common.ui.LoadingIndicator
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.uicore.StripeTheme
-import com.stripe.android.uicore.getHorizontalPaddingValues
+import com.stripe.android.uicore.getOuterFormInsets
 import com.stripe.android.uicore.stripeColors
 import com.stripe.android.uicore.utils.collectAsState
 import kotlin.time.Duration
@@ -111,7 +111,7 @@ private fun ActivePolling(
         modifier = modifier
             .fillMaxSize()
             .padding(vertical = dimensionResource(R.dimen.stripe_paymentsheet_outer_spacing_top))
-            .padding(StripeTheme.getHorizontalPaddingValues())
+            .padding(StripeTheme.getOuterFormInsets())
     ) {
         LoadingIndicator(
             modifier = Modifier.padding(bottom = Spacing.extended),
@@ -173,7 +173,7 @@ private fun FailedPolling(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(vertical = dimensionResource(R.dimen.stripe_paymentsheet_outer_spacing_top))
-                    .padding(StripeTheme.getHorizontalPaddingValues())
+                    .padding(StripeTheme.getOuterFormInsets())
             ) {
                 Image(
                     painter = painterResource(R.drawable.stripe_ic_paymentsheet_polling_failure),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingScreen.kt
@@ -36,6 +36,7 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.stripe.android.common.ui.LoadingIndicator
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.uicore.StripeTheme
+import com.stripe.android.uicore.getHorizontalPaddingValues
 import com.stripe.android.uicore.stripeColors
 import com.stripe.android.uicore.utils.collectAsState
 import kotlin.time.Duration
@@ -109,10 +110,8 @@ private fun ActivePolling(
         verticalArrangement = Arrangement.Center,
         modifier = modifier
             .fillMaxSize()
-            .padding(
-                vertical = dimensionResource(R.dimen.stripe_paymentsheet_outer_spacing_top),
-                horizontal = dimensionResource(R.dimen.stripe_paymentsheet_outer_spacing_horizontal),
-            ),
+            .padding(vertical = dimensionResource(R.dimen.stripe_paymentsheet_outer_spacing_top))
+            .padding(StripeTheme.getHorizontalPaddingValues())
     ) {
         LoadingIndicator(
             modifier = Modifier.padding(bottom = Spacing.extended),
@@ -173,10 +172,8 @@ private fun FailedPolling(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(
-                        vertical = dimensionResource(R.dimen.stripe_paymentsheet_outer_spacing_top),
-                        horizontal = dimensionResource(R.dimen.stripe_paymentsheet_outer_spacing_horizontal),
-                    ),
+                    .padding(vertical = dimensionResource(R.dimen.stripe_paymentsheet_outer_spacing_top))
+                    .padding(StripeTheme.getHorizontalPaddingValues())
             ) {
                 Image(
                     painter = painterResource(R.drawable.stripe_ic_paymentsheet_polling_failure),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/NewPaymentMethodTabLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/NewPaymentMethodTabLayoutUI.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.unit.dp
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.paymentsheet.model.PaymentMethodIncentive
 import com.stripe.android.uicore.StripeTheme
-import com.stripe.android.uicore.getHorizontalPaddingValues
+import com.stripe.android.uicore.getOuterFormInsets
 import com.stripe.android.uicore.image.StripeImageLoader
 import com.stripe.android.uicore.strings.resolve
 
@@ -67,7 +67,7 @@ internal fun NewPaymentMethodTabLayoutUI(
 
         LazyRow(
             state = state,
-            contentPadding = StripeTheme.getHorizontalPaddingValues(),
+            contentPadding = StripeTheme.getOuterFormInsets(),
             horizontalArrangement = Arrangement.spacedBy(PaymentMethodsUISpacing.carouselInnerPadding),
             userScrollEnabled = isEnabled,
             modifier = Modifier.testTag(TEST_TAG_LIST)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/NewPaymentMethodTabLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/NewPaymentMethodTabLayoutUI.kt
@@ -7,7 +7,6 @@ import androidx.annotation.VisibleForTesting
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -22,11 +21,12 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.paymentsheet.model.PaymentMethodIncentive
+import com.stripe.android.uicore.StripeTheme
+import com.stripe.android.uicore.getHorizontalPaddingValues
 import com.stripe.android.uicore.image.StripeImageLoader
 import com.stripe.android.uicore.strings.resolve
 
 private object PaymentMethodsUISpacing {
-    val carouselOuterPadding = 20.dp
     val carouselInnerPadding = 12.dp
 }
 
@@ -67,7 +67,7 @@ internal fun NewPaymentMethodTabLayoutUI(
 
         LazyRow(
             state = state,
-            contentPadding = PaddingValues(horizontal = PaymentMethodsUISpacing.carouselOuterPadding),
+            contentPadding = StripeTheme.getHorizontalPaddingValues(),
             horizontalArrangement = Arrangement.spacedBy(PaymentMethodsUISpacing.carouselInnerPadding),
             userScrollEnabled = isEnabled,
             modifier = Modifier.testTag(TEST_TAG_LIST)
@@ -112,7 +112,7 @@ internal fun calculateViewWidth(
     maxWidth: Dp,
     numberOfPaymentMethods: Int
 ): Dp {
-    val targetWidth = maxWidth - (PaymentMethodsUISpacing.carouselOuterPadding * 2)
+    val targetWidth = maxWidth - (StripeTheme.formInsets.end + StripeTheme.formInsets.start).dp
     val minItemWidth = 90.dp
 
     val minimumCardsWidth = minItemWidth * numberOfPaymentMethods

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentElement.kt
@@ -4,6 +4,7 @@ import androidx.annotation.RestrictTo
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
@@ -18,20 +19,19 @@ import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.dimensionResource
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.model.PaymentMethod.Type.Link
 import com.stripe.android.model.PaymentMethod.Type.USBankAccount
 import com.stripe.android.model.PaymentMethodCode
-import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentMethodIncentive
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountForm
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormArguments
+import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.elements.FormElement
+import com.stripe.android.uicore.getHorizontalPaddingValues
 import com.stripe.android.uicore.image.StripeImageLoader
 import java.util.UUID
 
@@ -54,9 +54,7 @@ internal fun PaymentElement(
         StripeImageLoader(context.applicationContext)
     }
 
-    val horizontalPadding = dimensionResource(
-        id = R.dimen.stripe_paymentsheet_outer_spacing_horizontal
-    )
+    val horizontalPadding = StripeTheme.getHorizontalPaddingValues()
 
     val selectedIndex = remember(selectedItemCode, supportedPaymentMethods) {
         supportedPaymentMethods.map { it.code }.indexOf(selectedItemCode)
@@ -84,7 +82,7 @@ internal fun PaymentElement(
             formElements = formElements,
             formArguments = formArguments,
             usBankAccountFormArguments = usBankAccountFormArguments,
-            horizontalPadding = horizontalPadding,
+            horizontalPaddingValues = horizontalPadding,
             onFormFieldValuesChanged = onFormFieldValuesChanged,
             onInteractionEvent = onInteractionEvent,
         )
@@ -98,7 +96,7 @@ internal fun FormElement(
     formElements: List<FormElement>,
     formArguments: FormArguments,
     usBankAccountFormArguments: USBankAccountFormArguments,
-    horizontalPadding: Dp,
+    horizontalPaddingValues: PaddingValues,
     onFormFieldValuesChanged: (FormFieldValues?) -> Unit,
     onInteractionEvent: () -> Unit,
 ) {
@@ -139,7 +137,7 @@ internal fun FormElement(
                     }
                     previouslyCompletedUSBankAccountForm = true
                 },
-                modifier = Modifier.padding(horizontal = horizontalPadding),
+                modifier = Modifier.padding(horizontalPaddingValues),
                 enabled = enabled
             )
         } else {
@@ -149,7 +147,7 @@ internal fun FormElement(
                 enabled = enabled,
                 onFormFieldValuesChanged = onFormFieldValuesChanged,
                 formElements = formElements,
-                modifier = Modifier.padding(horizontal = horizontalPadding)
+                modifier = Modifier.padding(horizontalPaddingValues)
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentElement.kt
@@ -31,7 +31,7 @@ import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFo
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormArguments
 import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.elements.FormElement
-import com.stripe.android.uicore.getHorizontalPaddingValues
+import com.stripe.android.uicore.getOuterFormInsets
 import com.stripe.android.uicore.image.StripeImageLoader
 import java.util.UUID
 
@@ -54,7 +54,7 @@ internal fun PaymentElement(
         StripeImageLoader(context.applicationContext)
     }
 
-    val horizontalPadding = StripeTheme.getHorizontalPaddingValues()
+    val horizontalPadding = StripeTheme.getOuterFormInsets()
 
     val selectedIndex = remember(selectedItemCode, supportedPaymentMethods) {
         supportedPaymentMethods.map { it.code }.indexOf(selectedItemCode)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
@@ -72,7 +72,7 @@ import com.stripe.android.ui.core.elements.H4Text
 import com.stripe.android.ui.core.elements.Mandate
 import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.getBackgroundColor
-import com.stripe.android.uicore.getHorizontalPaddingValues
+import com.stripe.android.uicore.getOuterFormInsets
 import com.stripe.android.uicore.strings.resolve
 import com.stripe.android.uicore.utils.collectAsState
 import kotlinx.coroutines.delay
@@ -298,7 +298,7 @@ private fun PaymentSheetContent(
     mandateText: MandateText?,
     modifier: Modifier
 ) {
-    val horizontalPadding = StripeTheme.getHorizontalPaddingValues()
+    val horizontalPadding = StripeTheme.getOuterFormInsets()
     Column(modifier = modifier.padding(bottom = currentScreen.bottomContentPadding)) {
         headerText?.let { text ->
             H4Text(
@@ -376,7 +376,7 @@ internal fun Wallet(
     modifier: Modifier = Modifier,
     cardBrandFilter: CardBrandFilter
 ) {
-    val padding = StripeTheme.getHorizontalPaddingValues()
+    val padding = StripeTheme.getOuterFormInsets()
 
     Column(modifier = modifier.padding(padding)) {
         state.googlePay?.let { googlePay ->
@@ -425,7 +425,7 @@ private fun PrimaryButton(viewModel: BaseSheetViewModel) {
     val uiState by viewModel.primaryButtonUiState.collectAsState()
 
     val modifier = Modifier
-        .padding(StripeTheme.getHorizontalPaddingValues())
+        .padding(StripeTheme.getOuterFormInsets())
         .testTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG)
         .semantics {
             role = Role.Button

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
@@ -72,6 +72,7 @@ import com.stripe.android.ui.core.elements.H4Text
 import com.stripe.android.ui.core.elements.Mandate
 import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.getBackgroundColor
+import com.stripe.android.uicore.getHorizontalPaddingValues
 import com.stripe.android.uicore.strings.resolve
 import com.stripe.android.uicore.utils.collectAsState
 import kotlinx.coroutines.delay
@@ -297,14 +298,14 @@ private fun PaymentSheetContent(
     mandateText: MandateText?,
     modifier: Modifier
 ) {
-    val horizontalPadding = dimensionResource(R.dimen.stripe_paymentsheet_outer_spacing_horizontal)
+    val horizontalPadding = StripeTheme.getHorizontalPaddingValues()
     Column(modifier = modifier.padding(bottom = currentScreen.bottomContentPadding)) {
         headerText?.let { text ->
             H4Text(
                 text = text.resolve(),
                 modifier = Modifier
                     .padding(bottom = 16.dp)
-                    .padding(horizontal = horizontalPadding),
+                    .padding(horizontalPadding),
             )
         }
 
@@ -333,7 +334,7 @@ private fun PaymentSheetContent(
             Mandate(
                 mandateText = mandateText.text?.resolve(),
                 modifier = Modifier
-                    .padding(horizontal = horizontalPadding)
+                    .padding(horizontalPadding)
                     .padding(bottom = 8.dp)
                     .testTag(PAYMENT_SHEET_MANDATE_TEXT_TEST_TAG),
             )
@@ -343,7 +344,7 @@ private fun PaymentSheetContent(
             ErrorMessage(
                 error = it.resolve(),
                 modifier = Modifier
-                    .padding(horizontal = horizontalPadding)
+                    .padding(horizontalPadding)
                     .padding(top = 2.dp, bottom = 8.dp)
                     .testTag(PAYMENT_SHEET_ERROR_TEXT_TEST_TAG),
             )
@@ -358,7 +359,7 @@ private fun PaymentSheetContent(
                 mandateText = mandateText.text?.resolve(),
                 modifier = Modifier
                     .padding(top = 8.dp)
-                    .padding(horizontal = horizontalPadding)
+                    .padding(horizontalPadding)
                     .testTag(PAYMENT_SHEET_MANDATE_TEXT_TEST_TAG),
             )
         }
@@ -375,9 +376,9 @@ internal fun Wallet(
     modifier: Modifier = Modifier,
     cardBrandFilter: CardBrandFilter
 ) {
-    val padding = dimensionResource(R.dimen.stripe_paymentsheet_outer_spacing_horizontal)
+    val padding = StripeTheme.getHorizontalPaddingValues()
 
-    Column(modifier = modifier.padding(horizontal = padding)) {
+    Column(modifier = modifier.padding(padding)) {
         state.googlePay?.let { googlePay ->
             GooglePayButton(
                 state = PrimaryButton.State.Ready,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
@@ -425,6 +425,7 @@ private fun PrimaryButton(viewModel: BaseSheetViewModel) {
     val uiState by viewModel.primaryButtonUiState.collectAsState()
 
     val modifier = Modifier
+        .padding(StripeTheme.getHorizontalPaddingValues())
         .testTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG)
         .semantics {
             role = Role.Button

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButton.kt
@@ -115,11 +115,7 @@ internal class PrimaryButton @JvmOverloads constructor(
         backgroundTintList = tintList
         finishedBackgroundColor = primaryButtonStyle.getSuccessBackgroundColor(context)
         finishedOnBackgroundColor = primaryButtonStyle.getOnSuccessBackgroundColor(context)
-        (layoutParams as? MarginLayoutParams)?.apply {
-            height = context.convertDpToPx(primaryButtonStyle.shape.height.dp).toInt()
-            marginEnd = context.convertDpToPx(StripeTheme.formInsets.end.dp).toInt()
-            marginStart = context.convertDpToPx(StripeTheme.formInsets.start.dp).toInt()
-        }
+        layoutParams?.height = context.convertDpToPx(primaryButtonStyle.shape.height.dp).toInt()
     }
 
     fun setDefaultLabelColor(@ColorInt color: Int) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButton.kt
@@ -115,7 +115,11 @@ internal class PrimaryButton @JvmOverloads constructor(
         backgroundTintList = tintList
         finishedBackgroundColor = primaryButtonStyle.getSuccessBackgroundColor(context)
         finishedOnBackgroundColor = primaryButtonStyle.getOnSuccessBackgroundColor(context)
-        layoutParams?.height = context.convertDpToPx(primaryButtonStyle.shape.height.dp).toInt()
+        (layoutParams as? MarginLayoutParams)?.apply {
+            height = context.convertDpToPx(primaryButtonStyle.shape.height.dp).toInt()
+            marginEnd = context.convertDpToPx(StripeTheme.formInsets.end.dp).toInt()
+            marginStart = context.convertDpToPx(StripeTheme.formInsets.start.dp).toInt()
+        }
     }
 
     fun setDefaultLabelColor(@ColorInt color: Int) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -58,9 +57,11 @@ import com.stripe.android.paymentsheet.toPaymentSelection
 import com.stripe.android.ui.core.elements.CvcController
 import com.stripe.android.ui.core.elements.CvcElement
 import com.stripe.android.uicore.DefaultStripeTheme
+import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SectionCard
 import com.stripe.android.uicore.elements.SectionError
+import com.stripe.android.uicore.getHorizontalPaddingValues
 import com.stripe.android.uicore.shouldUseDarkDynamicColor
 import com.stripe.android.uicore.strings.resolve
 import com.stripe.android.uicore.stripeColors
@@ -145,7 +146,7 @@ internal fun SavedPaymentMethodTabLayoutUI(
         LazyRow(
             state = scrollState,
             userScrollEnabled = !isProcessing,
-            contentPadding = PaddingValues(horizontal = 17.dp),
+            contentPadding = StripeTheme.getHorizontalPaddingValues(),
         ) {
             items(
                 items = paymentOptionsItems,
@@ -484,7 +485,7 @@ internal fun CvcRecollectionField(
         }
     ) {
         Column(
-            Modifier.padding(20.dp, 20.dp, 20.dp, 0.dp)
+            Modifier.padding(top = 20.dp).padding(StripeTheme.getHorizontalPaddingValues())
         ) {
             Text(
                 text = stringResource(R.string.stripe_paymentsheet_confirm_your_cvc),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
@@ -62,7 +62,7 @@ import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SectionCard
 import com.stripe.android.uicore.elements.SectionError
-import com.stripe.android.uicore.getHorizontalPaddingValues
+import com.stripe.android.uicore.getOuterFormInsets
 import com.stripe.android.uicore.shouldUseDarkDynamicColor
 import com.stripe.android.uicore.strings.resolve
 import com.stripe.android.uicore.stripeColors
@@ -486,7 +486,7 @@ internal fun CvcRecollectionField(
         }
     ) {
         Column(
-            Modifier.padding(top = 20.dp).padding(StripeTheme.getHorizontalPaddingValues())
+            Modifier.padding(top = 20.dp).padding(StripeTheme.getOuterFormInsets())
         ) {
             Text(
                 text = stringResource(R.string.stripe_paymentsheet_confirm_your_cvc),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -146,7 +147,7 @@ internal fun SavedPaymentMethodTabLayoutUI(
         LazyRow(
             state = scrollState,
             userScrollEnabled = !isProcessing,
-            contentPadding = StripeTheme.getHorizontalPaddingValues(),
+            contentPadding = PaddingValues(horizontal = 17.dp),
         ) {
             items(
                 items = paymentOptionsItems,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
@@ -35,7 +35,7 @@ import com.stripe.android.paymentsheet.utils.testMetadata
 import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.elements.CheckboxElementUI
 import com.stripe.android.uicore.getBorderStroke
-import com.stripe.android.uicore.getHorizontalPaddingValues
+import com.stripe.android.uicore.getOuterFormInsets
 import com.stripe.android.uicore.strings.resolve
 import com.stripe.android.uicore.stripeColors
 import com.stripe.android.uicore.utils.collectAsState
@@ -45,7 +45,7 @@ import com.stripe.android.paymentsheet.R as PaymentSheetR
 @Composable
 internal fun UpdatePaymentMethodUI(interactor: UpdatePaymentMethodInteractor, modifier: Modifier) {
     val context = LocalContext.current
-    val horizontalPadding = StripeTheme.getHorizontalPaddingValues()
+    val horizontalPadding = StripeTheme.getOuterFormInsets()
     val state by interactor.state.collectAsState()
     val shouldShowCardBrandDropdown = interactor.isModifiablePaymentMethod &&
         interactor.displayableSavedPaymentMethod.canChangeCbc()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
@@ -16,7 +16,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -33,8 +32,10 @@ import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode
 import com.stripe.android.paymentsheet.SavedPaymentMethod
 import com.stripe.android.paymentsheet.utils.testMetadata
+import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.elements.CheckboxElementUI
 import com.stripe.android.uicore.getBorderStroke
+import com.stripe.android.uicore.getHorizontalPaddingValues
 import com.stripe.android.uicore.strings.resolve
 import com.stripe.android.uicore.stripeColors
 import com.stripe.android.uicore.utils.collectAsState
@@ -44,16 +45,14 @@ import com.stripe.android.paymentsheet.R as PaymentSheetR
 @Composable
 internal fun UpdatePaymentMethodUI(interactor: UpdatePaymentMethodInteractor, modifier: Modifier) {
     val context = LocalContext.current
-    val horizontalPadding = dimensionResource(
-        id = PaymentSheetR.dimen.stripe_paymentsheet_outer_spacing_horizontal
-    )
+    val horizontalPadding = StripeTheme.getHorizontalPaddingValues()
     val state by interactor.state.collectAsState()
     val shouldShowCardBrandDropdown = interactor.isModifiablePaymentMethod &&
         interactor.displayableSavedPaymentMethod.canChangeCbc()
 
     Column(
         modifier = modifier
-            .padding(horizontal = horizontalPadding)
+            .padding(horizontalPadding)
             .testTag(UPDATE_PM_SCREEN_TEST_TAG),
     ) {
         when (val savedPaymentMethod = interactor.displayableSavedPaymentMethod.savedPaymentMethod) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenUI.kt
@@ -12,13 +12,13 @@ import androidx.compose.ui.unit.dp
 import com.stripe.android.paymentelement.ExperimentalEmbeddedPaymentElementApi
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.uicore.StripeTheme
-import com.stripe.android.uicore.getHorizontalPaddingValues
+import com.stripe.android.uicore.getOuterFormInsets
 import com.stripe.android.uicore.utils.collectAsState
 
 @OptIn(ExperimentalEmbeddedPaymentElementApi::class)
 @Composable
 internal fun ManageScreenUI(interactor: ManageScreenInteractor) {
-    val horizontalPadding = StripeTheme.getHorizontalPaddingValues()
+    val horizontalPadding = StripeTheme.getOuterFormInsets()
 
     val state by interactor.state.collectAsState()
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenUI.kt
@@ -8,25 +8,23 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.unit.dp
 import com.stripe.android.paymentelement.ExperimentalEmbeddedPaymentElementApi
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
-import com.stripe.android.paymentsheet.R
+import com.stripe.android.uicore.StripeTheme
+import com.stripe.android.uicore.getHorizontalPaddingValues
 import com.stripe.android.uicore.utils.collectAsState
 
 @OptIn(ExperimentalEmbeddedPaymentElementApi::class)
 @Composable
 internal fun ManageScreenUI(interactor: ManageScreenInteractor) {
-    val horizontalPadding = dimensionResource(
-        id = R.dimen.stripe_paymentsheet_outer_spacing_horizontal
-    )
+    val horizontalPadding = StripeTheme.getHorizontalPaddingValues()
 
     val state by interactor.state.collectAsState()
 
     Column(
         modifier = Modifier
-            .padding(horizontal = horizontalPadding)
+            .padding(horizontalPadding)
             .testTag(TEST_TAG_MANAGE_SCREEN_SAVED_PMS_LIST),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUI.kt
@@ -17,14 +17,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.stripe.android.lpmfoundations.FormHeaderInformation
-import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.ui.FormElement
 import com.stripe.android.paymentsheet.ui.PaymentMethodIcon
 import com.stripe.android.paymentsheet.ui.PromoBadge
+import com.stripe.android.uicore.StripeTheme
+import com.stripe.android.uicore.getHorizontalPaddingValues
 import com.stripe.android.uicore.image.StripeImageLoader
 import com.stripe.android.uicore.strings.resolve
 import com.stripe.android.uicore.utils.collectAsState
@@ -38,9 +38,7 @@ internal fun VerticalModeFormUI(
     showsWalletHeader: Boolean,
     modifier: Modifier = Modifier
 ) {
-    val horizontalPadding = dimensionResource(
-        id = R.dimen.stripe_paymentsheet_outer_spacing_horizontal
-    )
+    val horizontalPadding = StripeTheme.getHorizontalPaddingValues()
 
     var hasSentInteractionEvent by remember { mutableStateOf(false) }
     val state by interactor.state.collectAsState()
@@ -58,7 +56,7 @@ internal fun VerticalModeFormUI(
             formElements = state.formElements,
             formArguments = state.formArguments,
             usBankAccountFormArguments = state.usBankAccountFormArguments,
-            horizontalPadding = horizontalPadding,
+            horizontalPaddingValues = horizontalPadding,
             onFormFieldValuesChanged = { formValues ->
                 interactor.handleViewAction(
                     VerticalModeFormInteractor.ViewAction.FormFieldValuesChanged(formValues)
@@ -90,7 +88,9 @@ internal fun VerticalModeFormHeaderUI(
     }
 
     Row(
-        modifier = Modifier.padding(horizontal = 20.dp).padding(bottom = 12.dp),
+        modifier = Modifier
+            .padding(bottom = 12.dp)
+            .padding(StripeTheme.getHorizontalPaddingValues()),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         if (formHeaderInformation.shouldShowIcon) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUI.kt
@@ -24,7 +24,7 @@ import com.stripe.android.paymentsheet.ui.FormElement
 import com.stripe.android.paymentsheet.ui.PaymentMethodIcon
 import com.stripe.android.paymentsheet.ui.PromoBadge
 import com.stripe.android.uicore.StripeTheme
-import com.stripe.android.uicore.getHorizontalPaddingValues
+import com.stripe.android.uicore.getOuterFormInsets
 import com.stripe.android.uicore.image.StripeImageLoader
 import com.stripe.android.uicore.strings.resolve
 import com.stripe.android.uicore.utils.collectAsState
@@ -38,7 +38,7 @@ internal fun VerticalModeFormUI(
     showsWalletHeader: Boolean,
     modifier: Modifier = Modifier
 ) {
-    val horizontalPadding = StripeTheme.getHorizontalPaddingValues()
+    val horizontalPadding = StripeTheme.getOuterFormInsets()
 
     var hasSentInteractionEvent by remember { mutableStateOf(false) }
     val state by interactor.state.collectAsState()
@@ -90,7 +90,7 @@ internal fun VerticalModeFormHeaderUI(
     Row(
         modifier = Modifier
             .padding(bottom = 12.dp)
-            .padding(StripeTheme.getHorizontalPaddingValues()),
+            .padding(StripeTheme.getOuterFormInsets()),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         if (formHeaderInformation.shouldShowIcon) {

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/StripeTheme.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/StripeTheme.kt
@@ -16,6 +16,7 @@ import androidx.annotation.FontRes
 import androidx.annotation.RestrictTo
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Colors
 import androidx.compose.material.LocalTextStyle
@@ -159,6 +160,14 @@ data class EmbeddedFloatingStyle(
 )
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class FormInsets(
+    val start: Float,
+    val top: Float,
+    val end: Float,
+    val bottom: Float
+)
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 val PRIMARY_BUTTON_SUCCESS_BACKGROUND_COLOR = Color(0xFF24B47E)
 private val EMBEDDED_SEPARATOR_COLOR_DARK = Color(0x40FFFFFF)
 
@@ -285,6 +294,13 @@ object StripeThemeDefaults {
 
     val floating = EmbeddedFloatingStyle(
         spacing = 12.0f
+    )
+
+    val formInsets = FormInsets(
+        start = 20f,
+        top = 0f,
+        end = 20f,
+        bottom = 0f
     )
 }
 
@@ -526,6 +542,8 @@ object StripeTheme {
 
     var primaryButtonStyle = StripeThemeDefaults.primaryButtonStyle
 
+    var formInsets = StripeThemeDefaults.formInsets
+
     fun getColors(isDark: Boolean): StripeColors {
         return if (isDark) colorsDarkMutable else colorsLightMutable
     }
@@ -671,6 +689,12 @@ fun Color.darken(amount: Float): Color {
         max(it - amount, 0f)
     }
 }
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun StripeTheme.getHorizontalPaddingValues(): PaddingValues = PaddingValues(
+    start = formInsets.start.dp,
+    end = formInsets.end.dp
+)
 
 private fun TextStyle.toCompat(): TextStyle {
     return copy(

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/StripeTheme.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/StripeTheme.kt
@@ -691,7 +691,7 @@ fun Color.darken(amount: Float): Color {
 }
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-fun StripeTheme.getHorizontalPaddingValues(): PaddingValues = PaddingValues(
+fun StripeTheme.getOuterFormInsets(): PaddingValues = PaddingValues(
     start = formInsets.start.dp,
     end = formInsets.end.dp
 )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Replace usages of `stripe_paymentsheet_outer_spacing_horizontal` with `StripeTheme.getHorizontalPaddingValues`
Remove margins from stripe_fragment_primary_button_container
Pure refactor, no behavior or UI change

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Pre work for https://jira.corp.stripe.com/browse/MOBILESDK-3607
Ideally, we can consolidate how padding is set for all PaymentElement screens. In the interest of execution speed I'm replacing stripe_paymentsheet_outer_spacing_horizontal with StripeTheme.getHorizontalPaddingValues. Follow up task [created](stripe_paymentsheet_outer_spacing_horizontal) to refactor to have one location to set horizontal padding for all screens.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified


