### PR TITLE
Fix `CustomerSession` parsing to not require all components to be available

### DIFF
--- a/payments-core/detekt-baseline.xml
+++ b/payments-core/detekt-baseline.xml
@@ -36,6 +36,8 @@
     <ID>LongMethod:CollectBankAccountViewModel.kt$CollectBankAccountViewModel$private suspend fun createFinancialConnectionsSession()</ID>
     <ID>LongMethod:ElementsSessionFixtures.kt$ElementsSessionFixtures$fun createWithCustomPaymentMethods( customPaymentMethodData: String, ): JSONObject</ID>
     <ID>LongMethod:ElementsSessionJsonParser.kt$ElementsSessionJsonParser$override fun parse(json: JSONObject): ElementsSession?</ID>
+    <ID>LongMethod:ElementsSessionJsonParserTest.kt$ElementsSessionJsonParserTest$@Test fun `ElementsSession has expected CS information in the response if 'mobile_payment_element' is null`()</ID>
+    <ID>LongMethod:ElementsSessionJsonParserTest.kt$ElementsSessionJsonParserTest$@Test fun `ElementsSession has expected customer session information in the response if 'customer_sheet' is null`()</ID>
     <ID>LongMethod:ElementsSessionJsonParserTest.kt$ElementsSessionJsonParserTest$@Test fun `ElementsSession has expected customer session information in the response`()</ID>
     <ID>LongMethod:GooglePayJsonFactoryTest.kt$GooglePayJsonFactoryTest$@Test fun testCreatePaymentMethodRequestJson()</ID>
     <ID>LongMethod:PaymentAuthConfigTest.kt$PaymentAuthConfigTest$@Test fun testUiCustomizationWrapper()</ID>

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/ElementsSessionJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/ElementsSessionJsonParser.kt
@@ -285,7 +285,6 @@ internal class ElementsSessionJsonParser(
         }
 
         val paymentElementComponent = parsePaymentElementComponent(json.optJSONObject(FIELD_MOBILE_PAYMENT_ELEMENT))
-            ?: return null
         val customerSheetComponent = parseCustomerSheetComponent(json.optJSONObject(FIELD_CUSTOMER_SHEET))
             ?: return null
 
@@ -297,15 +296,16 @@ internal class ElementsSessionJsonParser(
 
     private fun parsePaymentElementComponent(
         json: JSONObject?
-    ): ElementsSession.Customer.Components.MobilePaymentElement? {
+    ): ElementsSession.Customer.Components.MobilePaymentElement {
         if (json == null) {
-            return null
+            return ElementsSession.Customer.Components.MobilePaymentElement.Disabled
         }
 
         val paymentSheetEnabled = json.optBoolean(FIELD_ENABLED)
 
         return if (paymentSheetEnabled) {
-            val paymentSheetFeatures = json.optJSONObject(FIELD_FEATURES) ?: return null
+            val paymentSheetFeatures = json.optJSONObject(FIELD_FEATURES)
+                ?: return ElementsSession.Customer.Components.MobilePaymentElement.Disabled
 
             val paymentMethodSaveFeature = paymentSheetFeatures.optString(FIELD_PAYMENT_METHOD_SAVE)
             val paymentMethodRemoveFeature = paymentSheetFeatures.optString(FIELD_PAYMENT_METHOD_REMOVE)
@@ -332,13 +332,14 @@ internal class ElementsSessionJsonParser(
 
     private fun parseCustomerSheetComponent(json: JSONObject?): ElementsSession.Customer.Components.CustomerSheet? {
         if (json == null) {
-            return null
+            return ElementsSession.Customer.Components.CustomerSheet.Disabled
         }
 
         val customerSheetEnabled = json.optBoolean(FIELD_ENABLED)
 
         return if (customerSheetEnabled) {
-            val customerSheetFeatures = json.optJSONObject(FIELD_FEATURES) ?: return null
+            val customerSheetFeatures = json.optJSONObject(FIELD_FEATURES)
+                ?: return ElementsSession.Customer.Components.CustomerSheet.Disabled
 
             val paymentMethodRemoveFeature = customerSheetFeatures.optString(FIELD_PAYMENT_METHOD_REMOVE)
             val paymentMethodRemoveLastFeature = customerSheetFeatures.optString(FIELD_PAYMENT_METHOD_REMOVE_LAST)

--- a/payments-core/src/test/java/com/stripe/android/model/ElementsSessionFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/ElementsSessionFixtures.kt
@@ -453,6 +453,8 @@ internal object ElementsSessionFixtures {
         paymentMethodSyncDefaultFeature: String = "disabled",
         enableLinkSpm: Boolean = false,
         paymentMethodsWithLinkDetails: String = "",
+        passMobilePaymentElement: Boolean = true,
+        passCustomerSheet: Boolean = true,
     ): JSONObject {
         return JSONObject(
             """
@@ -534,24 +536,40 @@ internal object ElementsSessionFixtures {
                       "enabled": false,
                       "features": null
                     },
-                    "mobile_payment_element": {
-                      "enabled": true,
-                      "features": {
-                        "payment_method_remove": ${paymentMethodRemoveFeature ?: "enabled"},
-                        "payment_method_save": "disabled",
-                        "payment_method_remove_last": ${paymentMethodRemoveLastFeature ?: "enabled"},
-                        "payment_method_save_allow_redisplay_override": ${allowRedisplay?.let { "\"$it\""} ?: "null"},
-                        "payment_method_set_as_default": $paymentMethodSetAsDefaultFeature,
-                      }
-                    },
-                    "customer_sheet": {
-                      "enabled": true,
-                      "features": {
-                        "payment_method_remove": ${paymentMethodRemoveFeature ?: "enabled"},
-                        "payment_method_remove_last": ${paymentMethodRemoveLastFeature ?: "enabled"},
-                        "payment_method_sync_default": $paymentMethodSyncDefaultFeature,
-                      }
-                    },
+                    "mobile_payment_element": ${
+                if (passMobilePaymentElement) {
+                    """
+                            {
+                              "enabled": true,
+                              "features": {
+                                "payment_method_remove": ${paymentMethodRemoveFeature ?: "enabled"},
+                                "payment_method_save": "disabled",
+                                "payment_method_remove_last": ${paymentMethodRemoveLastFeature ?: "enabled"},
+                                "payment_method_save_allow_redisplay_override": ${allowRedisplay?.let { "\"$it\""} ?: "null"},
+                                "payment_method_set_as_default": $paymentMethodSetAsDefaultFeature,
+                              }
+                            }
+                    """.trimIndent()
+                } else {
+                    "null"
+                }
+            },
+                    "customer_sheet": ${
+                if (passCustomerSheet) {
+                    """
+                                {
+                                  "enabled": true,
+                                  "features": {
+                                    "payment_method_remove": ${paymentMethodRemoveFeature ?: "enabled"},
+                                    "payment_method_remove_last": ${paymentMethodRemoveLastFeature ?: "enabled"},
+                                    "payment_method_sync_default": $paymentMethodSyncDefaultFeature,
+                                  }
+                                }
+                    """.trimIndent()
+                } else {
+                    "null"
+                }
+            },
                     "pricing_table": {
                       "enabled": false
                     }

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
@@ -757,6 +757,144 @@ class ElementsSessionJsonParserTest {
     }
 
     @Test
+    fun `ElementsSession has expected CS information in the response if 'mobile_payment_element' is null`() {
+        val parser = ElementsSessionJsonParser(
+            ElementsSessionParams.PaymentIntentType(
+                clientSecret = "secret",
+                customerSessionClientSecret = "customer_session_client_secret",
+                externalPaymentMethods = emptyList(),
+                customPaymentMethods = emptyList(),
+                appId = APP_ID
+            ),
+            isLiveMode = false,
+        )
+
+        val intent = createPaymentIntentWithCustomerSession(
+            passMobilePaymentElement = false,
+        )
+        val elementsSession = parser.parse(intent)
+
+        assertThat(elementsSession?.customer).isEqualTo(
+            ElementsSession.Customer(
+                session = ElementsSession.Customer.Session(
+                    id = "cuss_123",
+                    apiKey = "ek_test_1234",
+                    apiKeyExpiry = 1713890664,
+                    customerId = "cus_1",
+                    liveMode = false,
+                    components = ElementsSession.Customer.Components(
+                        mobilePaymentElement = ElementsSession.Customer.Components.MobilePaymentElement.Disabled,
+                        customerSheet = ElementsSession.Customer.Components.CustomerSheet.Enabled(
+                            isPaymentMethodRemoveEnabled = true,
+                            canRemoveLastPaymentMethod = true,
+                            isPaymentMethodSyncDefaultEnabled = false,
+                        ),
+                    )
+                ),
+                defaultPaymentMethod = "pm_123",
+                paymentMethods = listOf(
+                    PaymentMethod(
+                        id = "pm_123",
+                        customerId = "cus_1",
+                        type = PaymentMethod.Type.Card,
+                        code = "card",
+                        created = 1550757934255,
+                        liveMode = false,
+                        billingDetails = null,
+                        card = PaymentMethod.Card(
+                            brand = CardBrand.Visa,
+                            last4 = "4242",
+                            expiryMonth = 8,
+                            expiryYear = 2032,
+                            country = "US",
+                            funding = "credit",
+                            fingerprint = "fingerprint123",
+                            checks = PaymentMethod.Card.Checks(
+                                addressLine1Check = "unchecked",
+                                cvcCheck = "unchecked",
+                                addressPostalCodeCheck = null,
+                            ),
+                            threeDSecureUsage = PaymentMethod.Card.ThreeDSecureUsage(
+                                isSupported = true
+                            )
+                        )
+                    )
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `ElementsSession has expected customer session information in the response if 'customer_sheet' is null`() {
+        val parser = ElementsSessionJsonParser(
+            ElementsSessionParams.PaymentIntentType(
+                clientSecret = "secret",
+                customerSessionClientSecret = "customer_session_client_secret",
+                externalPaymentMethods = emptyList(),
+                customPaymentMethods = emptyList(),
+                appId = APP_ID
+            ),
+            isLiveMode = false,
+        )
+
+        val intent = createPaymentIntentWithCustomerSession(
+            passCustomerSheet = false,
+        )
+        val elementsSession = parser.parse(intent)
+
+        assertThat(elementsSession?.customer).isEqualTo(
+            ElementsSession.Customer(
+                session = ElementsSession.Customer.Session(
+                    id = "cuss_123",
+                    apiKey = "ek_test_1234",
+                    apiKeyExpiry = 1713890664,
+                    customerId = "cus_1",
+                    liveMode = false,
+                    components = ElementsSession.Customer.Components(
+                        mobilePaymentElement = ElementsSession.Customer.Components.MobilePaymentElement.Enabled(
+                            isPaymentMethodSaveEnabled = false,
+                            isPaymentMethodRemoveEnabled = true,
+                            canRemoveLastPaymentMethod = true,
+                            allowRedisplayOverride = PaymentMethod.AllowRedisplay.LIMITED,
+                            isPaymentMethodSetAsDefaultEnabled = false,
+                        ),
+                        customerSheet = ElementsSession.Customer.Components.CustomerSheet.Disabled,
+                    )
+                ),
+                defaultPaymentMethod = "pm_123",
+                paymentMethods = listOf(
+                    PaymentMethod(
+                        id = "pm_123",
+                        customerId = "cus_1",
+                        type = PaymentMethod.Type.Card,
+                        code = "card",
+                        created = 1550757934255,
+                        liveMode = false,
+                        billingDetails = null,
+                        card = PaymentMethod.Card(
+                            brand = CardBrand.Visa,
+                            last4 = "4242",
+                            expiryMonth = 8,
+                            expiryYear = 2032,
+                            country = "US",
+                            funding = "credit",
+                            fingerprint = "fingerprint123",
+                            checks = PaymentMethod.Card.Checks(
+                                addressLine1Check = "unchecked",
+                                cvcCheck = "unchecked",
+                                addressPostalCodeCheck = null,
+                            ),
+                            threeDSecureUsage = PaymentMethod.Card.ThreeDSecureUsage(
+                                isSupported = true
+                            )
+                        )
+                    )
+                )
+            )
+        )
+    }
+
+    @Test
     fun `ElementsSession has 'unspecified' allow redisplay override`() {
         allowRedisplayTest(
             rawAllowRedisplayValue = "unspecified",


### PR DESCRIPTION
# Summary
Fix `CustomerSession` parsing to not require all components to be available

# Motivation
We shouldn't require both `mobile_payment_element` and `customer_sheet` to be passed if the merchant only wants to use one product.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified