### PR TITLE
Remove copy usage of PaymentSheet.Color

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/AppearanceBottomSheetDialogFragment.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/AppearanceBottomSheetDialogFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.annotation.ColorInt
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -259,6 +260,32 @@ private fun Icons(
         )
     }
 }
+
+private fun PaymentSheet.Colors.copy(
+    @ColorInt primary: Int = this.primary,
+    @ColorInt surface: Int = this.surface,
+    @ColorInt component: Int = this.component,
+    @ColorInt componentBorder: Int = this.componentBorder,
+    @ColorInt componentDivider: Int = this.componentDivider,
+    @ColorInt onComponent: Int = this.onComponent,
+    @ColorInt onSurface: Int = this.onSurface,
+    @ColorInt subtitle: Int = this.subtitle,
+    @ColorInt placeholderText: Int = this.placeholderText,
+    @ColorInt appBarIcon: Int = this.appBarIcon,
+    @ColorInt error: Int = this.error
+) = PaymentSheet.Colors(
+    primary = primary,
+    surface = surface,
+    component = component,
+    componentBorder = componentBorder,
+    componentDivider = componentDivider,
+    onComponent = onComponent,
+    onSurface = onSurface,
+    subtitle = subtitle,
+    placeholderText = placeholderText,
+    appBarIcon = appBarIcon,
+    error = error
+)
 
 @Composable
 private fun Colors(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -37,6 +37,8 @@ import com.stripe.android.paymentelement.WalletButtonsPreview
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbacks
 import com.stripe.android.paymentelement.confirmation.intent.IntentConfirmationInterceptor
+import com.stripe.android.paymentsheet.PaymentSheet.ShopPayConfiguration.LineItem
+import com.stripe.android.paymentsheet.PaymentSheet.ShopPayConfiguration.ShippingRate
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.flowcontroller.FlowControllerFactory
 import com.stripe.android.paymentsheet.model.PaymentOption
@@ -1784,7 +1786,7 @@ class PaymentSheet internal constructor(
     }
 
     @Parcelize
-    data class Colors(
+    class Colors(
         /**
          * A primary color used throughout PaymentSheet.
          */
@@ -1879,9 +1881,12 @@ class PaymentSheet internal constructor(
         )
 
         companion object {
-            val defaultLight = Colors(
-                primary = StripeThemeDefaults.colorsLight.materialColors.primary,
-                surface = StripeThemeDefaults.colorsLight.materialColors.surface,
+            internal fun configureDefaultLight(
+                primary: Color = StripeThemeDefaults.colorsLight.materialColors.primary,
+                surface: Color = StripeThemeDefaults.colorsLight.materialColors.surface,
+            ) = Colors(
+                primary = primary,
+                surface = surface,
                 component = StripeThemeDefaults.colorsLight.component,
                 componentBorder = StripeThemeDefaults.colorsLight.componentBorder,
                 componentDivider = StripeThemeDefaults.colorsLight.componentDivider,
@@ -1892,10 +1897,14 @@ class PaymentSheet internal constructor(
                 appBarIcon = StripeThemeDefaults.colorsLight.appBarIcon,
                 error = StripeThemeDefaults.colorsLight.materialColors.error
             )
+            val defaultLight = configureDefaultLight()
 
-            val defaultDark = Colors(
-                primary = StripeThemeDefaults.colorsDark.materialColors.primary,
-                surface = StripeThemeDefaults.colorsDark.materialColors.surface,
+            internal fun configureDefaultDark(
+                primary: Color = StripeThemeDefaults.colorsDark.materialColors.primary,
+                surface: Color = StripeThemeDefaults.colorsDark.materialColors.surface,
+            ) = Colors(
+                primary = primary,
+                surface = surface,
                 component = StripeThemeDefaults.colorsDark.component,
                 componentBorder = StripeThemeDefaults.colorsDark.componentBorder,
                 componentDivider = StripeThemeDefaults.colorsDark.componentDivider,
@@ -1906,6 +1915,7 @@ class PaymentSheet internal constructor(
                 appBarIcon = StripeThemeDefaults.colorsDark.appBarIcon,
                 error = StripeThemeDefaults.colorsDark.materialColors.error
             )
+            val defaultDark = configureDefaultDark()
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -1786,7 +1786,7 @@ class PaymentSheet internal constructor(
     }
 
     @Parcelize
-    class Colors(
+    data class Colors(
         /**
          * A primary color used throughout PaymentSheet.
          */

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetFixtures.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.customersheet
 
+import androidx.compose.ui.graphics.Color
 import com.stripe.android.ExperimentalAllowsRemovalOfLastSavedPaymentMethodApi
 import com.stripe.android.model.CardBrand
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -21,8 +22,8 @@ internal object CustomerSheetFixtures {
         .headerTextForSelectionScreen("Select a payment method!")
         .appearance(
             PaymentSheet.Appearance(
-                colorsLight = PaymentSheet.Colors.defaultLight.copy(primary = 0),
-                colorsDark = PaymentSheet.Colors.defaultDark.copy(primary = 0),
+                colorsLight = PaymentSheet.Colors.configureDefaultLight(primary = Color(0)),
+                colorsDark = PaymentSheet.Colors.configureDefaultDark(primary = Color(0)),
                 shapes = PaymentSheet.Shapes(
                     cornerRadiusDp = 0.0f,
                     borderStrokeWidthDp = 0.0f

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/LinkButtonScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/LinkButtonScreenshotTest.kt
@@ -1,9 +1,9 @@
 package com.stripe.android.link.ui
 
-import android.graphics.Color
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.parseAppearance
@@ -20,12 +20,8 @@ private enum class LinkButtonAppearance(private val appearance: PaymentSheet.App
 
     TestSurfaceBackgroundAppearance(
         appearance = PaymentSheet.Appearance(
-            colorsLight = PaymentSheet.Colors.defaultLight.copy(
-                surface = Color.RED,
-            ),
-            colorsDark = PaymentSheet.Colors.defaultDark.copy(
-                surface = Color.RED,
-            ),
+            colorsLight = PaymentSheet.Colors.configureDefaultLight(surface = Color.Red),
+            colorsDark = PaymentSheet.Colors.configureDefaultDark(surface = Color.Red),
         ),
     );
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
@@ -1,7 +1,8 @@
 package com.stripe.android.paymentsheet
 
 import android.content.res.ColorStateList
-import android.graphics.Color
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.core.graphics.toColorInt
 import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.core.strings.resolvableString
@@ -56,15 +57,15 @@ internal object PaymentSheetFixtures {
             "ek_123"
         ),
         googlePay = ConfigFixtures.GOOGLE_PAY,
-        primaryButtonColor = ColorStateList.valueOf(Color.BLACK),
+        primaryButtonColor = ColorStateList.valueOf(Color.Black.toArgb()),
         defaultBillingDetails = PaymentSheet.BillingDetails(name = "Skyler"),
         allowsDelayedPaymentMethods = true,
         allowsPaymentMethodsRequiringShippingAddress = true,
         allowsRemovalOfLastSavedPaymentMethod = false,
         paymentMethodOrder = listOf("klarna", "afterpay", "card"),
         appearance = PaymentSheet.Appearance(
-            colorsLight = PaymentSheet.Colors.defaultLight.copy(primary = 0),
-            colorsDark = PaymentSheet.Colors.defaultDark.copy(primary = 0),
+            colorsLight = PaymentSheet.Colors.configureDefaultLight(primary = Color(0)),
+            colorsDark = PaymentSheet.Colors.configureDefaultDark(primary = Color(0)),
             shapes = PaymentSheet.Shapes(
                 cornerRadiusDp = 0.0f,
                 borderStrokeWidthDp = 0.0f

--- a/paymentsheet/src/test/java/com/stripe/android/utils/screenshots/PaymentSheetAppearance.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/screenshots/PaymentSheetAppearance.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.utils.screenshots
 
-import android.graphics.Color
+import androidx.compose.ui.graphics.Color
 import com.stripe.android.paymentelement.AppearanceAPIAdditionsPreview
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
@@ -13,12 +13,8 @@ enum class PaymentSheetAppearance(val appearance: PaymentSheet.Appearance) : Pap
 
     CustomAppearance(
         appearance = PaymentSheet.Appearance(
-            colorsLight = PaymentSheet.Colors.defaultLight.copy(
-                primary = Color.RED,
-            ),
-            colorsDark = PaymentSheet.Colors.defaultDark.copy(
-                primary = Color.RED,
-            ),
+            colorsLight = PaymentSheet.Colors.configureDefaultLight(primary = Color.Red),
+            colorsDark = PaymentSheet.Colors.configureDefaultDark(primary = Color.Red),
             shapes = PaymentSheet.Shapes.default.copy(
                 cornerRadiusDp = 8f,
             ),
@@ -33,30 +29,30 @@ enum class PaymentSheetAppearance(val appearance: PaymentSheet.Appearance) : Pap
     CrazyAppearance(
         appearance = PaymentSheet.Appearance(
             colorsLight = PaymentSheet.Colors(
-                primary = Color.MAGENTA,
-                surface = Color.CYAN,
-                component = Color.YELLOW,
-                componentBorder = Color.RED,
-                componentDivider = Color.BLACK,
-                onComponent = Color.BLUE,
-                onSurface = Color.GRAY,
-                subtitle = Color.WHITE,
-                placeholderText = Color.DKGRAY,
-                appBarIcon = Color.GREEN,
-                error = Color.GREEN,
+                primary = Color.Magenta,
+                surface = Color.Cyan,
+                component = Color.Yellow,
+                componentBorder = Color.Red,
+                componentDivider = Color.Black,
+                onComponent = Color.Blue,
+                onSurface = Color.Gray,
+                subtitle = Color.White,
+                placeholderText = Color.DarkGray,
+                appBarIcon = Color.Green,
+                error = Color.Green,
             ),
             colorsDark = PaymentSheet.Colors(
-                primary = Color.MAGENTA,
-                surface = Color.CYAN,
-                component = Color.YELLOW,
-                componentBorder = Color.RED,
-                componentDivider = Color.BLACK,
-                onComponent = Color.BLUE,
-                onSurface = Color.GRAY,
-                subtitle = Color.WHITE,
-                placeholderText = Color.DKGRAY,
-                appBarIcon = Color.GREEN,
-                error = Color.GREEN,
+                primary = Color.Magenta,
+                surface = Color.Cyan,
+                component = Color.Yellow,
+                componentBorder = Color.Red,
+                componentDivider = Color.Black,
+                onComponent = Color.Blue,
+                onSurface = Color.Gray,
+                subtitle = Color.White,
+                placeholderText = Color.DarkGray,
+                appBarIcon = Color.Green,
+                error = Color.Green,
             ),
             shapes = PaymentSheet.Shapes(
                 cornerRadiusDp = 0.0f,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Replace `copy()` with `configureDefaultLight/Dark`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
[MOBILESDK-3712](https://jira.corp.stripe.com/browse/MOBILESDK-3712)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
