### PR TITLE
Add missing Appearance API options to `Appearance` playground picker

### DIFF
--- a/paymentsheet-example/detekt-baseline.xml
+++ b/paymentsheet-example/detekt-baseline.xml
@@ -9,6 +9,7 @@
     <ID>LongMethod:AppearanceBottomSheetDialogFragment.kt$@Composable private fun Colors( currentAppearance: AppearanceStore.State, updateAppearance: (AppearanceStore.State) -> Unit, )</ID>
     <ID>LongMethod:AppearanceBottomSheetDialogFragment.kt$@Composable private fun EmbeddedPicker( currentAppearance: AppearanceStore.State, updateAppearance: (AppearanceStore.State) -> Unit )</ID>
     <ID>LongMethod:AppearanceBottomSheetDialogFragment.kt$@Composable private fun PrimaryButton( currentAppearance: AppearanceStore.State, updateAppearance: (AppearanceStore.State) -> Unit, )</ID>
+    <ID>LongMethod:AppearanceBottomSheetDialogFragment.kt$@OptIn(AppearanceAPIAdditionsPreview::class) @Composable private fun Typography( currentAppearance: AppearanceStore.State, updateAppearance: (AppearanceStore.State) -> Unit, )</ID>
     <ID>MagicNumber:AppearanceBottomSheetDialogFragment.kt$16</ID>
     <ID>MagicNumber:AppearanceStore.kt$AppearanceStore.State.Embedded$0x33787880</ID>
     <ID>MagicNumber:AppearanceStore.kt$AppearanceStore.State.Embedded$0x40FFFFFF</ID>

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/AppearanceBottomSheetDialogFragment.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/AppearanceBottomSheetDialogFragment.kt
@@ -66,7 +66,9 @@ import com.godaddy.android.colorpicker.ClassicColorPicker
 import com.godaddy.android.colorpicker.HsvColor
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.stripe.android.paymentelement.AppearanceAPIAdditionsPreview
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.example.R
+import kotlin.math.roundToInt
 
 private val BASE_FONT_SIZE = 20.sp
 private val BASE_PADDING = 8.dp
@@ -154,6 +156,17 @@ private fun AppearancePicker(
                     },
                 )
             }
+            CustomizationCard("Text Field Insets") {
+                Insets(
+                    currentInsets = currentAppearance.textFieldInsets,
+                    defaultCustomInsets = AppearanceStore.State.Insets.defaultTextInsets,
+                    updateInsets = {
+                        updateAppearance(
+                            currentAppearance.copy(textFieldInsets = it)
+                        )
+                    },
+                )
+            }
             CustomizationCard("Section Spacing") {
                 SectionSpacing(
                     currentAppearance = currentAppearance,
@@ -168,6 +181,12 @@ private fun AppearancePicker(
             }
             CustomizationCard("PrimaryButton") {
                 PrimaryButton(
+                    currentAppearance = currentAppearance,
+                    updateAppearance = updateAppearance,
+                )
+            }
+            CustomizationCard("Vertical Mode") {
+                VerticalMode(
                     currentAppearance = currentAppearance,
                     updateAppearance = updateAppearance,
                 )
@@ -567,6 +586,111 @@ private fun Typography(
             )
         )
     }
+    Divider()
+
+    val h1 = currentAppearance.typography.custom.h1
+
+    AppearanceToggle("customH1", h1 != null) {
+        updateAppearance(
+            currentAppearance.copy(
+                typography = currentAppearance.typography.copy(
+                    custom = PaymentSheet.Typography.Custom(
+                        h1 = if (it) {
+                            PaymentSheet.Typography.Font(
+                                fontSizeSp = 20f,
+                                fontWeight = 400,
+                                letterSpacingSp = 0.13f
+                            )
+                        } else {
+                            null
+                        }
+                    )
+                )
+            )
+        )
+    }
+
+    h1?.run {
+        Divider()
+        FontDropDown(fontFamily) {
+            updateAppearance(
+                currentAppearance.copy(
+                    typography = currentAppearance.typography.copy(
+                        custom = PaymentSheet.Typography.Custom(
+                            h1 = PaymentSheet.Typography.Font(
+                                fontFamily = it,
+                                fontWeight = fontWeight,
+                                fontSizeSp = fontSizeSp,
+                                letterSpacingSp = letterSpacingSp,
+                            )
+                        )
+                    )
+                )
+            )
+        }
+        Divider()
+        IncrementDecrementItem(
+            label = "fontSizeSp",
+            value = fontSizeSp ?: AppearanceStore.State.defaultCustomH1LetterSpacingSp,
+        ) {
+            updateAppearance(
+                currentAppearance.copy(
+                    typography = currentAppearance.typography.copy(
+                        custom = PaymentSheet.Typography.Custom(
+                            h1 = PaymentSheet.Typography.Font(
+                                fontFamily = fontFamily,
+                                fontWeight = fontWeight,
+                                fontSizeSp = it,
+                                letterSpacingSp = letterSpacingSp,
+                            )
+                        )
+                    )
+                )
+            )
+        }
+        Divider()
+        IncrementDecrementItem(
+            label = "fontWeight",
+            value = fontWeight?.toFloat() ?: AppearanceStore.State.defaultCustomH1FontSizeDp,
+            incrementDecrementAmount = 100f
+        ) {
+            updateAppearance(
+                currentAppearance.copy(
+                    typography = currentAppearance.typography.copy(
+                        custom = PaymentSheet.Typography.Custom(
+                            h1 = PaymentSheet.Typography.Font(
+                                fontFamily = fontFamily,
+                                fontWeight = it.roundToInt(),
+                                fontSizeSp = fontSizeSp,
+                                letterSpacingSp = letterSpacingSp,
+                            )
+                        )
+                    )
+                )
+            )
+        }
+        Divider()
+        IncrementDecrementItem(
+            label = "letterSpacingSp",
+            value = letterSpacingSp ?: AppearanceStore.State.defaultCustomH1LetterSpacingSp,
+            incrementDecrementAmount = 0.01f
+        ) {
+            updateAppearance(
+                currentAppearance.copy(
+                    typography = currentAppearance.typography.copy(
+                        custom = PaymentSheet.Typography.Custom(
+                            h1 = PaymentSheet.Typography.Font(
+                                fontFamily = fontFamily,
+                                fontWeight = fontWeight,
+                                fontSizeSp = fontSizeSp,
+                                letterSpacingSp = it,
+                            )
+                        )
+                    )
+                )
+            )
+        }
+    }
 }
 
 @Composable
@@ -752,6 +876,20 @@ private fun PrimaryButton(
                         fontResId = it
                     )
                 )
+            )
+        )
+    }
+}
+
+@Composable
+private fun VerticalMode(
+    currentAppearance: AppearanceStore.State,
+    updateAppearance: (AppearanceStore.State) -> Unit,
+) {
+    IncrementDecrementItem("verticalModeRowPaddingDp", currentAppearance.verticalModeRowPadding) {
+        updateAppearance(
+            currentAppearance.copy(
+                verticalModeRowPadding = it
             )
         )
     }
@@ -1010,7 +1148,12 @@ private fun ColorIcon(innerColor: Color) {
 }
 
 @Composable
-private fun IncrementDecrementItem(label: String, value: Float, onValueChange: (Float) -> Unit) {
+private fun IncrementDecrementItem(
+    label: String,
+    value: Float,
+    incrementDecrementAmount: Float = 1f,
+    onValueChange: (Float) -> Unit,
+) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -1027,7 +1170,7 @@ private fun IncrementDecrementItem(label: String, value: Float, onValueChange: (
                     .height(32.dp)
                     .width(50.dp)
                     .clickable {
-                        val newValue = value - 1
+                        val newValue = value - incrementDecrementAmount
                         onValueChange(if (newValue < 0) 0.0f else newValue)
                     }
             ) {
@@ -1043,7 +1186,7 @@ private fun IncrementDecrementItem(label: String, value: Float, onValueChange: (
                     .height(32.dp)
                     .width(50.dp)
                     .clickable {
-                        onValueChange(value + 1)
+                        onValueChange(value + incrementDecrementAmount)
                     }
             ) {
                 Icon(

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/AppearanceStore.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/AppearanceStore.kt
@@ -8,6 +8,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import com.stripe.android.paymentelement.AppearanceAPIAdditionsPreview
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.example.playground.activity.AppearanceStore.State.Insets.Custom
+import com.stripe.android.uicore.StripeThemeDefaults
 import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.Serializable
 
@@ -30,6 +32,7 @@ internal object AppearanceStore {
         val formInsetValues: Insets = Insets.Default,
         val sectionSpacing: SectionSpacing = SectionSpacing.Default,
         val textFieldInsets: Insets = Insets.Default,
+        val verticalModeRowPadding: Float = StripeThemeDefaults.verticalModeRowPadding,
         val iconStyle: IconStyle = IconStyle.Filled,
     ) {
         @OptIn(AppearanceAPIAdditionsPreview::class)
@@ -41,6 +44,7 @@ internal object AppearanceStore {
                 .typography(typography)
                 .primaryButton(primaryButton)
                 .embeddedAppearance(PaymentSheet.Appearance.Embedded(embedded.getRow()))
+                .verticalModeRowPadding(verticalModeRowPadding)
                 .apply {
                     formInsetValues.getPaymentSheetInsets()?.let {
                         formInsetValues(it)
@@ -114,6 +118,13 @@ internal object AppearanceStore {
                     top = 0f,
                     end = 20f,
                     bottom = 40f,
+                )
+
+                val defaultTextInsets = Custom(
+                    start = StripeThemeDefaults.textFieldInsets.start,
+                    top = StripeThemeDefaults.textFieldInsets.top,
+                    end = StripeThemeDefaults.textFieldInsets.end,
+                    bottom = StripeThemeDefaults.textFieldInsets.bottom,
                 )
             }
         }
@@ -220,6 +231,12 @@ internal object AppearanceStore {
                     Outlined -> PaymentSheet.IconStyle.Outlined
                 }
             }
+        }
+
+        companion object {
+            const val defaultCustomH1FontSizeDp = 20f
+            const val defaultCustomH1LetterSpacingSp = 0.13f
+            const val defaultCustomH1FontWeight = 400f
         }
     }
 }


### PR DESCRIPTION
# Summary
Add missing Appearance API options to `Appearance` playground picker

# Motivation
Allow testing appearance API options in the playground that weren't added before.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified