### PR TITLE
Ensure custom spacing not applied to `Link` & `Financial Connections` surfaces

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/theme/StripeThemeForConnections.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/theme/StripeThemeForConnections.kt
@@ -26,7 +26,8 @@ internal fun StripeThemeForConnections(
         shapes = StripeThemeDefaults.shapes.copy(
             cornerRadius = 12f
         ),
-        typography = StripeThemeDefaults.typography
+        typography = StripeThemeDefaults.typography,
+        sectionSpacing = StripeThemeDefaults.sectionSpacing,
     ) {
         content()
     }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/FormUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/FormUI.kt
@@ -30,7 +30,7 @@ import com.stripe.android.ui.core.elements.SetAsDefaultPaymentMethodElement
 import com.stripe.android.ui.core.elements.SetAsDefaultPaymentMethodElementUI
 import com.stripe.android.ui.core.elements.StaticTextElement
 import com.stripe.android.ui.core.elements.StaticTextElementUI
-import com.stripe.android.uicore.StripeTheme
+import com.stripe.android.uicore.LocalSectionSpacing
 import com.stripe.android.uicore.elements.CheckboxFieldElement
 import com.stripe.android.uicore.elements.CheckboxFieldUI
 import com.stripe.android.uicore.elements.FormElement
@@ -76,7 +76,7 @@ fun FormUI(
     lastTextFieldIdentifier: IdentifierSpec?,
     modifier: Modifier = Modifier
 ) {
-    val sectionSpacing = StripeTheme.customSectionSpacing
+    val sectionSpacing = LocalSectionSpacing.current
 
     Column(
         modifier = modifier.fillMaxWidth(1f),

--- a/paymentsheet/src/main/java/com/stripe/android/link/theme/Color.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/theme/Color.kt
@@ -163,7 +163,8 @@ internal fun StripeThemeForLink(
         shapes = StripeThemeDefaults.shapes.copy(
             cornerRadius = 9f
         ),
-        typography = StripeThemeDefaults.typography
+        typography = StripeThemeDefaults.typography,
+        sectionSpacing = StripeThemeDefaults.sectionSpacing,
     ) {
         content()
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElement.kt
@@ -11,7 +11,7 @@ import com.stripe.android.link.ui.inline.LinkElement
 import com.stripe.android.link.ui.inline.LinkSignupMode
 import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.ui.core.elements.RenderableFormElement
-import com.stripe.android.uicore.StripeTheme
+import com.stripe.android.uicore.LocalSectionSpacing
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.uicore.utils.stateFlowOf
@@ -34,7 +34,7 @@ internal class LinkFormElement(
     @Composable
     override fun ComposeUI(enabled: Boolean) {
         val modifier = Modifier.run {
-            if (StripeTheme.customSectionSpacing == null) {
+            if (LocalSectionSpacing.current == null) {
                 padding(vertical = 6.dp)
             } else {
                 this

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/StripeTheme.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/StripeTheme.kt
@@ -304,6 +304,8 @@ object StripeThemeDefaults {
         end = 20f,
         bottom = 40f
     )
+
+    val sectionSpacing: Float? = null
 }
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -417,6 +419,9 @@ val LocalShapes = staticCompositionLocalOf { StripeTheme.shapesMutable }
 val LocalTypography = staticCompositionLocalOf { StripeTheme.typographyMutable }
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+val LocalSectionSpacing = staticCompositionLocalOf { StripeTheme.customSectionSpacing }
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 val LocalInstrumentationTest = staticCompositionLocalOf { false }
 
 /**
@@ -430,6 +435,7 @@ fun StripeTheme(
     colors: StripeColors = StripeTheme.getColors(isSystemInDarkTheme()),
     shapes: StripeShapes = StripeTheme.shapesMutable,
     typography: StripeTypography = StripeTheme.typographyMutable,
+    sectionSpacing: Float? = StripeTheme.customSectionSpacing,
     content: @Composable () -> Unit
 ) {
     val isRobolectricTest = runCatching {
@@ -452,6 +458,7 @@ fun StripeTheme(
         LocalColors provides colors,
         LocalShapes provides shapes,
         LocalTypography provides typography,
+        LocalSectionSpacing provides sectionSpacing,
         LocalInspectionMode provides inspectionMode,
         LocalInstrumentationTest provides isInstrumentationTest,
     ) {
@@ -549,7 +556,7 @@ object StripeTheme {
 
     var formInsets = StripeThemeDefaults.formInsets
 
-    var customSectionSpacing: Float? = null
+    var customSectionSpacing: Float? = StripeThemeDefaults.sectionSpacing
 
     fun getColors(isDark: Boolean): StripeColors {
         return if (isDark) colorsDarkMutable else colorsLightMutable


### PR DESCRIPTION
# Summary
Ensure custom spacing not applied to `Link` & `Financial Connections` surfaces

# Motivation
Link & FC have their own design philosophy outside of Payment Element. We shouldn't apply the same merchant provided styling to either product. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified