### PR TITLE
Fix issue where original country element from Address Element is retained.

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardBillingAddressElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardBillingAddressElement.kt
@@ -61,7 +61,7 @@ class CardBillingAddressElement(
         )
     }
 
-    override val countryElement: CountryElement = addressElement.countryElement
+    override val countryElement: StateFlow<CountryElement> = addressElement.countryElement
 
     // Save for future use puts this in the controller rather than element
     // card and achv2 uses save for future use

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/PlaceholderHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/PlaceholderHelper.kt
@@ -20,6 +20,7 @@ import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.PhoneNumberElement
 import com.stripe.android.uicore.elements.SectionElement
+import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.flow.filterNotNull
 
 internal object PlaceholderHelper {
@@ -184,6 +185,9 @@ internal object PlaceholderHelper {
             .flatMap { it.fields }
             .filterIsInstance<CountryElement>()
             .firstOrNull()
+            ?.let {
+                stateFlowOf(it)
+            }
 
         // If not found, look for one inside an AddressElement.
         if (countryElement == null) {
@@ -195,9 +199,11 @@ internal object PlaceholderHelper {
                 ?.countryElement
         }
 
-        countryElement?.controller?.rawFieldValue?.filterNotNull()?.collect {
-            if (phoneNumberElement?.controller?.getLocalNumber().isNullOrBlank()) {
-                phoneNumberElement?.controller?.countryDropdownController?.onRawValueChange(it)
+        countryElement?.collect {
+            it.controller.rawFieldValue.filterNotNull().collect {
+                if (phoneNumberElement?.controller?.getLocalNumber().isNullOrBlank()) {
+                    phoneNumberElement?.controller?.countryDropdownController?.onRawValueChange(it)
+                }
             }
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -56,6 +56,7 @@ import com.stripe.android.uicore.elements.SameAsShippingController
 import com.stripe.android.uicore.elements.SameAsShippingElement
 import com.stripe.android.uicore.elements.TextFieldController
 import com.stripe.android.uicore.utils.combineAsStateFlow
+import com.stripe.android.uicore.utils.flatMapLatestAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -278,9 +279,11 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
 
     init {
         viewModelScope.launch {
-            addressElement.countryElement.controller.rawFieldValue.collect {
-                it?.let {
-                    phoneController.countryDropdownController.onRawValueChange(it)
+            addressElement.countryElement.collect { it ->
+                it.controller.rawFieldValue.collect {
+                    it?.let {
+                        phoneController.countryDropdownController.onRawValueChange(it)
+                    }
                 }
             }
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
@@ -554,11 +554,11 @@ internal class FormViewModelTest {
 
             assertThat(countryElement).isNotNull()
             assertThat(phoneElement).isNotNull()
-            countryElement?.controller?.onRawValueChange("CA")
+            countryElement?.value?.controller?.onRawValueChange("CA")
             assertThat(phoneElement?.controller?.countryDropdownController?.rawFieldValue?.first())
                 .isEqualTo("CA")
             phoneElement?.controller?.onValueChange("+13105551234")
-            countryElement?.controller?.onRawValueChange("US")
+            countryElement?.value?.controller?.onRawValueChange("US")
             // Phone number shouldn't change because it is already filled.
             assertThat(phoneElement?.controller?.countryDropdownController?.rawFieldValue?.first())
                 .isEqualTo("CA")

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
@@ -582,7 +582,7 @@ class USBankAccountFormViewModelTest {
             )
         )
 
-        viewModel.addressElement.countryElement.controller.onRawValueChange("CA")
+        viewModel.addressElement.countryElement.value.controller.onRawValueChange("CA")
         assertThat(viewModel.phoneController.countryDropdownController.rawFieldValue.value).isEqualTo("CA")
     }
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressFieldsElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressFieldsElement.kt
@@ -1,8 +1,9 @@
 package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
+import kotlinx.coroutines.flow.StateFlow
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 interface AddressFieldsElement : SectionFieldElement {
-    val countryElement: CountryElement
+    val countryElement: StateFlow<CountryElement>
 }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressElement.kt
@@ -2,6 +2,9 @@ package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
 import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.uicore.utils.flatMapLatestAsStateFlow
+import com.stripe.android.uicore.utils.mapAsStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class AutocompleteAddressElement(
@@ -34,8 +37,10 @@ class AutocompleteAddressElement(
         )
     }
 
-    override val countryElement: CountryElement
-        get() = controller.addressElementFlow.value.countryElement
+    override val countryElement: StateFlow<CountryElement> =
+        controller.addressElementFlow.flatMapLatestAsStateFlow {
+            it.countryElement
+        }
 
     override val allowsUserInteraction: Boolean = true
 


### PR DESCRIPTION
# Summary
Fix issue where original country element from Address Element is retained.

# Motivation
Realized after merging the `AddressElement` autocomplete updates that this could be problem when switching between condensed and expanded forms since the country element is changed when `AddressElement` is recreated.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified