### PR TITLE
Make PaymentSelection non-nullable for EventReporter events

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityConfirmationHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityConfirmationHelper.kt
@@ -49,7 +49,9 @@ internal class DefaultFormActivityConfirmationHelper @Inject constructor(
         if (onClickDelegate.onClickOverride != null) {
             onClickDelegate.onClickOverride?.invoke()
         } else {
-            eventReporter.onPressConfirmButton(selectionHolder.selection.value)
+            selectionHolder.selection.value?.let { paymentSelection ->
+                eventReporter.onPressConfirmButton(paymentSelection)
+            }
 
             when (configuration.formSheetAction) {
                 EmbeddedPaymentElement.FormSheetAction.Continue -> {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -85,7 +85,9 @@ internal class PaymentOptionsViewModel @Inject constructor(
         customPrimaryButtonUiStateFlow = customPrimaryButtonUiState,
         cvcCompleteFlow = cvcRecollectionCompleteFlow,
         onClick = {
-            eventReporter.onPressConfirmButton(selection.value)
+            selection.value?.let { paymentSelection ->
+                eventReporter.onPressConfirmButton(paymentSelection)
+            }
             onUserSelection()
         },
     )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -109,7 +109,9 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         customPrimaryButtonUiStateFlow = customPrimaryButtonUiState,
         cvcCompleteFlow = cvcRecollectionCompleteFlow,
         onClick = {
-            eventReporter.onPressConfirmButton(selection.value)
+            selection.value?.let { paymentSelection ->
+                eventReporter.onPressConfirmButton(paymentSelection)
+            }
             checkout()
         },
     )
@@ -527,10 +529,12 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         error: PaymentSheetConfirmationError,
         message: ResolvableString
     ) {
-        eventReporter.onPaymentFailure(
-            paymentSelection = inProgressSelection,
-            error = error,
-        )
+        inProgressSelection?.let { paymentSelection ->
+            eventReporter.onPaymentFailure(
+                paymentSelection = paymentSelection,
+                error = error,
+            )
+        }
 
         resetViewState(
             userErrorMessage = message
@@ -543,10 +547,12 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         finishImmediately: Boolean
     ) {
         val currentSelection = inProgressSelection
-        eventReporter.onPaymentSuccess(
-            paymentSelection = currentSelection,
-            deferredIntentConfirmationType = deferredIntentConfirmationType,
-        )
+        currentSelection?.let { paymentSelection ->
+            eventReporter.onPaymentSuccess(
+                paymentSelection = paymentSelection,
+                deferredIntentConfirmationType = deferredIntentConfirmationType,
+            )
+        }
 
         // Log out of Link to invalidate the token
         if (currentSelection != null && currentSelection.isLink) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -326,12 +326,10 @@ internal class DefaultEventReporter @Inject internal constructor(
         )
     }
 
-    override fun onPressConfirmButton(paymentSelection: PaymentSelection?) {
+    override fun onPressConfirmButton(paymentSelection: PaymentSelection) {
         val duration = durationProvider.end(DurationProvider.Key.ConfirmButtonClicked)
 
-        paymentSelection.code()?.let {
-            fireAnalyticEvent(AnalyticEvent.TappedConfirmButton(it))
-        }
+        fireAnalyticEvent(AnalyticEvent.TappedConfirmButton(paymentSelection.code()))
         fireEvent(
             PaymentSheetEvent.PressConfirmButton(
                 currency = currency,
@@ -347,7 +345,7 @@ internal class DefaultEventReporter @Inject internal constructor(
     }
 
     override fun onPaymentSuccess(
-        paymentSelection: PaymentSelection?,
+        paymentSelection: PaymentSelection,
         deferredIntentConfirmationType: DeferredIntentConfirmationType?,
     ) {
         // Wallets are treated as a saved payment method after confirmation, so we need
@@ -373,7 +371,7 @@ internal class DefaultEventReporter @Inject internal constructor(
     }
 
     override fun onPaymentFailure(
-        paymentSelection: PaymentSelection?,
+        paymentSelection: PaymentSelection,
         error: PaymentSheetConfirmationError,
     ) {
         val duration = durationProvider.end(DurationProvider.Key.Checkout)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
@@ -130,14 +130,14 @@ internal interface EventReporter {
      * The customer has pressed the confirm button.
      */
     fun onPressConfirmButton(
-        paymentSelection: PaymentSelection?,
+        paymentSelection: PaymentSelection,
     )
 
     /**
      * Payment or setup have succeeded.
      */
     fun onPaymentSuccess(
-        paymentSelection: PaymentSelection?,
+        paymentSelection: PaymentSelection,
         deferredIntentConfirmationType: DeferredIntentConfirmationType?,
     )
 
@@ -145,7 +145,7 @@ internal interface EventReporter {
      * Payment or setup have failed.
      */
     fun onPaymentFailure(
-        paymentSelection: PaymentSelection?,
+        paymentSelection: PaymentSelection,
         error: PaymentSheetConfirmationError,
     )
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/utils/ConfirmationReportingUtils.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/utils/ConfirmationReportingUtils.kt
@@ -23,16 +23,18 @@ internal fun EventReporter.reportPaymentResult(
     result: ConfirmationHandler.Result,
     paymentSelection: PaymentSelection?
 ) {
-    when (result) {
-        is ConfirmationHandler.Result.Succeeded -> onPaymentSuccess(
-            paymentSelection,
-            result.deferredIntentConfirmationType
-        )
-        is ConfirmationHandler.Result.Failed -> {
-            result.toConfirmationError()?.let { confirmationError ->
-                onPaymentFailure(paymentSelection, confirmationError)
+    paymentSelection?.let { selection ->
+        when (result) {
+            is ConfirmationHandler.Result.Succeeded -> onPaymentSuccess(
+                selection,
+                result.deferredIntentConfirmationType
+            )
+            is ConfirmationHandler.Result.Failed -> {
+                result.toConfirmationError()?.let { confirmationError ->
+                    onPaymentFailure(selection, confirmationError)
+                }
             }
+            is ConfirmationHandler.Result.Canceled -> {}
         }
-        is ConfirmationHandler.Result.Canceled -> {}
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -250,7 +250,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
     ) { displayablePaymentMethods, isProcessing, mostRecentSelection, displayedSavedPaymentMethod, action,
         temporarySelectionCode ->
         val temporarySelection = if (temporarySelectionCode != null) {
-            val changeDetails = if (temporarySelectionCode == mostRecentSelection.code()) {
+            val changeDetails = if (temporarySelectionCode == mostRecentSelection?.code()) {
                 (mostRecentSelection as? PaymentSelection.New?)?.changeDetails()
             } else {
                 null
@@ -258,7 +258,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
             PaymentMethodVerticalLayoutInteractor.Selection.New(
                 code = temporarySelectionCode,
                 changeDetails = changeDetails,
-                canBeChanged = temporarySelectionCode == (mostRecentSelection as? PaymentSelection.New?).code(),
+                canBeChanged = temporarySelectionCode == (mostRecentSelection as? PaymentSelection.New?)?.code(),
             )
         } else {
             null
@@ -471,7 +471,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
     }
 
     private fun getMandate(temporarySelectionCode: String?, selection: PaymentSelection?): ResolvableString? {
-        val selectionCode = temporarySelectionCode ?: (selection as? PaymentSelection.New).code()
+        val selectionCode = temporarySelectionCode ?: (selection as? PaymentSelection.New)?.code()
         return if (selectionCode != null) {
             (formTypeForCode(selectionCode) as? FormType.MandateOnly)?.mandate
         } else {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/DefaultFormActivityConfirmationHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/DefaultFormActivityConfirmationHelperTest.kt
@@ -65,10 +65,11 @@ class DefaultFormActivityConfirmationHelperTest {
     }
 
     @Test
-    fun `confirm invokes eventReporter but does not start confirmation with null selection`() = testScenario {
+    fun `confirm does not invoke eventReporter when selection is null`() = testScenario {
         assertThat(confirmationHelper.confirm()).isNull()
 
-        assertThat(eventReporter.pressConfirmButtonCalls.awaitItem()).isNull()
+        // Should not report button press when there's no selection
+        eventReporter.pressConfirmButtonCalls.ensureAllEventsConsumed()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeEventReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeEventReporter.kt
@@ -65,8 +65,8 @@ internal class FakeEventReporter : EventReporter {
     private val _formCompletedCalls = Turbine<FormCompletedCall>()
     val formCompletedCalls: ReceiveTurbine<FormCompletedCall> = _formCompletedCalls
 
-    private val _pressConfirmButtonCalls = Turbine<PaymentSelection?>()
-    val pressConfirmButtonCalls: ReceiveTurbine<PaymentSelection?> = _pressConfirmButtonCalls
+    private val _pressConfirmButtonCalls = Turbine<PaymentSelection>()
+    val pressConfirmButtonCalls: ReceiveTurbine<PaymentSelection> = _pressConfirmButtonCalls
 
     private val _usBankAccountFormEventCalls = Turbine<USBankAccountFormViewModel.AnalyticsEvent>()
     val usBankAccountFormEventCalls: ReceiveTurbine<USBankAccountFormViewModel.AnalyticsEvent> =
@@ -168,12 +168,12 @@ internal class FakeEventReporter : EventReporter {
     override fun onSelectPaymentOption(paymentSelection: PaymentSelection) {
     }
 
-    override fun onPressConfirmButton(paymentSelection: PaymentSelection?) {
+    override fun onPressConfirmButton(paymentSelection: PaymentSelection) {
         _pressConfirmButtonCalls.add(paymentSelection)
     }
 
     override fun onPaymentSuccess(
-        paymentSelection: PaymentSelection?,
+        paymentSelection: PaymentSelection,
         deferredIntentConfirmationType: DeferredIntentConfirmationType?
     ) {
         _paymentSuccessCalls.add(
@@ -185,7 +185,7 @@ internal class FakeEventReporter : EventReporter {
     }
 
     override fun onPaymentFailure(
-        paymentSelection: PaymentSelection?,
+        paymentSelection: PaymentSelection,
         error: PaymentSheetConfirmationError
     ) {
         _paymentFailureCalls.add(
@@ -276,12 +276,12 @@ internal class FakeEventReporter : EventReporter {
     }
 
     data class PaymentFailureCall(
-        val paymentSelection: PaymentSelection?,
+        val paymentSelection: PaymentSelection,
         val error: PaymentSheetConfirmationError
     )
 
     data class PaymentSuccessCall(
-        val paymentSelection: PaymentSelection?,
+        val paymentSelection: PaymentSelection,
         val deferredIntentConfirmationType: DeferredIntentConfirmationType?
     )
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Made PaymentSelection non-nullable for core EventReporter business events (`onPressConfirmButton`, `onPaymentSuccess`, `onPaymentFailure`) while maintaining nullability where it makes business sense (`onLoadSucceeded`).

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
[MOBILESDK-3464](https://jira.corp.stripe.com/browse/MOBILESDK-3464)
#10592 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

