### PR TITLE
Clean up confirmation tests in `PaymentSheetViewModelTest` to no longer have full confirmation context.

### DIFF
--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -52,6 +52,7 @@
     <ID>LongMethod:PaymentSheetConfigurationKtx.kt$@OptIn(AppearanceAPIAdditionsPreview::class) internal fun PaymentSheet.Appearance.parseAppearance()</ID>
     <ID>LongMethod:PaymentSheetScreen.kt$@Composable private fun PaymentSheetContent( viewModel: BaseSheetViewModel, headerText: ResolvableString?, walletsState: WalletsState?, walletsProcessingState: WalletsProcessingState?, error: ResolvableString?, currentScreen: PaymentSheetScreen, mandateText: MandateText?, modifier: Modifier )</ID>
     <ID>LongMethod:PaymentSheetViewModelTest.kt$PaymentSheetViewModelTest$@Test fun `Can complete payment after switching to another LPM from card selection with inline Link signup state`()</ID>
+    <ID>LongMethod:PaymentSheetViewModelTest.kt$PaymentSheetViewModelTest$@Test fun `On inline link payment, should process with primary button`()</ID>
     <ID>LongMethod:PlaceholderHelperTest.kt$PlaceholderHelperTest$@Test fun `Test correct placeholder is removed for placeholder spec`()</ID>
     <ID>LongMethod:SignUpScreen.kt$@Composable internal fun SignUpBody( emailController: TextFieldController, phoneNumberController: PhoneNumberController, nameController: TextFieldController, signUpScreenState: SignUpScreenState, onSignUpClick: () -> Unit )</ID>
     <ID>LongMethod:USBankAccountForm.kt$@Composable private fun BankAccountDetails( bankName: String?, enabled: Boolean, last4: String?, promoBadgeState: PromoBadgeState?, onIconButtonClick: () -> Unit, )</ID>

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/FakeConfirmationHandler.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/FakeConfirmationHandler.kt
@@ -43,4 +43,39 @@ internal class FakeConfirmationHandler(
         val activityResultCaller: ActivityResultCaller,
         val lifecycleOwner: LifecycleOwner,
     )
+
+    class Scenario(
+        val handler: ConfirmationHandler,
+        val confirmationState: MutableStateFlow<ConfirmationHandler.State>,
+        val registerTurbine: Turbine<RegisterCall>,
+        val startTurbine: Turbine<ConfirmationHandler.Args>,
+        val awaitResultTurbine: Turbine<ConfirmationHandler.Result?>,
+    )
+
+    companion object {
+        suspend fun test(
+            hasReloadedFromProcessDeath: Boolean = false,
+            initialState: ConfirmationHandler.State,
+            block: suspend Scenario.() -> Unit,
+        ) {
+            val state = MutableStateFlow(initialState)
+
+            val handler = FakeConfirmationHandler(
+                hasReloadedFromProcessDeath = hasReloadedFromProcessDeath,
+                state = state,
+            )
+
+            block(
+                Scenario(
+                    handler = handler,
+                    confirmationState = state,
+                    registerTurbine = handler.registerTurbine,
+                    startTurbine = handler.startTurbine,
+                    awaitResultTurbine = handler.awaitResultTurbine,
+                )
+            )
+
+            handler.validate()
+        }
+    }
 }


### PR DESCRIPTION
# Summary
Clean up confirmation tests in `PaymentSheetViewModelTest` to no longer have full confirmation context.

What does this mean:
- Confirmation Launchers are no longer tested in `PaymentSheetViewModel` unless explicitly defined by the view model.
- All confirmation tests run through `FakeConfirmationHandler.Scenario` which validates that all the interactions with the handler are collected and handled.
- Tests individually control the confirmation handler state rather than the confirmation flow callbacks.

# Motivation
`PaymentSheetViewModelTest` should not test with full confirmation context. This PR removes all the confirmation context from the test file and just tests the interactions with the handler instead.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified