### PR TITLE
[Link] Adds internal authentication only mode to `LinkController`

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/LinkControllerPlaygroundState.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/LinkControllerPlaygroundState.kt
@@ -6,4 +6,5 @@ data class LinkControllerPlaygroundState(
     val presentPaymentMethodsResult: LinkController.PresentPaymentMethodsResult? = null,
     val lookupConsumerResult: LinkController.LookupConsumerResult? = null,
     val createPaymentMethodResult: LinkController.CreatePaymentMethodResult? = null,
+    val presentForAuthenticationResult: LinkController.PresentForAuthenticationResult? = null,
 )

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/LinkControllerUi.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/LinkControllerUi.kt
@@ -84,20 +84,7 @@ internal fun LinkControllerUi(
     onPresentForAuthenticationClick: (email: String) -> Unit,
 ) {
     var email by rememberSaveable { mutableStateOf("") }
-    val errorToPresent = listOf(
-        playgroundState.presentPaymentMethodsResult,
-        playgroundState.lookupConsumerResult,
-        playgroundState.createPaymentMethodResult,
-        playgroundState.presentForAuthenticationResult
-    ).firstNotNullOfOrNull { result ->
-        when (result) {
-            is LinkController.PresentPaymentMethodsResult.Failed -> result.error
-            is LinkController.LookupConsumerResult.Failed -> result.error
-            is LinkController.CreatePaymentMethodResult.Failed -> result.error
-            is LinkController.PresentForAuthenticationResult.Failed -> result.error
-            else -> null
-        }
-    }
+    val errorToPresent = playgroundState.linkControllerError()
 
     val scope = rememberCoroutineScope()
     DisposableEffect(email) {
@@ -153,7 +140,7 @@ internal fun LinkControllerUi(
             onClick = { onPaymentMethodButtonClick(email) },
         )
         Spacer(Modifier.height(16.dp))
-        
+
         // Authentication Test Button
         Button(
             onClick = { onPresentForAuthenticationClick(email) },
@@ -162,7 +149,7 @@ internal fun LinkControllerUi(
             Text("Test Authentication Flow")
         }
         Spacer(Modifier.height(16.dp))
-        
+
         ConfirmButton(
             onClick = onCreatePaymentMethodClick,
             enabled = controllerState.selectedPaymentMethodPreview != null,
@@ -184,6 +171,14 @@ internal fun LinkControllerUi(
         }
     }
 }
+
+@Composable
+private fun LinkControllerPlaygroundState.linkControllerError(): Throwable? = listOf(
+    (presentPaymentMethodsResult as? LinkController.PresentPaymentMethodsResult.Failed)?.error,
+    (lookupConsumerResult as? LinkController.LookupConsumerResult.Failed)?.error,
+    (createPaymentMethodResult as? LinkController.CreatePaymentMethodResult.Failed)?.error,
+    (presentForAuthenticationResult as? LinkController.PresentForAuthenticationResult.Failed)?.error,
+).firstOrNull { it != null }
 
 @Composable
 @Preview(showBackground = true)

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/LinkControllerUi.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/LinkControllerUi.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
 import androidx.compose.material.Divider
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
@@ -67,6 +68,9 @@ internal fun LinkControllerUi(
             linkController.presentPaymentMethods(email = email.takeIf { it.isNotBlank() })
         },
         onCreatePaymentMethodClick = linkController::createPaymentMethod,
+        onPresentForAuthenticationClick = { email ->
+            linkController.presentForAuthentication(email = email.takeIf { it.isNotBlank() })
+        },
     )
 }
 
@@ -77,18 +81,23 @@ internal fun LinkControllerUi(
     onEmailChange: (email: String) -> Unit,
     onPaymentMethodButtonClick: (email: String) -> Unit,
     onCreatePaymentMethodClick: () -> Unit,
+    onPresentForAuthenticationClick: (email: String) -> Unit,
 ) {
     var email by rememberSaveable { mutableStateOf("") }
-    val presentPaymentMethodsResultError =
-        (playgroundState.presentPaymentMethodsResult as? LinkController.PresentPaymentMethodsResult.Failed)
-            ?.error
-    val lookupConsumerError =
-        (playgroundState.lookupConsumerResult as? LinkController.LookupConsumerResult.Failed)
-            ?.error
-    val createPaymentMethodError =
-        (playgroundState.createPaymentMethodResult as? LinkController.CreatePaymentMethodResult.Failed)
-            ?.error
-    val errorToPresent = presentPaymentMethodsResultError ?: lookupConsumerError ?: createPaymentMethodError
+    val errorToPresent = listOf(
+        playgroundState.presentPaymentMethodsResult,
+        playgroundState.lookupConsumerResult,
+        playgroundState.createPaymentMethodResult,
+        playgroundState.presentForAuthenticationResult
+    ).firstNotNullOfOrNull { result ->
+        when (result) {
+            is LinkController.PresentPaymentMethodsResult.Failed -> result.error
+            is LinkController.LookupConsumerResult.Failed -> result.error
+            is LinkController.CreatePaymentMethodResult.Failed -> result.error
+            is LinkController.PresentForAuthenticationResult.Failed -> result.error
+            else -> null
+        }
+    }
 
     val scope = rememberCoroutineScope()
     DisposableEffect(email) {
@@ -144,6 +153,16 @@ internal fun LinkControllerUi(
             onClick = { onPaymentMethodButtonClick(email) },
         )
         Spacer(Modifier.height(16.dp))
+        
+        // Authentication Test Button
+        Button(
+            onClick = { onPresentForAuthenticationClick(email) },
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text("Test Authentication Flow")
+        }
+        Spacer(Modifier.height(16.dp))
+        
         ConfirmButton(
             onClick = onCreatePaymentMethodClick,
             enabled = controllerState.selectedPaymentMethodPreview != null,
@@ -156,6 +175,13 @@ internal fun LinkControllerUi(
             text = createPaymentMethodResultText,
             style = MaterialTheme.typography.body1,
         )
+
+        if (playgroundState.presentForAuthenticationResult != null) {
+            Text(
+                text = playgroundState.presentForAuthenticationResult.toString(),
+                style = MaterialTheme.typography.body1
+            )
+        }
     }
 }
 
@@ -168,7 +194,8 @@ private fun LinkControllerUiPreview() {
             playgroundState = LinkControllerPlaygroundState(),
             onEmailChange = {},
             onPaymentMethodButtonClick = {},
-            onCreatePaymentMethodClick = {}
+            onCreatePaymentMethodClick = {},
+            onPresentForAuthenticationClick = {},
         )
     }
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
@@ -166,6 +166,7 @@ internal class PaymentSheetPlaygroundActivity :
                     presentPaymentMethodsCallback = viewModel::onLinkControllerPresentPaymentMethod,
                     lookupConsumerCallback = viewModel::onLinkControllerLookupConsumer,
                     createPaymentMethodCallback = viewModel::onLinkControllerCreatePaymentMethod,
