### PR TITLE
[BDCC] Use effective details when valid to confirm the payment + cache phone / name from signup

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
@@ -351,6 +351,8 @@ internal class DefaultLinkAccountManager @Inject constructor(
                 setAccountNullable(
                     consumerSession = consumerSession,
                     publishableKey = lookup.publishableKey,
+                    nameUsedInSignup = null,
+                    phoneNumberUsedInSignup = null
                 )
             } else {
                 LinkAccount(consumerSession, lookup.publishableKey)
@@ -457,8 +459,8 @@ internal class DefaultLinkAccountManager @Inject constructor(
     internal suspend fun setAccountNullable(
         consumerSession: ConsumerSession?,
         publishableKey: String?,
-        nameUsedInSignup: String? = null,
-        phoneNumberUsedInSignup: String? = null,
+        nameUsedInSignup: String?,
+        phoneNumberUsedInSignup: String?,
     ): LinkAccount? {
         return consumerSession?.let {
             setAccount(

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
@@ -211,6 +211,8 @@ internal class DefaultLinkAccountManager @Inject constructor(
                 setAccount(
                     consumerSession = consumerSessionSignup.consumerSession,
                     publishableKey = consumerSessionSignup.publishableKey,
+                    nameUsedInSignup = name,
+                    phoneNumberUsedInSignup = phone
                 )
             }
 
@@ -238,6 +240,8 @@ internal class DefaultLinkAccountManager @Inject constructor(
             setAccount(
                 consumerSession = consumerSessionSignUp.consumerSession,
                 publishableKey = consumerSessionSignUp.publishableKey,
+                nameUsedInSignup = name,
+                phoneNumberUsedInSignup = phone
             )
         }
     }
@@ -319,12 +323,19 @@ internal class DefaultLinkAccountManager @Inject constructor(
     private suspend fun setAccount(
         consumerSession: ConsumerSession,
         publishableKey: String?,
+        nameUsedInSignup: String?,
+        phoneNumberUsedInSignup: String?,
     ): LinkAccount {
         val currentAccount = linkAccountHolder.linkAccountInfo.value.account
         val newConsumerPublishableKey = publishableKey
             ?: currentAccount?.consumerPublishableKey
                 ?.takeIf { currentAccount.email == consumerSession.emailAddress }
-        val newAccount = LinkAccount(consumerSession, newConsumerPublishableKey)
+        val newAccount = LinkAccount(
+            consumerSession = consumerSession,
+            consumerPublishableKey = newConsumerPublishableKey,
+            nameUsedInSignup = nameUsedInSignup,
+            phoneNumberUsedInSignup = phoneNumberUsedInSignup
+        )
         withContext(Dispatchers.Main.immediate) {
             linkAccountHolder.set(LinkAccountUpdate.Value(newAccount))
         }
@@ -358,7 +369,12 @@ internal class DefaultLinkAccountManager @Inject constructor(
             .onFailure {
                 linkEventsReporter.on2FAStartFailure()
             }.map { consumerSession ->
-                setAccount(consumerSession, null)
+                setAccount(
+                    consumerSession = consumerSession,
+                    publishableKey = null,
+                    nameUsedInSignup = null,
+                    phoneNumberUsedInSignup = null
+                )
             }
     }
 
@@ -375,7 +391,12 @@ internal class DefaultLinkAccountManager @Inject constructor(
             }.onFailure {
                 linkEventsReporter.on2FAFailure()
             }.map { consumerSession ->
-                setAccount(consumerSession, null)
+                setAccount(
+                    consumerSession = consumerSession,
+                    publishableKey = null,
+                    nameUsedInSignup = null,
+                    phoneNumberUsedInSignup = null
+                )
             }
     }
 
@@ -436,9 +457,16 @@ internal class DefaultLinkAccountManager @Inject constructor(
     internal suspend fun setAccountNullable(
         consumerSession: ConsumerSession?,
         publishableKey: String?,
+        nameUsedInSignup: String? = null,
+        phoneNumberUsedInSignup: String? = null,
     ): LinkAccount? {
         return consumerSession?.let {
-            setAccount(consumerSession = it, publishableKey = publishableKey)
+            setAccount(
+                consumerSession = it,
+                publishableKey = publishableKey,
+                nameUsedInSignup = nameUsedInSignup,
+                phoneNumberUsedInSignup = phoneNumberUsedInSignup
+            )
         } ?: run {
             withContext(Dispatchers.Main.immediate) {
                 linkAccountHolder.set(LinkAccountUpdate.Value(account = null))

--- a/paymentsheet/src/main/java/com/stripe/android/link/model/LinkAccount.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/model/LinkAccount.kt
@@ -72,20 +72,4 @@ internal class LinkAccount(
         it.type == ConsumerSession.VerificationSession.SessionType.SignUp &&
             it.state == ConsumerSession.VerificationSession.SessionState.Started
     } != null
-
-    /**
-     * Creates a new LinkAccount with the provided signup data.
-     * This is used to store name and phone number collected during signup for later use.
-     */
-    fun withSignupData(
-        name: String?,
-        phoneNumber: String?
-    ): LinkAccount {
-        return LinkAccount(
-            consumerSession = consumerSession,
-            consumerPublishableKey = consumerPublishableKey,
-            nameUsedInSignup = name,
-            phoneNumberUsedInSignup = phoneNumber
-        )
-    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/model/LinkAccount.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/model/LinkAccount.kt
@@ -13,6 +13,8 @@ import kotlinx.parcelize.Parcelize
 internal class LinkAccount(
     private val consumerSession: ConsumerSession,
     val consumerPublishableKey: String? = null,
+    val nameUsedInSignup: String? = null,
+    val phoneNumberUsedInSignup: String? = null,
 ) : Parcelable {
 
     @IgnoredOnParcel
@@ -70,4 +72,20 @@ internal class LinkAccount(
         it.type == ConsumerSession.VerificationSession.SessionType.SignUp &&
             it.state == ConsumerSession.VerificationSession.SessionState.Started
     } != null
+
+    /**
+     * Creates a new LinkAccount with the provided signup data.
+     * This is used to store name and phone number collected during signup for later use.
+     */
+    fun withSignupData(
+        name: String?,
+        phoneNumber: String?
+    ): LinkAccount {
+        return LinkAccount(
+            consumerSession = consumerSession,
+            consumerPublishableKey = consumerPublishableKey,
+            nameUsedInSignup = name,
+            phoneNumberUsedInSignup = phoneNumber
+        )
+    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/utils/LinkBillingDetailsUtils.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/utils/LinkBillingDetailsUtils.kt
@@ -43,12 +43,12 @@ internal fun PaymentDetails.supports(
         // Check if full address is required but missing or incomplete
         billingDetailsConfig.address == AddressCollectionMode.Full && billingAddress.isIncomplete() -> false
         // Check if phone is required but missing from Link account (including signup data)
-        billingDetailsConfig.collectsPhone && 
-            linkAccount.unredactedPhoneNumber == null && 
+        billingDetailsConfig.collectsPhone &&
+            linkAccount.unredactedPhoneNumber == null &&
             linkAccount.phoneNumberUsedInSignup == null -> false
         // Check if name is required but missing (including signup data)
-        billingDetailsConfig.collectsName && 
-            billingAddress?.name == null && 
+        billingDetailsConfig.collectsName &&
+            billingAddress?.name == null &&
             linkAccount.nameUsedInSignup == null -> false
         // All billing configuration details are supported.
         else -> true
@@ -65,8 +65,9 @@ private fun ConsumerPaymentDetails.BillingAddress?.isIncomplete(): Boolean {
 }
 
 /**
- * Enhances a ConsumerPaymentDetails.Card's billing details with [effectiveBillingDetails].
+ * Merges this payment method's billing details with fallback data from Link account and configuration.
  * This is used for prefilling billing details in update flows.
+ * Uses compatibility logic to determine when to preserve vs replace billing details.
  */
 internal fun PaymentDetails.withEffectiveBillingDetails(
     configuration: LinkConfiguration,

--- a/paymentsheet/src/main/java/com/stripe/android/link/utils/LinkBillingDetailsUtils.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/utils/LinkBillingDetailsUtils.kt
@@ -24,8 +24,10 @@ internal fun effectiveBillingDetails(
         email = defaultBillingDetails.email
             ?: linkAccount.email.takeIf { billingConfig.collectsEmail },
         phone = defaultBillingDetails.phone
-            ?: linkAccount.unredactedPhoneNumber.takeIf { billingConfig.collectsPhone },
-        // Name and address cannot be supplemented from Link account data
+            ?: linkAccount.unredactedPhoneNumber.takeIf { billingConfig.collectsPhone }
+            ?: linkAccount.phoneNumberUsedInSignup.takeIf { billingConfig.collectsPhone },
+        name = defaultBillingDetails.name
+            ?: linkAccount.nameUsedInSignup.takeIf { billingConfig.collectsName },
     )
 }
 
@@ -40,10 +42,14 @@ internal fun PaymentDetails.supports(
     is ConsumerPaymentDetails.Card -> when {
         // Check if full address is required but missing or incomplete
         billingDetailsConfig.address == AddressCollectionMode.Full && billingAddress.isIncomplete() -> false
-        // Check if phone is required but missing from Link account
-        billingDetailsConfig.collectsPhone && linkAccount.unredactedPhoneNumber == null -> false
-        // Check if name is required but missing
-        billingDetailsConfig.collectsName && billingAddress?.name == null -> false
+        // Check if phone is required but missing from Link account (including signup data)
+        billingDetailsConfig.collectsPhone && 
+            linkAccount.unredactedPhoneNumber == null && 
+            linkAccount.phoneNumberUsedInSignup == null -> false
+        // Check if name is required but missing (including signup data)
+        billingDetailsConfig.collectsName && 
+            billingAddress?.name == null && 
+            linkAccount.nameUsedInSignup == null -> false
         // All billing configuration details are supported.
         else -> true
     }


### PR DESCRIPTION
# Summary

- To match iOS, we'll use the effective billing details to confirm the payment if they're valid, rather than always presenting the billing details confirmation flow.
- Also Improves Link billing details collection to use signup data (name and phone number) as fallback when collecting billing details for payments. When users sign up for Link, they provide their name and phone number. Previously, this data wasn't being used to satisfy billing details collection requirements, forcing users to re-enter information they had already provided during signup.

# Testing
- [x] Added tests
- [x] Modified tests  
- [x] Manually verified

Added tests for:
- Signup data storage in LinkAccount
- Effective billing details calculation using signup data
- WalletViewModel behavior with signup data
- Billing details compatibility logic