### PR TITLE
Add internal newBuilder method and replace usages of copy with it for PaymentSheet.Configuration

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -37,6 +37,8 @@ import com.stripe.android.paymentelement.WalletButtonsPreview
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbacks
 import com.stripe.android.paymentelement.confirmation.intent.IntentConfirmationInterceptor
+import com.stripe.android.paymentsheet.PaymentSheet.ShopPayConfiguration.LineItem
+import com.stripe.android.paymentsheet.PaymentSheet.ShopPayConfiguration.ShippingRate
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.flowcontroller.FlowControllerFactory
 import com.stripe.android.paymentsheet.model.PaymentOption
@@ -1123,6 +1125,36 @@ class PaymentSheet internal constructor(
                 return Configuration(appName)
             }
         }
+
+        @OptIn(
+            ExperimentalAllowsRemovalOfLastSavedPaymentMethodApi::class,
+            ExperimentalCustomPaymentMethodsApi::class,
+            WalletButtonsPreview::class,
+            ShopPayPreview::class
+        )
+        internal fun newBuilder(): Builder = Builder(merchantDisplayName)
+            .customer(customer)
+            .googlePay(googlePay)
+            .primaryButtonColor(primaryButtonColor)
+            .defaultBillingDetails(defaultBillingDetails)
+            .shippingDetails(shippingDetails)
+            .allowsDelayedPaymentMethods(allowsDelayedPaymentMethods)
+            .allowsPaymentMethodsRequiringShippingAddress(allowsPaymentMethodsRequiringShippingAddress)
+            .appearance(appearance)
+            .billingDetailsCollectionConfiguration(billingDetailsCollectionConfiguration)
+            .preferredNetworks(preferredNetworks)
+            .allowsRemovalOfLastSavedPaymentMethod(allowsRemovalOfLastSavedPaymentMethod)
+            .paymentMethodOrder(paymentMethodOrder)
+            .externalPaymentMethods(externalPaymentMethods)
+            .paymentMethodLayout(paymentMethodLayout)
+            .cardBrandAcceptance(cardBrandAcceptance)
+            .customPaymentMethods(customPaymentMethods)
+            .link(link)
+            .walletButtons(walletButtons)
+            .apply {
+                primaryButtonLabel?.let { primaryButtonLabel(it) }
+                shopPayConfiguration?.let { shopPayConfiguration(it) }
+            }
     }
 
     /**

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
@@ -227,13 +227,16 @@ class ConfirmationHandlerOptionKtxTest {
     fun `On Google Pay selection with config with google pay config, should return expected option`() {
         assertThat(
             PaymentSelection.GooglePay.toConfirmationOption(
-                configuration = PaymentSheetFixtures.CONFIG_GOOGLEPAY.copy(
-                    googlePay = PaymentSheetFixtures.CONFIG_GOOGLEPAY.googlePay?.copy(
-                        label = "Merchant Payments",
-                        amount = 5000,
-                        environment = PaymentSheet.GooglePayConfiguration.Environment.Production
+                configuration = PaymentSheetFixtures.CONFIG_GOOGLEPAY.newBuilder()
+                    .googlePay(
+                        PaymentSheetFixtures.CONFIG_GOOGLEPAY.googlePay?.copy(
+                            label = "Merchant Payments",
+                            amount = 5000,
+                            environment = PaymentSheet.GooglePayConfiguration.Environment.Production
+                        )
                     )
-                ).asCommonConfiguration(),
+                    .build()
+                    .asCommonConfiguration(),
                 linkConfiguration = null,
             )
         ).isEqualTo(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
@@ -397,7 +397,7 @@ class ConfirmationHandlerOptionKtxTest {
         )
 
         val confirmationOption = customPaymentMethodSelection.toConfirmationOption(
-            configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.prefilledBuilder()
+            configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.newBuilder()
                 .customPaymentMethods(customPaymentMethods = listOf())
                 .build()
                 .asCommonConfiguration(),
@@ -426,7 +426,7 @@ class ConfirmationHandlerOptionKtxTest {
         )
 
         val confirmationOption = customPaymentMethodSelection.toConfirmationOption(
-            configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.prefilledBuilder()
+            configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.newBuilder()
                 .customPaymentMethods(customPaymentMethods = listOf(customPaymentMethod))
                 .build()
                 .asCommonConfiguration(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -975,7 +975,7 @@ internal class PaymentSheetActivityTest {
     @Test
     fun `mandate text is shown above primary button when in vertical mode`() {
         val args = PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-            config = PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY.config.prefilledBuilder()
+            config = PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY.config.newBuilder()
                 .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Vertical)
                 .build()
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
@@ -236,7 +236,7 @@ internal object PaymentSheetFixtures {
 
     internal val ARGS_WITHOUT_CUSTOMER
         get() = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-            config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.prefilledBuilder()
+            config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.newBuilder()
                 .customer(null)
                 .build()
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
@@ -12,6 +12,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.WalletType
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures.BILLING_DETAILS
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.paymentelement.ExperimentalCustomPaymentMethodsApi
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode
 import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -121,30 +122,33 @@ internal object PaymentSheetFixtures {
         )
 
     internal val CONFIG_CUSTOMER_WITH_GOOGLEPAY
-        get() = CONFIG_CUSTOMER.copy(
-            googlePay = ConfigFixtures.GOOGLE_PAY
-        )
+        get() = CONFIG_CUSTOMER.newBuilder()
+            .googlePay(ConfigFixtures.GOOGLE_PAY)
+            .build()
 
     internal val CONFIG_CUSTOMER_WITH_EXTERNAL_PAYMENT_METHODS
-        get() = CONFIG_CUSTOMER.copy(
-            externalPaymentMethods = listOf("external_paypal", "external_fawry")
-        )
+        get() = CONFIG_CUSTOMER.newBuilder()
+            .externalPaymentMethods(listOf("external_paypal", "external_fawry"))
+            .build()
 
+    @OptIn(ExperimentalCustomPaymentMethodsApi::class)
     internal val CONFIG_CUSTOMER_WITH_CUSTOM_PAYMENT_METHODS
-        get() = CONFIG_CUSTOMER.copy(
-            customPaymentMethods = listOf(
-                PaymentSheet.CustomPaymentMethod(
-                    id = "cpmt_123",
-                    subtitle = "Pay now with BuFoPay".resolvableString,
-                    disableBillingDetailCollection = false,
-                ),
-                PaymentSheet.CustomPaymentMethod(
-                    id = "cpmt_456",
-                    subtitle = "Pay now with PayPal".resolvableString,
-                    disableBillingDetailCollection = true,
-                ),
+        get() = CONFIG_CUSTOMER.newBuilder()
+            .customPaymentMethods(
+                listOf(
+                    PaymentSheet.CustomPaymentMethod(
+                        id = "cpmt_123",
+                        subtitle = "Pay now with BuFoPay".resolvableString,
+                        disableBillingDetailCollection = false,
+                    ),
+                    PaymentSheet.CustomPaymentMethod(
+                        id = "cpmt_456",
+                        subtitle = "Pay now with PayPal".resolvableString,
+                        disableBillingDetailCollection = true,
+                    ),
+                )
             )
-        )
+            .build()
 
     internal val CONFIG_BILLING_DETAILS_COLLECTION = PaymentSheet.Configuration(
         merchantDisplayName = MERCHANT_DISPLAY_NAME,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -254,7 +254,7 @@ internal class PaymentSheetViewModelTest {
         )
         val viewModel = createViewModel(
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.prefilledBuilder()
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.newBuilder()
                     .customer(
                         PaymentSheet.CustomerConfiguration(
                             id = "cus_1",
@@ -593,7 +593,7 @@ internal class PaymentSheetViewModelTest {
             createViewModel(
                 stripeIntent = stripeIntent,
                 args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-                    config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.prefilledBuilder()
+                    config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.newBuilder()
                         .shippingDetails(
                             AddressDetails(
                                 address = PaymentSheet.Address(
@@ -1306,7 +1306,7 @@ internal class PaymentSheetViewModelTest {
     fun `Verify supported payment methods includes afterpay if no shipping and no allow flag`() {
         val viewModel = createViewModel(
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.prefilledBuilder()
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.newBuilder()
                     .shippingDetails(null)
                     .allowsPaymentMethodsRequiringShippingAddress(false)
                     .build()
@@ -1324,7 +1324,7 @@ internal class PaymentSheetViewModelTest {
     fun `Verify supported payment methods include afterpay if allow flag but no shipping`() {
         val viewModel = createViewModel(
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.prefilledBuilder()
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.newBuilder()
                     .allowsPaymentMethodsRequiringShippingAddress(true)
                     .build()
             ),
@@ -1341,7 +1341,7 @@ internal class PaymentSheetViewModelTest {
     fun `Verify supported payment methods include afterpay if shipping but no allow flag`() {
         val viewModel = createViewModel(
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.prefilledBuilder()
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.newBuilder()
                     .allowsPaymentMethodsRequiringShippingAddress(true)
                     .build()
             ),
@@ -1643,7 +1643,7 @@ internal class PaymentSheetViewModelTest {
     fun `launched with correct screen when in horizontal mode`() = runTest {
         val viewModel = createViewModel(
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.prefilledBuilder()
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.newBuilder()
                     .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Horizontal)
                     .build()
             ),
@@ -1657,7 +1657,7 @@ internal class PaymentSheetViewModelTest {
     fun `launched with correct screen when in vertical mode`() = runTest {
         val viewModel = createViewModel(
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.prefilledBuilder()
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.newBuilder()
                     .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Vertical)
                     .build()
             ),
@@ -1671,7 +1671,7 @@ internal class PaymentSheetViewModelTest {
     fun `launched with correct screen when in automatic mode`() = runTest {
         val viewModel = createViewModel(
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.prefilledBuilder()
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.newBuilder()
                     .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Automatic)
                     .build()
             ),
@@ -2056,7 +2056,7 @@ internal class PaymentSheetViewModelTest {
         val viewModel = createViewModel(
             isGooglePayReady = true,
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.prefilledBuilder()
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.newBuilder()
                     .allowsDelayedPaymentMethods(true)
                     .build(),
             ),
@@ -2089,7 +2089,7 @@ internal class PaymentSheetViewModelTest {
         val viewModel = createViewModel(
             isGooglePayReady = true,
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.prefilledBuilder()
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.newBuilder()
                     .allowsDelayedPaymentMethods(true)
                     .build(),
             ),
@@ -2410,7 +2410,7 @@ internal class PaymentSheetViewModelTest {
         val expectedAmount = 1099L
 
         val args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-            config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.prefilledBuilder()
+            config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.newBuilder()
                 .googlePay(
                     PaymentSheet.GooglePayConfiguration(
                         environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
@@ -2444,7 +2444,7 @@ internal class PaymentSheetViewModelTest {
         val expectedAmount = 1234L
 
         val args = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.copy(
-            config = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.config.prefilledBuilder()
+            config = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.config.newBuilder()
                 .googlePay(
                     PaymentSheet.GooglePayConfiguration(
                         environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
@@ -2537,7 +2537,7 @@ internal class PaymentSheetViewModelTest {
     @Test
     fun `Requires email and phone with Google Pay when collection mode is set to always`() {
         val args = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.copy(
-            config = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.config.prefilledBuilder()
+            config = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.config.newBuilder()
                 .googlePay(
                     PaymentSheet.GooglePayConfiguration(
                         environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
@@ -2572,7 +2572,7 @@ internal class PaymentSheetViewModelTest {
     @Test
     fun `Requires full billing details with Google Pay when collection mode is set to full`() {
         val args = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.copy(
-            config = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.config.prefilledBuilder()
+            config = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.config.newBuilder()
                 .googlePay(
                     PaymentSheet.GooglePayConfiguration(
                         environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
@@ -2606,7 +2606,7 @@ internal class PaymentSheetViewModelTest {
     @Test
     fun `Does not require email and phone with Google Pay when collection mode is not set to always`() {
         val args = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.copy(
-            config = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.config.prefilledBuilder()
+            config = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.config.newBuilder()
                 .billingDetailsCollectionConfiguration(
                     PaymentSheet.BillingDetailsCollectionConfiguration(
                         phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic,
@@ -2641,7 +2641,7 @@ internal class PaymentSheetViewModelTest {
     @Test
     fun `Does not require billing details with Google Pay when collection mode is set to never`() {
         val args = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.copy(
-            config = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.config.prefilledBuilder()
+            config = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.config.newBuilder()
                 .billingDetailsCollectionConfiguration(
                     PaymentSheet.BillingDetailsCollectionConfiguration(
                         address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never,
@@ -3234,7 +3234,7 @@ internal class PaymentSheetViewModelTest {
     fun `requiresCvcRecollection should return correct value`() {
         var viewModel = createViewModel(
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.prefilledBuilder()
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.newBuilder()
                     .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Vertical)
                     .build()
             )
@@ -3269,7 +3269,7 @@ internal class PaymentSheetViewModelTest {
     fun `requiresCvcRecollection should return correct value in automatic mode`() {
         var viewModel = createViewModel(
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.prefilledBuilder()
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.newBuilder()
                     .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Automatic)
                     .build()
             )
@@ -3304,7 +3304,7 @@ internal class PaymentSheetViewModelTest {
     fun `CvcRecollection screen should be displayed on checkout when required in vertical mode`() = runTest {
         val viewModel = createViewModel(
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.prefilledBuilder()
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.newBuilder()
                     .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Vertical)
                     .build()
             ),
@@ -3324,7 +3324,7 @@ internal class PaymentSheetViewModelTest {
     fun `CvcRecollection screen should be displayed on checkout when required in automatic mode`() = runTest {
         val viewModel = createViewModel(
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.prefilledBuilder()
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.newBuilder()
                     .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Automatic)
                     .build()
             ),
@@ -3345,7 +3345,7 @@ internal class PaymentSheetViewModelTest {
         val cvcRecollectionInteractor = FakeCvcRecollectionInteractor()
         val viewModel = createViewModel(
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.prefilledBuilder()
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.newBuilder()
                     .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Vertical)
                     .build()
             ),
@@ -3387,7 +3387,7 @@ internal class PaymentSheetViewModelTest {
     fun `CvcRecollection screen should not be displayed on checkout when not required in vertical mode`() = runTest {
         val viewModel = createViewModel(
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.prefilledBuilder()
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.newBuilder()
                     .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Vertical)
                     .build()
             ),
@@ -3407,7 +3407,7 @@ internal class PaymentSheetViewModelTest {
     fun `CvcRecollection screen should not be displayed on checkout when not required in automatic mode`() = runTest {
         val viewModel = createViewModel(
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
-                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.prefilledBuilder()
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config.newBuilder()
                     .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Automatic)
                     .build()
             ),
@@ -3687,7 +3687,7 @@ internal class PaymentSheetViewModelTest {
         val viewModel = createViewModel(
             isGooglePayReady = true,
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.copy(
-                config = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.config.prefilledBuilder()
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.config.newBuilder()
                     .googlePay(
                         ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.googlePayConfig?.prefillCreate(
                             buttonType = buttonType,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandlerTest.kt
@@ -87,7 +87,7 @@ class FlowControllerConfigurationHandlerTest {
 
         val beforeSessionId = AnalyticsRequestFactory.sessionId
 
-        val configuration = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY.prefilledBuilder()
+        val configuration = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY.newBuilder()
             .appearance(
                 PaymentSheet.Appearance.Builder()
                     .primaryButton(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/PaymentSheetConfigUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/PaymentSheetConfigUtils.kt
@@ -1,36 +1,8 @@
 package com.stripe.android.paymentsheet.utils
 
-import com.stripe.android.ExperimentalAllowsRemovalOfLastSavedPaymentMethodApi
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheet.GooglePayConfiguration
 import com.stripe.android.paymentsheet.PaymentSheet.GooglePayConfiguration.ButtonType
 import com.stripe.android.paymentsheet.PaymentSheet.GooglePayConfiguration.Environment
-
-@OptIn(ExperimentalAllowsRemovalOfLastSavedPaymentMethodApi::class)
-@Suppress("DEPRECATION")
-fun PaymentSheet.Configuration.prefilledBuilder() =
-    PaymentSheet.Configuration.Builder(merchantDisplayName)
-        .customer(customer)
-        .googlePay(googlePay)
-        .primaryButtonColor(primaryButtonColor)
-        .defaultBillingDetails(defaultBillingDetails)
-        .shippingDetails(shippingDetails)
-        .allowsDelayedPaymentMethods(allowsDelayedPaymentMethods)
-        .allowsPaymentMethodsRequiringShippingAddress(allowsPaymentMethodsRequiringShippingAddress)
-        .appearance(appearance)
-        .billingDetailsCollectionConfiguration(billingDetailsCollectionConfiguration)
-        .preferredNetworks(preferredNetworks)
-        .allowsRemovalOfLastSavedPaymentMethod(allowsRemovalOfLastSavedPaymentMethod)
-        .preferredNetworks(preferredNetworks)
-        .paymentMethodOrder(paymentMethodOrder)
-        .externalPaymentMethods(externalPaymentMethods)
-        .paymentMethodLayout(paymentMethodLayout)
-        .cardBrandAcceptance(cardBrandAcceptance)
-        .apply {
-            primaryButtonLabel?.let {
-                primaryButtonLabel(it)
-            }
-        }
 
 fun GooglePayConfiguration.prefillCreate(
     environment: Environment = this.environment,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Replace `copy()` and `prefilledBuilder()` method usage with `newBuilder()` pattern to prepare for data class removal in v25. This prevents future merge conflicts when migrating away from data classes.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
[MOBILESDK-3711](https://jira.corp.stripe.com/browse/MOBILESDK-3711)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
