### PR TITLE
RowSelectionBehavior playground setting

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/embedded/EmbeddedPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/embedded/EmbeddedPlaygroundActivity.kt
@@ -49,6 +49,7 @@ import com.stripe.android.paymentsheet.example.playground.network.PlaygroundRequ
 import com.stripe.android.paymentsheet.example.playground.settings.CheckoutMode
 import com.stripe.android.paymentsheet.example.playground.settings.CheckoutModeSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.DropdownSetting
+import com.stripe.android.paymentsheet.example.playground.settings.EmbeddedRowSelectionBehaviorSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.EmbeddedViewDisplaysMandateSettingDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.PlaygroundConfigurationData
 import com.stripe.android.paymentsheet.example.playground.settings.PlaygroundSettings
@@ -119,6 +120,9 @@ internal class EmbeddedPlaygroundActivity :
             .confirmCustomPaymentMethodCallback(this)
             .externalPaymentMethodConfirmHandler(this)
             .analyticEventCallback(this)
+            .rowSelectionBehavior(
+                playgroundSettings[EmbeddedRowSelectionBehaviorSettingsDefinition].value.rowSelectionBehavior
+            )
         val embeddedViewDisplaysMandateText =
             initialPlaygroundState.snapshot[EmbeddedViewDisplaysMandateSettingDefinition]
         setContent {

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/EmbeddedRowSelectionBehaviorSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/EmbeddedRowSelectionBehaviorSettingsDefinition.kt
@@ -1,0 +1,60 @@
+package com.stripe.android.paymentsheet.example.playground.settings
+
+import android.util.Log
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentelement.ExperimentalEmbeddedPaymentElementApi
+import com.stripe.android.paymentsheet.example.playground.PlaygroundState
+
+@OptIn(ExperimentalEmbeddedPaymentElementApi::class)
+internal object EmbeddedRowSelectionBehaviorSettingsDefinition :
+    PlaygroundSettingDefinition<
+        EmbeddedRowSelectionBehaviorSettingsDefinition.RowSelectionBehavior
+        >,
+    PlaygroundSettingDefinition.Saveable<EmbeddedRowSelectionBehaviorSettingsDefinition.RowSelectionBehavior> by
+    EnumSaveable(
+        key = "embeddedRowSelectionBehavior",
+        values = RowSelectionBehavior.entries.toTypedArray(),
+        defaultValue = RowSelectionBehavior.Default
+    ),
+    PlaygroundSettingDefinition.Displayable<EmbeddedRowSelectionBehaviorSettingsDefinition.RowSelectionBehavior> {
+
+    override fun applicable(configurationData: PlaygroundConfigurationData): Boolean {
+        return configurationData.integrationType == PlaygroundConfigurationData.IntegrationType.Embedded
+    }
+
+    override val displayName: String = "Embedded Form Sheet Action"
+
+    override fun createOptions(
+        configurationData: PlaygroundConfigurationData
+    ) = listOf(
+        option("Default", RowSelectionBehavior.Default),
+        option("Immediate Action", RowSelectionBehavior.ImmediateAction),
+    )
+
+    override fun configure(
+        value: RowSelectionBehavior,
+        configurationBuilder: EmbeddedPaymentElement.Configuration.Builder,
+        playgroundState: PlaygroundState.Payment,
+        configurationData: PlaygroundSettingDefinition.EmbeddedConfigurationData
+    ) {
+        // This has to run in the EmbeddedPaymentElement Builder
+        return
+    }
+
+    enum class RowSelectionBehavior(
+        override val value: String,
+        val rowSelectionBehavior: EmbeddedPaymentElement.RowSelectionBehavior,
+    ) : ValueEnum {
+        Default("default", EmbeddedPaymentElement.RowSelectionBehavior.default()),
+        ImmediateAction(
+            "immediate_action",
+            EmbeddedPaymentElement.RowSelectionBehavior.immediateAction { embeddedPaymentElement ->
+                val paymentOption = embeddedPaymentElement.paymentOption.value
+                Log.d(
+                    "ImmediateAction",
+                    "Payment Option ${paymentOption?.paymentMethodType}: ${paymentOption?.label}"
+                )
+            }
+        )
+    }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -455,6 +455,7 @@ internal class PlaygroundSettings private constructor(
             EmbeddedViewDisplaysMandateSettingDefinition,
             EmbeddedFormSheetActionSettingDefinition,
             EmbeddedTwoStepSettingsDefinition,
+            EmbeddedRowSelectionBehaviorSettingsDefinition,
             PaymentMethodOptionsSetupFutureUsageSettingsDefinition,
             PaymentMethodOptionsSetupFutureUsageOverrideSettingsDefinition,
             WalletButtonsSettingsDefinition,


### PR DESCRIPTION
# Summary
A playground setting to enable rowSelection Behavior.

It is built off this PR / branch https://github.com/stripe/stripe-android/pull/10831

# Motivation
Make it easier to test rowSelectionBehavior in the playground

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

# Screenshots
![1000000328](https://github.com/user-attachments/assets/582a99d4-5457-4e84-9977-49c38e1cd8d3)
