### PR TITLE
Fix ripple effect on Link wallet items

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/PaymentDetails.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/PaymentDetails.kt
@@ -81,8 +81,8 @@ internal fun PaymentDetailsListItem(
     // without knowing the dimensions of the radio button on the first layout pass.
     Layout(
         modifier = modifier
-            .padding(top = 8.dp, bottom = 8.dp, start = 20.dp)
-            .clickable(enabled = isClickable, onClick = onClick),
+            .clickable(enabled = isClickable, onClick = onClick)
+            .padding(top = 8.dp, bottom = 8.dp, start = 20.dp),
         content = {
             RadioButton(
                 selected = isSelected,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes a minor issue with the ripple effect on Link wallet items. The clickable modifier was called after the padding modifier, which limited the ripple effect's area.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
