### PR TITLE
Remove custom focus direction attributes in forms.

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/ui/AddressSection.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/AddressSection.kt
@@ -11,7 +11,6 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
@@ -126,8 +125,6 @@ private fun AddressSectionContent(
         element = sectionElement,
         hiddenIdentifiers = emptySet(),
         lastTextFieldIdentifier = textIdentifiers.lastOrNull(),
-        nextFocusDirection = FocusDirection.Next,
-        previousFocusDirection = FocusDirection.Previous
     )
 
     TextButton(

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
@@ -2,7 +2,6 @@ package com.stripe.android.ui.core.elements
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.DefaultCardBrandFilter
@@ -127,9 +126,7 @@ internal class CardDetailsController(
         field: SectionFieldElement,
         modifier: Modifier,
         hiddenIdentifiers: Set<IdentifierSpec>,
-        lastTextFieldIdentifier: IdentifierSpec?,
-        nextFocusDirection: FocusDirection,
-        previousFocusDirection: FocusDirection
+        lastTextFieldIdentifier: IdentifierSpec?
     ) {
         CardDetailsElementUI(
             enabled,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElementUI.kt
@@ -5,7 +5,6 @@ import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.unit.dp
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SectionFieldElementUI
@@ -21,23 +20,12 @@ internal fun CardDetailsElementUI(
     modifier: Modifier = Modifier,
 ) {
     controller.fields.forEachIndexed { index, field ->
-        // We need to adjust the focus direction, because some devices (Samsung, OnePlus) will
-        // navigate to the CVC field if we use `FocusDirection.Down`. We only adjust this for the
-        // card number field, because changing this for all fields will allow loops where pressing
-        // the backspace in the first field will circle back to the last field.
-        val nextFocusDirection = if (field.identifier == IdentifierSpec.CardNumber) {
-            FocusDirection.Next
-        } else {
-            FocusDirection.Down
-        }
-
         SectionFieldElementUI(
             enabled,
             field,
             modifier = modifier,
             hiddenIdentifiers = hiddenIdentifiers,
             lastTextFieldIdentifier = lastTextFieldIdentifier,
-            nextFocusDirection = nextFocusDirection
         )
         if (index != controller.fields.lastIndex) {
             Divider(

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.autofill.AutofillType
-import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.LayoutDirection
@@ -362,9 +361,7 @@ internal class DefaultCardNumberController(
         field: SectionFieldElement,
         modifier: Modifier,
         hiddenIdentifiers: Set<IdentifierSpec>,
-        lastTextFieldIdentifier: IdentifierSpec?,
-        nextFocusDirection: FocusDirection,
-        previousFocusDirection: FocusDirection
+        lastTextFieldIdentifier: IdentifierSpec?
     ) {
         val reporter = LocalCardNumberCompletedEventReporter.current
         val disallowedBrandReporter = LocalCardBrandDisallowedReporter.current
@@ -400,9 +397,7 @@ internal class DefaultCardNumberController(
             field,
             modifier,
             hiddenIdentifiers,
-            lastTextFieldIdentifier,
-            nextFocusDirection,
-            previousFocusDirection
+            lastTextFieldIdentifier
         )
     }
 

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberControllerTest.kt
@@ -2,7 +2,6 @@ package com.stripe.android.ui.core.elements
 
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.unit.LayoutDirection
@@ -420,9 +419,7 @@ internal class CardNumberControllerTest {
                     ),
                     modifier = Modifier.testTag(TEST_TAG),
                     hiddenIdentifiers = emptySet(),
-                    lastTextFieldIdentifier = null,
-                    nextFocusDirection = FocusDirection.Next,
-                    previousFocusDirection = FocusDirection.Next
+                    lastTextFieldIdentifier = null
                 )
             }
         }
@@ -456,8 +453,6 @@ internal class CardNumberControllerTest {
                     modifier = Modifier.testTag(TEST_TAG),
                     hiddenIdentifiers = emptySet(),
                     lastTextFieldIdentifier = null,
-                    nextFocusDirection = FocusDirection.Next,
-                    previousFocusDirection = FocusDirection.Next,
                 )
             }
         }
@@ -533,9 +528,7 @@ internal class CardNumberControllerTest {
                     ),
                     modifier = Modifier.testTag(TEST_TAG),
                     hiddenIdentifiers = emptySet(),
-                    lastTextFieldIdentifier = null,
-                    nextFocusDirection = FocusDirection.Next,
-                    previousFocusDirection = FocusDirection.Next
+                    lastTextFieldIdentifier = null
                 )
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
@@ -29,7 +29,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalFocusManager
@@ -505,9 +504,7 @@ internal fun CvcRecollectionField(
                         .fillMaxWidth()
                         .focusRequester(focusRequester),
                     hiddenIdentifiers = setOf(),
-                    lastTextFieldIdentifier = null,
-                    nextFocusDirection = FocusDirection.Exit,
-                    previousFocusDirection = FocusDirection.Previous
+                    lastTextFieldIdentifier = null
                 )
             }
             error?.errorMessage?.let {

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressController.kt
@@ -4,7 +4,6 @@ import androidx.annotation.RestrictTo
 import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusDirection
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.flatMapLatestAsStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -36,8 +35,6 @@ class AddressController(
         modifier: Modifier,
         hiddenIdentifiers: Set<IdentifierSpec>,
         lastTextFieldIdentifier: IdentifierSpec?,
-        nextFocusDirection: FocusDirection,
-        previousFocusDirection: FocusDirection
     ) {
         AddressElementUI(
             enabled,

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldController.kt
@@ -5,7 +5,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.autofill.AutofillType
-import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
@@ -114,9 +113,7 @@ class AddressTextFieldController(
         field: SectionFieldElement,
         modifier: Modifier,
         hiddenIdentifiers: Set<IdentifierSpec>,
-        lastTextFieldIdentifier: IdentifierSpec?,
-        nextFocusDirection: FocusDirection,
-        previousFocusDirection: FocusDirection
+        lastTextFieldIdentifier: IdentifierSpec?
     ) {
         AddressTextFieldUI(this, modifier)
     }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/CheckboxFieldController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/CheckboxFieldController.kt
@@ -4,7 +4,6 @@ import androidx.annotation.RestrictTo
 import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusDirection
 import com.stripe.android.uicore.R
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -50,9 +49,7 @@ class CheckboxFieldController constructor(
         field: SectionFieldElement,
         modifier: Modifier,
         hiddenIdentifiers: Set<IdentifierSpec>,
-        lastTextFieldIdentifier: IdentifierSpec?,
-        nextFocusDirection: FocusDirection,
-        previousFocusDirection: FocusDirection
+        lastTextFieldIdentifier: IdentifierSpec?
     ) {
         CheckboxFieldUI(modifier = modifier, controller = this, enabled = enabled)
     }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DropdownFieldController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DropdownFieldController.kt
@@ -3,7 +3,6 @@ package com.stripe.android.uicore.elements
 import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusDirection
 import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
@@ -73,9 +72,7 @@ class DropdownFieldController(
         field: SectionFieldElement,
         modifier: Modifier,
         hiddenIdentifiers: Set<IdentifierSpec>,
-        lastTextFieldIdentifier: IdentifierSpec?,
-        nextFocusDirection: FocusDirection,
-        previousFocusDirection: FocusDirection
+        lastTextFieldIdentifier: IdentifierSpec?
     ) {
         DropDown(
             this,

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberController.kt
@@ -3,7 +3,6 @@ package com.stripe.android.uicore.elements
 import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.text.input.ImeAction
 import com.stripe.android.uicore.R
 import com.stripe.android.uicore.forms.FormFieldEntry
@@ -181,9 +180,7 @@ class PhoneNumberController private constructor(
         field: SectionFieldElement,
         modifier: Modifier,
         hiddenIdentifiers: Set<IdentifierSpec>,
-        lastTextFieldIdentifier: IdentifierSpec?,
-        nextFocusDirection: FocusDirection,
-        previousFocusDirection: FocusDirection
+        lastTextFieldIdentifier: IdentifierSpec?
     ) {
         PhoneNumberElementUI(
             enabled,

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/RowController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/RowController.kt
@@ -3,7 +3,6 @@ package com.stripe.android.uicore.elements
 import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusDirection
 import com.stripe.android.uicore.utils.combineAsStateFlow
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -23,9 +22,7 @@ class RowController(
         field: SectionFieldElement,
         modifier: Modifier,
         hiddenIdentifiers: Set<IdentifierSpec>,
-        lastTextFieldIdentifier: IdentifierSpec?,
-        nextFocusDirection: FocusDirection,
-        previousFocusDirection: FocusDirection
+        lastTextFieldIdentifier: IdentifierSpec?
     ) {
         RowElementUI(
             enabled,

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/RowElementUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/RowElementUI.kt
@@ -12,10 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.layout.onSizeChanged
-import androidx.compose.ui.platform.LocalLayoutDirection
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import com.stripe.android.uicore.stripeColors
 import com.stripe.android.uicore.stripeShapes
@@ -31,28 +28,11 @@ fun RowElementUI(
 ) {
     val visibleFields = controller.fields.filter { !hiddenIdentifiers.contains(it.identifier) }
     val dividerHeight = remember { mutableStateOf(0.dp) }
-    val layoutDirection = LocalLayoutDirection.current
     // Only draw the row if there are items in the row that are not hidden, otherwise the entire
     // section will fail to draw
     if (visibleFields.isNotEmpty()) {
         Row(modifier = Modifier.fillMaxWidth()) {
             visibleFields.forEachIndexed { index, field ->
-                val nextFocusDirection = if (index == visibleFields.lastIndex) {
-                    FocusDirection.Down
-                } else if (layoutDirection == LayoutDirection.Ltr) {
-                    FocusDirection.Right
-                } else {
-                    FocusDirection.Left
-                }
-
-                val previousFocusDirection = if (index == 0) {
-                    FocusDirection.Up
-                } else if (layoutDirection == LayoutDirection.Ltr) {
-                    FocusDirection.Left
-                } else {
-                    FocusDirection.Right
-                }
-
                 SectionFieldElementUI(
                     enabled,
                     field,
@@ -64,8 +44,6 @@ fun RowElementUI(
                             dividerHeight.value =
                                 (it.height / Resources.getSystem().displayMetrics.density).dp
                         },
-                    nextFocusDirection = nextFocusDirection,
-                    previousFocusDirection = previousFocusDirection
                 )
 
                 if (index != visibleFields.lastIndex) {

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionElementUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionElementUI.kt
@@ -9,7 +9,6 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.stripe.android.uicore.stripeColors
@@ -24,8 +23,6 @@ fun SectionElementUI(
     hiddenIdentifiers: Set<IdentifierSpec>,
     lastTextFieldIdentifier: IdentifierSpec?,
     modifier: Modifier = Modifier,
-    nextFocusDirection: FocusDirection = FocusDirection.Down,
-    previousFocusDirection: FocusDirection = FocusDirection.Up
 ) {
     if (!hiddenIdentifiers.contains(element.identifier)) {
         val controller = element.controller
@@ -51,8 +48,6 @@ fun SectionElementUI(
                     field,
                     hiddenIdentifiers = hiddenIdentifiers,
                     lastTextFieldIdentifier = lastTextFieldIdentifier,
-                    nextFocusDirection = nextFocusDirection,
-                    previousFocusDirection = previousFocusDirection
                 )
                 if (index != element.fields.lastIndex) {
                     Divider(

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionFieldComposable.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionFieldComposable.kt
@@ -3,7 +3,6 @@ package com.stripe.android.uicore.elements
 import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusDirection
 
 /**
  * Indicates a class could be drawn as a Composable within SectionFieldElementUI.
@@ -16,8 +15,6 @@ fun interface SectionFieldComposable {
         field: SectionFieldElement,
         modifier: Modifier,
         hiddenIdentifiers: Set<IdentifierSpec>,
-        lastTextFieldIdentifier: IdentifierSpec?,
-        nextFocusDirection: FocusDirection,
-        previousFocusDirection: FocusDirection
+        lastTextFieldIdentifier: IdentifierSpec?
     )
 }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionFieldElementUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionFieldElementUI.kt
@@ -3,7 +3,6 @@ package com.stripe.android.uicore.elements
 import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusDirection
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Composable
@@ -13,8 +12,6 @@ fun SectionFieldElementUI(
     modifier: Modifier = Modifier,
     hiddenIdentifiers: Set<IdentifierSpec> = emptySet(),
     lastTextFieldIdentifier: IdentifierSpec?,
-    nextFocusDirection: FocusDirection = FocusDirection.Down,
-    previousFocusDirection: FocusDirection = FocusDirection.Up
 ) {
     if (!hiddenIdentifiers.contains(field.identifier)) {
         (field.sectionFieldErrorController() as? SectionFieldComposable)?.ComposeUI(
@@ -22,9 +19,7 @@ fun SectionFieldElementUI(
             field,
             modifier,
             hiddenIdentifiers,
-            lastTextFieldIdentifier,
-            nextFocusDirection,
-            previousFocusDirection
+            lastTextFieldIdentifier
         )
     }
 }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldController.kt
@@ -7,7 +7,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.autofill.AutofillType
-import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
@@ -63,8 +62,6 @@ interface TextFieldController : InputController, SectionFieldComposable, Section
         modifier: Modifier,
         hiddenIdentifiers: Set<IdentifierSpec>,
         lastTextFieldIdentifier: IdentifierSpec?,
-        nextFocusDirection: FocusDirection,
-        previousFocusDirection: FocusDirection,
     ) {
         TextField(
             textFieldController = this,
@@ -75,8 +72,6 @@ interface TextFieldController : InputController, SectionFieldComposable, Section
                 ImeAction.Next
             },
             modifier = modifier,
-            nextFocusDirection = nextFocusDirection,
-            previousFocusDirection = previousFocusDirection
         )
     }
 }
@@ -229,8 +224,6 @@ class SimpleTextFieldController(
         modifier: Modifier,
         hiddenIdentifiers: Set<IdentifierSpec>,
         lastTextFieldIdentifier: IdentifierSpec?,
-        nextFocusDirection: FocusDirection,
-        previousFocusDirection: FocusDirection,
     ) {
         TextField(
             textFieldController = this,
@@ -241,8 +234,6 @@ class SimpleTextFieldController(
                 ImeAction.Next
             },
             modifier = modifier,
-            nextFocusDirection = nextFocusDirection,
-            previousFocusDirection = previousFocusDirection,
             shouldAnnounceLabel = textFieldConfig.shouldAnnounceLabel,
             shouldAnnounceFieldValue = textFieldConfig.shouldAnnounceFieldValue
         )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Fixes an issue where going to the next/previous field was not occurring correctly.

We had a lot of custom code to do something custom for focus direction, but it proved to causes issues. I'm not sure if compose has just improved since this was added, or if it was never necessary to begin with.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-3592

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
|  https://github.com/user-attachments/assets/3d940894-c45d-461b-a9ce-eeb696dcde92  |  https://github.com/user-attachments/assets/4a4de104-1440-4681-ab9e-00be2c1de7cc |
