### PR TITLE
PaymentMethod id is no longer nullable.

### DIFF
--- a/payment-element-test-pages/src/main/java/com/stripe/paymentelementnetwork/PaymentMethodModificationExtensions.kt
+++ b/payment-element-test-pages/src/main/java/com/stripe/paymentelementnetwork/PaymentMethodModificationExtensions.kt
@@ -20,7 +20,14 @@ fun NetworkRule.setupPaymentMethodDetachResponse(
         method("POST"),
         path("/v1/payment_methods/$paymentMethodId/detach"),
     ) { response ->
-        response.setResponseCode(200)
+        response.setBody(
+            """
+            {
+            	"id": "$paymentMethodId",
+                "type": "card"
+            }
+            """.trimIndent()
+        )
     }
 }
 

--- a/payments-core-testing/src/main/java/com/stripe/android/testing/PaymentMethodFactory.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/PaymentMethodFactory.kt
@@ -70,7 +70,7 @@ object PaymentMethodFactory {
         return card(id = id)
     }
 
-    fun card(id: String?): PaymentMethod {
+    fun card(id: String): PaymentMethod {
         return PaymentMethod(
             id = id,
             created = 123456789L,

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
@@ -33,7 +33,7 @@ constructor(
      *
      * [id](https://stripe.com/docs/api/payment_methods/object#payment_method_object-id)
      */
-    @JvmField val id: String?,
+    @JvmField val id: String,
 
     /**
      * Time at which the object was created. Measured in seconds since the Unix epoch.
@@ -710,7 +710,7 @@ constructor(
 
         fun build(): PaymentMethod {
             return PaymentMethod(
-                id = id,
+                id = requireNotNull(id) { "PaymentMethod id was null" },
                 created = created,
                 liveMode = liveMode,
                 type = type,

--- a/payments-core/src/test/java/com/stripe/android/model/PaymentMethodFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/PaymentMethodFixtures.kt
@@ -626,28 +626,26 @@ internal object PaymentMethodFixtures {
     val BLIK_JSON = JSONObject(
         """
         {
-            "payment_method": {
-                "id": "pm_1Mm5TUKG6vc7r7YC41rnkvqS",
-                "object": "payment_method",
-                "billing_details": {
-                  "address": {
-                    "city": null,
-                    "country": null,
-                    "line1": null,
-                    "line2": null,
-                    "postal_code": null,
-                    "state": null
-                  },
-                  "email": null,
-                  "name": null,
-                  "phone": null
-                },
-                "blik": {},
-                "created": 1678929564,
-                "customer": null,
-                "livemode": false,
-                "type": "blik"
-            }
+            "id": "pm_1Mm5TUKG6vc7r7YC41rnkvqS",
+            "object": "payment_method",
+            "billing_details": {
+              "address": {
+                "city": null,
+                "country": null,
+                "line1": null,
+                "line2": null,
+                "postal_code": null,
+                "state": null
+              },
+              "email": null,
+              "name": null,
+              "phone": null
+            },
+            "blik": {},
+            "created": 1678929564,
+            "customer": null,
+            "livemode": false,
+            "type": "blik"
         }
         """.trimIndent()
     )

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -517,7 +517,7 @@ internal class CustomerSheetViewModel(
 
     private suspend fun removePaymentMethod(paymentMethod: PaymentMethod): CustomerSheetDataResult<PaymentMethod> {
         return awaitPaymentMethodDataSource().detachPaymentMethod(
-            paymentMethodId = paymentMethod.id!!,
+            paymentMethodId = paymentMethod.id,
         ).onSuccess {
             eventReporter.onRemovePaymentMethodSucceeded()
         }.onFailure { cause, _ ->
@@ -534,7 +534,7 @@ internal class CustomerSheetViewModel(
         cardUpdateParams: CardUpdateParams
     ): CustomerSheetDataResult<PaymentMethod> {
         return awaitPaymentMethodDataSource().updatePaymentMethod(
-            paymentMethodId = paymentMethod.id!!,
+            paymentMethodId = paymentMethod.id,
             params = PaymentMethodUpdateParams.createCard(
                 networks = cardUpdateParams.cardBrand?.let {
                     PaymentMethodUpdateParams.Card.Networks(
@@ -632,7 +632,7 @@ internal class CustomerSheetViewModel(
 
     private suspend fun removePaymentMethodFromState(paymentMethod: PaymentMethod) {
         val currentCustomerState = customerState.value
-        val newSavedPaymentMethods = currentCustomerState.paymentMethods.filter { it.id != paymentMethod.id!! }
+        val newSavedPaymentMethods = currentCustomerState.paymentMethods.filter { it.id != paymentMethod.id }
 
         val currentSelection = currentCustomerState.currentSelection
         val originalSelection = originalPaymentSelection
@@ -665,7 +665,7 @@ internal class CustomerSheetViewModel(
                 val savedId = savedMethod.id
                 val updatedId = updatedMethod.id
 
-                if (updatedId != null && savedId != null && updatedId == savedId) {
+                if (updatedId == savedId) {
                     updatedMethod
                 } else {
                     savedMethod
@@ -1007,7 +1007,7 @@ internal class CustomerSheetViewModel(
             if (awaitIntentDataSource().canCreateSetupIntents) {
                 attachWithSetupIntent(paymentMethod = paymentMethod)
             } else {
-                attachPaymentMethod(id = paymentMethod.id!!)
+                attachPaymentMethod(id = paymentMethod.id)
             }
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DisplayableSavedPaymentMethod.kt
@@ -122,7 +122,7 @@ internal data class DisplayableSavedPaymentMethod private constructor(
     }
 
     fun isDefaultPaymentMethod(defaultPaymentMethodId: String?): Boolean {
-        return paymentMethod.id != null && paymentMethod.id == defaultPaymentMethodId
+        return paymentMethod.id == defaultPaymentMethodId
     }
 
     companion object {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactory.kt
@@ -30,7 +30,7 @@ internal object PaymentOptionsStateFactory {
                     displayName = nameProvider(it.type?.code),
                     paymentMethod = it,
                     isCbcEligible = isCbcEligible,
-                    shouldShowDefaultBadge = it.id != null && it.id == defaultPaymentMethodId
+                    shouldShowDefaultBadge = it.id == defaultPaymentMethodId
                 ),
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -132,7 +132,7 @@ internal class SavedPaymentMethodMutator(
     }
 
     fun removePaymentMethod(paymentMethod: PaymentMethod) {
-        val paymentMethodId = paymentMethod.id ?: return
+        val paymentMethodId = paymentMethod.id
 
         coroutineScope.launch(workContext) {
             removePaymentMethodInternal(paymentMethodId)
@@ -242,7 +242,7 @@ internal class SavedPaymentMethodMutator(
     }
 
     suspend fun removePaymentMethodInEditScreen(paymentMethod: PaymentMethod): Throwable? {
-        val paymentMethodId = paymentMethod.id!!
+        val paymentMethodId = paymentMethod.id
         val result = removePaymentMethodInternal(paymentMethodId)
 
         if (result.isSuccess) {
@@ -274,7 +274,7 @@ internal class SavedPaymentMethodMutator(
                 ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
                 customerSessionClientSecret = customerMetadata.customerSessionClientSecret,
             ),
-            paymentMethodId = paymentMethod.id!!,
+            paymentMethodId = paymentMethod.id,
             params = PaymentMethodUpdateParams.createCard(
                 networks = cardUpdateParams.cardBrand?.let {
                     PaymentMethodUpdateParams.Card.Networks(
@@ -299,7 +299,7 @@ internal class SavedPaymentMethodMutator(
                             val savedId = savedMethod.id
                             val updatedId = updatedMethod.id
 
-                            if (updatedId != null && savedId != null && updatedId == savedId) {
+                            if (updatedId == savedId) {
                                 updatedMethod
                             } else {
                                 savedMethod

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodsExtension.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodsExtension.kt
@@ -16,6 +16,6 @@ internal fun PaymentMethod.toDisplayableSavedPaymentMethod(
         displayName = providePaymentMethodName(type?.code),
         paymentMethod = this,
         isCbcEligible = paymentMethodMetadata?.cbcEligibility is CardBrandChoiceEligibility.Eligible,
-        shouldShowDefaultBadge = this.id != null && this.id == defaultPaymentMethodId
+        shouldShowDefaultBadge = id == defaultPaymentMethodId
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/link/analytics/DefaultLinkAnalyticsHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/analytics/DefaultLinkAnalyticsHelperTest.kt
@@ -30,7 +30,7 @@ internal class DefaultLinkAnalyticsHelperTest {
         analyticsHelper.onLinkResult(
             linkActivityResult = LinkActivityResult.PaymentMethodObtained(
                 paymentMethod = PaymentMethod(
-                    id = null,
+                    id = "pm_123",
                     created = null,
                     liveMode = false,
                     code = null,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodsExtensionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodsExtensionTest.kt
@@ -28,8 +28,8 @@ class SavedPaymentMethodsExtensionTest {
     }
 
     @Test
-    fun `shouldShowDefaultBadge is false when defaultPaymentMethodId is null and paymentMethod id null`() {
-        val actual = testSetup(null, null)
+    fun `shouldShowDefaultBadge is false when defaultPaymentMethodId is null`() {
+        val actual = testSetup(paymentMethodId = "pm_123", null)
         assertEquals(actual.shouldShowDefaultBadge, false)
     }
 
@@ -39,7 +39,7 @@ class SavedPaymentMethodsExtensionTest {
         assertEquals(actual.shouldShowDefaultBadge, true)
     }
 
-    private fun testSetup(paymentMethodId: String?, defaultPaymentMethodId: String?): DisplayableSavedPaymentMethod {
+    private fun testSetup(paymentMethodId: String, defaultPaymentMethodId: String?): DisplayableSavedPaymentMethod {
         val resolvableString = "acbde123".resolvableString
 
         val paymentMethod = PaymentMethodFactory.card(paymentMethodId)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultManageScreenInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultManageScreenInteractorTest.kt
@@ -24,11 +24,7 @@ class DefaultManageScreenInteractorTest {
 
     @Test
     fun initializeState_nullCurrentSelection() {
-        val initialPaymentMethods = PaymentMethodFixtures.createCards(2).plus(
-            // This is here because an easy bug to write would be selecting a PM with a null ID when the current
-            // selection is also null
-            PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(id = null)
-        )
+        val initialPaymentMethods = PaymentMethodFixtures.createCards(3)
         runScenario(initialPaymentMethods, currentSelection = null) {
             interactor.state.test {
                 awaitItem().run {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
PaymentMethod.id was public and nullable -- but in practice was never null. This fixes that modeling problem.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-3698
