### PR TITLE
[paymentsheet-example] Search box to filter settings in Playground

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
@@ -16,11 +16,12 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.exclude
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.Button
@@ -286,9 +287,10 @@ internal class PaymentSheetPlaygroundActivity :
                     }
 
                     Spacer(
-                        Modifier.padding(
-                            WindowInsets.ime.exclude(WindowInsets.navigationBars)
+                        Modifier.height(
+                            WindowInsets.ime.exclude(WindowInsets.systemBars)
                                 .asPaddingValues()
+                                .calculateBottomPadding()
                         )
                     )
                 },

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
@@ -306,74 +306,6 @@ internal class PaymentSheetPlaygroundActivity :
     }
 
     @Composable
-    private fun SearchSettingsField(
-        query: String,
-        onQueryChanged: (String) -> Unit,
-        modifier: Modifier = Modifier,
-    ) {
-        var hasFocus by remember { mutableStateOf(false) }
-        val keyboardController = LocalSoftwareKeyboardController.current
-        TextField(
-            modifier = modifier
-                .onFocusChanged { hasFocus = it.isFocused }
-                .onKeyEvent {
-                    if (it.key == Key.Enter) {
-                        keyboardController?.hide()
-                        true
-                    } else {
-                        false
-                    }
-                }
-                .fillMaxWidth(),
-            value = query,
-            placeholder = if (hasFocus) {
-                null
-            } else {
-                @Composable {
-                    Text(text = "Search")
-                }
-            },
-            singleLine = true,
-            keyboardOptions = KeyboardOptions(
-                keyboardType = KeyboardType.Text,
-                imeAction = ImeAction.Done
-            ),
-            keyboardActions = KeyboardActions(
-                onDone = { keyboardController?.show() }
-            ),
-            leadingIcon = {
-                Icon(
-                    imageVector = Icons.Default.Search,
-                    contentDescription = null,
-                )
-            },
-            trailingIcon = if (query.isEmpty()) {
-                null
-            } else {
-                @Composable {
-                    IconButton(onClick = { onQueryChanged("") }) {
-                        Icon(
-                            imageVector = Icons.Default.Close,
-                            contentDescription = null,
-                        )
-                    }
-                }
-            },
-            onValueChange = onQueryChanged,
-        )
-    }
-
-    @Preview(showBackground = true)
-    @Composable
-    private fun SearchSettingsFieldPreview() {
-        var query by remember { mutableStateOf("") }
-        SearchSettingsField(
-            query = query,
-            onQueryChanged = { query = it },
-        )
-    }
-
-    @Composable
     private fun AppearanceButton() {
         Button(
             onClick = {
@@ -804,6 +736,74 @@ internal class PaymentSheetPlaygroundActivity :
                 .putExtra(CustomPaymentMethodActivity.EXTRA_BILLING_DETAILS, billingDetails)
         )
     }
+}
+
+@Composable
+private fun SearchSettingsField(
+    query: String,
+    onQueryChanged: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var hasFocus by remember { mutableStateOf(false) }
+    val keyboardController = LocalSoftwareKeyboardController.current
+    TextField(
+        modifier = modifier
+            .onFocusChanged { hasFocus = it.isFocused }
+            .onKeyEvent {
+                if (it.key == Key.Enter) {
+                    keyboardController?.hide()
+                    true
+                } else {
+                    false
+                }
+            }
+            .fillMaxWidth(),
+        value = query,
+        placeholder = if (hasFocus) {
+            null
+        } else {
+            @Composable {
+                Text(text = "Search")
+            }
+        },
+        singleLine = true,
+        keyboardOptions = KeyboardOptions(
+            keyboardType = KeyboardType.Text,
+            imeAction = ImeAction.Done
+        ),
+        keyboardActions = KeyboardActions(
+            onDone = { keyboardController?.show() }
+        ),
+        leadingIcon = {
+            Icon(
+                imageVector = Icons.Default.Search,
+                contentDescription = null,
+            )
+        },
+        trailingIcon = if (query.isEmpty()) {
+            null
+        } else {
+            @Composable {
+                IconButton(onClick = { onQueryChanged("") }) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = null,
+                    )
+                }
+            }
+        },
+        onValueChange = onQueryChanged,
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SearchSettingsFieldPreview() {
+    var query by remember { mutableStateOf("") }
+    SearchSettingsField(
+        query = query,
+        onQueryChanged = { query = it },
+    )
 }
 
 const val RELOAD_TEST_TAG = "RELOAD"

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
@@ -763,7 +763,7 @@ private fun SearchSettingsField(
             null
         } else {
             @Composable {
-                Text(text = "Search")
+                Text(text = "Search settings")
             }
         },
         singleLine = true,

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
@@ -11,8 +11,14 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.exclude
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.text.KeyboardActions
@@ -278,6 +284,13 @@ internal class PaymentSheetPlaygroundActivity :
                             )
                         }
                     }
