### PR TITLE
Migrate cardscan to use CameraX

### DIFF
--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/camera/GetScanCameraAdapter.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/camera/GetScanCameraAdapter.kt
@@ -5,16 +5,16 @@ import android.graphics.Bitmap
 import android.util.Log
 import android.util.Size
 import android.view.ViewGroup
-import com.stripe.android.camera.Camera1Adapter
 import com.stripe.android.camera.CameraAdapter
 import com.stripe.android.camera.CameraErrorListener
 import com.stripe.android.camera.CameraPreviewImage
+import com.stripe.android.camera.CameraXAdapter
 
 private const val LOG_TAG = "CameraSelector"
 
 /**
  * Get the appropriate camera adapter. If the customer has provided an additional camera adapter,
- * use that in place of camera 1.
+ * use that in place of camera X.
  */
 internal fun getScanCameraAdapter(
     activity: Activity,
@@ -22,6 +22,6 @@ internal fun getScanCameraAdapter(
     minimumResolution: Size,
     cameraErrorListener: CameraErrorListener
 ): CameraAdapter<CameraPreviewImage<Bitmap>> =
-    Camera1Adapter(activity, previewView, minimumResolution, cameraErrorListener).apply {
+    CameraXAdapter(activity, previewView, minimumResolution, cameraErrorListener).apply {
         Log.d(LOG_TAG, "Using camera implementation ${this.implementationName}")
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Migrate cardscan to use CameraX to attempt fixing hard-to-reproduce bugs. This is the stacktrace in the bug report
```
Fatal Exception: java.lang.RuntimeException
getParameters failed (empty parameters)
android.hardware.Camera.native_getParameters (Camera.java)
android.hardware.Camera.getParameters (Camera.java:2151)
```
`Camera.Parameters` is deprecated on Camera 1 and we would avoid calling this if we used CameraX instead.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-4434

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
