### PR TITLE
Fix PaymentSheetContentPadding bug

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/utils/ComposeUtils.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/utils/ComposeUtils.kt
@@ -7,13 +7,14 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.coerceAtLeast
 import androidx.compose.ui.unit.dp
 import com.stripe.android.uicore.StripeTheme
 
 @Composable
 internal fun PaymentSheetContentPadding(subtractingExtraPadding: Dp = 0.dp) {
-    val bottomPadding = StripeTheme.formInsets.bottom.dp
-    Spacer(modifier = Modifier.requiredHeight(bottomPadding - subtractingExtraPadding))
+    val bottomPadding = StripeTheme.formInsets.bottom.dp - subtractingExtraPadding
+    Spacer(modifier = Modifier.requiredHeight(bottomPadding.coerceAtLeast(0.dp)))
 }
 
 @Composable


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Refactor `PaymentSheetContentPadding` to coerce spacer height to at least 0.dp

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Exception will occur if `subtractingExtraPadding` is greater than `StripeTheme.formInsets.bottom` resulting in negative value being passed to `Spacer`

