### PR TITLE
Remove data modifier from public classes.

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -1527,14 +1527,6 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$Address : androi
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun component5 ()Ljava/lang/String;
-	public final fun component6 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentSheet$Address;
-	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$Address;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCity ()Ljava/lang/String;
@@ -1576,13 +1568,6 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$Appearance : and
 	public synthetic fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$Colors;Lcom/stripe/android/paymentsheet/PaymentSheet$Colors;Lcom/stripe/android/paymentsheet/PaymentSheet$Shapes;Lcom/stripe/android/paymentsheet/PaymentSheet$Typography;Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButton;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$Colors;Lcom/stripe/android/paymentsheet/PaymentSheet$Colors;Lcom/stripe/android/paymentsheet/PaymentSheet$Shapes;Lcom/stripe/android/paymentsheet/PaymentSheet$Typography;Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButton;Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance$Embedded;Lcom/stripe/android/paymentsheet/PaymentSheet$Insets;)V
 	public synthetic fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$Colors;Lcom/stripe/android/paymentsheet/PaymentSheet$Colors;Lcom/stripe/android/paymentsheet/PaymentSheet$Shapes;Lcom/stripe/android/paymentsheet/PaymentSheet$Typography;Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButton;Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance$Embedded;Lcom/stripe/android/paymentsheet/PaymentSheet$Insets;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/stripe/android/paymentsheet/PaymentSheet$Colors;
-	public final fun component2 ()Lcom/stripe/android/paymentsheet/PaymentSheet$Colors;
-	public final fun component3 ()Lcom/stripe/android/paymentsheet/PaymentSheet$Shapes;
-	public final fun component4 ()Lcom/stripe/android/paymentsheet/PaymentSheet$Typography;
-	public final fun component5 ()Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButton;
-	public final fun copy (Lcom/stripe/android/paymentsheet/PaymentSheet$Colors;Lcom/stripe/android/paymentsheet/PaymentSheet$Colors;Lcom/stripe/android/paymentsheet/PaymentSheet$Shapes;Lcom/stripe/android/paymentsheet/PaymentSheet$Typography;Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButton;Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance$Embedded;Lcom/stripe/android/paymentsheet/PaymentSheet$Insets;Lcom/stripe/android/paymentsheet/PaymentSheet$Spacing;Lcom/stripe/android/paymentsheet/PaymentSheet$Insets;Lcom/stripe/android/paymentsheet/PaymentSheet$IconStyle;F)Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance;
-	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance;Lcom/stripe/android/paymentsheet/PaymentSheet$Colors;Lcom/stripe/android/paymentsheet/PaymentSheet$Colors;Lcom/stripe/android/paymentsheet/PaymentSheet$Shapes;Lcom/stripe/android/paymentsheet/PaymentSheet$Typography;Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButton;Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance$Embedded;Lcom/stripe/android/paymentsheet/PaymentSheet$Insets;Lcom/stripe/android/paymentsheet/PaymentSheet$Spacing;Lcom/stripe/android/paymentsheet/PaymentSheet$Insets;Lcom/stripe/android/paymentsheet/PaymentSheet$IconStyle;FILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getColors (Z)Lcom/stripe/android/paymentsheet/PaymentSheet$Colors;
@@ -1851,12 +1836,6 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$BillingDetails :
 	public fun <init> ()V
 	public fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/stripe/android/paymentsheet/PaymentSheet$Address;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun copy (Lcom/stripe/android/paymentsheet/PaymentSheet$Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;
-	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/PaymentSheet$Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAddress ()Lcom/stripe/android/paymentsheet/PaymentSheet$Address;
@@ -1895,13 +1874,6 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCo
 	public synthetic fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$AddressCollectionMode;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$AddressCollectionMode;ZLjava/util/Set;)V
 	public synthetic fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$AddressCollectionMode;ZLjava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;
