### PR TITLE
Add file existence validation to testBodyFromFile functions

### DIFF
--- a/network-testing/src/main/java/com/stripe/android/networktesting/TestBodyFromFile.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/TestBodyFromFile.kt
@@ -5,13 +5,27 @@ import okio.Buffer
 import org.json.JSONException
 import org.json.JSONObject
 
+/**
+ * Validates that the specified file exists in the classpath resources and returns the input stream.
+ *
+ * @param filename The filename to check for existence
+ * @return The input stream for the file
+ * @throws AssertionError If the file doesn't exist, with a clear error message
+ */
+private fun getFileInputStream(filename: String): java.io.InputStream {
+    val inputStream = MockResponse::class.java.classLoader!!.getResourceAsStream(filename)
+        ?: // MockWebServer catches the exception so we need an error to fail the test
+        throw AssertionError("Test file not found: $filename\n")
+    return inputStream
+}
+
 fun MockResponse.testBodyFromFile(
     filename: String,
     replacements: List<ResponseReplacement>,
 ): MockResponse {
     addHeader("request-id", filename)
 
-    val inputStream = MockResponse::class.java.classLoader!!.getResourceAsStream(filename)
+    val inputStream = getFileInputStream(filename)
     val textBuilder = StringBuilder()
 
     val reader = inputStream.reader().buffered()
@@ -33,7 +47,7 @@ fun MockResponse.testBodyFromFile(
 fun MockResponse.testBodyFromFile(filename: String): MockResponse {
     addHeader("request-id", filename)
 
-    val inputStream = MockResponse::class.java.classLoader!!.getResourceAsStream(filename)
+    val inputStream = getFileInputStream(filename)
     val buffer = Buffer()
     buffer.readFrom(inputStream)
     assertIsValidJsonString(buffer.clone().readUtf8(), filename)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add file validation during response enqueuing that crashes the app with a clear error message if the file doesn't exist, making issues easier for developers to identify and debug.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
[MOBILESDK-3376](https://jira.corp.stripe.com/browse/MOBILESDK-3376)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->
