### PR TITLE
[EditCardUI] Fix ExpiryTextField cursor positioning by using correct CompatTextField overload

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/CommonTextField.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/CommonTextField.kt
@@ -12,7 +12,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.VisualTransformation
 import com.stripe.android.uicore.LocalTextFieldInsets
 import com.stripe.android.uicore.elements.TextFieldColors
@@ -42,7 +41,7 @@ internal fun CommonTextField(
 
     CompatTextField(
         modifier = modifier.fillMaxWidth(),
-        value = TextFieldValue(value),
+        value = value,
         enabled = enabled,
         label = {
             Label(
@@ -55,9 +54,7 @@ internal fun CommonTextField(
         keyboardOptions = keyboardOptions,
         keyboardActions = keyboardActions,
         visualTransformation = visualTransformation,
-        onValueChange = {
-            onValueChange(it.text)
-        },
+        onValueChange = onValueChange,
         errorMessage = null,
         contentPadding = textFieldInsets.asPaddingValues()
     )


### PR DESCRIPTION
# Summary
Fixed ExpiryTextField cursor positioning issue by using the correct CompatTextField overload that accepts String instead of TextFieldValue.

# Motivation
The ExpiryTextField in Link's CardDetailsUI was not editable - the cursor was fixed at the beginning of the field, making it impossible to type or delete characters. 

The issue was caused by `CommonTextField` using the `TextFieldValue` overload of `CompatTextField`, which requires manual cursor management. `CompatTextField` provides a String overload that handles cursor positioning automatically.

# Testing
- [x] Manually verified
- Field is now editable with proper cursor positioning
- Users can type and delete characters normally
- The MM/YY visual transformation continues to work correctly

# Screenshots
[fix-expiry.webm](https://github.com/user-attachments/assets/10fd972e-729a-4742-b41f-307ab5a3f5b8)

# Changelog
- [Fixed] ExpiryTextField cursor positioning issue by using correct CompatTextField overload