### PR TITLE
Use correct shipping address for Shop Pay

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/shoppay/ShopPayViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/shoppay/ShopPayViewModel.kt
@@ -87,6 +87,7 @@ internal class ShopPayViewModel @Inject constructor(
         confirmationState: ShopPayConfirmationState.Success
     ): ShopPayActivityResult {
         val address = confirmationState.billingDetails.address
+        val shippingAddressData = confirmationState.shippingAddressData
         val paymentMethodCreateParams = PaymentMethodCreateParams.createShopPay(
             externalSourceId = confirmationState.externalSourceId,
             billingDetails = PaymentMethod.BillingDetails(
@@ -101,7 +102,7 @@ internal class ShopPayViewModel @Inject constructor(
                     postalCode = address?.postalCode,
                     state = address?.state,
                 )
-            )
+            ),
         )
         return stripeApiRepository.createPaymentMethod(
             paymentMethodCreateParams = paymentMethodCreateParams,
@@ -113,17 +114,21 @@ internal class ShopPayViewModel @Inject constructor(
                 )
             paymentMethodHandler.onPreparePaymentMethod(
                 paymentMethod = paymentMethod,
-                shippingAddress = AddressDetails(
-                    name = confirmationState.billingDetails.name,
-                    address = PaymentSheet.Address(
-                        city = address?.city,
-                        country = address?.country,
-                        line1 = address?.line1,
-                        line2 = address?.line2,
-                        postalCode = address?.postalCode,
-                        state = address?.state,
+                shippingAddress = shippingAddressData?.let {
+                    AddressDetails(
+                        name = shippingAddressData.name,
+                        address = shippingAddressData.address?.let { address ->
+                            PaymentSheet.Address(
+                                city = address.city,
+                                country = address.country,
+                                line1 = address.line1,
+                                line2 = address.line2,
+                                postalCode = address.postalCode,
+                                state = address.state,
+                            )
+                        }
                     )
-                )
+                }
             )
             ShopPayActivityResult.Completed
         }.getOrElse {

--- a/paymentsheet/src/main/java/com/stripe/android/shoppay/bridge/DefaultShopPayBridgeHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/shoppay/bridge/DefaultShopPayBridgeHandler.kt
@@ -152,7 +152,8 @@ internal class DefaultShopPayBridgeHandler @Inject constructor(
         _confirmationState.emit(
             value = ShopPayConfirmationState.Success(
                 externalSourceId = externalSourceId,
-                billingDetails = confirmationRequest.paymentDetails.billingDetails
+                billingDetails = confirmationRequest.paymentDetails.billingDetails,
+                shippingAddressData = confirmationRequest.paymentDetails.shippingAddress
             )
         )
         ConfirmationResponse(

--- a/paymentsheet/src/main/java/com/stripe/android/shoppay/bridge/ShopPayConfirmationState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/shoppay/bridge/ShopPayConfirmationState.kt
@@ -5,6 +5,7 @@ internal sealed interface ShopPayConfirmationState {
     data class Success(
         val externalSourceId: String,
         val billingDetails: ECEBillingDetails,
+        val shippingAddressData: ECEShippingAddressData?
     ) : ShopPayConfirmationState
     data class Failure(val cause: Throwable) : ShopPayConfirmationState
 }

--- a/paymentsheet/src/test/java/com/stripe/android/shoppay/ShopPayActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/shoppay/ShopPayActivityTest.kt
@@ -26,8 +26,9 @@ import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferen
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbacks
 import com.stripe.android.paymentsheet.ShopPayHandlers
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
+import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.shoppay.bridge.ECEBillingDetails
-import com.stripe.android.shoppay.bridge.ECEFullAddress
+import com.stripe.android.shoppay.bridge.ECEShippingAddressData
 import com.stripe.android.shoppay.bridge.ShopPayBridgeHandler
 import com.stripe.android.shoppay.bridge.ShopPayConfirmationState
 import com.stripe.android.testing.AbsFakeStripeRepository
@@ -126,7 +127,8 @@ internal class ShopPayActivityTest {
 
         confirmationState.value = ShopPayConfirmationState.Success(
             externalSourceId = "test_id",
-            billingDetails = createTestBillingDetails()
+            billingDetails = createTestBillingDetails(),
+            shippingAddressData = null
         )
 
         advanceUntilIdle()
@@ -149,7 +151,8 @@ internal class ShopPayActivityTest {
 
         confirmationState.value = ShopPayConfirmationState.Success(
             externalSourceId = "test_id",
-            billingDetails = createTestBillingDetails()
+            billingDetails = createTestBillingDetails(),
+            shippingAddressData = null
         )
 
         advanceUntilIdle()
@@ -183,6 +186,128 @@ internal class ShopPayActivityTest {
         assertNoUnverifiedIntents()
     }
 
+    @Test
+    fun `finishes with Completed result when payment succeeds with shipping address data`() = runTest(dispatcher) {
+        val (fakeHandler, activity) = testShopPayConfirmation(
+            shippingAddressData = ShopPayTestFactory.SHIPPING_ADDRESS_DATA,
+            billingDetails = ShopPayTestFactory.BILLING_DETAILS,
+            stripeRepositoryResult = Result.success(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+        )
+
+        advanceUntilIdle()
+
+        assertShopPayResult(
+            activity = activity,
+            fakeHandler = fakeHandler,
+            expectedResult = ShopPayActivityResult.Completed::class.java
+        ) { capturedAddress ->
+            assertThat(capturedAddress).isNotNull()
+            assertThat(capturedAddress?.name).isEqualTo("Jane Smith")
+            assertThat(capturedAddress?.address?.line1).isEqualTo("456 Shipping Ave")
+            assertThat(capturedAddress?.address?.line2).isEqualTo("Unit 2B")
+            assertThat(capturedAddress?.address?.city).isEqualTo("Shipping City")
+            assertThat(capturedAddress?.address?.state).isEqualTo("NY")
+            assertThat(capturedAddress?.address?.postalCode).isEqualTo("10002")
+            assertThat(capturedAddress?.address?.country).isEqualTo("US")
+        }
+    }
+
+    @Test
+    fun `finishes with Completed result when payment succeeds with null shipping address data`() = runTest(dispatcher) {
+        val (fakeHandler, activity) = testShopPayConfirmation(
+            shippingAddressData = null,
+            billingDetails = ShopPayTestFactory.BILLING_DETAILS,
+            stripeRepositoryResult = Result.success(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+        )
+
+        advanceUntilIdle()
+
+        assertShopPayResult(
+            activity = activity,
+            fakeHandler = fakeHandler,
+            expectedResult = ShopPayActivityResult.Completed::class.java
+        ) { capturedAddress ->
+            assertThat(capturedAddress).isNull()
+        }
+    }
+
+    @Test
+    fun `finishes with Completed result when shipping address data has null address`() = runTest(dispatcher) {
+        val (fakeHandler, activity) = testShopPayConfirmation(
+            shippingAddressData = ShopPayTestFactory.SHIPPING_ADDRESS_DATA_WITH_NULL_ADDRESS,
+            billingDetails = ShopPayTestFactory.BILLING_DETAILS,
+            stripeRepositoryResult = Result.success(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+        )
+
+        advanceUntilIdle()
+
+        assertShopPayResult(
+            activity = activity,
+            fakeHandler = fakeHandler,
+            expectedResult = ShopPayActivityResult.Completed::class.java
+        ) { capturedAddress ->
+            assertThat(capturedAddress).isNotNull()
+            assertThat(capturedAddress?.name).isEqualTo("Jane Smith")
+            assertThat(capturedAddress?.address).isNull()
+        }
+    }
+
+    @Test
+    fun `finishes with Completed result when payment succeeds with international shipping address`() =
+        runTest(dispatcher) {
+            val internationalShippingData = ECEShippingAddressData(
+                name = "John Smith",
+                address = ShopPayTestFactory.INTERNATIONAL_ADDRESS
+            )
+
+            val (fakeHandler, activity) = testShopPayConfirmation(
+                shippingAddressData = internationalShippingData,
+                billingDetails = ShopPayTestFactory.INTERNATIONAL_BILLING_DETAILS,
+                stripeRepositoryResult = Result.success(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+            )
+
+            advanceUntilIdle()
+
+            assertShopPayResult(
+                activity = activity,
+                fakeHandler = fakeHandler,
+                expectedResult = ShopPayActivityResult.Completed::class.java
+            ) { capturedAddress ->
+                assertThat(capturedAddress).isNotNull()
+                assertThat(capturedAddress?.name).isEqualTo("John Smith")
+                assertThat(capturedAddress?.address?.line1).isEqualTo("10 Downing Street")
+                assertThat(capturedAddress?.address?.line2).isNull()
+                assertThat(capturedAddress?.address?.city).isEqualTo("London")
+                assertThat(capturedAddress?.address?.state).isNull()
+                assertThat(capturedAddress?.address?.postalCode).isEqualTo("SW1A 2AA")
+                assertThat(capturedAddress?.address?.country).isEqualTo("GB")
+            }
+        }
+
+    @Test
+    fun `finishes with Failed result when payment fails with shipping address data`() = runTest(dispatcher) {
+        val exception = RuntimeException("Payment failed with shipping")
+
+        val (fakeHandler, activity) = testShopPayConfirmation(
+            shippingAddressData = ShopPayTestFactory.SHIPPING_ADDRESS_DATA,
+            billingDetails = ShopPayTestFactory.BILLING_DETAILS,
+            stripeRepositoryResult = Result.failure(exception),
+        )
+
+        advanceUntilIdle()
+
+        assertShopPayResult(
+            activity = activity,
+            fakeHandler = fakeHandler,
+            expectedResult = ShopPayActivityResult.Failed::class.java,
+            expectedError = exception
+        ) { capturedAddress ->
+            // When payment method creation fails, the PreparePaymentMethodHandler is not called
+            // so shipping address is not captured
+            assertThat(capturedAddress).isNull()
+        }
+    }
+
     private fun createTestBridgeHandler(
         confirmationState: MutableStateFlow<ShopPayConfirmationState>
     ): ShopPayBridgeHandler {
@@ -211,7 +336,8 @@ internal class ShopPayActivityTest {
 
     private fun createTestViewModelFactory(
         bridgeHandler: ShopPayBridgeHandler,
-        stripeRepository: StripeRepository
+        stripeRepository: StripeRepository,
+        preparePaymentMethodHandler: PreparePaymentMethodHandler
     ): ViewModelProvider.Factory {
         return object : ViewModelProvider.Factory {
             @Suppress("UNCHECKED_CAST")
@@ -221,7 +347,7 @@ internal class ShopPayActivityTest {
                     stripeApiRepository = stripeRepository,
                     requestOptions = ApiRequest.Options("pk_test"),
                     preparePaymentMethodHandlerProvider = {
-                        PreparePaymentMethodHandler { _, _ -> }
+                        preparePaymentMethodHandler
                     },
                     workContext = dispatcher,
                     eventReporter = FakeEventReporter(),
@@ -231,19 +357,7 @@ internal class ShopPayActivityTest {
     }
 
     private fun createTestBillingDetails(): ECEBillingDetails {
-        return ECEBillingDetails(
-            name = "Test User",
-            email = "test@example.com",
-            phone = "+1234567890",
-            address = ECEFullAddress(
-                line1 = "123 Main St",
-                line2 = null,
-                city = "Test City",
-                state = "TS",
-                postalCode = "12345",
-                country = "US"
-            )
-        )
+        return ShopPayTestFactory.BILLING_DETAILS
     }
 
     private fun getResultFromIntent(intent: Intent?): ShopPayActivityResult? {
@@ -254,14 +368,78 @@ internal class ShopPayActivityTest {
 
     private fun setupActivityController(
         bridgeHandler: ShopPayBridgeHandler,
-        stripeRepository: StripeRepository
+        stripeRepository: StripeRepository,
+        preparePaymentMethodHandler: PreparePaymentMethodHandler = PreparePaymentMethodHandler { _, _ ->  }
     ): ShopPayActivity {
         val intent = ShopPayActivity.createIntent(context, ShopPayTestFactory.SHOP_PAY_ARGS)
 
         val activityController = Robolectric.buildActivity(ShopPayActivity::class.java, intent)
 
-        activityController.get().viewModelFactory = createTestViewModelFactory(bridgeHandler, stripeRepository)
+        activityController.get().viewModelFactory = createTestViewModelFactory(
+            bridgeHandler,
+            stripeRepository,
+            preparePaymentMethodHandler
+        )
         return activityController.setup().get()
+    }
+
+    private class FakePreparePaymentMethodHandler : PreparePaymentMethodHandler {
+        var capturedShippingAddress: AddressDetails? = null
+        var capturedPaymentMethod: PaymentMethod? = null
+
+        override suspend fun onPreparePaymentMethod(
+            paymentMethod: PaymentMethod,
+            shippingAddress: AddressDetails?
+        ) {
+            capturedPaymentMethod = paymentMethod
+            capturedShippingAddress = shippingAddress
+        }
+    }
+
+    private fun testShopPayConfirmation(
+        shippingAddressData: ECEShippingAddressData?,
+        billingDetails: ECEBillingDetails,
+        stripeRepositoryResult: Result<PaymentMethod>,
+    ): Pair<FakePreparePaymentMethodHandler, ShopPayActivity> {
+        val confirmationState = MutableStateFlow<ShopPayConfirmationState>(ShopPayConfirmationState.Pending)
+        val bridgeHandler = createTestBridgeHandler(confirmationState)
+        val stripeRepository = createTestStripeRepository(stripeRepositoryResult)
+
+        val fakeHandler = FakePreparePaymentMethodHandler()
+        val activity = setupActivityController(
+            bridgeHandler = bridgeHandler,
+            stripeRepository = stripeRepository,
+            preparePaymentMethodHandler = fakeHandler
+        )
+
+        confirmationState.value = ShopPayConfirmationState.Success(
+            externalSourceId = "test_id",
+            billingDetails = billingDetails,
+            shippingAddressData = shippingAddressData
+        )
+
+        return fakeHandler to activity
+    }
+
+    private fun assertShopPayResult(
+        activity: ShopPayActivity,
+        fakeHandler: FakePreparePaymentMethodHandler,
+        expectedResult: Class<out ShopPayActivityResult>,
+        expectedError: Throwable? = null,
+        shippingAddressAssertion: (AddressDetails?) -> Unit
+    ) {
+        val shadowActivity = shadowOf(activity)
+        assertThat(shadowActivity.resultCode).isEqualTo(63636)
+        val result = getResultFromIntent(shadowActivity.resultIntent)
+        assertThat(result).isInstanceOf(expectedResult)
+
+        if (expectedError != null && result is ShopPayActivityResult.Failed) {
+            assertThat(result.error).isEqualTo(expectedError)
+        }
+
+        shippingAddressAssertion(fakeHandler.capturedShippingAddress)
+
+        assertNoUnverifiedIntents()
     }
 
     private fun setupPaymentElementCallbackReferences() {

--- a/paymentsheet/src/test/java/com/stripe/android/shoppay/ShopPayActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/shoppay/ShopPayActivityTest.kt
@@ -25,8 +25,8 @@ import com.stripe.android.paymentelement.ShopPayPreview
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbacks
 import com.stripe.android.paymentsheet.ShopPayHandlers
-import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
+import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.shoppay.bridge.ECEBillingDetails
 import com.stripe.android.shoppay.bridge.ECEShippingAddressData
 import com.stripe.android.shoppay.bridge.ShopPayBridgeHandler
@@ -369,7 +369,7 @@ internal class ShopPayActivityTest {
     private fun setupActivityController(
         bridgeHandler: ShopPayBridgeHandler,
         stripeRepository: StripeRepository,
-        preparePaymentMethodHandler: PreparePaymentMethodHandler = PreparePaymentMethodHandler { _, _ ->  }
+        preparePaymentMethodHandler: PreparePaymentMethodHandler = PreparePaymentMethodHandler { _, _ -> }
     ): ShopPayActivity {
         val intent = ShopPayActivity.createIntent(context, ShopPayTestFactory.SHOP_PAY_ARGS)
 

--- a/paymentsheet/src/test/java/com/stripe/android/shoppay/ShopPayTestFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/shoppay/ShopPayTestFactory.kt
@@ -1,7 +1,10 @@
 package com.stripe.android.shoppay
 
 import com.stripe.android.common.model.SHOP_PAY_CONFIGURATION
+import com.stripe.android.shoppay.bridge.ECEBillingDetails
 import com.stripe.android.shoppay.bridge.ECEDeliveryEstimate
+import com.stripe.android.shoppay.bridge.ECEFullAddress
+import com.stripe.android.shoppay.bridge.ECEShippingAddressData
 import com.stripe.android.shoppay.bridge.ECEShippingRate
 
 internal object ShopPayTestFactory {
@@ -10,6 +13,71 @@ internal object ShopPayTestFactory {
         displayName = "Standard Shipping",
         amount = 500,
         deliveryEstimate = ECEDeliveryEstimate.Text("5-7 business days")
+    )
+
+    val ECE_EXPRESS_SHIPPING_RATE = ECEShippingRate(
+        id = "rate_2",
+        displayName = "Express Shipping",
+        amount = 1000,
+        deliveryEstimate = ECEDeliveryEstimate.Text("1-2 business days")
+    )
+
+    val BILLING_ADDRESS = ECEFullAddress(
+        line1 = "123 Main St",
+        line2 = "Apt 4B",
+        city = "New York",
+        state = "NY",
+        postalCode = "10001",
+        country = "US"
+    )
+
+    val SHIPPING_ADDRESS = ECEFullAddress(
+        line1 = "456 Shipping Ave",
+        line2 = "Unit 2B",
+        city = "Shipping City",
+        state = "NY",
+        postalCode = "10002",
+        country = "US"
+    )
+
+    val BILLING_DETAILS = ECEBillingDetails(
+        name = "John Doe",
+        email = "john.doe@example.com",
+        phone = "+1234567890",
+        address = BILLING_ADDRESS
+    )
+
+    val SHIPPING_ADDRESS_DATA = ECEShippingAddressData(
+        name = "Jane Smith",
+        address = SHIPPING_ADDRESS
+    )
+
+    val SHIPPING_ADDRESS_DATA_WITH_NULL_ADDRESS = ECEShippingAddressData(
+        name = "Jane Smith",
+        address = null
+    )
+
+    val MINIMAL_BILLING_DETAILS = ECEBillingDetails(
+        name = "Test User",
+        email = null,
+        phone = null,
+        address = null
+    )
+
+    val INTERNATIONAL_ADDRESS = ECEFullAddress(
+        line1 = "10 Downing Street",
+        line2 = null,
+        city = "London",
+        state = null,
+        postalCode = "SW1A 2AA",
+        country = "GB"
+    )
+
+    val INTERNATIONAL_BILLING_DETAILS = ECEBillingDetails(
+        name = "John Smith",
+        email = "john.smith@example.co.uk",
+        phone = "+447123456789",
+        address = INTERNATIONAL_ADDRESS
     )
 
     val SHOP_PAY_ARGS = ShopPayArgs(

--- a/paymentsheet/src/test/java/com/stripe/android/shoppay/ShopPayViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/shoppay/ShopPayViewModelTest.kt
@@ -28,6 +28,7 @@ import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferen
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbacks
 import com.stripe.android.paymentsheet.ShopPayHandlers
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.shoppay.bridge.ECEBillingDetails
 import com.stripe.android.shoppay.bridge.ECEFullAddress
 import com.stripe.android.shoppay.bridge.ShopPayBridgeHandler
@@ -137,7 +138,8 @@ internal class ShopPayViewModelTest {
             val billingDetails = createTestBillingDetails()
             val confirmationState = ShopPayConfirmationState.Success(
                 externalSourceId = "test_external_id",
-                billingDetails = billingDetails
+                billingDetails = billingDetails,
+                shippingAddressData = null
             )
             val bridgeHandler = FakeShopPayBridgeHandler()
             val stripeRepository = FakeStripeRepository(Result.success(PaymentMethodFixtures.CARD_PAYMENT_METHOD))
@@ -264,7 +266,8 @@ internal class ShopPayViewModelTest {
         )
         val confirmationState = ShopPayConfirmationState.Success(
             externalSourceId = "test_external_id",
-            billingDetails = billingDetails
+            billingDetails = billingDetails,
+            shippingAddressData = null
         )
         val bridgeHandler = FakeShopPayBridgeHandler()
 
@@ -300,6 +303,100 @@ internal class ShopPayViewModelTest {
             assertThat(capturedParams?.billingDetails?.address?.state).isEqualTo("NY")
             assertThat(capturedParams?.billingDetails?.address?.postalCode).isEqualTo("10001")
             assertThat(capturedParams?.billingDetails?.address?.country).isEqualTo("US")
+        }
+    }
+
+    @Test
+    fun `handleSuccessfulPayment uses shipping address data when available`() = runTest(dispatcher) {
+        val confirmationState = ShopPayConfirmationState.Success(
+            externalSourceId = "test_external_id",
+            billingDetails = ShopPayTestFactory.BILLING_DETAILS,
+            shippingAddressData = ShopPayTestFactory.SHIPPING_ADDRESS_DATA
+        )
+        val bridgeHandler = FakeShopPayBridgeHandler()
+
+        var capturedShippingAddress: AddressDetails? = null
+        val mockHandler = PreparePaymentMethodHandler { _, shippingAddress ->
+            capturedShippingAddress = shippingAddress
+        }
+
+        val viewModel = createViewModel(
+            bridgeHandler = bridgeHandler,
+            preparePaymentMethodHandler = mockHandler
+        )
+
+        viewModel.paymentResult.test {
+            bridgeHandler.confirmationState.value = confirmationState
+
+            awaitItem()
+
+            assertThat(capturedShippingAddress).isNotNull()
+            assertThat(capturedShippingAddress?.name).isEqualTo("Jane Smith")
+            assertThat(capturedShippingAddress?.address?.line1).isEqualTo("456 Shipping Ave")
+            assertThat(capturedShippingAddress?.address?.line2).isEqualTo("Unit 2B")
+            assertThat(capturedShippingAddress?.address?.city).isEqualTo("Shipping City")
+            assertThat(capturedShippingAddress?.address?.state).isEqualTo("NY")
+            assertThat(capturedShippingAddress?.address?.postalCode).isEqualTo("10002")
+            assertThat(capturedShippingAddress?.address?.country).isEqualTo("US")
+        }
+    }
+
+    @Test
+    fun `handleSuccessfulPayment passes null shipping address when shippingAddressData is null`() =
+        runTest(dispatcher) {
+            val confirmationState = ShopPayConfirmationState.Success(
+                externalSourceId = "test_external_id",
+                billingDetails = createTestBillingDetails(),
+                shippingAddressData = null
+            )
+            val bridgeHandler = FakeShopPayBridgeHandler()
+
+            var capturedShippingAddress: AddressDetails? = null
+            val mockHandler = PreparePaymentMethodHandler { _, shippingAddress ->
+                capturedShippingAddress = shippingAddress
+            }
+
+            val viewModel = createViewModel(
+                bridgeHandler = bridgeHandler,
+                preparePaymentMethodHandler = mockHandler
+            )
+
+            viewModel.paymentResult.test {
+                bridgeHandler.confirmationState.value = confirmationState
+
+                awaitItem()
+
+                assertThat(capturedShippingAddress).isNull()
+            }
+        }
+
+    @Test
+    fun `handleSuccessfulPayment handles shipping address data with null address`() = runTest(dispatcher) {
+        val confirmationState = ShopPayConfirmationState.Success(
+            externalSourceId = "test_external_id",
+            billingDetails = ShopPayTestFactory.BILLING_DETAILS,
+            shippingAddressData = ShopPayTestFactory.SHIPPING_ADDRESS_DATA_WITH_NULL_ADDRESS
+        )
+        val bridgeHandler = FakeShopPayBridgeHandler()
+
+        var capturedShippingAddress: AddressDetails? = null
+        val mockHandler = PreparePaymentMethodHandler { _, shippingAddress ->
+            capturedShippingAddress = shippingAddress
+        }
+
+        val viewModel = createViewModel(
+            bridgeHandler = bridgeHandler,
+            preparePaymentMethodHandler = mockHandler
+        )
+
+        viewModel.paymentResult.test {
+            bridgeHandler.confirmationState.value = confirmationState
+
+            awaitItem()
+
+            assertThat(capturedShippingAddress).isNotNull()
+            assertThat(capturedShippingAddress?.name).isEqualTo("Jane Smith")
+            assertThat(capturedShippingAddress?.address).isNull()
         }
     }
 
@@ -376,7 +473,8 @@ internal class ShopPayViewModelTest {
 
     private fun createSuccessConfirmationState() = ShopPayConfirmationState.Success(
         externalSourceId = "test_external_id",
-        billingDetails = createTestBillingDetails()
+        billingDetails = createTestBillingDetails(),
+        shippingAddressData = null
     )
 
     private suspend fun testPaymentResultWithConfirmationState(
@@ -434,18 +532,6 @@ internal class ShopPayViewModelTest {
     }
 
     private fun createTestBillingDetails(): ECEBillingDetails {
-        return ECEBillingDetails(
-            name = "Test User",
-            email = "test@example.com",
-            phone = "+1234567890",
-            address = ECEFullAddress(
-                line1 = "123 Main St",
-                line2 = null,
-                city = "Anytown",
-                state = "CA",
-                postalCode = "12345",
-                country = "US"
-            )
-        )
+        return ShopPayTestFactory.BILLING_DETAILS
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/shoppay/ShopPayViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/shoppay/ShopPayViewModelTest.kt
@@ -27,8 +27,8 @@ import com.stripe.android.paymentelement.ShopPayPreview
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbacks
 import com.stripe.android.paymentsheet.ShopPayHandlers
-import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
+import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.shoppay.bridge.ECEBillingDetails
 import com.stripe.android.shoppay.bridge.ECEFullAddress
 import com.stripe.android.shoppay.bridge.ShopPayBridgeHandler

--- a/paymentsheet/src/test/java/com/stripe/android/shoppay/bridge/DefaultShopPayBridgeHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/shoppay/bridge/DefaultShopPayBridgeHandlerTest.kt
@@ -305,7 +305,8 @@ internal class DefaultShopPayBridgeHandlerTest {
         val fakeParser = FakeConfirmationRequestParser(returnValue = confirmationRequest)
         val handler = createDefaultBridgeHandler(confirmationRequestJsonParser = fakeParser)
         val message = """{"paymentDetails": {"billingDetails": {"name": "Test User"}, "shippingAddress":
-            | {"name": "Jane Smith"}}}""".trimMargin()
+            | {"name": "Jane Smith"}}}
+        """.trimMargin()
 
         val result = handler.confirmPayment(message)
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Use correct shipping address for Shop Pay when calling `PreparePaymentMethodHandler`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
We are currently using billing address in place of shipping address

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
