### PR TITLE
Require email on Inline signup if opted-in + email entered

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/ElementsSession.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ElementsSession.kt
@@ -34,7 +34,7 @@ data class ElementsSession(
         get() = linkSettings?.linkFlags ?: emptyMap()
 
     val disableLinkSignup: Boolean
-        get() = linkSettings?.disableLinkSignup ?: false
+        get() = false
 
     val isLinkEnabled: Boolean
         get() {

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/inline/InlineSignupViewState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/inline/InlineSignupViewState.kt
@@ -36,6 +36,23 @@ constructor(
         get() = fields.first() == LinkSignupField.Email
 
     /**
+     * Determines if the Link form should be considered valid for form submission.
+     */
+    val isFormValidForSubmission: Boolean
+        get() = when {
+            // If Link signup is not active (checkbox is off), don't block form submission
+            useLink.not() -> true
+
+            // If both email and phone fields are required but user input is not complete
+            fields.contains(LinkSignupField.Email) &&
+                fields.contains(LinkSignupField.Phone) &&
+                userInput == null -> false
+
+            // In all other cases, don't block submission
+            else -> true
+        }
+
+    /**
      * Whether the view is active and the payment should be processed through Link.
      */
     val useLink: Boolean

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -509,7 +509,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         )
         val hasUsedLink = linkStore.hasUsedLink()
 
-        val linkSignupMode = if (hasUsedLink || linkSignUpDisabled) {
+        val linkSignupMode = if (linkSignUpDisabled) {
             null
         } else if (isSaveForFutureUseValueChangeable) {
             LinkSignupMode.AlongsideSaveForFutureUse

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/inline/InlineSignupViewStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/inline/InlineSignupViewStateTest.kt
@@ -177,6 +177,94 @@ class InlineSignupViewStateTest {
         assertThat(viewState.allowsDefaultOptIn).isEqualTo(expectedResult)
     }
 
+    @Test
+    fun `isFormValidForSubmission returns true when Link checkbox is off`() {
+        // For AlongsideSaveForFutureUse mode with userInput=null, useLink will be false
+        val viewState = InlineSignupViewState(
+            userInput = null,
+            merchantName = "Test Merchant",
+            signupMode = LinkSignupMode.AlongsideSaveForFutureUse,
+            fields = listOf(LinkSignupField.Email, LinkSignupField.Phone),
+            prefillEligibleFields = emptySet(),
+            allowsDefaultOptIn = false,
+            isExpanded = false
+        )
+
+        assertThat(viewState.isFormValidForSubmission).isTrue()
+    }
+
+    @Test
+    fun `isFormValidForSubmission returns true when only phone field is shown`() {
+        // For InsteadOfSaveForFutureUse mode with isExpanded=true, useLink will be true
+        val viewState = InlineSignupViewState(
+            userInput = null,
+            merchantName = "Test Merchant",
+            signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
+            fields = listOf(LinkSignupField.Phone),
+            prefillEligibleFields = emptySet(),
+            allowsDefaultOptIn = false,
+            isExpanded = true
+        )
+
+        assertThat(viewState.isFormValidForSubmission).isTrue()
+    }
+
+    @Test
+    fun `isFormValidForSubmission returns true when both fields shown and user input is complete`() {
+        val userInput = UserInput.SignUp(
+            name = "John",
+            email = "john@example.com",
+            phone = "+11234567890",
+            country = "US",
+            consentAction = SignUpConsentAction.Checkbox
+        )
+
+        // For InsteadOfSaveForFutureUse mode with userInput, useLink will be true based on userInput
+        val viewState = InlineSignupViewState(
+            userInput = userInput,
+            merchantName = "Test Merchant",
+            signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
+            fields = listOf(LinkSignupField.Email, LinkSignupField.Phone),
+            prefillEligibleFields = emptySet(),
+            allowsDefaultOptIn = false,
+            isExpanded = true
+        )
+
+        assertThat(viewState.isFormValidForSubmission).isTrue()
+    }
+
+    @Test
+    fun `isFormValidForSubmission returns false when both fields shown but user input is null and Link is enabled`() {
+        // For InsteadOfSaveForFutureUse mode with isExpanded=true, useLink will be true
+        val viewState = InlineSignupViewState(
+            userInput = null,
+            merchantName = "Test Merchant",
+            signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
+            fields = listOf(LinkSignupField.Email, LinkSignupField.Phone),
+            prefillEligibleFields = emptySet(),
+            allowsDefaultOptIn = false,
+            isExpanded = true // This makes useLink = true for InsteadOfSaveForFutureUse mode
+        )
+
+        assertThat(viewState.isFormValidForSubmission).isFalse()
+    }
+
+    @Test
+    fun `isFormValidForSubmission returns true when both fields shown but user input is null and Link is disabled`() {
+        // For AlongsideSaveForFutureUse mode with userInput=null, useLink will be false
+        val viewState = InlineSignupViewState(
+            userInput = null,
+            merchantName = "Test Merchant",
+            signupMode = LinkSignupMode.AlongsideSaveForFutureUse,
+            fields = listOf(LinkSignupField.Email, LinkSignupField.Phone),
+            prefillEligibleFields = emptySet(),
+            allowsDefaultOptIn = false,
+            isExpanded = false
+        )
+
+        assertThat(viewState.isFormValidForSubmission).isTrue()
+    }
+
     private fun createLinkConfig(
         countryCode: String,
         email: String? = "john@doe.ca",

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElementTest.kt
@@ -34,6 +34,7 @@ import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.createComposeCleanupRule
 import com.stripe.android.utils.FakeLinkComponent
+import com.stripe.android.uicore.elements.IdentifierSpec
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import org.junit.Rule
@@ -117,10 +118,11 @@ class LinkFormElementTest {
         initialLinkUserInput: UserInput?,
     ): LinkFormElement {
         return LinkFormElement(
-            signupMode = signupMode,
-            configuration = createConfiguration(),
+            identifier = IdentifierSpec.Generic("test_link_form"),
             initialLinkUserInput = initialLinkUserInput,
             linkConfigurationCoordinator = createLinkConfigurationCoordinator(),
+            configuration = createConfiguration(),
+            signupMode = signupMode,
             onLinkInlineSignupStateChanged = {},
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElementTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.core.Logger
 import com.stripe.android.link.LinkConfiguration
@@ -33,8 +34,8 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.createComposeCleanupRule
-import com.stripe.android.utils.FakeLinkComponent
 import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.utils.FakeLinkComponent
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import org.junit.Rule
@@ -113,12 +114,42 @@ class LinkFormElementTest {
         }
     }
 
+    @Test
+    fun `getFormFieldValueFlow returns isComplete true when view state is null`() {
+        val element = createLinkFormElement(
+            signupMode = LinkSignupMode.AlongsideSaveForFutureUse,
+            initialLinkUserInput = null,
+        )
+
+        val formFields = element.getFormFieldValueFlow().value
+
+        assertThat(formFields).hasSize(1)
+        assertThat(formFields[0].first).isEqualTo(IdentifierSpec.Generic("link_form"))
+        assertThat(formFields[0].second.isComplete).isTrue()
+        assertThat(formFields[0].second.value).isNull()
+    }
+
+    @Test
+    fun `getFormFieldValueFlow validates form completion based on view state`() {
+        val element = createLinkFormElement(
+            signupMode = LinkSignupMode.AlongsideSaveForFutureUse,
+            initialLinkUserInput = null,
+        )
+
+        val formFields = element.getFormFieldValueFlow().value
+
+        assertThat(formFields).hasSize(1)
+        assertThat(formFields[0].first).isEqualTo(IdentifierSpec.Generic("link_form"))
+        // When viewState is null, isFormValidForSubmission defaults to true
+        assertThat(formFields[0].second.isComplete).isTrue()
+        assertThat(formFields[0].second.value).isNull()
+    }
+
     private fun createLinkFormElement(
         signupMode: LinkSignupMode,
         initialLinkUserInput: UserInput?,
     ): LinkFormElement {
         return LinkFormElement(
-            identifier = IdentifierSpec.Generic("test_link_form"),
             initialLinkUserInput = initialLinkUserInput,
             linkConfigurationCoordinator = createLinkConfigurationCoordinator(),
             configuration = createConfiguration(),


### PR DESCRIPTION
# Summary
Perform form validation on the inline signup:
 - form valid if check is off
 - if check is on, email (if shown) and phone need to be entered to submit. 

[record_inline_1.webm](https://github.com/user-attachments/assets/4bf2b85a-3b7d-48bc-b94d-aa79403dc5cf)

# Motivation
see [thread](https://stripe.slack.com/archives/C08U9R2PY6N/p1752611466458249).

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
