### PR TITLE
Migrate Glitch projects used in Financial Connections

### DIFF
--- a/financial-connections-example/README.md
+++ b/financial-connections-example/README.md
@@ -61,31 +61,3 @@ To run the Financial Connections Example app:
 1. Clone the `stripe-android` repository.
 2. Open the project in Android Studio.
 3. Build and run the `financial-connections-example` project.
-
-#### Remix the example project on Glitch
-
-We provide an example backend hosted on Glitch, allowing you to easily test an integration
-end-to-end.
-
-1. [Open the Glitch project](https://glitch.com/edit/#!/stripe-mobile-connections-example).
-2. Click on "Remix", on the top right.
-3. In your newly created project, open the `.env` file in the left sidebar.
-4. Set your [Stripe testmode public and secret keys](https://dashboard.stripe.com/test/apikeys) as
-   the `STRIPE_TEST_PUBLIC_KEY` and `STRIPE_TEST_SECRET_KEY` fields.
-5. Your backend implementation should now be running. You can see the logs by clicking on "Logs" in
-   the bottom bar.
-
-#### Configure the app
-
-1. If it doesn't exist, create a `gradle.properties` in a location defined in the
-   [Gradle Build Environment docs](https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_configuration_properties)
-   .
-   For example, the default location on macOS is `~/.gradle/gradle.properties`.
-2. Append the following entries to `gradle.properties`.
-
-```
-# Set to the remixed example backend project in Glitch
-STRIPE_FINANCIAL_CONNECTIONS_EXAMPLE_BACKEND_URL=https://stripe-mobile-connections-example.glitch.me/
-```
-
-

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsWebviewExampleActivity.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsWebviewExampleActivity.kt
@@ -40,7 +40,7 @@ class FinancialConnectionsWebviewExampleActivity : AppCompatActivity() {
             settings.loadWithOverviewMode = true
             webViewClient = buildWebviewClient()
             webChromeClient = buildWebChromeClient()
-            loadUrl(GLITCH_EXAMPLE_URL)
+            loadUrl(SERVER_EXAMPLE_URL)
         }
     }
 
@@ -52,9 +52,9 @@ class FinancialConnectionsWebviewExampleActivity : AppCompatActivity() {
             Log.d("Webview", "url loading: ${webResourceRequest.url}")
             val url = webResourceRequest.url.toString()
             return when {
-                // Glitch-only: instance is idle it'll wake up and redirect when ready. This prevents
+                // If the instance is idle it'll wake up and redirect when ready. This prevents
                 // the redirect from opening in an external browser.
-                url.startsWith(GLITCH_EXAMPLE_URL) -> false
+                url.startsWith(SERVER_EXAMPLE_URL) -> false
                 else -> {
                     CustomTabsIntent.Builder()
                         .build()
@@ -90,4 +90,4 @@ class FinancialConnectionsWebviewExampleActivity : AppCompatActivity() {
     }
 }
 
-private const val GLITCH_EXAMPLE_URL = "https://connections-webview-example.glitch.me/"
+private const val SERVER_EXAMPLE_URL = "https://zpcg4s-4000.csb.app/"

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/data/Settings.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/data/Settings.kt
@@ -27,12 +27,8 @@ class Settings(context: Context) {
     private companion object {
         /**
          * Note: only necessary if not configured via `gradle.properties`.
-         *
-         * Set to the base URL of your test backend. If you are using
-         * [example-mobile-backend](https://github.com/stripe/example-mobile-backend),
-         * the URL will be something like `https://stripe-example-mobile-backend.glitch.me/`.
          */
-        private const val BASE_URL = "https://stripe-mobile-connections-example.glitch.me/"
+        private const val BASE_URL = "https://km2chh-4000.csb.app/"
 
         private const val METADATA_BACKEND_URL_KEY =
             "com.stripe.financialconnections.example.metadata.backend_url"


### PR DESCRIPTION
# Summary

Moves off of Glitch for our `financial-connections-example` backends and webview examples.

# Motivation

Glitch hosting is being deprecated.

# Testing

Verified there are no references to Glitch in `financial-connections-example`:

<img width="343" alt="Screenshot 2025-06-24 at 3 02 56 PM" src="https://github.com/user-attachments/assets/5b301c3a-6418-4916-aa49-dac164a587ae" />

Verified things still work with the new server:

https://github.com/user-attachments/assets/b60a41e0-4d00-4389-a6cc-cbf751f44860

# Changelog

N/a