### PR TITLE
Move validation to StateHelper.handleLoadedState to handle 2-step integration case 

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfigurationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfigurationHandler.kt
@@ -8,7 +8,6 @@ import com.stripe.android.common.coroutines.CoalescingOrchestrator
 import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
-import com.stripe.android.paymentelement.EmbeddedPaymentElement.Configuration
 import com.stripe.android.paymentelement.ExperimentalEmbeddedPaymentElementApi
 import com.stripe.android.paymentelement.embedded.InternalRowSelectionCallback
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -52,21 +51,6 @@ internal class DefaultEmbeddedConfigurationHandler @Inject constructor(
         intentConfiguration: PaymentSheet.IntentConfiguration,
         configuration: EmbeddedPaymentElement.Configuration,
     ): Result<PaymentElementLoader.State> {
-        val isRowSelectionImmediateAction = internalRowSelectionCallback.get() != null
-        val hasGooglePayOrCustomerConfig = configuration.googlePay != null || configuration.customer != null
-        if (isRowSelectionImmediateAction &&
-            configuration.formSheetAction == EmbeddedPaymentElement.FormSheetAction.Confirm &&
-            hasGooglePayOrCustomerConfig
-        ) {
-            return Result.failure(
-                IllegalArgumentException(
-                    "Using RowSelectionBehavior.ImmediateAction with FormSheetAction.Confirm is not supported " +
-                        "when Google Pay or a customer configuration is provided. " +
-                        "Use RowSelectionBehavior.Default or disable Apple Pay and saved payment methods."
-                )
-            )
-        }
-
         val targetConfiguration = configuration.asCommonConfiguration()
         eventReporter.onInit(
             commonConfiguration = targetConfiguration,
@@ -75,7 +59,7 @@ internal class DefaultEmbeddedConfigurationHandler @Inject constructor(
             primaryButtonColor = null,
             configurationSpecificPayload = PaymentSheetEvent.ConfigurationSpecificPayload.Embedded(
                 configuration = configuration,
-                isRowSelectionImmediateAction = isRowSelectionImmediateAction
+                isRowSelectionImmediateAction = internalRowSelectionCallback.get() != null
             ),
         )
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedStateHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedStateHelper.kt
@@ -5,9 +5,11 @@ package com.stripe.android.paymentelement.embedded.content
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.ExperimentalEmbeddedPaymentElementApi
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.paymentelement.embedded.InternalRowSelectionCallback
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.parseAppearance
 import javax.inject.Inject
+import javax.inject.Provider
 
 internal interface EmbeddedStateHelper {
     var state: EmbeddedPaymentElement.State?
@@ -18,6 +20,7 @@ internal class DefaultEmbeddedStateHelper @Inject constructor(
     private val customerStateHolder: CustomerStateHolder,
     private val confirmationStateHolder: EmbeddedConfirmationStateHolder,
     private val embeddedContentHelper: EmbeddedContentHelper,
+    private val internalRowSelectionCallback: Provider<InternalRowSelectionCallback?>,
 ) : EmbeddedStateHelper {
     override var state: EmbeddedPaymentElement.State?
         get() {
@@ -40,6 +43,10 @@ internal class DefaultEmbeddedStateHelper @Inject constructor(
     private fun handleLoadedState(
         state: EmbeddedPaymentElement.State,
     ) {
+        validateRowSelectionBehaviorConfiguration(
+            configuration = state.confirmationState.configuration
+        )
+
         state.confirmationState.configuration.appearance.parseAppearance()
         confirmationStateHolder.state = state.confirmationState
         customerStateHolder.setCustomerState(state.customer)
@@ -50,6 +57,24 @@ internal class DefaultEmbeddedStateHelper @Inject constructor(
             rowStyle = state.confirmationState.configuration.appearance.embeddedAppearance.style,
             embeddedViewDisplaysMandateText = state.confirmationState.configuration.embeddedViewDisplaysMandateText,
         )
+    }
+
+    private fun validateRowSelectionBehaviorConfiguration(
+        configuration: EmbeddedPaymentElement.Configuration
+    ) {
+        val isRowSelectionImmediateAction = internalRowSelectionCallback.get() != null
+        val hasGooglePayOrCustomerConfig = configuration.googlePay != null || configuration.customer != null
+
+        if (isRowSelectionImmediateAction &&
+            configuration.formSheetAction == EmbeddedPaymentElement.FormSheetAction.Confirm &&
+            hasGooglePayOrCustomerConfig
+        ) {
+            throw IllegalArgumentException(
+                "Using RowSelectionBehavior.ImmediateAction with FormSheetAction.Confirm is not supported " +
+                    "when Google Pay or a customer configuration is provided. " +
+                    "Use RowSelectionBehavior.Default or disable Google Pay and saved payment methods."
+            )
+        }
     }
 
     private fun clearState() {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfigurationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfigurationHandlerTest.kt
@@ -12,7 +12,6 @@ import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.ExperimentalEmbeddedPaymentElementApi
-import com.stripe.android.paymentelement.embedded.InternalRowSelectionCallback
 import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedConfigurationHandler.ConfigurationCache
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
@@ -54,131 +53,6 @@ internal class DefaultEmbeddedConfigurationHandlerTest {
             configuration = configuration,
         )
         assertThat(result.exceptionOrNull()?.message).isEqualTo("Configuring while a sheet is open is not supported.")
-    }
-
-    @Test
-    fun `configuration fails rowSelectionCallback not null, action confirm, gPay`() = runScenario(
-        rowSelectionCallback = {}
-    ) {
-        val result = handler.configure(
-            intentConfiguration = PaymentSheet.IntentConfiguration(
-                mode = PaymentSheet.IntentConfiguration.Mode.Setup(currency = "USD"),
-            ),
-            configuration = EmbeddedPaymentElement.Configuration.Builder("Example Inc.")
-                .googlePay(
-                    PaymentSheet.GooglePayConfiguration(
-                        environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
-                        countryCode = "USD",
-                    )
-                )
-                .formSheetAction(EmbeddedPaymentElement.FormSheetAction.Confirm)
-                .build(),
-        )
-
-        assertThat(result.exceptionOrNull()?.message).isEqualTo(
-            "Using RowSelectionBehavior.ImmediateAction with FormSheetAction.Confirm is not supported " +
-                "when Google Pay or a customer configuration is provided. " +
-                "Use RowSelectionBehavior.Default or disable Apple Pay and saved payment methods."
-        )
-    }
-
-    @Test
-    fun `configuration fails rowSelectionCallback not null, action confirm, customer`() = runScenario(
-        rowSelectionCallback = {}
-    ) {
-        val result = handler.configure(
-            intentConfiguration = PaymentSheet.IntentConfiguration(
-                mode = PaymentSheet.IntentConfiguration.Mode.Setup(currency = "USD"),
-            ),
-            configuration = EmbeddedPaymentElement.Configuration.Builder("Example Inc.")
-                .customer(PaymentSheet.CustomerConfiguration("cus_123", "ek_test"))
-                .formSheetAction(EmbeddedPaymentElement.FormSheetAction.Confirm)
-                .build(),
-        )
-
-        assertThat(result.exceptionOrNull()?.message).isEqualTo(
-            "Using RowSelectionBehavior.ImmediateAction with FormSheetAction.Confirm is not supported " +
-                "when Google Pay or a customer configuration is provided. " +
-                "Use RowSelectionBehavior.Default or disable Apple Pay and saved payment methods."
-        )
-    }
-
-    @Test
-    fun `configuration succeeds rowSelectionCallback null, action confirm, customer & gPay`() = runScenario(
-        rowSelectionCallback = null
-    ) {
-        val configuration = EmbeddedPaymentElement.Configuration.Builder("Example Inc.")
-            .googlePay(
-                PaymentSheet.GooglePayConfiguration(
-                    environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
-                    countryCode = "USD",
-                )
-            )
-            .customer(PaymentSheet.CustomerConfiguration("cus_123", "ek_test"))
-            .formSheetAction(EmbeddedPaymentElement.FormSheetAction.Confirm)
-            .build()
-        loader.emit(loader.createSuccess(configuration.asCommonConfiguration()))
-
-        val result = handler.configure(
-            intentConfiguration = PaymentSheet.IntentConfiguration(
-                mode = PaymentSheet.IntentConfiguration.Mode.Setup(currency = "USD"),
-            ),
-            configuration = configuration,
-        )
-
-        assertThat(result.getOrThrow())
-            .isInstanceOf<PaymentElementLoader.State>()
-        assertThat(result.isSuccess)
-    }
-
-    @Test
-    fun `configuration succeeds rowSelectionCallback !null, action confirm, no gpay, no customer`() = runScenario(
-        rowSelectionCallback = {}
-    ) {
-        val configuration = EmbeddedPaymentElement.Configuration.Builder("Example Inc.")
-            .formSheetAction(EmbeddedPaymentElement.FormSheetAction.Confirm)
-            .build()
-        loader.emit(loader.createSuccess(configuration.asCommonConfiguration()))
-
-        val result = handler.configure(
-            intentConfiguration = PaymentSheet.IntentConfiguration(
-                mode = PaymentSheet.IntentConfiguration.Mode.Setup(currency = "USD"),
-            ),
-            configuration = configuration,
-        )
-
-        assertThat(result.getOrThrow())
-            .isInstanceOf<PaymentElementLoader.State>()
-        assertThat(result.isSuccess)
-    }
-
-    @Test
-    fun `configuration succeeds rowSelectionCallback !null, action continue, gPay & Customer`() = runScenario(
-        rowSelectionCallback = {}
-    ) {
-        val configuration = EmbeddedPaymentElement.Configuration.Builder("Example Inc.")
-            .googlePay(
-                PaymentSheet.GooglePayConfiguration(
-                    environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
-                    countryCode = "USD",
-                )
-            )
-            .customer(PaymentSheet.CustomerConfiguration("cus_123", "ek_test"))
-            .formSheetAction(EmbeddedPaymentElement.FormSheetAction.Continue)
-            .build()
-
-        loader.emit(loader.createSuccess(configuration.asCommonConfiguration()))
-
-        val result = handler.configure(
-            intentConfiguration = PaymentSheet.IntentConfiguration(
-                mode = PaymentSheet.IntentConfiguration.Mode.Setup(currency = "USD"),
-            ),
-            configuration = configuration,
-        )
-
-        assertThat(result.getOrThrow())
-            .isInstanceOf<PaymentElementLoader.State>()
-        assertThat(result.isSuccess)
     }
 
     @Test
@@ -428,7 +302,6 @@ internal class DefaultEmbeddedConfigurationHandlerTest {
     }
 
     private fun runScenario(
-        rowSelectionCallback: InternalRowSelectionCallback? = null,
         block: suspend Scenario.() -> Unit
     ) {
         runTest {
@@ -441,7 +314,7 @@ internal class DefaultEmbeddedConfigurationHandlerTest {
                 savedStateHandle,
                 sheetStateHolder,
                 eventReporter
-            ) { rowSelectionCallback }
+            ) { null }
             Scenario(
                 loader = loader,
                 savedStateHandle = savedStateHandle,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedStateHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedStateHelperTest.kt
@@ -12,6 +12,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixt
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.ExperimentalEmbeddedPaymentElementApi
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.paymentelement.embedded.InternalRowSelectionCallback
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded
@@ -28,6 +29,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
 
 internal class DefaultEmbeddedStateHelperTest {
     @Test
@@ -99,7 +101,94 @@ internal class DefaultEmbeddedStateHelperTest {
         assertThat(embeddedContentHelper.clearEmbeddedContentTurbine.awaitItem()).isEqualTo(Unit)
     }
 
+    @Test
+    fun `setState succeeds rowSelectionCallback not null, action confirm, customer null & gPay null`() = testScenario(
+        rowSelectionCallback = {}
+    ) {
+        setState {
+            googlePay(null)
+            customer(null)
+            formSheetAction(EmbeddedPaymentElement.FormSheetAction.Confirm)
+        }
+
+        assertThat(embeddedContentHelper.dataLoadedTurbine.awaitItem()).isNotNull()
+    }
+
+    @Test
+    fun `setState succeeds rowSelectionCallback null, action confirm, customer & gPay`() = testScenario(
+        rowSelectionCallback = null
+    ) {
+        setState {
+            googlePay(
+                PaymentSheet.GooglePayConfiguration(
+                    environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
+                    countryCode = "US",
+                )
+            )
+            customer(PaymentSheet.CustomerConfiguration("cus_123", "ek_test"))
+            formSheetAction(EmbeddedPaymentElement.FormSheetAction.Confirm)
+        }
+
+        assertThat(embeddedContentHelper.dataLoadedTurbine.awaitItem()).isNotNull()
+    }
+
+    @Test
+    fun `setState succeeds rowSelectionCallback not null, action continue, customer & gPay`() = testScenario(
+        rowSelectionCallback = {}
+    ) {
+        setState {
+            googlePay(
+                PaymentSheet.GooglePayConfiguration(
+                    environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
+                    countryCode = "US",
+                )
+            )
+            customer(PaymentSheet.CustomerConfiguration("cus_123", "ek_test"))
+            formSheetAction(EmbeddedPaymentElement.FormSheetAction.Continue)
+        }
+
+        assertThat(embeddedContentHelper.dataLoadedTurbine.awaitItem()).isNotNull()
+    }
+
+    @Test
+    fun `setState fails rowSelectionCallback not null, action confirm, customer`() = testScenario(
+        rowSelectionCallback = {}
+    ) {
+        assertFailsWith<IllegalArgumentException>(
+            "Using RowSelectionBehavior.ImmediateAction with FormSheetAction.Confirm is not supported " +
+                "when Google Pay or a customer configuration is provided. " +
+                "Use RowSelectionBehavior.Default or disable Google Pay and saved payment methods."
+        ) {
+            setState {
+                customer(PaymentSheet.CustomerConfiguration("cus_123", "ek_test"))
+                formSheetAction(EmbeddedPaymentElement.FormSheetAction.Confirm)
+            }
+        }
+    }
+
+    @Test
+    fun `setState fails rowSelectionCallback not null, action confirm, gPay`() = testScenario(
+        rowSelectionCallback = {}
+    ) {
+        assertFailsWith<IllegalArgumentException>(
+            "Using RowSelectionBehavior.ImmediateAction with FormSheetAction.Confirm is not supported " +
+                "when Google Pay or a customer configuration is provided. " +
+                "Use RowSelectionBehavior.Default or disable Google Pay and saved payment methods."
+        ) {
+            setState {
+                googlePay(
+                    PaymentSheet.GooglePayConfiguration(
+                        environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
+                        countryCode = "USD",
+                    )
+                )
+                formSheetAction(EmbeddedPaymentElement.FormSheetAction.Confirm)
+            }
+        }
+    }
+
     private fun testScenario(
+        rowSelectionCallback: InternalRowSelectionCallback? = null,
         block: suspend Scenario.() -> Unit,
     ) = runTest {
         val savedStateHandle = SavedStateHandle()
@@ -122,6 +211,7 @@ internal class DefaultEmbeddedStateHelperTest {
             customerStateHolder = customerStateHolder,
             confirmationStateHolder = confirmationStateHolder,
             embeddedContentHelper = embeddedContentHelper,
+            internalRowSelectionCallback = { rowSelectionCallback }
         )
 
         Scenario(


### PR DESCRIPTION
# Summary
Moved validation logic to EmbeddedStateHelper.handleLoadedState to handle 2-step integration case
Modified tests

# Motivation
Previously, in the 2 step integration case, when there was an invalid configuration, buyers were still able to use embedded, with rowSelectionBehavior set to ImmediateAction.

This is because the 1st instance of embedded in the 2-step case will not have a rowSelectionBehavior, so it can configure properly, but the 2nd instance skips configure, meaning that this validation will succeed incorrectly.

This fixes that bug by moving the validation logic to handleLoadedState, meaning that the 2nd instance will be able to validate correctly.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [X] Manually verified

# Screenshots
N.A.

# Changelog
N.A.