### PR TITLE
Remove data modifier from payments-core.

### DIFF
--- a/connect-example/dependencies/dependencies.txt
+++ b/connect-example/dependencies/dependencies.txt
@@ -353,7 +353,10 @@
 |    |    |    |    |    \--- androidx.appcompat:appcompat-resources:1.7.0 (c)
 |    |    |    |    +--- androidx.core:core-ktx:1.13.1 (*)
 |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0 (*)
-|    |    |    |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
+|    |    |    |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
+|    |    |    |    \--- dev.drewhamilton.poko:poko-annotations:0.18.2
+|    |    |    |         \--- dev.drewhamilton.poko:poko-annotations-jvm:0.18.2
+|    |    |    |              \--- org.jetbrains.kotlin:kotlin-stdlib:2.1.0 -> 2.1.10 (*)
 |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:2.1.10 (*)
 |    |    |    +--- androidx.activity:activity-ktx:1.9.3 (*)
 |    |    |    +--- androidx.fragment:fragment-ktx:1.8.6
@@ -755,9 +758,7 @@
 |    +--- androidx.compose.foundation:foundation:1.7.8 (*)
 |    +--- androidx.compose.material:material:1.7.8 (*)
 |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
-|    \--- dev.drewhamilton.poko:poko-annotations:0.18.2
-|         \--- dev.drewhamilton.poko:poko-annotations-jvm:0.18.2
-|              \--- org.jetbrains.kotlin:kotlin-stdlib:2.1.0 -> 2.1.10 (*)
+|    \--- dev.drewhamilton.poko:poko-annotations:0.18.2 (*)
 +--- project :stripe-core (*)
 +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1 (*)
 +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.1 (*)

--- a/connect/dependencies/dependencies.txt
+++ b/connect/dependencies/dependencies.txt
@@ -348,7 +348,10 @@
 |    |    |    |    \--- androidx.appcompat:appcompat-resources:1.7.0 (c)
 |    |    |    +--- androidx.core:core-ktx:1.13.1 (*)
 |    |    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0 (*)
-|    |    |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
+|    |    |    \--- dev.drewhamilton.poko:poko-annotations:0.18.2
+|    |    |         \--- dev.drewhamilton.poko:poko-annotations-jvm:0.18.2
+|    |    |              \--- org.jetbrains.kotlin:kotlin-stdlib:2.1.0 -> 2.1.10 (*)
 |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:2.1.10 (*)
 |    |    +--- androidx.activity:activity-ktx:1.9.3 (*)
 |    |    +--- androidx.fragment:fragment-ktx:1.8.6
@@ -742,6 +745,4 @@
 +--- androidx.compose.foundation:foundation:1.7.8 (*)
 +--- androidx.compose.material:material:1.7.8 (*)
 +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
-\--- dev.drewhamilton.poko:poko-annotations:0.18.2
-     \--- dev.drewhamilton.poko:poko-annotations-jvm:0.18.2
-          \--- org.jetbrains.kotlin:kotlin-stdlib:2.1.0 -> 2.1.10 (*)
+\--- dev.drewhamilton.poko:poko-annotations:0.18.2 (*)

--- a/crypto-onramp-example/dependencies/dependencies.txt
+++ b/crypto-onramp-example/dependencies/dependencies.txt
@@ -364,7 +364,10 @@
 |    |    |    |    \--- androidx.appcompat:appcompat-resources:1.7.0 (c)
 |    |    |    +--- androidx.core:core-ktx:1.13.1 (*)
 |    |    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0 (*)
-|    |    |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
+|    |    |    \--- dev.drewhamilton.poko:poko-annotations:0.18.2
+|    |    |         \--- dev.drewhamilton.poko:poko-annotations-jvm:0.18.2
+|    |    |              \--- org.jetbrains.kotlin:kotlin-stdlib:2.1.0 -> 2.1.10 (*)
 |    |    +--- androidx.databinding:viewbinding:8.8.2 (*)
 |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:2.1.10 (*)
 |    |    +--- project :hcaptcha
@@ -924,9 +927,7 @@
 |    |    |    |    \--- com.google.android.gms:play-services-basement:18.0.0 -> 18.4.0 (*)
 |    |    |    \--- com.google.android.gms:play-services-tasks:18.2.0 (*)
 |    |    +--- com.google.android.instantapps:instantapps:1.1.0
-|    |    +--- dev.drewhamilton.poko:poko-annotations:0.18.2
-|    |    |    \--- dev.drewhamilton.poko:poko-annotations-jvm:0.18.2
-|    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib:2.1.0 -> 2.1.10 (*)
+|    |    +--- dev.drewhamilton.poko:poko-annotations:0.18.2 (*)
 |    |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
 |    +--- project :paymentsheet
 |    |    +--- project :payments-core (*)

--- a/crypto-onramp/dependencies/dependencies.txt
+++ b/crypto-onramp/dependencies/dependencies.txt
@@ -360,7 +360,10 @@
 |    |    |    \--- androidx.appcompat:appcompat-resources:1.7.0 (c)
 |    |    +--- androidx.core:core-ktx:1.13.1 (*)
 |    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
+|    |    \--- dev.drewhamilton.poko:poko-annotations:0.18.2
+|    |         \--- dev.drewhamilton.poko:poko-annotations-jvm:0.18.2
+|    |              \--- org.jetbrains.kotlin:kotlin-stdlib:2.1.0 -> 2.1.10 (*)
 |    +--- androidx.databinding:viewbinding:8.8.2
 |    |    \--- androidx.annotation:annotation:1.0.0 -> 1.9.1 (*)
 |    +--- org.jetbrains.kotlin:kotlin-stdlib:2.1.10 (*)
@@ -921,9 +924,7 @@
 |    |    |    \--- com.google.android.gms:play-services-basement:18.0.0 -> 18.4.0 (*)
 |    |    \--- com.google.android.gms:play-services-tasks:18.2.0 (*)
 |    +--- com.google.android.instantapps:instantapps:1.1.0
-|    +--- dev.drewhamilton.poko:poko-annotations:0.18.2
-|    |    \--- dev.drewhamilton.poko:poko-annotations-jvm:0.18.2
-|    |         \--- org.jetbrains.kotlin:kotlin-stdlib:2.1.0 -> 2.1.10 (*)
+|    +--- dev.drewhamilton.poko:poko-annotations:0.18.2 (*)
 |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
 +--- project :paymentsheet
 |    +--- project :payments-core (*)

--- a/example/dependencies/dependencies.txt
+++ b/example/dependencies/dependencies.txt
@@ -361,7 +361,10 @@
 |    |    |    |    \--- androidx.appcompat:appcompat-resources:1.7.0 (c)
 |    |    |    +--- androidx.core:core-ktx:1.13.1 (*)
 |    |    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0 (*)
-|    |    |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
+|    |    |    \--- dev.drewhamilton.poko:poko-annotations:0.18.2
+|    |    |         \--- dev.drewhamilton.poko:poko-annotations-jvm:0.18.2
+|    |    |              \--- org.jetbrains.kotlin:kotlin-stdlib:2.1.0 -> 2.1.10 (*)
 |    |    +--- androidx.databinding:viewbinding:8.8.2 (*)
 |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:2.1.10 (*)
 |    |    +--- project :hcaptcha
@@ -901,9 +904,7 @@
 |    |    |    |    \--- com.google.android.gms:play-services-basement:18.0.0 -> 18.4.0 (*)
 |    |    |    \--- com.google.android.gms:play-services-tasks:18.2.0 (*)
 |    |    +--- com.google.android.instantapps:instantapps:1.1.0
-|    |    +--- dev.drewhamilton.poko:poko-annotations:0.18.2
-|    |    |    \--- dev.drewhamilton.poko:poko-annotations-jvm:0.18.2
-|    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib:2.1.0 -> 2.1.10 (*)
+|    |    +--- dev.drewhamilton.poko:poko-annotations:0.18.2 (*)
 |    |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
 |    +--- project :paymentsheet
 |    |    +--- project :payments-core (*)

--- a/financial-connections-core/dependencies/dependencies.txt
+++ b/financial-connections-core/dependencies/dependencies.txt
@@ -315,7 +315,10 @@
 |    |    \--- androidx.appcompat:appcompat-resources:1.7.0 (c)
 |    +--- androidx.core:core-ktx:1.13.1 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0 (*)
-|    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
+|    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
+|    \--- dev.drewhamilton.poko:poko-annotations:0.18.2
+|         \--- dev.drewhamilton.poko:poko-annotations-jvm:0.18.2
+|              \--- org.jetbrains.kotlin:kotlin-stdlib:2.1.0 -> 2.1.10 (*)
 +--- org.jetbrains.kotlin:kotlin-stdlib:2.1.10 (*)
 +--- androidx.activity:activity-ktx:1.9.3 (*)
 +--- androidx.fragment:fragment-ktx:1.8.6

--- a/financial-connections-example/dependencies/dependencies.txt
+++ b/financial-connections-example/dependencies/dependencies.txt
@@ -369,7 +369,10 @@
 |    |    |    |    \--- androidx.appcompat:appcompat-resources:1.7.0 (c)
 |    |    |    +--- androidx.core:core-ktx:1.13.1 (*)
 |    |    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0 (*)
-|    |    |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
+|    |    |    \--- dev.drewhamilton.poko:poko-annotations:0.18.2
+|    |    |         \--- dev.drewhamilton.poko:poko-annotations-jvm:0.18.2
+|    |    |              \--- org.jetbrains.kotlin:kotlin-stdlib:2.1.0 -> 2.1.10 (*)
 |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:2.1.10 (*)
 |    |    +--- androidx.activity:activity-ktx:1.9.3 (*)
 |    |    +--- androidx.fragment:fragment-ktx:1.8.6
@@ -949,9 +952,7 @@
 |    |    |    \--- com.google.android.gms:play-services-basement:18.0.0 -> 18.4.0 (*)
 |    |    \--- com.google.android.gms:play-services-tasks:18.2.0 (*)
 |    +--- com.google.android.instantapps:instantapps:1.1.0
-|    +--- dev.drewhamilton.poko:poko-annotations:0.18.2
-|    |    \--- dev.drewhamilton.poko:poko-annotations-jvm:0.18.2
-|    |         \--- org.jetbrains.kotlin:kotlin-stdlib:2.1.0 -> 2.1.10 (*)
+|    +--- dev.drewhamilton.poko:poko-annotations:0.18.2 (*)
 |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
 +--- project :paymentsheet
 |    +--- project :payments-core (*)

--- a/financial-connections-lite/dependencies/dependencies.txt
+++ b/financial-connections-lite/dependencies/dependencies.txt
@@ -316,7 +316,10 @@
 |    |    |    \--- androidx.appcompat:appcompat-resources:1.7.0 (c)
 |    |    +--- androidx.core:core-ktx:1.13.1 (*)
 |    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
+|    |    \--- dev.drewhamilton.poko:poko-annotations:0.18.2
+|    |         \--- dev.drewhamilton.poko:poko-annotations-jvm:0.18.2
+|    |              \--- org.jetbrains.kotlin:kotlin-stdlib:2.1.0 -> 2.1.10 (*)
 |    +--- org.jetbrains.kotlin:kotlin-stdlib:2.1.10 (*)
 |    +--- androidx.activity:activity-ktx:1.9.3 (*)
 |    +--- androidx.fragment:fragment-ktx:1.8.6

--- a/financial-connections/dependencies/dependencies.txt
+++ b/financial-connections/dependencies/dependencies.txt
@@ -345,7 +345,10 @@
 |    |    |    \--- androidx.appcompat:appcompat-resources:1.7.0 (c)
 |    |    +--- androidx.core:core-ktx:1.13.1 (*)
 |    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
+|    |    \--- dev.drewhamilton.poko:poko-annotations:0.18.2
+|    |         \--- dev.drewhamilton.poko:poko-annotations-jvm:0.18.2
+|    |              \--- org.jetbrains.kotlin:kotlin-stdlib:2.1.0 -> 2.1.10 (*)
 |    +--- org.jetbrains.kotlin:kotlin-stdlib:2.1.10 (*)
 |    +--- androidx.activity:activity-ktx:1.9.3 (*)
 |    +--- androidx.fragment:fragment-ktx:1.8.6

--- a/payment-method-messaging/dependencies/dependencies.txt
+++ b/payment-method-messaging/dependencies/dependencies.txt
@@ -357,7 +357,10 @@
 |    |    |    \--- androidx.appcompat:appcompat-resources:1.7.0 (c)
 |    |    +--- androidx.core:core-ktx:1.13.1 (*)
 |    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
+|    |    \--- dev.drewhamilton.poko:poko-annotations:0.18.2
+|    |         \--- dev.drewhamilton.poko:poko-annotations-jvm:0.18.2
+|    |              \--- org.jetbrains.kotlin:kotlin-stdlib:2.1.0 -> 2.1.10 (*)
 |    +--- androidx.databinding:viewbinding:8.8.2
 |    |    \--- androidx.annotation:annotation:1.0.0 -> 1.9.1 (*)
 |    +--- org.jetbrains.kotlin:kotlin-stdlib:2.1.10 (*)
@@ -887,9 +890,7 @@
 |    |    |    \--- com.google.android.gms:play-services-basement:18.0.0 -> 18.4.0 (*)
 |    |    \--- com.google.android.gms:play-services-tasks:18.2.0 (*)
 |    +--- com.google.android.instantapps:instantapps:1.1.0
