### PR TITLE
Fix occassional missing values in address autocomplete results  

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/model/TransformGoogleToStripeAddress.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/model/TransformGoogleToStripeAddress.kt
@@ -186,64 +186,66 @@ fun Place.transformGoogleToStripeAddress(
     val addressLine1 = AddressLine1()
 
     addressComponents?.forEach { field ->
-        when (field.types[0]) {
-            Place.Type.STREET_NUMBER.value -> {
+        val types = field.types
+
+        when {
+            types.contains(Place.Type.STREET_NUMBER.value) -> {
                 addressLine1.streetNumber = field.longName
             }
-            Place.Type.ROUTE.value -> {
+            types.contains(Place.Type.ROUTE.value) -> {
                 addressLine1.route = field.longName
             }
-            Place.Type.PREMISE.value -> {
+            types.contains(Place.Type.PREMISE.value) -> {
                 address.addressLine2 = field.longName
             }
-            Place.Type.LOCALITY.value,
-            Place.Type.SUBLOCALITY.value,
-            Place.Type.POSTAL_TOWN.value -> {
+            types.contains(Place.Type.SUBLOCALITY_LEVEL_1.value) -> {
+                if (address.locality == null) {
+                    address.dependentLocality = field.longName
+                } else {
+                    address.locality = field.longName
+                }
+            }
+            types.contains(Place.Type.SUBLOCALITY_LEVEL_2.value) -> {
+                addressLine1.subLocalityLevel2 = field.longName
+            }
+            types.contains(Place.Type.SUBLOCALITY_LEVEL_3.value) -> {
+                addressLine1.subLocalityLevel3 = field.longName
+            }
+            types.contains(Place.Type.SUBLOCALITY_LEVEL_4.value) -> {
+                addressLine1.subLocalityLevel4 = field.longName
+            }
+            types.contains(Place.Type.LOCALITY.value) ||
+                types.contains(Place.Type.SUBLOCALITY.value) ||
+                types.contains(Place.Type.POSTAL_TOWN.value) -> {
                 address.locality = field.longName
             }
-            Place.Type.ADMINISTRATIVE_AREA_LEVEL_1.value -> {
+            types.contains(Place.Type.ADMINISTRATIVE_AREA_LEVEL_1.value) -> {
                 address.administrativeArea = field.shortName
             }
-            Place.Type.ADMINISTRATIVE_AREA_LEVEL_3.value -> {
+            types.contains(Place.Type.ADMINISTRATIVE_AREA_LEVEL_3.value) -> {
                 if (address.locality == null) {
                     address.locality = field.longName
                 }
             }
-            Place.Type.ADMINISTRATIVE_AREA_LEVEL_2.value -> {
+            types.contains(Place.Type.ADMINISTRATIVE_AREA_LEVEL_2.value) -> {
                 if (address.administrativeArea == null && address.dependentLocality == null) {
                     address.dependentLocality = field.longName
                 } else {
                     address.administrativeArea = field.shortName
                 }
             }
-            Place.Type.NEIGHBORHOOD.value -> {
+            types.contains(Place.Type.NEIGHBORHOOD.value) -> {
                 if (address.locality == null) {
                     address.locality = field.longName
                 } else {
                     address.dependentLocality = field.longName
                 }
             }
-            Place.Type.POSTAL_CODE.value -> {
+            types.contains(Place.Type.POSTAL_CODE.value) -> {
                 address.postalCode = field.longName
             }
-            Place.Type.COUNTRY.value -> {
+            types.contains(Place.Type.COUNTRY.value) -> {
                 address.country = field.shortName
-            }
-            Place.Type.SUBLOCALITY_LEVEL_1.value -> {
-                if (address.locality == null) {
-                    address.dependentLocality = field.longName
-                } else {
-                    address.locality = field.longName
-                }
-            }
-            Place.Type.SUBLOCALITY_LEVEL_2.value -> {
-                addressLine1.subLocalityLevel2 = field.longName
-            }
-            Place.Type.SUBLOCALITY_LEVEL_3.value -> {
-                addressLine1.subLocalityLevel3 = field.longName
-            }
-            Place.Type.SUBLOCALITY_LEVEL_4.value -> {
-                addressLine1.subLocalityLevel4 = field.longName
             }
         }
     }

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/autocomplete/model/TransformGoogleToStripeAddressTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/autocomplete/model/TransformGoogleToStripeAddressTest.kt
@@ -399,6 +399,68 @@ class TransformGoogleToStripeAddressTest {
         )
     }
 
+    @Test
+    fun `test 'political' components are ignored`() {
+        val place = parseJson(
+            """
+                {
+                    "address_components": [
+                        {
+                            "long_name" : "123",
+                            "short_name" : "123",
+                            "types" : [ "street_number" ]
+                        },
+                        {
+                            "long_name" : "East Broadway",
+                            "short_name" : "E Broadway",
+                            "types" : [ "route" ]
+                        },
+                        {
+                            "long_name" : "Manhattan",
+                            "short_name" : "Manhattan",
+                            "types" : [ "political", "sublocality_level_1", "sublocality" ]
+                        },
+                        {
+                            "long_name" : "New York",
+                            "short_name" : "New York",
+                            "types" : [  "political", "locality" ]
+                        },
+                        {
+                            "long_name" : "New York County",
+                            "short_name" : "New York County",
+                            "types" : [ "political", "administrative_area_level_2" ]
+                        },
+                        {
+                            "long_name" : "New York",
+                            "short_name" : "NY",
+                            "types" : [  "political", "administrative_area_level_1" ]
+                        },
+                        {
+                            "long_name" : "United States",
+                            "short_name" : "US",
+                            "types" : [ "political", "country" ]
+                        },
+                        {
+                            "long_name" : "10002",
+                            "short_name" : "10002",
+                            "types" : [ "postal_code" ]
+                        }
+                    ]
+                }
+            """.trimIndent()
+        )
+
+        assertThat(place.transformGoogleToStripeAddress(context)).isEqualTo(
+            Address(
+                city = "New York",
+                country = "US",
+                line1 = "123 East Broadway",
+                postalCode = "10002",
+                state = "NY"
+            )
+        )
+    }
+
     private fun parseJson(json: String): Place {
         return Json.decodeFromString(
             Place.serializer(),


### PR DESCRIPTION
# Summary
This PR fixes missing values in the autocomplete results that occasionally occur due to the non-deterministic order of the autocomplete field types returned by the Places API. 

# Motivation
Ensures the same result of autocomplete is consistently parsed out into an equivalent internal result.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified