### PR TITLE
Add Top Inset to MPE

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/ui/BottomSheetScaffold.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/ui/BottomSheetScaffold.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.windowInsetsBottomHeight
@@ -18,6 +19,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
+import com.stripe.android.uicore.StripeTheme
 
 @Composable
 internal fun BottomSheetScaffold(
@@ -55,6 +57,7 @@ internal fun BottomSheetScaffold(
                 .imePadding()
                 .verticalScroll(scrollState)
         ) {
+            Spacer(Modifier.height(StripeTheme.formInsets.top.dp))
             content()
             Spacer(modifier = Modifier.windowInsetsBottomHeight(WindowInsets.navigationBars))
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreen.kt
@@ -127,7 +127,7 @@ internal fun AutocompleteScreenUI(viewModel: AutocompleteViewModel) {
                 .padding(paddingValues)
         ) {
             Column(
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth().padding(top = StripeTheme.formInsets.top.dp)
             ) {
                 Box(
                     modifier = Modifier

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
@@ -58,7 +58,7 @@ internal fun InputAddressScreen(
             modifier = Modifier.padding(it)
         ) {
             Column(
-                Modifier.padding(StripeTheme.getOuterFormInsets())
+                Modifier.padding(StripeTheme.getOuterFormInsets()).padding(top = StripeTheme.formInsets.top.dp)
             ) {
                 Text(
                     title,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add `Spacer` with height set to `StripeTheme.formInsets.top` to `BottomSheetScaffold`
Add top padding to `AutocompleteScreen` and `InputAddressScreen`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-3607

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

# Screenshots
Example with top inset set to 100
![Screenshot_1749069585](https://github.com/user-attachments/assets/f977f333-bf3d-4f0d-931e-26c7809098cf)

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
