### PR TITLE
[BDCC] Preserve phone number updates in cache to be used in wallet. 

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/ConsumerState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ConsumerState.kt
@@ -7,6 +7,6 @@ import com.stripe.android.link.LinkPaymentMethod.ConsumerPaymentDetails
  * When null, payment details have not been loaded yet.
  * When non-null, contains the loaded payment details (which may be an empty list).
  */
-internal data class LinkPaymentDetailsState(
+internal data class ConsumerState(
     val paymentDetails: List<ConsumerPaymentDetails>
 )

--- a/paymentsheet/src/main/java/com/stripe/android/link/ConsumerState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ConsumerState.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.link
 
-import com.stripe.android.link.LinkPaymentMethod.ConsumerPaymentDetails
+import com.stripe.android.model.ConsumerPaymentDetails
 
 /**
  * State container for Link payment details.
@@ -8,5 +8,67 @@ import com.stripe.android.link.LinkPaymentMethod.ConsumerPaymentDetails
  * When non-null, contains the loaded payment details (which may be an empty list).
  */
 internal data class ConsumerState(
-    val paymentDetails: List<ConsumerPaymentDetails>
-)
+    val paymentDetails: List<LinkPaymentMethod.ConsumerPaymentDetails>
+) {
+
+    /**
+     * Merges the backend payment details response with locally cached data.
+     *
+     * For payment details that exist in cache (matched by ID):
+     * - Updates the [ConsumerPaymentDetails.PaymentDetails] with fresh backend data
+     * - Preserves local fields like [collectedCvc] and [billingPhone]
+     *
+     * For new payment details from the response:
+     * - Creates new [LinkPaymentMethod.ConsumerPaymentDetails] with null local fields
+     */
+    fun withPaymentDetailsResponse(response: ConsumerPaymentDetails): ConsumerState {
+        val existingById = paymentDetails.associateBy { it.details.id }
+        return copy(
+            paymentDetails = response.paymentDetails.map { details ->
+                existingById[details.id]
+                    ?.copy(details = details)
+                    ?: LinkPaymentMethod.ConsumerPaymentDetails(details, null, null)
+            }
+        )
+    }
+
+    /**
+     * Updates a single payment detail in the state while preserving all local data.
+     *
+     * @param updatedPayment The updated payment detail from the backend
+     * @param billingPhone The billing phone to set, or null to preserve existing
+     * @return A new [ConsumerState] with the updated payment detail, or the same state if no match found
+     */
+    fun withUpdatedPaymentDetail(
+        updatedPayment: ConsumerPaymentDetails.PaymentDetails,
+        billingPhone: String?
+    ): ConsumerState {
+        return copy(
+            paymentDetails = paymentDetails.map { paymentDetail ->
+                if (paymentDetail.details.id == updatedPayment.id) {
+                    paymentDetail.copy(
+                        details = updatedPayment,
+                        billingPhone = billingPhone
+                    )
+                } else {
+                    paymentDetail.copy(
+                        billingPhone = billingPhone
+                    )
+                }
+            }
+        )
+    }
+
+    companion object {
+        /**
+         * Creates a [ConsumerState] from a backend response with no cached data.
+         */
+        fun fromResponse(response: ConsumerPaymentDetails): ConsumerState {
+            return ConsumerState(
+                paymentDetails = response.paymentDetails.map { detail ->
+                    LinkPaymentMethod.ConsumerPaymentDetails(detail, null, null)
+                }
+            )
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/link/ConsumerState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ConsumerState.kt
@@ -35,6 +35,9 @@ internal data class ConsumerState(
     /**
      * Updates a single payment detail in the state while preserving all local data.
      *
+     * If a billing phone is provided, it will also be applied to all other payment details
+     * that don't currently have a billing phone.
+     *
      * @param updatedPayment The updated payment detail from the backend
      * @param billingPhone The billing phone to set, or null to preserve existing
      * @return A new [ConsumerState] with the updated payment detail, or the same state if no match found
@@ -46,14 +49,14 @@ internal data class ConsumerState(
         return copy(
             paymentDetails = paymentDetails.map { paymentDetail ->
                 if (paymentDetail.details.id == updatedPayment.id) {
+                    // Update the matching payment detail
                     paymentDetail.copy(
                         details = updatedPayment,
-                        billingPhone = billingPhone
+                        billingPhone = billingPhone ?: paymentDetail.billingPhone
                     )
                 } else {
-                    paymentDetail.copy(
-                        billingPhone = billingPhone
-                    )
+                    // Apply phone to payment details that don't have one, preserving existing if any
+                    paymentDetail.copy(billingPhone = paymentDetail.billingPhone ?: billingPhone)
                 }
             }
         )

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkPaymentDetailsState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkPaymentDetailsState.kt
@@ -1,0 +1,12 @@
+package com.stripe.android.link
+
+import com.stripe.android.link.LinkPaymentMethod.ConsumerPaymentDetails
+
+/**
+ * State container for Link payment details.
+ * When null, payment details have not been loaded yet.
+ * When non-null, contains the loaded payment details (which may be an empty list).
+ */
+internal data class LinkPaymentDetailsState(
+    val paymentDetails: List<ConsumerPaymentDetails>
+)

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
@@ -7,7 +7,7 @@ import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.LinkAccountUpdate.Value.UpdateReason
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkPaymentDetails
-import com.stripe.android.link.LinkPaymentDetailsState
+import com.stripe.android.link.ConsumerState
 import com.stripe.android.link.LinkPaymentMethod
 import com.stripe.android.link.NoLinkAccountFoundException
 import com.stripe.android.link.analytics.LinkEventsReporter
@@ -53,10 +53,10 @@ internal class DefaultLinkAccountManager @Inject constructor(
     override val linkAccountInfo: StateFlow<LinkAccountUpdate.Value>
         get() = linkAccountHolder.linkAccountInfo
 
-    private val _consumerPaymentDetails: MutableStateFlow<LinkPaymentDetailsState?> =
+    private val _consumerPaymentDetails: MutableStateFlow<ConsumerState?> =
         MutableStateFlow(null)
 
-    override val consumerPaymentDetails: StateFlow<LinkPaymentDetailsState?> =
+    override val consumerState: StateFlow<ConsumerState?> =
         _consumerPaymentDetails.asStateFlow()
 
     override var cachedShippingAddresses: ConsumerShippingAddresses? = null
@@ -396,7 +396,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
                 val existingPhones = _consumerPaymentDetails.value?.paymentDetails?.associate {
                     it.details.id to it.billingPhone
                 } ?: emptyMap()
-                _consumerPaymentDetails.value = LinkPaymentDetailsState(
+                _consumerPaymentDetails.value = ConsumerState(
                     paymentDetails = it.paymentDetails.map { paymentDetail ->
                         LinkPaymentMethod.ConsumerPaymentDetails(
                             details = paymentDetail,
@@ -453,7 +453,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
         phone: String?
     ) {
         _consumerPaymentDetails.value = _consumerPaymentDetails.value?.let { currentState ->
-            LinkPaymentDetailsState(
+            ConsumerState(
                 paymentDetails = currentState.paymentDetails.map { paymentDetails ->
                     if (paymentDetails.details.id == updatedPayment.id) {
                         paymentDetails.copy(details = updatedPayment, billingPhone = phone)

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
@@ -437,21 +437,23 @@ internal class DefaultLinkAccountManager @Inject constructor(
             consumerPublishableKey = linkAccount.consumerPublishableKey
         ).map { updatedPaymentDetails ->
             updatedPaymentDetails.also {
-                updateCachedPaymentDetails(it.paymentDetails.first(), phone)
+                updateCachedPaymentDetails(
+                    updatedPayment = it.paymentDetails.first(),
+                    phone = phone
+                )
             }
         }
     }
 
     private fun updateCachedPaymentDetails(
         updatedPayment: ConsumerPaymentDetails.PaymentDetails,
-        phone: String? = null
+        phone: String?
     ) {
-        // Update the PaymentDetailWithPhone list
-        _consumerPaymentDetails.value = _consumerPaymentDetails.value.map { paymentDetailWithPhone ->
-            if (paymentDetailWithPhone.details.id == updatedPayment.id) {
-                paymentDetailWithPhone.copy(details = updatedPayment, billingPhone = phone)
+        _consumerPaymentDetails.value = _consumerPaymentDetails.value.map { paymentDetails ->
+            if (paymentDetails.details.id == updatedPayment.id) {
+                paymentDetails.copy(details = updatedPayment, billingPhone = phone)
             } else {
-                paymentDetailWithPhone
+                paymentDetails
             }
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
@@ -2,7 +2,7 @@ package com.stripe.android.link.account
 
 import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.LinkPaymentDetails
-import com.stripe.android.link.LinkPaymentMethod
+import com.stripe.android.link.LinkPaymentDetailsState
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.link.ui.inline.SignUpConsentAction
@@ -29,7 +29,7 @@ internal interface LinkAccountManager {
      * [listPaymentDetails] calls will refresh this value.
      * [updatePaymentDetails] calls will refresh the edited payment details on the list.
      */
-    val consumerPaymentDetails: StateFlow<List<LinkPaymentMethod.ConsumerPaymentDetails>>
+    val consumerPaymentDetails: StateFlow<LinkPaymentDetailsState?>
 
     /**
      * Cached shipping addresses for the current Link account.

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
@@ -2,6 +2,7 @@ package com.stripe.android.link.account
 
 import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.LinkPaymentDetails
+import com.stripe.android.link.LinkPaymentMethod
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.link.ui.inline.SignUpConsentAction
@@ -28,7 +29,7 @@ internal interface LinkAccountManager {
      * [listPaymentDetails] calls will refresh this value.
      * [updatePaymentDetails] calls will refresh the edited payment details on the list.
      */
-    val consumerPaymentDetails: StateFlow<ConsumerPaymentDetails?>
+    val consumerPaymentDetails: StateFlow<List<LinkPaymentMethod.ConsumerPaymentDetails>>
 
     /**
      * Cached shipping addresses for the current Link account.
@@ -147,7 +148,10 @@ internal interface LinkAccountManager {
     /**
      * Update an existing payment method in the signed in consumer account.
      */
-    suspend fun updatePaymentDetails(updateParams: ConsumerPaymentDetailsUpdateParams): Result<ConsumerPaymentDetails>
+    suspend fun updatePaymentDetails(
+        updateParams: ConsumerPaymentDetailsUpdateParams,
+        phone: String? = null
+    ): Result<ConsumerPaymentDetails>
 }
 
 internal val LinkAccountManager.consumerPublishableKey: String?

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
@@ -2,7 +2,7 @@ package com.stripe.android.link.account
 
 import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.LinkPaymentDetails
-import com.stripe.android.link.LinkPaymentDetailsState
+import com.stripe.android.link.ConsumerState
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.link.ui.inline.SignUpConsentAction
@@ -29,7 +29,7 @@ internal interface LinkAccountManager {
      * [listPaymentDetails] calls will refresh this value.
      * [updatePaymentDetails] calls will refresh the edited payment details on the list.
      */
-    val consumerPaymentDetails: StateFlow<LinkPaymentDetailsState?>
+    val consumerState: StateFlow<ConsumerState?>
 
     /**
      * Cached shipping addresses for the current Link account.

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
@@ -1,8 +1,8 @@
 package com.stripe.android.link.account
 
+import com.stripe.android.link.ConsumerState
 import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.LinkPaymentDetails
-import com.stripe.android.link.ConsumerState
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.link.ui.inline.SignUpConsentAction

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/updatecard/UpdateCardScreenViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/updatecard/UpdateCardScreenViewModel.kt
@@ -71,8 +71,8 @@ internal class UpdateCardScreenViewModel @Inject constructor(
     init {
         runCatching {
             val paymentDetails = linkAccountManager.consumerPaymentDetails.value
-                ?.paymentDetails
-                ?.firstOrNull { it.id == paymentDetailsId }
+                .find { it.details.id == paymentDetailsId }
+                ?.details
             require(
                 value = paymentDetails is ConsumerPaymentDetails.Card,
                 lazyMessage = { "Payment details with id $paymentDetailsId is not a card" }
@@ -105,7 +105,8 @@ internal class UpdateCardScreenViewModel @Inject constructor(
                         cardPaymentMethodCreateParamsMap = cardParams.toApiParams().toParamMap()
                     )
                     val result = linkAccountManager.updatePaymentDetails(
-                        updateParams = updateParams
+                        updateParams = updateParams,
+                        phone = cardParams.billingDetails?.phone
                     ).getOrThrow()
 
                     if (state.value.isBillingDetailsUpdateFlow) {

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/updatecard/UpdateCardScreenViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/updatecard/UpdateCardScreenViewModel.kt
@@ -71,7 +71,7 @@ internal class UpdateCardScreenViewModel @Inject constructor(
     init {
         runCatching {
             val paymentDetails = linkAccountManager.consumerPaymentDetails.value
-                .find { it.details.id == paymentDetailsId }
+                ?.paymentDetails?.find { it.details.id == paymentDetailsId }
                 ?.details
             require(
                 value = paymentDetails is ConsumerPaymentDetails.Card,

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/updatecard/UpdateCardScreenViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/updatecard/UpdateCardScreenViewModel.kt
@@ -70,7 +70,7 @@ internal class UpdateCardScreenViewModel @Inject constructor(
 
     init {
         runCatching {
-            val paymentDetails = linkAccountManager.consumerPaymentDetails.value
+            val paymentDetails = linkAccountManager.consumerState.value
                 ?.paymentDetails?.find { it.details.id == paymentDetailsId }
                 ?.details
             require(

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletUiState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletUiState.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Immutable
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.link.LinkPaymentMethod
 import com.stripe.android.link.ui.PrimaryButtonState
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.ConsumerPaymentDetails.Card
@@ -89,10 +90,10 @@ internal data class WalletUiState(
     }
 
     fun updateWithResponse(
-        response: ConsumerPaymentDetails,
+        response: List<LinkPaymentMethod.ConsumerPaymentDetails>,
     ): WalletUiState {
         return copy(
-            paymentDetailsList = response.paymentDetails,
+            paymentDetailsList = response.map { it.details },
             isProcessing = false,
             cardBeingUpdated = null
         )

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
@@ -116,7 +116,7 @@ internal class WalletViewModel @Inject constructor(
         }
 
         viewModelScope.launch {
-            linkAccountManager.consumerPaymentDetails.filterNotNull().collectLatest { paymentDetailsState ->
+            linkAccountManager.consumerState.filterNotNull().collectLatest { paymentDetailsState ->
                 if (paymentDetailsState.paymentDetails.isEmpty()) {
                     navigateAndClearStack(LinkScreen.PaymentMethod)
                 } else {
@@ -273,7 +273,7 @@ internal class WalletViewModel @Inject constructor(
         val cvc = cvcController.formFieldValue.value.takeIf { it.isComplete }?.value
 
         // Use the cached phone for this payment detail if available (ie the user updated it locally)
-        val linkPaymentMethod = linkAccountManager.consumerPaymentDetails.value
+        val linkPaymentMethod = linkAccountManager.consumerState.value
             ?.paymentDetails?.find { it.details.id == selectedPaymentDetails.id }
         val result = completeLinkFlow(
             selectedPaymentDetails = LinkPaymentMethod.ConsumerPaymentDetails(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -531,8 +531,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         elementsSession: ElementsSession,
         initializationMode: PaymentElementLoader.InitializationMode
     ): LinkConfiguration? {
-        val collectsPhone = configuration.billingDetailsCollectionConfiguration.collectsPhone
-        if (!configuration.link.shouldDisplay || !elementsSession.isLinkEnabled || collectsPhone) {
+        if (!configuration.link.shouldDisplay || !elementsSession.isLinkEnabled) {
             return null
         }
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/ConsumerStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ConsumerStateTest.kt
@@ -1,0 +1,333 @@
+package com.stripe.android.link
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.model.CountryCode
+import com.stripe.android.link.TestFactory.CONSUMER_PAYMENT_DETAILS_BANK_ACCOUNT
+import com.stripe.android.link.TestFactory.CONSUMER_PAYMENT_DETAILS_CARD
+import com.stripe.android.link.TestFactory.CONSUMER_PAYMENT_DETAILS_PASSTHROUGH
+import com.stripe.android.model.CardBrand
+import com.stripe.android.model.ConsumerPaymentDetails
+import com.stripe.android.model.CvcCheck
+import org.junit.Test
+
+class ConsumerStateTest {
+
+    @Test
+    fun `withPaymentDetailsResponse with empty existing state creates new payment details`() {
+        val emptyState = ConsumerState(emptyList())
+        val response = ConsumerPaymentDetails(
+            paymentDetails = listOf(CONSUMER_PAYMENT_DETAILS_CARD, CONSUMER_PAYMENT_DETAILS_BANK_ACCOUNT)
+        )
+
+        val result = emptyState.withPaymentDetailsResponse(response)
+
+        assertThat(result.paymentDetails).hasSize(2)
+        assertThat(result.paymentDetails[0].details).isEqualTo(CONSUMER_PAYMENT_DETAILS_CARD)
+        assertThat(result.paymentDetails[0].collectedCvc).isNull()
+        assertThat(result.paymentDetails[0].billingPhone).isNull()
+        assertThat(result.paymentDetails[1].details).isEqualTo(CONSUMER_PAYMENT_DETAILS_BANK_ACCOUNT)
+        assertThat(result.paymentDetails[1].collectedCvc).isNull()
+        assertThat(result.paymentDetails[1].billingPhone).isNull()
+    }
+
+    @Test
+    fun `withPaymentDetailsResponse preserves existing local data for matching payment details`() {
+        val existingPaymentDetails = listOf(
+            LinkPaymentMethod.ConsumerPaymentDetails(
+                details = CONSUMER_PAYMENT_DETAILS_CARD,
+                collectedCvc = "123",
+                billingPhone = "+1234567890"
+            ),
+            LinkPaymentMethod.ConsumerPaymentDetails(
+                details = CONSUMER_PAYMENT_DETAILS_BANK_ACCOUNT,
+                collectedCvc = null,
+                billingPhone = "+0987654321"
+            )
+        )
+        val existingState = ConsumerState(existingPaymentDetails)
+
+        val updatedCard = CONSUMER_PAYMENT_DETAILS_CARD.copy(last4 = "1234")
+        val updatedBankAccount = CONSUMER_PAYMENT_DETAILS_BANK_ACCOUNT.copy(last4 = "5678")
+        val response = ConsumerPaymentDetails(
+            paymentDetails = listOf(updatedCard, updatedBankAccount)
+        )
+
+        val result = existingState.withPaymentDetailsResponse(response)
+
+        assertThat(result.paymentDetails).hasSize(2)
+        // Check that backend data was updated but local data was preserved
+        assertThat(result.paymentDetails[0].details).isEqualTo(updatedCard)
+        assertThat(result.paymentDetails[0].collectedCvc).isEqualTo("123")
+        assertThat(result.paymentDetails[0].billingPhone).isEqualTo("+1234567890")
+        assertThat(result.paymentDetails[1].details).isEqualTo(updatedBankAccount)
+        assertThat(result.paymentDetails[1].collectedCvc).isNull()
+        assertThat(result.paymentDetails[1].billingPhone).isEqualTo("+0987654321")
+    }
+
+    @Test
+    fun `withPaymentDetailsResponse handles mixed existing and new payment details`() {
+        val existingPaymentDetails = listOf(
+            LinkPaymentMethod.ConsumerPaymentDetails(
+                details = CONSUMER_PAYMENT_DETAILS_CARD,
+                collectedCvc = "123",
+                billingPhone = "+1234567890"
+            )
+        )
+        val existingState = ConsumerState(existingPaymentDetails)
+
+        val updatedCard = CONSUMER_PAYMENT_DETAILS_CARD.copy(last4 = "1234")
+        val response = ConsumerPaymentDetails(
+            paymentDetails = listOf(
+                updatedCard,
+                CONSUMER_PAYMENT_DETAILS_BANK_ACCOUNT,
+                CONSUMER_PAYMENT_DETAILS_PASSTHROUGH
+            )
+        )
+
+        val result = existingState.withPaymentDetailsResponse(response)
+
+        assertThat(result.paymentDetails).hasSize(3)
+        // Existing payment detail should preserve local data
+        assertThat(result.paymentDetails[0].details).isEqualTo(updatedCard)
+        assertThat(result.paymentDetails[0].collectedCvc).isEqualTo("123")
+        assertThat(result.paymentDetails[0].billingPhone).isEqualTo("+1234567890")
+        // New payment details should have null local data
+        assertThat(result.paymentDetails[1].details).isEqualTo(CONSUMER_PAYMENT_DETAILS_BANK_ACCOUNT)
+        assertThat(result.paymentDetails[1].collectedCvc).isNull()
+        assertThat(result.paymentDetails[1].billingPhone).isNull()
+        assertThat(result.paymentDetails[2].details).isEqualTo(CONSUMER_PAYMENT_DETAILS_PASSTHROUGH)
+        assertThat(result.paymentDetails[2].collectedCvc).isNull()
+        assertThat(result.paymentDetails[2].billingPhone).isNull()
+    }
+
+    @Test
+    fun `withPaymentDetailsResponse with no matching IDs creates all new payment details`() {
+        val existingPaymentDetails = listOf(
+            LinkPaymentMethod.ConsumerPaymentDetails(
+                details = CONSUMER_PAYMENT_DETAILS_CARD,
+                collectedCvc = "123",
+                billingPhone = "+1234567890"
+            )
+        )
+        val existingState = ConsumerState(existingPaymentDetails)
+
+        val newCard = ConsumerPaymentDetails.Card(
+            id = "pm_different",
+            last4 = "5678",
+            expiryYear = 2025,
+            expiryMonth = 6,
+            brand = CardBrand.MasterCard,
+            cvcCheck = CvcCheck.Pass,
+            isDefault = false,
+            networks = emptyList(),
+            funding = "DEBIT",
+            nickname = "New Card",
+            billingAddress = ConsumerPaymentDetails.BillingAddress(
+                name = "Jane Doe",
+                line1 = "456 Oak St",
+                line2 = null,
+                locality = "New City",
+                administrativeArea = "NY",
+                countryCode = CountryCode.US,
+                postalCode = "54321"
+            )
+        )
+        val response = ConsumerPaymentDetails(paymentDetails = listOf(newCard))
+
+        val result = existingState.withPaymentDetailsResponse(response)
+
+        assertThat(result.paymentDetails).hasSize(1)
+        assertThat(result.paymentDetails[0].details).isEqualTo(newCard)
+        assertThat(result.paymentDetails[0].collectedCvc).isNull()
+        assertThat(result.paymentDetails[0].billingPhone).isNull()
+    }
+
+    @Test
+    fun `withPaymentDetailsResponse with empty response returns empty state`() {
+        val existingPaymentDetails = listOf(
+            LinkPaymentMethod.ConsumerPaymentDetails(
+                details = CONSUMER_PAYMENT_DETAILS_CARD,
+                collectedCvc = "123",
+                billingPhone = "+1234567890"
+            )
+        )
+        val existingState = ConsumerState(existingPaymentDetails)
+        val response = ConsumerPaymentDetails(paymentDetails = emptyList())
+
+        val result = existingState.withPaymentDetailsResponse(response)
+
+        assertThat(result.paymentDetails).isEmpty()
+    }
+
+    @Test
+    fun `withPaymentDetailsResponse removes cached payment details not in response`() {
+        val existingPaymentDetails = listOf(
+            LinkPaymentMethod.ConsumerPaymentDetails(
+                details = CONSUMER_PAYMENT_DETAILS_CARD,
+                collectedCvc = "123",
+                billingPhone = "+1234567890"
+            ),
+            LinkPaymentMethod.ConsumerPaymentDetails(
+                details = CONSUMER_PAYMENT_DETAILS_BANK_ACCOUNT,
+                collectedCvc = null,
+                billingPhone = "+0987654321"
+            ),
+            LinkPaymentMethod.ConsumerPaymentDetails(
+                details = CONSUMER_PAYMENT_DETAILS_PASSTHROUGH,
+                collectedCvc = null,
+                billingPhone = "+5555555555"
+            )
+        )
+        val existingState = ConsumerState(existingPaymentDetails)
+
+        // Response only includes the card, not the bank account or passthrough
+        val response = ConsumerPaymentDetails(
+            paymentDetails = listOf(CONSUMER_PAYMENT_DETAILS_CARD)
+        )
+
+        val result = existingState.withPaymentDetailsResponse(response)
+
+        // Only the card should remain, with preserved local data
+        assertThat(result.paymentDetails).hasSize(1)
+        assertThat(result.paymentDetails[0].details).isEqualTo(CONSUMER_PAYMENT_DETAILS_CARD)
+        assertThat(result.paymentDetails[0].collectedCvc).isEqualTo("123")
+        assertThat(result.paymentDetails[0].billingPhone).isEqualTo("+1234567890")
+    }
+
+    @Test
+    fun `fromResponse creates new state with null local fields`() {
+        val response = ConsumerPaymentDetails(
+            paymentDetails = listOf(
+                CONSUMER_PAYMENT_DETAILS_CARD,
+                CONSUMER_PAYMENT_DETAILS_BANK_ACCOUNT,
+                CONSUMER_PAYMENT_DETAILS_PASSTHROUGH
+            )
+        )
+
+        val result = ConsumerState.fromResponse(response)
+
+        assertThat(result.paymentDetails).hasSize(3)
+        assertThat(result.paymentDetails[0].details).isEqualTo(CONSUMER_PAYMENT_DETAILS_CARD)
+        assertThat(result.paymentDetails[0].collectedCvc).isNull()
+        assertThat(result.paymentDetails[0].billingPhone).isNull()
+        assertThat(result.paymentDetails[1].details).isEqualTo(CONSUMER_PAYMENT_DETAILS_BANK_ACCOUNT)
+        assertThat(result.paymentDetails[1].collectedCvc).isNull()
+        assertThat(result.paymentDetails[1].billingPhone).isNull()
+        assertThat(result.paymentDetails[2].details).isEqualTo(CONSUMER_PAYMENT_DETAILS_PASSTHROUGH)
+        assertThat(result.paymentDetails[2].collectedCvc).isNull()
+        assertThat(result.paymentDetails[2].billingPhone).isNull()
+    }
+
+    @Test
+    fun `fromResponse with empty response creates empty state`() {
+        val response = ConsumerPaymentDetails(paymentDetails = emptyList())
+
+        val result = ConsumerState.fromResponse(response)
+
+        assertThat(result.paymentDetails).isEmpty()
+    }
+
+    @Test
+    fun `withUpdatedPaymentDetail updates matching payment detail and preserves local data`() {
+        val existingPaymentDetails = listOf(
+            LinkPaymentMethod.ConsumerPaymentDetails(
+                details = CONSUMER_PAYMENT_DETAILS_CARD,
+                collectedCvc = "123",
+                billingPhone = "+1234567890"
+            ),
+            LinkPaymentMethod.ConsumerPaymentDetails(
+                details = CONSUMER_PAYMENT_DETAILS_BANK_ACCOUNT,
+                collectedCvc = null,
+                billingPhone = "+0987654321"
+            )
+        )
+        val existingState = ConsumerState(existingPaymentDetails)
+
+        val updatedCard = CONSUMER_PAYMENT_DETAILS_CARD.copy(last4 = "9999")
+        val newPhone = "+1111111111"
+
+        val result = existingState.withUpdatedPaymentDetail(
+            updatedPayment = updatedCard,
+            billingPhone = newPhone
+        )
+
+        assertThat(result.paymentDetails).hasSize(2)
+        // Check that the matching payment detail was updated
+        assertThat(result.paymentDetails[0].details).isEqualTo(updatedCard)
+        assertThat(result.paymentDetails[0].billingPhone).isEqualTo(newPhone)
+        assertThat(result.paymentDetails[0].collectedCvc).isEqualTo("123") // Preserved
+        // Check that the other payment detail was not affected
+        assertThat(result.paymentDetails[1].details).isEqualTo(CONSUMER_PAYMENT_DETAILS_BANK_ACCOUNT)
+        assertThat(result.paymentDetails[1].billingPhone).isEqualTo("+0987654321")
+        assertThat(result.paymentDetails[1].collectedCvc).isNull()
+    }
+
+    @Test
+    fun `withUpdatedPaymentDetail with no matching ID returns same state`() {
+        val existingPaymentDetails = listOf(
+            LinkPaymentMethod.ConsumerPaymentDetails(
+                details = CONSUMER_PAYMENT_DETAILS_CARD,
+                collectedCvc = "123",
+                billingPhone = "+1234567890"
+            )
+        )
+        val existingState = ConsumerState(existingPaymentDetails)
+
+        val differentCard = ConsumerPaymentDetails.Card(
+            id = "pm_different",
+            last4 = "1111",
+            expiryYear = 2025,
+            expiryMonth = 6,
+            brand = CardBrand.MasterCard,
+            cvcCheck = CvcCheck.Pass,
+            isDefault = false,
+            networks = emptyList(),
+            funding = "DEBIT",
+            nickname = "Different Card",
+            billingAddress = ConsumerPaymentDetails.BillingAddress(
+                name = "Jane Doe",
+                line1 = "456 Oak St",
+                line2 = null,
+                locality = "New City",
+                administrativeArea = "NY",
+                countryCode = CountryCode.US,
+                postalCode = "54321"
+            )
+        )
+
+        val result = existingState.withUpdatedPaymentDetail(
+            updatedPayment = differentCard,
+            billingPhone = "+9999999999"
+        )
+
+        // Should return the same state since no ID matched
+        assertThat(result.paymentDetails).hasSize(1)
+        assertThat(result.paymentDetails[0].details).isEqualTo(CONSUMER_PAYMENT_DETAILS_CARD)
+        assertThat(result.paymentDetails[0].billingPhone).isEqualTo("+1234567890")
+        assertThat(result.paymentDetails[0].collectedCvc).isEqualTo("123")
+    }
+
+    @Test
+    fun `withUpdatedPaymentDetail with null billingPhone deletes existing billingPhone`() {
+        val existingPaymentDetails = listOf(
+            LinkPaymentMethod.ConsumerPaymentDetails(
+                details = CONSUMER_PAYMENT_DETAILS_CARD,
+                collectedCvc = "123",
+                billingPhone = "+1234567890"
+            )
+        )
+        val existingState = ConsumerState(existingPaymentDetails)
+
+        val updatedCard = CONSUMER_PAYMENT_DETAILS_CARD.copy(last4 = "9999")
+
+        val result = existingState.withUpdatedPaymentDetail(
+            updatedPayment = updatedCard,
+            billingPhone = null // null means preserve existing
+        )
+
+        assertThat(result.paymentDetails).hasSize(1)
+        assertThat(result.paymentDetails[0].details).isEqualTo(updatedCard)
+        assertThat(result.paymentDetails[0].billingPhone).isNull() // Clears phone
+        assertThat(result.paymentDetails[0].collectedCvc).isEqualTo("123") // Preserved
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/FakeLinkAccountManager.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/FakeLinkAccountManager.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.Turbine
 import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.LinkPaymentDetails
-import com.stripe.android.link.LinkPaymentDetailsState
+import com.stripe.android.link.ConsumerState
 import com.stripe.android.link.LinkPaymentMethod
 import com.stripe.android.link.TestFactory
 import com.stripe.android.link.TestFactory.CONSUMER_SHIPPING_ADDRESSES
@@ -36,13 +36,13 @@ internal open class FakeLinkAccountManager(
     private val _accountStatus = MutableStateFlow(AccountStatus.SignedOut)
     override val accountStatus: Flow<AccountStatus> = accountStatusOverride ?: _accountStatus
 
-    private val _consumerPaymentDetails =
-        MutableStateFlow<LinkPaymentDetailsState?>(
-            LinkPaymentDetailsState(paymentDetails = TestFactory.CONSUMER_PAYMENT_DETAILS.toLinkPaymentMethod())
+    private val _consumerState =
+        MutableStateFlow<ConsumerState?>(
+            ConsumerState(paymentDetails = TestFactory.CONSUMER_PAYMENT_DETAILS.toLinkPaymentMethod())
         )
 
-    override val consumerPaymentDetails: StateFlow<LinkPaymentDetailsState?> =
-        _consumerPaymentDetails.asStateFlow()
+    override val consumerState: StateFlow<ConsumerState?> =
+        _consumerState.asStateFlow()
 
     override var cachedShippingAddresses: ConsumerShippingAddresses? = null
 
@@ -70,8 +70,8 @@ internal open class FakeLinkAccountManager(
     var listPaymentDetailsResult: Result<ConsumerPaymentDetails> = Result.success(TestFactory.CONSUMER_PAYMENT_DETAILS)
         set(value) {
             field = value
-            _consumerPaymentDetails.value = value.getOrNull()?.toLinkPaymentMethod()?.let {
-                LinkPaymentDetailsState(paymentDetails = it)
+            _consumerState.value = value.getOrNull()?.toLinkPaymentMethod()?.let {
+                ConsumerState(paymentDetails = it)
             }
         }
     var listShippingAddressesResult: Result<ConsumerShippingAddresses> = Result.success(CONSUMER_SHIPPING_ADDRESSES)
@@ -93,8 +93,8 @@ internal open class FakeLinkAccountManager(
     private val logoutCall = Turbine<Unit>()
 
     fun setConsumerPaymentDetails(consumerPaymentDetails: ConsumerPaymentDetails?) {
-        _consumerPaymentDetails.value = consumerPaymentDetails?.toLinkPaymentMethod()?.let {
-            LinkPaymentDetailsState(paymentDetails = it)
+        _consumerState.value = consumerPaymentDetails?.toLinkPaymentMethod()?.let {
+            ConsumerState(paymentDetails = it)
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/FakeLinkAccountManager.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/FakeLinkAccountManager.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.Turbine
 import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.LinkPaymentDetails
+import com.stripe.android.link.LinkPaymentMethod
 import com.stripe.android.link.TestFactory
 import com.stripe.android.link.TestFactory.CONSUMER_SHIPPING_ADDRESSES
 import com.stripe.android.link.model.AccountStatus
@@ -35,8 +36,12 @@ internal open class FakeLinkAccountManager(
     override val accountStatus: Flow<AccountStatus> = accountStatusOverride ?: _accountStatus
 
     private val _consumerPaymentDetails =
-        MutableStateFlow<ConsumerPaymentDetails?>(TestFactory.CONSUMER_PAYMENT_DETAILS)
-    override val consumerPaymentDetails: StateFlow<ConsumerPaymentDetails?> = _consumerPaymentDetails.asStateFlow()
+        MutableStateFlow<List<LinkPaymentMethod.ConsumerPaymentDetails>>(
+            TestFactory.CONSUMER_PAYMENT_DETAILS.toLinkPaymentMethod()
+        )
+
+    override val consumerPaymentDetails: StateFlow<List<LinkPaymentMethod.ConsumerPaymentDetails>> =
+        _consumerPaymentDetails.asStateFlow()
 
     override var cachedShippingAddresses: ConsumerShippingAddresses? = null
 
@@ -64,7 +69,7 @@ internal open class FakeLinkAccountManager(
     var listPaymentDetailsResult: Result<ConsumerPaymentDetails> = Result.success(TestFactory.CONSUMER_PAYMENT_DETAILS)
         set(value) {
             field = value
-            _consumerPaymentDetails.value = value.getOrNull()
+            _consumerPaymentDetails.value = value.getOrNull()?.toLinkPaymentMethod() ?: emptyList()
         }
     var listShippingAddressesResult: Result<ConsumerShippingAddresses> = Result.success(CONSUMER_SHIPPING_ADDRESSES)
         set(value) {
@@ -85,7 +90,7 @@ internal open class FakeLinkAccountManager(
     private val logoutCall = Turbine<Unit>()
 
     fun setConsumerPaymentDetails(consumerPaymentDetails: ConsumerPaymentDetails?) {
-        _consumerPaymentDetails.value = consumerPaymentDetails
+        _consumerPaymentDetails.value = consumerPaymentDetails?.toLinkPaymentMethod() ?: emptyList()
     }
 
     fun setLinkAccount(account: LinkAccountUpdate.Value) {
@@ -229,8 +234,10 @@ internal open class FakeLinkAccountManager(
     }
 
     override suspend fun deletePaymentDetails(paymentDetailsId: String) = deletePaymentDetailsResult
+
     override suspend fun updatePaymentDetails(
-        updateParams: ConsumerPaymentDetailsUpdateParams
+        updateParams: ConsumerPaymentDetailsUpdateParams,
+        billingPhone: String?
     ): Result<ConsumerPaymentDetails> {
         updateCardDetailsTurbine.add(
             updateParams
@@ -276,6 +283,15 @@ internal open class FakeLinkAccountManager(
         signupTurbine.ensureAllEventsConsumed()
         mobileSignUpTurbine.ensureAllEventsConsumed()
     }
+
+    private fun ConsumerPaymentDetails.toLinkPaymentMethod(): List<LinkPaymentMethod.ConsumerPaymentDetails> =
+        paymentDetails.map {
+            LinkPaymentMethod.ConsumerPaymentDetails(
+                it,
+                collectedCvc = null,
+                billingPhone = null
+            )
+        }
 
     data class LookupCall(
         val email: String,

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/FakeLinkAccountManager.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/FakeLinkAccountManager.kt
@@ -2,9 +2,9 @@ package com.stripe.android.link.account
 
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.Turbine
+import com.stripe.android.link.ConsumerState
 import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.LinkPaymentDetails
-import com.stripe.android.link.ConsumerState
 import com.stripe.android.link.LinkPaymentMethod
 import com.stripe.android.link.TestFactory
 import com.stripe.android.link.TestFactory.CONSUMER_SHIPPING_ADDRESSES

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletScreenTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletScreenTest.kt
@@ -626,10 +626,11 @@ internal class WalletScreenTest {
     fun `pay method row is loading when card is being updated`() = runTest(dispatcher) {
         val linkAccountManager = object : FakeLinkAccountManager() {
             override suspend fun updatePaymentDetails(
-                updateParams: ConsumerPaymentDetailsUpdateParams
+                updateParams: ConsumerPaymentDetailsUpdateParams,
+                phone: String?
             ): Result<ConsumerPaymentDetails> {
                 delay(1.seconds)
-                return super.updatePaymentDetails(updateParams)
+                return super.updatePaymentDetails(updateParams, phone)
             }
         }
         val card1 = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD.copy(id = "card1", isDefault = false)

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
@@ -589,10 +589,11 @@ class WalletViewModelTest {
         val card2 = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD.copy(id = "card2", isDefault = true)
         val linkAccountManager = object : WalletLinkAccountManager() {
             override suspend fun updatePaymentDetails(
-                updateParams: ConsumerPaymentDetailsUpdateParams
+                updateParams: ConsumerPaymentDetailsUpdateParams,
+                billingPhone: String?
             ): Result<ConsumerPaymentDetails> {
                 delay(CARD_PROCESSING_DELAY)
-                return super.updatePaymentDetails(updateParams)
+                return super.updatePaymentDetails(updateParams, billingPhone)
             }
         }
         linkAccountManager.listPaymentDetailsResult = Result.success(
@@ -1008,10 +1009,11 @@ private open class WalletLinkAccountManager : FakeLinkAccountManager() {
     }
 
     override suspend fun updatePaymentDetails(
-        updateParams: ConsumerPaymentDetailsUpdateParams
+        updateParams: ConsumerPaymentDetailsUpdateParams,
+        phone: String?
     ): Result<ConsumerPaymentDetails> {
         updatePaymentDetailsCalls.add(updateParams)
-        return super.updatePaymentDetails(updateParams)
+        return super.updatePaymentDetails(updateParams, phone)
     }
 
     override suspend fun deletePaymentDetails(paymentDetailsId: String): Result<Unit> {


### PR DESCRIPTION
# Summary
- Keeps a list of `LinkPaymentMethod` in the `LinkAccountManager` cache - this allows us to store more than just the API response locally.
  - Potentially useful to memory-store other information (ie store the CVC when collected in the wallet rather than passing it via params when confirming payment details)   
- Saves phone number edits taking place in the Update screen in the cache above
- Uses that collected phone number (if existing) on the Wallet, when confirming the payment.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
