### PR TITLE
Improve Sepa Debit saving experience

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -4480,6 +4480,14 @@ public final class com/stripe/android/model/PaymentMethodExtraParams$Link$Creato
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/model/PaymentMethodExtraParams$SepaDebit$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodExtraParams$SepaDebit;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethodExtraParams$SepaDebit;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/model/PaymentMethodExtraParams$USBankAccount$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodExtraParams$USBankAccount;
@@ -4572,6 +4580,14 @@ public final class com/stripe/android/model/PaymentMethodOptionsParams$Link$Crea
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodOptionsParams$Link;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethodOptionsParams$Link;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PaymentMethodOptionsParams$SepaDebit$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/PaymentMethodOptionsParams$SepaDebit;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/PaymentMethodOptionsParams$SepaDebit;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 

--- a/payments-core/src/main/java/com/stripe/android/ConfirmStripeIntentParamsFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/ConfirmStripeIntentParamsFactory.kt
@@ -158,6 +158,7 @@ private fun PaymentMethodExtraParams.extractSetAsDefaultPaymentMethodFromExtraPa
     return when (this) {
         is PaymentMethodExtraParams.Card -> this.setAsDefault
         is PaymentMethodExtraParams.USBankAccount -> this.setAsDefault
+        is PaymentMethodExtraParams.SepaDebit -> this.setAsDefault
         else -> null
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethodExtraParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethodExtraParams.kt
@@ -67,6 +67,18 @@ sealed class PaymentMethodExtraParams(
 
     @Parcelize
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    data class SepaDebit(
+        val setAsDefault: Boolean? = null
+    ) : PaymentMethodExtraParams(PaymentMethod.Type.SepaDebit) {
+        override fun createTypeParams(): List<Pair<String, Any?>> {
+            return listOf(
+                PARAM_SET_AS_DEFAULT_PAYMENT_METHOD to setAsDefault?.toString()
+            )
+        }
+    }
+
+    @Parcelize
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     data class USBankAccount(
         val setAsDefault: Boolean? = null
     ) : PaymentMethodExtraParams(PaymentMethod.Type.USBankAccount) {

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethodOptionsParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethodOptionsParams.kt
@@ -95,6 +95,22 @@ sealed class PaymentMethodOptionsParams(
 
     @Parcelize
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    data class SepaDebit(
+        var setupFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage? = null
+    ) : PaymentMethodOptionsParams(PaymentMethod.Type.SepaDebit) {
+        override fun createTypeParams(): List<Pair<String, Any?>> {
+            return listOf(
+                PARAM_SETUP_FUTURE_USAGE to setupFutureUsage?.code
+            )
+        }
+
+        internal companion object {
+            const val PARAM_SETUP_FUTURE_USAGE = "setup_future_usage"
+        }
+    }
+
+    @Parcelize
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     data class Konbini(
         private val confirmationNumber: String
     ) : PaymentMethodOptionsParams(PaymentMethod.Type.Konbini) {
@@ -155,6 +171,7 @@ fun PaymentMethodOptionsParams.setupFutureUsage(): ConfirmPaymentIntentParams.Se
     return when (this) {
         is PaymentMethodOptionsParams.Blik -> null
         is PaymentMethodOptionsParams.Card -> setupFutureUsage
+        is PaymentMethodOptionsParams.SepaDebit -> setupFutureUsage
         is PaymentMethodOptionsParams.Konbini -> null
         is PaymentMethodOptionsParams.Link -> setupFutureUsage
         is PaymentMethodOptionsParams.USBankAccount -> setupFutureUsage

--- a/payments-core/src/test/java/com/stripe/android/ConfirmPaymentIntentParamsFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/ConfirmPaymentIntentParamsFactoryTest.kt
@@ -140,6 +140,54 @@ class ConfirmPaymentIntentParamsFactoryTest {
     }
 
     @Test
+    fun `create() with new sepa debit when setAsDefaultPaymentMethod is true`() {
+        val paymentIntentParams = factory.create(
+            createParams = PaymentMethodCreateParamsFixtures.DEFAULT_SEPA_DEBIT,
+            optionsParams = null,
+            extraParams = PaymentMethodExtraParams.SepaDebit(
+                setAsDefault = true
+            )
+        )
+        assertThat(paymentIntentParams.setAsDefaultPaymentMethod).isTrue()
+    }
+
+    @Test
+    fun `create() with new sepa debit when setAsDefaultPaymentMethod is false`() {
+        val paymentIntentParams = factory.create(
+            createParams = PaymentMethodCreateParamsFixtures.DEFAULT_SEPA_DEBIT,
+            optionsParams = null,
+            extraParams = PaymentMethodExtraParams.SepaDebit(
+                setAsDefault = false
+            )
+        )
+        assertThat(paymentIntentParams.setAsDefaultPaymentMethod).isFalse()
+    }
+
+    @Test
+    fun `create() with new sepa debit when setAsDefaultPaymentMethod is true and using paymentMethod`() {
+        val paymentIntentParams = factory.create(
+            paymentMethod = PaymentMethodFixtures.SEPA_DEBIT_PAYMENT_METHOD,
+            optionsParams = null,
+            extraParams = PaymentMethodExtraParams.SepaDebit(
+                setAsDefault = true
+            )
+        )
+        assertThat(paymentIntentParams.setAsDefaultPaymentMethod).isTrue()
+    }
+
+    @Test
+    fun `create() with new sepa debit when setAsDefaultPaymentMethod is false and using paymentMethod`() {
+        val paymentIntentParams = factory.create(
+            paymentMethod = PaymentMethodFixtures.SEPA_DEBIT_PAYMENT_METHOD,
+            optionsParams = null,
+            extraParams = PaymentMethodExtraParams.SepaDebit(
+                setAsDefault = false
+            )
+        )
+        assertThat(paymentIntentParams.setAsDefaultPaymentMethod).isFalse()
+    }
+
+    @Test
     fun `create() with saved card and shippingDetails sets shipping field`() {
         val shippingDetails = ConfirmPaymentIntentParams.Shipping(
             name = "Test",

--- a/payments-core/src/test/java/com/stripe/android/ConfirmSetupIntentParamsFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/ConfirmSetupIntentParamsFactoryTest.kt
@@ -80,6 +80,62 @@ class ConfirmSetupIntentParamsFactoryTest {
         assertThat(params.setAsDefaultPaymentMethod).isFalse()
     }
 
+    @Test
+    fun `create() should set setAsDefault as true for sepa debit when using create params`() {
+        val result = getConfirmSetupIntentParamsForTesting(
+            createParams = PaymentMethodCreateParamsFixtures.DEFAULT_SEPA_DEBIT,
+            extraParams = PaymentMethodExtraParams.SepaDebit(
+                setAsDefault = true
+            )
+        )
+
+        val params = result.asConfirmSetupIntentParams()
+
+        assertThat(params.setAsDefaultPaymentMethod).isTrue()
+    }
+
+    @Test
+    fun `create() should set setAsDefault as false for sepa debit when using create params`() {
+        val result = getConfirmSetupIntentParamsForTesting(
+            createParams = PaymentMethodCreateParamsFixtures.DEFAULT_SEPA_DEBIT,
+            extraParams = PaymentMethodExtraParams.SepaDebit(
+                setAsDefault = false
+            )
+        )
+
+        val params = result.asConfirmSetupIntentParams()
+
+        assertThat(params.setAsDefaultPaymentMethod).isFalse()
+    }
+
+    @Test
+    fun `create() should set setAsDefault as true for sepa debit when using payment method`() {
+        val result = getConfirmSetupIntentParamsForTesting(
+            paymentMethod = PaymentMethodFixtures.SEPA_DEBIT_PAYMENT_METHOD,
+            extraParams = PaymentMethodExtraParams.SepaDebit(
+                setAsDefault = true
+            )
+        )
+
+        val params = result.asConfirmSetupIntentParams()
+
+        assertThat(params.setAsDefaultPaymentMethod).isTrue()
+    }
+
+    @Test
+    fun `create() should set setAsDefault as false for sepa debit when using payment method`() {
+        val result = getConfirmSetupIntentParamsForTesting(
+            paymentMethod = PaymentMethodFixtures.SEPA_DEBIT_PAYMENT_METHOD,
+            extraParams = PaymentMethodExtraParams.SepaDebit(
+                setAsDefault = false
+            )
+        )
+
+        val params = result.asConfirmSetupIntentParams()
+
+        assertThat(params.setAsDefaultPaymentMethod).isFalse()
+    }
+
     private fun getConfirmSetupIntentParamsForTesting(): ConfirmSetupIntentParams {
         val factoryWithConfig = ConfirmSetupIntentParamsFactory(
             clientSecret = CLIENT_SECRET,

--- a/payments-core/src/test/java/com/stripe/android/model/PaymentMethodOptionsParamsTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/PaymentMethodOptionsParamsTest.kt
@@ -51,4 +51,42 @@ class PaymentMethodOptionsParamsTest {
                 .toParamMap()
         ).isEmpty()
     }
+
+    @Test
+    fun sepaDebitToParamMap_withSetupFutureUsage_shouldIncludeSetupFutureUsage() {
+        assertThat(
+            PaymentMethodOptionsParams.SepaDebit(
+                setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
+            ).toParamMap()
+        ).isEqualTo(
+            mapOf(
+                "sepa_debit" to mapOf(
+                    "setup_future_usage" to "off_session"
+                )
+            )
+        )
+    }
+
+    @Test
+    fun sepaDebitToParamMap_withNoData_shouldHaveEmptyParams() {
+        assertThat(
+            PaymentMethodOptionsParams.SepaDebit()
+                .toParamMap()
+        ).isEmpty()
+    }
+
+    @Test
+    fun sepaDebitToParamMap_withSetupFutureUsageOnSession_shouldIncludeSetupFutureUsage() {
+        assertThat(
+            PaymentMethodOptionsParams.SepaDebit(
+                setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OnSession
+            ).toParamMap()
+        ).isEqualTo(
+            mapOf(
+                "sepa_debit" to mapOf(
+                    "setup_future_usage" to "on_session"
+                )
+            )
+        )
+    }
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverter.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverter.kt
@@ -3,6 +3,7 @@ package com.stripe.android.ui.core
 import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
 import com.stripe.android.model.Address
+import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.PaymentMethodCreateParams
@@ -91,6 +92,7 @@ class FieldValuesToParamsMapConverter {
         fun transformToPaymentMethodOptionsParams(
             fieldValuePairs: Map<IdentifierSpec, FormFieldEntry>,
             code: PaymentMethodCode,
+            setupFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage? = null
         ): PaymentMethodOptionsParams? {
             val fieldValuePairsForOptions = fieldValuePairs.filter { entry ->
                 entry.key.destination == ParameterDestination.Api.Options
@@ -110,6 +112,11 @@ class FieldValuesToParamsMapConverter {
                 }
                 PaymentMethod.Type.WeChatPay.code -> {
                     PaymentMethodOptionsParams.WeChatPayH5
+                }
+                PaymentMethod.Type.SepaDebit.code -> {
+                    PaymentMethodOptionsParams.SepaDebit(
+                        setupFutureUsage = setupFutureUsage,
+                    )
                 }
                 else -> {
                     null
@@ -141,7 +148,10 @@ class FieldValuesToParamsMapConverter {
                     setAsDefault =
                     fieldValuePairsForExtras[IdentifierSpec.SetAsDefaultPaymentMethod]?.value?.toBoolean()
                 )
-
+                PaymentMethod.Type.SepaDebit.code -> PaymentMethodExtraParams.SepaDebit(
+                    setAsDefault =
+                    fieldValuePairsForExtras[IdentifierSpec.SetAsDefaultPaymentMethod]?.value?.toBoolean()
+                )
                 else -> null
             }
         }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverter.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverter.kt
@@ -98,6 +98,11 @@ class FieldValuesToParamsMapConverter {
                 entry.key.destination == ParameterDestination.Api.Options
             }
             return when (code) {
+                PaymentMethod.Type.Card.code -> {
+                    PaymentMethodOptionsParams.Card(
+                        setupFutureUsage = setupFutureUsage,
+                    )
+                }
                 PaymentMethod.Type.Blik.code -> {
                     val blikCode = fieldValuePairsForOptions[IdentifierSpec.BlikCode]?.value
                     blikCode?.let {

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverterTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverterTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.ui.core
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.FieldValuesToParamsMapConverter.Companion.addPath
 import com.stripe.android.ui.core.FieldValuesToParamsMapConverter.Companion.getKeys
@@ -406,6 +407,71 @@ class FieldValuesToParamsMapConverterTest {
             )
 
         assertThat(paymentMethodParams).isNull()
+    }
+
+    @Test
+    fun `transformToPaymentMethodOptionsParams returns correct params for SepaDebit with setupFutureUsage`() {
+        val paymentMethodParams = FieldValuesToParamsMapConverter
+            .transformToPaymentMethodOptionsParams(
+                fieldValuePairs = emptyMap(),
+                code = PaymentMethod.Type.SepaDebit.code,
+                setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession,
+            )
+
+        assertThat(paymentMethodParams).isNotNull()
+        assertThat(
+            paymentMethodParams?.toParamMap().toString()
+        ).isEqualTo(
+            "{sepa_debit={setup_future_usage=off_session}}"
+        )
+    }
+
+    @Test
+    fun `transformToPaymentMethodOptionsParams returns correct params for SepaDebit without setupFutureUsage`() {
+        val paymentMethodParams = FieldValuesToParamsMapConverter
+            .transformToPaymentMethodOptionsParams(
+                fieldValuePairs = emptyMap(),
+                code = PaymentMethod.Type.SepaDebit.code,
+                setupFutureUsage = null
+            )
+
+        assertThat(paymentMethodParams).isNotNull()
+        assertThat(paymentMethodParams?.toParamMap().toString()).isEqualTo("{}")
+    }
+
+    @Test
+    fun `transformToPaymentMethodExtraParams returns correct params for SepaDebit with setAsDefault`() {
+        val paymentMethodExtraParams = FieldValuesToParamsMapConverter
+            .transformToPaymentMethodExtraParams(
+                mapOf(
+                    IdentifierSpec.SetAsDefaultPaymentMethod to FormFieldEntry(
+                        "true",
+                        true
+                    ),
+                ),
+                PaymentMethod.Type.SepaDebit.code,
+            )
+
+        assertThat(paymentMethodExtraParams).isNotNull()
+        assertThat(paymentMethodExtraParams?.toParamMap()).isEqualTo(
+            mapOf(
+                "sepa_debit" to mapOf(
+                    "set_as_default_payment_method" to "true"
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `transformToPaymentMethodExtraParams returns correct params for SepaDebit without setAsDefault`() {
+        val paymentMethodExtraParams = FieldValuesToParamsMapConverter
+            .transformToPaymentMethodExtraParams(
+                emptyMap(),
+                PaymentMethod.Type.SepaDebit.code,
+            )
+
+        assertThat(paymentMethodExtraParams).isNotNull()
+        assertThat(paymentMethodExtraParams?.toParamMap().toString()).isEqualTo("{}")
     }
 
     @Test

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverterTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverterTest.kt
@@ -275,6 +275,36 @@ class FieldValuesToParamsMapConverterTest {
     }
 
     @Test
+    fun `transformToPaymentMethodOptionsParams returns correct params for Card with setupFutureUsage`() {
+        val paymentMethodParams = FieldValuesToParamsMapConverter
+            .transformToPaymentMethodOptionsParams(
+                fieldValuePairs = emptyMap(),
+                code = PaymentMethod.Type.Card.code,
+                setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession,
+            )
+
+        assertThat(paymentMethodParams).isNotNull()
+        assertThat(
+            paymentMethodParams?.toParamMap().toString()
+        ).isEqualTo(
+            "{card={setup_future_usage=off_session}}"
+        )
+    }
+
+    @Test
+    fun `transformToPaymentMethodOptionsParams returns correct params for Card without setupFutureUsage`() {
+        val paymentMethodParams = FieldValuesToParamsMapConverter
+            .transformToPaymentMethodOptionsParams(
+                fieldValuePairs = emptyMap(),
+                code = PaymentMethod.Type.Card.code,
+                setupFutureUsage = null
+            )
+
+        assertThat(paymentMethodParams).isNotNull()
+        assertThat(paymentMethodParams?.toParamMap().toString()).isEqualTo("{}")
+    }
+
+    @Test
     fun `transformToPaymentMethodOptionsParams returns correct params for Blik`() {
         val paymentMethodParams = FieldValuesToParamsMapConverter
             .transformToPaymentMethodOptionsParams(
@@ -375,38 +405,6 @@ class FieldValuesToParamsMapConverterTest {
         assertThat(
             paymentMethodParams?.toParamMap().toString()
         ).isEqualTo("{konbini={confirmation_number=example_confirmation_number}}")
-    }
-
-    @Test
-    fun `transformToPaymentMethodOptionsParams returns null for card`() {
-        val paymentMethodParams = FieldValuesToParamsMapConverter
-            .transformToPaymentMethodOptionsParams(
-                mapOf(
-                    IdentifierSpec.Name to FormFieldEntry(
-                        "joe",
-                        true
-                    ),
-                    IdentifierSpec.Email to FormFieldEntry(
-                        "joe@gmail.com",
-                        true
-                    ),
-                    IdentifierSpec.Generic("billing_details[address][country]") to FormFieldEntry(
-                        "US",
-                        true
-                    ),
-                    IdentifierSpec.Line1 to FormFieldEntry(
-                        "123 Main Street",
-                        true
-                    ),
-                    IdentifierSpec.BlikCode to FormFieldEntry(
-                        "example_blik_code",
-                        true,
-                    )
-                ),
-                PaymentMethod.Type.Card.code,
-            )
-
-        assertThat(paymentMethodParams).isNull()
     }
 
     @Test

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/SaveForFutureUseHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/SaveForFutureUseHelper.kt
@@ -1,10 +1,29 @@
 package com.stripe.android.lpmfoundations.luxe
 
+import com.stripe.android.lpmfoundations.paymentmethod.IS_PAYMENT_METHOD_SET_AS_DEFAULT_ENABLED_DEFAULT_VALUE
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
+import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.ui.core.elements.SaveForFutureUseElement
+import com.stripe.android.ui.core.elements.SetAsDefaultPaymentMethodElement
+import com.stripe.android.uicore.elements.FormElement
+import com.stripe.android.uicore.elements.IdentifierSpec
+
+internal fun isSaveForFutureUseValueChangeable(
+    code: PaymentMethodCode,
+    metadata: PaymentMethodMetadata
+): Boolean {
+    return isSaveForFutureUseValueChangeable(
+        code = code,
+        intent = metadata.stripeIntent,
+        paymentMethodSaveConsentBehavior = metadata.paymentMethodSaveConsentBehavior,
+        hasCustomerConfiguration = metadata.customerMetadata?.hasCustomerConfiguration ?: false,
+    )
+}
 
 internal fun isSaveForFutureUseValueChangeable(
     code: PaymentMethodCode,
@@ -33,4 +52,41 @@ internal fun isSaveForFutureUseValueChangeable(
             }
         }
     }
+}
+
+internal fun MutableList<FormElement>.addSavePaymentOptionElements(
+    metadata: PaymentMethodMetadata,
+    arguments: UiDefinitionFactory.Arguments,
+): Boolean {
+    val saveForFutureUseElement =
+        SaveForFutureUseElement(
+            initialValue = arguments.saveForFutureUseInitialValue,
+            merchantName = arguments.merchantName
+        )
+
+    val isSaveForFutureUseCheckedFlow = saveForFutureUseElement.controller.saveForFutureUse
+    val isSetAsDefaultPaymentMethodEnabled = metadata.customerMetadata?.isPaymentMethodSetAsDefaultEnabled
+        ?: IS_PAYMENT_METHOD_SET_AS_DEFAULT_ENABLED_DEFAULT_VALUE
+
+    add(saveForFutureUseElement)
+
+    if (isSetAsDefaultPaymentMethodEnabled) {
+        add(
+            SetAsDefaultPaymentMethodElement(
+                initialValue = getSetAsDefaultInitialValueFromArguments(arguments),
+                saveForFutureUseCheckedFlow = isSaveForFutureUseCheckedFlow,
+                setAsDefaultMatchesSaveForFutureUse = arguments.setAsDefaultMatchesSaveForFutureUse,
+            )
+        )
+    }
+
+    return true
+}
+
+private fun getSetAsDefaultInitialValueFromArguments(
+    arguments: UiDefinitionFactory.Arguments
+): Boolean {
+    return arguments.initialValues.entries.firstOrNull {
+        it.key.v1.contains(IdentifierSpec.SetAsDefaultPaymentMethod.v1)
+    }?.value?.toBoolean() ?: false
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElements.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElements.kt
@@ -41,7 +41,7 @@ import com.stripe.android.uicore.elements.IdentifierSpec
  *
  */
 internal class TransformSpecToElements(
-    private val arguments: UiDefinitionFactory.Arguments,
+    val arguments: UiDefinitionFactory.Arguments,
 ) {
     fun transform(
         metadata: PaymentMethodMetadata?,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElements.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElements.kt
@@ -41,7 +41,7 @@ import com.stripe.android.uicore.elements.IdentifierSpec
  *
  */
 internal class TransformSpecToElements(
-    val arguments: UiDefinitionFactory.Arguments,
+    private val arguments: UiDefinitionFactory.Arguments,
 ) {
     fun transform(
         metadata: PaymentMethodMetadata?,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionFactory.kt
@@ -112,6 +112,19 @@ internal sealed interface UiDefinitionFactory {
             metadata: PaymentMethodMetadata,
             sharedDataSpec: SharedDataSpec,
             transformSpecToElements: TransformSpecToElements,
+            arguments: Arguments,
+        ): List<FormElement> {
+            return createFormElements(
+                metadata = metadata,
+                sharedDataSpec = sharedDataSpec,
+                transformSpecToElements = transformSpecToElements,
+            )
+        }
+
+        fun createFormElements(
+            metadata: PaymentMethodMetadata,
+            sharedDataSpec: SharedDataSpec,
+            transformSpecToElements: TransformSpecToElements,
         ): List<FormElement> {
             return transformSpecToElements.transform(
                 metadata = metadata,
@@ -212,6 +225,7 @@ internal sealed interface UiDefinitionFactory {
                     metadata = metadata,
                     sharedDataSpec = sharedDataSpec,
                     transformSpecToElements = TransformSpecToElements(arguments),
+                    arguments = arguments,
                 )
             } else {
                 null

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SepaDebitDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SepaDebitDefinition.kt
@@ -34,7 +34,8 @@ private object SepaDebitUiDefinitionFactory : UiDefinitionFactory.RequiresShared
     override fun createFormElements(
         metadata: PaymentMethodMetadata,
         sharedDataSpec: SharedDataSpec,
-        transformSpecToElements: TransformSpecToElements
+        transformSpecToElements: TransformSpecToElements,
+        arguments: UiDefinitionFactory.Arguments,
     ): List<FormElement> {
         val canSave = isSaveForFutureUseValueChangeable(
             code = SepaDebitDefinition.type.code,
@@ -56,7 +57,7 @@ private object SepaDebitUiDefinitionFactory : UiDefinitionFactory.RequiresShared
 
                     addSavePaymentOptionElements(
                         metadata = metadata,
-                        arguments = transformSpecToElements.arguments,
+                        arguments = arguments,
                     )
 
                     mandate?.let { add(it) }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SepaDebitDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SepaDebitDefinition.kt
@@ -1,13 +1,18 @@
 package com.stripe.android.lpmfoundations.paymentmethod.definitions
 
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
+import com.stripe.android.lpmfoundations.luxe.TransformSpecToElements
+import com.stripe.android.lpmfoundations.luxe.addSavePaymentOptionElements
+import com.stripe.android.lpmfoundations.luxe.isSaveForFutureUseValueChangeable
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
+import com.stripe.android.ui.core.elements.MandateTextElement
 import com.stripe.android.ui.core.elements.SharedDataSpec
+import com.stripe.android.uicore.elements.FormElement
 
 internal object SepaDebitDefinition : PaymentMethodDefinition {
     override val type: PaymentMethod.Type = PaymentMethod.Type.SepaDebit
@@ -26,6 +31,42 @@ internal object SepaDebitDefinition : PaymentMethodDefinition {
 }
 
 private object SepaDebitUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDataSpec {
+    override fun createFormElements(
+        metadata: PaymentMethodMetadata,
+        sharedDataSpec: SharedDataSpec,
+        transformSpecToElements: TransformSpecToElements
+    ): List<FormElement> {
+        val canSave = isSaveForFutureUseValueChangeable(
+            code = SepaDebitDefinition.type.code,
+            metadata = metadata,
+        )
+
+        val sharedSpecElements = super.createFormElements(metadata, sharedDataSpec, transformSpecToElements)
+
+        return if (canSave) {
+            sharedSpecElements.toMutableList()
+                .apply {
+                    val lastElement = lastOrNull()
+
+                    val mandate = if (lastElement is MandateTextElement) {
+                        removeAt(lastIndex)
+                    } else {
+                        null
+                    }
+
+                    addSavePaymentOptionElements(
+                        metadata = metadata,
+                        arguments = transformSpecToElements.arguments,
+                    )
+
+                    mandate?.let { add(it) }
+                }
+                .toList()
+        } else {
+            sharedSpecElements
+        }
+    }
+
     override fun createSupportedPaymentMethod(
         metadata: PaymentMethodMetadata,
         sharedDataSpec: SharedDataSpec,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptor.kt
@@ -639,6 +639,7 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
             is PaymentMethodExtraParams.Card -> paymentMethodExtraParams.setAsDefault == true
             is PaymentMethodExtraParams.USBankAccount -> paymentMethodExtraParams.setAsDefault == true
             is PaymentMethodExtraParams.Link -> paymentMethodExtraParams.setAsDefault == true
+            is PaymentMethodExtraParams.SepaDebit -> paymentMethodExtraParams.setAsDefault == true
             is PaymentMethodExtraParams.BacsDebit, null -> false
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -108,9 +108,7 @@ internal fun FormFieldValues.transformToPaymentSelection(
     val extras = transformToExtraParams(paymentMethod.code)
     return if (paymentMethod.code == PaymentMethod.Type.Card.code) {
         PaymentSelection.New.Card(
-            paymentMethodOptionsParams = PaymentMethodOptionsParams.Card(
-                setupFutureUsage = setupFutureUsage,
-            ),
+            paymentMethodOptionsParams = options,
             paymentMethodCreateParams = params,
             paymentMethodExtraParams = extras,
             brand = CardBrand.fromCode(fieldValuePairs[IdentifierSpec.CardBrand]?.value),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.platform.testTag
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.PaymentMethodCreateParams
@@ -75,11 +76,13 @@ internal fun FormFieldValues.transformToPaymentMethodCreateParams(
 }
 
 internal fun FormFieldValues.transformToPaymentMethodOptionsParams(
-    paymentMethodCode: PaymentMethodCode
+    paymentMethodCode: PaymentMethodCode,
+    setupFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage? = null,
 ): PaymentMethodOptionsParams? {
     return FieldValuesToParamsMapConverter.transformToPaymentMethodOptionsParams(
         fieldValuePairs = fieldValuePairs,
         code = paymentMethodCode,
+        setupFutureUsage = setupFutureUsage,
     )
 }
 
@@ -96,15 +99,17 @@ internal fun FormFieldValues.transformToPaymentSelection(
     paymentMethod: SupportedPaymentMethod,
     paymentMethodMetadata: PaymentMethodMetadata,
 ): PaymentSelection {
+    val setupFutureUsage = userRequestedReuse.getSetupFutureUseValue(
+        paymentMethodMetadata.hasIntentToSetup(PaymentMethod.Type.Card.code)
+    )
+
     val params = transformToPaymentMethodCreateParams(paymentMethod.code, paymentMethodMetadata)
-    val options = transformToPaymentMethodOptionsParams(paymentMethod.code)
+    val options = transformToPaymentMethodOptionsParams(paymentMethod.code, setupFutureUsage)
     val extras = transformToExtraParams(paymentMethod.code)
     return if (paymentMethod.code == PaymentMethod.Type.Card.code) {
         PaymentSelection.New.Card(
             paymentMethodOptionsParams = PaymentMethodOptionsParams.Card(
-                setupFutureUsage = userRequestedReuse.getSetupFutureUseValue(
-                    paymentMethodMetadata.hasIntentToSetup(PaymentMethod.Type.Card.code)
-                )
+                setupFutureUsage = setupFutureUsage,
             ),
             paymentMethodCreateParams = params,
             paymentMethodExtraParams = extras,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
@@ -108,7 +108,7 @@ internal class DefaultUpdatePaymentMethodInteractor(
     override val addressCollectionMode: AddressCollectionMode,
     override val canUpdateFullPaymentMethodDetails: Boolean,
     val isDefaultPaymentMethod: Boolean,
-    shouldShowSetAsDefaultCheckbox: Boolean,
+    override val shouldShowSetAsDefaultCheckbox: Boolean,
     private val removeExecutor: PaymentMethodRemoveOperation,
     private val updatePaymentMethodExecutor: UpdateCardPaymentMethodOperation,
     private val setDefaultPaymentMethodExecutor: PaymentMethodSetAsDefaultOperation,
@@ -123,12 +123,6 @@ internal class DefaultUpdatePaymentMethodInteractor(
     private val initialSetAsDefaultCheckedValue = isDefaultPaymentMethod
     private val setAsDefaultCheckboxChecked = MutableStateFlow(initialSetAsDefaultCheckedValue)
     private val cardUpdateParams = MutableStateFlow<CardUpdateParams?>(null)
-
-    // We don't yet support setting SEPA payment methods as defaults, so we hide the checkbox for now.
-    override val shouldShowSetAsDefaultCheckbox = (
-        shouldShowSetAsDefaultCheckbox &&
-            displayableSavedPaymentMethod.savedPaymentMethod !is SavedPaymentMethod.SepaDebit
-        )
 
     override val hasValidBrandChoices = hasValidBrandChoices()
     override val isExpiredCard = paymentMethodIsExpiredCard()

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/SaveForFutureUseHelperKtTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/SaveForFutureUseHelperKtTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.lpmfoundations.luxe
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
@@ -64,6 +65,48 @@ class SaveForFutureUseHelperKtTest {
     }
 
     @Test
+    fun `isSaveForFutureUseValueChangeable returns false for PI without SFU & LPM SFU set for legacy behavior`() {
+        val isSaveForFutureUseValueChangeable = isSaveForFutureUseValueChangeable(
+            code = PaymentMethod.Type.Card.code,
+            intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                setupFutureUsage = null,
+                paymentMethodOptionsJsonString = """
+                    {
+                        "card": {
+                            "setup_future_usage": "off_session"
+                        }
+                    }
+                """.trimIndent()
+            ),
+            paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
+            hasCustomerConfiguration = true,
+        )
+
+        assertThat(isSaveForFutureUseValueChangeable).isFalse()
+    }
+
+    @Test
+    fun `isSaveForFutureUseValueChangeable returns true for PI without SFU & LPM SFU as none for legacy behavior`() {
+        val isSaveForFutureUseValueChangeable = isSaveForFutureUseValueChangeable(
+            code = PaymentMethod.Type.Card.code,
+            intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                setupFutureUsage = null,
+                paymentMethodOptionsJsonString = """
+                    {
+                        "card": {
+                            "setup_future_usage": "none"
+                        }
+                    }
+                """.trimIndent()
+            ),
+            paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
+            hasCustomerConfiguration = true,
+        )
+
+        assertThat(isSaveForFutureUseValueChangeable).isTrue()
+    }
+
+    @Test
     fun `isSaveForFutureUseValueChangeable returns true if consent behavior is Enabled and has customer`() {
         val isSaveForFutureUseValueChangeable = isSaveForFutureUseValueChangeable(
             code = PaymentMethod.Type.Card.code,
@@ -99,5 +142,19 @@ class SaveForFutureUseHelperKtTest {
         )
 
         assertThat(isSaveForFutureUseValueChangeable).isFalse()
+    }
+
+    @Test
+    fun `isSaveForFutureUseValueChangeable with metadata works as expected`() {
+        val isSaveForFutureUseValueChangeable = isSaveForFutureUseValueChangeable(
+            code = PaymentMethod.Type.Card.code,
+            metadata = PaymentMethodMetadataFactory.create(
+                stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
+                hasCustomerConfiguration = true,
+                paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Enabled,
+            )
+        )
+
+        assertThat(isSaveForFutureUseValueChangeable).isTrue()
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SepaDebitDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SepaDebitDefinitionTest.kt
@@ -1,0 +1,101 @@
+package com.stripe.android.lpmfoundations.paymentmethod.definitions
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
+import com.stripe.android.lpmfoundations.paymentmethod.formElements
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.SetupIntentFixtures
+import com.stripe.android.ui.core.elements.MandateTextElement
+import com.stripe.android.ui.core.elements.SaveForFutureUseElement
+import com.stripe.android.ui.core.elements.SetAsDefaultPaymentMethodElement
+import org.junit.Test
+
+class SepaDebitDefinitionTest {
+    @Test
+    fun `'createFormElements' includes 'SaveForFutureUseElement' when changeable`() {
+        val formElements = SepaDebitDefinition.formElements(
+            PaymentMethodMetadataFactory.create(
+                stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                    paymentMethodTypes = listOf("sepa_debit")
+                ),
+                hasCustomerConfiguration = true
+            )
+        )
+
+        val saveForFutureUseElement = formElements.find { it is SaveForFutureUseElement }
+        assertThat(saveForFutureUseElement).isNotNull()
+        assertThat(saveForFutureUseElement).isInstanceOf(SaveForFutureUseElement::class.java)
+    }
+
+    @Test
+    fun `'createFormElements' includes 'SetAsDefaultPaymentMethodElement' when enabled`() {
+        val formElements = SepaDebitDefinition.formElements(
+            PaymentMethodMetadataFactory.create(
+                stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                    paymentMethodTypes = listOf("sepa_debit")
+                ),
+                hasCustomerConfiguration = true,
+                isPaymentMethodSetAsDefaultEnabled = true
+            )
+        )
+
+        val setAsDefaultElement = formElements.find { it is SetAsDefaultPaymentMethodElement }
+        assertThat(setAsDefaultElement).isNotNull()
+        assertThat(setAsDefaultElement).isInstanceOf(SetAsDefaultPaymentMethodElement::class.java)
+    }
+
+    @Test
+    fun `'createFormElements' does not include 'SetAsDefaultPaymentMethodElement' when disabled`() {
+        val formElements = SepaDebitDefinition.formElements(
+            PaymentMethodMetadataFactory.create(
+                stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                    paymentMethodTypes = listOf("sepa_debit")
+                ),
+                hasCustomerConfiguration = true,
+                isPaymentMethodSetAsDefaultEnabled = false
+            )
+        )
+
+        val setAsDefaultElement = formElements.find { it is SetAsDefaultPaymentMethodElement }
+        assertThat(setAsDefaultElement).isNull()
+    }
+
+    @Test
+    fun `'createFormElements' with SetupIntent includes 'SaveForFutureUseElement' when save behavior is enabled`() {
+        val formElements = SepaDebitDefinition.formElements(
+            PaymentMethodMetadataFactory.create(
+                stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD.copy(
+                    paymentMethodTypes = listOf("sepa_debit")
+                ),
+                paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Enabled,
+                hasCustomerConfiguration = true
+            )
+        )
+
+        val saveForFutureUseElement = formElements.find { it is SaveForFutureUseElement }
+        assertThat(saveForFutureUseElement).isNotNull()
+    }
+
+    @Test
+    fun `'createFormElements' always includes mandate as last element`() {
+        val formElements = SepaDebitDefinition.formElements(
+            PaymentMethodMetadataFactory.create(
+                stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                    paymentMethodTypes = listOf("sepa_debit")
+                ),
+                hasCustomerConfiguration = true,
+                isPaymentMethodSetAsDefaultEnabled = true
+            )
+        )
+
+        val setAsDefaultElement = formElements.find { it is SetAsDefaultPaymentMethodElement }
+        assertThat(setAsDefaultElement).isNotNull()
+
+        val lastElement = formElements.last()
+
+        assertThat(setAsDefaultElement).isNotEqualTo(lastElement)
+
+        assertThat(lastElement).isInstanceOf(MandateTextElement::class.java)
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodTest.kt
@@ -15,6 +15,7 @@ import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.PaymentMethodCreateParams.Companion.getNameFromParams
+import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.model.SetupIntentFixtures
@@ -437,6 +438,124 @@ internal class AddPaymentMethodTest {
         )
 
         assertThat(params.toParamMap()).containsEntry("allow_redisplay", "always")
+    }
+
+    @Test
+    fun `transformToPaymentSelection transforms SepaDebit with PMO setupFutureUsage correctly for RequestReuse`() {
+        val customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestReuse
+        val formFieldValues = FormFieldValues(
+            fieldValuePairs = mapOf(
+                IdentifierSpec.Generic("sepa_debit[iban]") to FormFieldEntry("DE89370400440532013000", true),
+            ),
+            userRequestedReuse = customerRequestedSave,
+        )
+
+        val metadataWithSepaDebit = metadata.copy(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("sepa_debit")
+            )
+        )
+        val sepaDebitPaymentMethod = metadataWithSepaDebit.supportedPaymentMethodForCode("sepa_debit")!!
+        val sepaDebitPaymentSelection = formFieldValues.transformToPaymentSelection(
+            sepaDebitPaymentMethod,
+            metadataWithSepaDebit
+        ) as PaymentSelection.New.GenericPaymentMethod
+
+        val options = sepaDebitPaymentSelection.paymentMethodOptionsParams as? PaymentMethodOptionsParams.SepaDebit
+        assertThat(sepaDebitPaymentSelection.customerRequestedSave).isEqualTo(customerRequestedSave)
+        assertThat(options?.setupFutureUsage).isEqualTo(ConfirmPaymentIntentParams.SetupFutureUsage.OffSession)
+    }
+
+    @Test
+    fun `transformToPaymentSelection transforms SepaDebit with PMO setupFutureUsage correctly for RequestNoReuse`() {
+        val customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestNoReuse
+        val formFieldValues = FormFieldValues(
+            fieldValuePairs = mapOf(
+                IdentifierSpec.Generic("sepa_debit[iban]") to
+                    FormFieldEntry("DE89370400440532013000", true),
+            ),
+            userRequestedReuse = customerRequestedSave,
+        )
+
+        val metadataWithSepaDebit = metadata.copy(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("sepa_debit")
+            )
+        )
+        val sepaDebitPaymentMethod = metadataWithSepaDebit.supportedPaymentMethodForCode("sepa_debit")!!
+        val sepaDebitPaymentSelection = formFieldValues.transformToPaymentSelection(
+            sepaDebitPaymentMethod,
+            metadataWithSepaDebit
+        ) as PaymentSelection.New.GenericPaymentMethod
+
+        val options = sepaDebitPaymentSelection.paymentMethodOptionsParams as? PaymentMethodOptionsParams.SepaDebit
+        assertThat(sepaDebitPaymentSelection.customerRequestedSave).isEqualTo(customerRequestedSave)
+        assertThat(options?.setupFutureUsage).isEqualTo(ConfirmPaymentIntentParams.SetupFutureUsage.Blank)
+    }
+
+    @Test
+    fun `transformToPaymentSelection transforms SepaDebit with PMO setupFutureUsage correctly for NoRequest`() {
+        val customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest
+        val formFieldValues = FormFieldValues(
+            fieldValuePairs = mapOf(
+                IdentifierSpec.Generic("sepa_debit[iban]") to FormFieldEntry("DE89370400440532013000", true),
+            ),
+            userRequestedReuse = customerRequestedSave,
+        )
+
+        val metadataWithSepaDebit = metadata.copy(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("sepa_debit")
+            )
+        )
+        val sepaDebitPaymentMethod = metadataWithSepaDebit.supportedPaymentMethodForCode("sepa_debit")!!
+        val sepaDebitPaymentSelection = formFieldValues.transformToPaymentSelection(
+            sepaDebitPaymentMethod,
+            metadataWithSepaDebit
+        ) as PaymentSelection.New.GenericPaymentMethod
+
+        val options = sepaDebitPaymentSelection.paymentMethodOptionsParams as? PaymentMethodOptionsParams.SepaDebit
+        assertThat(sepaDebitPaymentSelection.customerRequestedSave).isEqualTo(customerRequestedSave)
+        assertThat(options?.setupFutureUsage).isNull()
+    }
+
+    @Test
+    fun `transformToExtraParams returns correct params for SepaDebit with setAsDefault`() {
+        val formFieldValues = FormFieldValues(
+            fieldValuePairs = mapOf(
+                IdentifierSpec.Generic("sepa_debit[iban]") to FormFieldEntry("DE89370400440532013000", true),
+                IdentifierSpec.SetAsDefaultPaymentMethod to FormFieldEntry("true", true),
+            ),
+            userRequestedReuse = PaymentSelection.CustomerRequestedSave.RequestReuse,
+        )
+
+        val extraParams = formFieldValues.transformToExtraParams(PaymentMethod.Type.SepaDebit.code)
+
+        assertThat(extraParams).isNotNull()
+        assertThat(extraParams).isInstanceOf<PaymentMethodExtraParams.SepaDebit>()
+
+        val sepaExtraParams = extraParams as PaymentMethodExtraParams.SepaDebit
+
+        assertThat(sepaExtraParams.setAsDefault).isTrue()
+    }
+
+    @Test
+    fun `transformToExtraParams returns correct params for SepaDebit without setAsDefault`() {
+        val formFieldValues = FormFieldValues(
+            fieldValuePairs = mapOf(
+                IdentifierSpec.Generic("sepa_debit[iban]") to FormFieldEntry("DE89370400440532013000", true),
+            ),
+            userRequestedReuse = PaymentSelection.CustomerRequestedSave.RequestReuse,
+        )
+
+        val extraParams = formFieldValues.transformToExtraParams(PaymentMethod.Type.SepaDebit.code)
+
+        assertThat(extraParams).isNotNull()
+        assertThat(extraParams).isInstanceOf<PaymentMethodExtraParams.SepaDebit>()
+
+        val sepaExtraParams = extraParams as PaymentMethodExtraParams.SepaDebit
+
+        assertThat(sepaExtraParams.setAsDefault).isNull()
     }
 
     private fun runScenario(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultUpdatePaymentMethodInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultUpdatePaymentMethodInteractorTest.kt
@@ -248,12 +248,12 @@ class DefaultUpdatePaymentMethodInteractorTest {
     }
 
     @Test
-    fun setAsDefaultCheckbox_hiddenForSepaPm() = runScenario(
+    fun setAsDefaultCheckbox_shownForSepaPm() = runScenario(
         displayableSavedPaymentMethod =
         PaymentMethodFixtures.SEPA_DEBIT_PAYMENT_METHOD.toDisplayableSavedPaymentMethod(),
         shouldShowSetAsDefaultCheckbox = true,
     ) {
-        assertThat(interactor.shouldShowSetAsDefaultCheckbox).isFalse()
+        assertThat(interactor.shouldShowSetAsDefaultCheckbox).isTrue()
     }
 
     @Test


### PR DESCRIPTION
# Summary
Improve Sepa Debit saving experience for legacy and customer session save behaviors

# Motivation
Allows merchants to properly save and set `SepaDebit` as their default payment method in MPE.

[MOBILESDK-2838](https://jira.corp.stripe.com/browse/MOBILESDK-2838)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

 # Video
[SaveExperience.webm](https://github.com/user-attachments/assets/ef3eec91-eb5c-4872-9351-1bd91941ee74)