### PR TITLE
Use `ResolvableString` instead of `Int` resource identifier in most places & make `label` non-null

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.stripe.android.core.Logger
 import com.stripe.android.core.exception.PermissionException
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.financialconnections.ElementsSessionContext
 import com.stripe.android.financialconnections.R
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsAnalyticsEvent.Click
@@ -112,7 +113,9 @@ internal class NetworkingLinkSignupViewModel @AssistedInject constructor(
                 appVerificationEnabled = sync.manifest.appVerificationEnabled,
                 prefilledEmail = initialEmail,
                 emailController = SimpleTextFieldController(
-                    textFieldConfig = EmailConfig(label = R.string.stripe_networking_signup_email_label),
+                    textFieldConfig = EmailConfig(
+                        label = resolvableString(R.string.stripe_networking_signup_email_label)
+                    ),
                     initialValue = initialEmail,
                     showOptionalLabel = false
                 ),

--- a/identity-example/build.gradle
+++ b/identity-example/build.gradle
@@ -59,6 +59,7 @@ android {
 
 dependencies {
     implementation project(':identity')
+    implementation project(':stripe-core')
     implementation project(':stripe-ui-core')
 
     implementation libs.accompanist.materialThemeAdapter

--- a/identity/src/main/java/com/stripe/android/identity/ui/AddressSection.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/AddressSection.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.stripe.android.core.model.Country
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.identity.navigation.CountryNotListedDestination
 import com.stripe.android.identity.navigation.navigateTo
 import com.stripe.android.identity.networking.Resource
@@ -67,7 +68,10 @@ internal fun AddressSection(
         }
     }
     val sectionElement = remember(selectedCountryCode) {
-        SectionElement.wrap(sectionList, UiCoreR.string.stripe_address_label_address)
+        SectionElement.wrap(
+            sectionList,
+            resolvableString(UiCoreR.string.stripe_address_label_address)
+        )
     }
     val formFieldValues by sectionElement.getFormFieldValueFlow()
         .collectAsState()

--- a/identity/src/main/java/com/stripe/android/identity/ui/DOBSection.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/DOBSection.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.text.input.OffsetMapping
 import androidx.compose.ui.text.input.TransformedText
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.identity.R
 import com.stripe.android.identity.networking.Resource
 import com.stripe.android.identity.networking.models.DobParam
@@ -58,7 +59,7 @@ internal fun DOBSection(
                 identifier = IdentifierSpec.Generic(DOB_SPEC),
                 controller = dateController
             ),
-            label = R.string.stripe_dob
+            label = resolvableString(R.string.stripe_dob)
         )
     }
 
@@ -82,7 +83,7 @@ internal fun DOBSection(
 }
 
 internal object DobTextFieldConfig : SimpleTextFieldConfig(
-    label = R.string.stripe_dob_placeholder
+    label = resolvableString(R.string.stripe_dob_placeholder)
 ) {
     /**
      * Check if the string is a valid date and is between 01-01-1990 and now.

--- a/identity/src/main/java/com/stripe/android/identity/ui/IDNumberSection.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/IDNumberSection.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.stripe.android.core.model.Country
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.identity.R
 import com.stripe.android.identity.navigation.CountryNotListedDestination
 import com.stripe.android.identity.navigation.navigateTo
@@ -151,7 +152,7 @@ private fun IDNumberContent(
                     }
                 }
             ),
-            label = R.string.stripe_id_number
+            label = resolvableString(R.string.stripe_id_number)
         )
     }
     val textIdentifiers by idNumberSectionElement.getTextFieldIdentifiers()
@@ -194,7 +195,7 @@ private fun IDNumberContent(
 }
 
 private object USIDConfig : SimpleTextFieldConfig(
-    label = R.string.stripe_last_4_of_ssn
+    label = resolvableString(R.string.stripe_last_4_of_ssn)
 ) {
     override val placeHolder = US_ID_PLACEHOLDER
     override val keyboard = KeyboardType.Number
@@ -213,7 +214,7 @@ private object USIDConfig : SimpleTextFieldConfig(
 }
 
 private object BRIDConfig : SimpleTextFieldConfig(
-    label = R.string.stripe_individual_cpf
+    label = resolvableString(R.string.stripe_individual_cpf)
 ) {
     override val placeHolder = BRAZIL_ID_PLACEHOLDER
     override val keyboard = KeyboardType.Number
@@ -232,7 +233,7 @@ private object BRIDConfig : SimpleTextFieldConfig(
 }
 
 private object SGIDConfig : SimpleTextFieldConfig(
-    label = R.string.stripe_nric_or_fin
+    label = resolvableString(R.string.stripe_nric_or_fin)
 ) {
     override val placeHolder = SINGAPORE_ID_PLACEHOLDER
     override fun determineState(input: String): TextFieldState = object : TextFieldState {

--- a/identity/src/main/java/com/stripe/android/identity/ui/NameSection.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/NameSection.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.identity.R
 import com.stripe.android.identity.networking.Resource
 import com.stripe.android.identity.networking.models.NameParam
@@ -29,12 +30,12 @@ internal fun NameSection(
 ) {
     val firstNameController = remember {
         SimpleTextFieldController(
-            textFieldConfig = SimpleTextFieldConfig(R.string.stripe_first_name)
+            textFieldConfig = SimpleTextFieldConfig(resolvableString(R.string.stripe_first_name))
         )
     }
     val lastNameController = remember {
         SimpleTextFieldController(
-            textFieldConfig = SimpleTextFieldConfig(R.string.stripe_last_name)
+            textFieldConfig = SimpleTextFieldConfig(resolvableString(R.string.stripe_last_name))
         )
     }
     val nameSectionElement = remember {
@@ -49,7 +50,7 @@ internal fun NameSection(
                     controller = lastNameController
                 )
             ),
-            label = CoreR.string.stripe_address_label_name
+            label = resolvableString(CoreR.string.stripe_address_label_name)
         )
     }
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressSpec.kt
@@ -3,6 +3,7 @@ package com.stripe.android.ui.core.elements
 import android.os.Parcelable
 import androidx.annotation.RestrictTo
 import com.stripe.android.core.model.CountryUtils
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.ui.core.R
 import com.stripe.android.uicore.elements.AddressElement
 import com.stripe.android.uicore.elements.AddressType
@@ -57,7 +58,7 @@ data class AddressSpec(
         initialValues: Map<IdentifierSpec, String?>,
         shippingValues: Map<IdentifierSpec, String?>?,
     ): List<FormElement> {
-        val label = if (showLabel) R.string.stripe_billing_details else null
+        val label = if (showLabel) resolvableString(R.string.stripe_billing_details) else null
         return if (displayFields.size == 1 && displayFields.first() == DisplayField.Country) {
             listOfNotNull(
                 createSectionElement(

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AuBankAccountNumberConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AuBankAccountNumberConfig.kt
@@ -1,10 +1,10 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
-import androidx.annotation.StringRes
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.uicore.elements.TextFieldConfig
 import com.stripe.android.uicore.elements.TextFieldIcon
 import com.stripe.android.uicore.elements.TextFieldState
@@ -25,8 +25,7 @@ class AuBankAccountNumberConfig : TextFieldConfig {
     override val trailingIcon: StateFlow<TextFieldIcon?> = MutableStateFlow(null)
     override val loading: StateFlow<Boolean> = MutableStateFlow(false)
 
-    @StringRes
-    override val label = StripeR.string.stripe_becs_widget_account_number
+    override val label = resolvableString(StripeR.string.stripe_becs_widget_account_number)
     override val keyboard = KeyboardType.Number
 
     override fun filter(userTyped: String) =

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BacsDebitAccountNumberConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BacsDebitAccountNumberConfig.kt
@@ -1,10 +1,11 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
-import androidx.annotation.StringRes
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
+import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.ui.core.R
 import com.stripe.android.uicore.elements.TextFieldConfig
 import com.stripe.android.uicore.elements.TextFieldIcon
@@ -19,8 +20,7 @@ class BacsDebitAccountNumberConfig : TextFieldConfig {
 
     override val debugLabel: String = DEBUG_LABEL
 
-    @StringRes
-    override val label: Int = R.string.stripe_bacs_account_number
+    override val label: ResolvableString = resolvableString(R.string.stripe_bacs_account_number)
 
     override val placeHolder: String
         get() = PLACEHOLDER

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BacsDebitBankAccountSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BacsDebitBankAccountSpec.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.ui.core.R
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SimpleTextElement
@@ -41,7 +42,7 @@ class BacsDebitBankAccountSpec : FormItemSpec() {
                 )
             )
         ),
-        R.string.stripe_bacs_bank_account_title
+        resolvableString(R.string.stripe_bacs_bank_account_title)
     )
 
     private companion object {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BacsDebitSortCodeConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BacsDebitSortCodeConfig.kt
@@ -1,10 +1,11 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
-import androidx.annotation.StringRes
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
+import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.ui.core.R
 import com.stripe.android.uicore.elements.TextFieldConfig
 import com.stripe.android.uicore.elements.TextFieldIcon
@@ -19,8 +20,7 @@ class BacsDebitSortCodeConfig : TextFieldConfig {
 
     override val debugLabel: String = DEBUG_LABEL
 
-    @StringRes
-    override val label: Int = R.string.stripe_bacs_sort_code
+    override val label: ResolvableString = resolvableString(R.string.stripe_bacs_sort_code)
 
     override val placeHolder: String
         get() = PLACEHOLDER

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BlikConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BlikConfig.kt
@@ -1,10 +1,11 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
-import androidx.annotation.StringRes
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
+import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.ui.core.R
 import com.stripe.android.uicore.elements.TextFieldConfig
 import com.stripe.android.uicore.elements.TextFieldIcon
@@ -22,8 +23,7 @@ class BlikConfig : TextFieldConfig {
         "^[0-9]{6}\$".toRegex()
     }
 
-    @StringRes
-    override val label: Int = R.string.stripe_blik_code
+    override val label: ResolvableString = resolvableString(R.string.stripe_blik_code)
 
     override val capitalization: KeyboardCapitalization = KeyboardCapitalization.None
     override val debugLabel: String = "blik_code"

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BsbConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BsbConfig.kt
@@ -1,13 +1,13 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
-import androidx.annotation.StringRes
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.OffsetMapping
 import androidx.compose.ui.text.input.TransformedText
 import androidx.compose.ui.text.input.VisualTransformation
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.uicore.elements.TextFieldConfig
 import com.stripe.android.uicore.elements.TextFieldIcon
 import com.stripe.android.uicore.elements.TextFieldState
@@ -29,8 +29,7 @@ class BsbConfig(private val banks: List<BecsDebitBanks.Bank>) : TextFieldConfig 
     override val trailingIcon: StateFlow<TextFieldIcon?> = MutableStateFlow(null)
     override val loading: StateFlow<Boolean> = MutableStateFlow(false)
 
-    @StringRes
-    override val label = StripeR.string.stripe_becs_widget_bsb
+    override val label = resolvableString(StripeR.string.stripe_becs_widget_bsb)
     override val keyboard = KeyboardType.Number
 
     // Displays the BSB number in 2 groups of 3 characters with a dash added between them

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.text.input.KeyboardCapitalization
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.cards.CardAccountRangeRepository
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.CardBrand
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
@@ -38,7 +39,7 @@ internal class CardDetailsController(
         SimpleTextElement(
             controller = SimpleTextFieldController(
                 textFieldConfig = SimpleTextFieldConfig(
-                    label = R.string.stripe_name_on_card,
+                    label = resolvableString(R.string.stripe_name_on_card),
                     capitalization = KeyboardCapitalization.Words,
                     keyboard = androidx.compose.ui.text.input.KeyboardType.Text
                 ),

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsTextFieldConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsTextFieldConfig.kt
@@ -3,6 +3,7 @@ package com.stripe.android.ui.core.elements
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
+import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.model.CardBrand
 import com.stripe.android.uicore.elements.TextFieldState
 
@@ -13,7 +14,7 @@ import com.stripe.android.uicore.elements.TextFieldState
 internal interface CardDetailsTextFieldConfig {
     val capitalization: KeyboardCapitalization
     val debugLabel: String
-    val label: Int
+    val label: ResolvableString
     val keyboard: KeyboardType
     fun determineVisualTransformation(number: String, panLength: Int): VisualTransformation
     fun determineState(brand: CardBrand, number: String, numberAllowedDigits: Int): TextFieldState

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberConfig.kt
@@ -5,6 +5,8 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.CardUtils
+import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.CardBrand
 import com.stripe.android.uicore.elements.TextFieldState
 import com.stripe.android.uicore.elements.TextFieldStateConstants
@@ -16,7 +18,7 @@ internal class CardNumberConfig(
 ) : CardDetailsTextFieldConfig {
     override val capitalization: KeyboardCapitalization = KeyboardCapitalization.None
     override val debugLabel: String = "Card number"
-    override val label: Int = StripeR.string.stripe_acc_label_card_number
+    override val label: ResolvableString = resolvableString(StripeR.string.stripe_acc_label_card_number)
     override val keyboard: KeyboardType = KeyboardType.NumberPassword
 
     // Hardcoded number of card digits + a buffer entered before we hit the card metadata service in CBC

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
@@ -85,7 +85,7 @@ internal class DefaultCardNumberController(
     override val keyboardType: KeyboardType = cardTextFieldConfig.keyboard
     override val debugLabel = cardTextFieldConfig.debugLabel
 
-    override val label: StateFlow<Int> = stateFlowOf(cardTextFieldConfig.label)
+    override val label: StateFlow<ResolvableString> = stateFlowOf(cardTextFieldConfig.label)
 
     private val _fieldValue = MutableStateFlow("")
     override val fieldValue: StateFlow<String> = _fieldValue.asStateFlow()

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcConfig.kt
@@ -4,6 +4,8 @@ import androidx.annotation.RestrictTo
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
+import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.CardBrand
 import com.stripe.android.uicore.elements.TextFieldState
 import com.stripe.android.uicore.elements.TextFieldStateConstants
@@ -13,7 +15,7 @@ import com.stripe.android.R as StripeR
 class CvcConfig : CardDetailsTextFieldConfig {
     override val capitalization: KeyboardCapitalization = KeyboardCapitalization.None
     override val debugLabel: String = "cvc"
-    override val label: Int = StripeR.string.stripe_cvc_number_hint
+    override val label: ResolvableString = resolvableString(StripeR.string.stripe_cvc_number_hint)
     override val keyboard: KeyboardType = KeyboardType.NumberPassword
 
     override fun determineVisualTransformation(number: String, panLength: Int): VisualTransformation {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcController.kt
@@ -34,13 +34,15 @@ class CvcController constructor(
     override val keyboardType: KeyboardType = cvcTextFieldConfig.keyboard
 
     private val _label = cardBrandFlow.mapAsStateFlow { cardBrand ->
-        if (cardBrand == CardBrand.AmericanExpress) {
+        val resource = if (cardBrand == CardBrand.AmericanExpress) {
             StripeR.string.stripe_cvc_amex_hint
         } else {
             StripeR.string.stripe_cvc_number_hint
         }
+
+        resolvableString(resource)
     }
-    override val label: StateFlow<Int> = _label
+    override val label: StateFlow<ResolvableString> = _label
 
     override val debugLabel = cvcTextFieldConfig.debugLabel
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DropdownSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DropdownSpec.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.uicore.elements.DropdownFieldController
 import com.stripe.android.uicore.elements.IdentifierSpec
 import kotlinx.parcelize.Parcelize
@@ -27,7 +28,7 @@ data class DropdownSpec(
             this.apiPath,
             DropdownFieldController(
                 SimpleDropdownConfig(
-                    labelTranslationId.resourceId,
+                    resolvableString(labelTranslationId.resourceId),
                     items
                 ),
                 initialValue = initialValues[apiPath]

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/FormItemSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/FormItemSpec.kt
@@ -2,6 +2,7 @@ package com.stripe.android.ui.core.elements
 
 import android.os.Parcelable
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.SectionFieldElement
@@ -24,12 +25,12 @@ sealed class FormItemSpec : Parcelable {
 
     internal fun createSectionElement(
         sectionFieldElement: SectionFieldElement,
-        label: Int? = null
+        label: ResolvableString? = null
     ): SectionElement = SectionElement.wrap(sectionFieldElement, label)
 
     internal fun createSectionElement(
         sectionFieldElements: List<SectionFieldElement>,
-        label: Int? = null
+        label: ResolvableString? = null
     ): SectionElement = SectionElement.wrap(sectionFieldElements, label)
 }
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/IbanConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/IbanConfig.kt
@@ -1,13 +1,13 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
-import androidx.annotation.StringRes
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.OffsetMapping
 import androidx.compose.ui.text.input.TransformedText
 import androidx.compose.ui.text.input.VisualTransformation
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.ui.core.R
 import com.stripe.android.uicore.elements.TextFieldConfig
 import com.stripe.android.uicore.elements.TextFieldIcon
@@ -30,8 +30,7 @@ class IbanConfig : TextFieldConfig {
     override val capitalization: KeyboardCapitalization = KeyboardCapitalization.Characters
     override val debugLabel = "iban"
 
-    @StringRes
-    override val label = R.string.stripe_iban
+    override val label = resolvableString(R.string.stripe_iban)
     override val keyboard = KeyboardType.Ascii
 
     override val trailingIcon: MutableStateFlow<TextFieldIcon?> = MutableStateFlow(

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SaveForFutureUseController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SaveForFutureUseController.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.ui.core.R
 import com.stripe.android.uicore.elements.FieldError
 import com.stripe.android.uicore.elements.InputController
@@ -13,10 +15,11 @@ import kotlinx.coroutines.flow.StateFlow
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class SaveForFutureUseController(
+    merchantName: String?,
     saveForFutureUseInitialValue: Boolean
 ) : InputController {
-    override val label: StateFlow<Int> = MutableStateFlow(
-        R.string.stripe_save_payment_details_to_merchant_name
+    override val label: StateFlow<ResolvableString> = MutableStateFlow(
+        resolvableString(R.string.stripe_save_payment_details_to_merchant_name, merchantName)
     )
     private val _saveForFutureUse = MutableStateFlow(saveForFutureUseInitialValue)
     val saveForFutureUse: StateFlow<Boolean> = _saveForFutureUse

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SaveForFutureUseElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SaveForFutureUseElement.kt
@@ -21,6 +21,7 @@ data class SaveForFutureUseElement(
     override val mandateText: ResolvableString? = null
 
     override val controller: SaveForFutureUseController = SaveForFutureUseController(
+        merchantName,
         initialValue
     )
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SaveForFutureUseElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SaveForFutureUseElementUI.kt
@@ -4,8 +4,8 @@ import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import com.stripe.android.uicore.elements.CheckboxElementUI
+import com.stripe.android.uicore.strings.resolve
 import com.stripe.android.uicore.utils.collectAsState
 
 const val SAVE_FOR_FUTURE_CHECKBOX_TEST_TAG = "SAVE_FOR_FUTURE_CHECKBOX_TEST_TAG"
@@ -20,12 +20,11 @@ fun SaveForFutureUseElementUI(
     val controller = element.controller
     val checked by controller.saveForFutureUse.collectAsState()
     val label by controller.label.collectAsState()
-    val resources = LocalContext.current.resources
 
     CheckboxElementUI(
         automationTestTag = SAVE_FOR_FUTURE_CHECKBOX_TEST_TAG,
         isChecked = checked,
-        label = resources.getString(label, element.merchantName),
+        label = label.resolve(),
         isEnabled = enabled,
         modifier = modifier,
         onValueChange = {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SetAsDefaultPaymentMethodController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SetAsDefaultPaymentMethodController.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.ui.core.R
 import com.stripe.android.uicore.elements.FieldError
 import com.stripe.android.uicore.elements.InputController
@@ -17,7 +19,9 @@ class SetAsDefaultPaymentMethodController(
     saveForFutureUseCheckedFlow: StateFlow<Boolean>,
     setAsDefaultMatchesSaveForFutureUse: Boolean,
 ) : InputController {
-    override val label: StateFlow<Int> = MutableStateFlow(R.string.stripe_set_as_default_payment_method)
+    override val label: StateFlow<ResolvableString> = MutableStateFlow(
+        resolvableString(R.string.stripe_set_as_default_payment_method)
+    )
 
     private val _setAsDefaultPaymentMethodChecked = MutableStateFlow(setAsDefaultPaymentMethodInitialValue)
     val setAsDefaultPaymentMethodChecked: StateFlow<Boolean> = _setAsDefaultPaymentMethodChecked

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SetAsDefaultPaymentMethodElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SetAsDefaultPaymentMethodElementUI.kt
@@ -4,8 +4,8 @@ import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import com.stripe.android.uicore.elements.CheckboxElementUI
+import com.stripe.android.uicore.strings.resolve
 import com.stripe.android.uicore.utils.collectAsState
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -21,7 +21,6 @@ fun SetAsDefaultPaymentMethodElementUI(
     val controller = element.controller
     val checked by controller.setAsDefaultPaymentMethodChecked.collectAsState()
     val label by controller.label.collectAsState()
-    val resources = LocalContext.current.resources
 
     val shouldShow by element.shouldShowElementFlow.collectAsState()
 
@@ -29,7 +28,7 @@ fun SetAsDefaultPaymentMethodElementUI(
         CheckboxElementUI(
             automationTestTag = SET_AS_DEFAULT_PAYMENT_METHOD_TEST_TAG,
             isChecked = checked,
-            label = resources.getString(label),
+            label = label.resolve(),
             isEnabled = enabled,
             modifier = modifier,
             onValueChange = {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SimpleDropdownConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SimpleDropdownConfig.kt
@@ -1,12 +1,12 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
-import androidx.annotation.StringRes
+import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.uicore.elements.DropdownConfig
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class SimpleDropdownConfig(
-    @StringRes override val label: Int,
+    override val label: ResolvableString,
     private val items: List<DropdownItemSpec>
 ) : DropdownConfig {
     override val debugLabel = "simple_dropdown"

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SimpleTextSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SimpleTextSpec.kt
@@ -3,6 +3,7 @@ package com.stripe.android.ui.core.elements
 import androidx.annotation.RestrictTo
 import androidx.annotation.StringRes
 import androidx.compose.ui.text.input.KeyboardCapitalization
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SimpleTextElement
 import com.stripe.android.uicore.elements.SimpleTextFieldConfig
@@ -80,7 +81,7 @@ data class SimpleTextSpec(
             this.apiPath,
             SimpleTextFieldController(
                 SimpleTextFieldConfig(
-                    label = this.label,
+                    label = resolvableString(this.label),
                     capitalization = when (this.capitalization) {
                         Capitalization.None -> KeyboardCapitalization.None
                         Capitalization.Characters -> KeyboardCapitalization.Characters

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/UpiConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/UpiConfig.kt
@@ -1,10 +1,11 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
-import androidx.annotation.StringRes
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
+import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.ui.core.R
 import com.stripe.android.uicore.elements.TextFieldConfig
 import com.stripe.android.uicore.elements.TextFieldIcon
@@ -23,8 +24,7 @@ class UpiConfig : TextFieldConfig {
         "[a-zA-Z0-9.\\-_]{2,256}@[a-zA-Z]{2,64}".toRegex()
     }
 
-    @StringRes
-    override val label: Int = R.string.stripe_upi_id_label
+    override val label: ResolvableString = resolvableString(R.string.stripe_upi_id_label)
 
     override val capitalization: KeyboardCapitalization = KeyboardCapitalization.None
     override val debugLabel: String = "upi_id"

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AdministrativeAreaConfigTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AdministrativeAreaConfigTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.ui.core.elements
 
 import com.google.common.truth.Truth
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.uicore.elements.AdministrativeAreaConfig
 import org.junit.Test
 import com.stripe.android.core.R as CoreR
@@ -21,7 +22,7 @@ class AdministrativeAreaConfigTest {
             AdministrativeAreaConfig.Country.US()
         )
         Truth.assertThat(config.label)
-            .isEqualTo(CoreR.string.stripe_address_label_state)
+            .isEqualTo(resolvableString(CoreR.string.stripe_address_label_state))
     }
 
     @Test
@@ -30,7 +31,7 @@ class AdministrativeAreaConfigTest {
             AdministrativeAreaConfig.Country.Canada()
         )
         Truth.assertThat(config.label)
-            .isEqualTo(CoreR.string.stripe_address_label_province)
+            .isEqualTo(resolvableString(CoreR.string.stripe_address_label_province))
     }
 
     @Test

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberControllerTest.kt
@@ -414,7 +414,9 @@ internal class CardNumberControllerTest {
                     field = SimpleTextElement(
                         identifier = IdentifierSpec.Name,
                         controller = SimpleTextFieldController(
-                            textFieldConfig = SimpleTextFieldConfig()
+                            textFieldConfig = SimpleTextFieldConfig(
+                                resolvableString(value = "Card number")
+                            )
                         ),
                     ),
                     modifier = Modifier.testTag(TEST_TAG),
@@ -447,7 +449,9 @@ internal class CardNumberControllerTest {
                     field = SimpleTextElement(
                         identifier = IdentifierSpec.Name,
                         controller = SimpleTextFieldController(
-                            textFieldConfig = SimpleTextFieldConfig()
+                            textFieldConfig = SimpleTextFieldConfig(
+                                resolvableString(value = "Card number")
+                            )
                         ),
                     ),
                     modifier = Modifier.testTag(TEST_TAG),
@@ -523,7 +527,9 @@ internal class CardNumberControllerTest {
                     field = SimpleTextElement(
                         identifier = IdentifierSpec.Name,
                         controller = SimpleTextFieldController(
-                            textFieldConfig = SimpleTextFieldConfig()
+                            textFieldConfig = SimpleTextFieldConfig(
+                                resolvableString(value = "Card number")
+                            )
                         ),
                     ),
                     modifier = Modifier.testTag(TEST_TAG),

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/PostalCodeConfigTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/PostalCodeConfigTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import com.google.common.truth.Truth
 import com.stripe.android.core.R
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.uicore.elements.PostalCodeConfig
 import com.stripe.android.uicore.elements.TextFieldState
 import org.junit.Test
@@ -131,7 +132,7 @@ class PostalCodeConfigTest {
 
     private fun createConfigForCountry(country: String): PostalCodeConfig {
         return PostalCodeConfig(
-            label = R.string.stripe_address_label_postal_code,
+            label = resolvableString(R.string.stripe_address_label_postal_code),
             country = country
         )
     }

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/SimpleDropdownConfigTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/SimpleDropdownConfigTest.kt
@@ -1,13 +1,14 @@
 package com.stripe.android.ui.core.elements
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.ui.core.R
 import com.stripe.android.uicore.elements.DropdownConfig
 import org.junit.Test
 
 class SimpleDropdownConfigTest {
     private val config: DropdownConfig = SimpleDropdownConfig(
-        R.string.stripe_ideal_bank,
+        resolvableString(R.string.stripe_ideal_bank),
         listOf(
             DropdownItemSpec(displayText = "ABN AMRO", apiValue = "abn_amro"),
             DropdownItemSpec(displayText = "ASN Bank", apiValue = "asn_bank"),

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/SimpleTextFieldConfigTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/SimpleTextFieldConfigTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.ui.core.elements
 
 import androidx.compose.ui.text.input.KeyboardType
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.uicore.elements.SimpleTextFieldConfig
 import org.junit.Test
 
@@ -9,7 +10,7 @@ class SimpleTextFieldConfigTest {
     @Test
     fun `test number keyboards only accept numbers`() {
         val textConfig = SimpleTextFieldConfig(
-            label = 1,
+            label = resolvableString("Phone"),
             keyboard = KeyboardType.Number
         )
 
@@ -19,7 +20,7 @@ class SimpleTextFieldConfigTest {
     @Test
     fun `test number password keyboards only accept numbers`() {
         val textConfig = SimpleTextFieldConfig(
-            label = 1,
+            label = resolvableString("Password"),
             keyboard = KeyboardType.NumberPassword
         )
 

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/AddressTextFieldUITest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/AddressTextFieldUITest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.uicore.DefaultStripeTheme
 import com.stripe.android.uicore.elements.AddressTextFieldController
 import com.stripe.android.uicore.elements.AddressTextFieldUI
@@ -39,7 +40,7 @@ class AddressTextFieldUITest {
             DefaultStripeTheme {
                 AddressTextFieldUI(
                     controller = AddressTextFieldController(
-                        SimpleTextFieldConfig(label = UiCoreR.string.stripe_address_label_address)
+                        SimpleTextFieldConfig(label = resolvableString(UiCoreR.string.stripe_address_label_address))
                     ),
                     onClick = onClick
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BoletoDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BoletoDefinition.kt
@@ -2,6 +2,7 @@ package com.stripe.android.lpmfoundations.paymentmethod.definitions
 
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.lpmfoundations.luxe.ContactInformationCollectionMode
 import com.stripe.android.lpmfoundations.luxe.FormElementsBuilder
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
@@ -50,7 +51,7 @@ private object BoletoUiDefinitionFactory : UiDefinitionFactory.Simple {
             taxIdElementIdentifierSpec,
             SimpleTextFieldController(
                 SimpleTextFieldConfig(
-                    label = R.string.stripe_boleto_tax_id_label,
+                    label = resolvableString(R.string.stripe_boleto_tax_id_label),
                     capitalization = KeyboardCapitalization.None,
                     keyboard = KeyboardType.Ascii,
                 ),

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -276,7 +276,7 @@ private fun cardBillingElements(
     return listOfNotNull(
         SectionElement.wrap(
             addressElement,
-            PaymentsUiCoreR.string.stripe_billing_details,
+            resolvableString(PaymentsUiCoreR.string.stripe_billing_details),
         ),
         sameAsShippingElement,
     )
@@ -302,7 +302,7 @@ private fun contactInformationElement(
     if (elements.isEmpty()) return null
 
     return SectionElement.wrap(
-        label = PaymentsUiCoreR.string.stripe_contact_information,
+        label = resolvableString(PaymentsUiCoreR.string.stripe_contact_information),
         sectionFieldElements = elements,
     )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KonbiniDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KonbiniDefinition.kt
@@ -2,6 +2,7 @@ package com.stripe.android.lpmfoundations.paymentmethod.definitions
 
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.lpmfoundations.luxe.ContactInformationCollectionMode
 import com.stripe.android.lpmfoundations.luxe.FormElementsBuilder
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
@@ -50,7 +51,7 @@ private object KonbiniUiDefinitionFactory : UiDefinitionFactory.Simple {
             identifier = IdentifierSpec.KonbiniConfirmationNumber,
             controller = SimpleTextFieldController(
                 textFieldConfig = SimpleTextFieldConfig(
-                    label = R.string.stripe_konbini_confirmation_number_label,
+                    label = resolvableString(R.string.stripe_konbini_confirmation_number_label),
                     capitalization = KeyboardCapitalization.None,
                     keyboard = KeyboardType.Phone,
                 ),

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/UpiDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/UpiDefinition.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.lpmfoundations.paymentmethod.definitions
 
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.lpmfoundations.luxe.FormElementsBuilder
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement
@@ -39,7 +40,10 @@ private object UpiUiDefinitionFactory : UiDefinitionFactory.Simple {
         metadata: PaymentMethodMetadata,
         arguments: UiDefinitionFactory.Arguments
     ): List<FormElement> {
-        val section = SectionElement.wrap(UpiElement(), label = R.string.stripe_paymentsheet_buy_using_upi_id)
+        val section = SectionElement.wrap(
+            UpiElement(),
+            label = resolvableString(R.string.stripe_paymentsheet_buy_using_upi_id)
+        )
         return FormElementsBuilder(arguments).element(section).build()
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.AddressElementNavigator.Companion.FORCE_EXPANDED_FORM_KEY
 import com.stripe.android.paymentsheet.addresselement.analytics.AddressLauncherEventReporter
@@ -49,7 +50,7 @@ internal class AutocompleteViewModel @Inject constructor(
     val addressResult = MutableStateFlow<Result<AddressDetails?>?>(null)
 
     private val config = SimpleTextFieldConfig(
-        label = UiCoreR.string.stripe_address_label_address,
+        label = resolvableString(UiCoreR.string.stripe_address_label_address),
         trailingIcon = MutableStateFlow(null)
     )
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountForm.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode
 import com.stripe.android.paymentsheet.R
@@ -363,7 +364,7 @@ private fun AddressSection(
     ) {
         Column(modifier) {
             Section(
-                title = PaymentsUiCoreR.string.stripe_billing_details,
+                title = resolvableString(PaymentsUiCoreR.string.stripe_billing_details),
                 error = sectionErrorString,
             ) {
                 AddressElementUI(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BillingDetailsForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BillingDetailsForm.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.ui
 
 import androidx.compose.runtime.Stable
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.toInternal
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode
@@ -30,7 +31,7 @@ internal class BillingDetailsForm(
 
     val addressSectionElement = SectionElement.wrap(
         sectionFieldElement = cardBillingAddressElement,
-        label = R.string.stripe_billing_details,
+        label = resolvableString(R.string.stripe_billing_details),
     )
     val hiddenElements = cardBillingAddressElement.hiddenIdentifiers
     val formFieldsState = formFieldsState()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/CardDetailsUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/CardDetailsUI.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.stripe.android.R
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.CardBrand
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.Section
@@ -82,7 +83,7 @@ private fun CardDetailsEditUI(
     Column {
         Section(
             title = billingDetailsForm?.let {
-                CoreR.string.stripe_paymentsheet_add_payment_method_card_information
+                resolvableString(CoreR.string.stripe_paymentsheet_add_payment_method_card_information)
             },
             error = expiryDateState.sectionError()?.resolve(),
             modifier = Modifier.testTag(UPDATE_PM_CARD_TEST_TAG),

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElementsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElementsTest.kt
@@ -96,7 +96,7 @@ internal class TransformSpecToElementsTest {
             val idealElement = idealSectionElement.fields[0] as SimpleDropdownElement
 
             // Verify the correct config is setup for the controller
-            assertThat(idealElement.controller.label.first()).isEqualTo(R.string.stripe_ideal_bank)
+            assertThat(idealElement.controller.label.first()).isEqualTo(resolvableString(R.string.stripe_ideal_bank))
 
             assertThat(idealSectionElement.identifier.v1).isEqualTo("ideal[bank]_section")
 
@@ -144,7 +144,9 @@ internal class TransformSpecToElementsTest {
             as SimpleTextElement
 
         // Verify the correct config is setup for the controller
-        assertThat(nameElement.controller.label.first()).isEqualTo(CoreR.string.stripe_address_label_full_name)
+        assertThat(nameElement.controller.label.first()).isEqualTo(
+            resolvableString(CoreR.string.stripe_address_label_full_name)
+        )
         assertThat(nameElement.identifier.v1).isEqualTo("simple")
         assertThat(nameElement.controller.showOptionalLabel).isTrue()
     }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -447,17 +447,23 @@ internal class PaymentMethodMetadataTest {
 
         val nameSection = formElement[0] as SectionElement
         val nameElement = nameSection.fields[0] as SimpleTextElement
-        assertThat(nameElement.controller.label.first()).isEqualTo(CoreR.string.stripe_address_label_full_name)
+        assertThat(nameElement.controller.label.first()).isEqualTo(
+            resolvableString(CoreR.string.stripe_address_label_full_name)
+        )
         assertThat(nameElement.identifier.v1).isEqualTo("billing_details[name]")
 
         val emailSection = formElement[1] as SectionElement
         val emailElement = emailSection.fields[0] as EmailElement
-        assertThat(emailElement.controller.label.first()).isEqualTo(UiCoreR.string.stripe_email)
+        assertThat(emailElement.controller.label.first()).isEqualTo(
+            resolvableString(UiCoreR.string.stripe_email)
+        )
         assertThat(emailElement.identifier.v1).isEqualTo("billing_details[email]")
 
         val phoneSection = formElement[2] as SectionElement
         val phoneElement = phoneSection.fields[0] as PhoneNumberElement
-        assertThat(phoneElement.controller.label.first()).isEqualTo(CoreR.string.stripe_address_label_phone_number)
+        assertThat(phoneElement.controller.label.first()).isEqualTo(
+            resolvableString(CoreR.string.stripe_address_label_phone_number)
+        )
         assertThat(phoneElement.identifier.v1).isEqualTo("billing_details[phone]")
 
         val addressSection = formElement[3] as SectionElement
@@ -531,17 +537,23 @@ internal class PaymentMethodMetadataTest {
 
         val nameSection = formElement[0] as SectionElement
         val nameElement = nameSection.fields[0] as SimpleTextElement
-        assertThat(nameElement.controller.label.first()).isEqualTo(CoreR.string.stripe_address_label_full_name)
+        assertThat(nameElement.controller.label.first()).isEqualTo(
+            resolvableString(CoreR.string.stripe_address_label_full_name)
+        )
         assertThat(nameElement.identifier.v1).isEqualTo("billing_details[name]")
 
         val phoneSection = formElement[1] as SectionElement
         val phoneElement = phoneSection.fields[0] as PhoneNumberElement
-        assertThat(phoneElement.controller.label.first()).isEqualTo(CoreR.string.stripe_address_label_phone_number)
+        assertThat(phoneElement.controller.label.first()).isEqualTo(
+            resolvableString(CoreR.string.stripe_address_label_phone_number)
+        )
         assertThat(phoneElement.identifier.v1).isEqualTo("billing_details[phone]")
 
         val emailSection = formElement[2] as SectionElement
         val emailElement = emailSection.fields[0] as EmailElement
-        assertThat(emailElement.controller.label.first()).isEqualTo(UiCoreR.string.stripe_email)
+        assertThat(emailElement.controller.label.first()).isEqualTo(
+            resolvableString(UiCoreR.string.stripe_email)
+        )
         assertThat(emailElement.identifier.v1).isEqualTo("billing_details[email]")
 
         val addressSection = formElement[3] as SectionElement

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/FormControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/FormControllerTest.kt
@@ -6,6 +6,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.cards.DefaultCardAccountRangeRepositoryFactory
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.lpmfoundations.luxe.TransformSpecToElements
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -102,6 +103,6 @@ class FormControllerTest {
             .map { it.controller }
             .filterIsInstance<TextFieldController>()
             .firstOrNull {
-                it.label.first() == label
+                it.label.first() == resolvableString(label)
             }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/CompleteFormFieldValueFilterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/CompleteFormFieldValueFilterTest.kt
@@ -45,7 +45,10 @@ class CompleteFormFieldValueFilterTest {
                     IdentifierSpec.Email,
                     controller = emailController
                 ),
-                SectionController(emailController.label.first(), listOf(emailController))
+                SectionController(
+                    emailController.label.first(),
+                    listOf(emailController)
+                )
             )
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.forms
 import androidx.annotation.StringRes
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.TestUiDefinitionFactoryArgumentsFactory
 import com.stripe.android.model.PaymentMethod
@@ -373,7 +374,7 @@ internal class FormViewModelTest {
         // Fill all address values except line2
         val addressControllers = AddressControllers.create(formViewModel)
         val populateAddressControllers = addressControllers.controllers
-            .filter { it.label.first() != UiCoreR.string.stripe_address_label_address_line2 }
+            .filter { it.label.first() != resolvableString(UiCoreR.string.stripe_address_label_address_line2) }
         populateAddressControllers
             .forEachIndexed { index, textFieldController ->
                 textFieldController.onValueChange("12345")
@@ -629,7 +630,7 @@ internal class FormViewModelTest {
             .filterIsInstance<SectionSingleFieldElement>()
             .map { it.controller }
             .filterIsInstance<TextFieldController>()
-            .firstOrNull { it.label.first() == label }
+            .firstOrNull { it.label.first() == resolvableString(label) }
 
     private data class AddressControllers(
         val controllers: List<TextFieldController>
@@ -678,14 +679,14 @@ internal class FormViewModelTest {
             return addressElementFields
                 ?.filterIsInstance<SectionSingleFieldElement>()
                 ?.map { (it.controller as? SimpleTextFieldController) }
-                ?.firstOrNull { it?.label?.first() == label }
+                ?.firstOrNull { it?.label?.first() == resolvableString(label) }
                 ?: addressElementFields
                     ?.asSequence()
                     ?.filterIsInstance<RowElement>()
                     ?.map { it.fields }
                     ?.flatten()
                     ?.map { (it.controller as? SimpleTextFieldController) }
-                    ?.firstOrNull { it?.label?.first() == label }
+                    ?.firstOrNull { it?.label?.first() == resolvableString(label) }
         }
     }
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/TransformAddressToElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/TransformAddressToElement.kt
@@ -310,11 +310,11 @@ private fun FieldType.toConfig(
 ): TextFieldConfig {
     return when (this) {
         FieldType.PostalCode -> PostalCodeConfig(
-            label = label,
+            label = resolvableString(label),
             country = countryCode
         )
         else -> SimpleTextFieldConfig(
-            label = label,
+            label = resolvableString(label),
             capitalization = capitalization,
             keyboard = keyboardType
         )

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressElement.kt
@@ -3,6 +3,7 @@ package com.stripe.android.uicore.elements
 import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
 import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.uicore.R
 import com.stripe.android.uicore.address.AddressSchemaRegistry
 import com.stripe.android.uicore.address.AutocompleteCapableAddressType
@@ -42,7 +43,7 @@ open class AddressElement(
         IdentifierSpec.Name,
         SimpleTextFieldController(
             textFieldConfig = SimpleTextFieldConfig(
-                label = CoreR.string.stripe_address_label_full_name
+                label = resolvableString(CoreR.string.stripe_address_label_full_name)
             ),
             initialValue = rawValuesMap[IdentifierSpec.Name]
         )
@@ -50,7 +51,7 @@ open class AddressElement(
 
     private val addressAutoCompleteElement = AddressTextFieldElement(
         identifier = IdentifierSpec.OneLineAddress,
-        config = SimpleTextFieldConfig(label = R.string.stripe_address_label_address),
+        config = SimpleTextFieldConfig(label = resolvableString(R.string.stripe_address_label_address)),
         onNavigation = (addressType as? AddressType.ShippingCondensed)?.onNavigation
     )
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AdministrativeAreaConfig.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AdministrativeAreaConfig.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
-import androidx.annotation.StringRes
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.core.R as CoreR
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -14,8 +14,7 @@ class AdministrativeAreaConfig(
     override val tinyMode: Boolean = false
     override val debugLabel = "administrativeArea"
 
-    @StringRes
-    override val label = country.label
+    override val label = resolvableString(country.label)
 
     override val rawItems = shortAdministrativeAreaNames
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/CountryConfig.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/CountryConfig.kt
@@ -1,10 +1,10 @@
 package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
-import androidx.annotation.StringRes
 import com.stripe.android.core.model.Country
 import com.stripe.android.core.model.CountryCode
 import com.stripe.android.core.model.CountryUtils
+import com.stripe.android.core.strings.resolvableString
 import java.util.Locale
 import com.stripe.android.core.R as CoreR
 
@@ -32,8 +32,7 @@ class CountryConfig(
 ) : DropdownConfig {
     override val debugLabel = "country"
 
-    @StringRes
-    override val label = CoreR.string.stripe_address_label_country_or_region
+    override val label = resolvableString(CoreR.string.stripe_address_label_country_or_region)
 
     internal val countries = CountryUtils.getOrderedCountries(locale)
         .filter {

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DateConfig.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DateConfig.kt
@@ -1,11 +1,11 @@
 package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
-import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.LayoutDirection
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.uicore.R
 import com.stripe.android.uicore.elements.TextFieldStateConstants.Error
 import com.stripe.android.uicore.elements.TextFieldStateConstants.Valid
@@ -18,8 +18,7 @@ class DateConfig : TextFieldConfig {
     override val capitalization: KeyboardCapitalization = KeyboardCapitalization.None
     override val debugLabel = "date"
 
-    @StringRes
-    override val label = R.string.stripe_expiration_date_hint
+    override val label = resolvableString(R.string.stripe_expiration_date_hint)
     override val keyboard = KeyboardType.NumberPassword
     override val visualTransformation = ExpiryDateVisualTransformation()
     override val trailingIcon: StateFlow<TextFieldIcon?> = MutableStateFlow(null)

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DropdownConfig.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DropdownConfig.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.strings.ResolvableString
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 interface DropdownConfig {
@@ -8,7 +9,7 @@ interface DropdownConfig {
     val debugLabel: String
 
     /** This is the label to describe the field **/
-    val label: Int
+    val label: ResolvableString
 
     /** The list of raw values to use in the parameter map **/
     val rawItems: List<String?>

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DropdownFieldController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DropdownFieldController.kt
@@ -3,6 +3,7 @@ package com.stripe.android.uicore.elements
 import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
@@ -24,7 +25,7 @@ class DropdownFieldController(
     val disableDropdownWithSingleElement = config.disableDropdownWithSingleElement
     private val _selectedIndex = MutableStateFlow(0)
     val selectedIndex: StateFlow<Int> = _selectedIndex
-    override val label: StateFlow<Int> = MutableStateFlow(config.label)
+    override val label: StateFlow<ResolvableString> = MutableStateFlow(config.label)
     override val fieldValue = selectedIndex.mapAsStateFlow { displayItems[it] }
     override val rawFieldValue = selectedIndex.mapAsStateFlow { config.rawItems.getOrNull(it) }
     override val error: StateFlow<FieldError?> = stateFlowOf(null)

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DropdownFieldUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DropdownFieldUI.kt
@@ -42,7 +42,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.uicore.R
+import com.stripe.android.uicore.strings.resolve
 import com.stripe.android.uicore.stripeColors
 import com.stripe.android.uicore.utils.collectAsState
 import com.stripe.android.uicore.utils.mapAsStateFlow
@@ -193,7 +195,7 @@ fun DropDown(
 
 @Composable
 private fun LargeDropdownLabel(
-    label: Int?,
+    label: ResolvableString,
     selectedItemLabel: String,
     currentTextColor: Color,
     shouldDisableDropdownWithSingleItem: Boolean,
@@ -210,9 +212,7 @@ private fun LargeDropdownLabel(
                 bottom = 8.dp
             )
         ) {
-            label?.let {
-                FormLabel(stringResource(it))
-            }
+            FormLabel(label.resolve())
             Row(
                 modifier = Modifier.fillMaxWidth(.9f),
                 verticalAlignment = Alignment.Bottom

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/EmailConfig.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/EmailConfig.kt
@@ -1,10 +1,11 @@
 package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
-import androidx.annotation.StringRes
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
+import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.uicore.R
 import com.stripe.android.uicore.elements.TextFieldStateConstants.Error
 import com.stripe.android.uicore.elements.TextFieldStateConstants.Valid
@@ -14,7 +15,7 @@ import java.util.regex.Pattern
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class EmailConfig(
-    @StringRes override val label: Int = R.string.stripe_email
+    override val label: ResolvableString = resolvableString(R.string.stripe_email)
 ) : TextFieldConfig {
 
     override val capitalization: KeyboardCapitalization = KeyboardCapitalization.None

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/InputController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/InputController.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.uicore.forms.FormFieldEntry
 import kotlinx.coroutines.flow.StateFlow
 
@@ -9,7 +10,7 @@ import kotlinx.coroutines.flow.StateFlow
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 interface InputController : SectionFieldErrorController {
-    val label: StateFlow<Int?>
+    val label: StateFlow<ResolvableString>
     val fieldValue: StateFlow<String>
     val rawFieldValue: StateFlow<String?>
     val isComplete: StateFlow<Boolean>

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/NameConfig.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/NameConfig.kt
@@ -1,10 +1,10 @@
 package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
-import androidx.annotation.StringRes
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.uicore.elements.TextFieldStateConstants.Error
 import com.stripe.android.uicore.elements.TextFieldStateConstants.Valid
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -13,8 +13,7 @@ import com.stripe.android.core.R as CoreR
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class NameConfig : TextFieldConfig {
-    @StringRes
-    override val label = CoreR.string.stripe_address_label_full_name
+    override val label = resolvableString(CoreR.string.stripe_address_label_full_name)
     override val capitalization: KeyboardCapitalization = KeyboardCapitalization.Words
     override val debugLabel = "name"
     override val keyboard = KeyboardType.Text

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberController.kt
@@ -4,6 +4,7 @@ import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.ImeAction
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.uicore.R
 import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.uicore.utils.combineAsStateFlow
@@ -22,7 +23,9 @@ class PhoneNumberController private constructor(
     override val showOptionalLabel: Boolean = false,
     private val acceptAnyInput: Boolean = false,
 ) : InputController, SectionFieldComposable {
-    override val label = stateFlowOf(CoreR.string.stripe_address_label_phone_number)
+    override val label = stateFlowOf(
+        resolvableString(CoreR.string.stripe_address_label_phone_number)
+    )
 
     private val _fieldValue = MutableStateFlow(initialPhoneNumber)
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberElementUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberElementUI.kt
@@ -39,8 +39,10 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.uicore.R
 import com.stripe.android.uicore.moveFocusSafely
+import com.stripe.android.uicore.strings.resolve
 import com.stripe.android.uicore.text.autofill
 import com.stripe.android.uicore.utils.collectAsState
 import kotlinx.coroutines.job
@@ -85,7 +87,7 @@ fun PhoneNumberCollectionSection(
 
     Section(
         modifier = Modifier.padding(vertical = 8.dp),
-        title = sectionTitle,
+        title = sectionTitle?.let { resolvableString(it) },
         error = sectionErrorString,
         isSelected = isSelected
     ) {
@@ -168,10 +170,10 @@ fun PhoneNumberElementUI(
                     text = if (controller.showOptionalLabel) {
                         stringResource(
                             R.string.stripe_form_label_optional,
-                            stringResource(label)
+                            label.resolve()
                         )
                     } else {
-                        stringResource(label)
+                        label.resolve()
                     }
                 )
             },

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PostalCodeConfig.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PostalCodeConfig.kt
@@ -1,16 +1,16 @@
 package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
-import androidx.annotation.StringRes
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
+import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.uicore.R
 import kotlinx.coroutines.flow.MutableStateFlow
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class PostalCodeConfig(
-    @StringRes override val label: Int,
+    override val label: ResolvableString,
     override val trailingIcon: MutableStateFlow<TextFieldIcon?> = MutableStateFlow(null),
     private val country: String
 ) : TextFieldConfig {

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SameAsShippingController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SameAsShippingController.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.uicore.R
 import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.uicore.utils.mapAsStateFlow
@@ -13,7 +15,9 @@ import kotlinx.coroutines.flow.asStateFlow
 class SameAsShippingController(
     initialValue: Boolean
 ) : InputController {
-    override val label: StateFlow<Int> = stateFlowOf(R.string.stripe_billing_same_as_shipping)
+    override val label: StateFlow<ResolvableString> = stateFlowOf(
+        resolvableString(R.string.stripe_billing_same_as_shipping)
+    )
     private val _value = MutableStateFlow(initialValue)
     val value: StateFlow<Boolean> = _value.asStateFlow()
     override val fieldValue: StateFlow<String> = value.mapAsStateFlow { it.toString() }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SameAsShippingElementUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SameAsShippingElementUI.kt
@@ -4,7 +4,7 @@ import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
+import com.stripe.android.uicore.strings.resolve
 import com.stripe.android.uicore.utils.collectAsState
 
 const val SAME_AS_SHIPPING_CHECKBOX_TEST_TAG = "SAME_AS_SHIPPING_CHECKBOX_TEST_TAG"
@@ -22,7 +22,7 @@ fun SameAsShippingElementUI(
         modifier = modifier,
         automationTestTag = SAME_AS_SHIPPING_CHECKBOX_TEST_TAG,
         isChecked = checked,
-        label = stringResource(label),
+        label = label.resolve(),
         isEnabled = true,
         onValueChange = {
             controller.onValueChange(!checked)

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionController.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
-import androidx.annotation.StringRes
+import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.StateFlow
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class SectionController(
-    @StringRes val label: Int?,
+    val label: ResolvableString?,
     sectionFieldErrorControllers: List<SectionFieldErrorController>
 ) : Controller {
     val error: StateFlow<FieldError?> = combineAsStateFlow(

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionElement.kt
@@ -42,7 +42,7 @@ data class SectionElement(
 
         fun wrap(
             sectionFieldElement: SectionFieldElement,
-            label: Int? = null
+            label: ResolvableString? = null
         ): SectionElement {
             return wrap(
                 sectionFieldElements = listOf(sectionFieldElement),
@@ -52,7 +52,7 @@ data class SectionElement(
 
         fun wrap(
             sectionFieldElements: List<SectionFieldElement>,
-            label: Int? = null
+            label: ResolvableString? = null
         ): SectionElement {
             val errorControllers = sectionFieldElements.map {
                 it.sectionFieldErrorController()

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionUI.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
-import androidx.annotation.StringRes
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
@@ -12,11 +11,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
+import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.uicore.getBorderStroke
+import com.stripe.android.uicore.strings.resolve
 import com.stripe.android.uicore.stripeColors
 
 /**
@@ -26,7 +26,7 @@ import com.stripe.android.uicore.stripeColors
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun Section(
-    @StringRes title: Int?,
+    title: ResolvableString?,
     error: String?,
     modifier: Modifier = Modifier,
     isSelected: Boolean = false,
@@ -49,10 +49,10 @@ fun Section(
  * This is the layout for the section title
  */
 @Composable
-internal fun SectionTitle(@StringRes titleText: Int?) {
+internal fun SectionTitle(titleText: ResolvableString?) {
     titleText?.let {
         H6Text(
-            text = stringResource(titleText),
+            text = it.resolve(),
             modifier = Modifier
                 .padding(bottom = 4.dp)
                 .semantics(mergeDescendants = true) { // Need to prevent form as focusable accessibility

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SimpleTextFieldConfig.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SimpleTextFieldConfig.kt
@@ -1,15 +1,15 @@
 package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
-import androidx.annotation.StringRes
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
+import com.stripe.android.core.strings.ResolvableString
 import kotlinx.coroutines.flow.MutableStateFlow
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 open class SimpleTextFieldConfig(
-    @StringRes override val label: Int? = null,
+    override val label: ResolvableString,
     override val capitalization: KeyboardCapitalization = KeyboardCapitalization.Words,
     override val keyboard: KeyboardType = KeyboardType.Text,
     override val trailingIcon: MutableStateFlow<TextFieldIcon?> = MutableStateFlow(null)

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldConfig.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldConfig.kt
@@ -17,7 +17,7 @@ interface TextFieldConfig {
     val debugLabel: String
 
     /** This is the label to describe the field */
-    val label: Int?
+    val label: ResolvableString
 
     /** This is the type of keyboard to use for this field */
     val keyboard: KeyboardType

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldController.kt
@@ -37,7 +37,7 @@ interface TextFieldController : InputController, SectionFieldComposable, Section
     val capitalization: KeyboardCapitalization
     val keyboardType: KeyboardType
     val layoutDirection: LayoutDirection?
-    override val label: StateFlow<Int?>
+    override val label: StateFlow<ResolvableString>
     val visualTransformation: StateFlow<VisualTransformation>
     override val showOptionalLabel: Boolean
     val fieldState: StateFlow<TextFieldState>

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldUI.kt
@@ -65,11 +65,13 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import com.stripe.android.core.Logger
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.uicore.BuildConfig
 import com.stripe.android.uicore.LocalInstrumentationTest
 import com.stripe.android.uicore.R
 import com.stripe.android.uicore.elements.compat.CompatTextField
 import com.stripe.android.uicore.moveFocusSafely
+import com.stripe.android.uicore.strings.resolve
 import com.stripe.android.uicore.stripeColors
 import com.stripe.android.uicore.text.autofill
 import com.stripe.android.uicore.utils.collectAsState
@@ -113,7 +115,7 @@ fun TextFieldSection(
 
     Section(
         modifier = modifier,
-        title = sectionTitle,
+        title = sectionTitle?.let { resolvableString(it) },
         error = sectionErrorString,
         isSelected = isSelected,
         content = content,
@@ -231,9 +233,7 @@ fun TextField(
                 if (!shouldAnnounceFieldValue) this.editableText = AnnotatedString("")
             },
         enabled = enabled && textFieldController.enabled,
-        label = label?.let {
-            stringResource(it)
-        },
+        label = label.resolve(),
         showOptionalLabel = textFieldController.showOptionalLabel,
         shouldAnnounceLabel = shouldAnnounceLabel,
         placeholder = placeHolder,

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/address/TransformAddressToElementTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/address/TransformAddressToElementTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.uicore.address
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.uicore.R
 import com.stripe.android.uicore.elements.AdministrativeAreaConfig
 import com.stripe.android.uicore.elements.AdministrativeAreaElement
@@ -86,7 +87,7 @@ class TransformAddressToElementTest {
             AdministrativeAreaConfig.Country.US().administrativeAreas.map { it.second }
         )
         assertThat(stateDropdownController.label.first()).isEqualTo(
-            CoreR.string.stripe_address_label_state
+            resolvableString(CoreR.string.stripe_address_label_state)
         )
     }
 
@@ -127,7 +128,7 @@ class TransformAddressToElementTest {
         assertThat(actualController.capitalization).isEqualTo(simpleTextSpec.keyboardCapitalization)
         assertThat(actualController.keyboardType).isEqualTo(simpleTextSpec.keyboardType)
         assertThat(actualController.label.first()).isEqualTo(
-            simpleTextSpec.label
+            resolvableString(simpleTextSpec.label)
         )
     }
 }

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/CountryConfigTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/CountryConfigTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.uicore.elements
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.model.CountryUtils
+import com.stripe.android.core.strings.resolvableString
 import org.junit.Test
 import java.util.Locale
 import com.stripe.android.core.R as CoreR
@@ -17,7 +18,7 @@ class CountryConfigTest {
     @Test
     fun `Verify the label`() {
         assertThat(CountryConfig(locale = Locale.US).label)
-            .isEqualTo(CoreR.string.stripe_address_label_country_or_region)
+            .isEqualTo(resolvableString(CoreR.string.stripe_address_label_country_or_region))
     }
 
     @Test

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/SimpleTextFieldControllerTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/SimpleTextFieldControllerTest.kt
@@ -6,6 +6,7 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import app.cash.turbine.test
 import app.cash.turbine.turbineScope
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.uicore.elements.TextFieldStateConstants.Error.Blank
 import com.stripe.android.uicore.elements.TextFieldStateConstants.Error.Invalid
 import com.stripe.android.uicore.elements.TextFieldStateConstants.Valid.Full
@@ -189,15 +190,9 @@ internal class SimpleTextFieldControllerTest {
     }
 
     @Test
-    fun `Verify null label`() {
-        val controller = createControllerWithState(nullLabel = true)
-        assertThat(controller.label.value).isNull()
-    }
-
-    @Test
-    fun `Verify non-null label`() {
-        val controller = createControllerWithState(nullLabel = false)
-        assertThat(controller.label.value).isEqualTo(CoreR.string.stripe_address_label_full_name)
+    fun `Verify label`() {
+        val controller = createControllerWithState()
+        assertThat(controller.label.value).isEqualTo(resolvableString(CoreR.string.stripe_address_label_full_name))
     }
 
     @Test
@@ -214,7 +209,6 @@ internal class SimpleTextFieldControllerTest {
 
     private fun createControllerWithState(
         showOptionalLabel: Boolean = false,
-        nullLabel: Boolean = false,
         nullPlaceHolder: Boolean = true
     ): SimpleTextFieldController {
         val config: TextFieldConfig = mock {
@@ -237,11 +231,7 @@ internal class SimpleTextFieldControllerTest {
             on { determineState("") } doReturn Blank
             on { filter("") } doReturn ""
 
-            if (nullLabel) {
-                on { label } doReturn null
-            } else {
-                on { label } doReturn CoreR.string.stripe_address_label_full_name
-            }
+            on { label } doReturn resolvableString(CoreR.string.stripe_address_label_full_name)
 
             if (!nullPlaceHolder) {
                 on { placeHolder } doReturn "PlaceHolder"

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/TextFieldTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/TextFieldTest.kt
@@ -25,6 +25,8 @@ import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.core.strings.resolvableString
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import org.junit.Rule
@@ -159,7 +161,7 @@ class TextFieldTest {
     ) : TextFieldConfig {
         override val capitalization: KeyboardCapitalization = KeyboardCapitalization.Characters
         override val debugLabel: String = TEST_TAG
-        override val label: Int? = null
+        override val label: ResolvableString = resolvableString(value = "")
         override val keyboard: KeyboardType = KeyboardType.Text
         override val visualTransformation: VisualTransformation? = null
         override val trailingIcon: StateFlow<TextFieldIcon?> = MutableStateFlow(null)


### PR DESCRIPTION
# Summary
Use `ResolvableString` instead of `Int` resource identifier in most places in `stripe-ui-core`, `payments-ui-core`, and `paymentsheet` and make the text field `label` a non-nullable property.

# Motivation
Assists in standardizing padding for `TextField`. We also should always label our `TextField` elements since our design system does not use the outline approach.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified