### PR TITLE
Re-enable Link tests

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestInstantDebits.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestInstantDebits.kt
@@ -23,12 +23,10 @@ import com.stripe.android.test.core.DEFAULT_UI_TIMEOUT
 import com.stripe.android.test.core.TestParameters
 import com.stripe.android.test.core.ui.ComposeButton
 import com.stripe.android.utils.ForceNativeBankFlowTestRule
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@Ignore("Temporarily disabled by @link-mobile-run")
 @RunWith(AndroidJUnit4::class)
 internal class TestInstantDebits : BasePlaygroundTest() {
 

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestLink.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestLink.kt
@@ -15,7 +15,6 @@ import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@Ignore("Temporarily disabled by @link-mobile-run")
 @RunWith(AndroidJUnit4::class)
 internal class TestLink : BasePlaygroundTest() {
     private val linkNewUser = TestParameters.create(

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestLinkCardBrand.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestLinkCardBrand.kt
@@ -22,12 +22,10 @@ import com.stripe.android.test.core.DEFAULT_UI_TIMEOUT
 import com.stripe.android.test.core.TestParameters
 import com.stripe.android.test.core.ui.ComposeButton
 import com.stripe.android.utils.ForceNativeBankFlowTestRule
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@Ignore("Temporarily disabled by @link-mobile-run")
 @RunWith(AndroidJUnit4::class)
 internal class TestLinkCardBrand : BasePlaygroundTest() {
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request re-enables Link tests after they were temporarily disabled in https://github.com/stripe/stripe-android/pull/10941.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
