### PR TITLE
Pass `SellerDetails` to `elements/session`

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -2519,6 +2519,14 @@ public final class com/stripe/android/model/ElementsSessionParams$PaymentIntentT
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/model/ElementsSessionParams$SellerDetails$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/ElementsSessionParams$SellerDetails;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/ElementsSessionParams$SellerDetails;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/model/ElementsSessionParams$SetupIntentType$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/ElementsSessionParams$SetupIntentType;

--- a/payments-core/src/main/java/com/stripe/android/model/ElementsSessionParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ElementsSessionParams.kt
@@ -20,6 +20,7 @@ sealed interface ElementsSessionParams : Parcelable {
     val customPaymentMethods: List<String>
     val externalPaymentMethods: List<String>
     val appId: String
+    val sellerDetails: SellerDetails?
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Parcelize
@@ -40,6 +41,9 @@ sealed interface ElementsSessionParams : Parcelable {
 
         override val expandFields: List<String>
             get() = listOf("payment_method_preference.$type.payment_method")
+
+        override val sellerDetails: SellerDetails?
+            get() = null
     }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -61,6 +65,9 @@ sealed interface ElementsSessionParams : Parcelable {
 
         override val expandFields: List<String>
             get() = listOf("payment_method_preference.$type.payment_method")
+
+        override val sellerDetails: SellerDetails?
+            get() = null
     }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -75,6 +82,7 @@ sealed interface ElementsSessionParams : Parcelable {
         override val legacyCustomerEphemeralKey: String? = null,
         override val mobileSessionId: String? = null,
         override val appId: String,
+        override val sellerDetails: SellerDetails? = null,
     ) : ElementsSessionParams {
 
         override val clientSecret: String?
@@ -85,5 +93,19 @@ sealed interface ElementsSessionParams : Parcelable {
 
         override val expandFields: List<String>
             get() = emptyList()
+    }
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @Parcelize
+    data class SellerDetails(
+        val networkId: String,
+        val externalId: String,
+    ) : Parcelable {
+        fun toQueryParams(): Map<String, Any?> {
+            return mapOf(
+                "seller_details[network_id]" to networkId,
+                "seller_details[external_id]" to externalId,
+            )
+        }
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -1605,6 +1605,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
             params.customPaymentMethods.takeIf { it.isNotEmpty() }?.let { this["custom_payment_methods"] = it }
             params.mobileSessionId?.takeIf { it.isNotEmpty() }?.let { this["mobile_session_id"] = it }
             params.savedPaymentMethodSelectionId?.let { this["client_default_payment_method"] = it }
+            params.sellerDetails?.let { this.putAll(it.toQueryParams()) }
             (params as? ElementsSessionParams.DeferredIntentType)?.let { type ->
                 this.putAll(type.deferredIntentParams.toQueryParams())
             }

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -2629,7 +2629,7 @@ internal class StripeApiRepositoryTest {
     }
 
     @Test
-    fun `Verify seller details not in params when provided`() = runTest {
+    fun `Verify seller details not in params when not provided`() = runTest {
         val stripeResponse = StripeResponse(
             200,
             ElementsSessionFixtures.EXPANDED_PAYMENT_INTENT_JSON.toString(),

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -2629,6 +2629,101 @@ internal class StripeApiRepositoryTest {
     }
 
     @Test
+    fun `Verify seller details not in params when provided`() = runTest {
+        val stripeResponse = StripeResponse(
+            200,
+            ElementsSessionFixtures.EXPANDED_PAYMENT_INTENT_JSON.toString(),
+            emptyMap()
+        )
+
+        whenever(stripeNetworkClient.executeRequest(any<ApiRequest>())).thenReturn(stripeResponse)
+
+        create().retrieveElementsSession(
+            params = ElementsSessionParams.DeferredIntentType(
+                customerSessionClientSecret = "customer_session_client_secret",
+                deferredIntentParams = DeferredIntentParams(
+                    mode = DeferredIntentParams.Mode.Payment(
+                        amount = 2000,
+                        currency = "usd",
+                        captureMethod = PaymentIntent.CaptureMethod.Automatic,
+                        setupFutureUsage = null,
+                        paymentMethodOptionsJsonString = null
+                    ),
+                    paymentMethodTypes = listOf("card"),
+                    paymentMethodConfigurationId = null,
+                    onBehalfOf = null,
+                ),
+                externalPaymentMethods = emptyList(),
+                customPaymentMethods = emptyList(),
+                appId = APP_ID,
+                sellerDetails = null
+            ),
+            options = DEFAULT_OPTIONS,
+        )
+
+        verify(stripeNetworkClient).executeRequest(apiRequestArgumentCaptor.capture())
+
+        val request = apiRequestArgumentCaptor.firstValue
+        val params = requireNotNull(request.params)
+
+        assertThat(request.baseUrl).isEqualTo("https://api.stripe.com/v1/elements/sessions")
+
+        with(params) {
+            assertThat(this["seller_details[network_id]"]).isNull()
+            assertThat(this["seller_details[external_id]"]).isNull()
+        }
+    }
+
+    @Test
+    fun `Verify seller details in params when provided`() = runTest {
+        val stripeResponse = StripeResponse(
+            200,
+            ElementsSessionFixtures.EXPANDED_PAYMENT_INTENT_JSON.toString(),
+            emptyMap()
+        )
+
+        whenever(stripeNetworkClient.executeRequest(any<ApiRequest>())).thenReturn(stripeResponse)
+
+        create().retrieveElementsSession(
+            params = ElementsSessionParams.DeferredIntentType(
+                customerSessionClientSecret = "customer_session_client_secret",
+                deferredIntentParams = DeferredIntentParams(
+                    mode = DeferredIntentParams.Mode.Payment(
+                        amount = 2000,
+                        currency = "usd",
+                        captureMethod = PaymentIntent.CaptureMethod.Automatic,
+                        setupFutureUsage = null,
+                        paymentMethodOptionsJsonString = null
+                    ),
+                    paymentMethodTypes = listOf("card"),
+                    paymentMethodConfigurationId = null,
+                    onBehalfOf = null,
+                ),
+                externalPaymentMethods = emptyList(),
+                customPaymentMethods = emptyList(),
+                appId = APP_ID,
+                sellerDetails = ElementsSessionParams.SellerDetails(
+                    networkId = "network_123",
+                    externalId = "external_123",
+                )
+            ),
+            options = DEFAULT_OPTIONS,
+        )
+
+        verify(stripeNetworkClient).executeRequest(apiRequestArgumentCaptor.capture())
+
+        val request = apiRequestArgumentCaptor.firstValue
+        val params = requireNotNull(request.params)
+
+        assertThat(request.baseUrl).isEqualTo("https://api.stripe.com/v1/elements/sessions")
+
+        with(params) {
+            assertThat(this["seller_details[network_id]"]).isEqualTo("network_123")
+            assertThat(this["seller_details[external_id]"]).isEqualTo("external_123")
+        }
+    }
+
+    @Test
     fun `Verify legacy customer ephemeral key not in params when null`() = runTest {
         val stripeResponse = StripeResponse(
             200,

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -2162,6 +2162,22 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$IntentConfigurat
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$IntentBehavior$Default$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$IntentBehavior$Default;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$IntentBehavior$Default;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$IntentBehavior$SharedPaymentToken$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$IntentBehavior$SharedPaymentToken;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$IntentBehavior$SharedPaymentToken;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public abstract class com/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$Mode : android/os/Parcelable {
 	public static final field $stable I
 }
@@ -2231,6 +2247,14 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$IntentConfigurat
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$Mode$Setup;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$Mode$Setup;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$SellerDetails$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$SellerDetails;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$SellerDetails;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/SharedPaymentTokenSessionPreview.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/SharedPaymentTokenSessionPreview.kt
@@ -1,0 +1,11 @@
+package com.stripe.android.paymentelement
+
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@RequiresOptIn(
+    level = RequiresOptIn.Level.ERROR,
+    message = "This API is under construction. It can be changed or removed at any time (use at your own risk)."
+)
+@Retention(AnnotationRetention.BINARY)
+annotation class SharedPaymentTokenSessionPreview

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -31,6 +31,7 @@ import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
 import com.stripe.android.paymentelement.ExperimentalCustomPaymentMethodsApi
 import com.stripe.android.paymentelement.ExperimentalEmbeddedPaymentElementApi
 import com.stripe.android.paymentelement.PaymentMethodOptionsSetupFutureUsagePreview
+import com.stripe.android.paymentelement.SharedPaymentTokenSessionPreview
 import com.stripe.android.paymentelement.ShopPayPreview
 import com.stripe.android.paymentelement.WalletButtonsPreview
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
@@ -435,13 +436,48 @@ class PaymentSheet internal constructor(
      */
     @Poko
     @Parcelize
-    class IntentConfiguration @JvmOverloads constructor(
+    class IntentConfiguration internal constructor(
         val mode: Mode,
         val paymentMethodTypes: List<String> = emptyList(),
         val paymentMethodConfigurationId: String? = null,
         val onBehalfOf: String? = null,
         internal val requireCvcRecollection: Boolean = false,
+        internal val intentBehavior: IntentBehavior = IntentBehavior.Default,
     ) : Parcelable {
+        @JvmOverloads
+        constructor(
+            mode: Mode,
+            paymentMethodTypes: List<String> = emptyList(),
+            paymentMethodConfigurationId: String? = null,
+            onBehalfOf: String? = null,
+            requireCvcRecollection: Boolean = false,
+        ) : this(
+            mode = mode,
+            paymentMethodTypes = paymentMethodTypes,
+            paymentMethodConfigurationId = paymentMethodConfigurationId,
+            onBehalfOf = onBehalfOf,
+            requireCvcRecollection = requireCvcRecollection,
+            intentBehavior = IntentBehavior.Default,
+        )
+
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        @SharedPaymentTokenSessionPreview
+        @JvmOverloads
+        constructor(
+            sharedPaymentTokenSessionWithMode: Mode,
+            sellerDetails: SellerDetails?,
+            paymentMethodTypes: List<String> = emptyList(),
+            paymentMethodConfigurationId: String? = null,
+            onBehalfOf: String? = null,
+            requireCvcRecollection: Boolean = false,
+        ) : this(
+            mode = sharedPaymentTokenSessionWithMode,
+            paymentMethodTypes = paymentMethodTypes,
+            paymentMethodConfigurationId = paymentMethodConfigurationId,
+            onBehalfOf = onBehalfOf,
+            requireCvcRecollection = requireCvcRecollection,
+            intentBehavior = IntentBehavior.SharedPaymentToken(sellerDetails),
+        )
 
         /**
          * Contains information about the desired payment or setup flow.
@@ -567,6 +603,26 @@ class PaymentSheet internal constructor(
              * **Note**: Not all payment methods support this.
              */
             Manual,
+        }
+
+        @SharedPaymentTokenSessionPreview
+        @Parcelize
+        @Poko
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        class SellerDetails(
+            val networkId: String,
+            val externalId: String,
+        ) : Parcelable
+
+        @OptIn(SharedPaymentTokenSessionPreview::class)
+        internal sealed interface IntentBehavior : Parcelable {
+            @Parcelize
+            data object Default : IntentBehavior
+
+            @Parcelize
+            data class SharedPaymentToken(
+                val sellerDetails: SellerDetails?,
+            ) : IntentBehavior
         }
 
         companion object {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
@@ -13,6 +13,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.StripeRepository
+import com.stripe.android.paymentelement.SharedPaymentTokenSessionPreview
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.paymentsheet.toDeferredIntentParams
@@ -168,6 +169,7 @@ internal fun PaymentElementLoader.InitializationMode.toElementsSessionParams(
                 legacyCustomerEphemeralKey = legacyCustomerEphemeralKey,
                 savedPaymentMethodSelectionId = savedPaymentMethodSelectionId,
                 mobileSessionId = mobileSessionId,
+                sellerDetails = intentConfiguration.toSellerDetails(),
                 appId = appId
             )
         }
@@ -177,6 +179,19 @@ internal fun PaymentElementLoader.InitializationMode.toElementsSessionParams(
 private fun List<PaymentSheet.CustomPaymentMethod>.toElementSessionParam(): List<String> {
     return map { customPaymentMethod ->
         customPaymentMethod.id
+    }
+}
+
+@OptIn(SharedPaymentTokenSessionPreview::class)
+private fun PaymentSheet.IntentConfiguration.toSellerDetails(): ElementsSessionParams.SellerDetails? {
+    return when (intentBehavior) {
+        is PaymentSheet.IntentConfiguration.IntentBehavior.SharedPaymentToken -> intentBehavior.sellerDetails?.run {
+            ElementsSessionParams.SellerDetails(
+                externalId = externalId,
+                networkId = networkId,
+            )
+        }
+        is PaymentSheet.IntentConfiguration.IntentBehavior.Default -> null
     }
 }
 


### PR DESCRIPTION
# Summary
Pass `SellerDetails` to `elements/session`

# Motivation
Helps support new deferred API for Forest

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified