### PR TITLE
Re-enable Link card brand tests

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestLink.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestLink.kt
@@ -36,7 +36,6 @@ internal class TestLink : BasePlaygroundTest() {
     }
 
     @Test
-    @Ignore("Re-enable when Link card brand issues in test mode are resolved")
     fun testLinkPaymentWithBankAccountInPassthroughMode() {
         val testParameters = makeLinkTestParameters(passthroughMode = true)
         testDriver.confirmWithBankAccountInLink(testParameters)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Re-enables Link card brand tests following https://github.com/stripe/stripe-android/pull/10915.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