+
+                    Spacer(
+                        Modifier.padding(
+                            WindowInsets.ime.exclude(WindowInsets.navigationBars)
+                                .asPaddingValues()
+                        )
+                    )
                 },
             )
 
@@ -425,8 +438,10 @@ internal class PaymentSheetPlaygroundActivity :
 
     @Composable
     private fun ReloadButton(playgroundSettings: PlaygroundSettings) {
+        val keyboardController = LocalSoftwareKeyboardController.current
         Button(
             onClick = {
+                keyboardController?.hide()
                 viewModel.prepare(
                     playgroundSettings = playgroundSettings,
                 )

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/SettingsUI.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/SettingsUI.kt
@@ -51,8 +51,12 @@ internal fun SettingsUi(
             }
         }
 
-        for (settingDefinition in filteredDefinitions) {
-            Setting(settingDefinition, playgroundSettings)
+        if (filteredDefinitions.isEmpty()) {
+            Text("No matching settings found")
+        } else {
+            for (settingDefinition in filteredDefinitions) {
+                Setting(settingDefinition, playgroundSettings)
+            }
         }
     }
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/SettingsUI.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/SettingsUI.kt
@@ -217,7 +217,9 @@ private fun <T> RadioButtonSetting(
             )
         }
 
-        val selectedOption = remember(value) { options.firstOrNull { it.value == value } }
+        val selectedOption = remember(options, value) {
+            options.firstOrNull { it.value == value }
+        }
 
         Row {
             options.forEach { option ->
@@ -262,7 +264,9 @@ internal fun <T> DropdownSetting(
     onOptionChanged: (T) -> Unit,
 ) {
     var expanded by remember { mutableStateOf(false) }
-    val selectedOption = remember(value) { options.firstOrNull { it.value == value } }
+    val selectedOption = remember(options, value) {
+        options.firstOrNull { it.value == value }
+    }
 
     ExposedDropdownMenuBox(
         expanded = expanded,

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/SettingsUI.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/SettingsUI.kt
@@ -34,9 +34,10 @@ internal fun SettingsUi(
 ) {
     val configurationData by playgroundSettings.configurationData.collectAsState()
     val displayableDefinitions by playgroundSettings.displayableDefinitions.collectAsState()
-    val filteredDefinitions = remember(displayableDefinitions, searchQuery) {
+    val trimmedSearchQuery = searchQuery.trim()
+    val filteredDefinitions = remember(displayableDefinitions, trimmedSearchQuery) {
         displayableDefinitions.filter {
-            it.displayName.contains(searchQuery, ignoreCase = true)
+            it.displayName.contains(trimmedSearchQuery, ignoreCase = true)
         }
     }
 
@@ -44,11 +45,13 @@ internal fun SettingsUi(
         modifier = Modifier.padding(bottom = 16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        Row {
-            IntegrationTypeConfigurableSetting(
-                configurationData,
-                playgroundSettings::updateConfigurationData
-            )
+        if (searchQuery.isBlank()) {
+            Row {
+                IntegrationTypeConfigurableSetting(
+                    configurationData,
+                    playgroundSettings::updateConfigurationData
+                )
+            }
         }
 
         for (settingDefinition in filteredDefinitions) {

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/SettingsUI.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/SettingsUI.kt
@@ -34,16 +34,15 @@ internal fun SettingsUi(
 ) {
     val configurationData by playgroundSettings.configurationData.collectAsState()
     val displayableDefinitions by playgroundSettings.displayableDefinitions.collectAsState()
-    val trimmedSearchQuery = searchQuery.trim()
-    val filteredDefinitions = remember(displayableDefinitions, trimmedSearchQuery) {
-        displayableDefinitions.filter { it.displayName.matchesQuery(trimmedSearchQuery) }
+    val filteredDefinitions = remember(displayableDefinitions, searchQuery) {
+        displayableDefinitions.filter { it.displayName.matchesQuery(searchQuery) }
     }
 
     Column(
         modifier = Modifier.padding(bottom = 16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        if (IntegrationTypeSettingName.matchesQuery(trimmedSearchQuery)) {
+        if (IntegrationTypeSettingName.matchesQuery(searchQuery)) {
             Row {
                 IntegrationTypeConfigurableSetting(
                     configurationData,

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/SettingsUI.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/SettingsUI.kt
@@ -36,16 +36,14 @@ internal fun SettingsUi(
     val displayableDefinitions by playgroundSettings.displayableDefinitions.collectAsState()
     val trimmedSearchQuery = searchQuery.trim()
     val filteredDefinitions = remember(displayableDefinitions, trimmedSearchQuery) {
-        displayableDefinitions.filter {
-            it.displayName.contains(trimmedSearchQuery, ignoreCase = true)
-        }
+        displayableDefinitions.filter { it.displayName.matchesQuery(trimmedSearchQuery) }
     }
 
     Column(
         modifier = Modifier.padding(bottom = 16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        if (searchQuery.isBlank()) {
+        if (IntegrationTypeSettingName.matchesQuery(trimmedSearchQuery)) {
             Row {
                 IntegrationTypeConfigurableSetting(
                     configurationData,
@@ -58,6 +56,10 @@ internal fun SettingsUi(
             Setting(settingDefinition, playgroundSettings)
         }
     }
+}
+
+private fun String.matchesQuery(query: String): Boolean {
+    return this.contains(query, ignoreCase = true)
 }
 
 @Preview
@@ -127,13 +129,15 @@ private fun <T> Setting(
     }
 }
 
+private const val IntegrationTypeSettingName = "Integration Type"
+
 @Composable
 private fun IntegrationTypeConfigurableSetting(
     configurationData: PlaygroundConfigurationData,
     updateConfigurationData: (updater: (PlaygroundConfigurationData) -> PlaygroundConfigurationData) -> Unit
 ) {
     DropdownSetting(
-        name = "Integration Type",
+        name = IntegrationTypeSettingName,
         options = listOf(
             PlaygroundSettingDefinition.Displayable.Option(
                 name = "Payment Sheet",

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/SettingsUI.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/SettingsUI.kt
@@ -22,13 +22,23 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.stripe.android.paymentsheet.example.playground.PlaygroundTheme
 import kotlinx.coroutines.flow.StateFlow
 
 @Composable
-internal fun SettingsUi(playgroundSettings: PlaygroundSettings) {
+internal fun SettingsUi(
+    playgroundSettings: PlaygroundSettings,
+    searchQuery: String,
+) {
     val configurationData by playgroundSettings.configurationData.collectAsState()
     val displayableDefinitions by playgroundSettings.displayableDefinitions.collectAsState()
+    val filteredDefinitions = remember(displayableDefinitions, searchQuery) {
+        displayableDefinitions.filter {
+            it.displayName.contains(searchQuery, ignoreCase = true)
+        }
+    }
 
     Column(
         modifier = Modifier.padding(bottom = 16.dp),
@@ -41,12 +51,25 @@ internal fun SettingsUi(playgroundSettings: PlaygroundSettings) {
             )
         }
 
-        for (settingDefinition in displayableDefinitions) {
-            Row {
-                Setting(settingDefinition, playgroundSettings)
-            }
+        for (settingDefinition in filteredDefinitions) {
+            Setting(settingDefinition, playgroundSettings)
         }
     }
+}
+
+@Preview
+@Composable
+private fun SettingsUiPreview() {
+    PlaygroundTheme(
+        content = {
+            SettingsUi(
+                playgroundSettings = PlaygroundSettings.createFromDefaults(),
+                searchQuery = "",
+            )
+        },
+        bottomBarContent = {},
+        topBarContent = {}
+    )
 }
 
 @Composable
@@ -56,7 +79,7 @@ private fun <T> Setting(
 ) {
     val configurationData by playgroundSettings.configurationData.collectAsState()
 
-    val options = remember(configurationData) {
+    val options = remember(settingDefinition, configurationData) {
         settingDefinition.createOptions(configurationData)
     }
 

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/SettingsUI.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/SettingsUI.kt
@@ -58,8 +58,21 @@ internal fun SettingsUi(
     }
 }
 
+private val WordBoundaryRegex by lazy(LazyThreadSafetyMode.NONE) { "\\s+".toRegex() }
+
+/**
+ * Returns true if the string matches the query.
+ */
 private fun String.matchesQuery(query: String): Boolean {
-    return this.contains(query, ignoreCase = true)
+    if (query.isBlank()) {
+        return true
+    }
+
+    val words = this.trim().split(WordBoundaryRegex)
+    val queryWords = query.trim().split(WordBoundaryRegex)
+    return queryWords.all { queryWord ->
+        words.any { word -> word.startsWith(queryWord, ignoreCase = true) }
+    }
 }
 
 @Preview


### PR DESCRIPTION
# Summary
Adds a search box to the top of Playground to more quickly find settings within the ever-growing list.

# Motivation
Make it easier to access frequently used settings.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots

https://github.com/user-attachments/assets/1c614662-1a66-4eda-a468-e1f0cedd5212