-|    +--- dev.drewhamilton.poko:poko-annotations:0.18.2
-|    |    \--- dev.drewhamilton.poko:poko-annotations-jvm:0.18.2
-|    |         \--- org.jetbrains.kotlin:kotlin-stdlib:2.1.0 -> 2.1.10 (*)
+|    +--- dev.drewhamilton.poko:poko-annotations:0.18.2 (*)
 |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
 +--- project :payments-ui-core
 |    +--- androidx.databinding:viewbinding:8.8.2 (*)

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -28,7 +28,6 @@ public final class com/stripe/android/DefaultCardBrandFilter$Creator : android/o
 public final class com/stripe/android/EphemeralKey : com/stripe/android/core/model/StripeModel {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public final fun component7 ()Ljava/lang/String;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getSecret ()Ljava/lang/String;
@@ -171,8 +170,6 @@ public final class com/stripe/android/GooglePayJsonFactory$BillingAddressParamet
 	public fun <init> (ZLcom/stripe/android/GooglePayJsonFactory$BillingAddressParameters$Format;)V
 	public fun <init> (ZLcom/stripe/android/GooglePayJsonFactory$BillingAddressParameters$Format;Z)V
 	public synthetic fun <init> (ZLcom/stripe/android/GooglePayJsonFactory$BillingAddressParameters$Format;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun copy (ZLcom/stripe/android/GooglePayJsonFactory$BillingAddressParameters$Format;Z)Lcom/stripe/android/GooglePayJsonFactory$BillingAddressParameters;
-	public static synthetic fun copy$default (Lcom/stripe/android/GooglePayJsonFactory$BillingAddressParameters;ZLcom/stripe/android/GooglePayJsonFactory$BillingAddressParameters$Format;ZILjava/lang/Object;)Lcom/stripe/android/GooglePayJsonFactory$BillingAddressParameters;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
@@ -202,8 +199,6 @@ public final class com/stripe/android/GooglePayJsonFactory$MerchantInfo : androi
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/GooglePayJsonFactory$MerchantInfo;
-	public static synthetic fun copy$default (Lcom/stripe/android/GooglePayJsonFactory$MerchantInfo;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/GooglePayJsonFactory$MerchantInfo;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
@@ -227,8 +222,6 @@ public final class com/stripe/android/GooglePayJsonFactory$ShippingAddressParame
 	public fun <init> (ZLjava/util/Set;)V
 	public fun <init> (ZLjava/util/Set;Z)V
 	public synthetic fun <init> (ZLjava/util/Set;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun copy (ZLjava/util/Set;Z)Lcom/stripe/android/GooglePayJsonFactory$ShippingAddressParameters;
-	public static synthetic fun copy$default (Lcom/stripe/android/GooglePayJsonFactory$ShippingAddressParameters;ZLjava/util/Set;ZILjava/lang/Object;)Lcom/stripe/android/GooglePayJsonFactory$ShippingAddressParameters;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
@@ -254,8 +247,6 @@ public final class com/stripe/android/GooglePayJsonFactory$TransactionInfo : and
 	public fun <init> (Ljava/lang/String;Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$TotalPriceStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$TotalPriceStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$CheckoutOption;)V
 	public synthetic fun <init> (Ljava/lang/String;Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$TotalPriceStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$CheckoutOption;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun copy (Ljava/lang/String;Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$TotalPriceStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$CheckoutOption;)Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo;
-	public static synthetic fun copy$default (Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo;Ljava/lang/String;Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$TotalPriceStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$CheckoutOption;ILjava/lang/Object;)Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
@@ -515,10 +506,6 @@ public final class com/stripe/android/PaymentConfiguration : android/os/Parcelab
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/PaymentConfiguration$Companion;
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/PaymentConfiguration;
-	public static synthetic fun copy$default (Lcom/stripe/android/PaymentConfiguration;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/PaymentConfiguration;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun getInstance (Landroid/content/Context;)Lcom/stripe/android/PaymentConfiguration;
@@ -549,10 +536,6 @@ public final class com/stripe/android/PaymentConfiguration$Creator : android/os/
 public final class com/stripe/android/PaymentIntentResult : com/stripe/android/StripeIntentResult {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public final fun component1 ()Lcom/stripe/android/model/PaymentIntent;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Lcom/stripe/android/model/PaymentIntent;ILjava/lang/String;)Lcom/stripe/android/PaymentIntentResult;
-	public static synthetic fun copy$default (Lcom/stripe/android/PaymentIntentResult;Lcom/stripe/android/model/PaymentIntent;ILjava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/PaymentIntentResult;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getFailureMessage ()Ljava/lang/String;
@@ -606,8 +589,6 @@ public final class com/stripe/android/PaymentRelayStarter$Args$SourceArgs$Creato
 public final class com/stripe/android/SetupIntentResult : com/stripe/android/StripeIntentResult {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public final fun component1 ()Lcom/stripe/android/model/SetupIntent;
-	public final fun component3 ()Ljava/lang/String;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getFailureMessage ()Ljava/lang/String;
@@ -818,9 +799,12 @@ public final class com/stripe/android/StripeApiBeta : java/lang/Enum {
 
 public abstract class com/stripe/android/StripeIntentResult : com/stripe/android/core/model/StripeModel {
 	public static final field $stable I
+	public fun equals (Ljava/lang/Object;)Z
 	public abstract fun getFailureMessage ()Ljava/lang/String;
 	public abstract fun getIntent ()Lcom/stripe/android/model/StripeIntent;
 	public final fun getOutcome ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface annotation class com/stripe/android/StripeIntentResult$Outcome : java/lang/annotation/Annotation {
@@ -997,8 +981,6 @@ public final class com/stripe/android/googlepaylauncher/GooglePayLauncher$Billin
 	public fun <init> (ZLcom/stripe/android/googlepaylauncher/GooglePayLauncher$BillingAddressConfig$Format;)V
 	public fun <init> (ZLcom/stripe/android/googlepaylauncher/GooglePayLauncher$BillingAddressConfig$Format;Z)V
 	public synthetic fun <init> (ZLcom/stripe/android/googlepaylauncher/GooglePayLauncher$BillingAddressConfig$Format;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun copy (ZLcom/stripe/android/googlepaylauncher/GooglePayLauncher$BillingAddressConfig$Format;Z)Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$BillingAddressConfig;
-	public static synthetic fun copy$default (Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$BillingAddressConfig;ZLcom/stripe/android/googlepaylauncher/GooglePayLauncher$BillingAddressConfig$Format;ZILjava/lang/Object;)Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$BillingAddressConfig;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
@@ -1035,15 +1017,6 @@ public final class com/stripe/android/googlepaylauncher/GooglePayLauncher$Config
 	public fun <init> (Lcom/stripe/android/googlepaylauncher/GooglePayEnvironment;Ljava/lang/String;Ljava/lang/String;ZLcom/stripe/android/googlepaylauncher/GooglePayLauncher$BillingAddressConfig;Z)V
 	public fun <init> (Lcom/stripe/android/googlepaylauncher/GooglePayEnvironment;Ljava/lang/String;Ljava/lang/String;ZLcom/stripe/android/googlepaylauncher/GooglePayLauncher$BillingAddressConfig;ZZ)V
 	public synthetic fun <init> (Lcom/stripe/android/googlepaylauncher/GooglePayEnvironment;Ljava/lang/String;Ljava/lang/String;ZLcom/stripe/android/googlepaylauncher/GooglePayLauncher$BillingAddressConfig;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/stripe/android/googlepaylauncher/GooglePayEnvironment;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Z
-	public final fun component5 ()Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$BillingAddressConfig;
-	public final fun component6 ()Z
-	public final fun component7 ()Z
-	public final fun copy (Lcom/stripe/android/googlepaylauncher/GooglePayEnvironment;Ljava/lang/String;Ljava/lang/String;ZLcom/stripe/android/googlepaylauncher/GooglePayLauncher$BillingAddressConfig;ZZ)Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$Config;
-	public static synthetic fun copy$default (Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$Config;Lcom/stripe/android/googlepaylauncher/GooglePayEnvironment;Ljava/lang/String;Ljava/lang/String;ZLcom/stripe/android/googlepaylauncher/GooglePayLauncher$BillingAddressConfig;ZZILjava/lang/Object;)Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$Config;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAllowCreditCards ()Z
@@ -1120,9 +1093,6 @@ public final class com/stripe/android/googlepaylauncher/GooglePayLauncher$Result
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/Throwable;)V
-	public final fun component1 ()Ljava/lang/Throwable;
-	public final fun copy (Ljava/lang/Throwable;)Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$Result$Failed;
-	public static synthetic fun copy$default (Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$Result$Failed;Ljava/lang/Throwable;ILjava/lang/Object;)Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$Result$Failed;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getError ()Ljava/lang/Throwable;
@@ -1221,11 +1191,6 @@ public final class com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLa
 	public fun <init> (ZLcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$BillingAddressConfig$Format;)V
 	public fun <init> (ZLcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$BillingAddressConfig$Format;Z)V
 	public synthetic fun <init> (ZLcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$BillingAddressConfig$Format;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Z
-	public final fun component2 ()Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$BillingAddressConfig$Format;
-	public final fun component3 ()Z
-	public final fun copy (ZLcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$BillingAddressConfig$Format;Z)Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$BillingAddressConfig;
-	public static synthetic fun copy$default (Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$BillingAddressConfig;ZLcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$BillingAddressConfig$Format;ZILjava/lang/Object;)Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$BillingAddressConfig;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFormat ()Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$BillingAddressConfig$Format;
@@ -1265,15 +1230,6 @@ public final class com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLa
 	public fun <init> (Lcom/stripe/android/googlepaylauncher/GooglePayEnvironment;Ljava/lang/String;Ljava/lang/String;ZLcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$BillingAddressConfig;Z)V
 	public fun <init> (Lcom/stripe/android/googlepaylauncher/GooglePayEnvironment;Ljava/lang/String;Ljava/lang/String;ZLcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$BillingAddressConfig;ZZ)V
 	public synthetic fun <init> (Lcom/stripe/android/googlepaylauncher/GooglePayEnvironment;Ljava/lang/String;Ljava/lang/String;ZLcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$BillingAddressConfig;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/stripe/android/googlepaylauncher/GooglePayEnvironment;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Z
-	public final fun component5 ()Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$BillingAddressConfig;
-	public final fun component6 ()Z
-	public final fun component7 ()Z
-	public final fun copy (Lcom/stripe/android/googlepaylauncher/GooglePayEnvironment;Ljava/lang/String;Ljava/lang/String;ZLcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$BillingAddressConfig;ZZ)Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$Config;
-	public static synthetic fun copy$default (Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$Config;Lcom/stripe/android/googlepaylauncher/GooglePayEnvironment;Ljava/lang/String;Ljava/lang/String;ZLcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$BillingAddressConfig;ZZILjava/lang/Object;)Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$Config;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAllowCreditCards ()Z
@@ -1334,9 +1290,6 @@ public final class com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLa
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Lcom/stripe/android/model/PaymentMethod;)V
-	public final fun component1 ()Lcom/stripe/android/model/PaymentMethod;
-	public final fun copy (Lcom/stripe/android/model/PaymentMethod;)Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$Result$Completed;
-	public static synthetic fun copy$default (Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$Result$Completed;Lcom/stripe/android/model/PaymentMethod;ILjava/lang/Object;)Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$Result$Completed;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getPaymentMethod ()Lcom/stripe/android/model/PaymentMethod;
@@ -1357,10 +1310,6 @@ public final class com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLa
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/Throwable;I)V
-	public final fun component1 ()Ljava/lang/Throwable;
-	public final fun component2 ()I
-	public final fun copy (Ljava/lang/Throwable;I)Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$Result$Failed;
-	public static synthetic fun copy$default (Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$Result$Failed;Ljava/lang/Throwable;IILjava/lang/Object;)Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$Result$Failed;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getError ()Ljava/lang/Throwable;
@@ -1480,22 +1429,6 @@ public final class com/stripe/android/model/AccountParams$BusinessTypeParams$Com
 	public fun <init> ()V
 	public fun <init> (Lcom/stripe/android/model/Address;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/AddressJapanParams;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Verification;)V
 	public synthetic fun <init> (Lcom/stripe/android/model/Address;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/AddressJapanParams;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Verification;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/stripe/android/model/Address;
-	public final fun component10 ()Ljava/lang/String;
-	public final fun component11 ()Ljava/lang/String;
-	public final fun component12 ()Ljava/lang/String;
-	public final fun component13 ()Ljava/lang/String;
-	public final fun component14 ()Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Verification;
-	public final fun component2 ()Lcom/stripe/android/model/AddressJapanParams;
-	public final fun component3 ()Lcom/stripe/android/model/AddressJapanParams;
-	public final fun component4 ()Ljava/lang/Boolean;
-	public final fun component5 ()Ljava/lang/Boolean;
-	public final fun component6 ()Ljava/lang/String;
-	public final fun component7 ()Ljava/lang/String;
-	public final fun component8 ()Ljava/lang/String;
-	public final fun component9 ()Ljava/lang/Boolean;
-	public final fun copy (Lcom/stripe/android/model/Address;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/AddressJapanParams;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Verification;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company;Lcom/stripe/android/model/Address;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/AddressJapanParams;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Verification;ILjava/lang/Object;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAddress ()Lcom/stripe/android/model/Address;
@@ -1567,8 +1500,6 @@ public final class com/stripe/android/model/AccountParams$BusinessTypeParams$Com
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Document;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Document;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Document;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
@@ -1591,9 +1522,6 @@ public final class com/stripe/android/model/AccountParams$BusinessTypeParams$Com
 	public fun <init> ()V
 	public fun <init> (Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Document;)V
 	public synthetic fun <init> (Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Document;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Document;
-	public final fun copy (Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Document;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Verification;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Verification;Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Document;ILjava/lang/Object;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Verification;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDocument ()Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Company$Document;
@@ -1618,26 +1546,6 @@ public final class com/stripe/android/model/AccountParams$BusinessTypeParams$Ind
 	public fun <init> ()V
 	public fun <init> (Lcom/stripe/android/model/Address;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/DateOfBirth;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Verification;)V
 	public synthetic fun <init> (Lcom/stripe/android/model/Address;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/DateOfBirth;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Verification;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/stripe/android/model/Address;
-	public final fun component10 ()Ljava/lang/String;
-	public final fun component11 ()Ljava/lang/String;
-	public final fun component12 ()Ljava/lang/String;
-	public final fun component13 ()Ljava/lang/String;
-	public final fun component14 ()Ljava/lang/String;
-	public final fun component15 ()Ljava/util/Map;
-	public final fun component16 ()Ljava/lang/String;
-	public final fun component17 ()Ljava/lang/String;
-	public final fun component18 ()Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Verification;
-	public final fun component2 ()Lcom/stripe/android/model/AddressJapanParams;
-	public final fun component3 ()Lcom/stripe/android/model/AddressJapanParams;
-	public final fun component4 ()Lcom/stripe/android/model/DateOfBirth;
-	public final fun component5 ()Ljava/lang/String;
-	public final fun component6 ()Ljava/lang/String;
-	public final fun component7 ()Ljava/lang/String;
-	public final fun component8 ()Ljava/lang/String;
-	public final fun component9 ()Ljava/lang/String;
-	public final fun copy (Lcom/stripe/android/model/Address;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/DateOfBirth;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Verification;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual;Lcom/stripe/android/model/Address;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/DateOfBirth;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Verification;ILjava/lang/Object;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAddress ()Lcom/stripe/android/model/Address;
@@ -1721,8 +1629,6 @@ public final class com/stripe/android/model/AccountParams$BusinessTypeParams$Ind
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Document;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Document;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Document;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
@@ -1746,10 +1652,6 @@ public final class com/stripe/android/model/AccountParams$BusinessTypeParams$Ind
 	public fun <init> (Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Document;)V
 	public fun <init> (Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Document;Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Document;)V
 	public synthetic fun <init> (Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Document;Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Document;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Document;
-	public final fun component2 ()Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Document;
-	public final fun copy (Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Document;Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Document;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Verification;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Verification;Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Document;Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Document;ILjava/lang/Object;)Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Verification;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAdditionalDocument ()Lcom/stripe/android/model/AccountParams$BusinessTypeParams$Individual$Document;
@@ -1800,14 +1702,6 @@ public final class com/stripe/android/model/Address : com/stripe/android/core/mo
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun component5 ()Ljava/lang/String;
-	public final fun component6 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/Address;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/Address;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Lorg/json/JSONObject;)Lcom/stripe/android/model/Address;
@@ -1853,15 +1747,6 @@ public final class com/stripe/android/model/AddressJapanParams : android/os/Parc
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun component5 ()Ljava/lang/String;
-	public final fun component6 ()Ljava/lang/String;
-	public final fun component7 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/AddressJapanParams;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/AddressJapanParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/AddressJapanParams;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCity ()Ljava/lang/String;
@@ -1922,8 +1807,6 @@ public final class com/stripe/android/model/BankAccountTokenParams : com/stripe/
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/BankAccountTokenParams$Type;Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/BankAccountTokenParams$Type;Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/BankAccountTokenParams$Type;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/BankAccountTokenParams$Type;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/BankAccountTokenParams;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/BankAccountTokenParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/BankAccountTokenParams$Type;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/BankAccountTokenParams;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getTypeDataParams ()Ljava/util/Map;
@@ -1988,16 +1871,6 @@ public final class com/stripe/android/model/CardParams : com/stripe/android/mode
 	public fun <init> (Ljava/lang/String;IILjava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/Address;Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;IILjava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/util/Map;)V
 	public synthetic fun <init> (Ljava/lang/String;IILjava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/stripe/android/model/CardBrand;
-	public final fun component10 ()Lcom/stripe/android/model/Networks;
-	public final fun component11 ()Ljava/util/Map;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()I
-	public final fun component5 ()I
-	public final fun component6 ()Ljava/lang/String;
-	public final fun component7 ()Ljava/lang/String;
-	public final fun component8 ()Lcom/stripe/android/model/Address;
-	public final fun component9 ()Ljava/lang/String;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAddress ()Lcom/stripe/android/model/Address;
@@ -2041,22 +1914,6 @@ public final class com/stripe/android/model/ConfirmPaymentIntentParams : com/str
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/model/ConfirmPaymentIntentParams$Companion;
-	public final fun component1 ()Lcom/stripe/android/model/PaymentMethodCreateParams;
-	public final fun component10 ()Ljava/lang/String;
-	public final fun component11 ()Lcom/stripe/android/model/MandateDataParams;
-	public final fun component12 ()Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;
-	public final fun component13 ()Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;
-	public final fun component14 ()Ljava/lang/String;
-	public final fun component17 ()Lcom/stripe/android/model/RadarOptions;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Lcom/stripe/android/model/SourceParams;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun component5 ()Ljava/lang/String;
-	public final fun component6 ()Ljava/lang/String;
-	public final fun component7 ()Ljava/lang/Boolean;
-	public final fun component9 ()Lcom/stripe/android/model/PaymentMethodOptionsParams;
-	public final fun copy (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/SourceParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ZLcom/stripe/android/model/PaymentMethodOptionsParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lcom/stripe/android/model/RadarOptions;Lcom/stripe/android/model/ClientAttributionMetadata;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/ConfirmPaymentIntentParams;Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/SourceParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ZLcom/stripe/android/model/PaymentMethodOptionsParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lcom/stripe/android/model/RadarOptions;Lcom/stripe/android/model/ClientAttributionMetadata;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
 	public static final fun create (Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
 	public static final fun create (Ljava/lang/String;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
 	public static final fun create (Ljava/lang/String;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
@@ -2173,8 +2030,6 @@ public final class com/stripe/android/model/ConfirmPaymentIntentParams$Shipping 
 	public fun <init> (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public fun <init> (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun copy (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
@@ -2195,14 +2050,6 @@ public final class com/stripe/android/model/ConfirmSetupIntentParams : com/strip
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/model/ConfirmSetupIntentParams$Companion;
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component10 ()Lcom/stripe/android/model/PaymentMethodOptionsParams;
-	public final fun component11 ()Lcom/stripe/android/model/RadarOptions;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun component6 ()Ljava/lang/String;
-	public final fun component7 ()Lcom/stripe/android/model/MandateDataParams;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;ZLjava/lang/String;Lcom/stripe/android/model/MandateDataParams;Ljava/lang/Boolean;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethodOptionsParams;Lcom/stripe/android/model/RadarOptions;Lcom/stripe/android/model/ClientAttributionMetadata;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/ConfirmSetupIntentParams;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;ZLjava/lang/String;Lcom/stripe/android/model/MandateDataParams;Ljava/lang/Boolean;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethodOptionsParams;Lcom/stripe/android/model/RadarOptions;Lcom/stripe/android/model/ClientAttributionMetadata;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
@@ -2306,16 +2153,6 @@ public final class com/stripe/android/model/ConsumerPaymentDetailsShare$Creator 
 public final class com/stripe/android/model/Customer : com/stripe/android/core/model/StripeModel {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component10 ()Z
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Lcom/stripe/android/model/ShippingInformation;
-	public final fun component4 ()Ljava/util/List;
-	public final fun component5 ()Z
-	public final fun component6 ()Ljava/lang/Integer;
-	public final fun component7 ()Ljava/lang/String;
-	public final fun component8 ()Ljava/lang/String;
-	public final fun component9 ()Ljava/lang/String;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDefaultSource ()Ljava/lang/String;
@@ -2346,9 +2183,6 @@ public final class com/stripe/android/model/CustomerBankAccount : com/stripe/and
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Lcom/stripe/android/model/BankAccount;)V
-	public final fun component1 ()Lcom/stripe/android/model/BankAccount;
-	public final fun copy (Lcom/stripe/android/model/BankAccount;)Lcom/stripe/android/model/CustomerBankAccount;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/CustomerBankAccount;Lcom/stripe/android/model/BankAccount;ILjava/lang/Object;)Lcom/stripe/android/model/CustomerBankAccount;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBankAccount ()Lcom/stripe/android/model/BankAccount;
@@ -2371,9 +2205,6 @@ public final class com/stripe/android/model/CustomerCard : com/stripe/android/mo
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Lcom/stripe/android/model/Card;)V
-	public final fun component1 ()Lcom/stripe/android/model/Card;
-	public final fun copy (Lcom/stripe/android/model/Card;)Lcom/stripe/android/model/CustomerCard;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/CustomerCard;Lcom/stripe/android/model/Card;ILjava/lang/Object;)Lcom/stripe/android/model/CustomerCard;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCard ()Lcom/stripe/android/model/Card;
@@ -2402,9 +2233,6 @@ public final class com/stripe/android/model/CustomerSource : com/stripe/android/
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Lcom/stripe/android/model/Source;)V
-	public final fun component1 ()Lcom/stripe/android/model/Source;
-	public final fun copy (Lcom/stripe/android/model/Source;)Lcom/stripe/android/model/CustomerSource;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/CustomerSource;Lcom/stripe/android/model/Source;ILjava/lang/Object;)Lcom/stripe/android/model/CustomerSource;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getId ()Ljava/lang/String;
@@ -2427,8 +2255,6 @@ public final class com/stripe/android/model/CvcTokenParams : com/stripe/android/
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;)V
-	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/CvcTokenParams;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/CvcTokenParams;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/CvcTokenParams;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getTypeDataParams ()Ljava/util/Map;
@@ -2449,11 +2275,6 @@ public final class com/stripe/android/model/DateOfBirth : android/os/Parcelable,
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (III)V
-	public final fun component1 ()I
-	public final fun component2 ()I
-	public final fun component3 ()I
-	public final fun copy (III)Lcom/stripe/android/model/DateOfBirth;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/DateOfBirth;IIIILjava/lang/Object;)Lcom/stripe/android/model/DateOfBirth;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDay ()I
@@ -2651,10 +2472,6 @@ public abstract class com/stripe/android/model/ExpirationDate {
 public final class com/stripe/android/model/ExpirationDate$Validated : com/stripe/android/model/ExpirationDate {
 	public static final field $stable I
 	public fun <init> (II)V
-	public final fun component1 ()I
-	public final fun component2 ()I
-	public final fun copy (II)Lcom/stripe/android/model/ExpirationDate$Validated;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/ExpirationDate$Validated;IIILjava/lang/Object;)Lcom/stripe/android/model/ExpirationDate$Validated;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getMonth ()I
 	public final fun getYear ()I
@@ -2667,12 +2484,6 @@ public final class com/stripe/android/model/GooglePayResult : android/os/Parcela
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/model/GooglePayResult$Companion;
 	public fun <init> ()V
-	public final fun component1 ()Lcom/stripe/android/model/Token;
-	public final fun component2 ()Lcom/stripe/android/model/Address;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun component5 ()Ljava/lang/String;
-	public final fun component6 ()Lcom/stripe/android/model/ShippingInformation;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Lorg/json/JSONObject;)Lcom/stripe/android/model/GooglePayResult;
@@ -2703,9 +2514,6 @@ public final class com/stripe/android/model/IssuingCardPin : com/stripe/android/
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/IssuingCardPin;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/IssuingCardPin;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/IssuingCardPin;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getPin ()Ljava/lang/String;
@@ -2735,18 +2543,6 @@ public final class com/stripe/android/model/KlarnaSourceParams : android/os/Parc
 	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/Set;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/DateOfBirth;)V
 	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/Set;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/DateOfBirth;Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/Set;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/DateOfBirth;Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component10 ()Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions;
-	public final fun component2 ()Ljava/util/List;
-	public final fun component3 ()Ljava/util/Set;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun component5 ()Ljava/lang/String;
-	public final fun component6 ()Lcom/stripe/android/model/Address;
-	public final fun component7 ()Ljava/lang/String;
-	public final fun component8 ()Ljava/lang/String;
-	public final fun component9 ()Lcom/stripe/android/model/DateOfBirth;
-	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/util/Set;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/DateOfBirth;Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions;)Lcom/stripe/android/model/KlarnaSourceParams;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/KlarnaSourceParams;Ljava/lang/String;Ljava/util/List;Ljava/util/Set;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/DateOfBirth;Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions;ILjava/lang/Object;)Lcom/stripe/android/model/KlarnaSourceParams;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBillingAddress ()Lcom/stripe/android/model/Address;
@@ -2787,12 +2583,6 @@ public final class com/stripe/android/model/KlarnaSourceParams$LineItem : androi
 	public fun <init> (Lcom/stripe/android/model/KlarnaSourceParams$LineItem$Type;Ljava/lang/String;I)V
 	public fun <init> (Lcom/stripe/android/model/KlarnaSourceParams$LineItem$Type;Ljava/lang/String;ILjava/lang/Integer;)V
 	public synthetic fun <init> (Lcom/stripe/android/model/KlarnaSourceParams$LineItem$Type;Ljava/lang/String;ILjava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/stripe/android/model/KlarnaSourceParams$LineItem$Type;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()I
-	public final fun component4 ()Ljava/lang/Integer;
-	public final fun copy (Lcom/stripe/android/model/KlarnaSourceParams$LineItem$Type;Ljava/lang/String;ILjava/lang/Integer;)Lcom/stripe/android/model/KlarnaSourceParams$LineItem;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/KlarnaSourceParams$LineItem;Lcom/stripe/android/model/KlarnaSourceParams$LineItem$Type;Ljava/lang/String;ILjava/lang/Integer;ILjava/lang/Object;)Lcom/stripe/android/model/KlarnaSourceParams$LineItem;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getItemDescription ()Ljava/lang/String;
@@ -2827,12 +2617,6 @@ public final class com/stripe/android/model/KlarnaSourceParams$PaymentPageOption
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions$PurchaseType;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions$PurchaseType;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions$PurchaseType;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions$PurchaseType;)Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions$PurchaseType;ILjava/lang/Object;)Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBackgroundImageUrl ()Ljava/lang/String;
@@ -2895,8 +2679,6 @@ public final class com/stripe/android/model/MandateDataParams : android/os/Parce
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Lcom/stripe/android/model/MandateDataParams$Type;)V
-	public final fun copy (Lcom/stripe/android/model/MandateDataParams$Type;)Lcom/stripe/android/model/MandateDataParams;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/MandateDataParams;Lcom/stripe/android/model/MandateDataParams$Type;ILjava/lang/Object;)Lcom/stripe/android/model/MandateDataParams;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
@@ -2959,9 +2741,6 @@ public final class com/stripe/android/model/Networks : android/os/Parcelable, co
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/Networks;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/Networks;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/Networks;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getPreferred ()Ljava/lang/String;
@@ -2991,32 +2770,6 @@ public final class com/stripe/android/model/PaymentIntent : com/stripe/android/m
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/model/PaymentIntent$Companion;
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component10 ()J
-	public final fun component11 ()Ljava/lang/String;
-	public final fun component12 ()Ljava/lang/String;
-	public final fun component13 ()Z
-	public final fun component14 ()Lcom/stripe/android/model/PaymentMethod;
-	public final fun component15 ()Ljava/lang/String;
-	public final fun component16 ()Ljava/lang/String;
-	public final fun component17 ()Lcom/stripe/android/model/StripeIntent$Status;
-	public final fun component18 ()Lcom/stripe/android/model/StripeIntent$Usage;
-	public final fun component19 ()Lcom/stripe/android/model/PaymentIntent$Error;
-	public final fun component2 ()Ljava/util/List;
-	public final fun component20 ()Lcom/stripe/android/model/PaymentIntent$Shipping;
-	public final fun component21 ()Ljava/util/List;
-	public final fun component22 ()Ljava/util/List;
-	public final fun component23 ()Lcom/stripe/android/model/StripeIntent$NextActionData;
-	public final fun component25 ()Z
-	public final fun component3 ()Ljava/lang/Long;
-	public final fun component4 ()J
-	public final fun component5 ()Lcom/stripe/android/model/PaymentIntent$CancellationReason;
-	public final fun component6 ()Lcom/stripe/android/model/PaymentIntent$CaptureMethod;
-	public final fun component7 ()Ljava/lang/String;
-	public final fun component8 ()Lcom/stripe/android/model/PaymentIntent$ConfirmationMethod;
-	public final fun component9 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;JLcom/stripe/android/model/PaymentIntent$CancellationReason;Lcom/stripe/android/model/PaymentIntent$CaptureMethod;Ljava/lang/String;Lcom/stripe/android/model/PaymentIntent$ConfirmationMethod;Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;ZLcom/stripe/android/model/PaymentMethod;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/StripeIntent$Status;Lcom/stripe/android/model/StripeIntent$Usage;Lcom/stripe/android/model/PaymentIntent$Error;Lcom/stripe/android/model/PaymentIntent$Shipping;Ljava/util/List;Ljava/util/List;Lcom/stripe/android/model/StripeIntent$NextActionData;Ljava/lang/String;Z)Lcom/stripe/android/model/PaymentIntent;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentIntent;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;JLcom/stripe/android/model/PaymentIntent$CancellationReason;Lcom/stripe/android/model/PaymentIntent$CaptureMethod;Ljava/lang/String;Lcom/stripe/android/model/PaymentIntent$ConfirmationMethod;Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;ZLcom/stripe/android/model/PaymentMethod;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/StripeIntent$Status;Lcom/stripe/android/model/StripeIntent$Usage;Lcom/stripe/android/model/PaymentIntent$Error;Lcom/stripe/android/model/PaymentIntent$Shipping;Ljava/util/List;Ljava/util/List;Lcom/stripe/android/model/StripeIntent$NextActionData;Ljava/lang/String;ZILjava/lang/Object;)Lcom/stripe/android/model/PaymentIntent;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Lorg/json/JSONObject;)Lcom/stripe/android/model/PaymentIntent;
@@ -3098,14 +2851,6 @@ public final class com/stripe/android/model/PaymentIntent$Creator : android/os/P
 public final class com/stripe/android/model/PaymentIntent$Error : com/stripe/android/core/model/StripeModel {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun component5 ()Ljava/lang/String;
-	public final fun component6 ()Ljava/lang/String;
-	public final fun component7 ()Lcom/stripe/android/model/PaymentMethod;
-	public final fun component8 ()Lcom/stripe/android/model/PaymentIntent$Error$Type;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCharge ()Ljava/lang/String;
@@ -3148,13 +2893,6 @@ public final class com/stripe/android/model/PaymentIntent$Shipping : com/stripe/
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/stripe/android/model/Address;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun component5 ()Ljava/lang/String;
-	public final fun copy (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/PaymentIntent$Shipping;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentIntent$Shipping;Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentIntent$Shipping;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAddress ()Lcom/stripe/android/model/Address;
@@ -3197,28 +2935,6 @@ public final class com/stripe/android/model/PaymentMethod : com/stripe/android/c
 	public final field type Lcom/stripe/android/model/PaymentMethod$Type;
 	public final field upi Lcom/stripe/android/model/PaymentMethod$Upi;
 	public final field usBankAccount Lcom/stripe/android/model/PaymentMethod$USBankAccount;
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component10 ()Lcom/stripe/android/model/PaymentMethod$Fpx;
-	public final fun component11 ()Lcom/stripe/android/model/PaymentMethod$Ideal;
-	public final fun component12 ()Lcom/stripe/android/model/PaymentMethod$SepaDebit;
-	public final fun component13 ()Lcom/stripe/android/model/PaymentMethod$AuBecsDebit;
-	public final fun component14 ()Lcom/stripe/android/model/PaymentMethod$BacsDebit;
-	public final fun component15 ()Lcom/stripe/android/model/PaymentMethod$Sofort;
-	public final fun component16 ()Lcom/stripe/android/model/PaymentMethod$Upi;
-	public final fun component17 ()Lcom/stripe/android/model/PaymentMethod$Netbanking;
-	public final fun component18 ()Lcom/stripe/android/model/PaymentMethod$USBankAccount;
-	public final fun component19 ()Lcom/stripe/android/model/LinkPaymentDetails;
-	public final fun component2 ()Ljava/lang/Long;
-	public final fun component20 ()Z
-	public final fun component21 ()Lcom/stripe/android/model/PaymentMethod$AllowRedisplay;
-	public final fun component3 ()Z
-	public final fun component5 ()Lcom/stripe/android/model/PaymentMethod$Type;
-	public final fun component6 ()Lcom/stripe/android/model/PaymentMethod$BillingDetails;
-	public final fun component7 ()Ljava/lang/String;
-	public final fun component8 ()Lcom/stripe/android/model/PaymentMethod$Card;
-	public final fun component9 ()Lcom/stripe/android/model/PaymentMethod$CardPresent;
-	public final fun copy (Ljava/lang/String;Ljava/lang/Long;ZLjava/lang/String;Lcom/stripe/android/model/PaymentMethod$Type;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$Card;Lcom/stripe/android/model/PaymentMethod$CardPresent;Lcom/stripe/android/model/PaymentMethod$Fpx;Lcom/stripe/android/model/PaymentMethod$Ideal;Lcom/stripe/android/model/PaymentMethod$SepaDebit;Lcom/stripe/android/model/PaymentMethod$AuBecsDebit;Lcom/stripe/android/model/PaymentMethod$BacsDebit;Lcom/stripe/android/model/PaymentMethod$Sofort;Lcom/stripe/android/model/PaymentMethod$Upi;Lcom/stripe/android/model/PaymentMethod$Netbanking;Lcom/stripe/android/model/PaymentMethod$USBankAccount;Lcom/stripe/android/model/LinkPaymentDetails;ZLcom/stripe/android/model/PaymentMethod$AllowRedisplay;)Lcom/stripe/android/model/PaymentMethod;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethod;Ljava/lang/String;Ljava/lang/Long;ZLjava/lang/String;Lcom/stripe/android/model/PaymentMethod$Type;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$Card;Lcom/stripe/android/model/PaymentMethod$CardPresent;Lcom/stripe/android/model/PaymentMethod$Fpx;Lcom/stripe/android/model/PaymentMethod$Ideal;Lcom/stripe/android/model/PaymentMethod$SepaDebit;Lcom/stripe/android/model/PaymentMethod$AuBecsDebit;Lcom/stripe/android/model/PaymentMethod$BacsDebit;Lcom/stripe/android/model/PaymentMethod$Sofort;Lcom/stripe/android/model/PaymentMethod$Upi;Lcom/stripe/android/model/PaymentMethod$Netbanking;Lcom/stripe/android/model/PaymentMethod$USBankAccount;Lcom/stripe/android/model/LinkPaymentDetails;ZLcom/stripe/android/model/PaymentMethod$AllowRedisplay;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethod;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Lorg/json/JSONObject;)Lcom/stripe/android/model/PaymentMethod;
@@ -3277,11 +2993,6 @@ public final class com/stripe/android/model/PaymentMethod$AuBecsDebit : com/stri
 	public final field bsbNumber Ljava/lang/String;
 	public final field fingerprint Ljava/lang/String;
 	public final field last4 Ljava/lang/String;
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethod$AuBecsDebit;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethod$AuBecsDebit;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethod$AuBecsDebit;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getType ()Lcom/stripe/android/model/PaymentMethod$Type;
@@ -3304,11 +3015,6 @@ public final class com/stripe/android/model/PaymentMethod$BacsDebit : com/stripe
 	public final field fingerprint Ljava/lang/String;
 	public final field last4 Ljava/lang/String;
 	public final field sortCode Ljava/lang/String;
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethod$BacsDebit;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethod$BacsDebit;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethod$BacsDebit;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getType ()Lcom/stripe/android/model/PaymentMethod$Type;
@@ -3338,12 +3044,6 @@ public final class com/stripe/android/model/PaymentMethod$BillingDetails : com/s
 	public fun <init> (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;)V
 	public fun <init> (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/stripe/android/model/Address;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun copy (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethod$BillingDetails;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethod$BillingDetails;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
@@ -3411,20 +3111,6 @@ public final class com/stripe/android/model/PaymentMethod$Card : com/stripe/andr
 	public final field networks Lcom/stripe/android/model/PaymentMethod$Card$Networks;
 	public final field threeDSecureUsage Lcom/stripe/android/model/PaymentMethod$Card$ThreeDSecureUsage;
 	public final field wallet Lcom/stripe/android/model/wallets/Wallet;
-	public final fun component1 ()Lcom/stripe/android/model/CardBrand;
-	public final fun component10 ()Lcom/stripe/android/model/wallets/Wallet;
-	public final fun component11 ()Lcom/stripe/android/model/PaymentMethod$Card$Networks;
-	public final fun component12 ()Ljava/lang/String;
-	public final fun component2 ()Lcom/stripe/android/model/PaymentMethod$Card$Checks;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ljava/lang/Integer;
-	public final fun component5 ()Ljava/lang/Integer;
-	public final fun component6 ()Ljava/lang/String;
-	public final fun component7 ()Ljava/lang/String;
-	public final fun component8 ()Ljava/lang/String;
-	public final fun component9 ()Lcom/stripe/android/model/PaymentMethod$Card$ThreeDSecureUsage;
-	public final fun copy (Lcom/stripe/android/model/CardBrand;Lcom/stripe/android/model/PaymentMethod$Card$Checks;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$Card$ThreeDSecureUsage;Lcom/stripe/android/model/wallets/Wallet;Lcom/stripe/android/model/PaymentMethod$Card$Networks;Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethod$Card;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethod$Card;Lcom/stripe/android/model/CardBrand;Lcom/stripe/android/model/PaymentMethod$Card$Checks;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$Card$ThreeDSecureUsage;Lcom/stripe/android/model/wallets/Wallet;Lcom/stripe/android/model/PaymentMethod$Card$Networks;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethod$Card;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getType ()Lcom/stripe/android/model/PaymentMethod$Type;
@@ -3439,11 +3125,6 @@ public final class com/stripe/android/model/PaymentMethod$Card$Checks : com/stri
 	public final field addressLine1Check Ljava/lang/String;
 	public final field addressPostalCodeCheck Ljava/lang/String;
 	public final field cvcCheck Ljava/lang/String;
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethod$Card$Checks;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethod$Card$Checks;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethod$Card$Checks;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
@@ -3473,11 +3154,6 @@ public final class com/stripe/android/model/PaymentMethod$Card$Networks : com/st
 	public fun <init> ()V
 	public fun <init> (Ljava/util/Set;ZLjava/lang/String;)V
 	public synthetic fun <init> (Ljava/util/Set;ZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/util/Set;
-	public final fun component2 ()Z
-	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ljava/util/Set;ZLjava/lang/String;)Lcom/stripe/android/model/PaymentMethod$Card$Networks;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethod$Card$Networks;Ljava/util/Set;ZLjava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethod$Card$Networks;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAvailable ()Ljava/util/Set;
@@ -3500,9 +3176,6 @@ public final class com/stripe/android/model/PaymentMethod$Card$ThreeDSecureUsage
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final field isSupported Z
-	public final fun component1 ()Z
-	public final fun copy (Z)Lcom/stripe/android/model/PaymentMethod$Card$ThreeDSecureUsage;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethod$Card$ThreeDSecureUsage;ZILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethod$Card$ThreeDSecureUsage;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
@@ -3555,8 +3228,6 @@ public final class com/stripe/android/model/PaymentMethod$Fpx : com/stripe/andro
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final field accountHolderType Ljava/lang/String;
 	public final field bank Ljava/lang/String;
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getType ()Lcom/stripe/android/model/PaymentMethod$Type;
@@ -3578,8 +3249,6 @@ public final class com/stripe/android/model/PaymentMethod$Ideal : com/stripe/and
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final field bank Ljava/lang/String;
 	public final field bankIdentifierCode Ljava/lang/String;
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getType ()Lcom/stripe/android/model/PaymentMethod$Type;
@@ -3600,7 +3269,6 @@ public final class com/stripe/android/model/PaymentMethod$Netbanking : com/strip
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final field bank Ljava/lang/String;
-	public final fun component1 ()Ljava/lang/String;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getType ()Lcom/stripe/android/model/PaymentMethod$Type;
@@ -3625,13 +3293,6 @@ public final class com/stripe/android/model/PaymentMethod$SepaDebit : com/stripe
 	public final field country Ljava/lang/String;
 	public final field fingerprint Ljava/lang/String;
 	public final field last4 Ljava/lang/String;
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun component5 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethod$SepaDebit;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethod$SepaDebit;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethod$SepaDebit;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getType ()Lcom/stripe/android/model/PaymentMethod$Type;
@@ -3652,7 +3313,6 @@ public final class com/stripe/android/model/PaymentMethod$Sofort : com/stripe/an
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final field country Ljava/lang/String;
-	public final fun component1 ()Ljava/lang/String;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getType ()Lcom/stripe/android/model/PaymentMethod$Type;
@@ -3753,16 +3413,6 @@ public final class com/stripe/android/model/PaymentMethod$USBankAccount : com/st
 	public final field last4 Ljava/lang/String;
 	public final field networks Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankNetworks;
 	public final field routingNumber Ljava/lang/String;
-	public final fun component1 ()Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountHolderType;
-	public final fun component2 ()Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountType;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun component5 ()Ljava/lang/String;
-	public final fun component6 ()Ljava/lang/String;
-	public final fun component7 ()Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankNetworks;
-	public final fun component8 ()Ljava/lang/String;
-	public final fun copy (Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountHolderType;Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankNetworks;Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethod$USBankAccount;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethod$USBankAccount;Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountHolderType;Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankNetworks;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethod$USBankAccount;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getType ()Lcom/stripe/android/model/PaymentMethod$Type;
@@ -3825,10 +3475,6 @@ public final class com/stripe/android/model/PaymentMethod$USBankAccount$USBankNe
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/util/List;
-	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankNetworks;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankNetworks;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankNetworks;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getPreferred ()Ljava/lang/String;
@@ -3850,7 +3496,6 @@ public final class com/stripe/android/model/PaymentMethod$Upi : com/stripe/andro
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final field vpa Ljava/lang/String;
-	public final fun component1 ()Ljava/lang/String;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getType ()Lcom/stripe/android/model/PaymentMethod$Type;
@@ -3883,14 +3528,6 @@ public final class com/stripe/android/model/PaymentMethodCreateParams : android/
 	public synthetic fun <init> (Lcom/stripe/android/model/PaymentMethodCreateParams$Swish;Lcom/stripe/android/model/PaymentMethod$AllowRedisplay;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Lcom/stripe/android/model/PaymentMethodCreateParams$USBankAccount;Lcom/stripe/android/model/PaymentMethod$AllowRedisplay;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;Lcom/stripe/android/model/ClientAttributionMetadata;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Lcom/stripe/android/model/PaymentMethodCreateParams$Upi;Lcom/stripe/android/model/PaymentMethod$AllowRedisplay;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component17 ()Lcom/stripe/android/model/PaymentMethod$BillingDetails;
-	public final fun component18 ()Lcom/stripe/android/model/PaymentMethod$AllowRedisplay;
-	public final fun component19 ()Lcom/stripe/android/model/RadarOptions;
-	public final fun component2 ()Z
-	public final fun component22 ()Lcom/stripe/android/model/ClientAttributionMetadata;
-	public final fun component3 ()Lcom/stripe/android/model/PaymentMethodCreateParams$Card;
-	public final fun copy (Ljava/lang/String;ZLcom/stripe/android/model/PaymentMethodCreateParams$Card;Lcom/stripe/android/model/PaymentMethodCreateParams$Ideal;Lcom/stripe/android/model/PaymentMethodCreateParams$Fpx;Lcom/stripe/android/model/PaymentMethodCreateParams$SepaDebit;Lcom/stripe/android/model/PaymentMethodCreateParams$AuBecsDebit;Lcom/stripe/android/model/PaymentMethodCreateParams$BacsDebit;Lcom/stripe/android/model/PaymentMethodCreateParams$Sofort;Lcom/stripe/android/model/PaymentMethodCreateParams$Upi;Lcom/stripe/android/model/PaymentMethodCreateParams$Netbanking;Lcom/stripe/android/model/PaymentMethodCreateParams$USBankAccount;Lcom/stripe/android/model/PaymentMethodCreateParams$Link;Lcom/stripe/android/model/PaymentMethodCreateParams$CashAppPay;Lcom/stripe/android/model/PaymentMethodCreateParams$Swish;Lcom/stripe/android/model/PaymentMethodCreateParams$ShopPay;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Lcom/stripe/android/model/PaymentMethod$AllowRedisplay;Lcom/stripe/android/model/RadarOptions;Ljava/util/Map;Ljava/util/Set;Lcom/stripe/android/model/ClientAttributionMetadata;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;ZLcom/stripe/android/model/PaymentMethodCreateParams$Card;Lcom/stripe/android/model/PaymentMethodCreateParams$Ideal;Lcom/stripe/android/model/PaymentMethodCreateParams$Fpx;Lcom/stripe/android/model/PaymentMethodCreateParams$SepaDebit;Lcom/stripe/android/model/PaymentMethodCreateParams$AuBecsDebit;Lcom/stripe/android/model/PaymentMethodCreateParams$BacsDebit;Lcom/stripe/android/model/PaymentMethodCreateParams$Sofort;Lcom/stripe/android/model/PaymentMethodCreateParams$Upi;Lcom/stripe/android/model/PaymentMethodCreateParams$Netbanking;Lcom/stripe/android/model/PaymentMethodCreateParams$USBankAccount;Lcom/stripe/android/model/PaymentMethodCreateParams$Link;Lcom/stripe/android/model/PaymentMethodCreateParams$CashAppPay;Lcom/stripe/android/model/PaymentMethodCreateParams$Swish;Lcom/stripe/android/model/PaymentMethodCreateParams$ShopPay;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Lcom/stripe/android/model/PaymentMethod$AllowRedisplay;Lcom/stripe/android/model/RadarOptions;Ljava/util/Map;Ljava/util/Set;Lcom/stripe/android/model/ClientAttributionMetadata;Ljava/util/Map;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$AuBecsDebit;Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$AuBecsDebit;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$AuBecsDebit;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;Lcom/stripe/android/model/PaymentMethod$AllowRedisplay;)Lcom/stripe/android/model/PaymentMethodCreateParams;
@@ -4022,8 +3659,6 @@ public final class com/stripe/android/model/PaymentMethodCreateParams : android/
 	public static final fun createWeChatPay (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;Lcom/stripe/android/model/PaymentMethod$AllowRedisplay;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getBillingDetails ()Lcom/stripe/android/model/PaymentMethod$BillingDetails;
-	public final fun getCard ()Lcom/stripe/android/model/PaymentMethodCreateParams$Card;
 	public final fun getTypeCode ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toParamMap ()Ljava/util/Map;
@@ -4035,10 +3670,6 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$AuBecsDebi
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodCreateParams$AuBecsDebit;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethodCreateParams$AuBecsDebit;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams$AuBecsDebit;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAccountNumber ()Ljava/lang/String;
@@ -4063,10 +3694,6 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$BacsDebit 
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodCreateParams$BacsDebit;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethodCreateParams$BacsDebit;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams$BacsDebit;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAccountNumber ()Ljava/lang/String;
@@ -4091,8 +3718,6 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$Card : and
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/model/PaymentMethodCreateParams$Card$Companion;
-	public final fun copy (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Lcom/stripe/android/model/PaymentMethodCreateParams$Card$Networks;)Lcom/stripe/android/model/PaymentMethodCreateParams$Card;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Card;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Lcom/stripe/android/model/PaymentMethodCreateParams$Card$Networks;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams$Card;
 	public static final fun create (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodCreateParams$Card;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
@@ -4344,9 +3969,6 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$Fpx : andr
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodCreateParams$Fpx;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Fpx;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams$Fpx;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBank ()Ljava/lang/String;
@@ -4369,9 +3991,6 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$Ideal : an
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodCreateParams$Ideal;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Ideal;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams$Ideal;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBank ()Ljava/lang/String;
@@ -4395,8 +4014,6 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$Link : and
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams$Link;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Link;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams$Link;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
@@ -4417,8 +4034,6 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$Netbanking
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;)V
-	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodCreateParams$Netbanking;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Netbanking;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams$Netbanking;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
@@ -4439,9 +4054,6 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$SepaDebit 
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodCreateParams$SepaDebit;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethodCreateParams$SepaDebit;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams$SepaDebit;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getIban ()Ljava/lang/String;
@@ -4464,8 +4076,6 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$ShopPay : 
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;)V
-	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodCreateParams$ShopPay;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethodCreateParams$ShopPay;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams$ShopPay;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
@@ -4486,8 +4096,6 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$Sofort : a
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;)V
-	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodCreateParams$Sofort;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Sofort;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams$Sofort;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
@@ -4547,8 +4155,6 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$Upi : andr
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;)V
-	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodCreateParams$Upi;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Upi;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams$Upi;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
@@ -4628,10 +4234,6 @@ public final class com/stripe/android/model/PaymentMethodOptionsParams$Blik : co
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;)V
 	public synthetic fun <init> (Ljava/lang/String;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;
-	public final fun copy (Ljava/lang/String;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;)Lcom/stripe/android/model/PaymentMethodOptionsParams$Blik;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethodOptionsParams$Blik;Ljava/lang/String;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodOptionsParams$Blik;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCode ()Ljava/lang/String;
@@ -4656,11 +4258,6 @@ public final class com/stripe/android/model/PaymentMethodOptionsParams$Card : co
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;Ljava/lang/Boolean;)Lcom/stripe/android/model/PaymentMethodOptionsParams$Card;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethodOptionsParams$Card;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodOptionsParams$Card;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCvc ()Ljava/lang/String;
@@ -4721,9 +4318,6 @@ public final class com/stripe/android/model/PaymentMethodOptionsParams$USBankAcc
 	public fun <init> ()V
 	public fun <init> (Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;)V
 	public synthetic fun <init> (Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;
-	public final fun copy (Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;)Lcom/stripe/android/model/PaymentMethodOptionsParams$USBankAccount;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethodOptionsParams$USBankAccount;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodOptionsParams$USBankAccount;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getSetupFutureUsage ()Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;
@@ -4750,10 +4344,6 @@ public final class com/stripe/android/model/PaymentMethodOptionsParams$WeChatPay
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;)V
 	public synthetic fun <init> (Ljava/lang/String;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;
-	public final fun copy (Ljava/lang/String;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;)Lcom/stripe/android/model/PaymentMethodOptionsParams$WeChatPay;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethodOptionsParams$WeChatPay;Ljava/lang/String;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodOptionsParams$WeChatPay;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAppId ()Ljava/lang/String;
@@ -4786,10 +4376,6 @@ public final class com/stripe/android/model/PaymentMethodPreference : com/stripe
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Lcom/stripe/android/model/StripeIntent;Ljava/lang/String;)V
 	public synthetic fun <init> (Lcom/stripe/android/model/StripeIntent;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/stripe/android/model/StripeIntent;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun copy (Lcom/stripe/android/model/StripeIntent;Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodPreference;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethodPreference;Lcom/stripe/android/model/StripeIntent;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodPreference;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFormUI ()Ljava/lang/String;
@@ -4888,27 +4474,6 @@ public final class com/stripe/android/model/PersonTokenParams : com/stripe/andro
 	public fun <init> ()V
 	public fun <init> (Lcom/stripe/android/model/Address;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/DateOfBirth;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lcom/stripe/android/model/PersonTokenParams$Relationship;Ljava/lang/String;Lcom/stripe/android/model/PersonTokenParams$Verification;)V
 	public synthetic fun <init> (Lcom/stripe/android/model/Address;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/DateOfBirth;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lcom/stripe/android/model/PersonTokenParams$Relationship;Ljava/lang/String;Lcom/stripe/android/model/PersonTokenParams$Verification;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/stripe/android/model/Address;
-	public final fun component10 ()Ljava/lang/String;
-	public final fun component11 ()Ljava/lang/String;
-	public final fun component12 ()Ljava/lang/String;
-	public final fun component13 ()Ljava/lang/String;
-	public final fun component14 ()Ljava/lang/String;
-	public final fun component15 ()Ljava/util/Map;
-	public final fun component16 ()Ljava/lang/String;
-	public final fun component17 ()Lcom/stripe/android/model/PersonTokenParams$Relationship;
-	public final fun component18 ()Ljava/lang/String;
-	public final fun component19 ()Lcom/stripe/android/model/PersonTokenParams$Verification;
-	public final fun component2 ()Lcom/stripe/android/model/AddressJapanParams;
-	public final fun component3 ()Lcom/stripe/android/model/AddressJapanParams;
-	public final fun component4 ()Lcom/stripe/android/model/DateOfBirth;
-	public final fun component5 ()Ljava/lang/String;
-	public final fun component6 ()Ljava/lang/String;
-	public final fun component7 ()Ljava/lang/String;
-	public final fun component8 ()Ljava/lang/String;
-	public final fun component9 ()Ljava/lang/String;
-	public final fun copy (Lcom/stripe/android/model/Address;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/DateOfBirth;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lcom/stripe/android/model/PersonTokenParams$Relationship;Ljava/lang/String;Lcom/stripe/android/model/PersonTokenParams$Verification;)Lcom/stripe/android/model/PersonTokenParams;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PersonTokenParams;Lcom/stripe/android/model/Address;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/AddressJapanParams;Lcom/stripe/android/model/DateOfBirth;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lcom/stripe/android/model/PersonTokenParams$Relationship;Ljava/lang/String;Lcom/stripe/android/model/PersonTokenParams$Verification;ILjava/lang/Object;)Lcom/stripe/android/model/PersonTokenParams;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAddress ()Lcom/stripe/android/model/Address;
@@ -4976,10 +4541,6 @@ public final class com/stripe/android/model/PersonTokenParams$Document : android
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/PersonTokenParams$Document;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PersonTokenParams$Document;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PersonTokenParams$Document;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBack ()Ljava/lang/String;
@@ -5004,14 +4565,6 @@ public final class com/stripe/android/model/PersonTokenParams$Relationship : and
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/Boolean;
-	public final fun component2 ()Ljava/lang/Boolean;
-	public final fun component3 ()Ljava/lang/Boolean;
-	public final fun component4 ()Ljava/lang/Integer;
-	public final fun component5 ()Ljava/lang/Boolean;
-	public final fun component6 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;)Lcom/stripe/android/model/PersonTokenParams$Relationship;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PersonTokenParams$Relationship;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PersonTokenParams$Relationship;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDirector ()Ljava/lang/Boolean;
@@ -5053,10 +4606,6 @@ public final class com/stripe/android/model/PersonTokenParams$Verification : and
 	public fun <init> (Lcom/stripe/android/model/PersonTokenParams$Document;)V
 	public fun <init> (Lcom/stripe/android/model/PersonTokenParams$Document;Lcom/stripe/android/model/PersonTokenParams$Document;)V
 	public synthetic fun <init> (Lcom/stripe/android/model/PersonTokenParams$Document;Lcom/stripe/android/model/PersonTokenParams$Document;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/stripe/android/model/PersonTokenParams$Document;
-	public final fun component2 ()Lcom/stripe/android/model/PersonTokenParams$Document;
-	public final fun copy (Lcom/stripe/android/model/PersonTokenParams$Document;Lcom/stripe/android/model/PersonTokenParams$Document;)Lcom/stripe/android/model/PersonTokenParams$Verification;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PersonTokenParams$Verification;Lcom/stripe/android/model/PersonTokenParams$Document;Lcom/stripe/android/model/PersonTokenParams$Document;ILjava/lang/Object;)Lcom/stripe/android/model/PersonTokenParams$Verification;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAdditionalDocument ()Lcom/stripe/android/model/PersonTokenParams$Document;
@@ -5087,9 +4636,6 @@ public final class com/stripe/android/model/PossibleBrands : com/stripe/android/
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/util/List;)V
-	public final fun component1 ()Ljava/util/List;
-	public final fun copy (Ljava/util/List;)Lcom/stripe/android/model/PossibleBrands;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PossibleBrands;Ljava/util/List;ILjava/lang/Object;)Lcom/stripe/android/model/PossibleBrands;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBrands ()Ljava/util/List;
@@ -5118,9 +4664,6 @@ public final class com/stripe/android/model/RadarSession : com/stripe/android/co
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/RadarSession;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/RadarSession;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/RadarSession;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getId ()Ljava/lang/String;
@@ -5149,25 +4692,6 @@ public final class com/stripe/android/model/SetupIntent : com/stripe/android/mod
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/model/SetupIntent$Companion;
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component10 ()Ljava/util/List;
-	public final fun component11 ()Lcom/stripe/android/model/StripeIntent$Status;
-	public final fun component12 ()Lcom/stripe/android/model/StripeIntent$Usage;
-	public final fun component13 ()Lcom/stripe/android/model/SetupIntent$Error;
-	public final fun component14 ()Ljava/util/List;
-	public final fun component15 ()Ljava/util/List;
-	public final fun component16 ()Lcom/stripe/android/model/StripeIntent$NextActionData;
-	public final fun component18 ()Z
-	public final fun component2 ()Lcom/stripe/android/model/SetupIntent$CancellationReason;
-	public final fun component3 ()J
-	public final fun component4 ()Ljava/lang/String;
-	public final fun component5 ()Ljava/lang/String;
-	public final fun component6 ()Ljava/lang/String;
-	public final fun component7 ()Z
-	public final fun component8 ()Lcom/stripe/android/model/PaymentMethod;
-	public final fun component9 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Lcom/stripe/android/model/SetupIntent$CancellationReason;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLcom/stripe/android/model/PaymentMethod;Ljava/lang/String;Ljava/util/List;Lcom/stripe/android/model/StripeIntent$Status;Lcom/stripe/android/model/StripeIntent$Usage;Lcom/stripe/android/model/SetupIntent$Error;Ljava/util/List;Ljava/util/List;Lcom/stripe/android/model/StripeIntent$NextActionData;Ljava/lang/String;Z)Lcom/stripe/android/model/SetupIntent;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/SetupIntent;Ljava/lang/String;Lcom/stripe/android/model/SetupIntent$CancellationReason;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLcom/stripe/android/model/PaymentMethod;Ljava/lang/String;Ljava/util/List;Lcom/stripe/android/model/StripeIntent$Status;Lcom/stripe/android/model/StripeIntent$Usage;Lcom/stripe/android/model/SetupIntent$Error;Ljava/util/List;Ljava/util/List;Lcom/stripe/android/model/StripeIntent$NextActionData;Ljava/lang/String;ZILjava/lang/Object;)Lcom/stripe/android/model/SetupIntent;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Lorg/json/JSONObject;)Lcom/stripe/android/model/SetupIntent;
@@ -5220,13 +4744,6 @@ public final class com/stripe/android/model/SetupIntent$Creator : android/os/Par
 public final class com/stripe/android/model/SetupIntent$Error : com/stripe/android/core/model/StripeModel {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun component5 ()Ljava/lang/String;
-	public final fun component6 ()Lcom/stripe/android/model/PaymentMethod;
-	public final fun component7 ()Lcom/stripe/android/model/SetupIntent$Error$Type;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCode ()Ljava/lang/String;
@@ -5270,11 +4787,6 @@ public final class com/stripe/android/model/ShippingInformation : com/stripe/and
 	public fun <init> ()V
 	public fun <init> (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/stripe/android/model/Address;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ShippingInformation;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/ShippingInformation;Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/ShippingInformation;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAddress ()Lcom/stripe/android/model/Address;
@@ -5306,13 +4818,6 @@ public final class com/stripe/android/model/ShippingMethod : com/stripe/android/
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;JLjava/util/Currency;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;JLjava/util/Currency;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;JLjava/util/Currency;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()J
-	public final fun component4 ()Ljava/util/Currency;
-	public final fun component5 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;JLjava/util/Currency;Ljava/lang/String;)Lcom/stripe/android/model/ShippingMethod;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/ShippingMethod;Ljava/lang/String;Ljava/lang/String;JLjava/util/Currency;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/ShippingMethod;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAmount ()J
@@ -5446,26 +4951,6 @@ public final class com/stripe/android/model/Source$Klarna : com/stripe/android/c
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component10 ()Ljava/lang/String;
-	public final fun component11 ()Ljava/lang/String;
-	public final fun component12 ()Ljava/lang/String;
-	public final fun component13 ()Ljava/lang/String;
-	public final fun component14 ()Ljava/lang/String;
-	public final fun component15 ()Ljava/lang/String;
-	public final fun component16 ()Ljava/lang/String;
-	public final fun component17 ()Ljava/util/Set;
-	public final fun component18 ()Ljava/util/Set;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun component5 ()Ljava/lang/String;
-	public final fun component6 ()Ljava/lang/String;
-	public final fun component7 ()Ljava/lang/String;
-	public final fun component8 ()Ljava/lang/String;
-	public final fun component9 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;)Lcom/stripe/android/model/Source$Klarna;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/Source$Klarna;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;ILjava/lang/Object;)Lcom/stripe/android/model/Source$Klarna;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getClientToken ()Ljava/lang/String;
@@ -5563,11 +5048,6 @@ public final class com/stripe/android/model/Source$Redirect : com/stripe/android
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;Lcom/stripe/android/model/Source$Redirect$Status;Ljava/lang/String;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Lcom/stripe/android/model/Source$Redirect$Status;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Lcom/stripe/android/model/Source$Redirect$Status;Ljava/lang/String;)Lcom/stripe/android/model/Source$Redirect;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/Source$Redirect;Ljava/lang/String;Lcom/stripe/android/model/Source$Redirect$Status;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/Source$Redirect;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getReturnUrl ()Ljava/lang/String;
@@ -5749,14 +5229,9 @@ public final class com/stripe/android/model/SourceOrder$Shipping$Creator : andro
 public final class com/stripe/android/model/SourceOrderParams : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> ()V
 	public fun <init> (Ljava/util/List;)V
 	public fun <init> (Ljava/util/List;Lcom/stripe/android/model/SourceOrderParams$Shipping;)V
 	public synthetic fun <init> (Ljava/util/List;Lcom/stripe/android/model/SourceOrderParams$Shipping;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/util/List;
-	public final fun component2 ()Lcom/stripe/android/model/SourceOrderParams$Shipping;
-	public final fun copy (Ljava/util/List;Lcom/stripe/android/model/SourceOrderParams$Shipping;)Lcom/stripe/android/model/SourceOrderParams;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/SourceOrderParams;Ljava/util/List;Lcom/stripe/android/model/SourceOrderParams$Shipping;ILjava/lang/Object;)Lcom/stripe/android/model/SourceOrderParams;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getItems ()Ljava/util/List;
@@ -5781,14 +5256,6 @@ public final class com/stripe/android/model/SourceOrderParams$Item : android/os/
 	public fun <init> ()V
 	public fun <init> (Lcom/stripe/android/model/SourceOrderParams$Item$Type;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;)V
 	public synthetic fun <init> (Lcom/stripe/android/model/SourceOrderParams$Item$Type;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/stripe/android/model/SourceOrderParams$Item$Type;
-	public final fun component2 ()Ljava/lang/Integer;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun component5 ()Ljava/lang/String;
-	public final fun component6 ()Ljava/lang/Integer;
-	public final fun copy (Lcom/stripe/android/model/SourceOrderParams$Item$Type;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;)Lcom/stripe/android/model/SourceOrderParams$Item;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/SourceOrderParams$Item;Lcom/stripe/android/model/SourceOrderParams$Item$Type;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)Lcom/stripe/android/model/SourceOrderParams$Item;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAmount ()Ljava/lang/Integer;
@@ -5825,13 +5292,6 @@ public final class com/stripe/android/model/SourceOrderParams$Shipping : android
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/stripe/android/model/Address;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun component5 ()Ljava/lang/String;
-	public final fun copy (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/SourceOrderParams$Shipping;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/SourceOrderParams$Shipping;Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/SourceOrderParams$Shipping;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAddress ()Lcom/stripe/android/model/Address;
@@ -5857,16 +5317,6 @@ public final class com/stripe/android/model/SourceParams : android/os/Parcelable
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/model/SourceParams$Companion;
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component10 ()Ljava/lang/String;
-	public final fun component11 ()Ljava/util/Map;
-	public final fun component3 ()Ljava/lang/Long;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun component5 ()Lcom/stripe/android/model/SourceParams$OwnerParams;
-	public final fun component6 ()Lcom/stripe/android/model/Source$Usage;
-	public final fun component7 ()Ljava/lang/String;
-	public final fun component8 ()Lcom/stripe/android/model/SourceParams$Flow;
-	public final fun component9 ()Lcom/stripe/android/model/SourceOrderParams;
 	public static final fun createAlipayReusableParams (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
 	public static final fun createAlipaySingleUseParams (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
 	public static final fun createBancontactParams (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/SourceParams;
@@ -5982,8 +5432,6 @@ public final class com/stripe/android/model/SourceParams$OwnerParams : android/o
 	public fun <init> (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;)V
 	public fun <init> (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun copy (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/SourceParams$OwnerParams;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/SourceParams$OwnerParams;Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/SourceParams$OwnerParams;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
@@ -6281,9 +5729,6 @@ public final class com/stripe/android/model/StripeIntent$NextActionData$CashAppR
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/StripeIntent$NextActionData$CashAppRedirect;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/StripeIntent$NextActionData$CashAppRedirect;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/StripeIntent$NextActionData$CashAppRedirect;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getMobileAuthUrl ()Ljava/lang/String;
@@ -6352,10 +5797,6 @@ public final class com/stripe/android/model/StripeIntent$NextActionData$Redirect
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Landroid/net/Uri;Ljava/lang/String;)V
-	public final fun component1 ()Landroid/net/Uri;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun copy (Landroid/net/Uri;Ljava/lang/String;)Lcom/stripe/android/model/StripeIntent$NextActionData$RedirectToUrl;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/StripeIntent$NextActionData$RedirectToUrl;Landroid/net/Uri;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/StripeIntent$NextActionData$RedirectToUrl;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getReturnUrl ()Ljava/lang/String;
@@ -6381,14 +5822,6 @@ public final class com/stripe/android/model/StripeIntent$NextActionData$SdkData$
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS2$DirectoryServerEncryption;Ljava/lang/String;Ljava/lang/String;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Lcom/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS2$DirectoryServerEncryption;
-	public final fun component5 ()Ljava/lang/String;
-	public final fun component6 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS2$DirectoryServerEncryption;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS2;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS2;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS2$DirectoryServerEncryption;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS2;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getPublishableKey ()Ljava/lang/String;
@@ -6414,12 +5847,6 @@ public final class com/stripe/android/model/StripeIntent$NextActionData$SdkData$
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/util/List;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;)Lcom/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS2$DirectoryServerEncryption;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS2$DirectoryServerEncryption;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/StripeIntent$NextActionData$SdkData$Use3DS2$DirectoryServerEncryption;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDirectoryServerId ()Ljava/lang/String;
@@ -6443,9 +5870,6 @@ public final class com/stripe/android/model/StripeIntent$NextActionData$SwishRed
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/StripeIntent$NextActionData$SwishRedirect;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/StripeIntent$NextActionData$SwishRedirect;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/StripeIntent$NextActionData$SwishRedirect;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getMobileAuthUrl ()Ljava/lang/String;
@@ -6485,11 +5909,6 @@ public final class com/stripe/android/model/StripeIntent$NextActionData$VerifyWi
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (JLjava/lang/String;Lcom/stripe/android/model/MicrodepositType;)V
-	public final fun component1 ()J
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Lcom/stripe/android/model/MicrodepositType;
-	public final fun copy (JLjava/lang/String;Lcom/stripe/android/model/MicrodepositType;)Lcom/stripe/android/model/StripeIntent$NextActionData$VerifyWithMicrodeposits;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/StripeIntent$NextActionData$VerifyWithMicrodeposits;JLjava/lang/String;Lcom/stripe/android/model/MicrodepositType;ILjava/lang/Object;)Lcom/stripe/android/model/StripeIntent$NextActionData$VerifyWithMicrodeposits;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getArrivalDate ()J
@@ -6574,17 +5993,6 @@ public final class com/stripe/android/model/WeChat : com/stripe/android/core/mod
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun component5 ()Ljava/lang/String;
-	public final fun component6 ()Ljava/lang/String;
-	public final fun component7 ()Ljava/lang/String;
-	public final fun component8 ()Ljava/lang/String;
-	public final fun component9 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/WeChat;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/WeChat;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/WeChat;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAppId ()Ljava/lang/String;
@@ -6646,9 +6054,6 @@ public abstract class com/stripe/android/model/wallets/Wallet : com/stripe/andro
 public final class com/stripe/android/model/wallets/Wallet$AmexExpressCheckoutWallet : com/stripe/android/model/wallets/Wallet {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/wallets/Wallet$AmexExpressCheckoutWallet;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/wallets/Wallet$AmexExpressCheckoutWallet;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/wallets/Wallet$AmexExpressCheckoutWallet;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDynamicLast4 ()Ljava/lang/String;
@@ -6668,9 +6073,6 @@ public final class com/stripe/android/model/wallets/Wallet$AmexExpressCheckoutWa
 public final class com/stripe/android/model/wallets/Wallet$ApplePayWallet : com/stripe/android/model/wallets/Wallet {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/wallets/Wallet$ApplePayWallet;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/wallets/Wallet$ApplePayWallet;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/wallets/Wallet$ApplePayWallet;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDynamicLast4 ()Ljava/lang/String;
@@ -6687,12 +6089,9 @@ public final class com/stripe/android/model/wallets/Wallet$ApplePayWallet$Creato
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/stripe/android/model/wallets/Wallet$GooglePayWallet : com/stripe/android/model/wallets/Wallet, android/os/Parcelable {
+public final class com/stripe/android/model/wallets/Wallet$GooglePayWallet : com/stripe/android/model/wallets/Wallet {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/wallets/Wallet$GooglePayWallet;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/wallets/Wallet$GooglePayWallet;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/wallets/Wallet$GooglePayWallet;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDynamicLast4 ()Ljava/lang/String;
@@ -6712,9 +6111,6 @@ public final class com/stripe/android/model/wallets/Wallet$GooglePayWallet$Creat
 public final class com/stripe/android/model/wallets/Wallet$LinkWallet : com/stripe/android/model/wallets/Wallet {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/wallets/Wallet$LinkWallet;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/wallets/Wallet$LinkWallet;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/wallets/Wallet$LinkWallet;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDynamicLast4 ()Ljava/lang/String;
@@ -6760,9 +6156,6 @@ public final class com/stripe/android/model/wallets/Wallet$MasterpassWallet$Crea
 public final class com/stripe/android/model/wallets/Wallet$SamsungPayWallet : com/stripe/android/model/wallets/Wallet {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/wallets/Wallet$SamsungPayWallet;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/wallets/Wallet$SamsungPayWallet;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/wallets/Wallet$SamsungPayWallet;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDynamicLast4 ()Ljava/lang/String;
@@ -6813,12 +6206,6 @@ public final class com/stripe/android/payments/PaymentFlowResult$Unvalidated : a
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;ILcom/stripe/android/core/exception/StripeException;ZLjava/lang/String;Lcom/stripe/android/model/Source;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;ILcom/stripe/android/core/exception/StripeException;ZLjava/lang/String;Lcom/stripe/android/model/Source;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()I
-	public final fun component3 ()Lcom/stripe/android/core/exception/StripeException;
-	public final fun component7 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;ILcom/stripe/android/core/exception/StripeException;ZLjava/lang/String;Lcom/stripe/android/model/Source;Ljava/lang/String;)Lcom/stripe/android/payments/PaymentFlowResult$Unvalidated;
-	public static synthetic fun copy$default (Lcom/stripe/android/payments/PaymentFlowResult$Unvalidated;Ljava/lang/String;ILcom/stripe/android/core/exception/StripeException;ZLjava/lang/String;Lcom/stripe/android/model/Source;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/payments/PaymentFlowResult$Unvalidated;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getClientSecret ()Ljava/lang/String;
@@ -6858,14 +6245,10 @@ public final class com/stripe/android/payments/bankaccount/CollectBankAccountCon
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/stripe/android/payments/bankaccount/CollectBankAccountConfiguration$USBankAccount : android/os/Parcelable, com/stripe/android/payments/bankaccount/CollectBankAccountConfiguration {
+public final class com/stripe/android/payments/bankaccount/CollectBankAccountConfiguration$USBankAccount : com/stripe/android/payments/bankaccount/CollectBankAccountConfiguration {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/payments/bankaccount/CollectBankAccountConfiguration$USBankAccount;
-	public static synthetic fun copy$default (Lcom/stripe/android/payments/bankaccount/CollectBankAccountConfiguration$USBankAccount;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/payments/bankaccount/CollectBankAccountConfiguration$USBankAccount;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getEmail ()Ljava/lang/String;
@@ -6981,10 +6364,6 @@ public final class com/stripe/android/payments/bankaccount/navigation/CollectBan
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Lcom/stripe/android/model/StripeIntent;Lcom/stripe/android/financialconnections/model/FinancialConnectionsSession;)V
-	public final fun component1 ()Lcom/stripe/android/model/StripeIntent;
-	public final fun component2 ()Lcom/stripe/android/financialconnections/model/FinancialConnectionsSession;
-	public final fun copy (Lcom/stripe/android/model/StripeIntent;Lcom/stripe/android/financialconnections/model/FinancialConnectionsSession;)Lcom/stripe/android/payments/bankaccount/navigation/CollectBankAccountResponse;
-	public static synthetic fun copy$default (Lcom/stripe/android/payments/bankaccount/navigation/CollectBankAccountResponse;Lcom/stripe/android/model/StripeIntent;Lcom/stripe/android/financialconnections/model/FinancialConnectionsSession;ILjava/lang/Object;)Lcom/stripe/android/payments/bankaccount/navigation/CollectBankAccountResponse;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFinancialConnectionsSession ()Lcom/stripe/android/financialconnections/model/FinancialConnectionsSession;
@@ -7053,9 +6432,6 @@ public final class com/stripe/android/payments/bankaccount/navigation/CollectBan
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Lcom/stripe/android/payments/bankaccount/navigation/CollectBankAccountResponse;)V
-	public final fun component1 ()Lcom/stripe/android/payments/bankaccount/navigation/CollectBankAccountResponse;
-	public final fun copy (Lcom/stripe/android/payments/bankaccount/navigation/CollectBankAccountResponse;)Lcom/stripe/android/payments/bankaccount/navigation/CollectBankAccountResult$Completed;
-	public static synthetic fun copy$default (Lcom/stripe/android/payments/bankaccount/navigation/CollectBankAccountResult$Completed;Lcom/stripe/android/payments/bankaccount/navigation/CollectBankAccountResponse;ILjava/lang/Object;)Lcom/stripe/android/payments/bankaccount/navigation/CollectBankAccountResult$Completed;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getResponse ()Lcom/stripe/android/payments/bankaccount/navigation/CollectBankAccountResponse;
@@ -7076,9 +6452,6 @@ public final class com/stripe/android/payments/bankaccount/navigation/CollectBan
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/Throwable;)V
-	public final fun component1 ()Ljava/lang/Throwable;
-	public final fun copy (Ljava/lang/Throwable;)Lcom/stripe/android/payments/bankaccount/navigation/CollectBankAccountResult$Failed;
-	public static synthetic fun copy$default (Lcom/stripe/android/payments/bankaccount/navigation/CollectBankAccountResult$Failed;Ljava/lang/Throwable;ILjava/lang/Object;)Lcom/stripe/android/payments/bankaccount/navigation/CollectBankAccountResult$Failed;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getError ()Ljava/lang/Throwable;
@@ -7292,10 +6665,6 @@ public final class com/stripe/android/view/BecsDebitBanks$Bank : android/os/Parc
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/view/BecsDebitBanks$Bank;
-	public static synthetic fun copy$default (Lcom/stripe/android/view/BecsDebitBanks$Bank;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/view/BecsDebitBanks$Bank;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getName ()Ljava/lang/String;

--- a/payments-core/build.gradle
+++ b/payments-core/build.gradle
@@ -5,6 +5,7 @@ apply plugin: 'checkstyle'
 apply plugin: 'dev.drewhamilton.poko'
 apply plugin: 'org.jetbrains.kotlin.plugin.parcelize'
 apply plugin: 'org.jetbrains.kotlin.plugin.compose'
+apply plugin: 'dev.drewhamilton.poko'
 
 dependencies {
     api project(":stripe-core")

--- a/payments-core/dependencies/dependencies.txt
+++ b/payments-core/dependencies/dependencies.txt
@@ -354,7 +354,10 @@
 |    |    \--- androidx.appcompat:appcompat-resources:1.7.0 (c)
 |    +--- androidx.core:core-ktx:1.13.1 (*)
 |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0 (*)
-|    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
+|    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
+|    \--- dev.drewhamilton.poko:poko-annotations:0.18.2
+|         \--- dev.drewhamilton.poko:poko-annotations-jvm:0.18.2
+|              \--- org.jetbrains.kotlin:kotlin-stdlib:2.1.0 -> 2.1.10 (*)
 +--- androidx.databinding:viewbinding:8.8.2
 |    \--- androidx.annotation:annotation:1.0.0 -> 1.9.1 (*)
 +--- org.jetbrains.kotlin:kotlin-stdlib:2.1.10 (*)
@@ -884,7 +887,5 @@
 |    |    \--- com.google.android.gms:play-services-basement:18.0.0 -> 18.4.0 (*)
 |    \--- com.google.android.gms:play-services-tasks:18.2.0 (*)
 +--- com.google.android.instantapps:instantapps:1.1.0
-+--- dev.drewhamilton.poko:poko-annotations:0.18.2
-|    \--- dev.drewhamilton.poko:poko-annotations-jvm:0.18.2
-|         \--- org.jetbrains.kotlin:kotlin-stdlib:2.1.0 -> 2.1.10 (*)
++--- dev.drewhamilton.poko:poko-annotations:0.18.2 (*)
 \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)

--- a/payments-core/src/main/java/com/stripe/android/EphemeralKey.kt
+++ b/payments-core/src/main/java/com/stripe/android/EphemeralKey.kt
@@ -1,6 +1,7 @@
 package com.stripe.android
 
 import com.stripe.android.core.model.StripeModel
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -11,7 +12,8 @@ import kotlinx.parcelize.Parcelize
  * for more details on ephemeral keys.
  */
 @Parcelize
-data class EphemeralKey internal constructor(
+@Poko
+class EphemeralKey internal constructor(
     /**
      * Represents a customer id or issuing card id, depending on the context
      */

--- a/payments-core/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
@@ -7,6 +7,7 @@ import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.model.CardBrand
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 import org.json.JSONArray
 import org.json.JSONObject
@@ -317,7 +318,8 @@ class GooglePayJsonFactory internal constructor(
      * Configure additional fields to be returned for a requested billing address.
      */
     @Parcelize
-    data class BillingAddressParameters @JvmOverloads constructor(
+    @Poko
+    class BillingAddressParameters @JvmOverloads constructor(
         internal val isRequired: Boolean = false,
 
         /**
@@ -347,7 +349,8 @@ class GooglePayJsonFactory internal constructor(
     }
 
     @Parcelize
-    data class TransactionInfo internal constructor(
+    @Poko
+    class TransactionInfo internal constructor(
         internal val currencyCode: String,
         internal val totalPriceStatus: TotalPriceStatus,
         internal val countryCode: String?,
@@ -392,29 +395,6 @@ class GooglePayJsonFactory internal constructor(
             totalPriceLabel = totalPriceLabel,
             checkoutOption = checkoutOption,
         )
-
-        @Deprecated(
-            message = "This method isn't meant for public usage and will be removed in a future release.",
-        )
-        fun copy(
-            currencyCode: String = this.currencyCode,
-            totalPriceStatus: TotalPriceStatus = this.totalPriceStatus,
-            countryCode: String? = this.countryCode,
-            transactionId: String? = this.transactionId,
-            totalPrice: Int? = this.totalPrice?.toInt(),
-            totalPriceLabel: String? = this.totalPriceLabel,
-            checkoutOption: CheckoutOption? = this.checkoutOption,
-        ): TransactionInfo {
-            return copy(
-                currencyCode = currencyCode,
-                totalPriceStatus = totalPriceStatus,
-                countryCode = countryCode,
-                transactionId = transactionId,
-                totalPrice = totalPrice?.toLong(),
-                totalPriceLabel = totalPriceLabel,
-                checkoutOption = checkoutOption,
-            )
-        }
 
         /**
          * The status of the total price used.
@@ -461,7 +441,8 @@ class GooglePayJsonFactory internal constructor(
      * [ShippingAddressParameters](https://developers.google.com/pay/api/android/reference/request-objects#ShippingAddressParameters)
      */
     @Parcelize
-    data class ShippingAddressParameters @JvmOverloads constructor(
+    @Poko
+    class ShippingAddressParameters @JvmOverloads constructor(
         /**
          * Set to true to request a full shipping address.
          */
@@ -504,10 +485,11 @@ class GooglePayJsonFactory internal constructor(
      * [MerchantInfo](https://developers.google.com/pay/api/android/reference/request-objects#MerchantInfo)
      */
     @Parcelize
-    data class MerchantInfo(
+    @Poko
+    class MerchantInfo(
         /**
          * Merchant name encoded as UTF-8. Merchant name is rendered in the payment sheet.
-         * In TEST environment, or if a merchant isn't recognized, a “Pay Unverified Merchant”
+         * In TEST environment, or if a merchant isn't recognized, a "Pay Unverified Merchant"
          * message is displayed in the payment sheet.
          */
         internal val merchantName: String? = null

--- a/payments-core/src/main/java/com/stripe/android/PaymentConfiguration.kt
+++ b/payments-core/src/main/java/com/stripe/android/PaymentConfiguration.kt
@@ -5,10 +5,12 @@ import android.content.SharedPreferences
 import android.os.Parcelable
 import androidx.annotation.RestrictTo
 import com.stripe.android.core.ApiKeyValidator
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-data class PaymentConfiguration
+@Poko
+class PaymentConfiguration
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
     val publishableKey: String,

--- a/payments-core/src/main/java/com/stripe/android/PaymentIntentResult.kt
+++ b/payments-core/src/main/java/com/stripe/android/PaymentIntentResult.kt
@@ -2,6 +2,7 @@ package com.stripe.android
 
 import androidx.annotation.RestrictTo
 import com.stripe.android.model.PaymentIntent
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -9,7 +10,8 @@ import kotlinx.parcelize.Parcelize
  * or handling of next actions via [Stripe.handleNextActionForPayment].
  */
 @Parcelize
-data class PaymentIntentResult
+@Poko
+class PaymentIntentResult
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) // For paymentsheet
 constructor(
     override val intent: PaymentIntent,

--- a/payments-core/src/main/java/com/stripe/android/SetupIntentResult.kt
+++ b/payments-core/src/main/java/com/stripe/android/SetupIntentResult.kt
@@ -1,6 +1,7 @@
 package com.stripe.android
 
 import com.stripe.android.model.SetupIntent
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -8,7 +9,8 @@ import kotlinx.parcelize.Parcelize
  * or handling of next actions via [Stripe.handleNextActionForSetupIntent].
  */
 @Parcelize
-data class SetupIntentResult internal constructor(
+@Poko
+class SetupIntentResult internal constructor(
     override val intent: SetupIntent,
     @Outcome private val outcomeFromFlow: Int = 0,
     override val failureMessage: String? = null

--- a/payments-core/src/main/java/com/stripe/android/StripeIntentResult.kt
+++ b/payments-core/src/main/java/com/stripe/android/StripeIntentResult.kt
@@ -3,6 +3,7 @@ package com.stripe.android
 import androidx.annotation.IntDef
 import com.stripe.android.core.model.StripeModel
 import com.stripe.android.model.StripeIntent
+import dev.drewhamilton.poko.Poko
 
 /**
  * A model representing the result of a [StripeIntent] confirmation or authentication attempt
@@ -10,6 +11,7 @@ import com.stripe.android.model.StripeIntent
  *
  * [intent] is a [StripeIntent] retrieved after confirmation/authentication succeeded or failed.
  */
+@Poko
 abstract class StripeIntentResult<out T : StripeIntent> internal constructor(
     @Outcome private val outcomeFromFlow: Int
 ) : StripeModel {

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncher.kt
@@ -24,6 +24,7 @@ import com.stripe.android.model.SetupIntent
 import com.stripe.android.networking.PaymentAnalyticsEvent
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.payments.core.analytics.ErrorReporter
+import dev.drewhamilton.poko.Poko
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -273,7 +274,8 @@ class GooglePayLauncher internal constructor(
     }
 
     @Parcelize
-    data class Config @JvmOverloads constructor(
+    @Poko
+    class Config @JvmOverloads constructor(
         val environment: GooglePayEnvironment,
         val merchantCountryCode: String,
         val merchantName: String,
@@ -311,7 +313,8 @@ class GooglePayLauncher internal constructor(
     }
 
     @Parcelize
-    data class BillingAddressConfig @JvmOverloads constructor(
+    @Poko
+    class BillingAddressConfig @JvmOverloads constructor(
         internal val isRequired: Boolean = false,
 
         /**
@@ -345,7 +348,8 @@ class GooglePayLauncher internal constructor(
         data object Completed : Result()
 
         @Parcelize
-        data class Failed(
+        @Poko
+        class Failed(
             val error: Throwable
         ) : Result()
 

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
@@ -30,6 +30,7 @@ import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
+import dev.drewhamilton.poko.Poko
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -280,7 +281,8 @@ class GooglePayPaymentMethodLauncher @AssistedInject internal constructor(
     }
 
     @Parcelize
-    data class Config @JvmOverloads constructor(
+    @Poko
+    class Config @JvmOverloads constructor(
         val environment: GooglePayEnvironment,
         val merchantCountryCode: String,
         val merchantName: String,
@@ -318,7 +320,8 @@ class GooglePayPaymentMethodLauncher @AssistedInject internal constructor(
     }
 
     @Parcelize
-    data class BillingAddressConfig @JvmOverloads constructor(
+    @Poko
+    class BillingAddressConfig @JvmOverloads constructor(
         val isRequired: Boolean = false,
 
         /**
@@ -354,7 +357,8 @@ class GooglePayPaymentMethodLauncher @AssistedInject internal constructor(
          * @param paymentMethod The resulting payment method.
          */
         @Parcelize
-        data class Completed(
+        @Poko
+        class Completed(
             val paymentMethod: PaymentMethod
         ) : Result()
 
@@ -365,7 +369,8 @@ class GooglePayPaymentMethodLauncher @AssistedInject internal constructor(
          * @param errorCode The failure [ErrorCode].
          */
         @Parcelize
-        data class Failed(
+        @Poko
+        class Failed(
             val error: Throwable,
             @ErrorCode val errorCode: Int
         ) : Result()

--- a/payments-core/src/main/java/com/stripe/android/model/AccountParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/AccountParams.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.model
 
 import android.os.Parcelable
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -11,7 +12,8 @@ import kotlinx.parcelize.Parcelize
  * [account tokens documentation](https://stripe.com/docs/connect/account-tokens) to learn more.
  */
 @Parcelize
-data class AccountParams internal constructor(
+@Poko
+class AccountParams internal constructor(
     /**
      * Whether the user described by the data in the token has been shown the
      * [Stripe Connected Account Agreement](https://stripe.com/docs/connect/account-tokens#stripe-connected-account-agreement).
@@ -64,7 +66,8 @@ data class AccountParams internal constructor(
          * [account.company](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-company)
          */
         @Parcelize
-        data class Company(
+        @Poko
+        class Company(
             /**
              * The company’s primary address.
              *
@@ -196,7 +199,8 @@ data class AccountParams internal constructor(
                 )
 
             @Parcelize
-            data class Verification(
+            @Poko
+            class Verification(
                 /**
                  * A document verifying the business.
                  */
@@ -214,7 +218,8 @@ data class AccountParams internal constructor(
             }
 
             @Parcelize
-            data class Document @JvmOverloads constructor(
+            @Poko
+            class Document @JvmOverloads constructor(
                 /**
                  * The front of a document returned by a
                  * [file upload](https://stripe.com/docs/api/tokens/create_account#create_file)
@@ -454,7 +459,8 @@ data class AccountParams internal constructor(
          * [account.individual](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-individual)
          */
         @Parcelize
-        data class Individual(
+        @Poko
+        class Individual(
             /**
              * The individual’s primary address.
              *
@@ -610,7 +616,8 @@ data class AccountParams internal constructor(
                 )
 
             @Parcelize
-            data class Verification @JvmOverloads constructor(
+            @Poko
+            class Verification @JvmOverloads constructor(
                 /**
                  * An identifying document, either a passport or local ID card.
                  */
@@ -640,7 +647,8 @@ data class AccountParams internal constructor(
             }
 
             @Parcelize
-            data class Document @JvmOverloads constructor(
+            @Poko
+            class Document @JvmOverloads constructor(
                 /**
                  * The front of an ID returned by a
                  * [file upload](https://stripe.com/docs/api/tokens/create_account#create_file) with

--- a/payments-core/src/main/java/com/stripe/android/model/Address.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/Address.kt
@@ -4,6 +4,7 @@ import androidx.annotation.RestrictTo
 import com.stripe.android.core.model.CountryCode
 import com.stripe.android.core.model.StripeModel
 import com.stripe.android.model.parsers.AddressJsonParser
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 import org.json.JSONObject
 
@@ -12,7 +13,8 @@ import org.json.JSONObject
  * object in the Source api.
  */
 @Parcelize
-data class Address(
+@Poko
+class Address(
     val city: String? = null,
     val country: String? = null, // two-character country code
     val line1: String? = null,
@@ -39,6 +41,25 @@ data class Address(
 
     internal fun isFilledOut(): Boolean {
         return city != null || country != null || line1 != null || line2 != null || postalCode != null || state != null
+    }
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    fun copy(
+        city: String? = this.city,
+        country: String? = this.country,
+        line1: String? = this.line1,
+        line2: String? = this.line2,
+        postalCode: String? = this.postalCode,
+        state: String? = this.state
+    ): Address {
+        return Address(
+            city = city,
+            country = country,
+            line1 = line1,
+            line2 = line2,
+            postalCode = postalCode,
+            state = state
+        )
     }
 
     class Builder {

--- a/payments-core/src/main/java/com/stripe/android/model/AddressJapanParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/AddressJapanParams.kt
@@ -1,10 +1,12 @@
 package com.stripe.android.model
 
 import android.os.Parcelable
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-data class AddressJapanParams(
+@Poko
+class AddressJapanParams(
     /**
      * City or ward.
      */

--- a/payments-core/src/main/java/com/stripe/android/model/BankAccountTokenParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/BankAccountTokenParams.kt
@@ -1,12 +1,14 @@
 package com.stripe.android.model
 
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
 /**
  * [Create a bank account token](https://stripe.com/docs/api/tokens/create_bank_account)
  */
 @Parcelize
-data class BankAccountTokenParams @JvmOverloads constructor(
+@Poko
+class BankAccountTokenParams @JvmOverloads constructor(
     /**
      * The country in which the bank account is located.
      *

--- a/payments-core/src/main/java/com/stripe/android/model/CardParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/CardParams.kt
@@ -1,13 +1,15 @@
 package com.stripe.android.model
 
 import com.stripe.android.CardUtils
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
 /**
  * [Create a card token](https://stripe.com/docs/api/tokens/create_card)
  */
 @Parcelize
-data class CardParams internal constructor(
+@Poko
+class CardParams internal constructor(
     /**
      * The likely [CardBrand] based on the [number].
      */

--- a/payments-core/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
@@ -14,13 +14,15 @@ import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_RADAR_
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_RETURN_URL
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_SET_AS_DEFAULT_PAYMENT_METHOD
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_USE_STRIPE_SDK
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
 /**
  * Model representing parameters for [confirming a PaymentIntent](https://stripe.com/docs/api/payment_intents/confirm).
  */
 @Parcelize
-data class ConfirmPaymentIntentParams
+@Poko
+class ConfirmPaymentIntentParams
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
     val paymentMethodCreateParams: PaymentMethodCreateParams? = null,
@@ -152,6 +154,51 @@ constructor(
 
     override fun shouldUseStripeSdk(): Boolean {
         return useStripeSdk
+    }
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    fun copy(
+        paymentMethodCreateParams: PaymentMethodCreateParams? = this.paymentMethodCreateParams,
+        paymentMethodId: String? = this.paymentMethodId,
+        sourceParams: SourceParams? = this.sourceParams,
+        sourceId: String? = this.sourceId,
+        clientSecret: String = this.clientSecret,
+        returnUrl: String? = this.returnUrl,
+        savePaymentMethod: Boolean? = this.savePaymentMethod,
+        useStripeSdk: Boolean = this.useStripeSdk,
+        paymentMethodOptions: PaymentMethodOptionsParams? = this.paymentMethodOptions,
+        mandateId: String? = this.mandateId,
+        mandateData: MandateDataParams? = this.mandateData,
+        setupFutureUsage: SetupFutureUsage? = this.setupFutureUsage,
+        shipping: Shipping? = this.shipping,
+        receiptEmail: String? = this.receiptEmail,
+        setAsDefaultPaymentMethod: Boolean? = this.setAsDefaultPaymentMethod,
+        paymentMethodCode: PaymentMethodCode? = this.paymentMethodCode,
+        radarOptions: RadarOptions? = this.radarOptions,
+        clientAttributionMetadata: ClientAttributionMetadata? = this.clientAttributionMetadata,
+        confirmationTokenId: String? = this.confirmationTokenId,
+    ): ConfirmPaymentIntentParams {
+        return ConfirmPaymentIntentParams(
+            paymentMethodCreateParams = paymentMethodCreateParams,
+            paymentMethodId = paymentMethodId,
+            sourceParams = sourceParams,
+            sourceId = sourceId,
+            clientSecret = clientSecret,
+            returnUrl = returnUrl,
+            savePaymentMethod = savePaymentMethod,
+            useStripeSdk = useStripeSdk,
+            paymentMethodOptions = paymentMethodOptions,
+            mandateId = mandateId,
+            mandateData = mandateData,
+            setupFutureUsage = setupFutureUsage,
+            shipping = shipping,
+            receiptEmail = receiptEmail,
+            setAsDefaultPaymentMethod = setAsDefaultPaymentMethod,
+            paymentMethodCode = paymentMethodCode,
+            radarOptions = radarOptions,
+            clientAttributionMetadata = clientAttributionMetadata,
+            confirmationTokenId = confirmationTokenId,
+        )
     }
 
     override fun withShouldUseStripeSdk(shouldUseStripeSdk: Boolean): ConfirmPaymentIntentParams {
@@ -299,7 +346,8 @@ constructor(
      * [shipping](https://stripe.com/docs/api/payment_intents/confirm#confirm_payment_intent-shipping)
      */
     @Parcelize
-    data class Shipping @JvmOverloads constructor(
+    @Poko
+    class Shipping @JvmOverloads constructor(
         /**
          * [shipping.address](https://stripe.com/docs/api/payment_intents/confirm#confirm_payment_intent-shipping-address)
          *

--- a/payments-core/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
@@ -12,13 +12,15 @@ import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_RADAR_
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_RETURN_URL
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_SET_AS_DEFAULT_PAYMENT_METHOD
 import com.stripe.android.model.ConfirmStripeIntentParams.Companion.PARAM_USE_STRIPE_SDK
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
 /**
  * Model representing parameters for [confirming a SetupIntent](https://stripe.com/docs/api/setup_intents/confirm).
  */
 @Parcelize
-data class ConfirmSetupIntentParams
+@Poko
+class ConfirmSetupIntentParams
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
     @get:JvmSynthetic override val clientSecret: String,
@@ -87,6 +89,37 @@ constructor(
 
     override fun shouldUseStripeSdk(): Boolean {
         return useStripeSdk
+    }
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    fun copy(
+        clientSecret: String = this.clientSecret,
+        paymentMethodId: String? = this.paymentMethodId,
+        paymentMethodCreateParams: PaymentMethodCreateParams? = this.paymentMethodCreateParams,
+        returnUrl: String? = this.returnUrl,
+        useStripeSdk: Boolean = this.useStripeSdk,
+        mandateId: String? = this.mandateId,
+        mandateData: MandateDataParams? = this.mandateData,
+        setAsDefaultPaymentMethod: Boolean? = this.setAsDefaultPaymentMethod,
+        paymentMethodCode: PaymentMethodCode? = this.paymentMethodCode,
+        radarOptions: RadarOptions? = this.radarOptions,
+        clientAttributionMetadata: ClientAttributionMetadata? = this.clientAttributionMetadata,
+        confirmationTokenId: String? = this.confirmationTokenId,
+    ): ConfirmSetupIntentParams {
+        return ConfirmSetupIntentParams(
+            clientSecret = clientSecret,
+            paymentMethodId = paymentMethodId,
+            paymentMethodCreateParams = paymentMethodCreateParams,
+            returnUrl = returnUrl,
+            useStripeSdk = useStripeSdk,
+            mandateId = mandateId,
+            mandateData = mandateData,
+            setAsDefaultPaymentMethod = setAsDefaultPaymentMethod,
+            paymentMethodCode = paymentMethodCode,
+            radarOptions = radarOptions,
+            clientAttributionMetadata = clientAttributionMetadata,
+            confirmationTokenId = confirmationTokenId,
+        )
     }
 
     override fun withShouldUseStripeSdk(shouldUseStripeSdk: Boolean): ConfirmSetupIntentParams {

--- a/payments-core/src/main/java/com/stripe/android/model/Customer.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/Customer.kt
@@ -1,13 +1,15 @@
 package com.stripe.android.model
 
 import com.stripe.android.core.model.StripeModel
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
 /**
  * Model for a Stripe Customer object
  */
 @Parcelize
-data class Customer internal constructor(
+@Poko
+class Customer internal constructor(
     val id: String?,
     val defaultSource: String?,
     val shippingInformation: ShippingInformation?,

--- a/payments-core/src/main/java/com/stripe/android/model/CustomerSource.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/CustomerSource.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.model
 
 import com.stripe.android.core.model.StripeModel
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -12,7 +13,8 @@ sealed class CustomerPaymentSource : StripeModel {
 }
 
 @Parcelize
-data class CustomerCard(
+@Poko
+class CustomerCard(
     val card: Card
 ) : CustomerPaymentSource() {
     override val id: String? get() = card.id
@@ -24,7 +26,8 @@ data class CustomerCard(
 }
 
 @Parcelize
-data class CustomerBankAccount(
+@Poko
+class CustomerBankAccount(
     val bankAccount: BankAccount
 ) : CustomerPaymentSource() {
     override val id: String? get() = bankAccount.id
@@ -33,7 +36,8 @@ data class CustomerBankAccount(
 }
 
 @Parcelize
-data class CustomerSource(
+@Poko
+class CustomerSource(
     val source: Source
 ) : CustomerPaymentSource() {
     override val id: String? get() = source.id

--- a/payments-core/src/main/java/com/stripe/android/model/CvcTokenParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/CvcTokenParams.kt
@@ -1,9 +1,11 @@
 package com.stripe.android.model
 
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-data class CvcTokenParams(
+@Poko
+class CvcTokenParams(
     private val cvc: String
 ) : TokenParams(Token.Type.CvcUpdate) {
     override val typeDataParams: Map<String, Any>

--- a/payments-core/src/main/java/com/stripe/android/model/DateOfBirth.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/DateOfBirth.kt
@@ -1,10 +1,12 @@
 package com.stripe.android.model
 
 import android.os.Parcelable
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-data class DateOfBirth(
+@Poko
+class DateOfBirth(
     val day: Int,
     val month: Int,
     val year: Int

--- a/payments-core/src/main/java/com/stripe/android/model/ExpirationDate.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ExpirationDate.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.model
 
 import com.stripe.android.core.utils.DateUtils
+import dev.drewhamilton.poko.Poko
 
 sealed class ExpirationDate {
     internal data class Unvalidated(
@@ -90,7 +91,8 @@ sealed class ExpirationDate {
         }
     }
 
-    data class Validated(
+    @Poko
+    class Validated(
         val month: Int,
         val year: Int
     ) : ExpirationDate()

--- a/payments-core/src/main/java/com/stripe/android/model/GooglePayResult.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/GooglePayResult.kt
@@ -3,6 +3,7 @@ package com.stripe.android.model
 import android.os.Parcelable
 import com.stripe.android.core.model.StripeJsonUtils.optString
 import com.stripe.android.model.parsers.TokenJsonParser
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
@@ -11,7 +12,8 @@ import org.json.JSONObject
  * Result of a successful Google Pay Payment Data Request
  */
 @Parcelize
-data class GooglePayResult internal constructor(
+@Poko
+class GooglePayResult internal constructor(
     val token: Token? = null,
     val address: Address? = null,
     val name: String? = null,

--- a/payments-core/src/main/java/com/stripe/android/model/IssuingCardPin.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/IssuingCardPin.kt
@@ -1,9 +1,11 @@
 package com.stripe.android.model
 
 import com.stripe.android.core.model.StripeModel
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-data class IssuingCardPin(
+@Poko
+class IssuingCardPin(
     val pin: String
 ) : StripeModel

--- a/payments-core/src/main/java/com/stripe/android/model/KlarnaSourceParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/KlarnaSourceParams.kt
@@ -2,6 +2,7 @@ package com.stripe.android.model
 
 import android.os.Parcelable
 import com.stripe.android.model.KlarnaSourceParams.LineItem
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -18,7 +19,8 @@ import kotlinx.parcelize.Parcelize
  * Klarna may reject the transaction without giving the customer a chance to correct it.
  */
 @Parcelize
-data class KlarnaSourceParams @JvmOverloads constructor(
+@Poko
+class KlarnaSourceParams @JvmOverloads constructor(
     /**
      * The URL the customer should be redirected to after they have successfully verified the
      * payment.
@@ -124,7 +126,8 @@ data class KlarnaSourceParams @JvmOverloads constructor(
     }
 
     @Parcelize
-    data class LineItem @JvmOverloads constructor(
+    @Poko
+    class LineItem @JvmOverloads constructor(
         /**
          * The line item's type. One of `sku` (for a product), `tax` (for taxes),
          * or `shipping` (for shipping costs).
@@ -172,7 +175,8 @@ data class KlarnaSourceParams @JvmOverloads constructor(
      * for more information.
      */
     @Parcelize
-    data class PaymentPageOptions(
+    @Poko
+    class PaymentPageOptions(
         /**
          * A public URL for your businesses logo, must be served over HTTPS.
          */

--- a/payments-core/src/main/java/com/stripe/android/model/ListPaymentMethodsParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ListPaymentMethodsParams.kt
@@ -2,11 +2,13 @@ package com.stripe.android.model
 
 import android.os.Parcelable
 import androidx.annotation.RestrictTo
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Parcelize
-data class ListPaymentMethodsParams(
+@Poko
+class ListPaymentMethodsParams(
     private val customerId: String,
     internal val paymentMethodType: PaymentMethod.Type,
     private val limit: Int? = null,

--- a/payments-core/src/main/java/com/stripe/android/model/MandateDataParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/MandateDataParams.kt
@@ -2,6 +2,7 @@ package com.stripe.android.model
 
 import android.os.Parcelable
 import androidx.annotation.RestrictTo
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -10,7 +11,8 @@ import kotlinx.parcelize.Parcelize
  * or [confirming a SetupIntent](https://stripe.com/docs/api/setup_intents/confirm#confirm_setup_intent-mandate_data)
  */
 @Parcelize
-data class MandateDataParams constructor(
+@Poko
+class MandateDataParams constructor(
     private val type: Type
 ) : StripeParamsModel, Parcelable {
     override fun toParamMap(): Map<String, Any> {
@@ -32,7 +34,8 @@ data class MandateDataParams constructor(
          * [mandate_data.customer_acceptance.online](https://stripe.com/docs/api/payment_intents/confirm#confirm_payment_intent-mandate_data-customer_acceptance-online)
          */
         @Parcelize
-        data class Online internal constructor(
+        @Poko
+        class Online internal constructor(
             /**
              * The IP address from which the Mandate was accepted by the customer.
              *

--- a/payments-core/src/main/java/com/stripe/android/model/Networks.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/Networks.kt
@@ -1,10 +1,12 @@
 package com.stripe.android.model
 
 import android.os.Parcelable
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-data class Networks(
+@Poko
+class Networks(
     /**
      * The customer’s preferred card network for co-branded cards. Supports cartes_bancaires, mastercard, or visa.
      * Selection of a network that does not apply to the card will be stored as invalid_preference on the card.

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentIntent.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentIntent.kt
@@ -3,9 +3,8 @@ package com.stripe.android.model
 import androidx.annotation.RestrictTo
 import com.stripe.android.core.model.StripeJsonUtils
 import com.stripe.android.core.model.StripeModel
-import com.stripe.android.model.PaymentIntent.CaptureMethod
-import com.stripe.android.model.PaymentIntent.ConfirmationMethod
 import com.stripe.android.model.parsers.PaymentIntentJsonParser
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 import org.json.JSONObject
 import java.util.regex.Pattern
@@ -17,7 +16,8 @@ import java.util.regex.Pattern
  * - [PaymentIntents API Reference](https://stripe.com/docs/api/payment_intents)
  */
 @Parcelize
-data class PaymentIntent
+@Poko
+class PaymentIntent
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
     /**
@@ -308,7 +308,8 @@ constructor(
      * See [last_payment_error](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-last_payment_error).
      */
     @Parcelize
-    data class Error internal constructor(
+    @Poko
+    class Error internal constructor(
         /**
          * For card errors, the ID of the failed charge.
          */
@@ -369,6 +370,28 @@ constructor(
             }
         }
 
+        internal fun copy(
+            charge: String? = this.charge,
+            code: String? = this.code,
+            declineCode: String? = this.declineCode,
+            docUrl: String? = this.docUrl,
+            message: String? = this.message,
+            param: String? = this.param,
+            paymentMethod: PaymentMethod? = this.paymentMethod,
+            type: Type? = this.type
+        ): Error {
+            return Error(
+                charge = charge,
+                code = code,
+                declineCode = declineCode,
+                docUrl = docUrl,
+                message = message,
+                param = param,
+                paymentMethod = paymentMethod,
+                type = type
+            )
+        }
+
         internal companion object {
             internal const val CODE_AUTHENTICATION_ERROR = "payment_intent_authentication_failure"
         }
@@ -380,7 +403,8 @@ constructor(
      * See [shipping](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-shipping)
      */
     @Parcelize
-    data class Shipping(
+    @Poko
+    class Shipping(
         /**
          * Shipping address.
          *
@@ -503,6 +527,63 @@ constructor(
         internal companion object {
             fun fromCode(code: String?) = entries.firstOrNull { it.code == code } ?: Automatic
         }
+    }
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    fun copy(
+        id: String? = this.id,
+        paymentMethodTypes: List<String> = this.paymentMethodTypes,
+        amount: Long? = this.amount,
+        canceledAt: Long = this.canceledAt,
+        cancellationReason: CancellationReason? = this.cancellationReason,
+        captureMethod: CaptureMethod = this.captureMethod,
+        clientSecret: String? = this.clientSecret,
+        confirmationMethod: ConfirmationMethod = this.confirmationMethod,
+        countryCode: String? = this.countryCode,
+        created: Long = this.created,
+        currency: String? = this.currency,
+        description: String? = this.description,
+        isLiveMode: Boolean = this.isLiveMode,
+        paymentMethod: PaymentMethod? = this.paymentMethod,
+        paymentMethodId: String? = this.paymentMethodId,
+        receiptEmail: String? = this.receiptEmail,
+        status: StripeIntent.Status? = this.status,
+        setupFutureUsage: StripeIntent.Usage? = this.setupFutureUsage,
+        lastPaymentError: Error? = this.lastPaymentError,
+        shipping: Shipping? = this.shipping,
+        unactivatedPaymentMethods: List<String> = this.unactivatedPaymentMethods,
+        linkFundingSources: List<String> = this.linkFundingSources,
+        nextActionData: StripeIntent.NextActionData? = this.nextActionData,
+        paymentMethodOptionsJsonString: String? = this.paymentMethodOptionsJsonString,
+        automaticPaymentMethodsEnabled: Boolean = this.automaticPaymentMethodsEnabled,
+    ): PaymentIntent {
+        return PaymentIntent(
+            id = id,
+            paymentMethodTypes = paymentMethodTypes,
+            amount = amount,
+            canceledAt = canceledAt,
+            cancellationReason = cancellationReason,
+            captureMethod = captureMethod,
+            clientSecret = clientSecret,
+            confirmationMethod = confirmationMethod,
+            countryCode = countryCode,
+            created = created,
+            currency = currency,
+            description = description,
+            isLiveMode = isLiveMode,
+            paymentMethod = paymentMethod,
+            paymentMethodId = paymentMethodId,
+            receiptEmail = receiptEmail,
+            status = status,
+            setupFutureUsage = setupFutureUsage,
+            lastPaymentError = lastPaymentError,
+            shipping = shipping,
+            unactivatedPaymentMethods = unactivatedPaymentMethods,
+            linkFundingSources = linkFundingSources,
+            nextActionData = nextActionData,
+            paymentMethodOptionsJsonString = paymentMethodOptionsJsonString,
+            automaticPaymentMethodsEnabled = automaticPaymentMethodsEnabled,
+        )
     }
 
     companion object {

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
@@ -7,6 +7,7 @@ import com.stripe.android.model.parsers.PaymentMethodJsonParser
 import com.stripe.android.model.wallets.Wallet
 import com.stripe.android.payments.PaymentFlowResultProcessor.Companion.MAX_POLLING_DURATION
 import com.stripe.android.payments.PaymentFlowResultProcessor.Companion.REDUCED_POLLING_DURATION
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import org.json.JSONObject
@@ -25,7 +26,8 @@ typealias PaymentMethodCode = String
  * See [PaymentMethodCreateParams] for PaymentMethod creation
  */
 @Parcelize
-data class PaymentMethod
+@Poko
+class PaymentMethod
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
     /**
@@ -573,7 +575,7 @@ constructor(
         val pollingDuration: Long
 
         @Parcelize
-        data object None : AfterRedirectAction {
+        object None : AfterRedirectAction {
 
             @IgnoredOnParcel
             override val shouldRefreshOrRetrieve: Boolean = false
@@ -583,7 +585,8 @@ constructor(
         }
 
         @Parcelize
-        data class Poll(override val pollingDuration: Long) : AfterRedirectAction {
+        @Poko
+        class Poll(override val pollingDuration: Long) : AfterRedirectAction {
             @IgnoredOnParcel
             override val shouldRefreshOrRetrieve: Boolean = true
         }
@@ -730,7 +733,8 @@ constructor(
      * [billing_details](https://stripe.com/docs/api/payment_methods/object#payment_method_object-billing_details)
      */
     @Parcelize
-    data class BillingDetails @JvmOverloads constructor(
+    @Poko
+    class BillingDetails @JvmOverloads constructor(
         /**
          * Billing address.
          *
@@ -867,7 +871,8 @@ constructor(
      * [card](https://stripe.com/docs/api/payment_methods/object#payment_method_object-card)
      */
     @Parcelize
-    data class Card
+    @Poko
+    class Card
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     constructor(
         /**
@@ -950,13 +955,45 @@ constructor(
     ) : TypeData() {
         override val type: Type get() = Type.Card
 
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        fun copy(
+            brand: CardBrand = this.brand,
+            checks: Checks? = this.checks,
+            country: String? = this.country,
+            expiryMonth: Int? = this.expiryMonth,
+            expiryYear: Int? = this.expiryYear,
+            fingerprint: String? = this.fingerprint,
+            funding: String? = this.funding,
+            last4: String? = this.last4,
+            threeDSecureUsage: ThreeDSecureUsage? = this.threeDSecureUsage,
+            wallet: Wallet? = this.wallet,
+            networks: Networks? = this.networks,
+            displayBrand: String? = this.displayBrand
+        ): Card {
+            return Card(
+                brand = brand,
+                checks = checks,
+                country = country,
+                expiryMonth = expiryMonth,
+                expiryYear = expiryYear,
+                fingerprint = fingerprint,
+                funding = funding,
+                last4 = last4,
+                threeDSecureUsage = threeDSecureUsage,
+                wallet = wallet,
+                networks = networks,
+                displayBrand = displayBrand
+            )
+        }
+
         /**
          * Checks on Card address and CVC if provided
          *
          * [card.checks](https://stripe.com/docs/api/payment_methods/object#payment_method_object-card-checks)
          */
         @Parcelize
-        data class Checks
+        @Poko
+        class Checks
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         constructor(
             /**
@@ -987,7 +1024,8 @@ constructor(
          * [card.three_d_secure_usage](https://stripe.com/docs/api/payment_methods/object#payment_method_object-card-three_d_secure_usage)
          */
         @Parcelize
-        data class ThreeDSecureUsage
+        @Poko
+        class ThreeDSecureUsage
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         constructor(
             /**
@@ -999,12 +1037,27 @@ constructor(
         ) : StripeModel
 
         @Parcelize
-        data class Networks(
+        @Poko
+        class Networks(
             val available: Set<String> = emptySet(),
             @Deprecated("This field is deprecated and will be removed in a future release.")
             val selectionMandatory: Boolean = false,
             val preferred: String? = null
-        ) : StripeModel
+        ) : StripeModel {
+
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            fun copy(
+                available: Set<String> = this.available,
+                selectionMandatory: Boolean = this.selectionMandatory,
+                preferred: String? = this.preferred
+            ): Networks {
+                return Networks(
+                    available = available,
+                    selectionMandatory = selectionMandatory,
+                    preferred = preferred
+                )
+            }
+        }
     }
 
     /**
@@ -1013,8 +1066,9 @@ constructor(
      * [card_present](https://stripe.com/docs/api/payment_methods/object#payment_method_object-card_present)
      */
     @Parcelize
-    data class CardPresent internal constructor(
-        private val ignore: Boolean = true
+    @Poko
+    class CardPresent internal constructor(
+        @Suppress("unused") private val ignore: Boolean = true
     ) : TypeData() {
         override val type: Type get() = Type.CardPresent
 
@@ -1030,7 +1084,8 @@ constructor(
      * [ideal](https://stripe.com/docs/api/payment_methods/object#payment_method_object-ideal)
      */
     @Parcelize
-    data class Ideal internal constructor(
+    @Poko
+    class Ideal internal constructor(
         /**
          * The customer’s bank, if provided. Can be one of `abn_amro`, `asn_bank`, `bunq`,
          * `handelsbanken`, `ing`, `knab`, `moneyou`, `rabobank`, `regiobank`, `sns_bank`,
@@ -1057,7 +1112,8 @@ constructor(
      * To obtain the FPX bank's display name, see [com.stripe.android.view.FpxBank].
      */
     @Parcelize
-    data class Fpx internal constructor(
+    @Poko
+    class Fpx internal constructor(
         @JvmField val bank: String?,
         @JvmField val accountHolderType: String?
     ) : TypeData() {
@@ -1070,7 +1126,8 @@ constructor(
      * [sepa_debit](https://stripe.com/docs/api/payment_methods/object#payment_method_object-sepa_debit)
      */
     @Parcelize
-    data class SepaDebit
+    @Poko
+    class SepaDebit
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     constructor(
         /**
@@ -1109,10 +1166,28 @@ constructor(
         @JvmField val last4: String?
     ) : TypeData() {
         override val type: Type get() = Type.SepaDebit
+
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        fun copy(
+            bankCode: String? = this.bankCode,
+            branchCode: String? = this.branchCode,
+            country: String? = this.country,
+            fingerprint: String? = this.fingerprint,
+            last4: String? = this.last4
+        ): SepaDebit {
+            return SepaDebit(
+                bankCode = bankCode,
+                branchCode = branchCode,
+                country = country,
+                fingerprint = fingerprint,
+                last4 = last4
+            )
+        }
     }
 
     @Parcelize
-    data class AuBecsDebit
+    @Poko
+    class AuBecsDebit
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     constructor(
         @JvmField val bsbNumber: String?,
@@ -1120,10 +1195,24 @@ constructor(
         @JvmField val last4: String?
     ) : TypeData() {
         override val type: Type get() = Type.AuBecsDebit
+
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        fun copy(
+            bsbNumber: String? = this.bsbNumber,
+            fingerprint: String? = this.fingerprint,
+            last4: String? = this.last4
+        ): AuBecsDebit {
+            return AuBecsDebit(
+                bsbNumber = bsbNumber,
+                fingerprint = fingerprint,
+                last4 = last4
+            )
+        }
     }
 
     @Parcelize
-    data class BacsDebit
+    @Poko
+    class BacsDebit
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     constructor(
         @JvmField val fingerprint: String?,
@@ -1131,24 +1220,40 @@ constructor(
         @JvmField val sortCode: String?
     ) : TypeData() {
         override val type: Type get() = Type.BacsDebit
+
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        fun copy(
+            fingerprint: String? = this.fingerprint,
+            last4: String? = this.last4,
+            sortCode: String? = this.sortCode
+        ): BacsDebit {
+            return BacsDebit(
+                fingerprint = fingerprint,
+                last4 = last4,
+                sortCode = sortCode
+            )
+        }
     }
 
     @Parcelize
-    data class Sofort internal constructor(
+    @Poko
+    class Sofort internal constructor(
         @JvmField val country: String?
     ) : TypeData() {
         override val type: Type get() = Type.Sofort
     }
 
     @Parcelize
-    data class Upi internal constructor(
+    @Poko
+    class Upi internal constructor(
         @JvmField val vpa: String?
     ) : TypeData() {
         override val type: Type get() = Type.Upi
     }
 
     @Parcelize
-    data class Netbanking internal constructor(
+    @Poko
+    class Netbanking internal constructor(
         /**
          * The customer’s bank.
          *
@@ -1160,7 +1265,8 @@ constructor(
     }
 
     @Parcelize
-    data class USBankAccount
+    @Poko
+    class USBankAccount
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     constructor(
         /**
@@ -1222,6 +1328,29 @@ constructor(
     ) : TypeData() {
         override val type: Type get() = Type.USBankAccount
 
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        fun copy(
+            accountHolderType: USBankAccountHolderType = this.accountHolderType,
+            accountType: USBankAccountType = this.accountType,
+            bankName: String? = this.bankName,
+            fingerprint: String? = this.fingerprint,
+            last4: String? = this.last4,
+            financialConnectionsAccount: String? = this.financialConnectionsAccount,
+            networks: USBankNetworks? = this.networks,
+            routingNumber: String? = this.routingNumber
+        ): USBankAccount {
+            return USBankAccount(
+                accountHolderType = accountHolderType,
+                accountType = accountType,
+                bankName = bankName,
+                fingerprint = fingerprint,
+                last4 = last4,
+                financialConnectionsAccount = financialConnectionsAccount,
+                networks = networks,
+                routingNumber = routingNumber
+            )
+        }
+
         @Parcelize
         enum class USBankAccountHolderType(val value: String) : StripeModel {
             UNKNOWN("unknown"),
@@ -1245,10 +1374,60 @@ constructor(
         }
 
         @Parcelize
-        data class USBankNetworks(
+        @Poko
+        class USBankNetworks(
             val preferred: String?,
             val supported: List<String>
         ) : StripeModel
+    }
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    fun copy(
+        id: String = this.id,
+        created: Long? = this.created,
+        liveMode: Boolean = this.liveMode,
+        code: PaymentMethodCode? = this.code,
+        type: Type? = this.type,
+        billingDetails: BillingDetails? = this.billingDetails,
+        customerId: String? = this.customerId,
+        card: Card? = this.card,
+        cardPresent: CardPresent? = this.cardPresent,
+        fpx: Fpx? = this.fpx,
+        ideal: Ideal? = this.ideal,
+        sepaDebit: SepaDebit? = this.sepaDebit,
+        auBecsDebit: AuBecsDebit? = this.auBecsDebit,
+        bacsDebit: BacsDebit? = this.bacsDebit,
+        sofort: Sofort? = this.sofort,
+        upi: Upi? = this.upi,
+        netbanking: Netbanking? = this.netbanking,
+        usBankAccount: USBankAccount? = this.usBankAccount,
+        linkPaymentDetails: LinkPaymentDetails? = this.linkPaymentDetails,
+        isLinkPassthroughMode: Boolean = this.isLinkPassthroughMode,
+        allowRedisplay: AllowRedisplay? = this.allowRedisplay,
+    ): PaymentMethod {
+        return PaymentMethod(
+            id = id,
+            created = created,
+            liveMode = liveMode,
+            code = code,
+            type = type,
+            billingDetails = billingDetails,
+            customerId = customerId,
+            card = card,
+            cardPresent = cardPresent,
+            fpx = fpx,
+            ideal = ideal,
+            sepaDebit = sepaDebit,
+            auBecsDebit = auBecsDebit,
+            bacsDebit = bacsDebit,
+            sofort = sofort,
+            upi = upi,
+            netbanking = netbanking,
+            usBankAccount = usBankAccount,
+            linkPaymentDetails = linkPaymentDetails,
+            isLinkPassthroughMode = isLinkPassthroughMode,
+            allowRedisplay = allowRedisplay,
+        )
     }
 
     companion object {

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
@@ -3,6 +3,7 @@ package com.stripe.android.model
 import android.os.Parcelable
 import androidx.annotation.RestrictTo
 import com.stripe.android.Stripe
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 import kotlinx.parcelize.RawValue
 import org.json.JSONException
@@ -19,12 +20,13 @@ import java.util.Objects
  * See [PaymentMethod] for API object.
  */
 @Parcelize
-data class PaymentMethodCreateParams
+@Poko
+class PaymentMethodCreateParams
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
     internal val code: PaymentMethodCode,
     @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val requiresMandate: Boolean,
-    val card: Card? = null,
+    @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val card: Card? = null,
     private val ideal: Ideal? = null,
     private val fpx: Fpx? = null,
     private val sepaDebit: SepaDebit? = null,
@@ -38,7 +40,7 @@ constructor(
     private val cashAppPay: CashAppPay? = null,
     private val swish: Swish? = null,
     private val shopPay: ShopPay? = null,
-    val billingDetails: PaymentMethod.BillingDetails? = null,
+    @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val billingDetails: PaymentMethod.BillingDetails? = null,
     @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val allowRedisplay: PaymentMethod.AllowRedisplay? = null,
     @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val radarOptions: RadarOptions? = null,
     private val metadata: Map<String, String>? = null,
@@ -57,6 +59,59 @@ constructor(
      */
     private val overrideParamMap: Map<String, @RawValue Any>? = null
 ) : StripeParamsModel, Parcelable {
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    fun copy(
+        code: PaymentMethodCode = this.code,
+        requiresMandate: Boolean = this.requiresMandate,
+        card: Card? = this.card,
+        ideal: Ideal? = this.ideal,
+        fpx: Fpx? = this.fpx,
+        sepaDebit: SepaDebit? = this.sepaDebit,
+        auBecsDebit: AuBecsDebit? = this.auBecsDebit,
+        bacsDebit: BacsDebit? = this.bacsDebit,
+        sofort: Sofort? = this.sofort,
+        upi: Upi? = this.upi,
+        netbanking: Netbanking? = this.netbanking,
+        usBankAccount: USBankAccount? = this.usBankAccount,
+        link: Link? = this.link,
+        cashAppPay: CashAppPay? = this.cashAppPay,
+        swish: Swish? = this.swish,
+        shopPay: ShopPay? = this.shopPay,
+        billingDetails: PaymentMethod.BillingDetails? = this.billingDetails,
+        allowRedisplay: PaymentMethod.AllowRedisplay? = this.allowRedisplay,
+        radarOptions: RadarOptions? = this.radarOptions,
+        metadata: Map<String, String>? = this.metadata,
+        productUsage: Set<String> = this.productUsage,
+        clientAttributionMetadata: ClientAttributionMetadata? = this.clientAttributionMetadata,
+        overrideParamMap: Map<String, @RawValue Any>? = this.overrideParamMap,
+    ): PaymentMethodCreateParams {
+        return PaymentMethodCreateParams(
+            code = code,
+            requiresMandate = requiresMandate,
+            card = card,
+            ideal = ideal,
+            fpx = fpx,
+            sepaDebit = sepaDebit,
+            auBecsDebit = auBecsDebit,
+            bacsDebit = bacsDebit,
+            sofort = sofort,
+            upi = upi,
+            netbanking = netbanking,
+            usBankAccount = usBankAccount,
+            link = link,
+            cashAppPay = cashAppPay,
+            swish = swish,
+            shopPay = shopPay,
+            billingDetails = billingDetails,
+            allowRedisplay = allowRedisplay,
+            radarOptions = radarOptions,
+            metadata = metadata,
+            productUsage = productUsage,
+            clientAttributionMetadata = clientAttributionMetadata,
+            overrideParamMap = overrideParamMap,
+        )
+    }
 
     internal constructor(
         type: PaymentMethod.Type,
@@ -352,7 +407,8 @@ constructor(
     }
 
     @Parcelize
-    data class Card
+    @Poko
+    class Card
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     constructor(
         internal val number: String? = null,
@@ -470,7 +526,8 @@ constructor(
     }
 
     @Parcelize
-    data class Ideal(
+    @Poko
+    class Ideal(
         var bank: String?
     ) : StripeParamsModel, Parcelable {
         override fun toParamMap(): Map<String, Any> {
@@ -483,7 +540,8 @@ constructor(
     }
 
     @Parcelize
-    data class Fpx(
+    @Poko
+    class Fpx(
         var bank: String?
     ) : StripeParamsModel, Parcelable {
         override fun toParamMap(): Map<String, Any> {
@@ -498,7 +556,8 @@ constructor(
     }
 
     @Parcelize
-    data class Upi(
+    @Poko
+    class Upi(
         private val vpa: String?
     ) : StripeParamsModel, Parcelable {
         override fun toParamMap(): Map<String, Any> {
@@ -513,7 +572,8 @@ constructor(
     }
 
     @Parcelize
-    data class SepaDebit(
+    @Poko
+    class SepaDebit(
         var iban: String?
     ) : StripeParamsModel, Parcelable {
         override fun toParamMap(): Map<String, Any> {
@@ -528,7 +588,8 @@ constructor(
     }
 
     @Parcelize
-    data class AuBecsDebit(
+    @Poko
+    class AuBecsDebit(
         var bsbNumber: String,
         var accountNumber: String
     ) : StripeParamsModel, Parcelable {
@@ -552,7 +613,8 @@ constructor(
      * See [https://stripe.com/docs/api/payment_methods/create#create_payment_method-bacs_debit](https://stripe.com/docs/api/payment_methods/create#create_payment_method-bacs_debit)
      */
     @Parcelize
-    data class BacsDebit(
+    @Poko
+    class BacsDebit(
         /**
          * The bank account number (e.g. 00012345)
          */
@@ -599,7 +661,8 @@ constructor(
     }
 
     @Parcelize
-    data class Sofort(
+    @Poko
+    class Sofort(
         internal var country: String
     ) : StripeParamsModel, Parcelable {
         override fun toParamMap(): Map<String, Any> {
@@ -614,7 +677,8 @@ constructor(
     }
 
     @Parcelize
-    data class Netbanking(
+    @Poko
+    class Netbanking(
         internal var bank: String
     ) : StripeParamsModel, Parcelable {
         override fun toParamMap(): Map<String, Any> {
@@ -646,7 +710,8 @@ constructor(
 
     @Parcelize
     @Suppress("DataClassPrivateConstructor")
-    data class USBankAccount private constructor(
+    @Poko
+    class USBankAccount private constructor(
         internal var linkAccountSessionId: String? = null,
         internal var accountNumber: String? = null,
         internal var routingNumber: String? = null,
@@ -701,7 +766,8 @@ constructor(
     }
 
     @Parcelize
-    data class Link(
+    @Poko
+    class Link(
         internal var paymentDetailsId: String,
         internal var consumerSessionClientSecret: String,
         internal var extraParams: Map<String, @RawValue Any>? = null
@@ -726,7 +792,8 @@ constructor(
     }
 
     @Parcelize
-    data class ShopPay(
+    @Poko
+    class ShopPay(
         internal var externalSourceId: String
     ) : StripeParamsModel, Parcelable {
         override fun toParamMap(): Map<String, Any> {

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethodOptionsParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethodOptionsParams.kt
@@ -2,6 +2,7 @@ package com.stripe.android.model
 
 import android.os.Parcelable
 import androidx.annotation.RestrictTo
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
 sealed class PaymentMethodOptionsParams(
@@ -24,7 +25,8 @@ sealed class PaymentMethodOptionsParams(
     }
 
     @Parcelize
-    data class Card
+    @Poko
+    class Card
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     constructor(
         var cvc: String? = null,
@@ -50,6 +52,21 @@ sealed class PaymentMethodOptionsParams(
                 PARAM_NETWORK to network,
                 PARAM_MOTO to moto,
                 PARAM_SETUP_FUTURE_USAGE to setupFutureUsage?.code
+            )
+        }
+
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        fun copy(
+            cvc: String? = this.cvc,
+            network: String? = this.network,
+            setupFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage? = this.setupFutureUsage,
+            moto: Boolean? = this.moto
+        ): Card {
+            return Card(
+                cvc = cvc,
+                network = network,
+                setupFutureUsage = setupFutureUsage,
+                moto = moto
             )
         }
 
@@ -79,10 +96,20 @@ sealed class PaymentMethodOptionsParams(
     }
 
     @Parcelize
-    data class Blik @JvmOverloads constructor(
+    @Poko
+    class Blik @JvmOverloads constructor(
         var code: String,
         var setupFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage? = null,
     ) : PaymentMethodOptionsParams(PaymentMethod.Type.Blik) {
+        internal fun copy(
+            setupFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage? = this.setupFutureUsage
+        ): Blik {
+            return Blik(
+                code = code,
+                setupFutureUsage = setupFutureUsage,
+            )
+        }
+
         override fun createTypeParams(): List<Pair<String, Any?>> {
             return listOf(
                 PARAM_CODE to code,
@@ -132,10 +159,20 @@ sealed class PaymentMethodOptionsParams(
     }
 
     @Parcelize
-    data class WeChatPay @JvmOverloads constructor(
+    @Poko
+    class WeChatPay @JvmOverloads constructor(
         var appId: String,
         var setupFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage? = null,
     ) : PaymentMethodOptionsParams(PaymentMethod.Type.WeChatPay) {
+        internal fun copy(
+            setupFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage? = this.setupFutureUsage
+        ): WeChatPay {
+            return WeChatPay(
+                appId = appId,
+                setupFutureUsage = setupFutureUsage,
+            )
+        }
+
         override fun createTypeParams(): List<Pair<String, Any?>> {
             return listOf(
                 PARAM_CLIENT to "android",
@@ -170,9 +207,18 @@ sealed class PaymentMethodOptionsParams(
     }
 
     @Parcelize
-    data class USBankAccount(
+    @Poko
+    class USBankAccount(
         var setupFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage? = null
     ) : PaymentMethodOptionsParams(PaymentMethod.Type.USBankAccount) {
+        internal fun copy(
+            setupFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage? = this.setupFutureUsage
+        ): USBankAccount {
+            return USBankAccount(
+                setupFutureUsage = setupFutureUsage,
+            )
+        }
+
         override fun createTypeParams(): List<Pair<String, Any?>> {
             return listOf(
                 PARAM_SETUP_FUTURE_USAGE to setupFutureUsage?.code

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethodPreference.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethodPreference.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.model
 
 import com.stripe.android.core.model.StripeModel
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -8,7 +9,8 @@ import kotlinx.parcelize.Parcelize
  * about the behaviors/features of the UI.
  */
 @Parcelize
-data class PaymentMethodPreference(
+@Poko
+class PaymentMethodPreference(
     val intent: StripeIntent,
     val formUI: String? = null
 ) : StripeModel

--- a/payments-core/src/main/java/com/stripe/android/model/PersonTokenParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PersonTokenParams.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.model
 
 import android.os.Parcelable
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -11,72 +12,73 @@ import kotlinx.parcelize.Parcelize
  * See [Create a person token](https://stripe.com/docs/api/tokens/create_person)
  */
 @Parcelize
-data class PersonTokenParams(
+@Poko
+class PersonTokenParams(
     /**
-     * The person’s address.
+     * The person's address.
      *
      * [person.address](https://stripe.com/docs/api/tokens/create_person#create_person_token-person-address)
      */
     val address: Address? = null,
 
     /**
-     * The Kana variation of the person’s address (Japan only).
+     * The Kana variation of the person's address (Japan only).
      *
      * [person.address_kana](https://stripe.com/docs/api/tokens/create_person#create_person_token-person-address_kana)
      */
     val addressKana: AddressJapanParams? = null,
 
     /**
-     * The Kanji variation of the person’s address (Japan only).
+     * The Kanji variation of the person's address (Japan only).
      *
      * [person.address_kanji](https://stripe.com/docs/api/tokens/create_person#create_person_token-person-address_kanji)
      */
     val addressKanji: AddressJapanParams? = null,
 
     /**
-     * The person’s date of birth.
+     * The person's date of birth.
      *
      * [person.dob](https://stripe.com/docs/api/tokens/create_person#create_person_token-person-dob)
      */
     val dateOfBirth: DateOfBirth? = null,
 
     /**
-     * The person’s email address.
+     * The person's email address.
      *
      * [person.email](https://stripe.com/docs/api/tokens/create_person#create_person_token-person-email)
      */
     val email: String? = null,
 
     /**
-     * The person’s first name.
+     * The person's first name.
      *
      * [person.first_name](https://stripe.com/docs/api/tokens/create_person#create_person_token-person-first_name)
      */
     val firstName: String? = null,
 
     /**
-     * The Kana variation of the person’s first name (Japan only).
+     * The Kana variation of the person's first name (Japan only).
      *
      * [person.first_name_kana](https://stripe.com/docs/api/tokens/create_person#create_person_token-person-first_name_kana)
      */
     val firstNameKana: String? = null,
 
     /**
-     * The Kanji variation of the person’s first name (Japan only).
+     * The Kanji variation of the person's first name (Japan only).
      *
      * [person.first_name_kanji](https://stripe.com/docs/api/tokens/create_person#create_person_token-person-first_name_kanji)
      */
     val firstNameKanji: String? = null,
 
     /**
-     * The person’s gender (International regulations require either “male” or “female”).
+     * The person's gender (International regulations require either "male" or "female").
      *
      * [person.gender](https://stripe.com/docs/api/tokens/create_person#create_person_token-person-gender)
      */
     val gender: String? = null,
 
     /**
-     * The person’s ID number, as appropriate for their country. For example, a social security
+     * The person's ID number, as appropriate for their country. For example, a social security
      * number in the U.S., social insurance number in Canada, etc. Instead of the number itself,
      * you can also provide a PII token.
      *
@@ -85,28 +87,28 @@ data class PersonTokenParams(
     val idNumber: String? = null,
 
     /**
-     * The person’s last name.
+     * The person's last name.
      *
      * [person.last_name](https://stripe.com/docs/api/tokens/create_person#create_person_token-person-last_name)
      */
     val lastName: String? = null,
 
     /**
-     * The Kana variation of the person’s last name (Japan only).
+     * The Kana variation of the person's last name (Japan only).
      *
      * [person.last_name_kana](https://stripe.com/docs/api/tokens/create_person#create_person_token-person-last_name_kana)
      */
     val lastNameKana: String? = null,
 
     /**
-     * The Kanji variation of the person’s last name (Japan only).
+     * The Kanji variation of the person's last name (Japan only).
      *
      * [person.last_name_kanji](https://stripe.com/docs/api/tokens/create_person#create_person_token-person-last_name_kanji)
      */
     val lastNameKanji: String? = null,
 
     /**
-     * The person’s maiden name.
+     * The person's maiden name.
      *
      * [person.maiden_name](https://stripe.com/docs/api/tokens/create_person#create_person_token-person-maiden_name)
      */
@@ -123,28 +125,28 @@ data class PersonTokenParams(
     val metadata: Map<String, String>? = null,
 
     /**
-     * The person’s phone number.
+     * The person's phone number.
      *
      * [person.phone](https://stripe.com/docs/api/tokens/create_person#create_person_token-person-phone)
      */
     val phone: String? = null,
 
     /**
-     * The relationship that this person has with the account’s legal entity.
+     * The relationship that this person has with the account's legal entity.
      *
      * [person.relationship](https://stripe.com/docs/api/tokens/create_person#create_person_token-person-relationship)
      */
     val relationship: Relationship? = null,
 
     /**
-     * The last 4 digits of the person’s social security number.
+     * The last 4 digits of the person's social security number.
      *
      * [person.ssn_last_4](https://stripe.com/docs/api/tokens/create_person#create_person_token-person-ssn_last_4)
      */
     val ssnLast4: String? = null,
 
     /**
-     * The person’s verification status.
+     * The person's verification status.
      *
      * [person.verification](https://stripe.com/docs/api/tokens/create_person#create_person_token-person-verification)
      */
@@ -178,14 +180,15 @@ data class PersonTokenParams(
         }
 
     /**
-     * The relationship that this person has with the account’s legal entity.
+     * The relationship that this person has with the account's legal entity.
      *
      * [person.relationship](https://stripe.com/docs/api/tokens/create_person#create_person_token-person-relationship)
      */
     @Parcelize
-    data class Relationship(
+    @Poko
+    class Relationship(
         /**
-         * Whether the person is a director of the account’s legal entity. Currently only required
+         * Whether the person is a director of the account's legal entity. Currently only required
          * for accounts in the EU. Directors are typically members of the governing board of the
          * company, or responsible for ensuring the company meets its regulatory obligations.
          *
@@ -202,14 +205,14 @@ data class PersonTokenParams(
         val executive: Boolean? = null,
 
         /**
-         * Whether the person is an owner of the account’s legal entity.
+         * Whether the person is an owner of the account's legal entity.
          *
          * [person.relationship.owner](https://stripe.com/docs/api/tokens/create_person#create_person_token-person-relationship-owner)
          */
         val owner: Boolean? = null,
 
         /**
-         * The percent owned by the person of the account’s legal entity.
+         * The percent owned by the person of the account's legal entity.
          *
          * [person.relationship.representative](https://stripe.com/docs/api/tokens/create_person#create_person_token-person-relationship-representative)
          */
@@ -227,7 +230,7 @@ data class PersonTokenParams(
         val representative: Boolean? = null,
 
         /**
-         * The person’s title (e.g., CEO, Support Engineer).
+         * The person's title (e.g., CEO, Support Engineer).
          *
          * [person.relationship.title](https://stripe.com/docs/api/tokens/create_person#create_person_token-person-relationship-title)
          */
@@ -303,12 +306,13 @@ data class PersonTokenParams(
     }
 
     /**
-     * The person’s verification status.
+     * The person's verification status.
      *
      * [person.verification](https://stripe.com/docs/api/tokens/create_person#create_person_token-person-verification)
      */
     @Parcelize
-    data class Verification @JvmOverloads constructor(
+    @Poko
+    class Verification @JvmOverloads constructor(
         /**
          * An identifying document, either a passport or local ID card.
          *
@@ -341,7 +345,8 @@ data class PersonTokenParams(
     }
 
     @Parcelize
-    data class Document @JvmOverloads constructor(
+    @Poko
+    class Document @JvmOverloads constructor(
         /**
          * The front of an ID returned by a
          * [file upload](https://stripe.com/docs/api/tokens/create_person#create_file) with a

--- a/payments-core/src/main/java/com/stripe/android/model/PossibleBrands.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PossibleBrands.kt
@@ -1,9 +1,11 @@
 package com.stripe.android.model
 
 import com.stripe.android.core.model.StripeModel
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-data class PossibleBrands(
+@Poko
+class PossibleBrands(
     val brands: List<CardBrand>
 ) : StripeModel

--- a/payments-core/src/main/java/com/stripe/android/model/RadarSession.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/RadarSession.kt
@@ -1,9 +1,11 @@
 package com.stripe.android.model
 
 import com.stripe.android.core.model.StripeModel
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-data class RadarSession(
+@Poko
+class RadarSession(
     val id: String
 ) : StripeModel

--- a/payments-core/src/main/java/com/stripe/android/model/SetupIntent.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/SetupIntent.kt
@@ -4,6 +4,7 @@ import androidx.annotation.RestrictTo
 import com.stripe.android.core.model.StripeJsonUtils
 import com.stripe.android.core.model.StripeModel
 import com.stripe.android.model.parsers.SetupIntentJsonParser
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 import org.json.JSONObject
 import java.util.regex.Pattern
@@ -16,7 +17,8 @@ import java.util.regex.Pattern
  * - [SetupIntents API Reference](https://stripe.com/docs/api/setup_intents)
  */
 @Parcelize
-data class SetupIntent
+@Poko
+class SetupIntent
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
     /**
@@ -180,7 +182,8 @@ constructor(
      * See [last_setup_error](https://stripe.com/docs/api/setup_intents/object#setup_intent_object-last_setup_error).
      */
     @Parcelize
-    data class Error internal constructor(
+    @Poko
+    class Error internal constructor(
 
         /**
          * For some errors that could be handled programmatically, a short string indicating the
@@ -239,6 +242,26 @@ constructor(
             }
         }
 
+        internal fun copy(
+            code: String? = this.code,
+            declineCode: String? = this.declineCode,
+            docUrl: String? = this.docUrl,
+            message: String? = this.message,
+            param: String? = this.param,
+            paymentMethod: PaymentMethod? = this.paymentMethod,
+            type: Type? = this.type
+        ): Error {
+            return Error(
+                code = code,
+                declineCode = declineCode,
+                docUrl = docUrl,
+                message = message,
+                param = param,
+                paymentMethod = paymentMethod,
+                type = type
+            )
+        }
+
         internal companion object {
             internal const val CODE_AUTHENTICATION_ERROR = "setup_intent_authentication_failure"
         }
@@ -275,6 +298,49 @@ constructor(
                 return entries.firstOrNull { it.code == code }
             }
         }
+    }
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    fun copy(
+        id: String? = this.id,
+        cancellationReason: CancellationReason? = this.cancellationReason,
+        created: Long = this.created,
+        countryCode: String? = this.countryCode,
+        clientSecret: String? = this.clientSecret,
+        description: String? = this.description,
+        isLiveMode: Boolean = this.isLiveMode,
+        paymentMethod: PaymentMethod? = this.paymentMethod,
+        paymentMethodId: String? = this.paymentMethodId,
+        paymentMethodTypes: List<String> = this.paymentMethodTypes,
+        status: StripeIntent.Status? = this.status,
+        usage: StripeIntent.Usage? = this.usage,
+        lastSetupError: Error? = this.lastSetupError,
+        unactivatedPaymentMethods: List<String> = this.unactivatedPaymentMethods,
+        linkFundingSources: List<String> = this.linkFundingSources,
+        nextActionData: StripeIntent.NextActionData? = this.nextActionData,
+        paymentMethodOptionsJsonString: String? = this.paymentMethodOptionsJsonString,
+        automaticPaymentMethodsEnabled: Boolean = this.automaticPaymentMethodsEnabled,
+    ): SetupIntent {
+        return SetupIntent(
+            id = id,
+            cancellationReason = cancellationReason,
+            created = created,
+            countryCode = countryCode,
+            clientSecret = clientSecret,
+            description = description,
+            isLiveMode = isLiveMode,
+            paymentMethod = paymentMethod,
+            paymentMethodId = paymentMethodId,
+            paymentMethodTypes = paymentMethodTypes,
+            status = status,
+            usage = usage,
+            lastSetupError = lastSetupError,
+            unactivatedPaymentMethods = unactivatedPaymentMethods,
+            linkFundingSources = linkFundingSources,
+            nextActionData = nextActionData,
+            paymentMethodOptionsJsonString = paymentMethodOptionsJsonString,
+            automaticPaymentMethodsEnabled = automaticPaymentMethodsEnabled,
+        )
     }
 
     companion object {

--- a/payments-core/src/main/java/com/stripe/android/model/ShippingInformation.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ShippingInformation.kt
@@ -1,13 +1,15 @@
 package com.stripe.android.model
 
 import com.stripe.android.core.model.StripeModel
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
 /**
  * Model representing a shipping address object
  */
 @Parcelize
-data class ShippingInformation constructor(
+@Poko
+class ShippingInformation constructor(
     val address: Address? = null,
     val name: String? = null,
     val phone: String? = null

--- a/payments-core/src/main/java/com/stripe/android/model/ShippingMethod.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ShippingMethod.kt
@@ -2,6 +2,7 @@ package com.stripe.android.model
 
 import androidx.annotation.Size
 import com.stripe.android.core.model.StripeModel
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 import java.util.Currency
 
@@ -9,7 +10,8 @@ import java.util.Currency
  * Model representing a shipping method in the Android SDK.
  */
 @Parcelize
-data class ShippingMethod @JvmOverloads constructor(
+@Poko
+class ShippingMethod @JvmOverloads constructor(
     /**
      * Human friendly label specifying the shipping method that can be shown in the UI.
      */

--- a/payments-core/src/main/java/com/stripe/android/model/Source.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/Source.kt
@@ -4,6 +4,7 @@ import androidx.annotation.Keep
 import androidx.annotation.StringDef
 import com.stripe.android.core.model.StripeModel
 import com.stripe.android.model.parsers.SourceJsonParser
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 import kotlinx.parcelize.RawValue
 import org.json.JSONObject
@@ -233,7 +234,8 @@ data class Source internal constructor(
      * redirect ([flow] is [Flow.Redirect]).
      */
     @Parcelize
-    data class Redirect(
+    @Poko
+    class Redirect(
         /**
          * The URL you provide to redirect the customer to after they authenticated their payment.
          */
@@ -395,7 +397,8 @@ data class Source internal constructor(
     ) : StripeModel
 
     @Parcelize
-    data class Klarna(
+    @Poko
+    class Klarna(
         val firstName: String?,
         val lastName: String?,
         val purchaseCountry: String?,

--- a/payments-core/src/main/java/com/stripe/android/model/SourceOrderParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/SourceOrderParams.kt
@@ -1,25 +1,25 @@
 package com.stripe.android.model
 
 import android.os.Parcelable
-import com.stripe.android.model.SourceOrderParams.Item.Type
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
 /**
- * Information about the items and shipping associated with the source. Required for transactional
- * credit (for example Klarna) sources before you can charge it.
+ * Source order parameters.
  *
- * [API reference](https://stripe.com/docs/api/sources/create#create_source-source_order)
+ * See [Source Orders](https://stripe.com/docs/sources/redirect#source-orders).
  */
 @Parcelize
-data class SourceOrderParams @JvmOverloads constructor(
+@Poko
+class SourceOrderParams @JvmOverloads constructor(
     /**
      * List of items constituting the order.
      */
-    val items: List<Item>? = null,
+    val items: List<Item>,
 
     /**
-     * Shipping address for the order. Required if any of the SKUs are for products that have
-     * `shippable` set to true.
+     * The shipping address for the order. A dictionary containing the fields defined in the
+     * [Address](https://stripe.com/docs/api#address_object) API reference.
      */
     val shipping: Shipping? = null
 ) : StripeParamsModel, Parcelable {
@@ -40,7 +40,8 @@ data class SourceOrderParams @JvmOverloads constructor(
      * [API reference](https://stripe.com/docs/api/sources/create#create_source-source_order-items)
      */
     @Parcelize
-    data class Item(
+    @Poko
+    class Item(
         /**
          * Optional. The type of this order item.
          * Must be [Type.Sku], [Type.Tax], or [Type.Shipping].
@@ -113,13 +114,14 @@ data class SourceOrderParams @JvmOverloads constructor(
     }
 
     /**
-     * Shipping address for the order.
-     * Required if any of the SKUs are for products that have `shippable` set to true.
+     * Shipping address for the order. Required if any of the SKUs are for products that have
+     * `shippable` set to true.
      *
      * [API reference](https://stripe.com/docs/api/sources/create#create_source-source_order-shipping)
      */
     @Parcelize
-    data class Shipping(
+    @Poko
+    class Shipping(
         /**
          * Required. Shipping address.
          */

--- a/payments-core/src/main/java/com/stripe/android/model/SourceParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/SourceParams.kt
@@ -7,6 +7,7 @@ import androidx.annotation.Size
 import com.stripe.android.core.model.StripeJsonUtils
 import com.stripe.android.model.Source.Companion.asSourceType
 import com.stripe.android.model.Source.SourceType
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parceler
 import kotlinx.parcelize.Parcelize
 import org.json.JSONException
@@ -16,7 +17,8 @@ import org.json.JSONObject
  * Represents a grouping of parameters needed to create a [Source] object on the server.
  */
 @Parcelize
-data class SourceParams internal constructor(
+@Poko
+class SourceParams internal constructor(
     /**
      * The type of the source to create.
      */
@@ -194,7 +196,8 @@ data class SourceParams internal constructor(
     }
 
     @Parcelize
-    internal data class WeChatParams(
+    @Poko
+    internal class WeChatParams(
         private val appId: String? = null,
         private val statementDescriptor: String? = null
     ) : StripeParamsModel, Parcelable {
@@ -225,7 +228,8 @@ data class SourceParams internal constructor(
      * See [owner](https://stripe.com/docs/api/sources/create#create_source-owner).
      */
     @Parcelize
-    data class OwnerParams @JvmOverloads constructor(
+    @Poko
+    class OwnerParams @JvmOverloads constructor(
         internal var address: Address? = null,
         internal var email: String? = null,
         internal var name: String? = null,
@@ -885,7 +889,8 @@ data class SourceParams internal constructor(
     }
 
     @Parcelize
-    internal data class ApiParams(
+    @Poko
+    internal class ApiParams(
         val value: Map<String, Any?> = emptyMap()
     ) : Parcelable {
         internal companion object : Parceler<ApiParams> {
@@ -927,7 +932,8 @@ data class SourceParams internal constructor(
         }
 
         @Parcelize
-        data class Card(
+        @Poko
+        class Card(
             /**
              * The [number] of this card
              */
@@ -972,7 +978,8 @@ data class SourceParams internal constructor(
         }
 
         @Parcelize
-        data class Eps(
+        @Poko
+        class Eps(
             var statementDescriptor: String? = null
         ) : TypeData() {
             override val type: String get() = SourceType.EPS
@@ -986,7 +993,8 @@ data class SourceParams internal constructor(
         }
 
         @Parcelize
-        data class Ideal(
+        @Poko
+        class Ideal(
             var statementDescriptor: String? = null,
             var bank: String? = null
         ) : TypeData() {
@@ -1005,7 +1013,8 @@ data class SourceParams internal constructor(
         }
 
         @Parcelize
-        data class Masterpass(
+        @Poko
+        class Masterpass(
             var transactionId: String,
             var cartId: String
         ) : TypeData() {
@@ -1027,7 +1036,8 @@ data class SourceParams internal constructor(
         }
 
         @Parcelize
-        data class Sofort(
+        @Poko
+        class Sofort(
             @Size(2) var country: String,
             var statementDescriptor: String? = null
         ) : TypeData() {
@@ -1046,7 +1056,8 @@ data class SourceParams internal constructor(
         }
 
         @Parcelize
-        data class SepaDebit(
+        @Poko
+        class SepaDebit(
             var iban: String
         ) : TypeData() {
             override val type: String get() = SourceType.SEPA_DEBIT
@@ -1060,7 +1071,8 @@ data class SourceParams internal constructor(
         }
 
         @Parcelize
-        data class ThreeDSecure(
+        @Poko
+        class ThreeDSecure(
             var cardId: String
         ) : TypeData() {
             override val type: String get() = SourceType.THREE_D_SECURE
@@ -1074,7 +1086,8 @@ data class SourceParams internal constructor(
         }
 
         @Parcelize
-        data class VisaCheckout(
+        @Poko
+        class VisaCheckout(
             var callId: String
         ) : TypeData() {
             override val type: String get() = SourceType.CARD
@@ -1093,7 +1106,8 @@ data class SourceParams internal constructor(
         }
 
         @Parcelize
-        data class Bancontact(
+        @Poko
+        class Bancontact(
             var statementDescriptor: String? = null,
             var preferredLanguage: String? = null
         ) : TypeData() {

--- a/payments-core/src/main/java/com/stripe/android/model/StripeIntent.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/StripeIntent.kt
@@ -6,6 +6,7 @@ import androidx.annotation.Keep
 import androidx.annotation.RestrictTo
 import com.stripe.android.core.model.StripeModel
 import com.stripe.android.utils.StripeUrlUtils
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -251,7 +252,8 @@ sealed interface StripeIntent : StripeModel {
          * page or application.
          */
         @Parcelize
-        data class RedirectToUrl(
+        @Poko
+        class RedirectToUrl(
             /**
              * The URL you must redirect your customer to in order to authenticate.
              */
@@ -309,7 +311,8 @@ sealed interface StripeIntent : StripeModel {
              * different than the original merchant's key.
              */
             @Parcelize
-            data class Use3DS2(
+            @Poko
+            class Use3DS2(
                 val source: String,
                 val serverName: String,
                 val transactionId: String,
@@ -318,7 +321,8 @@ sealed interface StripeIntent : StripeModel {
                 val publishableKey: String?
             ) : SdkData() {
                 @Parcelize
-                data class DirectoryServerEncryption(
+                @Poko
+                class DirectoryServerEncryption(
                     val directoryServerId: String,
                     val dsCertificateData: String,
                     val rootCertsData: List<String>,
@@ -335,7 +339,8 @@ sealed interface StripeIntent : StripeModel {
         data class WeChatPayRedirect(val weChat: WeChat) : NextActionData()
 
         @Parcelize
-        data class VerifyWithMicrodeposits(
+        @Poko
+        class VerifyWithMicrodeposits(
             val arrivalDate: Long,
             val hostedVerificationUrl: String,
             val microdepositType: MicrodepositType
@@ -348,7 +353,8 @@ sealed interface StripeIntent : StripeModel {
          * Contains the authentication URL for redirecting your customer to Cash App.
          */
         @Parcelize
-        data class CashAppRedirect(
+        @Poko
+        class CashAppRedirect(
             val mobileAuthUrl: String,
         ) : NextActionData()
 
@@ -356,7 +362,8 @@ sealed interface StripeIntent : StripeModel {
          * Contains the authentication URL for redirecting your customer to Swish.
          */
         @Parcelize
-        data class SwishRedirect(
+        @Poko
+        class SwishRedirect(
             val mobileAuthUrl: String,
         ) : NextActionData()
     }

--- a/payments-core/src/main/java/com/stripe/android/model/WeChat.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/WeChat.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.model
 
 import com.stripe.android.core.model.StripeModel
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -9,7 +10,8 @@ import kotlinx.parcelize.Parcelize
  * [WeChat Pay Payments with PaymentIntents](https://stripe.com/docs/payments/wechat-pay/accept-a-payment?platform=android)
  */
 @Parcelize
-data class WeChat constructor(
+@Poko
+class WeChat constructor(
     val statementDescriptor: String? = null,
     val appId: String?,
     val nonce: String?,

--- a/payments-core/src/main/java/com/stripe/android/model/wallets/Wallet.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/wallets/Wallet.kt
@@ -1,9 +1,9 @@
 package com.stripe.android.model.wallets
 
-import android.os.Parcelable
 import androidx.annotation.RestrictTo
 import com.stripe.android.core.model.StripeModel
 import com.stripe.android.model.Address
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -17,25 +17,28 @@ sealed class Wallet(
 ) : StripeModel {
 
     @Parcelize
-    data class AmexExpressCheckoutWallet
+    @Poko
+    class AmexExpressCheckoutWallet
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     constructor(
         val dynamicLast4: String?
     ) : Wallet(Type.AmexExpressCheckout)
 
     @Parcelize
-    data class ApplePayWallet
+    @Poko
+    class ApplePayWallet
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     constructor(
         val dynamicLast4: String?
     ) : Wallet(Type.ApplePay)
 
     @Parcelize
-    data class GooglePayWallet
+    @Poko
+    class GooglePayWallet
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     constructor(
         val dynamicLast4: String?
-    ) : Wallet(Type.GooglePay), Parcelable
+    ) : Wallet(Type.GooglePay)
 
     @Parcelize
     data class MasterpassWallet internal constructor(
@@ -46,7 +49,8 @@ sealed class Wallet(
     ) : Wallet(Type.Masterpass)
 
     @Parcelize
-    data class SamsungPayWallet
+    @Poko
+    class SamsungPayWallet
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     constructor(
         val dynamicLast4: String?
@@ -62,7 +66,8 @@ sealed class Wallet(
     ) : Wallet(Type.VisaCheckout)
 
     @Parcelize
-    data class LinkWallet
+    @Poko
+    class LinkWallet
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     constructor(
         val dynamicLast4: String?

--- a/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResult.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResult.kt
@@ -9,6 +9,7 @@ import com.stripe.android.PaymentController
 import com.stripe.android.StripeIntentResult
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.model.Source
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parceler
 import kotlinx.parcelize.Parcelize
 
@@ -23,7 +24,8 @@ import kotlinx.parcelize.Parcelize
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 sealed class PaymentFlowResult {
     @Parcelize
-    data class Unvalidated constructor(
+    @Poko
+    class Unvalidated(
         val clientSecret: String? = null,
         @StripeIntentResult.Outcome val flowOutcome: Int = StripeIntentResult.Outcome.UNKNOWN,
         val exception: StripeException? = null,

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/CollectBankAccountLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/CollectBankAccountLauncher.kt
@@ -16,6 +16,7 @@ import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResu
 import com.stripe.android.payments.bankaccount.navigation.toUSBankAccountResult
 import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 import com.stripe.android.payments.financialconnections.GetFinancialConnectionsAvailability
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -161,10 +162,11 @@ interface CollectBankAccountLauncher {
 sealed interface CollectBankAccountConfiguration : Parcelable {
 
     @Parcelize
-    data class USBankAccount(
+    @Poko
+    class USBankAccount(
         val name: String,
         val email: String?
-    ) : Parcelable, CollectBankAccountConfiguration
+    ) : CollectBankAccountConfiguration
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Parcelize

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/navigation/CollectBankAccountResult.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/navigation/CollectBankAccountResult.kt
@@ -5,6 +5,7 @@ import androidx.annotation.RestrictTo
 import com.stripe.android.core.model.StripeModel
 import com.stripe.android.financialconnections.model.FinancialConnectionsSession
 import com.stripe.android.model.StripeIntent
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -13,12 +14,14 @@ import kotlinx.parcelize.Parcelize
 sealed class CollectBankAccountResult : Parcelable {
 
     @Parcelize
-    data class Completed(
+    @Poko
+    class Completed(
         val response: CollectBankAccountResponse
     ) : CollectBankAccountResult()
 
     @Parcelize
-    data class Failed(
+    @Poko
+    class Failed(
         val error: Throwable
     ) : CollectBankAccountResult()
 
@@ -27,7 +30,8 @@ sealed class CollectBankAccountResult : Parcelable {
 }
 
 @Parcelize
-data class CollectBankAccountResponse(
+@Poko
+class CollectBankAccountResponse(
     val intent: StripeIntent,
     val financialConnectionsSession: FinancialConnectionsSession
 ) : StripeModel

--- a/payments-core/src/main/java/com/stripe/android/view/BecsDebitBanks.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/BecsDebitBanks.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.os.Parcelable
 import androidx.annotation.RestrictTo
 import com.stripe.android.core.model.StripeJsonUtils
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 import org.json.JSONObject
 import java.util.Scanner
@@ -30,7 +31,8 @@ class BecsDebitBanks(
     }
 
     @Parcelize
-    data class Bank(
+    @Poko
+    class Bank(
         val prefix: String,
         val name: String
     ) : Parcelable

--- a/payments-core/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.kt
@@ -134,12 +134,15 @@ class PaymentAuthWebViewActivity : AppCompatActivity() {
             setResult(
                 Activity.RESULT_OK,
                 createResultIntent(
-                    viewModel.paymentResult
-                        .copy(
-                            exception = StripeException.create(error),
-                            flowOutcome = StripeIntentResult.Outcome.FAILED,
-                            canCancelSource = true
-                        )
+                    PaymentFlowResult.Unvalidated(
+                        clientSecret = viewModel.paymentResult.clientSecret,
+                        flowOutcome = StripeIntentResult.Outcome.FAILED,
+                        exception = StripeException.create(error),
+                        canCancelSource = true,
+                        sourceId = viewModel.paymentResult.sourceId,
+                        source = viewModel.paymentResult.source,
+                        stripeAccountId = viewModel.paymentResult.stripeAccountId
+                    )
                 )
             )
         } else {

--- a/payments-core/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModel.kt
@@ -62,13 +62,18 @@ internal class PaymentAuthWebViewActivityViewModel(
         @JvmSynthetic
         get() {
             return Intent().putExtras(
-                paymentResult.copy(
+                PaymentFlowResult.Unvalidated(
+                    clientSecret = paymentResult.clientSecret,
                     flowOutcome = if (args.shouldCancelIntentOnUserNavigation) {
                         StripeIntentResult.Outcome.CANCELED
                     } else {
                         StripeIntentResult.Outcome.UNKNOWN
                     },
-                    canCancelSource = args.shouldCancelSource
+                    exception = paymentResult.exception,
+                    canCancelSource = args.shouldCancelSource,
+                    sourceId = paymentResult.sourceId,
+                    source = paymentResult.source,
+                    stripeAccountId = paymentResult.stripeAccountId
                 ).toBundle()
             )
         }

--- a/payments-core/src/test/java/com/stripe/android/EphemeralKeyFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/EphemeralKeyFixtures.kt
@@ -49,3 +49,25 @@ internal object EphemeralKeyFixtures {
         )
     }
 }
+
+internal fun EphemeralKey.copy(
+    objectId: String = this.objectId,
+    created: Long = this.created,
+    expires: Long = this.expires,
+    id: String = this.id,
+    isLiveMode: Boolean = this.isLiveMode,
+    objectType: String = this.objectType,
+    secret: String = this.secret,
+    type: String = this.type
+): EphemeralKey {
+    return EphemeralKey(
+        objectId = objectId,
+        created = created,
+        expires = expires,
+        id = id,
+        isLiveMode = isLiveMode,
+        objectType = objectType,
+        secret = secret,
+        type = type
+    )
+}

--- a/payments-core/src/test/java/com/stripe/android/PaymentMethodEndToEndTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/PaymentMethodEndToEndTest.kt
@@ -80,7 +80,7 @@ internal class PaymentMethodEndToEndTest {
     @Test
     fun createPaymentMethod_withBancontact_missingName_shouldFail() {
         val params = PaymentMethodCreateParams.createBancontact(
-            billingDetails = PaymentMethodCreateParamsFixtures.BILLING_DETAILS.copy(name = null)
+            billingDetails = PaymentMethodCreateParamsFixtures.BILLING_DETAILS.toBuilder().setName(null).build()
         )
 
         val exception = assertFailsWith<InvalidRequestException>(
@@ -122,7 +122,7 @@ internal class PaymentMethodEndToEndTest {
     @Test
     fun createPaymentMethod_withUSBankAccount_missingEmail_shouldCreateObject() {
         val params = PaymentMethodCreateParamsFixtures.US_BANK_ACCOUNT.copy(
-            billingDetails = PaymentMethodCreateParamsFixtures.BILLING_DETAILS.copy(email = null)
+            billingDetails = PaymentMethodCreateParamsFixtures.BILLING_DETAILS.toBuilder().setEmail(null).build()
         )
         val paymentMethod =
             Stripe(
@@ -136,7 +136,7 @@ internal class PaymentMethodEndToEndTest {
     @Test
     fun createPaymentMethod_withUSBankAccount_missingName_shouldFail() {
         val params = PaymentMethodCreateParamsFixtures.US_BANK_ACCOUNT.copy(
-            billingDetails = PaymentMethodCreateParamsFixtures.BILLING_DETAILS.copy(name = null)
+            billingDetails = PaymentMethodCreateParamsFixtures.BILLING_DETAILS.toBuilder().setName(null).build()
         )
         val exception = assertFailsWith<InvalidRequestException>(
             "A name is required to create a US Bank Account payment method"
@@ -163,7 +163,7 @@ internal class PaymentMethodEndToEndTest {
     @Test
     fun createPaymentMethod_withEps_missingName_shouldFail() {
         val params = PaymentMethodCreateParams.createEps(
-            billingDetails = PaymentMethodCreateParamsFixtures.BILLING_DETAILS.copy(name = null)
+            billingDetails = PaymentMethodCreateParamsFixtures.BILLING_DETAILS.toBuilder().setName(null).build()
         )
         val exception = assertFailsWith<InvalidRequestException>(
             "A name is required to create a EPS payment method"
@@ -205,9 +205,8 @@ internal class PaymentMethodEndToEndTest {
             stripe
                 .createPaymentMethodSynchronous(
                     PaymentMethodCreateParams.createOxxo(
-                        billingDetails = PaymentMethodCreateParamsFixtures.BILLING_DETAILS.copy(
-                            name = null
-                        )
+                        billingDetails = PaymentMethodCreateParamsFixtures.BILLING_DETAILS.toBuilder().setName(null)
+                            .build()
                     )
                 )
         }
@@ -219,9 +218,8 @@ internal class PaymentMethodEndToEndTest {
         ) {
             stripe.createPaymentMethodSynchronous(
                 PaymentMethodCreateParams.createOxxo(
-                    billingDetails = PaymentMethodCreateParamsFixtures.BILLING_DETAILS.copy(
-                        email = null
-                    )
+                    billingDetails = PaymentMethodCreateParamsFixtures.BILLING_DETAILS.toBuilder().setEmail(null)
+                        .build()
                 )
             )
         }
@@ -294,7 +292,8 @@ internal class PaymentMethodEndToEndTest {
             stripe
                 .createPaymentMethodSynchronous(
                     PaymentMethodCreateParams.createAfterpayClearpay(
-                        billingDetails = PaymentMethodCreateParamsFixtures.BILLING_DETAILS.copy(name = null)
+                        billingDetails = PaymentMethodCreateParamsFixtures.BILLING_DETAILS.toBuilder().setName(null)
+                            .build()
                     )
                 )
         }
@@ -308,7 +307,8 @@ internal class PaymentMethodEndToEndTest {
             stripe
                 .createPaymentMethodSynchronous(
                     PaymentMethodCreateParams.createAfterpayClearpay(
-                        billingDetails = PaymentMethodCreateParamsFixtures.BILLING_DETAILS.copy(email = null)
+                        billingDetails = PaymentMethodCreateParamsFixtures.BILLING_DETAILS.toBuilder().setEmail(null)
+                            .build()
                     )
                 )
         }
@@ -321,7 +321,8 @@ internal class PaymentMethodEndToEndTest {
             stripe
                 .createPaymentMethodSynchronous(
                     PaymentMethodCreateParams.createAfterpayClearpay(
-                        billingDetails = PaymentMethodCreateParamsFixtures.BILLING_DETAILS.copy(address = null)
+                        billingDetails = PaymentMethodCreateParamsFixtures.BILLING_DETAILS.toBuilder().setAddress(null)
+                            .build()
                     )
                 )
         ).isNotNull()
@@ -354,7 +355,7 @@ internal class PaymentMethodEndToEndTest {
     @Test
     fun createPaymentMethod_withKlarna_shouldCreateObject() {
         val params = PaymentMethodCreateParams.createKlarna(
-            billingDetails = PaymentMethodCreateParamsFixtures.BILLING_DETAILS.copy()
+            billingDetails = PaymentMethodCreateParamsFixtures.BILLING_DETAILS
         )
 
         val paymentMethod =

--- a/payments-core/src/test/java/com/stripe/android/StripeEndToEndTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/StripeEndToEndTest.kt
@@ -19,6 +19,7 @@ import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.SourceParams
 import com.stripe.android.model.SourceTypeModel
 import com.stripe.android.model.Token
+import com.stripe.android.model.copy
 import com.stripe.android.networking.RequestSurface
 import com.stripe.android.networking.StripeApiRepository
 import com.stripe.android.utils.TestUtils.idleLooper

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayLauncherTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayLauncherTest.kt
@@ -138,3 +138,23 @@ internal class GooglePayLauncherTest {
         )
     }
 }
+
+private fun GooglePayLauncher.Config.copy(
+    environment: GooglePayEnvironment = this.environment,
+    merchantCountryCode: String = this.merchantCountryCode,
+    merchantName: String = this.merchantName,
+    isEmailRequired: Boolean = this.isEmailRequired,
+    billingAddressConfig: GooglePayLauncher.BillingAddressConfig = this.billingAddressConfig,
+    existingPaymentMethodRequired: Boolean = this.existingPaymentMethodRequired,
+    allowCreditCards: Boolean = this.allowCreditCards
+): GooglePayLauncher.Config {
+    return GooglePayLauncher.Config(
+        environment = environment,
+        merchantCountryCode = merchantCountryCode,
+        merchantName = merchantName,
+        isEmailRequired = isEmailRequired,
+        billingAddressConfig = billingAddressConfig,
+        existingPaymentMethodRequired = existingPaymentMethodRequired,
+        allowCreditCards = allowCreditCards
+    )
+}

--- a/payments-core/src/test/java/com/stripe/android/model/CardParamsTestExtensions.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/CardParamsTestExtensions.kt
@@ -1,0 +1,28 @@
+package com.stripe.android.model
+
+@OptIn(DelicateCardDetailsApi::class)
+fun CardParams.copy(
+    number: String = this.number,
+    expMonth: Int = this.expMonth,
+    expYear: Int = this.expYear,
+    cvc: String? = this.cvc,
+    name: String? = this.name,
+    address: Address? = this.address,
+    currency: String? = this.currency,
+    metadata: Map<String, String>? = this.metadata,
+    loggingTokens: Set<String> = this.attribution
+): CardParams {
+    return CardParams(
+        brand = this.brand,
+        loggingTokens = loggingTokens,
+        number = number,
+        expMonth = expMonth,
+        expYear = expYear,
+        cvc = cvc,
+        name = name,
+        address = address,
+        currency = currency,
+        networks = this.networks,
+        metadata = metadata
+    )
+}

--- a/payments-core/src/test/java/com/stripe/android/model/PaymentMethodCreateParamsTestExtensions.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/PaymentMethodCreateParamsTestExtensions.kt
@@ -1,0 +1,19 @@
+package com.stripe.android.model
+
+fun PaymentMethodCreateParams.Card.copy(
+    number: String? = this.number,
+    expiryMonth: Int? = this.expiryMonth,
+    expiryYear: Int? = this.expiryYear,
+    cvc: String? = this.cvc,
+    attribution: Set<String>? = this.attribution,
+    networks: PaymentMethodCreateParams.Card.Networks? = this.networks,
+): PaymentMethodCreateParams.Card {
+    return PaymentMethodCreateParams.Card(
+        number = number,
+        expiryMonth = expiryMonth,
+        expiryYear = expiryYear,
+        cvc = cvc,
+        attribution = attribution,
+        networks = networks,
+    )
+}

--- a/payments-core/src/test/java/com/stripe/android/model/StripeIntentTestExtensions.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/StripeIntentTestExtensions.kt
@@ -1,0 +1,19 @@
+package com.stripe.android.model
+
+fun StripeIntent.NextActionData.SdkData.Use3DS2.copy(
+    source: String = this.source,
+    serverName: String = this.serverName,
+    transactionId: String = this.transactionId,
+    serverEncryption: StripeIntent.NextActionData.SdkData.Use3DS2.DirectoryServerEncryption = this.serverEncryption,
+    threeDS2IntentId: String? = this.threeDS2IntentId,
+    publishableKey: String? = this.publishableKey,
+): StripeIntent.NextActionData.SdkData.Use3DS2 {
+    return StripeIntent.NextActionData.SdkData.Use3DS2(
+        source = source,
+        serverName = serverName,
+        transactionId = transactionId,
+        serverEncryption = serverEncryption,
+        threeDS2IntentId = threeDS2IntentId,
+        publishableKey = publishableKey,
+    )
+}

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -63,6 +63,7 @@ import com.stripe.android.model.Stripe3ds2Fixtures
 import com.stripe.android.model.StripeFileFixtures
 import com.stripe.android.model.TokenFixtures
 import com.stripe.android.model.VerificationMethodParam
+import com.stripe.android.model.copy
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.json.JSONObject

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModelTest.kt
@@ -15,6 +15,7 @@ import com.stripe.android.PaymentAuthConfig
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.model.copy
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.stripe3ds2.init.ui.StripeUiCustomization
 import com.stripe.android.stripe3ds2.service.StripeThreeDs2ServiceImpl

--- a/payments-model/api/payments-model.api
+++ b/payments-model/api/payments-model.api
@@ -98,29 +98,6 @@ public final class com/stripe/android/model/BankAccount$Type : java/lang/Enum {
 
 public final class com/stripe/android/model/Card : com/stripe/android/core/model/StripeModel, com/stripe/android/model/StripePaymentSource {
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public final fun component1 ()Ljava/lang/Integer;
-	public final fun component10 ()Ljava/lang/String;
-	public final fun component11 ()Ljava/lang/String;
-	public final fun component12 ()Ljava/lang/String;
-	public final fun component13 ()Lcom/stripe/android/model/CardBrand;
-	public final fun component14 ()Lcom/stripe/android/model/CardFunding;
-	public final fun component15 ()Ljava/lang/String;
-	public final fun component16 ()Ljava/lang/String;
-	public final fun component17 ()Ljava/lang/String;
-	public final fun component18 ()Ljava/lang/String;
-	public final fun component19 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/Integer;
-	public final fun component20 ()Ljava/lang/String;
-	public final fun component21 ()Lcom/stripe/android/model/TokenizationMethod;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun component5 ()Ljava/lang/String;
-	public final fun component6 ()Ljava/lang/String;
-	public final fun component7 ()Ljava/lang/String;
-	public final fun component8 ()Ljava/lang/String;
-	public final fun component9 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/CardBrand;Lcom/stripe/android/model/CardFunding;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/TokenizationMethod;)Lcom/stripe/android/model/Card;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/Card;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/CardBrand;Lcom/stripe/android/model/CardFunding;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/TokenizationMethod;ILjava/lang/Object;)Lcom/stripe/android/model/Card;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAddressCity ()Ljava/lang/String;
@@ -686,15 +663,6 @@ public abstract interface class com/stripe/android/model/StripePaymentSource : a
 public final class com/stripe/android/model/Token : com/stripe/android/core/model/StripeModel, com/stripe/android/model/StripePaymentSource {
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/model/Token$Companion;
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Lcom/stripe/android/model/Token$Type;
-	public final fun component3 ()Ljava/util/Date;
-	public final fun component4 ()Z
-	public final fun component5 ()Z
-	public final fun component6 ()Lcom/stripe/android/model/BankAccount;
-	public final fun component7 ()Lcom/stripe/android/model/Card;
-	public final fun copy (Ljava/lang/String;Lcom/stripe/android/model/Token$Type;Ljava/util/Date;ZZLcom/stripe/android/model/BankAccount;Lcom/stripe/android/model/Card;)Lcom/stripe/android/model/Token;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/Token;Ljava/lang/String;Lcom/stripe/android/model/Token$Type;Ljava/util/Date;ZZLcom/stripe/android/model/BankAccount;Lcom/stripe/android/model/Card;ILjava/lang/Object;)Lcom/stripe/android/model/Token;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Lorg/json/JSONObject;)Lcom/stripe/android/model/Token;

--- a/payments-model/build.gradle
+++ b/payments-model/build.gradle
@@ -3,6 +3,7 @@ apply from: configs.androidLibrary
 apply plugin: 'checkstyle'
 apply plugin: 'kotlinx-serialization'
 apply plugin: 'org.jetbrains.kotlin.plugin.parcelize'
+apply plugin: 'dev.drewhamilton.poko'
 
 android {
     testOptions {

--- a/payments-model/dependencies/dependencies.txt
+++ b/payments-model/dependencies/dependencies.txt
@@ -310,4 +310,7 @@
 |    \--- androidx.appcompat:appcompat-resources:1.7.0 (c)
 +--- androidx.core:core-ktx:1.13.1 (*)
 +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0 (*)
-\--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
++--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
+\--- dev.drewhamilton.poko:poko-annotations:0.18.2
+     \--- dev.drewhamilton.poko:poko-annotations-jvm:0.18.2
+          \--- org.jetbrains.kotlin:kotlin-stdlib:2.1.0 -> 2.1.10 (*)

--- a/payments-model/src/main/java/com/stripe/android/model/Card.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/Card.kt
@@ -4,13 +4,15 @@ import androidx.annotation.IntRange
 import androidx.annotation.RestrictTo
 import androidx.annotation.Size
 import com.stripe.android.core.model.StripeModel
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
 /**
  * A representation of a [Card API object](https://stripe.com/docs/api/cards/object).
  */
 @Parcelize
-data class Card
+@Poko
+class Card
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
     /**
@@ -171,6 +173,55 @@ constructor(
      */
     val tokenizationMethod: TokenizationMethod? = null
 ) : StripeModel, StripePaymentSource {
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    fun copy(
+        expMonth: Int? = this.expMonth,
+        expYear: Int? = this.expYear,
+        name: String? = this.name,
+        addressLine1: String? = this.addressLine1,
+        addressLine1Check: String? = this.addressLine1Check,
+        addressLine2: String? = this.addressLine2,
+        addressCity: String? = this.addressCity,
+        addressState: String? = this.addressState,
+        addressZip: String? = this.addressZip,
+        addressZipCheck: String? = this.addressZipCheck,
+        addressCountry: String? = this.addressCountry,
+        last4: String? = this.last4,
+        brand: CardBrand = this.brand,
+        funding: CardFunding? = this.funding,
+        fingerprint: String? = this.fingerprint,
+        country: String? = this.country,
+        currency: String? = this.currency,
+        customerId: String? = this.customerId,
+        cvcCheck: String? = this.cvcCheck,
+        id: String? = this.id,
+        tokenizationMethod: TokenizationMethod? = this.tokenizationMethod
+    ): Card {
+        return Card(
+            expMonth = expMonth,
+            expYear = expYear,
+            name = name,
+            addressLine1 = addressLine1,
+            addressLine1Check = addressLine1Check,
+            addressLine2 = addressLine2,
+            addressCity = addressCity,
+            addressState = addressState,
+            addressZip = addressZip,
+            addressZipCheck = addressZipCheck,
+            addressCountry = addressCountry,
+            last4 = last4,
+            brand = brand,
+            funding = funding,
+            fingerprint = fingerprint,
+            country = country,
+            currency = currency,
+            customerId = customerId,
+            cvcCheck = cvcCheck,
+            id = id,
+            tokenizationMethod = tokenizationMethod
+        )
+    }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     companion object {

--- a/payments-model/src/main/java/com/stripe/android/model/Token.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/Token.kt
@@ -2,8 +2,8 @@ package com.stripe.android.model
 
 import androidx.annotation.RestrictTo
 import com.stripe.android.core.model.StripeModel
-import com.stripe.android.model.Token.Type
 import com.stripe.android.model.parsers.TokenJsonParser
+import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 import org.json.JSONObject
 import java.util.Date
@@ -14,7 +14,8 @@ import java.util.Date
  * secure manner. A Token representing this information is returned to you to use.
  */
 @Parcelize
-data class Token
+@Poko
+class Token
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
 

--- a/payments-ui-core/dependencies/dependencies.txt
+++ b/payments-ui-core/dependencies/dependencies.txt
@@ -359,7 +359,10 @@
 |    |    |    \--- androidx.appcompat:appcompat-resources:1.7.0 (c)
 |    |    +--- androidx.core:core-ktx:1.13.1 (*)
 |    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
+|    |    \--- dev.drewhamilton.poko:poko-annotations:0.18.2
+|    |         \--- dev.drewhamilton.poko:poko-annotations-jvm:0.18.2
+|    |              \--- org.jetbrains.kotlin:kotlin-stdlib:2.1.0 -> 2.1.10 (*)
 |    +--- androidx.databinding:viewbinding:8.8.2 (*)
 |    +--- org.jetbrains.kotlin:kotlin-stdlib:2.1.10 (*)
 |    +--- project :hcaptcha
@@ -888,9 +891,7 @@
 |    |    |    \--- com.google.android.gms:play-services-basement:18.0.0 -> 18.4.0 (*)
 |    |    \--- com.google.android.gms:play-services-tasks:18.2.0 (*)
 |    +--- com.google.android.instantapps:instantapps:1.1.0
-|    +--- dev.drewhamilton.poko:poko-annotations:0.18.2
-|    |    \--- dev.drewhamilton.poko:poko-annotations-jvm:0.18.2
-|    |         \--- org.jetbrains.kotlin:kotlin-stdlib:2.1.0 -> 2.1.10 (*)
+|    +--- dev.drewhamilton.poko:poko-annotations:0.18.2 (*)
 |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
 +--- project :stripe-ui-core (*)
 +--- androidx.constraintlayout:constraintlayout:2.2.0 (*)

--- a/payments/dependencies/dependencies.txt
+++ b/payments/dependencies/dependencies.txt
@@ -357,7 +357,10 @@
 |    |    |    \--- androidx.appcompat:appcompat-resources:1.7.0 (c)
 |    |    +--- androidx.core:core-ktx:1.13.1 (*)
 |    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
+|    |    \--- dev.drewhamilton.poko:poko-annotations:0.18.2
+|    |         \--- dev.drewhamilton.poko:poko-annotations-jvm:0.18.2
+|    |              \--- org.jetbrains.kotlin:kotlin-stdlib:2.1.0 -> 2.1.10 (*)
 |    +--- androidx.databinding:viewbinding:8.8.2
 |    |    \--- androidx.annotation:annotation:1.0.0 -> 1.9.1 (*)
 |    +--- org.jetbrains.kotlin:kotlin-stdlib:2.1.10 (*)
@@ -896,9 +899,7 @@
 |    |    |    \--- com.google.android.gms:play-services-basement:18.0.0 -> 18.4.0 (*)
 |    |    \--- com.google.android.gms:play-services-tasks:18.2.0 (*)
 |    +--- com.google.android.instantapps:instantapps:1.1.0
-|    +--- dev.drewhamilton.poko:poko-annotations:0.18.2
-|    |    \--- dev.drewhamilton.poko:poko-annotations-jvm:0.18.2
-|    |         \--- org.jetbrains.kotlin:kotlin-stdlib:2.1.0 -> 2.1.10 (*)
+|    +--- dev.drewhamilton.poko:poko-annotations:0.18.2 (*)
 |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
 +--- project :paymentsheet
 |    +--- project :payments-core (*)

--- a/paymentsheet-example/dependencies/dependencies.txt
+++ b/paymentsheet-example/dependencies/dependencies.txt
@@ -376,7 +376,10 @@
 |    |    |    |    \--- androidx.appcompat:appcompat-resources:1.7.0 (c)
 |    |    |    +--- androidx.core:core-ktx:1.13.1 (*)
 |    |    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0 (*)
-|    |    |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
+|    |    |    \--- dev.drewhamilton.poko:poko-annotations:0.18.2
+|    |    |         \--- dev.drewhamilton.poko:poko-annotations-jvm:0.18.2
+|    |    |              \--- org.jetbrains.kotlin:kotlin-stdlib:2.1.0 -> 2.1.10 (*)
 |    |    +--- androidx.databinding:viewbinding:8.8.2 (*)
 |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:2.1.10 (*)
 |    |    +--- project :hcaptcha
@@ -973,9 +976,7 @@
 |    |    |    |    \--- com.google.android.gms:play-services-basement:18.0.0 -> 18.4.0 (*)
 |    |    |    \--- com.google.android.gms:play-services-tasks:18.2.0 (*)
 |    |    +--- com.google.android.instantapps:instantapps:1.1.0
-|    |    +--- dev.drewhamilton.poko:poko-annotations:0.18.2
-|    |    |    \--- dev.drewhamilton.poko:poko-annotations-jvm:0.18.2
-|    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib:2.1.0 -> 2.1.10 (*)
+|    |    +--- dev.drewhamilton.poko:poko-annotations:0.18.2 (*)
 |    |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
 |    +--- project :paymentsheet
 |    |    +--- project :payments-core (*)

--- a/paymentsheet/dependencies/dependencies.txt
+++ b/paymentsheet/dependencies/dependencies.txt
@@ -357,7 +357,10 @@
 |    |    |    \--- androidx.appcompat:appcompat-resources:1.7.0 (c)
 |    |    +--- androidx.core:core-ktx:1.13.1 (*)
 |    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
+|    |    \--- dev.drewhamilton.poko:poko-annotations:0.18.2
+|    |         \--- dev.drewhamilton.poko:poko-annotations-jvm:0.18.2
+|    |              \--- org.jetbrains.kotlin:kotlin-stdlib:2.1.0 -> 2.1.10 (*)
 |    +--- androidx.databinding:viewbinding:8.8.2
 |    |    \--- androidx.annotation:annotation:1.0.0 -> 1.9.1 (*)
 |    +--- org.jetbrains.kotlin:kotlin-stdlib:2.1.10 (*)
@@ -896,9 +899,7 @@
 |    |    |    \--- com.google.android.gms:play-services-basement:18.0.0 -> 18.4.0 (*)
 |    |    \--- com.google.android.gms:play-services-tasks:18.2.0 (*)
 |    +--- com.google.android.instantapps:instantapps:1.1.0
-|    +--- dev.drewhamilton.poko:poko-annotations:0.18.2
-|    |    \--- dev.drewhamilton.poko:poko-annotations-jvm:0.18.2
-|    |         \--- org.jetbrains.kotlin:kotlin-stdlib:2.1.0 -> 2.1.10 (*)
+|    +--- dev.drewhamilton.poko:poko-annotations:0.18.2 (*)
 |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
 +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1 (*)
 +--- androidx.activity:activity-ktx:1.9.3 (*)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
@@ -290,11 +290,11 @@ internal object PaymentSheetFixtures {
         ] 
     """.trimIndent()
 
-    internal val BILLING_DETAILS_FORM_DETAILS = BILLING_DETAILS.copy(
-        email = null,
-        name = null,
-        phone = null
-    )
+    internal val BILLING_DETAILS_FORM_DETAILS = BILLING_DETAILS.toBuilder()
+        .setEmail(null)
+        .setName(null)
+        .setPhone(null)
+        .build()
 
     internal fun billingDetailsFormState(
         line1: FormFieldEntry? = FormFieldEntry("1234 Main Street", isComplete = true),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/BillingDetailsEntryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/BillingDetailsEntryTest.kt
@@ -101,11 +101,11 @@ internal class BillingDetailsEntryTest {
 
     @Test
     fun `hasChanged() returns true when postal code changes in Automatic mode`() {
-        val billingDetails = BILLING_DETAILS_FORM_DETAILS.copy(
+        val billingDetails = BILLING_DETAILS_FORM_DETAILS.toBuilder().setAddress(
             address = Address(
                 postalCode = "94107",
             )
-        )
+        ).build()
 
         val state = billingDetailsEntry(
             billingDetailsFormState = billingDetailsFormState(
@@ -122,11 +122,11 @@ internal class BillingDetailsEntryTest {
 
     @Test
     fun `hasChanged() returns true when country changes in Automatic mode`() {
-        val billingDetails = BILLING_DETAILS_FORM_DETAILS.copy(
+        val billingDetails = BILLING_DETAILS_FORM_DETAILS.toBuilder().setAddress(
             address = Address(
                 country = "US"
             )
-        )
+        ).build()
 
         val state = billingDetailsEntry(
             billingDetailsFormState = billingDetailsFormState(
@@ -143,12 +143,12 @@ internal class BillingDetailsEntryTest {
 
     @Test
     fun `hasChanged() returns false when values are the same in Automatic mode`() {
-        val billingDetails = BILLING_DETAILS_FORM_DETAILS.copy(
+        val billingDetails = BILLING_DETAILS_FORM_DETAILS.toBuilder().setAddress(
             address = Address(
                 postalCode = "94107",
                 country = "US"
             )
-        )
+        ).build()
 
         val state = billingDetailsEntry(
             billingDetailsFormState = billingDetailsFormState(
@@ -241,12 +241,12 @@ internal class BillingDetailsEntryTest {
 
     @Test
     fun `hasChanged() handles null vs empty string in address fields`() {
-        val billingDetails = BILLING_DETAILS_FORM_DETAILS.copy(
+        val billingDetails = BILLING_DETAILS_FORM_DETAILS.toBuilder().setAddress(
             address = BILLING_DETAILS_FORM_DETAILS.address?.copy(
                 line2 = null,
                 state = null,
             )
-        )
+        ).build()
 
         val state = billingDetailsEntry(
             billingDetailsFormState = billingDetailsFormState(
@@ -414,9 +414,9 @@ internal class BillingDetailsEntryTest {
 
     @Test
     fun `hasChanged() returns true when name changes`() {
-        val billingDetails = BILLING_DETAILS_FORM_DETAILS.copy(
+        val billingDetails = BILLING_DETAILS_FORM_DETAILS.toBuilder().setName(
             name = "Original Name"
-        )
+        ).build()
 
         val configWithName = BillingDetailsCollectionConfiguration(
             name = BillingDetailsCollectionConfiguration.CollectionMode.Always,
@@ -444,9 +444,9 @@ internal class BillingDetailsEntryTest {
 
     @Test
     fun `hasChanged() returns true when email changes`() {
-        val billingDetails = BILLING_DETAILS_FORM_DETAILS.copy(
+        val billingDetails = BILLING_DETAILS_FORM_DETAILS.toBuilder().setEmail(
             email = "original@example.com"
-        )
+        ).build()
 
         val configWithEmail = BillingDetailsCollectionConfiguration(
             email = BillingDetailsCollectionConfiguration.CollectionMode.Always,
@@ -474,9 +474,9 @@ internal class BillingDetailsEntryTest {
 
     @Test
     fun `hasChanged() returns true when phone changes`() {
-        val billingDetails = BILLING_DETAILS_FORM_DETAILS.copy(
+        val billingDetails = BILLING_DETAILS_FORM_DETAILS.toBuilder().setPhone(
             phone = "+1234567890"
-        )
+        ).build()
 
         val configWithPhone = BillingDetailsCollectionConfiguration(
             phone = BillingDetailsCollectionConfiguration.CollectionMode.Always,

--- a/stripecardscan-example/dependencies/dependencies.txt
+++ b/stripecardscan-example/dependencies/dependencies.txt
@@ -461,7 +461,10 @@
 |    |    |    +--- androidx.appcompat:appcompat:1.7.0 (*)
 |    |    |    +--- androidx.core:core-ktx:1.13.1 (*)
 |    |    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0 (*)
-|    |    |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
+|    |    |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
+|    |    |    \--- dev.drewhamilton.poko:poko-annotations:0.18.2
+|    |    |         \--- dev.drewhamilton.poko:poko-annotations-jvm:0.18.2
+|    |    |              \--- org.jetbrains.kotlin:kotlin-stdlib:2.1.0 -> 2.1.10 (*)
 |    |    +--- androidx.databinding:viewbinding:8.8.2 (*)
 |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:2.1.10 (*)
 |    |    +--- project :hcaptcha
@@ -1007,9 +1010,7 @@
 |    |    |    |    \--- com.google.android.gms:play-services-basement:18.0.0 -> 18.4.0 (*)
 |    |    |    \--- com.google.android.gms:play-services-tasks:18.2.0 (*)
 |    |    +--- com.google.android.instantapps:instantapps:1.1.0
-|    |    +--- dev.drewhamilton.poko:poko-annotations:0.18.2
-|    |    |    \--- dev.drewhamilton.poko:poko-annotations-jvm:0.18.2
-|    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib:2.1.0 -> 2.1.10 (*)
+|    |    +--- dev.drewhamilton.poko:poko-annotations:0.18.2 (*)
 |    |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
 |    +--- com.google.dagger:dagger:2.55 (*)
 |    +--- androidx.appcompat:appcompat:1.7.0 (*)

--- a/stripecardscan/dependencies/dependencies.txt
+++ b/stripecardscan/dependencies/dependencies.txt
@@ -456,7 +456,10 @@
 |    |    +--- androidx.appcompat:appcompat:1.7.0 (*)
 |    |    +--- androidx.core:core-ktx:1.13.1 (*)
 |    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
+|    |    \--- dev.drewhamilton.poko:poko-annotations:0.18.2
+|    |         \--- dev.drewhamilton.poko:poko-annotations-jvm:0.18.2
+|    |              \--- org.jetbrains.kotlin:kotlin-stdlib:2.1.0 -> 2.1.10 (*)
 |    +--- androidx.databinding:viewbinding:8.8.2 (*)
 |    +--- org.jetbrains.kotlin:kotlin-stdlib:2.1.10 (*)
 |    +--- project :hcaptcha
@@ -980,9 +983,7 @@
 |    |    |    \--- com.google.android.gms:play-services-basement:18.0.0 -> 18.4.0 (*)
 |    |    \--- com.google.android.gms:play-services-tasks:18.2.0 (*)
 |    +--- com.google.android.instantapps:instantapps:1.1.0
-|    +--- dev.drewhamilton.poko:poko-annotations:0.18.2
-|    |    \--- dev.drewhamilton.poko:poko-annotations-jvm:0.18.2
-|    |         \--- org.jetbrains.kotlin:kotlin-stdlib:2.1.0 -> 2.1.10 (*)
+|    +--- dev.drewhamilton.poko:poko-annotations:0.18.2 (*)
 |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
 +--- com.google.dagger:dagger:2.55 (*)
 +--- androidx.appcompat:appcompat:1.7.0 (*)

--- a/wechatpay/dependencies/dependencies.txt
+++ b/wechatpay/dependencies/dependencies.txt
@@ -356,7 +356,10 @@
 |    |    |    \--- androidx.appcompat:appcompat-resources:1.7.0 (c)
 |    |    +--- androidx.core:core-ktx:1.13.1 (*)
 |    |    +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0 (*)
-|    |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
+|    |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
+|    |    \--- dev.drewhamilton.poko:poko-annotations:0.18.2
+|    |         \--- dev.drewhamilton.poko:poko-annotations-jvm:0.18.2
+|    |              \--- org.jetbrains.kotlin:kotlin-stdlib:2.1.0 -> 2.1.10 (*)
 |    +--- androidx.databinding:viewbinding:8.8.2
 |    |    \--- androidx.annotation:annotation:1.0.0 -> 1.9.1 (*)
 |    +--- org.jetbrains.kotlin:kotlin-stdlib:2.1.10 (*)
@@ -886,9 +889,7 @@
 |    |    |    \--- com.google.android.gms:play-services-basement:18.0.0 -> 18.4.0 (*)
 |    |    \--- com.google.android.gms:play-services-tasks:18.2.0 (*)
 |    +--- com.google.android.instantapps:instantapps:1.1.0
-|    +--- dev.drewhamilton.poko:poko-annotations:0.18.2
-|    |    \--- dev.drewhamilton.poko:poko-annotations-jvm:0.18.2
-|    |         \--- org.jetbrains.kotlin:kotlin-stdlib:2.1.0 -> 2.1.10 (*)
+|    +--- dev.drewhamilton.poko:poko-annotations:0.18.2 (*)
 |    \--- org.jetbrains.kotlin:kotlin-parcelize-runtime:2.1.10 (*)
 +--- androidx.appcompat:appcompat:1.7.0 (*)
 +--- androidx.core:core-ktx:1.13.1 (*)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This removes the data modifier from all classes in `payments-core`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
data classes are hard to maintain binary compatibility with moving forward. If merchants needed access to any of these copy methods, we will add them back as needed (or introduce a toBuilder/newBuilder pattern).
