### PR TITLE
Use new backend endpoint for connect example app

### DIFF
--- a/connect-example/src/main/java/com/stripe/android/connect/example/data/EmbeddedComponentService.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/data/EmbeddedComponentService.kt
@@ -48,7 +48,7 @@ interface EmbeddedComponentService {
     suspend fun fetchClientSecret(account: String): String
 
     companion object {
-        const val DEFAULT_SERVER_BASE_URL = "https://stripe-connect-mobile-example-v1.glitch.me/"
+        const val DEFAULT_SERVER_BASE_URL = "https://connect-test.vercelapp.stripe.dev/api/mobile-example-app/"
     }
 }
 


### PR DESCRIPTION
# Summary
As Glitch gets sunset, I've moved the backend server implementation into a test site that Connect owns as we'll continue to need this functionality for a while. 

https://github.com/user-attachments/assets/3d0c975f-2d16-4c47-9051-48f1b8656c17




# Motivation
Glitch shutting down

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
