### PR TITLE
[Link] Authentication only mode fixes

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerViewModel.kt
@@ -170,6 +170,12 @@ internal class LinkControllerViewModel @Inject constructor(
                     val state = _state.value
                     val linkAccountInfo = getLinkAccountInfo(email, state)
 
+                    if (linkAccountInfo.account?.isVerified == true) {
+                        logger.debug("$tag: account is already verified, skipping authentication")
+                        _presentForAuthenticationResultFlow.emit(PresentForAuthenticationResult.Success)
+                        return@withConfiguration
+                    }
+
                     val launchMode = LinkLaunchMode.Authentication
 
                     _state.update {

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/signup/SignUpViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/signup/SignUpViewModel.kt
@@ -15,6 +15,7 @@ import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkDismissalCoordinator
 import com.stripe.android.link.LinkLaunchMode
+import com.stripe.android.link.LinkLaunchMode.Authentication
 import com.stripe.android.link.LinkScreen
 import com.stripe.android.link.NoLinkAccountFoundException
 import com.stripe.android.link.account.LinkAuth
@@ -230,23 +231,28 @@ internal class SignUpViewModel @Inject constructor(
     }
 
     private fun onAccountFetched(linkAccount: LinkAccount?) {
-        // For Authentication mode, dismiss with success after account is fetched
-        if (linkLaunchMode is LinkLaunchMode.Authentication) {
+        val targetScreen = when {
+            linkAccount?.completedSignup == true -> LinkScreen.PaymentMethod
+            linkAccount?.isVerified == true -> LinkScreen.Wallet
+            else -> LinkScreen.Verification
+        }
+
+        // Return the account in authentication mode if verification not required
+        if (linkLaunchMode is Authentication && targetScreen != LinkScreen.Verification) {
+            dismissWithAccount(linkAccount)
+        } else {
+            navigateAndClearStack(targetScreen)
+        }
+    }
+
+    private fun dismissWithAccount(linkAccount: LinkAccount?) {
+        if (linkLaunchMode is Authentication) {
             dismissWithResult(
                 LinkActivityResult.Completed(
                     linkAccountUpdate = LinkAccountUpdate.Value(linkAccount),
                     selectedPayment = null,
                 )
             )
-        } else {
-            // Regular flow navigation
-            if (linkAccount?.completedSignup == true) {
-                navigateAndClearStack(LinkScreen.PaymentMethod)
-            } else if (linkAccount?.isVerified == true) {
-                navigateAndClearStack(LinkScreen.Wallet)
-            } else {
-                navigateAndClearStack(LinkScreen.Verification)
-            }
         }
     }
 


### PR DESCRIPTION
# Summary
Fixed authentication flow in SignUpViewModel's onAccountFetched method with two key improvements.

# Motivation
The original method had issues with authentication mode handling:
1. Would return success even for accounts that weren't properly authenticated
2. Didn't properly handle verification flow before returning accounts

# Testing
- [x] Added tests
- [x] Modified tests  
- [x] Manually verified

Added comprehensive test cases covering:
- Authentication mode with completed signup → dismisses with account
- Authentication mode with verified account → dismisses with account
- Authentication mode with unverified account → goes to verification first
- Regular mode navigation to correct screens

# Changes
- Return success only if already authenticated (completed signup or verified)
- Go to verification before returning account in authentication mode when verification is required
- Clean up duplicate code and improve readability