### PR TITLE
Add new parameter as `rememberGooglePayLauncher`

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncher.kt
@@ -360,7 +360,8 @@ class GooglePayLauncher internal constructor(
 fun rememberGooglePayLauncher(
     config: GooglePayLauncher.Config,
     readyCallback: GooglePayLauncher.ReadyCallback,
-    resultCallback: GooglePayLauncher.ResultCallback
+    resultCallback: GooglePayLauncher.ResultCallback,
+    publishableKey: String? = null
 ): GooglePayLauncher {
     val currentReadyCallback by rememberUpdatedState(readyCallback)
 
@@ -394,7 +395,7 @@ fun rememberGooglePayLauncher(
             },
             PaymentAnalyticsRequestFactory(
                 context,
-                PaymentConfiguration.getInstance(context).publishableKey,
+                publishableKey ?: PaymentConfiguration.getInstance(context).publishableKey,
                 setOf(GooglePayLauncher.PRODUCT_USAGE)
             ),
             DefaultAnalyticsRequestExecutor()

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayLauncherTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayLauncherTest.kt
@@ -29,6 +29,15 @@ internal class GooglePayLauncherTest {
     }
 
     @Test
+    fun `presentForPaymentIntent() should successfully return a result with manual injection publishable key`() {
+        runGooglePayLauncherTest(
+            publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+        ) { _, launcher ->
+            launcher.presentForPaymentIntent("pi_123_secret_456")
+        }
+    }
+
+    @Test
     fun `init should fire expected event`() {
         runGooglePayLauncherTest(
             integrationTypes = listOf(LauncherIntegrationType.Activity),

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/utils/GooglePayLauncherTestRunner.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/utils/GooglePayLauncherTestRunner.kt
@@ -39,6 +39,7 @@ internal fun runGooglePayLauncherTest(
     result: GooglePayLauncher.Result = GooglePayLauncher.Result.Completed,
     integrationTypes: List<LauncherIntegrationType> = LauncherIntegrationType.entries,
     expectResult: Boolean = true,
+    publishableKey: String? = null,
     block: (ComponentActivity, GooglePayLauncher) -> Unit,
 ) {
     for (integrationType in integrationTypes) {
@@ -47,6 +48,7 @@ internal fun runGooglePayLauncherTest(
             isReady = isReady,
             result = result,
             verifyResult = expectResult,
+            publishableKey = publishableKey,
             block = block,
         )
     }
@@ -57,6 +59,7 @@ private fun runGooglePayLauncherTest(
     isReady: Boolean,
     result: GooglePayLauncher.Result,
     verifyResult: Boolean,
+    publishableKey: String? = null,
     block: (ComponentActivity, GooglePayLauncher) -> Unit,
 ) {
     val readyCallback = mock<GooglePayLauncher.ReadyCallback>()
@@ -102,6 +105,7 @@ private fun runGooglePayLauncherTest(
                             config = defaultConfig,
                             readyCallback = readyCallback,
                             resultCallback = resultCallback,
+                            publishableKey = publishableKey,
                         )
                     }
                 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Added optional publishableKey parameter to rememberGooglePayLauncher() to allow direct key specification without modifying singleton configuration.

 - https://github.com/stripe/stripe-android/issues/10937

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Eliminates need to reinitialize PaymentConfiguration singleton when switching between different country-specific publishable keys, reducing code complexity and preventing potential race conditions.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified
