### PR TITLE
Show consumer email in Link row button

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -327,6 +327,9 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
         val wallets = mutableListOf<DisplayablePaymentMethod>()
         if (showsWalletsInline(walletsState)) {
             walletsState?.link?.let {
+                val subtitle = it.email?.resolvableString
+                    ?: PaymentsCoreR.string.stripe_link_simple_secure_payments.resolvableString
+
                 wallets += DisplayablePaymentMethod(
                     code = PaymentMethod.Type.Link.code,
                     displayName = PaymentsCoreR.string.stripe_link.resolvableString,
@@ -334,7 +337,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
                     lightThemeIconUrl = null,
                     darkThemeIconUrl = null,
                     iconRequiresTinting = false,
-                    subtitle = PaymentsCoreR.string.stripe_link_simple_secure_payments.resolvableString,
+                    subtitle = subtitle,
                     onClick = {
                         updateSelection(PaymentSelection.Link())
                     },


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request make the Link row button render the email address of a returning Link user as the subtitle, instead of rendering a generic message. We do this in both FlowController (in vertical mode) and Embedded.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
