### PR TITLE
Use StripeTheme.getOuterFormInsets for AutocompleteScreen horizontal padding

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreen.kt
@@ -41,8 +41,10 @@ import com.stripe.android.common.ui.LoadingIndicator
 import com.stripe.android.paymentsheet.injection.AutocompleteViewModelSubcomponent
 import com.stripe.android.paymentsheet.ui.AddressOptionsAppBar
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
+import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.elements.TextField
 import com.stripe.android.uicore.elements.TextFieldSection
+import com.stripe.android.uicore.getOuterFormInsets
 import com.stripe.android.uicore.shouldUseDarkDynamicColor
 import com.stripe.android.uicore.stripeColors
 import com.stripe.android.uicore.text.annotatedStringResource
@@ -130,10 +132,11 @@ internal fun AutocompleteScreenUI(viewModel: AutocompleteViewModel) {
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                        .padding(vertical = 8.dp)
                 ) {
                     TextFieldSection(
                         textFieldController = viewModel.textFieldController,
+                        modifier = Modifier.padding(StripeTheme.getOuterFormInsets())
                     ) {
                         TextField(
                             modifier = Modifier
@@ -156,7 +159,7 @@ internal fun AutocompleteScreenUI(viewModel: AutocompleteViewModel) {
                                 modifier = Modifier.padding(vertical = 8.dp)
                             )
                             Column(
-                                modifier = Modifier.fillMaxWidth()
+                                modifier = Modifier.fillMaxWidth().padding(StripeTheme.getOuterFormInsets())
                             ) {
                                 it.forEach { prediction ->
                                     val primaryText = prediction.primaryText
@@ -168,8 +171,7 @@ internal fun AutocompleteScreenUI(viewModel: AutocompleteViewModel) {
                                                 viewModel.selectPrediction(prediction)
                                             }
                                             .padding(
-                                                vertical = 8.dp,
-                                                horizontal = 16.dp
+                                                vertical = 8.dp
                                             )
                                     ) {
                                         val regex = query
@@ -194,9 +196,7 @@ internal fun AutocompleteScreenUI(viewModel: AutocompleteViewModel) {
                                             style = MaterialTheme.typography.body1
                                         )
                                     }
-                                    Divider(
-                                        modifier = Modifier.padding(horizontal = 16.dp)
-                                    )
+                                    Divider()
                                 }
                             }
                         }
@@ -208,10 +208,8 @@ internal fun AutocompleteScreenUI(viewModel: AutocompleteViewModel) {
                                 ),
                                 contentDescription = null,
                                 modifier = Modifier
-                                    .padding(
-                                        vertical = 16.dp,
-                                        horizontal = 16.dp
-                                    )
+                                    .padding(vertical = 16.dp)
+                                    .padding(StripeTheme.getOuterFormInsets())
                                     .testTag(TEST_TAG_ATTRIBUTION_DRAWABLE)
                             )
                         }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Update `AutocompleteScreen` to use `StripeTheme.getOuterFormInsets` for horizontal padding

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-3607

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [X] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| ![Screenshot_1748983559](https://github.com/user-attachments/assets/ce629d0c-9c2d-45c8-9fee-dd81e94eb359)  | ![Screenshot_1748983514](https://github.com/user-attachments/assets/1194d5cb-110d-41f7-be94-c3cb7450f9ca) |
