### PR TITLE
[link] LinkController improvements and tests

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
@@ -163,7 +163,7 @@ internal class PaymentSheetPlaygroundActivity :
             val linkController = remember {
                 LinkController.create(
                     activity = this,
-                    presentPaymentMethodCallback = viewModel::onLinkControllerPresentPaymentMethod,
+                    presentPaymentMethodsCallback = viewModel::onLinkControllerPresentPaymentMethod,
                     lookupConsumerCallback = viewModel::onLinkControllerLookupConsumer,
                     createPaymentMethodCallback = viewModel::onLinkControllerCreatePaymentMethod,
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityResult.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityResult.kt
@@ -79,9 +79,4 @@ internal sealed interface LinkAccountUpdate : Parcelable {
 
     @Parcelize
     data object None : LinkAccountUpdate
-
-    fun asValue(): Value = when (this) {
-        None -> Value(null)
-        is Value -> this
-    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkConfigurationLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkConfigurationLoader.kt
@@ -1,0 +1,49 @@
+package com.stripe.android.link
+
+import com.stripe.android.common.model.asCommonConfiguration
+import com.stripe.android.core.Logger
+import com.stripe.android.link.LinkController.Configuration
+import com.stripe.android.link.exceptions.LinkUnavailableException
+import com.stripe.android.link.gate.LinkGate
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.state.PaymentElementLoader
+import javax.inject.Inject
+
+internal interface LinkConfigurationLoader {
+    suspend fun load(configuration: Configuration): Result<LinkConfiguration>
+}
+
+internal class DefaultLinkConfigurationLoader @Inject constructor(
+    private val logger: Logger,
+    private val paymentElementLoader: PaymentElementLoader,
+    private val linkGateFactory: LinkGate.Factory,
+) : LinkConfigurationLoader {
+    private val tag = "LinkConfigurationLoader"
+
+    override suspend fun load(configuration: Configuration): Result<LinkConfiguration> {
+        return paymentElementLoader.load(
+            initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
+                PaymentSheet.IntentConfiguration(
+                    mode = PaymentSheet.IntentConfiguration.Mode.Setup(),
+                ),
+            ),
+            configuration = configuration.asCommonConfiguration(),
+            metadata = PaymentElementLoader.Metadata(
+                isReloadingAfterProcessDeath = false,
+                initializedViaCompose = false,
+            )
+        ).mapCatching { state ->
+            @Suppress("TooGenericExceptionCaught")
+            try {
+                checkNotNull(state.paymentMethodMetadata.linkState?.configuration).also {
+                    val linkGate = linkGateFactory.create(it)
+                    check(linkGate.useNativeLink) { "Native Link is not available" }
+                }
+            } catch (e: Throwable) {
+                throw LinkUnavailableException(e)
+            }
+        }.onFailure { error ->
+            logger.error("$tag: Failed to load LinkConfiguration", error)
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkController.kt
@@ -282,7 +282,7 @@ class LinkController @Inject internal constructor(
          * Create a [LinkController] instance.
          *
          * @param activity The Activity that will present Link-related UI.
-         * @param presentPaymentMethodCallback Called with the result when [presentPaymentMethods] completes.
+         * @param presentPaymentMethodsCallback Called with the result when [presentPaymentMethods] completes.
          * @param lookupConsumerCallback Called with the result when [lookupConsumer] completes.
          * @param createPaymentMethodCallback Called with the result when [createPaymentMethod] completes.
          *
@@ -291,7 +291,7 @@ class LinkController @Inject internal constructor(
         @JvmStatic
         fun create(
             activity: ComponentActivity,
-            presentPaymentMethodCallback: PresentPaymentMethodsCallback,
+            presentPaymentMethodsCallback: PresentPaymentMethodsCallback,
             lookupConsumerCallback: LookupConsumerCallback,
             createPaymentMethodCallback: CreatePaymentMethodCallback,
         ): LinkController {
@@ -305,7 +305,7 @@ class LinkController @Inject internal constructor(
                     activity = activity,
                     lifecycleOwner = activity,
                     activityResultRegistryOwner = activity,
-                    presentPaymentMethodCallback = presentPaymentMethodCallback,
+                    presentPaymentMethodsCallback = presentPaymentMethodsCallback,
                     lookupConsumerCallback = lookupConsumerCallback,
                     createPaymentMethodCallback = createPaymentMethodCallback,
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkController.kt
@@ -34,9 +34,10 @@ class LinkController @Inject internal constructor(
      * The [state] will reset and the Link session will be reloaded to reflect the new configuration.
      *
      * @param configuration The [Configuration] to use for Link operations.
+     * @return The result of the configuration.
      */
-    fun configure(configuration: Configuration) {
-        viewModel.configure(configuration)
+    suspend fun configure(configuration: Configuration): ConfigureResult {
+        return viewModel.configure(configuration)
     }
 
     /**
@@ -162,6 +163,26 @@ class LinkController @Inject internal constructor(
         val selectedPaymentMethodPreview: PaymentMethodPreview? = null,
         val createdPaymentMethod: PaymentMethod? = null,
     ) : Parcelable
+
+    /**
+     * Result of presenting Link payment methods to the user.
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    sealed interface ConfigureResult {
+        /**
+         * Configuration was successful.
+         */
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        data object Success : ConfigureResult
+
+        /**
+         * Configuration failed.
+         *
+         * @param error The error that occurred.
+         */
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        class Failed internal constructor(val error: Throwable) : ConfigureResult
+    }
 
     /**
      * Result of presenting Link payment methods to the user.

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkController.kt
@@ -181,6 +181,7 @@ class LinkController @Inject internal constructor(
          * @param error The error that occurred.
          */
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        @Poko
         class Failed internal constructor(val error: Throwable) : ConfigureResult
     }
 
@@ -208,6 +209,7 @@ class LinkController @Inject internal constructor(
          * @param error The error that occurred.
          */
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        @Poko
         class Failed internal constructor(val error: Throwable) : PresentPaymentMethodsResult
     }
 
@@ -224,6 +226,7 @@ class LinkController @Inject internal constructor(
          * @param isConsumer Whether the email is associated with an existing Link consumer account.
          */
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        @Poko
         class Success internal constructor(val email: String, val isConsumer: Boolean) : LookupConsumerResult
 
         /**
@@ -233,6 +236,7 @@ class LinkController @Inject internal constructor(
          * @param error The error that occurred.
          */
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        @Poko
         class Failed internal constructor(val email: String, val error: Throwable) : LookupConsumerResult
     }
 
@@ -254,6 +258,7 @@ class LinkController @Inject internal constructor(
          * @param error The error that occurred.
          */
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        @Poko
         class Failed internal constructor(val error: Throwable) : CreatePaymentMethodResult
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerViewModel.kt
@@ -16,7 +16,7 @@ import com.stripe.android.link.confirmation.computeExpectedPaymentMethodType
 import com.stripe.android.link.exceptions.MissingConfigurationException
 import com.stripe.android.link.injection.DaggerLinkControllerViewModelComponent
 import com.stripe.android.link.injection.LinkControllerComponent
-import com.stripe.android.link.repositories.LinkApiRepository
+import com.stripe.android.link.repositories.LinkRepository
 import com.stripe.android.link.ui.wallet.displayName
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.parsers.PaymentMethodJsonParser
@@ -40,7 +40,7 @@ internal class LinkControllerViewModel @Inject constructor(
     private val logger: Logger,
     private val linkConfigurationLoader: LinkConfigurationLoader,
     private val linkAccountHolder: LinkAccountHolder,
-    private val linkApiRepository: LinkApiRepository,
+    private val linkApiRepository: LinkRepository,
     val controllerComponentFactory: LinkControllerComponent.Factory,
 ) : AndroidViewModel(application) {
 

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerViewModel.kt
@@ -172,14 +172,20 @@ internal class LinkControllerViewModel @Inject constructor(
 
         // Update account, clearing state if null.
         result.linkAccountUpdate?.let { update ->
-            val value = update.asValue()
-            linkAccountHolder.set(value)
-            if (value.account == null) {
-                updateState {
-                    it.copy(
-                        selectedPaymentMethod = null,
-                        createdPaymentMethod = null,
-                    )
+            when (update) {
+                is LinkAccountUpdate.Value -> {
+                    linkAccountHolder.set(update)
+                    if (update.account == null) {
+                        updateState {
+                            it.copy(
+                                selectedPaymentMethod = null,
+                                createdPaymentMethod = null,
+                            )
+                        }
+                    }
+                }
+                LinkAccountUpdate.None -> {
+                    // Do nothing.
                 }
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerViewModel.kt
@@ -51,15 +51,15 @@ internal class LinkControllerViewModel @Inject constructor(
     private val _state = MutableStateFlow(State())
 
     private val _presentPaymentMethodsResultFlow =
-        MutableSharedFlow<LinkController.PresentPaymentMethodsResult>(replay = 1, extraBufferCapacity = 1)
+        MutableSharedFlow<LinkController.PresentPaymentMethodsResult>(replay = 1)
     val presentPaymentMethodsResultFlow = _presentPaymentMethodsResultFlow.asSharedFlow()
 
     private val _lookupConsumerResultFlow =
-        MutableSharedFlow<LinkController.LookupConsumerResult>(replay = 1, extraBufferCapacity = 1)
+        MutableSharedFlow<LinkController.LookupConsumerResult>(replay = 1)
     val lookupConsumerResultFlow = _lookupConsumerResultFlow.asSharedFlow()
 
     private val _createPaymentMethodResultFlow =
-        MutableSharedFlow<LinkController.CreatePaymentMethodResult>(replay = 1, extraBufferCapacity = 1)
+        MutableSharedFlow<LinkController.CreatePaymentMethodResult>(replay = 1)
     val createPaymentMethodResultFlow = _createPaymentMethodResultFlow.asSharedFlow()
 
     fun state(context: Context): StateFlow<LinkController.State> {

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerViewModel.kt
@@ -51,15 +51,15 @@ internal class LinkControllerViewModel @Inject constructor(
     private val _state = MutableStateFlow(State())
 
     private val _presentPaymentMethodsResultFlow =
-        MutableSharedFlow<LinkController.PresentPaymentMethodsResult>(extraBufferCapacity = 1)
+        MutableSharedFlow<LinkController.PresentPaymentMethodsResult>(replay = 1, extraBufferCapacity = 1)
     val presentPaymentMethodsResultFlow = _presentPaymentMethodsResultFlow.asSharedFlow()
 
     private val _lookupConsumerResultFlow =
-        MutableSharedFlow<LinkController.LookupConsumerResult>(extraBufferCapacity = 1)
+        MutableSharedFlow<LinkController.LookupConsumerResult>(replay = 1, extraBufferCapacity = 1)
     val lookupConsumerResultFlow = _lookupConsumerResultFlow.asSharedFlow()
 
     private val _createPaymentMethodResultFlow =
-        MutableSharedFlow<LinkController.CreatePaymentMethodResult>(extraBufferCapacity = 1)
+        MutableSharedFlow<LinkController.CreatePaymentMethodResult>(replay = 1, extraBufferCapacity = 1)
     val createPaymentMethodResultFlow = _createPaymentMethodResultFlow.asSharedFlow()
 
     fun state(context: Context): StateFlow<LinkController.State> {

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerViewModel.kt
@@ -87,7 +87,10 @@ internal class LinkControllerViewModel @Inject constructor(
     fun configure(configuration: LinkController.Configuration) {
         logger.debug("$tag: updating configuration")
         this.configuration = configuration
-        reloadSession()
+        _state.update { State() }
+        viewModelScope.launch {
+            updateLinkConfiguration()
+        }
     }
 
     fun onPresentPaymentMethods(
@@ -222,14 +225,6 @@ internal class LinkControllerViewModel @Inject constructor(
                     onFailure = { LinkController.CreatePaymentMethodResult.Failed(it) },
                 )
             )
-        }
-    }
-
-    fun reloadSession() {
-        logger.debug("$tag: loading session")
-        _state.update { State() }
-        viewModelScope.launch {
-            updateLinkConfiguration()
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerViewModel.kt
@@ -41,7 +41,7 @@ internal class LinkControllerViewModel @Inject constructor(
     private val logger: Logger,
     private val linkConfigurationLoader: LinkConfigurationLoader,
     private val linkAccountHolder: LinkAccountHolder,
-    private val linkApiRepository: LinkRepository,
+    private val linkRepository: LinkRepository,
     val controllerComponentFactory: LinkControllerComponent.Factory,
 ) : AndroidViewModel(application) {
 
@@ -196,7 +196,7 @@ internal class LinkControllerViewModel @Inject constructor(
 
     fun onLookupConsumer(email: String) {
         viewModelScope.launch {
-            val result = linkApiRepository.lookupConsumer(email)
+            val result = linkRepository.lookupConsumer(email)
                 .map { it.exists }
                 .fold(
                     onSuccess = { LinkController.LookupConsumerResult.Success(email, it) },
@@ -237,7 +237,7 @@ internal class LinkControllerViewModel @Inject constructor(
         }
 
         return if (configuration.passthroughModeEnabled) {
-            linkApiRepository.sharePaymentDetails(
+            linkRepository.sharePaymentDetails(
                 consumerSessionClientSecret = account.clientSecret,
                 paymentDetailsId = paymentMethod.details.id,
                 expectedPaymentMethodType = computeExpectedPaymentMethodType(configuration, paymentMethod.details),
@@ -248,7 +248,7 @@ internal class LinkControllerViewModel @Inject constructor(
                 PaymentMethodJsonParser().parse(json)
             }
         } else {
-            linkApiRepository.createPaymentMethod(
+            linkRepository.createPaymentMethod(
                 consumerSessionClientSecret = account.clientSecret,
                 paymentMethod = paymentMethod,
             )

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerViewModel.kt
@@ -24,7 +24,6 @@ import com.stripe.android.model.parsers.PaymentMethodJsonParser
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow

--- a/paymentsheet/src/main/java/com/stripe/android/link/exceptions/MissingConfigurationException.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/exceptions/MissingConfigurationException.kt
@@ -1,0 +1,7 @@
+package com.stripe.android.link.exceptions
+
+import androidx.annotation.RestrictTo
+import com.stripe.android.core.exception.StripeException
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class MissingConfigurationException : StripeException()

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerComponent.kt
@@ -18,7 +18,7 @@ internal interface LinkControllerComponent {
             @BindsInstance activity: Activity,
             @BindsInstance lifecycleOwner: LifecycleOwner,
             @BindsInstance activityResultRegistryOwner: ActivityResultRegistryOwner,
-            @BindsInstance presentPaymentMethodCallback: LinkController.PresentPaymentMethodsCallback,
+            @BindsInstance presentPaymentMethodsCallback: LinkController.PresentPaymentMethodsCallback,
             @BindsInstance lookupConsumerCallback: LinkController.LookupConsumerCallback,
             @BindsInstance createPaymentMethodCallback: LinkController.CreatePaymentMethodCallback,
         ): LinkControllerComponent

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerModule.kt
@@ -7,6 +7,8 @@ import com.stripe.android.common.di.MobileSessionIdModule
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.googlepaylauncher.injection.GooglePayLauncherModule
+import com.stripe.android.link.DefaultLinkConfigurationLoader
+import com.stripe.android.link.LinkConfigurationLoader
 import com.stripe.android.paymentelement.confirmation.injection.ExtendedPaymentElementConfirmationModule
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
@@ -15,6 +17,7 @@ import com.stripe.android.paymentsheet.injection.LinkHoldbackExposureModule
 import com.stripe.android.paymentsheet.injection.PaymentSheetCommonModule
 import com.stripe.android.ui.core.di.CardScanModule
 import com.stripe.android.ui.core.forms.resources.injection.ResourceRepositoryModule
+import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import javax.inject.Named
@@ -38,18 +41,24 @@ import javax.inject.Singleton
         LinkControllerComponent::class
     ]
 )
-internal object LinkControllerModule {
-    @Provides
+internal interface LinkControllerModule {
+    @Binds
     @Singleton
-    fun provideAppContext(application: Application): Context = application.applicationContext
+    fun bindLinkConfigurationLoader(impl: DefaultLinkConfigurationLoader): LinkConfigurationLoader
 
-    // TODO
-    @Provides
-    @Singleton
-    fun provideEventReporterMode(): EventReporter.Mode = EventReporter.Mode.Custom
+    companion object {
+        @Provides
+        @Singleton
+        fun provideAppContext(application: Application): Context = application.applicationContext
 
-    @Provides
-    @Singleton
-    @Named(PRODUCT_USAGE)
-    fun provideProductUsageTokens() = setOf("LinkPaymentMethodLauncher")
+        // TODO
+        @Provides
+        @Singleton
+        fun provideEventReporterMode(): EventReporter.Mode = EventReporter.Mode.Custom
+
+        @Provides
+        @Singleton
+        @Named(PRODUCT_USAGE)
+        fun provideProductUsageTokens() = setOf("LinkPaymentMethodLauncher")
+    }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/link/DefaultLinkConfigurationLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/DefaultLinkConfigurationLoaderTest.kt
@@ -1,0 +1,116 @@
+package com.stripe.android.link
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.link.exceptions.LinkUnavailableException
+import com.stripe.android.link.gate.FakeLinkGate
+import com.stripe.android.link.gate.LinkGate
+import com.stripe.android.paymentsheet.state.LinkState
+import com.stripe.android.testing.FakeLogger
+import com.stripe.android.utils.FakePaymentElementLoader
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+internal class DefaultLinkConfigurationLoaderTest {
+    private val logger = FakeLogger()
+    private val linkGate = FakeLinkGate()
+    private val linkGateFactory = LinkGate.Factory { linkGate }
+    private val configuration = LinkController.Configuration.Builder("Test Merchant").build()
+    private val linkConfiguration = TestFactory.LINK_CONFIGURATION
+
+    @Test
+    fun `load() returns success when LinkConfiguration is available and useNativeLink is true`() = runTest {
+        val linkState = LinkState(
+            configuration = linkConfiguration,
+            loginState = LinkState.LoginState.LoggedIn,
+            signupMode = null
+        )
+        val paymentElementLoader = FakePaymentElementLoader(
+            linkState = linkState
+        )
+        val loader = DefaultLinkConfigurationLoader(
+            logger = logger,
+            paymentElementLoader = paymentElementLoader,
+            linkGateFactory = linkGateFactory,
+        )
+        linkGate.setUseNativeLink(true)
+
+        val result = loader.load(configuration)
+        assertThat(result.isSuccess).isTrue()
+        assertThat(result.getOrNull()).isEqualTo(linkConfiguration)
+    }
+
+    @Test
+    fun `load() returns failure when linkState configuration is null`() = runTest {
+        val paymentElementLoader = FakePaymentElementLoader(
+            linkState = null
+        )
+        val loader = DefaultLinkConfigurationLoader(
+            logger = logger,
+            paymentElementLoader = paymentElementLoader,
+            linkGateFactory = linkGateFactory,
+        )
+
+        val result = loader.load(configuration)
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()).isInstanceOf(LinkUnavailableException::class.java)
+    }
+
+    @Test
+    fun `load() returns failure when useNativeLink is false`() = runTest {
+        val linkState = LinkState(
+            configuration = linkConfiguration,
+            loginState = LinkState.LoginState.LoggedIn,
+            signupMode = null
+        )
+        val paymentElementLoader = FakePaymentElementLoader(
+            linkState = linkState
+        )
+        val loader = DefaultLinkConfigurationLoader(
+            logger = logger,
+            paymentElementLoader = paymentElementLoader,
+            linkGateFactory = linkGateFactory,
+        )
+        linkGate.setUseNativeLink(false)
+
+        val result = loader.load(configuration)
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()).isInstanceOf(LinkUnavailableException::class.java)
+    }
+
+    @Test
+    fun `load() returns failure when paymentElementLoader returns failure`() = runTest {
+        val paymentElementLoader = FakePaymentElementLoader(
+            shouldFail = true
+        )
+        val loader = DefaultLinkConfigurationLoader(
+            logger = logger,
+            paymentElementLoader = paymentElementLoader,
+            linkGateFactory = linkGateFactory,
+        )
+
+        val result = loader.load(configuration)
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()).isInstanceOf(IllegalStateException::class.java)
+    }
+
+    @Test
+    fun `load() calls paymentElementLoader with expected parameters`() = runTest {
+        val linkState = LinkState(
+            configuration = linkConfiguration,
+            loginState = LinkState.LoginState.LoggedIn,
+            signupMode = null
+        )
+        val paymentElementLoader = FakePaymentElementLoader(
+            linkState = linkState
+        )
+        val loader = DefaultLinkConfigurationLoader(
+            logger = logger,
+            paymentElementLoader = paymentElementLoader,
+            linkGateFactory = linkGateFactory,
+        )
+        linkGate.setUseNativeLink(true)
+
+        val result = loader.load(configuration)
+        assertThat(result.isSuccess).isTrue()
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/link/DefaultLinkConfigurationLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/DefaultLinkConfigurationLoaderTest.kt
@@ -17,6 +17,12 @@ internal class DefaultLinkConfigurationLoaderTest {
     private val configuration = LinkController.Configuration.Builder("Test Merchant").build()
     private val linkConfiguration = TestFactory.LINK_CONFIGURATION
 
+    private val linkState = LinkState(
+        configuration = linkConfiguration,
+        loginState = LinkState.LoginState.LoggedIn,
+        signupMode = null,
+    )
+
     private fun createLoader(
         paymentElementLoader: FakePaymentElementLoader,
         useNativeLink: Boolean? = null
@@ -31,11 +37,6 @@ internal class DefaultLinkConfigurationLoaderTest {
 
     @Test
     fun `load() returns success when LinkConfiguration is available and useNativeLink is true`() = runTest {
-        val linkState = LinkState(
-            configuration = linkConfiguration,
-            loginState = LinkState.LoginState.LoggedIn,
-            signupMode = null
-        )
         val loader = createLoader(
             paymentElementLoader = FakePaymentElementLoader(linkState = linkState),
             useNativeLink = true
@@ -59,11 +60,6 @@ internal class DefaultLinkConfigurationLoaderTest {
 
     @Test
     fun `load() returns failure when useNativeLink is false`() = runTest {
-        val linkState = LinkState(
-            configuration = linkConfiguration,
-            loginState = LinkState.LoginState.LoggedIn,
-            signupMode = null
-        )
         val loader = createLoader(
             paymentElementLoader = FakePaymentElementLoader(linkState = linkState),
             useNativeLink = false
@@ -87,11 +83,6 @@ internal class DefaultLinkConfigurationLoaderTest {
 
     @Test
     fun `load() calls paymentElementLoader with expected parameters`() = runTest {
-        val linkState = LinkState(
-            configuration = linkConfiguration,
-            loginState = LinkState.LoginState.LoggedIn,
-            signupMode = null
-        )
         val loader = createLoader(
             paymentElementLoader = FakePaymentElementLoader(linkState = linkState),
             useNativeLink = true

--- a/paymentsheet/src/test/java/com/stripe/android/link/DefaultLinkConfigurationLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/DefaultLinkConfigurationLoaderTest.kt
@@ -17,6 +17,18 @@ internal class DefaultLinkConfigurationLoaderTest {
     private val configuration = LinkController.Configuration.Builder("Test Merchant").build()
     private val linkConfiguration = TestFactory.LINK_CONFIGURATION
 
+    private fun createLoader(
+        paymentElementLoader: FakePaymentElementLoader,
+        useNativeLink: Boolean? = null
+    ): DefaultLinkConfigurationLoader {
+        useNativeLink?.let { linkGate.setUseNativeLink(it) }
+        return DefaultLinkConfigurationLoader(
+            logger = logger,
+            paymentElementLoader = paymentElementLoader,
+            linkGateFactory = linkGateFactory,
+        )
+    }
+
     @Test
     fun `load() returns success when LinkConfiguration is available and useNativeLink is true`() = runTest {
         val linkState = LinkState(
@@ -24,15 +36,10 @@ internal class DefaultLinkConfigurationLoaderTest {
             loginState = LinkState.LoginState.LoggedIn,
             signupMode = null
         )
-        val paymentElementLoader = FakePaymentElementLoader(
-            linkState = linkState
+        val loader = createLoader(
+            paymentElementLoader = FakePaymentElementLoader(linkState = linkState),
+            useNativeLink = true
         )
-        val loader = DefaultLinkConfigurationLoader(
-            logger = logger,
-            paymentElementLoader = paymentElementLoader,
-            linkGateFactory = linkGateFactory,
-        )
-        linkGate.setUseNativeLink(true)
 
         val result = loader.load(configuration)
         assertThat(result.isSuccess).isTrue()
@@ -41,13 +48,8 @@ internal class DefaultLinkConfigurationLoaderTest {
 
     @Test
     fun `load() returns failure when linkState configuration is null`() = runTest {
-        val paymentElementLoader = FakePaymentElementLoader(
-            linkState = null
-        )
-        val loader = DefaultLinkConfigurationLoader(
-            logger = logger,
-            paymentElementLoader = paymentElementLoader,
-            linkGateFactory = linkGateFactory,
+        val loader = createLoader(
+            paymentElementLoader = FakePaymentElementLoader(linkState = null)
         )
 
         val result = loader.load(configuration)
@@ -62,15 +64,10 @@ internal class DefaultLinkConfigurationLoaderTest {
             loginState = LinkState.LoginState.LoggedIn,
             signupMode = null
         )
-        val paymentElementLoader = FakePaymentElementLoader(
-            linkState = linkState
+        val loader = createLoader(
+            paymentElementLoader = FakePaymentElementLoader(linkState = linkState),
+            useNativeLink = false
         )
-        val loader = DefaultLinkConfigurationLoader(
-            logger = logger,
-            paymentElementLoader = paymentElementLoader,
-            linkGateFactory = linkGateFactory,
-        )
-        linkGate.setUseNativeLink(false)
 
         val result = loader.load(configuration)
         assertThat(result.isFailure).isTrue()
@@ -79,13 +76,8 @@ internal class DefaultLinkConfigurationLoaderTest {
 
     @Test
     fun `load() returns failure when paymentElementLoader returns failure`() = runTest {
-        val paymentElementLoader = FakePaymentElementLoader(
-            shouldFail = true
-        )
-        val loader = DefaultLinkConfigurationLoader(
-            logger = logger,
-            paymentElementLoader = paymentElementLoader,
-            linkGateFactory = linkGateFactory,
+        val loader = createLoader(
+            paymentElementLoader = FakePaymentElementLoader(shouldFail = true)
         )
 
         val result = loader.load(configuration)
@@ -100,15 +92,10 @@ internal class DefaultLinkConfigurationLoaderTest {
             loginState = LinkState.LoginState.LoggedIn,
             signupMode = null
         )
-        val paymentElementLoader = FakePaymentElementLoader(
-            linkState = linkState
+        val loader = createLoader(
+            paymentElementLoader = FakePaymentElementLoader(linkState = linkState),
+            useNativeLink = true
         )
-        val loader = DefaultLinkConfigurationLoader(
-            logger = logger,
-            paymentElementLoader = paymentElementLoader,
-            linkGateFactory = linkGateFactory,
-        )
-        linkGate.setUseNativeLink(true)
 
         val result = loader.load(configuration)
         assertThat(result.isSuccess).isTrue()

--- a/paymentsheet/src/test/java/com/stripe/android/link/FakeLinkConfigurationLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/FakeLinkConfigurationLoader.kt
@@ -1,0 +1,9 @@
+package com.stripe.android.link
+
+internal class FakeLinkConfigurationLoader : LinkConfigurationLoader {
+    var linkConfigurationResult: Result<LinkConfiguration> = Result.success(TestFactory.LINK_CONFIGURATION)
+
+    override suspend fun load(configuration: LinkController.Configuration): Result<LinkConfiguration> {
+        return linkConfigurationResult
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerCoordinatorTest.kt
@@ -1,0 +1,164 @@
+package com.stripe.android.link
+
+import androidx.activity.result.ActivityResultRegistryOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.testing.TestLifecycleOwner
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.testing.CoroutineTestRule
+import com.stripe.android.utils.FakeActivityResultRegistry
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.assertFailsWith
+
+@ExperimentalCoroutinesApi
+@RunWith(RobolectricTestRunner::class)
+internal class LinkControllerCoordinatorTest {
+    private val dispatcher = UnconfinedTestDispatcher()
+
+    @get:Rule
+    val coroutineTestRule = CoroutineTestRule(dispatcher)
+
+    private val linkActivityContract: NativeLinkActivityContract = mock()
+
+    private val presentPaymentMethodsResultFlow = MutableSharedFlow<LinkController.PresentPaymentMethodsResult>()
+    private val lookupConsumerResultFlow = MutableSharedFlow<LinkController.LookupConsumerResult>()
+    private val createPaymentMethodResultFlow = MutableSharedFlow<LinkController.CreatePaymentMethodResult>()
+
+    private val viewModel: LinkControllerViewModel = mock {
+        on { presentPaymentMethodsResultFlow } doReturn presentPaymentMethodsResultFlow
+        on { lookupConsumerResultFlow } doReturn lookupConsumerResultFlow
+        on { createPaymentMethodResultFlow } doReturn createPaymentMethodResultFlow
+    }
+
+    private val presentPaymentMethodsResults = mutableListOf<LinkController.PresentPaymentMethodsResult>()
+    private val lookupConsumerResults = mutableListOf<LinkController.LookupConsumerResult>()
+    private val createPaymentMethodResults = mutableListOf<LinkController.CreatePaymentMethodResult>()
+
+    private val lifecycleOwner = TestLifecycleOwner(initialState = Lifecycle.State.CREATED)
+
+    private fun createCoordinator(
+        activityResult: LinkActivityResult? = null
+    ): LinkControllerCoordinator {
+        val registry = FakeActivityResultRegistry(activityResult)
+        val activityResultRegistryOwner = object : ActivityResultRegistryOwner {
+            override val activityResultRegistry = registry
+        }
+        return LinkControllerCoordinator(
+            viewModel = viewModel,
+            lifecycleOwner = lifecycleOwner,
+            activityResultRegistryOwner = activityResultRegistryOwner,
+            linkActivityContract = linkActivityContract,
+            selectedPaymentMethodCallback = { presentPaymentMethodsResults.add(it) },
+            lookupConsumerCallback = { lookupConsumerResults.add(it) },
+            createPaymentMethodCallback = { createPaymentMethodResults.add(it) },
+        )
+    }
+
+    @Test
+    fun `constructor() throws when lifecycle is not CREATED`() = runTest {
+        assertFailsWith<IllegalStateException> {
+            lifecycleOwner.setCurrentState(Lifecycle.State.INITIALIZED)
+            createCoordinator()
+        }
+    }
+
+    @Test
+    fun `constructor() succeeds when lifecycle is CREATED`() = runTest {
+        lifecycleOwner.setCurrentState(Lifecycle.State.CREATED)
+        val coordinator = createCoordinator()
+        assertThat(coordinator.linkActivityResultLauncher).isNotNull()
+    }
+
+    @Test
+    fun `when started, flows are collected and callbacks invoked`() = runTest {
+        lifecycleOwner.setCurrentState(Lifecycle.State.STARTED)
+        createCoordinator()
+
+        val presentResult = LinkController.PresentPaymentMethodsResult.Success
+        presentPaymentMethodsResultFlow.emit(presentResult)
+
+        val lookupResult = LinkController.LookupConsumerResult.Success("test@example.com", true)
+        lookupConsumerResultFlow.emit(lookupResult)
+
+        val createResult = LinkController.CreatePaymentMethodResult.Success
+        createPaymentMethodResultFlow.emit(createResult)
+
+        assertThat(presentPaymentMethodsResults).containsExactly(presentResult)
+        assertThat(lookupConsumerResults).containsExactly(lookupResult)
+        assertThat(createPaymentMethodResults).containsExactly(createResult)
+    }
+
+    @Test
+    fun `when not started, flows are not collected`() = runTest {
+        lifecycleOwner.setCurrentState(Lifecycle.State.CREATED)
+        createCoordinator()
+
+        presentPaymentMethodsResultFlow.emit(LinkController.PresentPaymentMethodsResult.Success)
+        lookupConsumerResultFlow.emit(LinkController.LookupConsumerResult.Success("test@example.com", true))
+        createPaymentMethodResultFlow.emit(LinkController.CreatePaymentMethodResult.Success)
+
+        assertThat(presentPaymentMethodsResults).isEmpty()
+        assertThat(lookupConsumerResults).isEmpty()
+        assertThat(createPaymentMethodResults).isEmpty()
+    }
+
+    @Test
+    fun `when started, multiple emissions are handled correctly`() = runTest {
+        lifecycleOwner.setCurrentState(Lifecycle.State.STARTED)
+        createCoordinator()
+
+        val result1 = LinkController.PresentPaymentMethodsResult.Success
+        val result2 = LinkController.PresentPaymentMethodsResult.Canceled
+        val result3 = LinkController.PresentPaymentMethodsResult.Failed(Exception("Error"))
+
+        presentPaymentMethodsResultFlow.emit(result1)
+        presentPaymentMethodsResultFlow.emit(result2)
+        presentPaymentMethodsResultFlow.emit(result3)
+
+        assertThat(presentPaymentMethodsResults).containsExactly(result1, result2, result3)
+    }
+
+    @Test
+    fun `on activity result, result is passed to viewModel`() = runTest {
+        lifecycleOwner.setCurrentState(Lifecycle.State.CREATED)
+        val testResult = LinkActivityResult.Completed(
+            linkAccountUpdate = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
+            selectedPayment = null,
+            shippingAddress = null,
+        )
+        val coordinator = createCoordinator(
+            activityResult = testResult
+        )
+        coordinator.linkActivityResultLauncher.launch(
+            LinkActivityContract.Args(
+                configuration = TestFactory.LINK_CONFIGURATION,
+                startWithVerificationDialog = false,
+                linkAccountInfo = LinkAccountUpdate.Value(null),
+                launchMode = LinkLaunchMode.PaymentMethodSelection(null),
+            )
+        )
+        verify(viewModel).onPresentPaymentMethodsActivityResult(testResult)
+    }
+
+    @Test
+    fun `flow collection starts when lifecycle transitions to STARTED`() = runTest {
+        lifecycleOwner.setCurrentState(Lifecycle.State.CREATED)
+        createCoordinator()
+
+        presentPaymentMethodsResultFlow.emit(LinkController.PresentPaymentMethodsResult.Success)
+        assertThat(presentPaymentMethodsResults).isEmpty()
+
+        lifecycleOwner.setCurrentState(Lifecycle.State.STARTED)
+        presentPaymentMethodsResultFlow.emit(LinkController.PresentPaymentMethodsResult.Canceled)
+        assertThat(presentPaymentMethodsResults).containsExactly(LinkController.PresentPaymentMethodsResult.Canceled)
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerViewModelTest.kt
@@ -251,7 +251,7 @@ class LinkControllerViewModelTest {
     }
 
     @Test
-    fun `onCreatePaymentMethod() succeeds when in passthrough mode`() = runTest {
+    fun `onCreatePaymentMethod() in passthrough mode on success stores payment method`() = runTest {
         val viewModel = createViewModel()
         configure(viewModel, passthroughModeEnabled = true)
         signIn()
@@ -315,7 +315,7 @@ class LinkControllerViewModelTest {
     }
 
     @Test
-    fun `onLookupConsumer() emits success result when repository returns success`() = runTest {
+    fun `onLookupConsumer() on success emits success result`() = runTest {
         val viewModel = createViewModel()
 
         val consumerSessionLookup = ConsumerSessionLookup(exists = true, consumerSession = null)
@@ -331,7 +331,7 @@ class LinkControllerViewModelTest {
     }
 
     @Test
-    fun `onLookupConsumer() emits failure result when repository returns failure`() = runTest {
+    fun `onLookupConsumer() on failure emits failure result`() = runTest {
         val viewModel = createViewModel()
 
         val error = Exception("Error")
@@ -347,7 +347,7 @@ class LinkControllerViewModelTest {
     }
 
     @Test
-    fun `onPresentPaymentMethods() launches LinkActivity`() = runTest {
+    fun `onPresentPaymentMethods() launches Link with correct arguments`() = runTest {
         val viewModel = createViewModel()
         configure(viewModel)
 
@@ -367,7 +367,7 @@ class LinkControllerViewModelTest {
     }
 
     @Test
-    fun `onPresentPaymentMethods() passes existing account if email matches`() = runTest(dispatcher) {
+    fun `onPresentPaymentMethods() on matching email passes existing account`() = runTest(dispatcher) {
         val viewModel = createViewModel()
         configure(viewModel)
         signIn()
@@ -383,7 +383,7 @@ class LinkControllerViewModelTest {
     }
 
     @Test
-    fun `onPresentPaymentMethods() clears account if email does not match`() = runTest {
+    fun `onPresentPaymentMethods() on non-matching email clears account state`() = runTest {
         val viewModel = createViewModel()
         configure(viewModel)
         signIn()
@@ -453,7 +453,7 @@ class LinkControllerViewModelTest {
     }
 
     @Test
-    fun `onPresentPaymentMethodsActivityResult() with Completed result`() = runTest {
+    fun `onPresentPaymentMethodsActivityResult() on Completed result emits Success and updates preview`() = runTest {
         val viewModel = createViewModel()
         configure(viewModel)
 
@@ -499,24 +499,6 @@ class LinkControllerViewModelTest {
     }
 
     @Test
-    fun `onPresentPaymentMethodsActivityResult() updates account`() = runTest {
-        val viewModel = createViewModel()
-        configure(viewModel)
-        signIn()
-
-        viewModel.onPresentPaymentMethodsActivityResult(
-            LinkActivityResult.Canceled(
-                reason = LinkActivityResult.Canceled.Reason.BackPressed,
-                linkAccountUpdate = LinkAccountUpdate.Value(null)
-            )
-        )
-
-        viewModel.state(application).test {
-            assertThat(awaitItem().isConsumerVerified).isNull()
-        }
-    }
-
-    @Test
     fun `onPresentPaymentMethodsActivityResult() updates to different account without clearing state`() = runTest {
         val viewModel = createViewModel()
         configure(viewModel)
@@ -547,6 +529,24 @@ class LinkControllerViewModelTest {
             assertThat(finalState.selectedPaymentMethodPreview).isNotNull()
         }
         assertThat(linkAccountHolder.linkAccountInfo.first().account).isEqualTo(anotherAccount)
+    }
+
+    @Test
+    fun `onPresentPaymentMethodsActivityResult() on account cleared clears verification state`() = runTest {
+        val viewModel = createViewModel()
+        configure(viewModel)
+        signIn()
+
+        viewModel.onPresentPaymentMethodsActivityResult(
+            LinkActivityResult.Canceled(
+                reason = LinkActivityResult.Canceled.Reason.BackPressed,
+                linkAccountUpdate = LinkAccountUpdate.Value(null)
+            )
+        )
+
+        viewModel.state(application).test {
+            assertThat(awaitItem().isConsumerVerified).isNull()
+        }
     }
 
     private fun createViewModel(

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerViewModelTest.kt
@@ -9,6 +9,7 @@ import androidx.test.core.app.ApplicationProvider
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.link.account.LinkAccountHolder
+import com.stripe.android.link.exceptions.MissingConfigurationException
 import com.stripe.android.link.injection.LinkControllerComponent
 import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.link.repositories.FakeLinkRepository
@@ -122,6 +123,34 @@ class LinkControllerViewModelTest {
             assertThat(awaitItem()).isNotEqualTo(LinkController.State())
             assertThat(viewModel.configure(mock())).isEqualTo(LinkController.ConfigureResult.Success)
             assertThat(awaitItem()).isEqualTo(LinkController.State())
+        }
+    }
+
+    @Test
+    fun `onPresentPaymentMethods() fails when configuration is not set`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.presentPaymentMethodsResultFlow.test {
+            viewModel.onPresentPaymentMethods(mock(), "test@example.com")
+
+            val result = awaitItem()
+            assertThat(result).isInstanceOf(LinkController.PresentPaymentMethodsResult.Failed::class.java)
+            val error = (result as LinkController.PresentPaymentMethodsResult.Failed).error
+            assertThat(error).isInstanceOf(MissingConfigurationException::class.java)
+        }
+    }
+
+    @Test
+    fun `onCreatePaymentMethod() fails when configuration is not set`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.createPaymentMethodResultFlow.test {
+            viewModel.onCreatePaymentMethod()
+
+            val result = awaitItem()
+            assertThat(result).isInstanceOf(LinkController.CreatePaymentMethodResult.Failed::class.java)
+            val error = (result as LinkController.CreatePaymentMethodResult.Failed).error
+            assertThat(error).isInstanceOf(MissingConfigurationException::class.java)
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerViewModelTest.kt
@@ -179,7 +179,7 @@ class LinkControllerViewModelTest {
             logger = logger,
             linkConfigurationLoader = linkConfigurationLoader,
             linkAccountHolder = linkAccountHolder,
-            linkApiRepository = linkRepository,
+            linkRepository = linkRepository,
             controllerComponentFactory = controllerComponentFactory
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerViewModelTest.kt
@@ -1,0 +1,64 @@
+package com.stripe.android.link
+
+import android.app.Application
+import androidx.lifecycle.SavedStateHandle
+import androidx.test.core.app.ApplicationProvider
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.Logger
+import com.stripe.android.link.account.LinkAccountHolder
+import com.stripe.android.link.gate.LinkGate
+import com.stripe.android.link.injection.LinkControllerComponent
+import com.stripe.android.link.repositories.LinkApiRepository
+import com.stripe.android.paymentsheet.state.PaymentElementLoader
+import com.stripe.android.testing.CoroutineTestRule
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class LinkControllerViewModelTest {
+    private val dispatcher = UnconfinedTestDispatcher()
+
+    @get:Rule
+    val coroutineTestRule = CoroutineTestRule(dispatcher)
+
+    private val application: Application = ApplicationProvider.getApplicationContext()
+    private val logger: Logger = mock()
+    private val paymentElementLoader: PaymentElementLoader = mock()
+    private val linkGateFactory: LinkGate.Factory = mock()
+    private val linkAccountHolder = LinkAccountHolder(SavedStateHandle())
+    private val linkApiRepository: LinkApiRepository = mock()
+    private val controllerComponentFactory: LinkControllerComponent.Factory = mock()
+
+    @Test
+    fun `Initial state is correct`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.state(application).test {
+            assertThat(awaitItem()).isEqualTo(
+                LinkController.State(
+                    isConsumerVerified = null,
+                    selectedPaymentMethodPreview = null,
+                    createdPaymentMethod = null
+                )
+            )
+        }
+    }
+
+    private fun createViewModel(): LinkControllerViewModel {
+        return LinkControllerViewModel(
+            application = application,
+            logger = logger,
+            paymentElementLoader = paymentElementLoader,
+            linkGateFactory = linkGateFactory,
+            linkAccountHolder = linkAccountHolder,
+            linkApiRepository = linkApiRepository,
+            controllerComponentFactory = controllerComponentFactory
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerViewModelTest.kt
@@ -388,6 +388,17 @@ class LinkControllerViewModelTest {
         configure(viewModel)
         signIn()
 
+        viewModel.updateState {
+            it.copy(
+                selectedPaymentMethod = LinkPaymentMethod.ConsumerPaymentDetails(
+                    details = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD,
+                    collectedCvc = "123",
+                    billingPhone = null
+                ),
+                createdPaymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
+            )
+        }
+
         val launcher = mock<ActivityResultLauncher<LinkActivityContract.Args>>()
         viewModel.onPresentPaymentMethods(launcher, "another@email.com")
 
@@ -396,6 +407,12 @@ class LinkControllerViewModelTest {
 
         val args = argsCaptor.firstValue
         assertThat(args.linkAccountInfo.account).isNull()
+
+        viewModel.state(application).test {
+            val state = awaitItem()
+            assertThat(state.selectedPaymentMethodPreview).isNull()
+            assertThat(state.createdPaymentMethod).isNull()
+        }
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerViewModelTest.kt
@@ -9,16 +9,12 @@ import androidx.test.core.app.ApplicationProvider
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.link.account.LinkAccountHolder
-import com.stripe.android.link.gate.FakeLinkGate
-import com.stripe.android.link.gate.LinkGate
 import com.stripe.android.link.injection.LinkControllerComponent
 import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.link.repositories.FakeLinkRepository
 import com.stripe.android.link.repositories.LinkRepository
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FakeLogger
-import com.stripe.android.utils.FakePaymentElementLoader
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -36,8 +32,7 @@ class LinkControllerViewModelTest {
 
     private val application: Application = ApplicationProvider.getApplicationContext()
     private val logger = FakeLogger()
-    private val paymentElementLoader: PaymentElementLoader = FakePaymentElementLoader()
-    private val linkGateFactory: LinkGate.Factory = LinkGate.Factory { FakeLinkGate() }
+    private val linkConfigurationLoader = FakeLinkConfigurationLoader()
     private val linkAccountHolder = LinkAccountHolder(SavedStateHandle())
     private val linkApiRepository: LinkRepository = FakeLinkRepository()
     private val controllerComponentFactory: LinkControllerComponent.Factory =
@@ -46,7 +41,7 @@ class LinkControllerViewModelTest {
                 activity: Activity,
                 lifecycleOwner: LifecycleOwner,
                 activityResultRegistryOwner: ActivityResultRegistryOwner,
-                presentPaymentMethodCallback: LinkController.PresentPaymentMethodsCallback,
+                presentPaymentMethodsCallback: LinkController.PresentPaymentMethodsCallback,
                 lookupConsumerCallback: LinkController.LookupConsumerCallback,
                 createPaymentMethodCallback: LinkController.CreatePaymentMethodCallback
             ): LinkControllerComponent {
@@ -93,8 +88,7 @@ class LinkControllerViewModelTest {
         return LinkControllerViewModel(
             application = application,
             logger = logger,
-            paymentElementLoader = paymentElementLoader,
-            linkGateFactory = linkGateFactory,
+            linkConfigurationLoader = linkConfigurationLoader,
             linkAccountHolder = linkAccountHolder,
             linkApiRepository = linkApiRepository,
             controllerComponentFactory = controllerComponentFactory


### PR DESCRIPTION
# Summary
Follow-ups to https://github.com/stripe/stripe-android/pull/11082:
 * Add tests
 * Fix LinkAccountUpdate logic
 * Extracted out `LinkConfigurationLoader` for separation of concerns and testability
 * Change API to `suspend fun configure(configuration: Configuration): ConfigureResult and add `LinkController.ConfigureResult`
 * Simplify configuration logic. Require configuration before performing actions, otherwise error.
 * 

# Motivation
👻 

# Testing
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
