### PR TITLE
Add .cursor/ to .gitignore to ignore Cursor IDE configuration directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ proguard/
 *.iws
 .idea
 
+# Cursor IDE
+.cursor/
+
 # Output
 payments/target
 payments/gen


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add .cursor/ to .gitignore to ignore Cursor IDE config files.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
We are introducing Cursor and the personalized rules can be set to better assist the usage of Cursor. These rule files should not be submitted to remote (at least for now).
