### PR TITLE
Add allowedShippingCountries to ShopPayConfiguration

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/data/ShopPayData.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/data/ShopPayData.kt
@@ -67,7 +67,8 @@ internal object ShopPayData {
                     amount = shippingRates.first().amount
                 ),
             ),
-            shippingRates = shippingRates
+            shippingRates = shippingRates,
+            allowedShippingCountries = listOf("US", "CA")
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -2906,6 +2906,7 @@ class PaymentSheet internal constructor(
         val billingAddressRequired: Boolean = true,
         val emailRequired: Boolean = true,
         val shippingAddressRequired: Boolean,
+        val allowedShippingCountries: List<String>,
         val lineItems: List<LineItem>,
         val shippingRates: List<ShippingRate>
     ) : Parcelable {

--- a/paymentsheet/src/main/java/com/stripe/android/shoppay/bridge/DefaultShopPayBridgeHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/shoppay/bridge/DefaultShopPayBridgeHandler.kt
@@ -57,7 +57,7 @@ internal class DefaultShopPayBridgeHandler @Inject constructor(
             emailRequired = shopPayConfiguration.emailRequired,
             phoneNumberRequired = true, // Shop Pay always requires phone
             shippingAddressRequired = shopPayConfiguration.shippingAddressRequired,
-            allowedShippingCountries = listOf("US", "CA"),
+            allowedShippingCountries = shopPayConfiguration.allowedShippingCountries,
             businessName = shopPayArgs.businessName,
             shopId = shopPayConfiguration.shopId,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/common/model/ShopPayConfigurationFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/model/ShopPayConfigurationFactory.kt
@@ -20,5 +20,6 @@ internal val SHOP_PAY_CONFIGURATION = PaymentSheet.ShopPayConfiguration(
             displayName = "Express",
             deliveryEstimate = PaymentSheet.ShopPayConfiguration.DeliveryEstimate.Text("2 business days")
         )
-    )
+    ),
+    allowedShippingCountries = listOf("US", "CA")
 )

--- a/paymentsheet/src/test/java/com/stripe/android/shoppay/bridge/DefaultShopPayBridgeHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/shoppay/bridge/DefaultShopPayBridgeHandlerTest.kt
@@ -48,7 +48,12 @@ internal class DefaultShopPayBridgeHandlerTest {
         assertThat(data.getJSONObject("business").getString("name")).isEqualTo("Test Business")
         assertThat(data.getString("shopId")).isEqualTo(SHOP_PAY_CONFIGURATION.shopId)
         assertThat(data.getBoolean("phoneNumberRequired")).isTrue()
-        assertThat(data.getJSONArray("allowedShippingCountries").length()).isEqualTo(2)
+
+        val allowedShippingCountries = data.getJSONArray("allowedShippingCountries")
+        for (i in 0 until allowedShippingCountries.length()) {
+            assertThat(allowedShippingCountries[i])
+                .isEqualTo(ShopPayTestFactory.SHOP_PAY_ARGS.shopPayConfiguration.allowedShippingCountries[i])
+        }
     }
 
     @Test


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
`allowedShippingCountries` was missed when creating `ShopPayConfiguration`
https://github.com/stripe/stripe-ios/blob/2892b69456a6d3b71234ffd12a924a2c63760203/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift#L596

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
