### PR TITLE
Remove `secret-acl-stripe-android-sonatype` permission check

### DIFF
--- a/scripts/deploy/permissions_check.rb
+++ b/scripts/deploy/permissions_check.rb
@@ -41,13 +41,6 @@ require_relative 'common'
             execute("add-password -n \"$USER\" bindings/gh-tokens/$USER")
         }
     },
-    {
-        "password_key" => "secret-acl-stripe-android-sonatype",
-        "error_actions" => -> {
-            rputs "Follow the prompts:"
-            execute("fetch-password secret-acl-stripe-android-sonatype")
-        }
-    },
 ]
 
 private def request_membership_at_link(link)


### PR DESCRIPTION
# Summary
Remove `secret-acl-stripe-android-sonatype` permission check

# Motivation
No longer needed!

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified