### PR TITLE
Always pass paymentMethodOptions when shop_id is available

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/data/ShopPayData.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/data/ShopPayData.kt
@@ -45,7 +45,7 @@ internal object ShopPayData {
 
     internal fun shopPayConfiguration(): PaymentSheet.ShopPayConfiguration {
         return PaymentSheet.ShopPayConfiguration(
-            shopId = "shop_id_123",
+            shopId = "92917334038",
             billingAddressRequired = true,
             emailRequired = true,
             shippingAddressRequired = true,

--- a/paymentsheet/src/main/assets/www/index.html
+++ b/paymentsheet/src/main/assets/www/index.html
@@ -33,13 +33,17 @@
           currency: "usd",
           payment_method_types: ["card", "link", "shop_pay"],
           customerSessionClientSecret: initParams.customerSessionClientSecret,
-          //paymentMethodOptions: {
-          //  shop_pay: {
-          //    shop_id: initParams.shopId,
-          //  },
-          //},
           __elementsInitSource: 'native_sdk',
         };
+
+        // Only add paymentMethodOptions if shop_id is not null or blank
+        if (initParams.shopId && initParams.shopId.trim() !== '') {
+          options.paymentMethodOptions = {
+            shop_pay: {
+              shop_id: initParams.shopId,
+            },
+          };
+        }
 
       console.log("Initializing stripe elements with options", options);
 
@@ -78,6 +82,8 @@
         console.log("Ready to mount");
       expressCheckoutElement.mount("#express-checkout-element");
       //When expressCheckoutElement is mounted, ready event tries to show the available payment methods
+
+      let clickEventReceived = false;
       expressCheckoutElement.on("ready", ({ availablePaymentMethods }) => {
         const expressCheckoutDiv = document.getElementById(
           "express-checkout-element"
@@ -87,10 +93,50 @@
         } else {
           expressCheckoutDiv.style.visibility = "initial";
         }
-        expressCheckoutElement._sendNativeSdkClick({paymentMethodType: 'shop_pay'})
+
+        console.log("Attempting to trigger Shop Pay click immediately...");
+        try {
+          // Check if a click event was already received
+          if (!clickEventReceived) {
+            expressCheckoutElement._sendNativeSdkClick({paymentMethodType: 'shop_pay'});
+            console.log("Initial Shop Pay click triggered");
+          } else {
+            console.log("Click event already received, skipping initial click");
+          }
+        } catch (error) {
+          console.error("Failed on initial Shop Pay click:", error);
+        }
+        // Then continue with additional attempts every 100ms for 1 second, up to 5 clicks
+        let clickCount = 1;
+        const maxClicks = 5;
+        const clickInterval = setInterval(() => {
+          // Stop if a click event was received
+          if (clickEventReceived) {
+            console.log("Click event received, stopping further click attempts");
+            clearInterval(clickInterval);
+            return;
+          }
+          // Stop if we've reached the maximum number of clicks
+          if (clickCount >= maxClicks) {
+              console.log(`Reached maximum ${maxClicks} click attempts, stopping further attempts`);
+              clearInterval(clickInterval);
+              return;
+          }
+          clickCount++;
+          console.log(`Attempting Shop Pay click #${clickCount}...`);
+          try {
+            expressCheckoutElement._sendNativeSdkClick({paymentMethodType: 'shop_pay'});
+            console.log(`Shop Pay click #${clickCount} triggered`);
+          } catch (error) {
+            console.error(`Failed on Shop Pay click #${clickCount}:`, error);
+          }
+        }, 100);
       });
 
       expressCheckoutElement.on("click", async function (event) {
+      // We need to know when to stop sending _sendNativeSdkClick
+        clickEventReceived = true;
+
         console.log(`Click received with event:\n${hashToString(event)}`);
         try {
           // Extract only serializable data from the event
@@ -127,7 +173,7 @@
               address: event.address
             });
 
-            console.log(`Bridge Response:\n${hashToString(response)}`);
+            // console.log(`Bridge Response:\n${hashToString(response)}`);
 
             // Check if merchant rejected the address
             if (response.error) {
@@ -162,7 +208,7 @@
         try {
             const response = await window.NativeStripeECE.calculateShippingRateChange(event.shippingRate);
 
-            console.log(`Bridge response:\n${hashToString(response)}`);
+            // console.log(`Bridge response:\n${hashToString(response)}`);
 
             // Check if merchant rejected the rate
             if (response.error) {
@@ -224,7 +270,7 @@
 
             const response = await window.NativeStripeECE.confirmPayment(paymentDetails);
 
-            console.log(`Native Payment API Response:\n${hashToString(response)}`);
+            // console.log(`Native Payment API Response:\n${hashToString(response)}`);
         } catch (error) {
           console.log(`Error confirming payment: ${error.message}`);
           console.error("Payment confirmation error:", error);

--- a/paymentsheet/src/main/assets/www/index.html
+++ b/paymentsheet/src/main/assets/www/index.html
@@ -173,8 +173,6 @@
               address: event.address
             });
 
-            // console.log(`Bridge Response:\n${hashToString(response)}`);
-
             // Check if merchant rejected the address
             if (response.error) {
               console.log(`Shipping rejected: ${response.error}`);
@@ -207,8 +205,6 @@
 
         try {
             const response = await window.NativeStripeECE.calculateShippingRateChange(event.shippingRate);
-
-            // console.log(`Bridge response:\n${hashToString(response)}`);
 
             // Check if merchant rejected the rate
             if (response.error) {
@@ -268,9 +264,7 @@
               paymentMethodOptions: event._paymentMethodOptions,
             };
 
-            const response = await window.NativeStripeECE.confirmPayment(paymentDetails);
-
-            // console.log(`Native Payment API Response:\n${hashToString(response)}`);
+            await window.NativeStripeECE.confirmPayment(paymentDetails);
         } catch (error) {
           console.log(`Error confirming payment: ${error.message}`);
           console.error("Payment confirmation error:", error);


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Always pass paymentMethodOptions when shop_id is available
[Also retry native click of shop pay button](https://github.com/stripe/stripe-ios/pull/5097#issue-3194506655)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
