### PR TITLE
Limit autofill to first text field

### DIFF
--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/OTPElementUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/OTPElementUI.kt
@@ -149,10 +149,6 @@ fun OTPElementUI(
 
                 var textFieldModifier = Modifier
                     .height(56.dp)
-                    .autofill(
-                        types = listOf(AutofillType.SmsOtpCode),
-                        onFill = element.controller::onAutofillDigit,
-                    )
                     .onFocusChanged { focusState ->
                         if (focusState.isFocused) {
                             focusedElementIndex = index
@@ -177,7 +173,12 @@ fun OTPElementUI(
                     .semantics { testTagsAsResourceId = true }
 
                 if (index == 0) {
-                    textFieldModifier = textFieldModifier.focusRequester(focusRequester)
+                    textFieldModifier = textFieldModifier
+                        .focusRequester(focusRequester)
+                        .autofill(
+                            types = listOf(AutofillType.SmsOtpCode),
+                            onFill = element.controller::onAutofillDigit,
+                        )
                 }
 
                 OTPInputBox(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where enabling autofill on every OTP text field caused some weird UI jank with the keyboard.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screen recording

**The issue**

https://github.com/user-attachments/assets/9834e6b9-1b1e-440e-99d3-c80f1cfc3704


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