+                    presentForAuthenticationCallback = { },
                 )
             }
 

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
@@ -166,7 +166,7 @@ internal class PaymentSheetPlaygroundActivity :
                     presentPaymentMethodsCallback = viewModel::onLinkControllerPresentPaymentMethod,
                     lookupConsumerCallback = viewModel::onLinkControllerLookupConsumer,
                     createPaymentMethodCallback = viewModel::onLinkControllerCreatePaymentMethod,
-                    presentForAuthenticationCallback = { },
+                    presentForAuthenticationCallback = viewModel::onLinkControllerPresentForAuthentication,
                 )
             }
 

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundViewModel.kt
@@ -702,6 +702,10 @@ internal class PaymentSheetPlaygroundViewModel(
         linkControllerState.update { it.copy(createPaymentMethodResult = result) }
     }
 
+    fun onLinkControllerPresentForAuthentication(result: LinkController.PresentForAuthenticationResult) {
+        linkControllerState.update { it.copy(presentForAuthenticationResult = result) }
+    }
+
     internal class Factory(
         private val applicationSupplier: () -> Application,
         private val uriSupplier: () -> Uri?,

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -368,6 +368,14 @@ public final class com/stripe/android/link/LinkController$State$Creator : androi
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/link/LinkLaunchMode$Authentication$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/link/LinkLaunchMode$Authentication;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/link/LinkLaunchMode$Authentication;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/link/LinkLaunchMode$Confirmation$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/link/LinkLaunchMode$Confirmation;

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivity.kt
@@ -80,7 +80,8 @@ internal class LinkActivity : ComponentActivity() {
     private fun LinkLaunchMode.setTheme() {
         when (this) {
             is LinkLaunchMode.Full,
-            is LinkLaunchMode.PaymentMethodSelection -> setTheme(R.style.StripePaymentSheetDefaultTheme)
+            is LinkLaunchMode.PaymentMethodSelection,
+            is LinkLaunchMode.Authentication -> setTheme(R.style.StripePaymentSheetDefaultTheme)
             is LinkLaunchMode.Confirmation -> setTheme(R.style.StripeTransparentTheme)
         }
         renderEdgeToEdge()

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
@@ -211,7 +211,8 @@ internal class LinkActivityViewModel @Inject constructor(
         viewModelScope.launch {
             when (linkLaunchMode) {
                 is LinkLaunchMode.Full,
-                is LinkLaunchMode.PaymentMethodSelection -> loadLink()
+                is LinkLaunchMode.PaymentMethodSelection,
+                is LinkLaunchMode.Authentication -> loadLink()
                 is LinkLaunchMode.Confirmation -> confirmLinkPayment(linkLaunchMode.selectedPayment)
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkController.kt
@@ -74,7 +74,7 @@ class LinkController @Inject internal constructor(
      * matches an existing Link account, the user will be able to authenticate with that account.
      * If null, the user will need to sign in or create a Link account.
      */
-    internal fun presentForAuthentication(email: String?) {
+    fun presentForAuthentication(email: String?) {
         viewModel.onPresentForAuthentication(
             launcher = linkControllerCoordinator.linkActivityResultLauncher,
             email = email

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkController.kt
@@ -74,6 +74,7 @@ class LinkController @Inject internal constructor(
      * matches an existing Link account, the user will be able to authenticate with that account.
      * If null, the user will need to sign in or create a Link account.
      */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     fun presentForAuthentication(email: String?) {
         viewModel.onPresentForAuthentication(
             launcher = linkControllerCoordinator.linkActivityResultLauncher,

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkController.kt
@@ -61,6 +61,27 @@ class LinkController @Inject internal constructor(
     }
 
     /**
+     * [CRYPTO ON-RAMP ONLY] Present the Link authentication screen.
+     *
+     * This will launch the Link activity where users can authenticate with their Link account.
+     * The authentication flow will close after successful authentication instead of continuing
+     * to payment selection. The result will be communicated through the [PresentForAuthenticationCallback]
+     * provided during controller creation.
+     *
+     * If a presentation is already in progress, this call will be ignored.
+     *
+     * @param email The email address to use for Link account lookup. If provided and the email
+     * matches an existing Link account, the user will be able to authenticate with that account.
+     * If null, the user will need to sign in or create a Link account.
+     */
+    internal fun presentForAuthentication(email: String?) {
+        viewModel.onPresentForAuthentication(
+            launcher = linkControllerCoordinator.linkActivityResultLauncher,
+            email = email
+        )
+    }
+
+    /**
      * Create a payment method from the currently selected Link payment method.
      *
      * This converts the selected Link payment method into a Stripe [PaymentMethod] that can be
@@ -263,6 +284,33 @@ class LinkController @Inject internal constructor(
     }
 
     /**
+     * Result of presenting Link for authentication.
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    sealed interface PresentForAuthenticationResult {
+
+        /**
+         * The user successfully authenticated with Link.
+         */
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        data object Success : PresentForAuthenticationResult
+
+        /**
+         * The user canceled the Link authentication.
+         */
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        data object Canceled : PresentForAuthenticationResult
+
+        /**
+         * An error occurred while presenting Link for authentication.
+         *
+         * @param error The error that occurred.
+         */
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        class Failed internal constructor(val error: Throwable) : PresentForAuthenticationResult
+    }
+
+    /**
      * Callback for receiving results from [presentPaymentMethods].
      */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -284,6 +332,14 @@ class LinkController @Inject internal constructor(
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     fun interface CreatePaymentMethodCallback {
         fun onCreatePaymentMethodResult(result: CreatePaymentMethodResult)
+    }
+
+    /**
+     * Callback for receiving results from [presentForAuthentication].
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    fun interface PresentForAuthenticationCallback {
+        fun onPresentForAuthenticationResult(result: PresentForAuthenticationResult)
     }
 
     /**
@@ -311,6 +367,7 @@ class LinkController @Inject internal constructor(
          * @param presentPaymentMethodsCallback Called with the result when [presentPaymentMethods] completes.
          * @param lookupConsumerCallback Called with the result when [lookupConsumer] completes.
          * @param createPaymentMethodCallback Called with the result when [createPaymentMethod] completes.
+         * @param presentForAuthenticationCallback Called with the result when [presentForAuthentication] completes.
          *
          * @return A configured [LinkController] instance.
          */
@@ -320,6 +377,7 @@ class LinkController @Inject internal constructor(
             presentPaymentMethodsCallback: PresentPaymentMethodsCallback,
             lookupConsumerCallback: LookupConsumerCallback,
             createPaymentMethodCallback: CreatePaymentMethodCallback,
+            presentForAuthenticationCallback: PresentForAuthenticationCallback,
         ): LinkController {
             val viewModelProvider = ViewModelProvider(
                 owner = activity,
@@ -334,6 +392,7 @@ class LinkController @Inject internal constructor(
                     presentPaymentMethodsCallback = presentPaymentMethodsCallback,
                     lookupConsumerCallback = lookupConsumerCallback,
                     createPaymentMethodCallback = createPaymentMethodCallback,
+                    presentForAuthenticationCallback = presentForAuthenticationCallback,
                 )
                 .controller
         }

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerCoordinator.kt
@@ -20,6 +20,7 @@ internal class LinkControllerCoordinator @Inject constructor(
     private val selectedPaymentMethodCallback: LinkController.PresentPaymentMethodsCallback,
     private val lookupConsumerCallback: LinkController.LookupConsumerCallback,
     private val createPaymentMethodCallback: LinkController.CreatePaymentMethodCallback,
+    private val presentForAuthenticationCallback: LinkController.PresentForAuthenticationCallback,
 ) {
     val linkActivityResultLauncher: ActivityResultLauncher<LinkActivityContract.Args>
 
@@ -30,7 +31,7 @@ internal class LinkControllerCoordinator @Inject constructor(
             key = "LinkController_LinkActivityResultLauncher",
             contract = linkActivityContract,
         ) { result ->
-            viewModel.onPresentPaymentMethodsActivityResult(result)
+            viewModel.onLinkActivityResult(result)
         }
 
         lifecycleOwner.lifecycleScope.launch {
@@ -43,10 +44,13 @@ internal class LinkControllerCoordinator @Inject constructor(
                     viewModel.lookupConsumerResultFlow
                         .collect(lookupConsumerCallback::onLookupConsumerResult)
                 }
-
                 launch {
                     viewModel.createPaymentMethodResultFlow
                         .collect(createPaymentMethodCallback::onCreatePaymentMethodResult)
+                }
+                launch {
+                    viewModel.presentForAuthenticationResultFlow
+                        .collect(presentForAuthenticationCallback::onPresentForAuthenticationResult)
                 }
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerViewModel.kt
@@ -246,20 +246,29 @@ internal class LinkControllerViewModel @Inject constructor(
 
         // Update account, clearing state if null.
         result.linkAccountUpdate?.let { update ->
-            val value = update.asValue()
-            linkAccountHolder.set(value)
-            if (value.account == null) {
-                _state.update {
-                    it.copy(
-                        selectedPaymentMethod = null,
-                        createdPaymentMethod = null,
-                        currentLaunchMode = null,
-                    )
+            when (update) {
+                is LinkAccountUpdate.Value -> {
+                    linkAccountHolder.set(update)
+                    if (update.account == null) {
+                        _state.update {
+                            it.copy(
+                                selectedPaymentMethod = null,
+                                createdPaymentMethod = null,
+                                currentLaunchMode = null,
+                            )
+                        }
+                    } else {
+                        // Reset launch mode
+                        _state.update {
+                            it.copy(currentLaunchMode = null)
+                        }
+                    }
                 }
-            } else {
-                // Reset launch mode
-                _state.update {
-                    it.copy(currentLaunchMode = null)
+                LinkAccountUpdate.None -> {
+                    // Reset launch mode
+                    _state.update {
+                        it.copy(currentLaunchMode = null)
+                    }
                 }
             }
         } ?: run {

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerViewModel.kt
@@ -197,12 +197,12 @@ internal class LinkControllerViewModel @Inject constructor(
 
     private fun getLinkAccountInfo(email: String?): LinkAccountUpdate.Value {
         val currentAccountInfo = linkAccountHolder.linkAccountInfo.value
-        
+
         // If we already have an authenticated account, preserve it
         if (currentAccountInfo.account != null) {
             return currentAccountInfo
         }
-        
+
         // Otherwise, check if the email matches the previously presented email
         val state = _state.value
         return currentAccountInfo
@@ -237,6 +237,7 @@ internal class LinkControllerViewModel @Inject constructor(
 
     fun onLinkActivityResult(result: LinkActivityResult) {
         val currentLaunchMode = _state.value.currentLaunchMode
+        _state.update { it.copy(currentLaunchMode = null) }
 
         when (currentLaunchMode) {
             is LinkLaunchMode.PaymentMethodSelection -> handlePaymentMethodSelectionResult(result)
@@ -250,31 +251,17 @@ internal class LinkControllerViewModel @Inject constructor(
                 is LinkAccountUpdate.Value -> {
                     linkAccountHolder.set(update)
                     if (update.account == null) {
-                        _state.update {
+                        updateState {
                             it.copy(
                                 selectedPaymentMethod = null,
                                 createdPaymentMethod = null,
-                                currentLaunchMode = null,
                             )
-                        }
-                    } else {
-                        // Reset launch mode
-                        _state.update {
-                            it.copy(currentLaunchMode = null)
                         }
                     }
                 }
                 LinkAccountUpdate.None -> {
-                    // Reset launch mode
-                    _state.update {
-                        it.copy(currentLaunchMode = null)
-                    }
+                    // Do nothing.
                 }
-            }
-        } ?: run {
-            // Reset launch mode even if no account update
-            _state.update {
-                it.copy(currentLaunchMode = null)
             }
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkLaunchMode.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkLaunchMode.kt
@@ -33,4 +33,11 @@ internal sealed interface LinkLaunchMode : Parcelable {
          */
         val selectedPayment: LinkPaymentMethod
     ) : LinkLaunchMode
+
+    /**
+     * Link is launched with the intent to authenticate the user only.
+     * The flow will close after successful authentication instead of continuing to payment selection.
+     */
+    @Parcelize
+    data object Authentication : LinkLaunchMode
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkScreenContent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkScreenContent.kt
@@ -107,7 +107,8 @@ internal fun LinkScreenContentBody(
                     .testTag(VERIFICATION_DIALOG_CONTENT_TAG),
                 linkAccount = screenState.linkAccount,
                 onVerificationSucceeded = onVerificationSucceeded,
-                onDismissClicked = onDismissClicked
+                onDismissClicked = onDismissClicked,
+                dismissWithResult = dismissWithResult
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/link/confirmation/CompleteLinkFlow.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/confirmation/CompleteLinkFlow.kt
@@ -110,6 +110,13 @@ internal class DefaultCompleteLinkFlow @Inject constructor(
                     shippingAddress = linkAccountManager.loadDefaultShippingAddress(),
                 )
             )
+            is LinkLaunchMode.Authentication -> Result.Completed(
+                linkActivityResult = LinkActivityResult.Completed(
+                    linkAccountUpdate = linkAccountManager.linkAccountUpdate,
+                    selectedPayment = null,
+                    shippingAddress = null,
+                )
+            )
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerComponent.kt
@@ -21,6 +21,7 @@ internal interface LinkControllerComponent {
             @BindsInstance presentPaymentMethodsCallback: LinkController.PresentPaymentMethodsCallback,
             @BindsInstance lookupConsumerCallback: LinkController.LookupConsumerCallback,
             @BindsInstance createPaymentMethodCallback: LinkController.CreatePaymentMethodCallback,
+            @BindsInstance presentForAuthenticationCallback: LinkController.PresentForAuthenticationCallback,
         ): LinkControllerComponent
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/LinkContent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/LinkContent.kt
@@ -129,7 +129,8 @@ private fun Screens(
             MinScreenHeightBox(screenHeightPercentage = 1f) {
                 SignUpRoute(
                     navigateAndClearStack = navigateAndClearStack,
-                    moveToWeb = moveToWeb
+                    moveToWeb = moveToWeb,
+                    dismissWithResult = dismissWithResult
                 )
             }
         }
@@ -154,7 +155,8 @@ private fun Screens(
                     linkAccount = linkAccount,
                     changeEmail = changeEmail,
                     navigateAndClearStack = navigateAndClearStack,
-                    goBack = goBack
+                    goBack = goBack,
+                    dismissWithResult = dismissWithResult
                 )
             }
         }
@@ -184,13 +186,15 @@ private fun Screens(
 @Composable
 private fun SignUpRoute(
     navigateAndClearStack: (route: LinkScreen) -> Unit,
-    moveToWeb: () -> Unit
+    moveToWeb: () -> Unit,
+    dismissWithResult: (LinkActivityResult) -> Unit
 ) {
     val viewModel: SignUpViewModel = linkViewModel { parentComponent ->
         SignUpViewModel.factory(
             parentComponent = parentComponent,
             navigateAndClearStack = navigateAndClearStack,
-            moveToWeb = moveToWeb
+            moveToWeb = moveToWeb,
+            dismissWithResult = dismissWithResult
         )
     }
     SignUpScreen(
@@ -203,7 +207,8 @@ private fun VerificationRoute(
     linkAccount: LinkAccount,
     navigateAndClearStack: (route: LinkScreen) -> Unit,
     changeEmail: () -> Unit,
-    goBack: () -> Unit
+    goBack: () -> Unit,
+    dismissWithResult: (LinkActivityResult) -> Unit
 ) {
     val viewModel: VerificationViewModel = linkViewModel { parentComponent ->
         VerificationViewModel.factory(
@@ -214,7 +219,8 @@ private fun VerificationRoute(
             onVerificationSucceeded = {
                 navigateAndClearStack(LinkScreen.Wallet)
             },
-            onChangeEmailClicked = changeEmail
+            onChangeEmailClicked = changeEmail,
+            dismissWithResult = dismissWithResult
         )
     }
     VerificationScreen(viewModel)

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/PrimaryButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/PrimaryButton.kt
@@ -160,7 +160,8 @@ internal fun completePaymentButtonLabel(
             uiCoreR.string.stripe_continue_button_label.resolvableString
         }
     }
-    is LinkLaunchMode.PaymentMethodSelection -> uiCoreR.string.stripe_continue_button_label.resolvableString
+    is LinkLaunchMode.PaymentMethodSelection,
+    is LinkLaunchMode.Authentication -> uiCoreR.string.stripe_continue_button_label.resolvableString
 }
 
 private val PrimaryButtonIconWidth = 13.dp

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/signup/SignUpViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/signup/SignUpViewModel.kt
@@ -10,8 +10,11 @@ import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.core.Logger
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.link.LinkAccountUpdate
+import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkDismissalCoordinator
+import com.stripe.android.link.LinkLaunchMode
 import com.stripe.android.link.LinkScreen
 import com.stripe.android.link.NoLinkAccountFoundException
 import com.stripe.android.link.account.LinkAuth
@@ -47,7 +50,9 @@ internal class SignUpViewModel @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
     private val dismissalCoordinator: LinkDismissalCoordinator,
     private val navigateAndClearStack: (LinkScreen) -> Unit,
-    private val moveToWeb: () -> Unit
+    private val moveToWeb: () -> Unit,
+    private val linkLaunchMode: LinkLaunchMode,
+    private val dismissWithResult: (LinkActivityResult) -> Unit
 ) : ViewModel() {
     private val useLinkConfigurationCustomerInfo =
         savedStateHandle.get<Boolean>(USE_LINK_CONFIGURATION_CUSTOMER_INFO) ?: true
@@ -225,12 +230,23 @@ internal class SignUpViewModel @Inject constructor(
     }
 
     private fun onAccountFetched(linkAccount: LinkAccount?) {
-        if (linkAccount?.completedSignup == true) {
-            navigateAndClearStack(LinkScreen.PaymentMethod)
-        } else if (linkAccount?.isVerified == true) {
-            navigateAndClearStack(LinkScreen.Wallet)
+        // For Authentication mode, dismiss with success after account is fetched
+        if (linkLaunchMode is LinkLaunchMode.Authentication) {
+            dismissWithResult(
+                LinkActivityResult.Completed(
+                    linkAccountUpdate = LinkAccountUpdate.Value(linkAccount),
+                    selectedPayment = null,
+                )
+            )
         } else {
-            navigateAndClearStack(LinkScreen.Verification)
+            // Regular flow navigation
+            if (linkAccount?.completedSignup == true) {
+                navigateAndClearStack(LinkScreen.PaymentMethod)
+            } else if (linkAccount?.isVerified == true) {
+                navigateAndClearStack(LinkScreen.Wallet)
+            } else {
+                navigateAndClearStack(LinkScreen.Verification)
+            }
         }
     }
 
@@ -278,7 +294,8 @@ internal class SignUpViewModel @Inject constructor(
         fun factory(
             parentComponent: NativeLinkComponent,
             navigateAndClearStack: (LinkScreen) -> Unit,
-            moveToWeb: () -> Unit
+            moveToWeb: () -> Unit,
+            dismissWithResult: (LinkActivityResult) -> Unit
         ): ViewModelProvider.Factory {
             return viewModelFactory {
                 initializer {
@@ -290,7 +307,9 @@ internal class SignUpViewModel @Inject constructor(
                         savedStateHandle = parentComponent.savedStateHandle,
                         dismissalCoordinator = parentComponent.dismissalCoordinator,
                         navigateAndClearStack = navigateAndClearStack,
-                        moveToWeb = moveToWeb
+                        moveToWeb = moveToWeb,
+                        linkLaunchMode = parentComponent.linkLaunchMode,
+                        dismissWithResult = dismissWithResult
                     )
                 }
             }

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/verification/VerificationDialog.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/verification/VerificationDialog.kt
@@ -38,9 +38,7 @@ internal fun VerificationDialog(
             parentComponent = parentComponent,
             linkAccount = linkAccount,
             isDialog = true,
-            onVerificationSucceeded = { linkAccountUpdate ->
-                onVerificationSucceeded()
-            },
+            onVerificationSucceeded = onVerificationSucceeded,
             onDismissClicked = onDismissClicked,
             dismissWithResult = dismissWithResult
         )

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/verification/VerificationDialog.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/verification/VerificationDialog.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.window.DialogWindowProvider
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.linkViewModel
 import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.link.theme.DefaultLinkTheme
@@ -29,15 +30,19 @@ internal fun VerificationDialog(
     modifier: Modifier,
     linkAccount: LinkAccount,
     onVerificationSucceeded: () -> Unit,
-    onDismissClicked: () -> Unit
+    onDismissClicked: () -> Unit,
+    dismissWithResult: (LinkActivityResult) -> Unit
 ) {
     val viewModel = linkViewModel<VerificationViewModel> { parentComponent ->
         VerificationViewModel.factory(
             parentComponent = parentComponent,
             linkAccount = linkAccount,
             isDialog = true,
-            onVerificationSucceeded = onVerificationSucceeded,
-            onDismissClicked = onDismissClicked
+            onVerificationSucceeded = { linkAccountUpdate ->
+                onVerificationSucceeded()
+            },
+            onDismissClicked = onDismissClicked,
+            dismissWithResult = dismissWithResult
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/verification/VerificationViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/verification/VerificationViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.stripe.android.core.Logger
-import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkLaunchMode
 import com.stripe.android.link.account.LinkAccountManager
@@ -35,7 +34,7 @@ internal class VerificationViewModel @Inject constructor(
     private val logger: Logger,
     private val linkLaunchMode: LinkLaunchMode,
     private val isDialog: Boolean,
-    private val onVerificationSucceeded: (LinkAccountUpdate.Value) -> Unit,
+    private val onVerificationSucceeded: () -> Unit,
     private val onChangeEmailRequested: () -> Unit,
     private val onDismissClicked: () -> Unit,
     private val dismissWithResult: (LinkActivityResult) -> Unit,
@@ -96,7 +95,7 @@ internal class VerificationViewModel @Inject constructor(
                         )
                     )
                 } else {
-                    onVerificationSucceeded(LinkAccountUpdate.Value(account))
+                    onVerificationSucceeded()
                 }
             },
             onFailure = {
@@ -182,7 +181,7 @@ internal class VerificationViewModel @Inject constructor(
             parentComponent: NativeLinkComponent,
             linkAccount: LinkAccount,
             isDialog: Boolean,
-            onVerificationSucceeded: (LinkAccountUpdate.Value) -> Unit,
+            onVerificationSucceeded: () -> Unit,
             onChangeEmailClicked: () -> Unit = {},
             onDismissClicked: () -> Unit,
             dismissWithResult: (LinkActivityResult) -> Unit,

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
@@ -95,6 +95,7 @@ internal class WalletViewModel @Inject constructor(
             is LinkLaunchMode.Full,
             is LinkLaunchMode.Confirmation -> null
             is LinkLaunchMode.PaymentMethodSelection -> selectedPayment?.id
+            is LinkLaunchMode.Authentication -> null
         }
 
     val uiState: StateFlow<WalletUiState> = _uiState.asStateFlow()
@@ -603,6 +604,7 @@ private fun StripeIntent.secondaryButtonLabel(linkLaunchMode: LinkLaunchMode): R
             is PaymentIntent -> resolvableString(R.string.stripe_wallet_pay_another_way)
             is SetupIntent -> resolvableString(R.string.stripe_wallet_continue_another_way)
         }
-        is LinkLaunchMode.PaymentMethodSelection -> resolvableString(R.string.stripe_wallet_continue_another_way)
+        is LinkLaunchMode.PaymentMethodSelection,
+        is LinkLaunchMode.Authentication -> resolvableString(R.string.stripe_wallet_continue_another_way)
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerCoordinatorTest.kt
@@ -32,11 +32,13 @@ internal class LinkControllerCoordinatorTest {
     private val presentPaymentMethodsResultFlow = MutableSharedFlow<LinkController.PresentPaymentMethodsResult>()
     private val lookupConsumerResultFlow = MutableSharedFlow<LinkController.LookupConsumerResult>()
     private val createPaymentMethodResultFlow = MutableSharedFlow<LinkController.CreatePaymentMethodResult>()
+    private val presentForAuthenticationResultFlow = MutableSharedFlow<LinkController.PresentForAuthenticationResult>()
 
     private val viewModel: LinkControllerViewModel = mock {
         on { presentPaymentMethodsResultFlow } doReturn presentPaymentMethodsResultFlow
         on { lookupConsumerResultFlow } doReturn lookupConsumerResultFlow
         on { createPaymentMethodResultFlow } doReturn createPaymentMethodResultFlow
+        on { presentForAuthenticationResultFlow } doReturn presentForAuthenticationResultFlow
     }
 
     private val presentPaymentMethodsResults = mutableListOf<LinkController.PresentPaymentMethodsResult>()
@@ -60,6 +62,7 @@ internal class LinkControllerCoordinatorTest {
             selectedPaymentMethodCallback = { presentPaymentMethodsResults.add(it) },
             lookupConsumerCallback = { lookupConsumerResults.add(it) },
             createPaymentMethodCallback = { createPaymentMethodResults.add(it) },
+            presentForAuthenticationCallback = { },
         )
     }
 
@@ -146,7 +149,7 @@ internal class LinkControllerCoordinatorTest {
                 launchMode = LinkLaunchMode.PaymentMethodSelection(null),
             )
         )
-        verify(viewModel).onPresentPaymentMethodsActivityResult(testResult)
+        verify(viewModel).onLinkActivityResult(testResult)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerViewModelTest.kt
@@ -416,7 +416,7 @@ class LinkControllerViewModelTest {
     }
 
     @Test
-    fun `onPresentPaymentMethodsActivityResult() with PaymentMethodObtained result does nothing`() = runTest {
+    fun `onLinkActivityResult() with PaymentMethodObtained result does nothing`() = runTest {
         val viewModel = createViewModel()
         configure(viewModel)
 
@@ -424,7 +424,7 @@ class LinkControllerViewModelTest {
         val initialAccount = linkAccountHolder.linkAccountInfo.first()
 
         viewModel.presentPaymentMethodsResultFlow.test {
-            viewModel.onPresentPaymentMethodsActivityResult(
+            viewModel.onLinkActivityResult(
                 LinkActivityResult.PaymentMethodObtained(
                     paymentMethod = mock()
                 )
@@ -437,12 +437,12 @@ class LinkControllerViewModelTest {
     }
 
     @Test
-    fun `onPresentPaymentMethodsActivityResult() with Canceled result`() = runTest {
+    fun `onLinkActivityResult() with Canceled result`() = runTest {
         val viewModel = createViewModel()
         configure(viewModel)
 
         viewModel.presentPaymentMethodsResultFlow.test {
-            viewModel.onPresentPaymentMethodsActivityResult(
+            viewModel.onLinkActivityResult(
                 LinkActivityResult.Canceled(
                     reason = LinkActivityResult.Canceled.Reason.BackPressed,
                     linkAccountUpdate = LinkAccountUpdate.Value(null)
@@ -453,7 +453,7 @@ class LinkControllerViewModelTest {
     }
 
     @Test
-    fun `onPresentPaymentMethodsActivityResult() on Completed result emits Success and updates preview`() = runTest {
+    fun `onLinkActivityResult() on Completed result emits Success and updates preview`() = runTest {
         val viewModel = createViewModel()
         configure(viewModel)
 
@@ -463,7 +463,7 @@ class LinkControllerViewModelTest {
             billingPhone = null
         )
         viewModel.presentPaymentMethodsResultFlow.test {
-            viewModel.onPresentPaymentMethodsActivityResult(
+            viewModel.onLinkActivityResult(
                 LinkActivityResult.Completed(
                     linkAccountUpdate = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
                     selectedPayment = linkPaymentMethod,
@@ -480,13 +480,13 @@ class LinkControllerViewModelTest {
     }
 
     @Test
-    fun `onPresentPaymentMethodsActivityResult() with Failed result`() = runTest {
+    fun `onLinkActivityResult() with Failed result`() = runTest {
         val viewModel = createViewModel()
         configure(viewModel)
 
         val error = Exception("Error")
         viewModel.presentPaymentMethodsResultFlow.test {
-            viewModel.onPresentPaymentMethodsActivityResult(
+            viewModel.onLinkActivityResult(
                 LinkActivityResult.Failed(
                     error = error,
                     linkAccountUpdate = LinkAccountUpdate.Value(null)
@@ -499,7 +499,7 @@ class LinkControllerViewModelTest {
     }
 
     @Test
-    fun `onPresentPaymentMethodsActivityResult() updates to different account without clearing state`() = runTest {
+    fun `onLinkActivityResult() updates to different account without clearing state`() = runTest {
         val viewModel = createViewModel()
         configure(viewModel)
         signIn()
@@ -516,7 +516,7 @@ class LinkControllerViewModelTest {
         val anotherAccount = LinkAccount(
             TestFactory.CONSUMER_SESSION.copy(emailAddress = "another@stripe.com")
         )
-        viewModel.onPresentPaymentMethodsActivityResult(
+        viewModel.onLinkActivityResult(
             LinkActivityResult.Canceled(
                 reason = LinkActivityResult.Canceled.Reason.BackPressed,
                 linkAccountUpdate = LinkAccountUpdate.Value(anotherAccount)
@@ -532,12 +532,12 @@ class LinkControllerViewModelTest {
     }
 
     @Test
-    fun `onPresentPaymentMethodsActivityResult() on account cleared clears verification state`() = runTest {
+    fun `onLinkActivityResult() on account cleared clears verification state`() = runTest {
         val viewModel = createViewModel()
         configure(viewModel)
         signIn()
 
-        viewModel.onPresentPaymentMethodsActivityResult(
+        viewModel.onLinkActivityResult(
             LinkActivityResult.Canceled(
                 reason = LinkActivityResult.Canceled.Reason.BackPressed,
                 linkAccountUpdate = LinkAccountUpdate.Value(null)

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerViewModelTest.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.link
 
 import android.app.Application
-import androidx.activity.result.ActivityResultLauncher
 import androidx.lifecycle.SavedStateHandle
 import androidx.test.core.app.ApplicationProvider
 import app.cash.turbine.test
@@ -27,8 +26,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.any
-import org.mockito.kotlin.never
 import org.robolectric.RobolectricTestRunner
 
 @ExperimentalCoroutinesApi

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerViewModelTest.kt
@@ -17,6 +17,7 @@ import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.parsers.PaymentMethodJsonParser
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FakeLogger
+import com.stripe.android.utils.FakeActivityResultLauncher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -423,6 +424,9 @@ class LinkControllerViewModelTest {
         val initialState = viewModel.state(application).first()
         val initialAccount = linkAccountHolder.linkAccountInfo.first()
 
+        // First call onPresentPaymentMethods to set up the launch mode
+        viewModel.onPresentPaymentMethods(FakeActivityResultLauncher(), "test@example.com")
+
         viewModel.presentPaymentMethodsResultFlow.test {
             viewModel.onLinkActivityResult(
                 LinkActivityResult.PaymentMethodObtained(
@@ -441,6 +445,9 @@ class LinkControllerViewModelTest {
         val viewModel = createViewModel()
         configure(viewModel)
 
+        // First call onPresentPaymentMethods to set up the launch mode
+        viewModel.onPresentPaymentMethods(FakeActivityResultLauncher(), "test@example.com")
+
         viewModel.presentPaymentMethodsResultFlow.test {
             viewModel.onLinkActivityResult(
                 LinkActivityResult.Canceled(
@@ -456,6 +463,9 @@ class LinkControllerViewModelTest {
     fun `onLinkActivityResult() on Completed result emits Success and updates preview`() = runTest {
         val viewModel = createViewModel()
         configure(viewModel)
+
+        // First call onPresentPaymentMethods to set up the launch mode
+        viewModel.onPresentPaymentMethods(FakeActivityResultLauncher(), "test@example.com")
 
         val linkPaymentMethod = LinkPaymentMethod.ConsumerPaymentDetails(
             details = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD,
@@ -483,6 +493,9 @@ class LinkControllerViewModelTest {
     fun `onLinkActivityResult() with Failed result`() = runTest {
         val viewModel = createViewModel()
         configure(viewModel)
+
+        // First call onPresentPaymentMethods to set up the launch mode
+        viewModel.onPresentPaymentMethods(FakeActivityResultLauncher(), "test@example.com")
 
         val error = Exception("Error")
         viewModel.presentPaymentMethodsResultFlow.test {

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenTest.kt
@@ -16,6 +16,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkDismissalCoordinator
+import com.stripe.android.link.LinkLaunchMode
 import com.stripe.android.link.RealLinkDismissalCoordinator
 import com.stripe.android.link.TestFactory
 import com.stripe.android.link.account.FakeLinkAuth
@@ -256,7 +257,9 @@ internal class SignUpScreenTest {
             savedStateHandle = SavedStateHandle(),
             navigateAndClearStack = {},
             dismissalCoordinator = dismissalCoordinator,
-            moveToWeb = moveToWeb
+            moveToWeb = moveToWeb,
+            linkLaunchMode = LinkLaunchMode.Full,
+            dismissWithResult = {}
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/verification/VerificationScreenTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/verification/VerificationScreenTest.kt
@@ -13,6 +13,8 @@ import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.Logger
+import com.stripe.android.link.LinkActivityResult
+import com.stripe.android.link.LinkLaunchMode
 import com.stripe.android.link.TestFactory
 import com.stripe.android.link.account.FakeLinkAccountManager
 import com.stripe.android.link.account.LinkAccountManager
@@ -255,7 +257,9 @@ internal class VerificationScreenTest {
         linkEventsReporter: LinkEventsReporter = VerificationLinkEventsReporter(),
         logger: Logger = FakeLogger(),
         isDialog: Boolean = false,
-        onDismissClicked: () -> Unit = {}
+        onDismissClicked: () -> Unit = {},
+        linkLaunchMode: LinkLaunchMode = LinkLaunchMode.PaymentMethodSelection(null),
+        dismissWithResult: (LinkActivityResult) -> Unit = {}
     ): VerificationViewModel {
         return VerificationViewModel(
             linkAccountManager = linkAccountManager,
@@ -265,7 +269,9 @@ internal class VerificationScreenTest {
             onVerificationSucceeded = {},
             onChangeEmailRequested = {},
             linkAccount = TestFactory.LINK_ACCOUNT,
-            isDialog = isDialog
+            isDialog = isDialog,
+            linkLaunchMode = linkLaunchMode,
+            dismissWithResult = dismissWithResult
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/verification/VerificationViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/verification/VerificationViewModelTest.kt
@@ -4,7 +4,6 @@ import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.Logger
 import com.stripe.android.core.strings.resolvableString
-import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkLaunchMode
 import com.stripe.android.link.TestFactory
@@ -62,9 +61,9 @@ internal class VerificationViewModelTest {
     @Test
     fun `When confirmVerification succeeds then it navigates to Wallet`() =
         runTest(dispatcher) {
-            val onVerificationSucceededCalls = arrayListOf<LinkAccountUpdate.Value>()
-            fun onVerificationSucceeded(linkAccountUpdate: LinkAccountUpdate.Value) {
-                onVerificationSucceededCalls.add(linkAccountUpdate)
+            val onVerificationSucceededCalls = arrayListOf<Unit>()
+            fun onVerificationSucceeded() {
+                onVerificationSucceededCalls.add(Unit)
             }
 
             val viewModel = createViewModel(
@@ -73,7 +72,6 @@ internal class VerificationViewModelTest {
             viewModel.onVerificationCodeEntered("code")
 
             assertThat(onVerificationSucceededCalls).hasSize(1)
-            assertThat(onVerificationSucceededCalls.first().account).isEqualTo(TestFactory.LINK_ACCOUNT)
         }
 
     @Test
@@ -207,21 +205,21 @@ internal class VerificationViewModelTest {
         linkEventsReporter: LinkEventsReporter = FakeLinkEventsReporter(),
         logger: Logger = FakeLogger(),
         linkLaunchMode: LinkLaunchMode = LinkLaunchMode.PaymentMethodSelection(null),
-        onVerificationSucceeded: (LinkAccountUpdate.Value) -> Unit = { },
+        onVerificationSucceeded: () -> Unit = { },
         onChangeEmailRequested: () -> Unit = {},
         onDismissClicked: () -> Unit = {},
         dismissWithResult: (LinkActivityResult) -> Unit = { },
     ): VerificationViewModel {
         return VerificationViewModel(
+            linkAccount = TestFactory.LINK_ACCOUNT,
             linkAccountManager = linkAccountManager,
             linkEventsReporter = linkEventsReporter,
             logger = logger,
             linkLaunchMode = linkLaunchMode,
-            linkAccount = TestFactory.LINK_ACCOUNT,
+            isDialog = false,
             onVerificationSucceeded = onVerificationSucceeded,
             onChangeEmailRequested = onChangeEmailRequested,
             onDismissClicked = onDismissClicked,
-            isDialog = false,
             dismissWithResult = dismissWithResult
         )
     }


### PR DESCRIPTION
# Summary
- Adds `Authentication` Launch mode. This halts the Link flow as soon as the user authenticates / signs up. 
- Adds new `presentForAuthentication` entry point (goal is to use it just for onRamp)

[full_controller.webm](https://github.com/user-attachments/assets/259588e2-7b28-4c15-84c2-b7b4ea559c8f)

# Motivation
Onramp support for verification only flows.

# Testing
- [x] Modified tests
- [x] Manually verified