-	public final fun component2 ()Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;
-	public final fun component3 ()Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;
-	public final fun component4 ()Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$AddressCollectionMode;
-	public final fun component5 ()Z
-	public final fun copy (Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$AddressCollectionMode;ZLjava/util/Set;)Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;
-	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$AddressCollectionMode;ZLjava/util/Set;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAddress ()Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$AddressCollectionMode;
@@ -2048,19 +2020,6 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$Colors : android
 	public static final field Companion Lcom/stripe/android/paymentsheet/PaymentSheet$Colors$Companion;
 	public fun <init> (IIIIIIIIIII)V
 	public synthetic fun <init> (JJJJJJJJJJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()I
-	public final fun component10 ()I
-	public final fun component11 ()I
-	public final fun component2 ()I
-	public final fun component3 ()I
-	public final fun component4 ()I
-	public final fun component5 ()I
-	public final fun component6 ()I
-	public final fun component7 ()I
-	public final fun component8 ()I
-	public final fun component9 ()I
-	public final fun copy (IIIIIIIIIII)Lcom/stripe/android/paymentsheet/PaymentSheet$Colors;
-	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$Colors;IIIIIIIIIIIILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$Colors;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAppBarIcon ()I
@@ -2112,18 +2071,6 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$Configuration : 
 	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;)V
 	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;Ljava/util/List;)V
 	public synthetic fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component10 ()Ljava/lang/String;
-	public final fun component11 ()Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;
-	public final fun component12 ()Ljava/util/List;
-	public final fun component2 ()Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;
-	public final fun component3 ()Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;
-	public final fun component4 ()Landroid/content/res/ColorStateList;
-	public final fun component5 ()Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;
-	public final fun component6 ()Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;
-	public final fun component7 ()Z
-	public final fun component8 ()Z
-	public final fun component9 ()Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAllowsDelayedPaymentMethods ()Z
@@ -2224,8 +2171,6 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$CustomerConfigur
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getEphemeralKeySecret ()Ljava/lang/String;
@@ -2329,14 +2274,6 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$GooglePayConfigu
 	public fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;)V
 	public fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$ButtonType;)V
 	public synthetic fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$ButtonType;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ljava/lang/Long;
-	public final fun component5 ()Ljava/lang/String;
-	public final fun component6 ()Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$ButtonType;
-	public final fun copy (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$ButtonType;)Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;
-	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$ButtonType;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAmount ()Ljava/lang/Long;
@@ -2638,12 +2575,6 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$PrimaryButton : 
 	public fun <init> ()V
 	public fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors;Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors;Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonShape;Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonTypography;)V
 	public synthetic fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors;Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors;Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonShape;Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonTypography;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors;
-	public final fun component2 ()Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors;
-	public final fun component3 ()Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonShape;
-	public final fun component4 ()Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonTypography;
-	public final fun copy (Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors;Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors;Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonShape;Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonTypography;)Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButton;
-	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButton;Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors;Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors;Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonShape;Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonTypography;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButton;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getColorsDark ()Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors;
@@ -2673,13 +2604,6 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonCol
 	public fun <init> (Ljava/lang/Integer;II)V
 	public fun <init> (Ljava/lang/Integer;IIII)V
 	public synthetic fun <init> (Ljava/lang/Integer;IIIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/Integer;
-	public final fun component2 ()I
-	public final fun component3 ()I
-	public final fun component4 ()I
-	public final fun component5 ()I
-	public final fun copy (Ljava/lang/Integer;IIII)Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors;
-	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors;Ljava/lang/Integer;IIIIILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBackground ()Ljava/lang/Integer;
@@ -2715,11 +2639,6 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonSha
 	public synthetic fun <init> (Landroid/content/Context;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;)V
 	public synthetic fun <init> (Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/Float;
-	public final fun component2 ()Ljava/lang/Float;
-	public final fun component3 ()Ljava/lang/Float;
-	public final fun copy (Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;)Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonShape;
-	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonShape;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonShape;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBorderStrokeWidthDp ()Ljava/lang/Float;
@@ -2746,10 +2665,6 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonTyp
 	public synthetic fun <init> (Landroid/content/Context;Ljava/lang/Integer;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/Integer;Ljava/lang/Float;)V
 	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/Float;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/Integer;
-	public final fun component2 ()Ljava/lang/Float;
-	public final fun copy (Ljava/lang/Integer;Ljava/lang/Float;)Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonTypography;
-	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonTypography;Ljava/lang/Integer;Ljava/lang/Float;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonTypography;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFontResId ()Ljava/lang/Integer;
@@ -2775,11 +2690,6 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$Shapes : android
 	public fun <init> (FFF)V
 	public synthetic fun <init> (FFFILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Landroid/content/Context;II)V
-	public final fun component1 ()F
-	public final fun component2 ()F
-	public final fun component3 ()F
-	public final fun copy (FFF)Lcom/stripe/android/paymentsheet/PaymentSheet$Shapes;
-	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$Shapes;FFFILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$Shapes;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBorderStrokeWidthDp ()F
@@ -2982,11 +2892,6 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$Typography : and
 	public static final field Companion Lcom/stripe/android/paymentsheet/PaymentSheet$Typography$Companion;
 	public fun <init> (FLjava/lang/Integer;)V
 	public fun <init> (FLjava/lang/Integer;Lcom/stripe/android/paymentsheet/PaymentSheet$Typography$Custom;)V
-	public final fun component1 ()F
-	public final fun component2 ()Ljava/lang/Integer;
-	public final fun component3 ()Lcom/stripe/android/paymentsheet/PaymentSheet$Typography$Custom;
-	public final fun copy (FLjava/lang/Integer;Lcom/stripe/android/paymentsheet/PaymentSheet$Typography$Custom;)Lcom/stripe/android/paymentsheet/PaymentSheet$Typography;
-	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$Typography;FLjava/lang/Integer;Lcom/stripe/android/paymentsheet/PaymentSheet$Typography$Custom;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$Typography;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCustom ()Lcom/stripe/android/paymentsheet/PaymentSheet$Typography$Custom;
@@ -3015,9 +2920,6 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$Typography$Custo
 	public fun <init> ()V
 	public fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$Typography$Font;)V
 	public synthetic fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$Typography$Font;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/stripe/android/paymentsheet/PaymentSheet$Typography$Font;
-	public final fun copy (Lcom/stripe/android/paymentsheet/PaymentSheet$Typography$Font;)Lcom/stripe/android/paymentsheet/PaymentSheet$Typography$Custom;
-	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$Typography$Custom;Lcom/stripe/android/paymentsheet/PaymentSheet$Typography$Font;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$Typography$Custom;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getH1 ()Lcom/stripe/android/paymentsheet/PaymentSheet$Typography$Font;
@@ -3040,12 +2942,6 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$Typography$Font 
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/Integer;Ljava/lang/Float;)V
 	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/Integer;Ljava/lang/Float;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/Integer;
-	public final fun component2 ()Ljava/lang/Float;
-	public final fun component3 ()Ljava/lang/Integer;
-	public final fun component4 ()Ljava/lang/Float;
-	public final fun copy (Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/Integer;Ljava/lang/Float;)Lcom/stripe/android/paymentsheet/PaymentSheet$Typography$Font;
-	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$Typography$Font;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/Integer;Ljava/lang/Float;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$Typography$Font;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFontFamily ()Ljava/lang/Integer;
@@ -3382,12 +3278,6 @@ public final class com/stripe/android/paymentsheet/addresselement/AddressDetails
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$Address;Ljava/lang/String;Ljava/lang/Boolean;)V
 	public synthetic fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$Address;Ljava/lang/String;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Lcom/stripe/android/paymentsheet/PaymentSheet$Address;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ljava/lang/Boolean;
-	public final fun copy (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$Address;Ljava/lang/String;Ljava/lang/Boolean;)Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;
-	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$Address;Ljava/lang/String;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAddress ()Lcom/stripe/android/paymentsheet/PaymentSheet$Address;
@@ -3457,10 +3347,6 @@ public final class com/stripe/android/paymentsheet/addresselement/AddressLaunche
 	public fun <init> ()V
 	public fun <init> (Lcom/stripe/android/paymentsheet/addresselement/AddressLauncher$AdditionalFieldsConfiguration$FieldConfiguration;Ljava/lang/String;)V
 	public synthetic fun <init> (Lcom/stripe/android/paymentsheet/addresselement/AddressLauncher$AdditionalFieldsConfiguration$FieldConfiguration;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/stripe/android/paymentsheet/addresselement/AddressLauncher$AdditionalFieldsConfiguration$FieldConfiguration;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun copy (Lcom/stripe/android/paymentsheet/addresselement/AddressLauncher$AdditionalFieldsConfiguration$FieldConfiguration;Ljava/lang/String;)Lcom/stripe/android/paymentsheet/addresselement/AddressLauncher$AdditionalFieldsConfiguration;
-	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/addresselement/AddressLauncher$AdditionalFieldsConfiguration;Lcom/stripe/android/paymentsheet/addresselement/AddressLauncher$AdditionalFieldsConfiguration$FieldConfiguration;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/addresselement/AddressLauncher$AdditionalFieldsConfiguration;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCheckboxLabel ()Ljava/lang/String;
@@ -3511,14 +3397,6 @@ public final class com/stripe/android/paymentsheet/addresselement/AddressLaunche
 	public fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;Ljava/util/Set;Ljava/lang/String;Lcom/stripe/android/paymentsheet/addresselement/AddressLauncher$AdditionalFieldsConfiguration;Ljava/lang/String;Ljava/lang/String;)V
 	public fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;Ljava/util/Set;Ljava/lang/String;Lcom/stripe/android/paymentsheet/addresselement/AddressLauncher$AdditionalFieldsConfiguration;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;)V
 	public synthetic fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;Ljava/util/Set;Ljava/lang/String;Lcom/stripe/android/paymentsheet/addresselement/AddressLauncher$AdditionalFieldsConfiguration;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance;
-	public final fun component2 ()Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;
-	public final fun component3 ()Ljava/util/Set;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun component5 ()Lcom/stripe/android/paymentsheet/addresselement/AddressLauncher$AdditionalFieldsConfiguration;
-	public final fun component6 ()Ljava/lang/String;
-	public final fun component7 ()Ljava/lang/String;
-	public final fun component8 ()Ljava/util/Set;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAdditionalFields ()Lcom/stripe/android/paymentsheet/addresselement/AddressLauncher$AdditionalFieldsConfiguration;
@@ -3733,10 +3611,6 @@ public final class com/stripe/android/paymentsheet/model/PaymentMethodIncentive$
 public final class com/stripe/android/paymentsheet/model/PaymentOption {
 	public static final field $stable I
 	public fun <init> (ILjava/lang/String;)V
-	public final fun component1 ()I
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBillingDetails ()Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;
 	public final fun getDrawableResourceId ()I

--- a/paymentsheet/src/main/java/com/stripe/android/link/utils/LinkBillingDetailsUtils.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/utils/LinkBillingDetailsUtils.kt
@@ -21,13 +21,14 @@ internal fun effectiveBillingDetails(
 ): PaymentSheet.BillingDetails {
     val billingConfig = configuration.billingDetailsCollectionConfiguration
     val defaultBillingDetails = configuration.defaultBillingDetails
-        ?: PaymentSheet.BillingDetails()
-    return defaultBillingDetails.copy(
-        email = defaultBillingDetails.email
+    return PaymentSheet.BillingDetails(
+        email = defaultBillingDetails?.email
             ?: linkAccount.email.takeIf { billingConfig.collectsEmail },
-        phone = defaultBillingDetails.phone
+        phone = defaultBillingDetails?.phone
             ?: linkAccount.unredactedPhoneNumber.takeIf { billingConfig.collectsPhone },
         // Name and address cannot be supplemented from Link account data
+        name = defaultBillingDetails?.name,
+        address = defaultBillingDetails?.address
     )
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -700,7 +700,8 @@ class PaymentSheet internal constructor(
 
     /** Configuration for [PaymentSheet] **/
     @Parcelize
-    data class Configuration internal constructor(
+    @Poko
+    class Configuration internal constructor(
         /**
          * Your customer-facing business name.
          *
@@ -1269,7 +1270,8 @@ class PaymentSheet internal constructor(
     }
 
     @Parcelize
-    data class Appearance
+    @Poko
+    class Appearance
     @OptIn(AppearanceAPIAdditionsPreview::class)
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     constructor(
@@ -2150,7 +2152,8 @@ class PaymentSheet internal constructor(
     }
 
     @Parcelize
-    data class Colors(
+    @Poko
+    class Colors(
         /**
          * A primary color used throughout PaymentSheet.
          */
@@ -2286,7 +2289,8 @@ class PaymentSheet internal constructor(
     }
 
     @Parcelize
-    data class Shapes @AppearanceAPIAdditionsPreview constructor(
+    @Poko
+    class Shapes @AppearanceAPIAdditionsPreview constructor(
         /**
          * The corner radius used for tabs, inputs, buttons, and other components in PaymentSheet.
          */
@@ -2340,7 +2344,8 @@ class PaymentSheet internal constructor(
     }
 
     @Parcelize
-    data class Typography @AppearanceAPIAdditionsPreview constructor(
+    @Poko
+    class Typography @AppearanceAPIAdditionsPreview constructor(
         /**
          * The scale factor for all fonts in PaymentSheet, the default value is 1.0.
          * When this value increases fonts will increase in size and decrease when this value is lowered.
@@ -2379,7 +2384,8 @@ class PaymentSheet internal constructor(
 
         @AppearanceAPIAdditionsPreview
         @Parcelize
-        data class Custom(
+        @Poko
+        class Custom(
             /**
              * The font used for headlines (e.g., "Add your payment information")
              *
@@ -2390,7 +2396,8 @@ class PaymentSheet internal constructor(
 
         @AppearanceAPIAdditionsPreview
         @Parcelize
-        data class Font(
+        @Poko
+        class Font(
             /**
              * The font used in text. This should be a resource ID value.
              */
@@ -2448,7 +2455,8 @@ class PaymentSheet internal constructor(
     }
 
     @Parcelize
-    data class PrimaryButton(
+    @Poko
+    class PrimaryButton(
         /**
          * Describes the colors used while the system is in light mode.
          */
@@ -2468,7 +2476,8 @@ class PaymentSheet internal constructor(
     ) : Parcelable
 
     @Parcelize
-    data class PrimaryButtonColors(
+    @Poko
+    class PrimaryButtonColors(
         /**
          * The background color of the primary button.
          * Note: If 'null', {@link Colors#primary} is used.
@@ -2553,7 +2562,8 @@ class PaymentSheet internal constructor(
     }
 
     @Parcelize
-    data class PrimaryButtonShape(
+    @Poko
+    class PrimaryButtonShape(
         /**
          * The corner radius of the primary button.
          * Note: If 'null', {@link Shapes#cornerRadiusDp} is used.
@@ -2603,7 +2613,8 @@ class PaymentSheet internal constructor(
     }
 
     @Parcelize
-    data class PrimaryButtonTypography(
+    @Poko
+    class PrimaryButtonTypography(
         /**
          * The font used in the primary button.
          * Note: If 'null', Appearance.Typography.fontResId is used.
@@ -2687,7 +2698,8 @@ class PaymentSheet internal constructor(
     }
 
     @Parcelize
-    data class Address(
+    @Poko
+    class Address(
         /**
          * City, district, suburb, town, or village.
          * The value set is displayed in the payment sheet as-is. Depending on the payment method, the customer may be required to edit this value.
@@ -2741,7 +2753,8 @@ class PaymentSheet internal constructor(
     }
 
     @Parcelize
-    data class BillingDetails(
+    @Poko
+    class BillingDetails(
         /**
          * The customer's billing address.
          */
@@ -2793,7 +2806,8 @@ class PaymentSheet internal constructor(
      * Configuration for how billing details are collected during checkout.
      */
     @Parcelize
-    data class BillingDetailsCollectionConfiguration(
+    @Poko
+    class BillingDetailsCollectionConfiguration(
         /**
          * How to collect the name field.
          */
@@ -2923,6 +2937,19 @@ class PaymentSheet internal constructor(
                 isRequired = collectsFullAddress || collectsPhone,
                 format = format,
                 isPhoneNumberRequired = collectsPhone,
+            )
+        }
+
+        internal fun copy(
+            name: CollectionMode = this.name,
+        ): BillingDetailsCollectionConfiguration {
+            return BillingDetailsCollectionConfiguration(
+                name = name,
+                phone = phone,
+                email = email,
+                address = address,
+                attachDefaultsToPaymentMethod = attachDefaultsToPaymentMethod,
+                allowedCountries = allowedCountries,
             )
         }
 
@@ -3125,7 +3152,8 @@ class PaymentSheet internal constructor(
     }
 
     @Parcelize
-    data class CustomerConfiguration internal constructor(
+    @Poko
+    class CustomerConfiguration internal constructor(
         /**
          * The identifier of the Stripe Customer object.
          * See [Stripe's documentation](https://stripe.com/docs/api/customers/object#customer_object-id).
@@ -3181,7 +3209,8 @@ class PaymentSheet internal constructor(
      * for more information on button types.
      */
     @Parcelize
-    data class GooglePayConfiguration @JvmOverloads constructor(
+    @Poko
+    class GooglePayConfiguration @JvmOverloads constructor(
         val environment: Environment,
         val countryCode: String,
         val currencyCode: String? = null,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressDetails.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressDetails.kt
@@ -5,10 +5,12 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.uicore.elements.IdentifierSpec
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-data class AddressDetails(
+@Poko
+class AddressDetails(
     /**
      * The customer's full name
      */

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressLauncher.kt
@@ -17,6 +17,7 @@ import com.stripe.android.core.reactnative.registerForReactNativeActivityResult
 import com.stripe.android.paymentelement.AddressElementSameAsBillingPreview
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.uicore.utils.AnimationConstants
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -100,7 +101,8 @@ class AddressLauncher internal constructor(
 
     /** Configuration for [AddressLauncher] **/
     @Parcelize
-    data class Configuration internal constructor(
+    @Poko
+    class Configuration internal constructor(
         val appearance: PaymentSheet.Appearance = PaymentSheet.Appearance(),
         val address: AddressDetails? = null,
         val allowedCountries: Set<String> = emptySet(),
@@ -232,7 +234,8 @@ class AddressLauncher internal constructor(
      * checkbox is not displayed. Defaults to null
      */
     @Parcelize
-    data class AdditionalFieldsConfiguration(
+    @Poko
+    class AdditionalFieldsConfiguration(
         val phone: FieldConfiguration = FieldConfiguration.HIDDEN,
         val checkboxLabel: String? = null,
     ) : Parcelable {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOption.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOption.kt
@@ -15,7 +15,8 @@ import dev.drewhamilton.poko.Poko
 /**
  * The customer's selected payment option.
  */
-data class PaymentOption internal constructor(
+@Poko
+class PaymentOption internal constructor(
     /**
      * The drawable resource id of the icon that represents the payment option.
      */

--- a/paymentsheet/src/test/java/com/stripe/android/link/utils/LinkBillingDetailsUtilsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/utils/LinkBillingDetailsUtilsTest.kt
@@ -31,17 +31,19 @@ class LinkBillingDetailsUtilsTest {
         )
     )
 
+    private val defaultAddress = PaymentSheet.Address(
+        line1 = "123 Main St",
+        city = "San Francisco",
+        state = "CA",
+        postalCode = "94105",
+        country = "US"
+    )
+
     private val defaultBillingDetails = PaymentSheet.BillingDetails(
         name = testName,
         email = "merchant@example.com",
         phone = "+0987654321",
-        address = PaymentSheet.Address(
-            line1 = "123 Main St",
-            city = "San Francisco",
-            state = "CA",
-            postalCode = "94105",
-            country = "US"
-        )
+        address = defaultAddress,
     )
 
     @Test
@@ -70,7 +72,11 @@ class LinkBillingDetailsUtilsTest {
             billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
                 email = CollectionMode.Always
             ),
-            defaultBillingDetails = defaultBillingDetails.copy(email = null)
+            defaultBillingDetails = PaymentSheet.BillingDetails(
+                name = testName,
+                phone = "+0987654321",
+                address = defaultAddress,
+            )
         )
 
         val result = effectiveBillingDetails(configurationWithoutEmail, linkAccount)
@@ -98,7 +104,11 @@ class LinkBillingDetailsUtilsTest {
             billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
                 phone = CollectionMode.Always
             ),
-            defaultBillingDetails = defaultBillingDetails.copy(phone = null)
+            defaultBillingDetails = PaymentSheet.BillingDetails(
+                name = testName,
+                email = "merchant@example.com",
+                address = defaultAddress,
+            )
         )
 
         val result = effectiveBillingDetails(configurationWithoutPhone, linkAccount)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -626,12 +626,13 @@ internal class DefaultFlowControllerTest {
         )
 
         flowController.configureExpectingSuccess(
-            configuration = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY.copy(
-                billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
-                    // Enable default payment method feature
-                    attachDefaultsToPaymentMethod = true
-                )
-            )
+            configuration = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY.newBuilder()
+                .billingDetailsCollectionConfiguration(
+                    PaymentSheet.BillingDetailsCollectionConfiguration(
+                        // Enable default payment method feature
+                        attachDefaultsToPaymentMethod = true
+                    )
+                ).build()
         )
 
         // Verify initial state - should have Link selected (getPaymentOption() returns null for Link)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -1699,11 +1699,12 @@ internal class DefaultPaymentElementLoaderTest {
 
         val result = loader.load(
             initializationMode = DEFAULT_INITIALIZATION_MODE,
-            paymentSheetConfiguration = DEFAULT_PAYMENT_SHEET_CONFIG.copy(
-                defaultBillingDetails = PaymentSheet.BillingDetails(
-                    email = "john@doe.com",
-                ),
-            ),
+            paymentSheetConfiguration = DEFAULT_PAYMENT_SHEET_CONFIG.newBuilder()
+                .defaultBillingDetails(
+                    defaultBillingDetails = PaymentSheet.BillingDetails(
+                        email = "john@doe.com",
+                    )
+                ).build(),
             metadata = PaymentElementLoader.Metadata(
                 initializedViaCompose = false,
             ),


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Data classes are near impossible to evolve in a binary/source compatible way. We've moved away from them in public APIs to better support future evolution.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-3703

