### PR TITLE
Fix app bar issue in signup flow

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/LinkAppBarState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/LinkAppBarState.kt
@@ -47,8 +47,18 @@ internal data class LinkAppBarState(
             }
 
             val title = when (route) {
-                LinkScreen.PaymentMethod.route -> R.string.stripe_add_payment_method.resolvableString
-                LinkScreen.UpdateCard.route -> updateCardTitle(currentEntry)
+                LinkScreen.PaymentMethod.route -> {
+                    if (consumerIsSigningUp) {
+                        // Don't show a title if there's no previous screen, which is the case
+                        // if we're in the signup flow
+                        null
+                    } else {
+                        R.string.stripe_add_payment_method.resolvableString
+                    }
+                }
+                LinkScreen.UpdateCard.route -> {
+                    updateCardTitle(currentEntry)
+                }
                 else -> null
             }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where the Link logo and the app bar title appear together when they shouldn't.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
