### PR TITLE
Add support for address autocomplete for US Bank account

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardBillingAddressElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardBillingAddressElement.kt
@@ -4,6 +4,7 @@ import androidx.annotation.RestrictTo
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
 import com.stripe.android.uicore.address.FieldType
+import com.stripe.android.uicore.elements.AddressController
 import com.stripe.android.uicore.elements.AddressElement
 import com.stripe.android.uicore.elements.AddressFieldsElement
 import com.stripe.android.uicore.elements.AddressInputMode
@@ -63,6 +64,8 @@ class CardBillingAddressElement(
             sameAsShippingElement = sameAsShippingElement,
         )
     }
+
+    override val addressController: StateFlow<AddressController> = addressElement.addressController
 
     override val countryElement: CountryElement = addressElement.countryElement
 

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AddressElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AddressElementTest.kt
@@ -57,9 +57,9 @@ class AddressElementTest {
             postalCodeController.onValueChange("9999")
             postalCodeController.onFocusChange(false)
 
-            assertThat(addressElement.controller.error.first())
+            assertThat(addressElement.addressController.value.error.first())
                 .isNotNull()
-            assertThat(addressElement.controller.error.first()?.errorMessage)
+            assertThat(addressElement.addressController.value.error.first()?.errorMessage)
                 .isEqualTo(UiCoreR.string.stripe_address_zip_invalid)
 
             countryElement.controller.onValueChange(1)
@@ -71,7 +71,7 @@ class AddressElementTest {
             postalCodeController.onFocusChange(false)
             ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
 
-            assertThat(addressElement.controller.error.first()?.errorMessage)
+            assertThat(addressElement.addressController.value.error.first()?.errorMessage)
                 .isEqualTo(UiCoreR.string.stripe_address_zip_postal_invalid)
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -871,6 +871,7 @@ internal class CustomerSheetViewModel(
             setAsDefaultPaymentMethodEnabled = false,
             financialConnectionsAvailability = GetFinancialConnectionsAvailability(elementsSession = null),
             setAsDefaultMatchesSaveForFutureUse = FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE,
+            autocompleteAddressInteractorFactory = null,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteLauncher.kt
@@ -20,6 +20,7 @@ import com.stripe.android.uicore.StripeTheme
 import kotlinx.parcelize.Parcelize
 import java.lang.ref.WeakReference
 import java.util.UUID
+import javax.inject.Inject
 
 internal interface AutocompleteLauncher {
     fun launch(
@@ -41,6 +42,10 @@ internal interface AutocompleteLauncher {
 
 internal interface AutocompleteActivityLauncher : AutocompleteLauncher {
     fun register(activityResultCaller: ActivityResultCaller, lifecycleOwner: LifecycleOwner)
+
+    fun interface Factory {
+        fun create(appearanceContext: AutocompleteAppearanceContext): AutocompleteActivityLauncher
+    }
 }
 
 internal fun interface AutocompleteLauncherResultHandler {
@@ -182,5 +187,11 @@ internal class DefaultAutocompleteLauncher(
                 appearanceContext = appearanceContext,
             )
         )
+    }
+
+    class Factory @Inject constructor() : AutocompleteActivityLauncher.Factory {
+        override fun create(appearanceContext: AutocompleteAppearanceContext): AutocompleteActivityLauncher {
+            return DefaultAutocompleteLauncher(appearanceContext)
+        }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountForm.kt
@@ -80,7 +80,7 @@ internal fun USBankAccountForm(
     enabled: Boolean
 ) {
     val viewModel = viewModel<USBankAccountFormViewModel>(
-        factory = USBankAccountFormViewModel.Factory {
+        factory = USBankAccountFormViewModel.Factory(usBankAccountFormArgs.autocompleteAddressInteractorFactory) {
             USBankAccountFormViewModel.Args(
                 instantDebits = usBankAccountFormArgs.instantDebits,
                 incentive = usBankAccountFormArgs.incentive,
@@ -104,6 +104,7 @@ internal fun USBankAccountForm(
 
     val state by viewModel.currentScreenState.collectAsState()
     val lastTextFieldIdentifier by viewModel.lastTextFieldIdentifier.collectAsState()
+    val addressController by viewModel.addressElement.addressController.collectAsState()
     val isEnabled = !state.isProcessing && enabled
 
     USBankAccountEmitters(
@@ -121,7 +122,7 @@ internal fun USBankAccountForm(
         nameController = viewModel.nameController,
         emailController = viewModel.emailController,
         phoneController = viewModel.phoneController,
-        addressController = viewModel.addressElement.controller,
+        addressController = addressController,
         lastTextFieldIdentifier = lastTextFieldIdentifier,
         sameAsShippingElement = viewModel.sameAsShippingElement,
         saveForFutureUseElement = viewModel.saveForFutureUseElement,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArguments.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArguments.kt
@@ -18,6 +18,7 @@ import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.verticalmode.BankFormInteractor
 import com.stripe.android.paymentsheet.verticalmode.PaymentMethodIncentiveInteractor
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
+import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import kotlinx.coroutines.flow.update
 
 /**
@@ -55,6 +56,7 @@ internal class USBankAccountFormArguments(
     val hostedSurface: String,
     val shippingDetails: AddressDetails?,
     val draftPaymentSelection: PaymentSelection?,
+    val autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
     val onAnalyticsEvent: (USBankAccountFormViewModel.AnalyticsEvent) -> Unit,
     val onMandateTextChanged: (mandate: ResolvableString?, showAbove: Boolean) -> Unit,
     val onLinkedBankAccountChanged: (PaymentSelection.New.USBankAccount?) -> Unit,
@@ -101,6 +103,7 @@ internal class USBankAccountFormArguments(
                 stripeIntentId = stripeIntent.id,
                 clientSecret = stripeIntent.clientSecret,
                 shippingDetails = viewModel.config.shippingDetails,
+                autocompleteAddressInteractorFactory = viewModel.autocompleteAddressInteractorFactory,
                 onAnalyticsEvent = { viewModel.eventReporter.onUsBankAccountFormEvent(it) },
                 draftPaymentSelection = viewModel.newPaymentSelection?.paymentSelection,
                 onMandateTextChanged = viewModel.mandateHandler::updateMandateText,
@@ -158,6 +161,7 @@ internal class USBankAccountFormArguments(
                 shippingDetails = paymentMethodMetadata.shippingDetails,
                 draftPaymentSelection = null,
                 onMandateTextChanged = onMandateTextChanged,
+                autocompleteAddressInteractorFactory = null,
                 onAnalyticsEvent = onAnalyticsEvent,
                 onLinkedBankAccountChanged = bankFormInteractor::handleLinkedBankAccountChanged,
                 onUpdatePrimaryButtonUIState = onUpdatePrimaryButtonUIState,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/di/USBankAccountFormViewModelSubcomponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/di/USBankAccountFormViewModelSubcomponent.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.paymentdatacollection.ach.di
 
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormViewModel
+import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import dagger.BindsInstance
 import dagger.Subcomponent
 
@@ -16,6 +17,9 @@ internal interface USBankAccountFormViewModelSubcomponent {
 
         @BindsInstance
         fun configuration(configuration: USBankAccountFormViewModel.Args): Builder
+
+        @BindsInstance
+        fun autocompleteAddressInteractorFactory(interactorFactory: AutocompleteAddressInteractor.Factory?): Builder
 
         fun build(): USBankAccountFormViewModelSubcomponent
     }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -82,6 +82,7 @@ internal class CustomerSheetScreenshotTest {
         financialConnectionsAvailability = FinancialConnectionsAvailability.Full,
         onAnalyticsEvent = { },
         setAsDefaultMatchesSaveForFutureUse = false,
+        autocompleteAddressInteractorFactory = null,
     )
 
     private val selectPaymentMethodViewState = CustomerSheetViewState.SelectPaymentMethod(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
@@ -341,7 +341,8 @@ class InputAddressViewModelTest {
             val addressFields = autocompleteElement.sectionFieldErrorController()
                 .addressElementFlow
                 .value
-                .controller
+                .addressController
+                .value
                 .fieldsFlowable
                 .value
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressElement.kt
@@ -199,7 +199,9 @@ class AddressElement(
         fields
     }
 
-    val controller = AddressController(fields)
+    private val controller = AddressController(fields)
+
+    override val addressController = stateFlowOf(controller)
 
     /**
      * This will return a controller that abides by the SectionFieldErrorController interface.

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressFieldsElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressFieldsElement.kt
@@ -1,8 +1,10 @@
 package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
+import kotlinx.coroutines.flow.StateFlow
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 interface AddressFieldsElement : SectionFieldElement {
+    val addressController: StateFlow<AddressController>
     val countryElement: CountryElement
 }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressController.kt
@@ -51,6 +51,10 @@ class AutocompleteAddressController(
         addressElement.getTextFieldIdentifiers()
     }
 
+    val addressController = addressElementFlow.flatMapLatestAsStateFlow {
+        it.addressController
+    }
+
     init {
         interactor.register { event ->
             val currentValues = getCurrentValues()
@@ -136,11 +140,11 @@ class AutocompleteAddressController(
         hiddenIdentifiers: Set<IdentifierSpec>,
         lastTextFieldIdentifier: IdentifierSpec?
     ) {
-        val element by addressElementFlow.collectAsState()
+        val controller by addressController.collectAsState()
 
         AddressElementUI(
             enabled = enabled,
-            controller = element.controller,
+            controller = controller,
             hiddenIdentifiers = hiddenIdentifiers,
             lastTextFieldIdentifier = lastTextFieldIdentifier,
             modifier = modifier,

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressElement.kt
@@ -2,6 +2,7 @@ package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
 import com.stripe.android.core.strings.ResolvableString
+import kotlinx.coroutines.flow.StateFlow
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class AutocompleteAddressElement(
@@ -33,6 +34,8 @@ class AutocompleteAddressElement(
             hideName = hideName,
         )
     }
+
+    override val addressController: StateFlow<AddressController> = controller.addressController
 
     override val countryElement: CountryElement = controller.countryElement
 

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/AddressElementUiTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/AddressElementUiTest.kt
@@ -46,13 +46,14 @@ class AddressElementUiTest {
         val formValues = element.getFormFieldValueFlow()
 
         composeTestRule.setContent {
+            val controller by element.addressController.collectAsState()
             val formValuesState by formValues.collectAsState()
 
             Text(formValuesState.toString())
 
             AddressElementUI(
                 enabled = true,
-                controller = element.controller,
+                controller = controller,
                 hiddenIdentifiers = setOf(),
                 lastTextFieldIdentifier = null,
             )

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/AutocompleteAddressControllerTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/AutocompleteAddressControllerTest.kt
@@ -465,6 +465,42 @@ class AutocompleteAddressControllerTest {
         }
     }
 
+    @Test
+    fun `on condensed to expanded form, should change address controllers`() = runTest {
+        TestAutocompleteAddressInteractor.test(
+            autocompleteConfig = AutocompleteAddressInteractor.Config(
+                googlePlacesApiKey = "123",
+                autocompleteCountries = setOf("US"),
+                isPlacesAvailable = true,
+            ),
+        ) {
+            val controller = createAutocompleteAddressController(interactor = interactor)
+
+            val registerCall = registerCalls.awaitItem()
+
+            controller.addressController.test {
+                val firstAddressController = awaitItem()
+
+                registerCall.onEvent(
+                    AutocompleteAddressInteractor.Event.OnValues(
+                        values = mapOf(
+                            IdentifierSpec.Line1 to "123 Main Street",
+                            IdentifierSpec.Line2 to "456",
+                            IdentifierSpec.City to "San Francisco",
+                            IdentifierSpec.State to "CA",
+                            IdentifierSpec.Country to "US",
+                            IdentifierSpec.PostalCode to "94111",
+                        )
+                    )
+                )
+
+                val secondAddressController = awaitItem()
+
+                assertThat(firstAddressController).isNotEqualTo(secondAddressController)
+            }
+        }
+    }
+
     private fun noAutocompleteTest(
         autocompleteConfig: AutocompleteAddressInteractor.Config,
     ) = elementsTest(


### PR DESCRIPTION
# Summary
Add support for address autocomplete for US Bank account

# Motivation
Ensures all LPMs now have address autocomplete support.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified