### PR TITLE
Support autocomplete in MPE

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressSpec.kt
@@ -93,7 +93,7 @@ data class AddressSpec(
                     sameAsShippingElement = sameAsShippingElement,
                     shippingValuesMap = shippingValues,
                     hideCountry = hideCountry,
-                    interactor = autocompleteAddressInteractorFactory.create()
+                    interactorFactory = autocompleteAddressInteractorFactory,
                 )
             } ?: run {
                 AddressElement(

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressSpec.kt
@@ -7,6 +7,8 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.ui.core.R
 import com.stripe.android.uicore.elements.AddressElement
 import com.stripe.android.uicore.elements.AddressInputMode
+import com.stripe.android.uicore.elements.AutocompleteAddressElement
+import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.CountryConfig
 import com.stripe.android.uicore.elements.CountryElement
 import com.stripe.android.uicore.elements.DropdownFieldController
@@ -57,6 +59,7 @@ data class AddressSpec(
     fun transform(
         initialValues: Map<IdentifierSpec, String?>,
         shippingValues: Map<IdentifierSpec, String?>?,
+        autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
     ): List<FormElement> {
         val label = if (showLabel) resolvableString(R.string.stripe_billing_details) else null
         return if (displayFields.size == 1 && displayFields.first() == DisplayField.Country) {
@@ -82,15 +85,28 @@ data class AddressSpec(
                             controller = SameAsShippingController(it)
                         )
                     }
-            val addressElement = AddressElement(
-                _identifier = apiPath,
-                rawValuesMap = initialValues,
-                countryCodes = allowedCountryCodes,
-                addressInputMode = type,
-                sameAsShippingElement = sameAsShippingElement,
-                shippingValuesMap = shippingValues,
-                hideCountry = hideCountry,
-            )
+            val addressElement = autocompleteAddressInteractorFactory?.let {
+                AutocompleteAddressElement(
+                    identifier = apiPath,
+                    initialValues = initialValues,
+                    countryCodes = allowedCountryCodes,
+                    sameAsShippingElement = sameAsShippingElement,
+                    shippingValuesMap = shippingValues,
+                    hideCountry = hideCountry,
+                    interactor = autocompleteAddressInteractorFactory.create()
+                )
+            } ?: run {
+                AddressElement(
+                    _identifier = apiPath,
+                    rawValuesMap = initialValues,
+                    countryCodes = allowedCountryCodes,
+                    addressInputMode = type,
+                    sameAsShippingElement = sameAsShippingElement,
+                    shippingValuesMap = shippingValues,
+                    hideCountry = hideCountry,
+                )
+            }
+
             listOfNotNull(
                 createSectionElement(
                     sectionFieldElement = addressElement,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardBillingAddressElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardBillingAddressElement.kt
@@ -45,10 +45,9 @@ class CardBillingAddressElement(
             initialValues = rawValuesMap,
             countryCodes = countryCodes,
             countryDropdownFieldController = countryDropdownFieldController,
-            interactor = factory.create(),
+            interactorFactory = factory,
             shippingValuesMap = shippingValuesMap,
             sameAsShippingElement = sameAsShippingElement,
-
         )
     } ?: run {
         AddressElement(

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardBillingAddressElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardBillingAddressElement.kt
@@ -1,11 +1,16 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
 import com.stripe.android.uicore.address.FieldType
 import com.stripe.android.uicore.elements.AddressElement
+import com.stripe.android.uicore.elements.AddressFieldsElement
 import com.stripe.android.uicore.elements.AddressInputMode
+import com.stripe.android.uicore.elements.AutocompleteAddressElement
+import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.CountryConfig
+import com.stripe.android.uicore.elements.CountryElement
 import com.stripe.android.uicore.elements.DropdownFieldController
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SameAsShippingElement
@@ -19,26 +24,46 @@ import kotlinx.coroutines.flow.StateFlow
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class CardBillingAddressElement(
-    identifier: IdentifierSpec,
+    override val identifier: IdentifierSpec,
     rawValuesMap: Map<IdentifierSpec, String?> = emptyMap(),
     countryCodes: Set<String> = emptySet(),
     countryDropdownFieldController: DropdownFieldController = DropdownFieldController(
         CountryConfig(countryCodes),
         rawValuesMap[IdentifierSpec.Country]
     ),
+    autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
     sameAsShippingElement: SameAsShippingElement?,
     shippingValuesMap: Map<IdentifierSpec, String?>?,
     private val collectionMode: BillingDetailsCollectionConfiguration.AddressCollectionMode =
         BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
-) : AddressElement(
-    identifier,
-    rawValuesMap,
-    AddressInputMode.NoAutocomplete(),
-    countryCodes,
-    countryDropdownFieldController,
-    sameAsShippingElement,
-    shippingValuesMap
-) {
+) : AddressFieldsElement {
+    private val addressElement = autocompleteAddressInteractorFactory?.takeIf {
+        collectionMode == BillingDetailsCollectionConfiguration.AddressCollectionMode.Full
+    }?.let { factory ->
+        AutocompleteAddressElement(
+            identifier = identifier,
+            initialValues = rawValuesMap,
+            countryCodes = countryCodes,
+            countryDropdownFieldController = countryDropdownFieldController,
+            interactor = factory.create(),
+            shippingValuesMap = shippingValuesMap,
+            sameAsShippingElement = sameAsShippingElement,
+
+        )
+    } ?: run {
+        AddressElement(
+            _identifier = identifier,
+            rawValuesMap = rawValuesMap,
+            countryCodes = countryCodes,
+            addressInputMode = AddressInputMode.NoAutocomplete(),
+            countryDropdownFieldController = countryDropdownFieldController,
+            shippingValuesMap = shippingValuesMap,
+            sameAsShippingElement = sameAsShippingElement,
+        )
+    }
+
+    override val countryElement: CountryElement = addressElement.countryElement
+
     // Save for future use puts this in the controller rather than element
     // card and achv2 uses save for future use
     val hiddenIdentifiers: StateFlow<Set<IdentifierSpec>> =
@@ -74,4 +99,16 @@ class CardBillingAddressElement(
                 }
             }
         }
+
+    override val allowsUserInteraction: Boolean = addressElement.allowsUserInteraction
+
+    override val mandateText: ResolvableString? = addressElement.mandateText
+
+    override fun getFormFieldValueFlow() = addressElement.getFormFieldValueFlow()
+
+    override fun sectionFieldErrorController() = addressElement.sectionFieldErrorController()
+
+    override fun setRawValue(rawValuesMap: Map<IdentifierSpec, String?>) = addressElement.setRawValue(rawValuesMap)
+
+    override fun getTextFieldIdentifiers() = addressElement.getTextFieldIdentifiers()
 }

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardBillingAddressElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardBillingAddressElementTest.kt
@@ -11,9 +11,6 @@ import com.stripe.android.uicore.elements.CountryConfig
 import com.stripe.android.uicore.elements.DropdownFieldController
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.utils.isInstanceOf
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -119,16 +116,15 @@ internal class CardBillingAddressElementTest {
                 countryDropdownFieldController = dropdownFieldController,
                 autocompleteAddressInteractorFactory = {
                     object : AutocompleteAddressInteractor {
-                        override val interactorScope: CoroutineScope = backgroundScope
-
                         override val autocompleteConfig: AutocompleteAddressInteractor.Config =
                             AutocompleteAddressInteractor.Config(
                                 googlePlacesApiKey = null,
                                 autocompleteCountries = emptySet()
                             )
 
-                        override val autocompleteEvent: SharedFlow<AutocompleteAddressInteractor.Event> =
-                            MutableSharedFlow()
+                        override fun register(onEvent: (AutocompleteAddressInteractor.Event) -> Unit) {
+                            // No-op
+                        }
 
                         override fun onAutocomplete(country: String) {
                             error("Should not be called!")

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardBillingAddressElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardBillingAddressElementTest.kt
@@ -2,9 +2,18 @@ package com.stripe.android.ui.core.elements
 
 import app.cash.turbine.test
 import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
+import com.stripe.android.uicore.elements.AddressController
+import com.stripe.android.uicore.elements.AutocompleteAddressController
+import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.CountryConfig
 import com.stripe.android.uicore.elements.DropdownFieldController
 import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.utils.isInstanceOf
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -20,6 +29,7 @@ internal class CardBillingAddressElementTest {
         rawValuesMap = emptyMap(),
         emptySet(),
         dropdownFieldController,
+        null,
         null,
         null
     )
@@ -56,6 +66,29 @@ internal class CardBillingAddressElementTest {
         }
     }
 
+    @Test
+    fun `Verify that AutocompleteAddressElement is used when billing details collection is Full`() =
+        autocompleteTest(
+            collectionMode = BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
+        ) { cardBillingAddressElement ->
+            assertThat(cardBillingAddressElement.sectionFieldErrorController())
+                .isInstanceOf<AutocompleteAddressController>()
+        }
+
+    @Test
+    fun `Verify that AddressElement is used when billing details collection is Never`() = autocompleteTest(
+        collectionMode = BillingDetailsCollectionConfiguration.AddressCollectionMode.Never,
+    ) { cardBillingAddressElement ->
+        assertThat(cardBillingAddressElement.sectionFieldErrorController()).isInstanceOf<AddressController>()
+    }
+
+    @Test
+    fun `Verify that AddressElement is used when billing details collection is Automatic`() = autocompleteTest(
+        collectionMode = BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
+    ) { cardBillingAddressElement ->
+        assertThat(cardBillingAddressElement.sectionFieldErrorController()).isInstanceOf<AddressController>()
+    }
+
     fun verifyPostalShown(hiddenIdentifiers: Set<IdentifierSpec>) {
         Truth.assertThat(hiddenIdentifiers).doesNotContain(IdentifierSpec.PostalCode)
         Truth.assertThat(hiddenIdentifiers).doesNotContain(IdentifierSpec.Country)
@@ -72,5 +105,40 @@ internal class CardBillingAddressElementTest {
         Truth.assertThat(hiddenIdentifiers).contains(IdentifierSpec.Line2)
         Truth.assertThat(hiddenIdentifiers).contains(IdentifierSpec.State)
         Truth.assertThat(hiddenIdentifiers).contains(IdentifierSpec.City)
+    }
+
+    private fun autocompleteTest(
+        collectionMode: BillingDetailsCollectionConfiguration.AddressCollectionMode,
+        block: (CardBillingAddressElement) -> Unit,
+    ) = runTest {
+        block(
+            CardBillingAddressElement(
+                identifier = IdentifierSpec.Generic("billing_element"),
+                rawValuesMap = emptyMap(),
+                countryCodes = emptySet(),
+                countryDropdownFieldController = dropdownFieldController,
+                autocompleteAddressInteractorFactory = {
+                    object : AutocompleteAddressInteractor {
+                        override val interactorScope: CoroutineScope = backgroundScope
+
+                        override val autocompleteConfig: AutocompleteAddressInteractor.Config =
+                            AutocompleteAddressInteractor.Config(
+                                googlePlacesApiKey = null,
+                                autocompleteCountries = emptySet()
+                            )
+
+                        override val autocompleteEvent: SharedFlow<AutocompleteAddressInteractor.Event> =
+                            MutableSharedFlow()
+
+                        override fun onAutocomplete(country: String) {
+                            error("Should not be called!")
+                        }
+                    }
+                },
+                sameAsShippingElement = null,
+                shippingValuesMap = null,
+                collectionMode = collectionMode,
+            )
+        )
     }
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
@@ -583,18 +583,18 @@ internal class PaymentSheetPlaygroundActivity :
             if (playgroundState.checkoutMode == CheckoutMode.SETUP) {
                 paymentSheet.presentWithSetupIntent(
                     setupIntentClientSecret = playgroundState.clientSecret,
-                    configuration = playgroundState.paymentSheetConfiguration()
+                    configuration = playgroundState.paymentSheetConfiguration(viewModel.settings)
                 )
             } else {
                 paymentSheet.presentWithPaymentIntent(
                     paymentIntentClientSecret = playgroundState.clientSecret,
-                    configuration = playgroundState.paymentSheetConfiguration()
+                    configuration = playgroundState.paymentSheetConfiguration(viewModel.settings)
                 )
             }
         } else {
             paymentSheet.presentWithIntentConfiguration(
                 intentConfiguration = playgroundState.intentConfiguration(),
-                configuration = playgroundState.paymentSheetConfiguration(),
+                configuration = playgroundState.paymentSheetConfiguration(viewModel.settings),
             )
         }
     }
@@ -607,20 +607,20 @@ internal class PaymentSheetPlaygroundActivity :
             if (playgroundState.checkoutMode == CheckoutMode.SETUP) {
                 flowController.configureWithSetupIntent(
                     setupIntentClientSecret = playgroundState.clientSecret,
-                    configuration = playgroundState.paymentSheetConfiguration(),
+                    configuration = playgroundState.paymentSheetConfiguration(viewModel.settings),
                     callback = viewModel::onFlowControllerConfigured,
                 )
             } else {
                 flowController.configureWithPaymentIntent(
                     paymentIntentClientSecret = playgroundState.clientSecret,
-                    configuration = playgroundState.paymentSheetConfiguration(),
+                    configuration = playgroundState.paymentSheetConfiguration(viewModel.settings),
                     callback = viewModel::onFlowControllerConfigured,
                 )
             }
         } else {
             flowController.configureWithIntentConfiguration(
                 intentConfiguration = playgroundState.intentConfiguration(),
-                configuration = playgroundState.paymentSheetConfiguration(),
+                configuration = playgroundState.paymentSheetConfiguration(viewModel.settings),
                 callback = viewModel::onFlowControllerConfigured,
             )
         }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundViewModel.kt
@@ -65,7 +65,7 @@ internal class PaymentSheetPlaygroundViewModel(
     launchUri: Uri?,
 ) : AndroidViewModel(application) {
 
-    private val settings by lazy {
+    val settings by lazy {
         Settings(application)
     }
 

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PlaygroundState.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PlaygroundState.kt
@@ -7,6 +7,7 @@ import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.PaymentMethodOptionsSetupFutureUsagePreview
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.example.Settings
 import com.stripe.android.paymentsheet.example.playground.model.CheckoutResponse
 import com.stripe.android.paymentsheet.example.playground.model.CustomerEphemeralKeyRequest
 import com.stripe.android.paymentsheet.example.playground.settings.AutomaticPaymentMethodsSettingsDefinition
@@ -96,8 +97,8 @@ internal sealed interface PlaygroundState : Parcelable {
             )
         }
 
-        fun paymentSheetConfiguration(): PaymentSheet.Configuration {
-            return snapshot.paymentSheetConfiguration(this)
+        fun paymentSheetConfiguration(settings: Settings): PaymentSheet.Configuration {
+            return snapshot.paymentSheetConfiguration(playgroundState = this, appSettings = settings)
         }
 
         fun embeddedConfiguration(): EmbeddedPaymentElement.Configuration {

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/AutocompleteAddressSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/AutocompleteAddressSettingsDefinition.kt
@@ -1,0 +1,33 @@
+package com.stripe.android.paymentsheet.example.playground.settings
+
+import com.stripe.android.paymentelement.AddressAutocompletePreview
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.example.Settings
+import com.stripe.android.paymentsheet.example.playground.PlaygroundState
+
+@OptIn(AddressAutocompletePreview::class)
+internal object AutocompleteAddressSettingsDefinition : BooleanSettingsDefinition(
+    key = "allowsAutocompleteAddress",
+    displayName = "Autocomplete for addresses",
+    defaultValue = false,
+) {
+    override fun applicable(configurationData: PlaygroundConfigurationData): Boolean {
+        return configurationData.integrationType == PlaygroundConfigurationData.IntegrationType.PaymentSheet ||
+            configurationData.integrationType == PlaygroundConfigurationData.IntegrationType.FlowController ||
+            configurationData.integrationType == PlaygroundConfigurationData.IntegrationType.FlowControllerWithSpt
+    }
+
+    override fun configure(
+        value: Boolean,
+        configurationBuilder: PaymentSheet.Configuration.Builder,
+        playgroundState: PlaygroundState.Payment,
+        configurationData: PlaygroundSettingDefinition.PaymentSheetConfigurationData,
+        settings: Settings,
+    ) {
+        if (value) {
+            settings.googlePlacesApiKey?.let {
+                configurationBuilder.googlePlacesApiKey(it)
+            }
+        }
+    }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettingDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettingDefinition.kt
@@ -3,12 +3,23 @@ package com.stripe.android.paymentsheet.example.playground.settings
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.example.Settings
 import com.stripe.android.paymentsheet.example.playground.PlaygroundState
 import com.stripe.android.paymentsheet.example.playground.model.CheckoutRequest
 import com.stripe.android.paymentsheet.example.playground.model.CustomerEphemeralKeyRequest
 
 internal interface PlaygroundSettingDefinition<T> {
     val defaultValue: T
+
+    fun configure(
+        value: T,
+        configurationBuilder: PaymentSheet.Configuration.Builder,
+        playgroundState: PlaygroundState.Payment,
+        configurationData: PaymentSheetConfigurationData,
+        settings: Settings,
+    ) {
+        configure(value, configurationBuilder, playgroundState, configurationData)
+    }
 
     fun configure(
         value: T,

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -10,6 +10,7 @@ import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.example.Settings
 import com.stripe.android.paymentsheet.example.playground.PlaygroundState
 import com.stripe.android.paymentsheet.example.playground.model.CheckoutRequest
 import com.stripe.android.paymentsheet.example.playground.model.CustomerEphemeralKeyRequest
@@ -134,7 +135,8 @@ internal class PlaygroundSettings private constructor(
         }
 
         fun paymentSheetConfiguration(
-            playgroundState: PlaygroundState.Payment
+            playgroundState: PlaygroundState.Payment,
+            appSettings: Settings,
         ): PaymentSheet.Configuration {
             val builder = PaymentSheet.Configuration.Builder("Example, Inc.")
             val paymentSheetConfigurationData =
@@ -142,7 +144,8 @@ internal class PlaygroundSettings private constructor(
             settings.filter { (definition, _) ->
                 definition.applicable(configurationData)
             }.onEach { (settingDefinition, value) ->
-                settingDefinition.configure(value, builder, playgroundState, paymentSheetConfigurationData)
+                settingDefinition
+                    .configure(value, builder, playgroundState, paymentSheetConfigurationData, appSettings)
             }
             return builder.build()
         }
@@ -193,6 +196,7 @@ internal class PlaygroundSettings private constructor(
             configurationBuilder: PaymentSheet.Configuration.Builder,
             playgroundState: PlaygroundState.Payment,
             configurationData: PlaygroundSettingDefinition.PaymentSheetConfigurationData,
+            settings: Settings,
         ) {
             @Suppress("UNCHECKED_CAST")
             configure(
@@ -200,6 +204,7 @@ internal class PlaygroundSettings private constructor(
                 configurationBuilder = configurationBuilder,
                 playgroundState = playgroundState,
                 configurationData = configurationData,
+                settings = settings,
             )
         }
 
@@ -462,6 +467,7 @@ internal class PlaygroundSettings private constructor(
             CollectEmailSettingsDefinition,
             CollectPhoneSettingsDefinition,
             CollectAddressSettingsDefinition,
+            AutocompleteAddressSettingsDefinition,
             DefaultShippingAddressSettingsDefinition,
             DelayedPaymentMethodsSettingsDefinition,
             AutomaticPaymentMethodsSettingsDefinition,

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -673,6 +673,9 @@ public final class com/stripe/android/lpmfoundations/paymentmethod/PaymentSheetC
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public abstract interface annotation class com/stripe/android/paymentelement/AddressAutocompletePreview : java/lang/annotation/Annotation {
+}
+
 public abstract class com/stripe/android/paymentelement/AnalyticEvent {
 	public static final field $stable I
 }
@@ -1894,6 +1897,7 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$Configuration$Bu
 	public final fun defaultBillingDetails (Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun externalPaymentMethods (Ljava/util/List;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun googlePay (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
+	public final fun googlePlacesApiKey (Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun link (Lcom/stripe/android/paymentsheet/PaymentSheet$LinkConfiguration;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun merchantDisplayName (Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun paymentMethodLayout (Lcom/stripe/android/paymentsheet/PaymentSheet$PaymentMethodLayout;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
@@ -3088,6 +3092,46 @@ public final class com/stripe/android/paymentsheet/addresselement/AddressLaunche
 
 public abstract interface class com/stripe/android/paymentsheet/addresselement/AddressLauncherResultCallback {
 	public abstract fun onAddressLauncherResult (Lcom/stripe/android/paymentsheet/addresselement/AddressLauncherResult;)V
+}
+
+public final class com/stripe/android/paymentsheet/addresselement/AutocompleteContract$Args$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/addresselement/AutocompleteContract$Args;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/addresselement/AutocompleteContract$Args;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/addresselement/AutocompleteContract$Result$Address$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/addresselement/AutocompleteContract$Result$Address;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/addresselement/AutocompleteContract$Result$Address;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/addresselement/AutocompleteContract$Result$EnterManually$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/addresselement/AutocompleteContract$Result$EnterManually;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/addresselement/AutocompleteContract$Result$EnterManually;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/addresselement/AutocompleteLauncher$Result$EnterManually$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/addresselement/AutocompleteLauncher$Result$EnterManually;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/addresselement/AutocompleteLauncher$Result$EnterManually;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/addresselement/AutocompleteLauncher$Result$OnBack$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/addresselement/AutocompleteLauncher$Result$OnBack;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/addresselement/AutocompleteLauncher$Result$OnBack;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public final class com/stripe/android/paymentsheet/databinding/StripeFragmentPrimaryButtonContainerBinding : androidx/viewbinding/ViewBinding {

--- a/paymentsheet/src/main/AndroidManifest.xml
+++ b/paymentsheet/src/main/AndroidManifest.xml
@@ -19,6 +19,10 @@
             android:theme="@style/StripePaymentSheetDefaultTheme"
             android:exported="false" />
         <activity
+            android:name=".addresselement.AutocompleteActivity"
+            android:theme="@style/StripePaymentSheetDefaultTheme"
+            android:exported="false" />
+        <activity
             android:name=".paymentdatacollection.bacs.BacsMandateConfirmationActivity"
             android:theme="@style/StripePaymentSheetDefaultTheme"
             android:exported="false" />

--- a/paymentsheet/src/main/java/com/stripe/android/common/configuration/ConfigurationDefaults.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/configuration/ConfigurationDefaults.kt
@@ -30,6 +30,7 @@ internal object ConfigurationDefaults {
     val customPaymentMethods: List<PaymentSheet.CustomPaymentMethod> = emptyList()
     val walletButtons: PaymentSheet.WalletButtonsConfiguration = PaymentSheet.WalletButtonsConfiguration()
     val shopPayConfiguration: PaymentSheet.ShopPayConfiguration? = null
+    val googlePlacesApiKey: String? = null
 
     const val embeddedViewDisplaysMandateText: Boolean = true
 }

--- a/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
@@ -26,6 +26,7 @@ internal data class CommonConfiguration(
     val cardBrandAcceptance: PaymentSheet.CardBrandAcceptance,
     val customPaymentMethods: List<PaymentSheet.CustomPaymentMethod>,
     val shopPayConfiguration: PaymentSheet.ShopPayConfiguration?,
+    val googlePlacesApiKey: String?,
 ) : Parcelable {
 
     fun validate() {
@@ -137,7 +138,8 @@ internal fun PaymentSheet.Configuration.asCommonConfiguration(): CommonConfigura
     cardBrandAcceptance = cardBrandAcceptance,
     customPaymentMethods = customPaymentMethods,
     link = link,
-    shopPayConfiguration = shopPayConfiguration
+    shopPayConfiguration = shopPayConfiguration,
+    googlePlacesApiKey = googlePlacesApiKey,
 )
 
 internal fun EmbeddedPaymentElement.Configuration.asCommonConfiguration(): CommonConfiguration = CommonConfiguration(
@@ -156,7 +158,8 @@ internal fun EmbeddedPaymentElement.Configuration.asCommonConfiguration(): Commo
     cardBrandAcceptance = cardBrandAcceptance,
     customPaymentMethods = customPaymentMethods,
     link = link,
-    shopPayConfiguration = null
+    shopPayConfiguration = null,
+    googlePlacesApiKey = null,
 )
 
 private fun String.isEKClientSecretValid(): Boolean {

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -465,7 +465,8 @@ internal class CustomerSheetViewModel(
                                 "`CustomerSheet` does not implement `Link` and should not " +
                                     "receive `InlineSignUpViewState` updates"
                             )
-                        }
+                        },
+                        autocompleteAddressInteractorFactory = null,
                     ),
                 ) ?: listOf(),
                 primaryButtonLabel = if (
@@ -810,7 +811,8 @@ internal class CustomerSheetViewModel(
                         "`CustomerSheet` does not implement `Link` and should not " +
                             "receive `InlineSignUpViewState` updates"
                     )
-                }
+                },
+                autocompleteAddressInteractorFactory = null,
             )
         ) ?: emptyList()
 

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
@@ -175,6 +175,7 @@ internal class PaymentMethodViewModel @Inject constructor(
                             ),
                             eventReporter = parentComponent.eventReporter,
                             savedStateHandle = parentComponent.viewModel.savedStateHandle,
+                            autocompleteAddressInteractorFactory = null,
                         ),
                         logger = parentComponent.logger,
                         dismissalCoordinator = parentComponent.dismissalCoordinator,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/FormElementsBuilder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/FormElementsBuilder.kt
@@ -86,6 +86,7 @@ internal class FormElementsBuilder(
                 val elements = AddressSpec(allowedCountryCodes = availableCountries).transform(
                     initialValues = arguments.initialValues,
                     shippingValues = arguments.shippingValues,
+                    autocompleteAddressInteractorFactory = arguments.autocompleteAddressInteractorFactory,
                 )
 
                 addAll(elements)

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElements.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElements.kt
@@ -74,7 +74,11 @@ internal class TransformSpecToElements(
                 is KlarnaHeaderStaticTextSpec -> listOf(spec.transform())
                 is DropdownSpec -> listOf(spec.transform(arguments.initialValues))
                 is CountrySpec -> listOf(spec.transform(arguments.initialValues))
-                is AddressSpec -> spec.transform(arguments.initialValues, arguments.shippingValues)
+                is AddressSpec -> spec.transform(
+                    arguments.initialValues,
+                    arguments.shippingValues,
+                    arguments.autocompleteAddressInteractorFactory,
+                )
                 is SepaMandateTextSpec -> listOf(spec.transform(arguments.merchantName))
                 is PlaceholderSpec -> listOf() // Placeholders should be processed before calling transform.
                 is CashAppPayMandateTextSpec -> listOf(spec.transform(arguments.merchantName))

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionFactory.kt
@@ -20,6 +20,7 @@ import com.stripe.android.paymentsheet.model.PaymentMethodIncentive
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.ui.core.elements.FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE
 import com.stripe.android.ui.core.elements.SharedDataSpec
+import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
 
@@ -38,6 +39,7 @@ internal sealed interface UiDefinitionFactory {
         val onLinkInlineSignupStateChanged: (InlineSignupViewState) -> Unit,
         val cardBrandFilter: CardBrandFilter,
         val setAsDefaultMatchesSaveForFutureUse: Boolean,
+        val autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
     ) {
         interface Factory {
             fun create(
@@ -55,6 +57,7 @@ internal sealed interface UiDefinitionFactory {
                 private val initialLinkUserInput: UserInput? = null,
                 private val setAsDefaultMatchesSaveForFutureUse: Boolean =
                     FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE,
+                private val autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
             ) : Factory {
                 override fun create(
                     metadata: PaymentMethodMetadata,
@@ -77,7 +80,8 @@ internal sealed interface UiDefinitionFactory {
                         onLinkInlineSignupStateChanged = onLinkInlineSignupStateChanged,
                         cardBrandFilter = metadata.cardBrandFilter,
                         initialLinkUserInput = initialLinkUserInput,
-                        setAsDefaultMatchesSaveForFutureUse = setAsDefaultMatchesSaveForFutureUse
+                        setAsDefaultMatchesSaveForFutureUse = setAsDefaultMatchesSaveForFutureUse,
+                        autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
                     )
                 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -23,6 +23,7 @@ import com.stripe.android.ui.core.elements.EmailElement
 import com.stripe.android.ui.core.elements.MandateTextElement
 import com.stripe.android.ui.core.elements.SaveForFutureUseElement
 import com.stripe.android.ui.core.elements.SetAsDefaultPaymentMethodElement
+import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.PhoneNumberController
@@ -185,6 +186,7 @@ private object CardUiDefinitionFactory : UiDefinitionFactory.Simple {
             addAll(
                 cardBillingElements(
                     billingDetailsCollectionConfiguration.address.toInternal(),
+                    arguments.autocompleteAddressInteractorFactory,
                     arguments.initialValues,
                     arguments.shippingValues,
                 )
@@ -253,6 +255,7 @@ internal fun PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectio
 
 private fun cardBillingElements(
     collectionMode: BillingDetailsCollectionConfiguration.AddressCollectionMode,
+    autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
     initialValues: Map<IdentifierSpec, String?>,
     shippingValues: Map<IdentifierSpec, String?>?,
 ): List<FormElement> {
@@ -272,6 +275,7 @@ private fun cardBillingElements(
         sameAsShippingElement = sameAsShippingElement,
         shippingValuesMap = shippingValues,
         collectionMode = collectionMode,
+        autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
     )
 
     return listOfNotNull(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/AddressAutocompletePreview.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/AddressAutocompletePreview.kt
@@ -1,0 +1,8 @@
+package com.stripe.android.paymentelement
+
+@RequiresOptIn(
+    level = RequiresOptIn.Level.ERROR,
+    message = "Address autocomplete support for MPE is beta. It may be changed in the future without notice."
+)
+@Retention(AnnotationRetention.BINARY)
+annotation class AddressAutocompletePreview

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedFormHelperFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedFormHelperFactory.kt
@@ -50,6 +50,7 @@ internal class EmbeddedFormHelperFactory @Inject constructor(
             setAsDefaultMatchesSaveForFutureUse = setAsDefaultMatchesSaveForFutureUse,
             eventReporter = eventReporter,
             savedStateHandle = savedStateHandle,
+            autocompleteAddressInteractorFactory = null,
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/NullUiDefinitionFactoryHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/NullUiDefinitionFactoryHelper.kt
@@ -12,6 +12,7 @@ internal object NullUiDefinitionFactoryHelper {
     val nullEmbeddedUiDefinitionFactory = UiDefinitionFactory.Arguments.Factory.Default(
         cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
         linkConfigurationCoordinator = null,
+        autocompleteAddressInteractorFactory = null,
         onLinkInlineSignupStateChanged = {
             throw IllegalStateException("Not possible.")
         },

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultFormHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultFormHelper.kt
@@ -21,6 +21,7 @@ import com.stripe.android.paymentsheet.ui.transformToPaymentMethodCreateParams
 import com.stripe.android.paymentsheet.ui.transformToPaymentSelection
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.ui.core.elements.FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE
+import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.FormElement
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
@@ -39,6 +40,7 @@ internal class DefaultFormHelper(
     private val setAsDefaultMatchesSaveForFutureUse: Boolean,
     private val eventReporter: EventReporter,
     private val savedStateHandle: SavedStateHandle,
+    private val autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
 ) : FormHelper {
     companion object {
         internal const val PREVIOUSLY_COMPLETED_PAYMENT_FORM = "previously_completed_payment_form"
@@ -62,12 +64,14 @@ internal class DefaultFormHelper(
                 setAsDefaultMatchesSaveForFutureUse = viewModel.customerStateHolder.paymentMethods.value.isEmpty(),
                 eventReporter = viewModel.eventReporter,
                 savedStateHandle = viewModel.savedStateHandle,
+                autocompleteAddressInteractorFactory = viewModel.autocompleteAddressInteractorFactory,
             )
         }
 
         fun create(
             coroutineScope: CoroutineScope,
             cardAccountRangeRepositoryFactory: CardAccountRangeRepository.Factory,
+            autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
             paymentMethodMetadata: PaymentMethodMetadata,
             eventReporter: EventReporter,
             savedStateHandle: SavedStateHandle,
@@ -83,6 +87,7 @@ internal class DefaultFormHelper(
                 setAsDefaultMatchesSaveForFutureUse = FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE,
                 eventReporter = eventReporter,
                 savedStateHandle = savedStateHandle,
+                autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
             )
         }
     }
@@ -154,6 +159,7 @@ internal class DefaultFormHelper(
                     else -> null
                 },
                 setAsDefaultMatchesSaveForFutureUse = setAsDefaultMatchesSaveForFutureUse,
+                autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
             ),
         ) ?: emptyList()
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -48,9 +48,9 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
             viewModel.analyticsListener.cannotProperlyReturnFromLinkAndOtherLPMs()
         }
 
-        viewModel.linkPaymentLauncher.register(
+        viewModel.registerForActivityResult(
             activityResultCaller = this,
-            callback = viewModel::onLinkAuthenticationResult
+            lifecycleOwner = this,
         )
 
         setContent {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -1,5 +1,8 @@
 package com.stripe.android.paymentsheet
 
+import androidx.activity.result.ActivityResultCaller
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
@@ -154,6 +157,22 @@ internal class PaymentOptionsViewModel @Inject constructor(
                 paymentMethodMetadata = args.state.paymentMethodMetadata,
                 customerStateHolder = customerStateHolder,
             )
+        )
+    }
+
+    override fun registerFromActivity(
+        activityResultCaller: ActivityResultCaller,
+        lifecycleOwner: LifecycleOwner
+    ) {
+        linkPaymentLauncher.register(activityResultCaller, ::onLinkAuthenticationResult)
+
+        lifecycleOwner.lifecycle.addObserver(
+            object : DefaultLifecycleObserver {
+                override fun onDestroy(owner: LifecycleOwner) {
+                    linkPaymentLauncher.unregister()
+                    super.onDestroy(owner)
+                }
+            }
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -25,6 +25,7 @@ import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.SetupIntent
+import com.stripe.android.paymentelement.AddressAutocompletePreview
 import com.stripe.android.paymentelement.AnalyticEventCallback
 import com.stripe.android.paymentelement.AppearanceAPIAdditionsPreview
 import com.stripe.android.paymentelement.ConfirmCustomPaymentMethodCallback
@@ -788,6 +789,8 @@ class PaymentSheet internal constructor(
         internal val walletButtons: WalletButtonsConfiguration = ConfigurationDefaults.walletButtons,
 
         internal val shopPayConfiguration: ShopPayConfiguration? = ConfigurationDefaults.shopPayConfiguration,
+
+        internal val googlePlacesApiKey: String? = ConfigurationDefaults.googlePlacesApiKey,
     ) : Parcelable {
 
         @JvmOverloads
@@ -942,6 +945,7 @@ class PaymentSheet internal constructor(
             private var link: PaymentSheet.LinkConfiguration = ConfigurationDefaults.link
             private var walletButtons: WalletButtonsConfiguration = ConfigurationDefaults.walletButtons
             private var shopPayConfiguration: ShopPayConfiguration? = ConfigurationDefaults.shopPayConfiguration
+            private var googlePlacesApiKey: String? = ConfigurationDefaults.googlePlacesApiKey
 
             private var customPaymentMethods: List<CustomPaymentMethod> =
                 ConfigurationDefaults.customPaymentMethods
@@ -1091,6 +1095,14 @@ class PaymentSheet internal constructor(
                 this.shopPayConfiguration = shopPayConfiguration
             }
 
+            /**
+             * Google Places API key to support autocomplete when collecting billing details
+             */
+            @AddressAutocompletePreview
+            fun googlePlacesApiKey(googlePlacesApiKey: String?) = apply {
+                this.googlePlacesApiKey = googlePlacesApiKey
+            }
+
             fun build() = Configuration(
                 merchantDisplayName = merchantDisplayName,
                 customer = customer,
@@ -1112,7 +1124,8 @@ class PaymentSheet internal constructor(
                 customPaymentMethods = customPaymentMethods,
                 link = link,
                 walletButtons = walletButtons,
-                shopPayConfiguration = shopPayConfiguration
+                shopPayConfiguration = shopPayConfiguration,
+                googlePlacesApiKey = googlePlacesApiKey,
             )
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -1099,7 +1099,7 @@ class PaymentSheet internal constructor(
              * Google Places API key to support autocomplete when collecting billing details
              */
             @AddressAutocompletePreview
-            fun googlePlacesApiKey(googlePlacesApiKey: String?) = apply {
+            fun googlePlacesApiKey(googlePlacesApiKey: String) = apply {
                 this.googlePlacesApiKey = googlePlacesApiKey
             }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -44,7 +44,7 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
             return
         }
 
-        viewModel.registerFromActivity(
+        viewModel.registerForActivityResult(
             activityResultCaller = this,
             lifecycleOwner = this,
         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -445,7 +445,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
      * Used to set up any dependencies that require a reference to the current Activity.
      * Must be called from the Activity's `onCreate`.
      */
-    fun registerFromActivity(
+    override fun registerFromActivity(
         activityResultCaller: ActivityResultCaller,
         lifecycleOwner: LifecycleOwner,
     ) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementDefaults.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementDefaults.kt
@@ -1,0 +1,6 @@
+package com.stripe.android.paymentsheet.addresselement
+
+internal val AUTOCOMPLETE_DEFAULT_COUNTRIES = setOf(
+    "AU", "BE", "BR", "CA", "CH", "DE", "ES", "FR", "GB", "IE", "IT", "MX", "NO", "NL",
+    "PL", "RU", "SE", "TR", "US", "ZA"
+)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressFormController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressFormController.kt
@@ -21,7 +21,7 @@ internal class AddressFormController(
         shippingValuesMap = null,
         sameAsShippingElement = null,
         hideName = false,
-        interactor = interactor,
+        interactorFactory = { interactor },
     )
 
     val elements: List<FormElement> = listOf(SectionElement.wrap(autocompleteAddressElement))

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressLauncher.kt
@@ -123,10 +123,7 @@ class AddressLauncher internal constructor(
          * A list of two-letter country codes that support autocomplete. Defaults to a list of
          * countries that Stripe has audited to ensure a good autocomplete experience.
          */
-        val autocompleteCountries: Set<String> = setOf(
-            "AU", "BE", "BR", "CA", "CH", "DE", "ES", "FR", "GB", "IE", "IT", "MX", "NO", "NL",
-            "PL", "RU", "SE", "TR", "US", "ZA"
-        )
+        val autocompleteCountries: Set<String> = AUTOCOMPLETE_DEFAULT_COUNTRIES
     ) : Parcelable {
         /**
          * [Configuration] builder for cleaner object creation from Java.

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteActivity.kt
@@ -1,0 +1,108 @@
+package com.stripe.android.paymentsheet.addresselement
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.compose.BackHandler
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Surface
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.core.view.WindowCompat
+import com.stripe.android.common.ui.ElementsBottomSheetLayout
+import com.stripe.android.paymentsheet.parseAppearance
+import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
+import com.stripe.android.uicore.StripeTheme
+import com.stripe.android.uicore.elements.bottomsheet.rememberStripeBottomSheetState
+import kotlinx.coroutines.flow.collectLatest
+
+internal class AutocompleteActivity : AppCompatActivity() {
+    private val starterArgs by lazy {
+        AutocompleteContract.Args.fromIntent(intent)
+    }
+
+    private val viewModel: AutocompleteViewModel by viewModels<AutocompleteViewModel> {
+        AutocompleteViewModel.Factory(requireNotNull(starterArgs))
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val starterArgs = starterArgs
+        if (starterArgs == null) {
+            finish()
+            return
+        }
+
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        starterArgs.appearance.parseAppearance()
+
+        setContent {
+            val bottomSheetState = rememberStripeBottomSheetState()
+
+            LaunchedEffect(Unit) {
+                viewModel.event.collectLatest { event ->
+                    val result = when (event) {
+                        is AutocompleteViewModel.Event.EnterManually -> AutocompleteContract.Result.EnterManually(
+                            id = starterArgs.id,
+                            addressDetails = event.addressDetails,
+                        )
+                        is AutocompleteViewModel.Event.GoBack -> AutocompleteContract.Result.Address(
+                            id = starterArgs.id,
+                            addressDetails = event.addressDetails,
+                        )
+                    }
+
+                    setResult(result)
+
+                    bottomSheetState.hide()
+                    finish()
+                }
+            }
+
+            BackHandler {
+                viewModel.onBackPressed()
+            }
+
+            StripeTheme {
+                ElementsBottomSheetLayout(
+                    state = bottomSheetState,
+                    onDismissed = viewModel::onBackPressed,
+                ) {
+                    Surface(modifier = Modifier.fillMaxSize()) {
+                        AutocompleteScreenUI(
+                            viewModel = viewModel,
+                            attributionDrawable =
+                            PlacesClientProxy.getPlacesPoweredByGoogleDrawable(isSystemInDarkTheme()),
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    override fun onStop() {
+        super.onStop()
+
+        if (!isFinishing && !isChangingConfigurations) {
+            setResult(
+                AutocompleteContract.Result.Address(
+                    id = starterArgs?.id ?: "",
+                    addressDetails = null,
+                )
+            )
+            finish()
+        }
+    }
+
+    private fun setResult(result: AutocompleteContract.Result) {
+        setResult(
+            Activity.RESULT_OK,
+            Intent().putExtras(result.toBundle())
+        )
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteContract.kt
@@ -1,0 +1,65 @@
+package com.stripe.android.paymentsheet.addresselement
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.core.os.bundleOf
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.view.ActivityStarter
+import kotlinx.parcelize.Parcelize
+
+internal object AutocompleteContract :
+    ActivityResultContract<AutocompleteContract.Args, AutocompleteContract.Result>() {
+    override fun createIntent(context: Context, input: Args): Intent {
+        return Intent(context, AutocompleteActivity::class.java).putExtra(EXTRA_ARGS, input)
+    }
+
+    @Suppress("DEPRECATION")
+    override fun parseResult(resultCode: Int, intent: Intent?): Result =
+        intent?.getParcelableExtra(EXTRA_RESULT) ?: throw IllegalStateException(
+            "Unknown MPE address autocomplete result!"
+        )
+
+    @Parcelize
+    data class Args internal constructor(
+        internal val id: String,
+        internal val country: String,
+        internal val googlePlacesApiKey: String,
+        internal val appearance: PaymentSheet.Appearance,
+    ) : ActivityStarter.Args {
+
+        internal companion object {
+            internal fun fromIntent(intent: Intent): Args? {
+                @Suppress("DEPRECATION")
+                return intent.getParcelableExtra(EXTRA_ARGS)
+            }
+        }
+    }
+
+    sealed class Result : ActivityStarter.Result {
+        abstract val id: String
+        abstract val addressDetails: AddressDetails?
+
+        @Parcelize
+        data class EnterManually(
+            override val id: String,
+            override val addressDetails: AddressDetails?,
+        ) : Result()
+
+        @Parcelize
+        data class Address(
+            override val id: String,
+            override val addressDetails: AddressDetails?,
+        ) : Result()
+
+        override fun toBundle(): Bundle {
+            return bundleOf(EXTRA_RESULT to this)
+        }
+    }
+
+    const val EXTRA_ARGS =
+        "com.stripe.android.paymentsheet.addresselement.AutocompleteContract.extra_args"
+    const val EXTRA_RESULT =
+        "com.stripe.android.paymentsheet.addresselement.AutocompleteContract.extra_result"
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteLauncher.kt
@@ -1,0 +1,86 @@
+package com.stripe.android.paymentsheet.addresselement
+
+import android.os.Parcelable
+import androidx.activity.result.ActivityResultCaller
+import androidx.activity.result.ActivityResultLauncher
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import com.stripe.android.paymentsheet.PaymentSheet
+import kotlinx.parcelize.Parcelize
+import java.util.UUID
+
+internal interface AutocompleteLauncher {
+    fun launch(
+        country: String,
+        googlePlacesApiKey: String,
+        onResult: (Result) -> Unit
+    )
+
+    sealed interface Result : Parcelable {
+        val addressDetails: AddressDetails?
+
+        @Parcelize
+        data class EnterManually(override val addressDetails: AddressDetails?) : Result
+
+        @Parcelize
+        data class OnBack(override val addressDetails: AddressDetails?) : Result
+    }
+}
+
+internal interface AutocompleteActivityLauncher : AutocompleteLauncher {
+    fun register(activityResultCaller: ActivityResultCaller, lifecycleOwner: LifecycleOwner)
+}
+
+internal class DefaultAutocompleteLauncher(
+    private val appearance: PaymentSheet.Appearance,
+) : AutocompleteActivityLauncher {
+    private var activityLauncher: ActivityResultLauncher<AutocompleteContract.Args>? = null
+
+    private val registeredAutocompleteListeners = mutableMapOf<String, (AutocompleteLauncher.Result) -> Unit>()
+
+    override fun register(activityResultCaller: ActivityResultCaller, lifecycleOwner: LifecycleOwner) {
+        activityLauncher = activityResultCaller.registerForActivityResult(
+            AutocompleteContract
+        ) { result ->
+            registeredAutocompleteListeners[result.id]?.invoke(
+                when (result) {
+                    is AutocompleteContract.Result.EnterManually -> AutocompleteLauncher.Result.EnterManually(
+                        result.addressDetails,
+                    )
+                    is AutocompleteContract.Result.Address -> AutocompleteLauncher.Result.OnBack(
+                        result.addressDetails
+                    )
+                }
+            )
+            registeredAutocompleteListeners.remove(result.id)
+        }
+
+        lifecycleOwner.lifecycle.addObserver(
+            object : DefaultLifecycleObserver {
+                override fun onDestroy(owner: LifecycleOwner) {
+                    activityLauncher?.unregister()
+                    activityLauncher = null
+                }
+            }
+        )
+    }
+
+    override fun launch(
+        country: String,
+        googlePlacesApiKey: String,
+        onResult: (AutocompleteLauncher.Result) -> Unit
+    ) {
+        val id = UUID.randomUUID().toString()
+
+        registeredAutocompleteListeners[id] = onResult
+
+        activityLauncher?.launch(
+            AutocompleteContract.Args(
+                id = id,
+                country = country,
+                googlePlacesApiKey = googlePlacesApiKey,
+                appearance = appearance,
+            )
+        )
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
@@ -1,0 +1,51 @@
+package com.stripe.android.paymentsheet.addresselement
+
+import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+
+internal class PaymentElementAutocompleteAddressInteractor(
+    private val launcher: AutocompleteLauncher,
+    override val interactorScope: CoroutineScope,
+    override val autocompleteConfig: AutocompleteAddressInteractor.Config,
+) : AutocompleteAddressInteractor {
+    override val autocompleteEvent = MutableSharedFlow<AutocompleteAddressInteractor.Event>()
+
+    override fun onAutocomplete(country: String) {
+        autocompleteConfig.googlePlacesApiKey?.let { googlePlacesApiKey ->
+            launcher.launch(country, googlePlacesApiKey) { result ->
+                val values = result.addressDetails?.toIdentifierMap()
+
+                interactorScope.launch {
+                    val event = when (result) {
+                        is AutocompleteLauncher.Result.EnterManually -> {
+                            AutocompleteAddressInteractor.Event.OnExpandForm(values)
+                        }
+                        is AutocompleteLauncher.Result.OnBack -> values?.let {
+                            AutocompleteAddressInteractor.Event.OnValues(it)
+                        }
+                    }
+
+                    event?.let {
+                        autocompleteEvent.emit(it)
+                    }
+                }
+            }
+        }
+    }
+
+    class Factory(
+        private val launcher: AutocompleteLauncher,
+        private val interactorScope: CoroutineScope,
+        private val autocompleteConfig: AutocompleteAddressInteractor.Config,
+    ) : AutocompleteAddressInteractor.Factory {
+        override fun create(): AutocompleteAddressInteractor {
+            return PaymentElementAutocompleteAddressInteractor(
+                launcher = launcher,
+                interactorScope = interactorScope,
+                autocompleteConfig = autocompleteConfig,
+            )
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
@@ -1,49 +1,51 @@
 package com.stripe.android.paymentsheet.addresselement
 
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.launch
 
 internal class PaymentElementAutocompleteAddressInteractor(
     private val launcher: AutocompleteLauncher,
-    override val interactorScope: CoroutineScope,
     override val autocompleteConfig: AutocompleteAddressInteractor.Config,
-) : AutocompleteAddressInteractor {
-    override val autocompleteEvent = MutableSharedFlow<AutocompleteAddressInteractor.Event>()
+) : AutocompleteAddressInteractor, AutocompleteLauncherResultHandler {
+    private var eventListener: ((AutocompleteAddressInteractor.Event) -> Unit)? = null
+
+    override fun register(onEvent: (AutocompleteAddressInteractor.Event) -> Unit) {
+        eventListener = onEvent
+    }
 
     override fun onAutocomplete(country: String) {
         autocompleteConfig.googlePlacesApiKey?.let { googlePlacesApiKey ->
-            launcher.launch(country, googlePlacesApiKey) { result ->
-                val values = result.addressDetails?.toIdentifierMap()
+            launcher.launch(
+                country = country,
+                googlePlacesApiKey = googlePlacesApiKey,
+                resultHandler = this,
+            )
+        }
+    }
 
-                interactorScope.launch {
-                    val event = when (result) {
-                        is AutocompleteLauncher.Result.EnterManually -> {
-                            AutocompleteAddressInteractor.Event.OnExpandForm(values)
-                        }
-                        is AutocompleteLauncher.Result.OnBack -> values?.let {
-                            AutocompleteAddressInteractor.Event.OnValues(it)
-                        }
-                    }
+    override fun onAutocompleteLauncherResult(result: AutocompleteLauncher.Result) {
+        val values = result.addressDetails?.toIdentifierMap()
 
-                    event?.let {
-                        autocompleteEvent.emit(it)
-                    }
-                }
+        val event = when (result) {
+            is AutocompleteLauncher.Result.EnterManually -> {
+                AutocompleteAddressInteractor.Event.OnExpandForm(values)
             }
+            is AutocompleteLauncher.Result.OnBack -> values?.let {
+                AutocompleteAddressInteractor.Event.OnValues(it)
+            }
+        }
+
+        event?.let {
+            eventListener?.invoke(it)
         }
     }
 
     class Factory(
         private val launcher: AutocompleteLauncher,
-        private val interactorScope: CoroutineScope,
         private val autocompleteConfig: AutocompleteAddressInteractor.Config,
     ) : AutocompleteAddressInteractor.Factory {
         override fun create(): AutocompleteAddressInteractor {
             return PaymentElementAutocompleteAddressInteractor(
                 launcher = launcher,
-                interactorScope = interactorScope,
                 autocompleteConfig = autocompleteConfig,
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/PlaceholderHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/PlaceholderHelper.kt
@@ -14,7 +14,7 @@ import com.stripe.android.ui.core.elements.PhoneSpec
 import com.stripe.android.ui.core.elements.PlaceholderSpec
 import com.stripe.android.ui.core.elements.PlaceholderSpec.PlaceholderField
 import com.stripe.android.ui.core.elements.SepaMandateTextSpec
-import com.stripe.android.uicore.elements.AddressElement
+import com.stripe.android.uicore.elements.AddressFieldsElement
 import com.stripe.android.uicore.elements.CountryElement
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
@@ -190,7 +190,7 @@ internal object PlaceholderHelper {
             countryElement = elements
                 .filterIsInstance<SectionElement>()
                 .flatMap { it.fields }
-                .filterIsInstance<AddressElement>()
+                .filterIsInstance<AddressFieldsElement>()
                 .firstOrNull()
                 ?.countryElement
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AutocompleteViewModelFactoryComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AutocompleteViewModelFactoryComponent.kt
@@ -1,0 +1,32 @@
+package com.stripe.android.paymentsheet.injection
+
+import android.app.Application
+import com.stripe.android.core.injection.CoreCommonModule
+import com.stripe.android.core.injection.CoroutineContextModule
+import com.stripe.android.payments.core.injection.StripeRepositoryModule
+import com.stripe.android.paymentsheet.addresselement.AutocompleteContract
+import com.stripe.android.paymentsheet.addresselement.AutocompleteViewModel
+import dagger.BindsInstance
+import dagger.Component
+import javax.inject.Singleton
+
+@Singleton
+@Component(
+    modules = [
+        CoreCommonModule::class,
+        CoroutineContextModule::class,
+        StripeRepositoryModule::class,
+        AutocompleteViewModelModule::class,
+    ]
+)
+internal interface AutocompleteViewModelFactoryComponent {
+    val autocompleteViewModel: AutocompleteViewModel
+
+    @Component.Factory
+    interface Factory {
+        fun build(
+            @BindsInstance application: Application,
+            @BindsInstance args: AutocompleteContract.Args,
+        ): AutocompleteViewModelFactoryComponent
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AutocompleteViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AutocompleteViewModelModule.kt
@@ -1,0 +1,80 @@
+package com.stripe.android.paymentsheet.injection
+
+import android.app.Application
+import android.content.Context
+import com.stripe.android.BuildConfig
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.injection.ENABLE_LOGGING
+import com.stripe.android.core.injection.PUBLISHABLE_KEY
+import com.stripe.android.core.networking.AnalyticsRequestFactory
+import com.stripe.android.networking.PaymentAnalyticsRequestFactory
+import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.payments.core.injection.PRODUCT_USAGE
+import com.stripe.android.paymentsheet.addresselement.AutocompleteContract
+import com.stripe.android.paymentsheet.addresselement.AutocompleteViewModel
+import com.stripe.android.paymentsheet.addresselement.analytics.AddressLauncherEventReporter
+import com.stripe.android.paymentsheet.addresselement.analytics.DefaultAddressLauncherEventReporter
+import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Module
+internal interface AutocompleteViewModelModule {
+    @Binds
+    fun bindsAnalyticsRequestFactory(
+        paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory
+    ): AnalyticsRequestFactory
+
+    companion object {
+        @Provides
+        @Singleton
+        fun providesContext(application: Application): Context = application.applicationContext
+
+        @Provides
+        @Singleton
+        fun provideEventReporterMode(): EventReporter.Mode = EventReporter.Mode.Custom
+
+        @Provides
+        @Named(PRODUCT_USAGE)
+        @Singleton
+        fun providesProductUsage() = setOf("PaymentElement.Autocomplete")
+
+        @Provides
+        @Singleton
+        fun providesAutocompleteViewModelArgs(
+            args: AutocompleteContract.Args
+        ): AutocompleteViewModel.Args = AutocompleteViewModel.Args(args.country)
+
+        @Provides
+        @Named(ENABLE_LOGGING)
+        fun providesEnableLogging(): Boolean = BuildConfig.DEBUG
+
+        @Provides
+        @Named(PUBLISHABLE_KEY)
+        @Singleton
+        fun providesPublishableKey(
+            context: Context
+        ): () -> String = { PaymentConfiguration.getInstance(context).publishableKey }
+
+        @Provides
+        @Singleton
+        internal fun provideGooglePlacesClient(
+            context: Context,
+            args: AutocompleteContract.Args
+        ): PlacesClientProxy = PlacesClientProxy.create(
+            context = context,
+            googlePlacesApiKey = args.googlePlacesApiKey,
+            errorReporter = ErrorReporter.createFallbackInstance(context),
+        )
+
+        @Provides
+        @Singleton
+        fun provideEventReporter(
+            defaultAddressLauncherEventReporter: DefaultAddressLauncherEventReporter
+        ): AddressLauncherEventReporter = defaultAddressLauncherEventReporter
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BillingDetailsForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BillingDetailsForm.kt
@@ -26,7 +26,8 @@ internal class BillingDetailsForm(
         sameAsShippingElement = null,
         shippingValuesMap = null,
         collectionMode = addressCollectionMode.toInternal(),
-        rawValuesMap = rawAddressValues(billingDetails)
+        rawValuesMap = rawAddressValues(billingDetails),
+        autocompleteAddressInteractorFactory = null,
     )
 
     val addressSectionElement = SectionElement.wrap(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -1,5 +1,7 @@
 package com.stripe.android.paymentsheet.viewmodels
 
+import androidx.activity.result.ActivityResultCaller
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -15,6 +17,9 @@ import com.stripe.android.paymentsheet.MandateHandler
 import com.stripe.android.paymentsheet.NewPaymentOptionSelection
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.SavedPaymentMethodMutator
+import com.stripe.android.paymentsheet.addresselement.AUTOCOMPLETE_DEFAULT_COUNTRIES
+import com.stripe.android.paymentsheet.addresselement.DefaultAutocompleteLauncher
+import com.stripe.android.paymentsheet.addresselement.PaymentElementAutocompleteAddressInteractor
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.PaymentSheetAnalyticsListener
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -26,6 +31,7 @@ import com.stripe.android.paymentsheet.state.WalletsState
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.ui.core.elements.CvcConfig
 import com.stripe.android.ui.core.elements.CvcController
+import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.flatMapLatestAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
@@ -51,6 +57,10 @@ internal abstract class BaseSheetViewModel(
     val cardAccountRangeRepositoryFactory: CardAccountRangeRepository.Factory,
     val isCompleteFlow: Boolean,
 ) : ViewModel() {
+    private val autocompleteLauncher = DefaultAutocompleteLauncher(
+        appearance = config.appearance,
+    )
+
     private val _paymentMethodMetadata = MutableStateFlow<PaymentMethodMetadata?>(null)
     internal val paymentMethodMetadata: StateFlow<PaymentMethodMetadata?> = _paymentMethodMetadata
 
@@ -60,6 +70,16 @@ internal abstract class BaseSheetViewModel(
     ) { poppedScreen ->
         analyticsListener.reportPaymentSheetHidden(poppedScreen)
     }
+
+    val autocompleteAddressInteractorFactory: PaymentElementAutocompleteAddressInteractor.Factory =
+        PaymentElementAutocompleteAddressInteractor.Factory(
+            launcher = autocompleteLauncher,
+            interactorScope = viewModelScope,
+            autocompleteConfig = AutocompleteAddressInteractor.Config(
+                googlePlacesApiKey = config.googlePlacesApiKey,
+                autocompleteCountries = AUTOCOMPLETE_DEFAULT_COUNTRIES,
+            )
+        )
 
     abstract val walletsState: StateFlow<WalletsState?>
     abstract val walletsProcessingState: StateFlow<WalletsProcessingState?>
@@ -129,6 +149,19 @@ internal abstract class BaseSheetViewModel(
             }
         }
     }
+
+    fun registerForActivityResult(
+        activityResultCaller: ActivityResultCaller,
+        lifecycleOwner: LifecycleOwner,
+    ) {
+        autocompleteLauncher.register(activityResultCaller, lifecycleOwner)
+        registerFromActivity(activityResultCaller, lifecycleOwner)
+    }
+
+    protected abstract fun registerFromActivity(
+        activityResultCaller: ActivityResultCaller,
+        lifecycleOwner: LifecycleOwner,
+    )
 
     protected fun setPaymentMethodMetadata(paymentMethodMetadata: PaymentMethodMetadata?) {
         _paymentMethodMetadata.value = paymentMethodMetadata

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -74,7 +74,6 @@ internal abstract class BaseSheetViewModel(
     val autocompleteAddressInteractorFactory: PaymentElementAutocompleteAddressInteractor.Factory =
         PaymentElementAutocompleteAddressInteractor.Factory(
             launcher = autocompleteLauncher,
-            interactorScope = viewModelScope,
             autocompleteConfig = AutocompleteAddressInteractor.Config(
                 googlePlacesApiKey = config.googlePlacesApiKey,
                 autocompleteCountries = AUTOCOMPLETE_DEFAULT_COUNTRIES,

--- a/paymentsheet/src/test/java/com/stripe/android/common/model/CommonConfigurationFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/model/CommonConfigurationFactory.kt
@@ -22,7 +22,8 @@ internal object CommonConfigurationFactory {
         customPaymentMethods: List<PaymentSheet.CustomPaymentMethod> = emptyList(),
         cardBrandAcceptance: PaymentSheet.CardBrandAcceptance = PaymentSheet.CardBrandAcceptance.all(),
         link: PaymentSheet.LinkConfiguration = PaymentSheet.LinkConfiguration(),
-        shopPayConfiguration: PaymentSheet.ShopPayConfiguration? = null
+        shopPayConfiguration: PaymentSheet.ShopPayConfiguration? = null,
+        googlePlacesApiKey: String? = null,
     ): CommonConfiguration = CommonConfiguration(
         merchantDisplayName = merchantDisplayName,
         customer = customer,
@@ -40,5 +41,6 @@ internal object CommonConfigurationFactory {
         cardBrandAcceptance = cardBrandAcceptance,
         link = link,
         shopPayConfiguration = shopPayConfiguration,
+        googlePlacesApiKey = googlePlacesApiKey,
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -111,6 +111,7 @@ internal class CustomerSheetScreenshotTest {
                 cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
                 linkConfigurationCoordinator = null,
                 onLinkInlineSignupStateChanged = {},
+                autocompleteAddressInteractorFactory = null,
             )
         ) ?: listOf(),
         formArguments = FormArguments(

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodScreenScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodScreenScreenshotTest.kt
@@ -86,6 +86,7 @@ internal class PaymentMethodScreenScreenshotTest {
             cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
             linkConfigurationCoordinator = null,
             onLinkInlineSignupStateChanged = { throw AssertionError("Not expected") },
+            autocompleteAddressInteractorFactory = null,
         )
         val formElements = metadata.formElementsForCode(
             code = PaymentMethod.Type.Card.code,

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/FormElementsBuilderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/FormElementsBuilderTest.kt
@@ -5,11 +5,18 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.cards.DefaultCardAccountRangeRepositoryFactory
+import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.addresselement.TestAutocompleteAddressInteractor
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.ui.core.elements.EmptyFormElement
+import com.stripe.android.uicore.elements.AutocompleteAddressElement
+import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.SectionElement
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -126,9 +133,39 @@ class FormElementsBuilderTest {
         assertThat(formElements[0].identifier.v1).isEqualTo("element")
     }
 
+    @Test
+    fun `build should return AutocompleteAddressElement if factory is provided`() = runTest {
+        val arguments = arguments(
+            billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
+            ),
+            autocompleteAddressInteractorFactory = {
+                TestAutocompleteAddressInteractor(
+                    interactorScope = backgroundScope,
+                    config = AutocompleteAddressInteractor.Config(
+                        googlePlacesApiKey = null,
+                        autocompleteCountries = emptySet(),
+                    ),
+                    autocompleteEvent = MutableSharedFlow()
+                )
+            }
+        )
+
+        val formElements = FormElementsBuilder(arguments).build()
+
+        assertThat(formElements).hasSize(1)
+        assertThat(formElements.firstOrNull()).isInstanceOf<SectionElement>()
+
+        val sectionElement = formElements.first() as SectionElement
+
+        assertThat(sectionElement.fields.size).isEqualTo(1)
+        assertThat(sectionElement.fields.firstOrNull()).isInstanceOf<AutocompleteAddressElement>()
+    }
+
     private fun arguments(
         billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration =
             PaymentSheet.BillingDetailsCollectionConfiguration(),
+        autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory? = null,
     ): UiDefinitionFactory.Arguments {
         val context = ApplicationProvider.getApplicationContext<Application>()
         return UiDefinitionFactory.Arguments(
@@ -145,6 +182,7 @@ class FormElementsBuilderTest {
             onLinkInlineSignupStateChanged = { throw AssertionError("Not implemented") },
             cardBrandFilter = DefaultCardBrandFilter,
             setAsDefaultMatchesSaveForFutureUse = false,
+            autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/FormElementsBuilderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/FormElementsBuilderTest.kt
@@ -15,7 +15,6 @@ import com.stripe.android.uicore.elements.AutocompleteAddressElement
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SectionElement
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -140,14 +139,7 @@ class FormElementsBuilderTest {
                 address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
             ),
             autocompleteAddressInteractorFactory = {
-                TestAutocompleteAddressInteractor(
-                    interactorScope = backgroundScope,
-                    config = AutocompleteAddressInteractor.Config(
-                        googlePlacesApiKey = null,
-                        autocompleteCountries = emptySet(),
-                    ),
-                    autocompleteEvent = MutableSharedFlow()
-                )
+                TestAutocompleteAddressInteractor.noOp()
             }
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElementsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElementsTest.kt
@@ -42,7 +42,6 @@ import com.stripe.android.uicore.elements.NameConfig
 import com.stripe.android.uicore.elements.PhoneNumberElement
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.SimpleTextElement
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
@@ -333,14 +332,7 @@ internal class TransformSpecToElementsTest {
         val formElement = TransformSpecToElementsFactory.create(
             requiresMandate = false,
             autocompleteAddressInteractorFactory = {
-                TestAutocompleteAddressInteractor(
-                    interactorScope = backgroundScope,
-                    config = AutocompleteAddressInteractor.Config(
-                        googlePlacesApiKey = null,
-                        autocompleteCountries = emptySet(),
-                    ),
-                    autocompleteEvent = MutableSharedFlow()
-                )
+                TestAutocompleteAddressInteractor.noOp()
             }
         ).transform(
             PaymentMethodMetadataFactory.create(),

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/TestUiDefinitionFactoryArgumentsFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/TestUiDefinitionFactoryArgumentsFactory.kt
@@ -10,6 +10,7 @@ import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.PaymentMethodOptionsParams
+import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
 
 internal object TestUiDefinitionFactoryArgumentsFactory {
@@ -18,6 +19,7 @@ internal object TestUiDefinitionFactoryArgumentsFactory {
         paymentMethodExtraParams: PaymentMethodExtraParams? = null,
         paymentMethodOptionsParams: PaymentMethodOptionsParams? = null,
         linkConfigurationCoordinator: LinkConfigurationCoordinator? = null,
+        autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory? = null,
         initialLinkUserInput: UserInput? = null,
         setAsDefaultMatchesSaveForFutureUse: Boolean = false,
     ): UiDefinitionFactory.Arguments.Factory {
@@ -35,6 +37,7 @@ internal object TestUiDefinitionFactoryArgumentsFactory {
             initialLinkUserInput = initialLinkUserInput,
             onLinkInlineSignupStateChanged = { throw AssertionError("Not implemented") },
             setAsDefaultMatchesSaveForFutureUse = setAsDefaultMatchesSaveForFutureUse,
+            autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionTestHelper.kt
@@ -5,6 +5,7 @@ import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.PaymentMethodOptionsParams
+import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.FormElement
 
 internal fun PaymentMethodDefinition.formElements(
@@ -15,6 +16,7 @@ internal fun PaymentMethodDefinition.formElements(
     initialLinkUserInput: UserInput? = null,
     linkConfigurationCoordinator: LinkConfigurationCoordinator? = null,
     setAsDefaultMatchesSaveForFutureUse: Boolean = false,
+    autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory? = null,
 ): List<FormElement> {
     return requireNotNull(
         metadata.formElementsForCode(
@@ -24,6 +26,7 @@ internal fun PaymentMethodDefinition.formElements(
                 paymentMethodOptionsParams = paymentMethodOptionsParams,
                 paymentMethodExtraParams = paymentMethodExtraParams,
                 linkConfigurationCoordinator = linkConfigurationCoordinator,
+                autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
                 initialLinkUserInput = initialLinkUserInput,
                 setAsDefaultMatchesSaveForFutureUse = setAsDefaultMatchesSaveForFutureUse,
             )

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinitionTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.lpmfoundations.paymentmethod.definitions
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.isInstanceOf
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.TestFactory
 import com.stripe.android.link.ui.inline.LinkSignupMode
@@ -16,14 +17,19 @@ import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
+import com.stripe.android.paymentsheet.addresselement.TestAutocompleteAddressInteractor
 import com.stripe.android.paymentsheet.state.LinkState
+import com.stripe.android.ui.core.elements.CardBillingAddressElement
 import com.stripe.android.ui.core.elements.MandateTextElement
 import com.stripe.android.ui.core.elements.SaveForFutureUseElement
 import com.stripe.android.ui.core.elements.SetAsDefaultPaymentMethodElement
+import com.stripe.android.uicore.elements.AutocompleteAddressController
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.SameAsShippingElement
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -281,6 +287,28 @@ class CardDefinitionTest {
         assertThat(formElements[2].identifier.v1).isEqualTo("link_form")
 
         testMandateElement(metadata, formElements[3])
+    }
+
+    @Test
+    fun `createFormElements should have autocomplete element if factory is used`() {
+        val formElements = CardDefinition.formElements(
+            metadata = PaymentMethodMetadataFactory.create(
+                billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                    address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
+                )
+            ),
+            autocompleteAddressInteractorFactory = {
+                TestAutocompleteAddressInteractor(CoroutineScope(UnconfinedTestDispatcher()))
+            }
+        )
+
+        val cardBillingAddressElements = formElements.filterIsInstance<SectionElement>().map {
+            it.fields.filterIsInstance<CardBillingAddressElement>().firstOrNull()
+        }
+
+        assertThat(cardBillingAddressElements).hasSize(1)
+        assertThat(cardBillingAddressElements.firstOrNull()?.sectionFieldErrorController())
+            .isInstanceOf<AutocompleteAddressController>()
     }
 
     private fun createLinkConfiguration(): LinkConfiguration {

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinitionTest.kt
@@ -28,8 +28,6 @@ import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.SameAsShippingElement
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -298,7 +296,7 @@ class CardDefinitionTest {
                 )
             ),
             autocompleteAddressInteractorFactory = {
-                TestAutocompleteAddressInteractor(CoroutineScope(UnconfinedTestDispatcher()))
+                TestAutocompleteAddressInteractor.noOp()
             }
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/UiDefinitionTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/UiDefinitionTestHelper.kt
@@ -9,6 +9,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.formElements
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.ui.core.FormUI
+import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 
 @Composable
 internal fun PaymentMethodDefinition.CreateFormUi(
@@ -17,6 +18,7 @@ internal fun PaymentMethodDefinition.CreateFormUi(
     paymentMethodExtraParams: PaymentMethodExtraParams? = null,
     initialLinkUserInput: UserInput? = null,
     linkConfigurationCoordinator: LinkConfigurationCoordinator? = null,
+    autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory? = null
 ) {
     val formElements = formElements(
         metadata = metadata,
@@ -24,6 +26,7 @@ internal fun PaymentMethodDefinition.CreateFormUi(
         paymentMethodExtraParams = paymentMethodExtraParams,
         initialLinkUserInput = initialLinkUserInput,
         linkConfigurationCoordinator = linkConfigurationCoordinator,
+        autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
     )
     FormUI(
         hiddenIdentifiers = emptySet(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperTest.kt
@@ -628,7 +628,8 @@ internal class FormHelperTest {
             selectionUpdater = selectionUpdater,
             setAsDefaultMatchesSaveForFutureUse = false,
             eventReporter = eventReporter,
-            savedStateHandle = SavedStateHandle()
+            savedStateHandle = SavedStateHandle(),
+            autocompleteAddressInteractorFactory = null,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -1292,7 +1292,7 @@ internal class PaymentSheetActivityTest {
             } doReturn mock()
         }
 
-        registerFromActivity(mockActivityResultCaller, TestLifecycleOwner())
+        registerForActivityResult(mockActivityResultCaller, TestLifecycleOwner())
 
         val googlePayListenerCaptor =
             argumentCaptor<ActivityResultCallback<GooglePayPaymentMethodLauncher.Result>>()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AddressFormControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AddressFormControllerTest.kt
@@ -14,9 +14,6 @@ import com.stripe.android.uicore.elements.RowElement
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.SectionFieldElement
 import com.stripe.android.uicore.forms.FormFieldEntry
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.test.TestScope
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -98,23 +95,22 @@ class AddressFormControllerTest {
     )
 
     @Test
-    fun `Complete form values are set when element flows are complete`() = runTest(UnconfinedTestDispatcher()) {
-        val autocompleteEvent = MutableSharedFlow<AutocompleteAddressInteractor.Event>()
-
-        val addressFormController = createAddressFormController(
-            autocompleteEvent = autocompleteEvent,
-            autocompleteConfig = AutocompleteAddressInteractor.Config(
-                autocompleteCountries = setOf("US"),
-                googlePlacesApiKey = "123",
-            ),
+    fun `Complete form values are set when element flows are complete`() = test(
+        autocompleteConfig = AutocompleteAddressInteractor.Config(
+            autocompleteCountries = setOf("US"),
+            googlePlacesApiKey = "123",
         )
+    ) {
+        val addressFormController = createAddressFormController()
+
+        val registerCall = registerCalls.awaitItem()
 
         addressFormController.completeFormValues.test {
             val formValues = awaitItem()
 
             assertThat(formValues).isNull()
 
-            autocompleteEvent.emit(
+            registerCall.onEvent(
                 AutocompleteAddressInteractor.Event.OnValues(
                     values = mapOf(
                         IdentifierSpec.Name to "John Doe",
@@ -145,18 +141,17 @@ class AddressFormControllerTest {
     }
 
     @Test
-    fun `Complete form values is empty when element flows are not complete`() = runTest(UnconfinedTestDispatcher()) {
-        val autocompleteEvent = MutableSharedFlow<AutocompleteAddressInteractor.Event>()
+    fun `Complete form values is empty when element flows are not complete`() = test(
+        autocompleteConfig = AutocompleteAddressInteractor.Config(
+            autocompleteCountries = setOf("US"),
+            googlePlacesApiKey = "123",
+        ),
+    ) {
+        val addressFormController = createAddressFormController()
 
-        val addressFormController = createAddressFormController(
-            autocompleteEvent = autocompleteEvent,
-            autocompleteConfig = AutocompleteAddressInteractor.Config(
-                autocompleteCountries = setOf("US"),
-                googlePlacesApiKey = "123",
-            ),
-        )
+        val registerCall = registerCalls.awaitItem()
 
-        autocompleteEvent.emit(
+        registerCall.onEvent(
             AutocompleteAddressInteractor.Event.OnValues(
                 values = mapOf(
                     IdentifierSpec.Name to "John Doe",
@@ -176,18 +171,17 @@ class AddressFormControllerTest {
     }
 
     @Test
-    fun `Last text field identifier points to last element`() = runTest(UnconfinedTestDispatcher()) {
-        val autocompleteEvent = MutableSharedFlow<AutocompleteAddressInteractor.Event>()
+    fun `Last text field identifier points to last element`() = test(
+        autocompleteConfig = AutocompleteAddressInteractor.Config(
+            autocompleteCountries = setOf("US"),
+            googlePlacesApiKey = "123",
+        ),
+    ) {
+        val addressFormController = createAddressFormController()
 
-        val addressFormController = createAddressFormController(
-            autocompleteConfig = AutocompleteAddressInteractor.Config(
-                autocompleteCountries = setOf("US"),
-                googlePlacesApiKey = "123",
-            ),
-            autocompleteEvent = autocompleteEvent,
-        )
+        val registerCall = registerCalls.awaitItem()
 
-        autocompleteEvent.emit(
+        registerCall.onEvent(
             AutocompleteAddressInteractor.Event.OnExpandForm(
                 values = emptyMap(),
             )
@@ -222,15 +216,14 @@ class AddressFormControllerTest {
             autocompleteCountries = setOf("US"),
             googlePlacesApiKey = null,
         ),
-        autocompleteEvent: MutableSharedFlow<AutocompleteAddressInteractor.Event> = MutableSharedFlow(),
         launcherConfig: AddressLauncher.Configuration = AddressLauncher.Configuration(),
         test: suspend TurbineTestContext<List<SectionFieldElement>>.() -> Unit
-    ) = runTest(UnconfinedTestDispatcher()) {
+    ) = test(autocompleteConfig) {
         val addressFormController = createAddressFormController(
-            autocompleteConfig = autocompleteConfig,
             launcherConfig = launcherConfig,
-            autocompleteEvent = autocompleteEvent,
         )
+
+        assertThat(registerCalls.awaitItem()).isNotNull()
 
         val elements = addressFormController.elements
 
@@ -260,23 +253,28 @@ class AddressFormControllerTest {
         }
     }
 
-    private fun TestScope.createAddressFormController(
+    private fun test(
         autocompleteConfig: AutocompleteAddressInteractor.Config = AutocompleteAddressInteractor.Config(
             autocompleteCountries = setOf("US"),
             googlePlacesApiKey = "123",
         ),
-        autocompleteEvent: MutableSharedFlow<AutocompleteAddressInteractor.Event> = MutableSharedFlow(),
+        block: suspend TestAutocompleteAddressInteractor.Scenario.() -> Unit
+    ) = runTest {
+        TestAutocompleteAddressInteractor.test(
+            autocompleteConfig = autocompleteConfig,
+        ) {
+            block()
+        }
+    }
+
+    private fun TestAutocompleteAddressInteractor.Scenario.createAddressFormController(
         launcherConfig: AddressLauncher.Configuration = AddressLauncher.Configuration(
             additionalFields = AddressLauncher.AdditionalFieldsConfiguration(
                 phone = AddressLauncher.AdditionalFieldsConfiguration.FieldConfiguration.HIDDEN,
             )
         )
     ) = AddressFormController(
-        interactor = TestAutocompleteAddressInteractor(
-            interactorScope = backgroundScope,
-            config = autocompleteConfig,
-            autocompleteEvent = autocompleteEvent,
-        ),
+        interactor = interactor,
         config = launcherConfig,
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AddressFormControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AddressFormControllerTest.kt
@@ -14,7 +14,6 @@ import com.stripe.android.uicore.elements.RowElement
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.SectionFieldElement
 import com.stripe.android.uicore.forms.FormFieldEntry
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -280,16 +279,4 @@ class AddressFormControllerTest {
         ),
         config = launcherConfig,
     )
-
-    private class TestAutocompleteAddressInteractor(
-        override val interactorScope: CoroutineScope,
-        config: AutocompleteAddressInteractor.Config,
-        override val autocompleteEvent: MutableSharedFlow<AutocompleteAddressInteractor.Event>,
-    ) : AutocompleteAddressInteractor {
-        override val autocompleteConfig: AutocompleteAddressInteractor.Config = config
-
-        override fun onAutocomplete(country: String) {
-            error("Should not be called!")
-        }
-    }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteContractTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteContractTest.kt
@@ -30,6 +30,7 @@ class AutocompleteContractTest {
 
         val extras = intent.extras
 
+        @Suppress("DEPRECATION")
         assertThat(extras?.getParcelable<AutocompleteContract.Args>(EXTRA_ARGS))
             .isEqualTo(args)
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteContractTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteContractTest.kt
@@ -1,0 +1,84 @@
+package com.stripe.android.paymentsheet.addresselement
+
+import android.app.Activity
+import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.addresselement.AutocompleteContract.EXTRA_ARGS
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AutocompleteContractTest {
+    @Test
+    fun `on create intent, should have expected extras`() {
+        val args = AutocompleteContract.Args(
+            id = "123",
+            googlePlacesApiKey = "gp_123",
+            country = "US",
+            appearance = PaymentSheet.Appearance.Builder()
+                .colorsDark(PaymentSheet.Colors.defaultLight)
+                .build()
+        )
+
+        val intent = AutocompleteContract.createIntent(
+            context = ApplicationProvider.getApplicationContext(),
+            input = args,
+        )
+
+        val extras = intent.extras
+
+        assertThat(extras?.getParcelable<AutocompleteContract.Args>(EXTRA_ARGS))
+            .isEqualTo(args)
+    }
+
+    @Test
+    fun `should parse out address result`() {
+        val expectedResult = AutocompleteContract.Result.Address(
+            id = "123",
+            addressDetails = AddressDetails(
+                name = "John Doe",
+                address = PaymentSheet.Address(
+                    line1 = "123 Apple Street",
+                    city = "San Francisco",
+                    state = "CA",
+                    country = "US",
+                    postalCode = "99999"
+                )
+            )
+        )
+
+        val actualResult = AutocompleteContract.parseResult(
+            Activity.RESULT_OK,
+            intent = Intent().putExtras(expectedResult.toBundle())
+        )
+
+        assertThat(actualResult).isEqualTo(expectedResult)
+    }
+
+    @Test
+    fun `should parse out enter manually result`() {
+        val expectedResult = AutocompleteContract.Result.EnterManually(
+            id = "123",
+            addressDetails = AddressDetails(
+                name = "John Doe",
+                address = PaymentSheet.Address(
+                    line1 = "123 Apple Street",
+                    city = "San Francisco",
+                    state = "CA",
+                    country = "US",
+                    postalCode = "99999"
+                )
+            )
+        )
+
+        val actualResult = AutocompleteContract.parseResult(
+            Activity.RESULT_OK,
+            intent = Intent().putExtras(expectedResult.toBundle())
+        )
+
+        assertThat(actualResult).isEqualTo(expectedResult)
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/DefaultAutocompleteLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/DefaultAutocompleteLauncherTest.kt
@@ -1,0 +1,354 @@
+package com.stripe.android.paymentsheet.addresselement
+
+import androidx.compose.ui.graphics.Color
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.testing.TestLifecycleOwner
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.isInstanceOf
+import com.stripe.android.paymentelement.confirmation.asCallbackFor
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.testing.CoroutineTestRule
+import com.stripe.android.utils.DummyActivityResultCaller
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+
+class DefaultAutocompleteLauncherTest {
+    @get:Rule
+    val coroutineTestRule = CoroutineTestRule()
+
+    private val appearance = PaymentSheet.Appearance.Builder()
+        .colorsLight(PaymentSheet.Colors.defaultDark)
+        .build()
+
+    private val addressDetails = AddressDetails(
+        name = "John Doe",
+        address = PaymentSheet.Address(
+            line1 = "123 Main Street",
+            line2 = "Apt 4B",
+            city = "San Francisco",
+            state = "CA",
+            postalCode = "94105",
+            country = "US"
+        ),
+        phoneNumber = "555-123-4567",
+        isCheckboxSelected = true
+    )
+
+    @Test
+    fun `register sets up activity result launcher`() = test {
+        val launcher = createLauncher()
+
+        launcher.register(activityResultCaller, TestLifecycleOwner())
+
+        val registerCall = awaitRegisterCall()
+        assertThat(registerCall.contract).isEqualTo(AutocompleteContract)
+
+        assertThat(awaitNextRegisteredLauncher()).isNotNull()
+    }
+
+    @Test
+    fun `launch does nothing when not registered`() = runTest {
+        val launcher = createLauncher()
+
+        launcher.launch(country = "US", googlePlacesApiKey = "test-api-key") {
+            error("Should not be called!")
+        }
+    }
+
+    @Test
+    fun `launch calls activity launcher with correct arguments after register`() = test {
+        val launcher = createLauncher()
+
+        launcher.register(activityResultCaller, TestLifecycleOwner())
+
+        assertThat(awaitRegisterCall()).isNotNull()
+        assertThat(awaitNextRegisteredLauncher()).isNotNull()
+
+        launcher.launch(country = "US", googlePlacesApiKey = "test-api-key") {
+            error("Should not be called!")
+        }
+
+        val launchArgs = awaitLaunchCall()
+
+        assertThat(launchArgs).isInstanceOf<AutocompleteContract.Args>()
+
+        val autocompleteArgs = launchArgs as AutocompleteContract.Args
+
+        assertThat(autocompleteArgs.country).isEqualTo("US")
+        assertThat(autocompleteArgs.googlePlacesApiKey).isEqualTo("test-api-key")
+        assertThat(autocompleteArgs.appearance).isEqualTo(appearance)
+    }
+
+    @Test
+    fun `launch creates unique IDs for multiple calls`() = test {
+        val launcher = createLauncher()
+
+        launcher.register(activityResultCaller, TestLifecycleOwner())
+
+        assertThat(awaitRegisterCall()).isNotNull()
+        assertThat(awaitNextRegisteredLauncher()).isNotNull()
+
+        launcher.launch(country = "US", googlePlacesApiKey = "test-api-key") {
+            error("Should not be called!")
+        }
+
+        launcher.launch(country = "CA", googlePlacesApiKey = "test-api-key") {
+            error("Should not be called!")
+        }
+
+        val firstLaunchArguments = awaitLaunchCall()
+
+        assertThat(firstLaunchArguments).isInstanceOf<AutocompleteContract.Args>()
+
+        val firstAutocompleteArgs = firstLaunchArguments as AutocompleteContract.Args
+
+        assertThat(firstAutocompleteArgs.id).isEqualTo(firstAutocompleteArgs.id)
+        assertThat(firstAutocompleteArgs.country).isEqualTo("US")
+        assertThat(firstAutocompleteArgs.googlePlacesApiKey).isEqualTo("test-api-key")
+
+        val secondLaunchArguments = awaitLaunchCall()
+
+        assertThat(secondLaunchArguments).isInstanceOf<AutocompleteContract.Args>()
+
+        val secondAutocompleteArgs = secondLaunchArguments as AutocompleteContract.Args
+
+        assertThat(secondAutocompleteArgs.id).isEqualTo(secondAutocompleteArgs.id)
+        assertThat(secondAutocompleteArgs.country).isEqualTo("CA")
+        assertThat(secondAutocompleteArgs.googlePlacesApiKey).isEqualTo("test-api-key")
+    }
+
+    @Test
+    fun `launch passes custom appearance to contract args`() = test {
+        val customAppearance = PaymentSheet.Appearance(
+            colorsLight = PaymentSheet.Colors.configureDefaultLight(
+                primary = Color.Red
+            )
+        )
+        val launcher = createLauncher(customAppearance)
+
+        launcher.register(activityResultCaller, TestLifecycleOwner())
+
+        assertThat(awaitRegisterCall()).isNotNull()
+        assertThat(awaitNextRegisteredLauncher()).isNotNull()
+
+        launcher.launch(country = "US", googlePlacesApiKey = "test-api-key") {
+            error("Should not be called!")
+        }
+
+        val launchArgs = awaitLaunchCall()
+
+        assertThat(launchArgs).isInstanceOf<AutocompleteContract.Args>()
+
+        val autocompleteArgs = launchArgs as AutocompleteContract.Args
+
+        assertThat(autocompleteArgs.appearance).isEqualTo(customAppearance)
+    }
+
+    @Test
+    fun `activity result callback converts EnterManually result correctly`() = test {
+        val launcher = createLauncher()
+
+        var capturedResult: AutocompleteLauncher.Result? = null
+
+        launcher.register(activityResultCaller, TestLifecycleOwner())
+
+        val registerCall = awaitRegisterCall()
+
+        assertThat(registerCall.contract).isEqualTo(AutocompleteContract)
+        assertThat(awaitNextRegisteredLauncher()).isNotNull()
+
+        launcher.launch(country = "US", googlePlacesApiKey = "test-api-key") {
+            capturedResult = it
+        }
+
+        val launchArgs = awaitLaunchCall()
+
+        assertThat(launchArgs).isInstanceOf<AutocompleteContract.Args>()
+
+        val autocompleteArgs = launchArgs as AutocompleteContract.Args
+
+        val result = AutocompleteContract.Result.EnterManually(
+            id = autocompleteArgs.id,
+            addressDetails = addressDetails
+        )
+
+        registerCall.callback.asCallbackFor<AutocompleteContract.Result>().onActivityResult(result)
+
+        assertThat(capturedResult).isInstanceOf(AutocompleteLauncher.Result.EnterManually::class.java)
+
+        val enterManuallyResult = capturedResult as AutocompleteLauncher.Result.EnterManually
+
+        assertThat(enterManuallyResult.addressDetails).isEqualTo(addressDetails)
+    }
+
+    @Test
+    fun `activity result callback converts Address result correctly`() = test {
+        val launcher = createLauncher()
+
+        var capturedResult: AutocompleteLauncher.Result? = null
+
+        launcher.register(activityResultCaller, TestLifecycleOwner())
+
+        val registerCall = awaitRegisterCall()
+
+        assertThat(registerCall.contract).isEqualTo(AutocompleteContract)
+        assertThat(awaitNextRegisteredLauncher()).isNotNull()
+
+        launcher.launch(country = "US", googlePlacesApiKey = "test-api-key") {
+            capturedResult = it
+        }
+
+        val launchArgs = awaitLaunchCall()
+
+        assertThat(launchArgs).isInstanceOf<AutocompleteContract.Args>()
+
+        val autocompleteArgs = launchArgs as AutocompleteContract.Args
+
+        val result = AutocompleteContract.Result.Address(
+            id = autocompleteArgs.id,
+            addressDetails = addressDetails
+        )
+
+        registerCall.callback.asCallbackFor<AutocompleteContract.Result>().onActivityResult(result)
+
+        assertThat(capturedResult).isInstanceOf<AutocompleteLauncher.Result.OnBack>()
+
+        val onBackResult = capturedResult as AutocompleteLauncher.Result.OnBack
+
+        assertThat(onBackResult.addressDetails).isEqualTo(addressDetails)
+    }
+
+    @Test
+    fun `activity result callback removes listener after invocation`() = test {
+        val launcher = createLauncher()
+        var callbackCalledCount = 0
+
+        launcher.register(activityResultCaller, TestLifecycleOwner())
+
+        val registerCall = awaitRegisterCall()
+
+        assertThat(registerCall.contract).isEqualTo(AutocompleteContract)
+        assertThat(awaitNextRegisteredLauncher()).isNotNull()
+
+        launcher.launch(country = "US", googlePlacesApiKey = "test-api-key") {
+            callbackCalledCount++
+        }
+
+        val launchArgs = awaitLaunchCall()
+
+        assertThat(launchArgs).isInstanceOf<AutocompleteContract.Args>()
+
+        val autocompleteArgs = launchArgs as AutocompleteContract.Args
+
+        val result = AutocompleteContract.Result.EnterManually(
+            id = autocompleteArgs.id,
+            addressDetails = addressDetails
+        )
+
+        val callback = registerCall.callback.asCallbackFor<AutocompleteContract.Result>()
+
+        callback.onActivityResult(result)
+        assertThat(callbackCalledCount).isEqualTo(1)
+
+        callback.onActivityResult(result)
+        assertThat(callbackCalledCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `lifecycle observer unregisters activity launcher on destroy`() = test {
+        val launcher = createLauncher()
+        val lifecycleOwner = TestLifecycleOwner()
+
+        launcher.register(activityResultCaller, lifecycleOwner)
+
+        assertThat(awaitRegisterCall()).isNotNull()
+
+        val registeredLauncher = awaitNextRegisteredLauncher()
+
+        lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+
+        val unregisteredLauncher = awaitNextUnregisteredLauncher()
+        assertThat(unregisteredLauncher).isEqualTo(registeredLauncher)
+    }
+
+    @Test
+    fun `multiple registrations replace previous launcher`() = test {
+        val launcher = createLauncher()
+        val lifecycleOwner1 = TestLifecycleOwner()
+        val lifecycleOwner2 = TestLifecycleOwner()
+
+        // First registration
+        launcher.register(activityResultCaller, lifecycleOwner1)
+        awaitRegisterCall()
+        awaitNextRegisteredLauncher()
+
+        // Second registration should work without issues
+        launcher.register(activityResultCaller, lifecycleOwner2)
+        awaitRegisterCall()
+        awaitNextRegisteredLauncher()
+    }
+
+    @Test
+    fun `launch with different result callbacks maintains separation`() = test {
+        val launcher = createLauncher()
+
+        var firstReceivedResult: AutocompleteLauncher.Result? = null
+        var secondReceivedResult: AutocompleteLauncher.Result? = null
+
+        launcher.register(activityResultCaller, TestLifecycleOwner())
+
+        val registerCall = awaitRegisterCall()
+
+        assertThat(registerCall.contract).isEqualTo(AutocompleteContract)
+        assertThat(awaitNextRegisteredLauncher()).isNotNull()
+
+        launcher.launch(country = "US", googlePlacesApiKey = "test-api-key") {
+            firstReceivedResult = it
+        }
+
+        launcher.launch(country = "CA", googlePlacesApiKey = "test-api-key") {
+            secondReceivedResult = it
+        }
+
+        val firstLaunchCall = awaitLaunchCall()
+
+        assertThat(firstLaunchCall).isInstanceOf<AutocompleteContract.Args>()
+
+        val firstAutocompleteArgs = firstLaunchCall as AutocompleteContract.Args
+
+        val secondLaunchCall = awaitLaunchCall()
+
+        assertThat(firstLaunchCall).isInstanceOf<AutocompleteContract.Args>()
+
+        val secondAutocompleteArgs = secondLaunchCall as AutocompleteContract.Args
+
+        val callback = registerCall.callback.asCallbackFor<AutocompleteContract.Result>()
+
+        val firstAutocompleteResult = AutocompleteContract.Result.EnterManually(
+            id = firstAutocompleteArgs.id,
+            addressDetails = addressDetails
+        )
+
+        callback.onActivityResult(firstAutocompleteResult)
+
+        val secondAutocompleteResult = AutocompleteContract.Result.Address(
+            id = secondAutocompleteArgs.id,
+            addressDetails = addressDetails
+        )
+        callback.onActivityResult(secondAutocompleteResult)
+
+        assertThat(firstReceivedResult).isInstanceOf(AutocompleteLauncher.Result.EnterManually::class.java)
+        assertThat(secondReceivedResult).isInstanceOf(AutocompleteLauncher.Result.OnBack::class.java)
+    }
+
+    private fun test(
+        test: suspend DummyActivityResultCaller.Scenario.() -> Unit
+    ) = runTest {
+        DummyActivityResultCaller.test(test)
+    }
+
+    private fun createLauncher(
+        appearance: PaymentSheet.Appearance = this.appearance
+    ) = DefaultAutocompleteLauncher(appearance)
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractorTest.kt
@@ -1,0 +1,227 @@
+package com.stripe.android.paymentsheet.addresselement
+
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
+import com.stripe.android.uicore.elements.IdentifierSpec
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class PaymentElementAutocompleteAddressInteractorTest {
+    @Test
+    fun `onAutocomplete launches when googlePlacesApiKey is present`() = test { scenario ->
+        val interactor = createInteractor(
+            launcher = scenario.launcher,
+            autocompleteConfig = AutocompleteAddressInteractor.Config(
+                googlePlacesApiKey = "test-api-key",
+                autocompleteCountries = setOf("US", "CA")
+            )
+        )
+
+        interactor.onAutocomplete("US")
+
+        scenario.launchCalls.expectMostRecentItem().let { call ->
+            assertThat(call.country).isEqualTo("US")
+            assertThat(call.googlePlacesApiKey).isEqualTo("test-api-key")
+        }
+    }
+
+    @Test
+    fun `onAutocomplete does nothing when googlePlacesApiKey is null`() = test { scenario ->
+        val interactor = createInteractor(
+            launcher = scenario.launcher,
+            autocompleteConfig = AutocompleteAddressInteractor.Config(
+                googlePlacesApiKey = null,
+                autocompleteCountries = setOf("US", "CA")
+            )
+        )
+
+        interactor.onAutocomplete("US")
+
+        scenario.launchCalls.expectNoEvents()
+    }
+
+    @Test
+    fun `emits 'OnExpandForm' event when launcher result is EnterManually`() = test { scenario ->
+        val interactor = createInteractor(launcher = scenario.launcher)
+
+        interactor.autocompleteEvent.test {
+            interactor.onAutocomplete("US")
+
+            val launchCall = scenario.launchCalls.awaitItem()
+
+            val addressDetails = createTestAddressDetails()
+            val result = AutocompleteLauncher.Result.EnterManually(addressDetails)
+
+            launchCall.onResult(result)
+
+            val event = awaitItem()
+
+            assertThat(event).isInstanceOf(AutocompleteAddressInteractor.Event.OnExpandForm::class.java)
+
+            val expandFormEvent = event as AutocompleteAddressInteractor.Event.OnExpandForm
+
+            assertThat(expandFormEvent.values).isNotNull()
+            assertThat(expandFormEvent.values?.get(IdentifierSpec.Line1)).isEqualTo("123 Main Street")
+        }
+    }
+
+    @Test
+    fun `emits OnValues event when launcher result is OnBack with address details`() = test { scenario ->
+        val interactor = createInteractor(launcher = scenario.launcher)
+
+        interactor.autocompleteEvent.test {
+            interactor.onAutocomplete("US")
+
+            val launchCall = scenario.launchCalls.awaitItem()
+
+            val addressDetails = createTestAddressDetails()
+            val result = AutocompleteLauncher.Result.OnBack(addressDetails)
+
+            launchCall.onResult(result)
+
+            val event = awaitItem()
+
+            assertThat(event).isInstanceOf(AutocompleteAddressInteractor.Event.OnValues::class.java)
+
+            val valuesEvent = event as AutocompleteAddressInteractor.Event.OnValues
+
+            assertThat(valuesEvent.values).isNotNull()
+            assertThat(valuesEvent.values[IdentifierSpec.Line1]).isEqualTo("123 Main Street")
+        }
+    }
+
+    @Test
+    fun `does not emit event when launcher result is OnBack with null address details`() = test { scenario ->
+        val interactor = createInteractor(launcher = scenario.launcher)
+
+        interactor.autocompleteEvent.test {
+            interactor.onAutocomplete("US")
+
+            val launchCall = scenario.launchCalls.awaitItem()
+            val result = AutocompleteLauncher.Result.OnBack(null)
+
+            launchCall.onResult(result)
+
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `emits OnExpandForm event when launcher result is EnterManually with null address`() = test { scenario ->
+        val interactor = createInteractor(launcher = scenario.launcher)
+
+        interactor.autocompleteEvent.test {
+            interactor.onAutocomplete("US")
+
+            val launchCall = scenario.launchCalls.awaitItem()
+            val result = AutocompleteLauncher.Result.EnterManually(null)
+
+            launchCall.onResult(result)
+
+            val event = awaitItem()
+
+            assertThat(event).isInstanceOf(AutocompleteAddressInteractor.Event.OnExpandForm::class.java)
+
+            val expandFormEvent = event as AutocompleteAddressInteractor.Event.OnExpandForm
+
+            assertThat(expandFormEvent.values).isNull()
+        }
+    }
+
+    @Test
+    fun `autocompleteConfig property returns provided config`() = test { scenario ->
+        val config = AutocompleteAddressInteractor.Config(
+            googlePlacesApiKey = "test-key",
+            autocompleteCountries = setOf("US", "GB")
+        )
+        val interactor = createInteractor(launcher = scenario.launcher, autocompleteConfig = config)
+
+        assertThat(interactor.autocompleteConfig).isEqualTo(config)
+        assertThat(interactor.autocompleteConfig.googlePlacesApiKey).isEqualTo("test-key")
+        assertThat(interactor.autocompleteConfig.autocompleteCountries).containsExactly("US", "GB")
+    }
+
+    @Test
+    fun `Factory creates PaymentElementAutocompleteAddressInteractor`() = test { scenario ->
+        val config = AutocompleteAddressInteractor.Config(
+            googlePlacesApiKey = "test-key",
+            autocompleteCountries = setOf("US")
+        )
+
+        val factory = PaymentElementAutocompleteAddressInteractor.Factory(
+            launcher = scenario.launcher,
+            interactorScope = backgroundScope,
+            autocompleteConfig = config
+        )
+
+        val interactor = factory.create()
+
+        assertThat(interactor).isInstanceOf(PaymentElementAutocompleteAddressInteractor::class.java)
+        assertThat(interactor.autocompleteConfig).isEqualTo(config)
+        assertThat(interactor.interactorScope).isEqualTo(backgroundScope)
+    }
+
+    @Test
+    fun `multiple onAutocomplete calls with different countries`() = test { scenario ->
+        val interactor = createInteractor(launcher = scenario.launcher)
+
+        interactor.onAutocomplete("US")
+        interactor.onAutocomplete("CA")
+        interactor.onAutocomplete("GB")
+
+        val usCall = scenario.launchCalls.awaitItem()
+
+        assertThat(usCall.country).isEqualTo("US")
+        assertThat(usCall.googlePlacesApiKey).isEqualTo("test-api-key")
+
+        val caCall = scenario.launchCalls.awaitItem()
+
+        assertThat(caCall.country).isEqualTo("CA")
+        assertThat(caCall.googlePlacesApiKey).isEqualTo("test-api-key")
+
+        val gbCall = scenario.launchCalls.awaitItem()
+
+        assertThat(gbCall.country).isEqualTo("GB")
+        assertThat(gbCall.googlePlacesApiKey).isEqualTo("test-api-key")
+    }
+
+    private fun test(test: suspend TestScope.(TestAutocompleteLauncher.Scenario) -> Unit) = runTest(
+        UnconfinedTestDispatcher()
+    ) {
+        TestAutocompleteLauncher.test {
+            test(this)
+        }
+    }
+
+    private fun TestScope.createInteractor(
+        launcher: AutocompleteLauncher = TestAutocompleteLauncher.noOp(),
+        autocompleteConfig: AutocompleteAddressInteractor.Config = AutocompleteAddressInteractor.Config(
+            googlePlacesApiKey = "test-api-key",
+            autocompleteCountries = setOf("US", "CA")
+        ),
+        interactorScope: CoroutineScope = backgroundScope
+    ) = PaymentElementAutocompleteAddressInteractor(
+        launcher = launcher,
+        interactorScope = interactorScope,
+        autocompleteConfig = autocompleteConfig
+    )
+
+    private fun createTestAddressDetails() = AddressDetails(
+        name = "John Doe",
+        address = PaymentSheet.Address(
+            line1 = "123 Main Street",
+            line2 = "Apt 4B",
+            city = "San Francisco",
+            state = "CA",
+            postalCode = "94105",
+            country = "US"
+        ),
+        phoneNumber = "555-123-4567",
+        isCheckboxSelected = true
+    )
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/TestAutocompleteAddressInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/TestAutocompleteAddressInteractor.kt
@@ -1,0 +1,20 @@
+package com.stripe.android.paymentsheet.addresselement
+
+import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+
+class TestAutocompleteAddressInteractor(
+    override val interactorScope: CoroutineScope,
+    config: AutocompleteAddressInteractor.Config = AutocompleteAddressInteractor.Config(
+        googlePlacesApiKey = null,
+        autocompleteCountries = emptySet()
+    ),
+    override val autocompleteEvent: MutableSharedFlow<AutocompleteAddressInteractor.Event> = MutableSharedFlow(),
+) : AutocompleteAddressInteractor {
+    override val autocompleteConfig: AutocompleteAddressInteractor.Config = config
+
+    override fun onAutocomplete(country: String) {
+        error("Should not be called!")
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/TestAutocompleteAddressInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/TestAutocompleteAddressInteractor.kt
@@ -1,20 +1,70 @@
 package com.stripe.android.paymentsheet.addresselement
 
+import app.cash.turbine.ReceiveTurbine
+import app.cash.turbine.Turbine
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.MutableSharedFlow
 
-class TestAutocompleteAddressInteractor(
-    override val interactorScope: CoroutineScope,
-    config: AutocompleteAddressInteractor.Config = AutocompleteAddressInteractor.Config(
-        googlePlacesApiKey = null,
-        autocompleteCountries = emptySet()
-    ),
-    override val autocompleteEvent: MutableSharedFlow<AutocompleteAddressInteractor.Event> = MutableSharedFlow(),
+class TestAutocompleteAddressInteractor private constructor(
+    override val autocompleteConfig: AutocompleteAddressInteractor.Config,
 ) : AutocompleteAddressInteractor {
-    override val autocompleteConfig: AutocompleteAddressInteractor.Config = config
+    private val registerCalls = Turbine<Call.Register>()
+    private val onAutocompleteCalls = Turbine<Call.OnAutocomplete>()
+
+    override fun register(onEvent: (AutocompleteAddressInteractor.Event) -> Unit) {
+        registerCalls.add(Call.Register(onEvent))
+    }
 
     override fun onAutocomplete(country: String) {
-        error("Should not be called!")
+        onAutocompleteCalls.add(Call.OnAutocomplete(country))
+    }
+
+    sealed interface Call {
+        class Register(
+            val onEvent: (AutocompleteAddressInteractor.Event) -> Unit
+        )
+
+        class OnAutocomplete(
+            val country: String
+        )
+    }
+
+    class Scenario(
+        val interactor: AutocompleteAddressInteractor,
+        val registerCalls: ReceiveTurbine<Call.Register>,
+        val onAutocompleteCalls: ReceiveTurbine<Call.OnAutocomplete>,
+    )
+
+    companion object {
+        suspend fun test(
+            autocompleteConfig: AutocompleteAddressInteractor.Config,
+            test: suspend Scenario.() -> Unit,
+        ) {
+            val interactor = TestAutocompleteAddressInteractor(
+                autocompleteConfig = autocompleteConfig,
+            )
+
+            val registerCalls = interactor.registerCalls
+            val onAutocompleteCalls = interactor.onAutocompleteCalls
+
+            test(
+                Scenario(
+                    interactor = interactor,
+                    registerCalls = registerCalls,
+                    onAutocompleteCalls = onAutocompleteCalls,
+                )
+            )
+
+            registerCalls.ensureAllEventsConsumed()
+            onAutocompleteCalls.ensureAllEventsConsumed()
+        }
+
+        fun noOp(
+            autocompleteConfig: AutocompleteAddressInteractor.Config = AutocompleteAddressInteractor.Config(
+                googlePlacesApiKey = null,
+                autocompleteCountries = emptySet()
+            ),
+        ) = TestAutocompleteAddressInteractor(
+            autocompleteConfig = autocompleteConfig,
+        )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/TestAutocompleteLauncher.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/TestAutocompleteLauncher.kt
@@ -9,13 +9,13 @@ internal class TestAutocompleteLauncher private constructor() : AutocompleteLaun
     override fun launch(
         country: String,
         googlePlacesApiKey: String,
-        onResult: (AutocompleteLauncher.Result) -> Unit
+        resultHandler: AutocompleteLauncherResultHandler,
     ) {
         launchCalls.add(
             LaunchCall(
                 country = country,
                 googlePlacesApiKey = googlePlacesApiKey,
-                onResult = onResult,
+                resultHandler = resultHandler,
             )
         )
     }
@@ -23,7 +23,7 @@ internal class TestAutocompleteLauncher private constructor() : AutocompleteLaun
     class LaunchCall(
         val country: String,
         val googlePlacesApiKey: String,
-        val onResult: (AutocompleteLauncher.Result) -> Unit
+        val resultHandler: AutocompleteLauncherResultHandler,
     )
 
     class Scenario(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/TestAutocompleteLauncher.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/TestAutocompleteLauncher.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.paymentsheet.addresselement
+
+import app.cash.turbine.ReceiveTurbine
+import app.cash.turbine.Turbine
+
+internal class TestAutocompleteLauncher private constructor() : AutocompleteLauncher {
+    private val launchCalls = Turbine<LaunchCall>()
+
+    override fun launch(
+        country: String,
+        googlePlacesApiKey: String,
+        onResult: (AutocompleteLauncher.Result) -> Unit
+    ) {
+        launchCalls.add(
+            LaunchCall(
+                country = country,
+                googlePlacesApiKey = googlePlacesApiKey,
+                onResult = onResult,
+            )
+        )
+    }
+
+    class LaunchCall(
+        val country: String,
+        val googlePlacesApiKey: String,
+        val onResult: (AutocompleteLauncher.Result) -> Unit
+    )
+
+    class Scenario(
+        val launcher: AutocompleteLauncher,
+        val launchCalls: ReceiveTurbine<LaunchCall>
+    )
+
+    companion object {
+        suspend fun test(test: suspend Scenario.() -> Unit) {
+            val launcher = TestAutocompleteLauncher()
+
+            test(
+                Scenario(
+                    launcher = launcher,
+                    launchCalls = launcher.launchCalls
+                )
+            )
+
+            launcher.launchCalls.ensureAllEventsConsumed()
+        }
+
+        fun noOp(): AutocompleteLauncher = TestAutocompleteLauncher()
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
@@ -21,6 +21,7 @@ import com.stripe.android.ui.core.elements.NameSpec
 import com.stripe.android.ui.core.elements.PhoneSpec
 import com.stripe.android.ui.core.elements.SaveForFutureUseElement
 import com.stripe.android.uicore.elements.AddressElement
+import com.stripe.android.uicore.elements.AddressFieldsElement
 import com.stripe.android.uicore.elements.CountryElement
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
@@ -242,7 +243,7 @@ internal class FormViewModelTest {
             IdentifierSpec.Generic("address"),
             allowedCountryCodes = setOf("US", "JP")
         )
-            .transform(emptyMap(), emptyMap())
+            .transform(emptyMap(), emptyMap(), null)
             .toTypedArray()
 
         val formViewModel = createViewModel(
@@ -327,7 +328,7 @@ internal class FormViewModelTest {
             IdentifierSpec.Generic("address"),
             allowedCountryCodes = setOf("US", "JP")
         )
-            .transform(emptyMap(), emptyMap())
+            .transform(emptyMap(), emptyMap(), null)
             .toTypedArray()
 
         val formViewModel = createViewModel(
@@ -542,7 +543,7 @@ internal class FormViewModelTest {
             val countryElement = elements
                 .filterIsInstance<SectionElement>()
                 .flatMap { it.fields }
-                .filterIsInstance<AddressElement>()
+                .filterIsInstance<AddressFieldsElement>()
                 .firstOrNull()
                 ?.countryElement
             val phoneElement = elements
@@ -583,6 +584,7 @@ internal class FormViewModelTest {
                 .transform(
                     initialValues = emptyMap(),
                     shippingValues = emptyMap(),
+                    autocompleteAddressInteractorFactory = null,
                 )
                 .toTypedArray()
             val formViewModel = createViewModel(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeAddPaymentMethodInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeAddPaymentMethodInteractor.kt
@@ -39,6 +39,7 @@ internal class FakeAddPaymentMethodInteractor(
                 cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
                 linkConfigurationCoordinator = null,
                 onLinkInlineSignupStateChanged = { throw AssertionError("Not expected") },
+                autocompleteAddressInteractorFactory = null,
             )
 
             return AddPaymentMethodInteractor.State(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakeVerticalModeFormInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakeVerticalModeFormInteractor.kt
@@ -37,6 +37,7 @@ internal class FakeVerticalModeFormInteractor private constructor(
                 cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
                 linkConfigurationCoordinator = null,
                 onLinkInlineSignupStateChanged = { throw AssertionError("Not expected") },
+                autocompleteAddressInteractorFactory = null,
             )
 
             return FakeVerticalModeFormInteractor(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/FakeBaseSheetViewModel.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/FakeBaseSheetViewModel.kt
@@ -1,5 +1,7 @@
 package com.stripe.android.paymentsheet.viewmodels
 
+import androidx.activity.result.ActivityResultCaller
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
@@ -91,6 +93,10 @@ internal class FakeBaseSheetViewModel private constructor(
     override val error: StateFlow<ResolvableString?> = errorSource.asStateFlow()
 
     override var newPaymentSelection: NewPaymentOptionSelection? = null
+
+    override fun registerFromActivity(activityResultCaller: ActivityResultCaller, lifecycleOwner: LifecycleOwner) {
+        throw AssertionError("Not expected.")
+    }
 
     override fun onError(error: ResolvableString?) {
         errorSource.value = error

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressElement.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.flow.StateFlow
 import com.stripe.android.core.R as CoreR
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-open class AddressElement(
+class AddressElement(
     _identifier: IdentifierSpec,
     private var rawValuesMap: Map<IdentifierSpec, String?> = emptyMap(),
     private val addressInputMode: AddressInputMode = AddressInputMode.NoAutocomplete(),
@@ -29,13 +29,13 @@ open class AddressElement(
     private val isPlacesAvailable: IsPlacesAvailable = DefaultIsPlacesAvailable(),
     private val hideCountry: Boolean = false,
     private val hideName: Boolean = true,
-) : SectionMultiFieldElement(_identifier) {
+) : SectionMultiFieldElement(_identifier), AddressFieldsElement {
 
     override val allowsUserInteraction: Boolean = true
     override val mandateText: ResolvableString? = null
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    val countryElement = CountryElement(
+    override val countryElement = CountryElement(
         IdentifierSpec.Country,
         countryDropdownFieldController
     )

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressElement.kt
@@ -18,7 +18,7 @@ import com.stripe.android.core.R as CoreR
 class AddressElement(
     _identifier: IdentifierSpec,
     private var rawValuesMap: Map<IdentifierSpec, String?> = emptyMap(),
-    private val addressInputMode: AddressInputMode = AddressInputMode.NoAutocomplete(),
+    val addressInputMode: AddressInputMode = AddressInputMode.NoAutocomplete(),
     countryCodes: Set<String> = emptySet(),
     countryDropdownFieldController: DropdownFieldController = DropdownFieldController(
         CountryConfig(countryCodes),

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressFieldsElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressFieldsElement.kt
@@ -1,0 +1,8 @@
+package com.stripe.android.uicore.elements
+
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+interface AddressFieldsElement : SectionFieldElement {
+    val countryElement: CountryElement
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressController.kt
@@ -23,6 +23,10 @@ class AutocompleteAddressController(
     val initialValues: Map<IdentifierSpec, String?>,
     private val interactor: AutocompleteAddressInteractor,
     countryCodes: Set<String> = emptySet(),
+    private val countryDropdownFieldController: DropdownFieldController = DropdownFieldController(
+        CountryConfig(countryCodes),
+        initialValues[IdentifierSpec.Country]
+    ),
     private val phoneNumberState: PhoneNumberState,
     private val sameAsShippingElement: SameAsShippingElement?,
     private val shippingValuesMap: Map<IdentifierSpec, String?>?,
@@ -35,11 +39,6 @@ class AutocompleteAddressController(
     private var currentValues = initialValues
     private var expandForm = false
     private val addressInputMode = MutableStateFlow(toAddressInputMode(expandForm, initialValues))
-
-    private val countryDropdownFieldController = DropdownFieldController(
-        CountryConfig(countryCodes),
-        initialValues[IdentifierSpec.Country]
-    )
 
     override val error: StateFlow<FieldError?> = stateFlowOf(null)
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressElement.kt
@@ -16,7 +16,7 @@ class AutocompleteAddressElement(
     sameAsShippingElement: SameAsShippingElement?,
     shippingValuesMap: Map<IdentifierSpec, String?>?,
     isPlacesAvailable: IsPlacesAvailable = DefaultIsPlacesAvailable(),
-    interactor: AutocompleteAddressInteractor,
+    interactorFactory: AutocompleteAddressInteractor.Factory,
     hideCountry: Boolean = false,
     hideName: Boolean = true,
 ) : AddressFieldsElement {
@@ -30,7 +30,7 @@ class AutocompleteAddressElement(
             sameAsShippingElement = sameAsShippingElement,
             shippingValuesMap = shippingValuesMap,
             isPlacesAvailable = isPlacesAvailable,
-            interactor = interactor,
+            interactorFactory = interactorFactory,
             hideCountry = hideCountry,
             hideName = hideName,
         )

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressElement.kt
@@ -4,10 +4,14 @@ import androidx.annotation.RestrictTo
 import com.stripe.android.core.strings.ResolvableString
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-open class AutocompleteAddressElement(
+class AutocompleteAddressElement(
     override val identifier: IdentifierSpec,
     initialValues: Map<IdentifierSpec, String?>,
     countryCodes: Set<String> = emptySet(),
+    countryDropdownFieldController: DropdownFieldController = DropdownFieldController(
+        CountryConfig(countryCodes),
+        initialValues[IdentifierSpec.Country]
+    ),
     phoneNumberState: PhoneNumberState = PhoneNumberState.HIDDEN,
     sameAsShippingElement: SameAsShippingElement?,
     shippingValuesMap: Map<IdentifierSpec, String?>?,
@@ -15,12 +19,13 @@ open class AutocompleteAddressElement(
     interactor: AutocompleteAddressInteractor,
     hideCountry: Boolean = false,
     hideName: Boolean = true,
-) : SectionFieldElement {
+) : AddressFieldsElement {
     private val controller by lazy {
         AutocompleteAddressController(
             identifier = identifier,
             initialValues = initialValues,
             countryCodes = countryCodes,
+            countryDropdownFieldController = countryDropdownFieldController,
             phoneNumberState = phoneNumberState,
             sameAsShippingElement = sameAsShippingElement,
             shippingValuesMap = shippingValuesMap,
@@ -30,6 +35,9 @@ open class AutocompleteAddressElement(
             hideName = hideName,
         )
     }
+
+    override val countryElement: CountryElement
+        get() = controller.addressElementFlow.value.countryElement
 
     override val allowsUserInteraction: Boolean = true
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressInteractor.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressInteractor.kt
@@ -1,16 +1,12 @@
 package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.SharedFlow
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 interface AutocompleteAddressInteractor {
-    val interactorScope: CoroutineScope
-
     val autocompleteConfig: Config
 
-    val autocompleteEvent: SharedFlow<Event>
+    fun register(onEvent: (Event) -> Unit)
 
     fun onAutocomplete(country: String)
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressInteractor.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressInteractor.kt
@@ -30,4 +30,9 @@ interface AutocompleteAddressInteractor {
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         data class OnValues(override val values: Map<IdentifierSpec, String?>) : Event
     }
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    fun interface Factory {
+        fun create(): AutocompleteAddressInteractor
+    }
 }


### PR DESCRIPTION
# Summary
Supports address autocomplete in `PaymentSheet` and `FlowController`.

**Note**: We will also be supporting Customer Sheet, Embedded, Link, and US Bank Account. This support will follow this PR.

# Motivation
Merchant ask for address autocomplete in MPE

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified