### PR TITLE
Fix dark mode for CPM and EPM playground

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/CustomPaymentMethodActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/CustomPaymentMethodActivity.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -98,14 +99,20 @@ class CustomPaymentMethodActivity : AppCompatActivity() {
 
     @Composable
     fun BillingDetails(billingDetails: PaymentMethod.BillingDetails) {
-        Text("Billing details: $billingDetails")
+        Text(
+            text = "Billing details: $billingDetails",
+            color = MaterialTheme.colors.onSurface
+        )
     }
 
     @Composable
     fun Title(
         customPaymentMethodType: PaymentSheet.CustomPaymentMethod,
     ) {
-        Text(customPaymentMethodType.id)
+        Text(
+            text = customPaymentMethodType.id,
+            color = MaterialTheme.colors.onSurface
+        )
     }
 
     companion object {

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/FawryActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/FawryActivity.kt
@@ -6,10 +6,10 @@ import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.ExternalPaymentMethodResult
@@ -73,7 +73,10 @@ class FawryActivity : AppCompatActivity() {
 
     @Composable
     fun BillingDetails(billingDetails: PaymentMethod.BillingDetails) {
-        Text("Billing details: $billingDetails", color = Color.White)
+        Text(
+            text = "Billing details: $billingDetails",
+            color = MaterialTheme.colors.onSurface
+        )
     }
 
     companion object {


### PR DESCRIPTION
# Summary
Fix dark mode for CPM and EPM playground

# Motivation
Better dark mode support

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
<img src="https://github.com/user-attachments/assets/e381229c-3b26-4017-98b2-24bb2ea99059" width="40%" height="40%" />