### PR TITLE
Don't clear `FlowController` for `preparePaymentMethod` API

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationDefinition.kt
@@ -170,6 +170,12 @@ internal interface ConfirmationDefinition<
              * DO NOT USE OUTSIDE OF INTENT CONFIRMATION
              */
             val deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+            /**
+             * Indicates if the full payment flow was completed by the handler. Can be used to decide if internal
+             * product state needs to be reset. Useful for confirmation flows that are handed off to merchants to
+             * complete and require no action by Stripe flows afterwards.
+             */
+            val completedFullPaymentFlow: Boolean = true,
         ) : Result
 
         /**
@@ -231,6 +237,12 @@ internal interface ConfirmationDefinition<
              * DO NOT USE OUTSIDE OF INTENT CONFIRMATION
              */
             val deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+            /**
+             * Indicates if the full payment flow was completed by the handler. Can be used to decide if internal
+             * product state needs to be reset. Useful for confirmation flows that are handed off to merchants to
+             * complete and require no action by Stripe flows afterwards.
+             */
+            val completedFullPaymentFlow: Boolean,
         ) : Action<TLauncherArgs>
 
         /**

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandler.kt
@@ -155,6 +155,7 @@ internal interface ConfirmationHandler {
         data class Succeeded(
             val intent: StripeIntent,
             val deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+            val completedFullPaymentFlow: Boolean = true,
         ) : Result
 
         /**

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediator.kt
@@ -130,6 +130,7 @@ internal class ConfirmationMediator<
                     intent = action.intent,
                     confirmationOption = action.confirmationOption,
                     deferredIntentConfirmationType = action.deferredIntentConfirmationType,
+                    completedFullPaymentFlow = action.completedFullPaymentFlow,
                 )
             }
             is ConfirmationDefinition.Action.Fail -> {
@@ -158,6 +159,7 @@ internal class ConfirmationMediator<
             val intent: StripeIntent,
             val confirmationOption: ConfirmationHandler.Option,
             val deferredIntentConfirmationType: DeferredIntentConfirmationType? = null,
+            val completedFullPaymentFlow: Boolean,
         ) : Action
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandler.kt
@@ -178,6 +178,7 @@ internal class DefaultConfirmationHandler(
                     ConfirmationHandler.Result.Succeeded(
                         intent = action.intent,
                         deferredIntentConfirmationType = action.deferredIntentConfirmationType,
+                        completedFullPaymentFlow = action.completedFullPaymentFlow,
                     )
                 )
             }
@@ -208,6 +209,7 @@ internal class DefaultConfirmationHandler(
             is ConfirmationDefinition.Result.Succeeded -> ConfirmationHandler.Result.Succeeded(
                 intent = result.intent,
                 deferredIntentConfirmationType = result.deferredIntentConfirmationType,
+                completedFullPaymentFlow = result.completedFullPaymentFlow,
             )
             is ConfirmationDefinition.Result.Failed -> ConfirmationHandler.Result.Failed(
                 cause = result.cause,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationDefinition.kt
@@ -71,6 +71,7 @@ internal class IntentConfirmationDefinition(
                     intent = confirmationParameters.intent,
                     confirmationOption = confirmationOption,
                     deferredIntentConfirmationType = deferredIntentConfirmationType,
+                    completedFullPaymentFlow = nextStep.completedFullPaymentFlow,
                 )
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptor.kt
@@ -69,7 +69,10 @@ internal interface IntentConfirmationInterceptor {
                 get() = DeferredIntentConfirmationType.Server
         }
 
-        data class Complete(val isForceSuccess: Boolean) : NextStep {
+        data class Complete(
+            val isForceSuccess: Boolean,
+            val completedFullPaymentFlow: Boolean = true,
+        ) : NextStep {
 
             override val deferredIntentConfirmationType: DeferredIntentConfirmationType
                 get() = if (isForceSuccess) {
@@ -369,7 +372,7 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
                         shippingAddress = shippingValues?.toAddressDetails(),
                     )
 
-                    NextStep.Complete(isForceSuccess = true)
+                    NextStep.Complete(isForceSuccess = true, completedFullPaymentFlow = false)
                 } catch (exception: Exception) {
                     NextStep.Fail(
                         cause = exception,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/shoppay/ShopPayConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/shoppay/ShopPayConfirmationDefinition.kt
@@ -39,7 +39,9 @@ internal class ShopPayConfirmationDefinition @Inject constructor(
             is ShopPayActivityResult.Completed -> {
                 ConfirmationDefinition.Result.Succeeded(
                     intent = confirmationParameters.intent,
-                    deferredIntentConfirmationType = deferredIntentConfirmationType
+                    deferredIntentConfirmationType = deferredIntentConfirmationType,
+                    // Shop Pay is handed off for `preparePaymentMethod` purposes
+                    completedFullPaymentFlow = false,
                 )
             }
             is ShopPayActivityResult.Failed -> {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -591,6 +591,7 @@ internal class DefaultFlowController @Inject internal constructor(
                     paymentResult = PaymentResult.Completed,
                     deferredIntentConfirmationType = result.deferredIntentConfirmationType,
                     shouldLog = false,
+                    shouldResetOnCompleted = result.completedFullPaymentFlow,
                 )
             }
             is ConfirmationHandler.Result.Failed -> {
@@ -667,6 +668,7 @@ internal class DefaultFlowController @Inject internal constructor(
         paymentResult: PaymentResult,
         deferredIntentConfirmationType: DeferredIntentConfirmationType? = null,
         shouldLog: Boolean = true,
+        shouldResetOnCompleted: Boolean = true,
     ) {
         if (shouldLog) {
             logPaymentResult(paymentResult, deferredIntentConfirmationType)
@@ -678,7 +680,7 @@ internal class DefaultFlowController @Inject internal constructor(
             linkHandler.logOut()
         }
 
-        if (paymentResult is PaymentResult.Completed) {
+        if (paymentResult is PaymentResult.Completed && shouldResetOnCompleted) {
             viewModel.paymentSelection = null
             viewModel.state = null
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediatorTest.kt
@@ -161,6 +161,7 @@ class ConfirmationMediatorTest {
             confirmationOption = TestConfirmationDefinition.Option,
             intent = INTENT,
             deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
+            completedFullPaymentFlow = true,
         ),
     ) {
         val mediator = ConfirmationMediator(
@@ -185,6 +186,41 @@ class ConfirmationMediatorTest {
         assertThat(completeAction.confirmationOption).isEqualTo(TestConfirmationDefinition.Option)
         assertThat(completeAction.intent).isEqualTo(INTENT)
         assertThat(completeAction.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Client)
+        assertThat(completeAction.completedFullPaymentFlow).isTrue()
+    }
+
+    @Test
+    fun `On complete confirmation action with uncompleted flow, should return expected action`() = test(
+        action = ConfirmationDefinition.Action.Complete(
+            confirmationOption = TestConfirmationDefinition.Option,
+            intent = INTENT,
+            deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
+            completedFullPaymentFlow = false,
+        ),
+    ) {
+        val mediator = ConfirmationMediator(
+            savedStateHandle = SavedStateHandle(),
+            definition = definition
+        )
+
+        val action = mediator.action(
+            option = TestConfirmationDefinition.Option,
+            parameters = CONFIRMATION_PARAMETERS,
+        )
+
+        assertThat(optionCalls.awaitItem().option).isEqualTo(TestConfirmationDefinition.Option)
+
+        val actionCall = actionCalls.awaitItem()
+
+        assertThat(actionCall.confirmationOption).isEqualTo(TestConfirmationDefinition.Option)
+        assertThat(actionCall.confirmationParameters).isEqualTo(CONFIRMATION_PARAMETERS)
+
+        val completeAction = action.asComplete()
+
+        assertThat(completeAction.confirmationOption).isEqualTo(TestConfirmationDefinition.Option)
+        assertThat(completeAction.intent).isEqualTo(INTENT)
+        assertThat(completeAction.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Client)
+        assertThat(completeAction.completedFullPaymentFlow).isFalse()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandlerTest.kt
@@ -225,6 +225,7 @@ class DefaultConfirmationHandlerTest {
             intent = UPDATED_PAYMENT_INTENT,
             confirmationOption = SomeConfirmationDefinition.Option,
             deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
+            completedFullPaymentFlow = true,
         ),
     ) {
         confirmationHandler.state.test {
@@ -241,6 +242,36 @@ class DefaultConfirmationHandlerTest {
             assertThat(successResult.intent).isEqualTo(UPDATED_PAYMENT_INTENT)
             assertThat(successResult.deferredIntentConfirmationType)
                 .isEqualTo(DeferredIntentConfirmationType.Client)
+            assertThat(successResult.completedFullPaymentFlow).isTrue()
+
+            confirmationHandler.assertAwaitResultCallReceivesSameResult(completeState)
+        }
+    }
+
+    @Test
+    fun `On complete action with uncompleted flow, should complete with success result`() = test(
+        someDefinitionAction = ConfirmationDefinition.Action.Complete(
+            intent = UPDATED_PAYMENT_INTENT,
+            confirmationOption = SomeConfirmationDefinition.Option,
+            deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
+            completedFullPaymentFlow = false,
+        ),
+    ) {
+        confirmationHandler.state.test {
+            assertIdleState()
+
+            confirmationHandler.start(createArguments(SomeConfirmationDefinition.Option))
+
+            assertSomeDefinitionActionCalled()
+            assertSomeDefinitionConfirmingState()
+
+            val completeState = awaitCompleteState()
+            val successResult = completeState.result.assertSucceeded()
+
+            assertThat(successResult.intent).isEqualTo(UPDATED_PAYMENT_INTENT)
+            assertThat(successResult.deferredIntentConfirmationType)
+                .isEqualTo(DeferredIntentConfirmationType.Client)
+            assertThat(successResult.completedFullPaymentFlow).isFalse()
 
             confirmationHandler.assertAwaitResultCallReceivesSameResult(completeState)
         }
@@ -259,13 +290,31 @@ class DefaultConfirmationHandlerTest {
         result = ConfirmationDefinition.Result.Succeeded(
             intent = UPDATED_PAYMENT_INTENT,
             deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
+            completedFullPaymentFlow = true,
         ),
     ) { completeState ->
         val successResult = completeState.result.assertSucceeded()
 
         assertThat(successResult.intent).isEqualTo(UPDATED_PAYMENT_INTENT)
         assertThat(successResult.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Server)
+        assertThat(successResult.completedFullPaymentFlow).isTrue()
     }
+
+    @Test
+    fun `On success result with uncompleted flow from launched action, should complete as expected`() =
+        launcherResultTest(
+            result = ConfirmationDefinition.Result.Succeeded(
+                intent = UPDATED_PAYMENT_INTENT,
+                deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
+                completedFullPaymentFlow = false,
+            ),
+        ) { completeState ->
+            val successResult = completeState.result.assertSucceeded()
+
+            assertThat(successResult.intent).isEqualTo(UPDATED_PAYMENT_INTENT)
+            assertThat(successResult.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Server)
+            assertThat(successResult.completedFullPaymentFlow).isFalse()
+        }
 
     @Test
     fun `On failed result from launched action, should complete with failed result`() = launcherResultTest(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultIntentConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultIntentConfirmationInterceptorTest.kt
@@ -889,9 +889,7 @@ class DefaultIntentConfirmationInterceptorTest {
                 stripeAccountIdProvider = { null },
                 errorReporter = FakeErrorReporter(),
                 allowsManualConfirmation = false,
-                intentCreationCallbackProvider = {
-                    null
-                },
+                intentCreationCallbackProvider = { null },
                 preparePaymentMethodHandlerProvider = {
                     PreparePaymentMethodHandler { paymentMethod, shippingAddress ->
                         completablePaymentMethod.complete(paymentMethod)
@@ -921,7 +919,10 @@ class DefaultIntentConfirmationInterceptorTest {
             )
 
             assertThat(nextStep).isEqualTo(
-                IntentConfirmationInterceptor.NextStep.Complete(isForceSuccess = true)
+                IntentConfirmationInterceptor.NextStep.Complete(
+                    isForceSuccess = true,
+                    completedFullPaymentFlow = false,
+                )
             )
 
             val paymentMethod = completablePaymentMethod.await()
@@ -988,7 +989,10 @@ class DefaultIntentConfirmationInterceptorTest {
             )
 
             assertThat(nextStep).isEqualTo(
-                IntentConfirmationInterceptor.NextStep.Complete(isForceSuccess = true)
+                IntentConfirmationInterceptor.NextStep.Complete(
+                    isForceSuccess = true,
+                    completedFullPaymentFlow = false,
+                )
             )
 
             val paymentMethod = completablePaymentMethod.await()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationDefinitionTest.kt
@@ -137,6 +137,32 @@ class IntentConfirmationDefinitionTest {
     }
 
     @Test
+    fun `On 'IntentConfirmationInterceptor' complete with uncompleted flow, should return expected action`() =
+        runTest {
+            val intentConfirmationInterceptor = FakeIntentConfirmationInterceptor().apply {
+                enqueueCompleteStep(
+                    completedFullPaymentFlow = false
+                )
+            }
+
+            val definition = createIntentConfirmationDefinition(
+                intentConfirmationInterceptor = intentConfirmationInterceptor,
+            )
+
+            val action = definition.action(
+                confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
+                confirmationParameters = CONFIRMATION_PARAMETERS,
+            )
+
+            val completeAction = action.asComplete()
+
+            assertThat(completeAction.intent).isEqualTo(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+            assertThat(completeAction.confirmationOption).isEqualTo(SAVED_PAYMENT_CONFIRMATION_OPTION)
+            assertThat(completeAction.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Server)
+            assertThat(completeAction.completedFullPaymentFlow).isFalse()
+        }
+
+    @Test
     fun `On 'IntentConfirmationInterceptor' failure, should return 'Fail' confirmation action`() = runTest {
         val message = "Failed!"
         val cause = IllegalStateException("Failed with exception!")
@@ -330,6 +356,7 @@ class IntentConfirmationDefinitionTest {
 
         assertThat(succeededResult.intent).isEqualTo(PaymentIntentFixtures.PI_SUCCEEDED)
         assertThat(succeededResult.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Client)
+        assertThat(succeededResult.completedFullPaymentFlow).isTrue()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationFlowTest.kt
@@ -15,6 +15,7 @@ import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.PaymentMethodFixtures.CARD_PAYMENT_METHOD
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.paymentelement.PreparePaymentMethodHandler
 import com.stripe.android.paymentelement.confirmation.intent.DefaultIntentConfirmationInterceptor
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
 import com.stripe.android.paymentelement.confirmation.intent.IntentConfirmationDefinition
@@ -115,6 +116,38 @@ internal class IntentConfirmationFlowTest {
         assertThat(completeAction.confirmationOption).isEqualTo(CONFIRMATION_OPTION)
         assertThat(completeAction.deferredIntentConfirmationType)
             .isEqualTo(DeferredIntentConfirmationType.None)
+        assertThat(completeAction.completedFullPaymentFlow).isTrue()
+    }
+
+    @Test
+    fun `On deferred intent, action should be complete in uncomplete flow if preparing payment method`() = runTest {
+        val intentConfirmationDefinition = createIntentConfirmationDefinition(
+            preparePaymentMethodHandler = { _, _ ->
+                // No-op
+            }
+        )
+
+        val action = intentConfirmationDefinition.action(
+            confirmationOption = CONFIRMATION_OPTION,
+            confirmationParameters = DEFERRED_CONFIRMATION_PARAMETERS.copy(
+                initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
+                    intentConfiguration = PaymentSheet.IntentConfiguration(
+                        sharedPaymentTokenSessionWithMode = PaymentSheet.IntentConfiguration.Mode.Setup(
+                            currency = "USD",
+                        ),
+                        sellerDetails = null,
+                    )
+                )
+            ),
+        )
+
+        val completeAction = action.asComplete()
+
+        assertThat(completeAction.intent).isEqualTo(SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD)
+        assertThat(completeAction.confirmationOption).isEqualTo(CONFIRMATION_OPTION)
+        assertThat(completeAction.deferredIntentConfirmationType)
+            .isEqualTo(DeferredIntentConfirmationType.None)
+        assertThat(completeAction.completedFullPaymentFlow).isFalse()
     }
 
     @Test
@@ -244,6 +277,7 @@ internal class IntentConfirmationFlowTest {
         createPaymentMethodResult: Result<PaymentMethod> = Result.success(CARD_PAYMENT_METHOD),
         intentResult: Result<StripeIntent> =
             Result.success(SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD),
+        preparePaymentMethodHandler: PreparePaymentMethodHandler? = null,
         createIntentCallback: CreateIntentCallback? = null,
     ): IntentConfirmationDefinition {
         return IntentConfirmationDefinition(
@@ -263,7 +297,7 @@ internal class IntentConfirmationFlowTest {
                 intentCreationCallbackProvider = {
                     createIntentCallback
                 },
-                preparePaymentMethodHandlerProvider = { null }
+                preparePaymentMethodHandlerProvider = { preparePaymentMethodHandler }
             ),
             paymentLauncherFactory = {
                 FakePaymentLauncher()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cpms/CustomPaymentMethodConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cpms/CustomPaymentMethodConfirmationActivityTest.kt
@@ -85,6 +85,7 @@ internal class CustomPaymentMethodConfirmationActivityTest {
 
             assertThat(successResult.intent).isEqualTo(PAYMENT_INTENT)
             assertThat(successResult.deferredIntentConfirmationType).isNull()
+            assertThat(successResult.completedFullPaymentFlow).isTrue()
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cpms/CustomPaymentMethodConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cpms/CustomPaymentMethodConfirmationDefinitionTest.kt
@@ -164,6 +164,7 @@ class CustomPaymentMethodConfirmationDefinitionTest {
         val succeededResult = result.asSucceeded()
         assertThat(succeededResult.intent).isEqualTo(CONFIRMATION_PARAMETERS.intent)
         assertThat(succeededResult.deferredIntentConfirmationType).isNull()
+        assertThat(succeededResult.completedFullPaymentFlow).isTrue()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationActivityTest.kt
@@ -90,6 +90,7 @@ internal class ExternalPaymentMethodConfirmationActivityTest {
 
             assertThat(successResult.intent).isEqualTo(PAYMENT_INTENT)
             assertThat(successResult.deferredIntentConfirmationType).isNull()
+            assertThat(successResult.completedFullPaymentFlow).isTrue()
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationDefinitionTest.kt
@@ -105,6 +105,7 @@ class ExternalPaymentMethodConfirmationDefinitionTest {
 
         assertThat(successResult.intent).isEqualTo(PAYMENT_INTENT)
         assertThat(successResult.deferredIntentConfirmationType).isNull()
+        assertThat(successResult.completedFullPaymentFlow).isTrue()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationActivityTest.kt
@@ -92,6 +92,7 @@ internal class GooglePayConfirmationActivityTest {
 
             assertThat(successResult.intent).isEqualTo(PAYMENT_INTENT.copy(paymentMethod = paymentMethod))
             assertThat(successResult.deferredIntentConfirmationType).isNull()
+            assertThat(successResult.completedFullPaymentFlow).isTrue()
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationActivityTest.kt
@@ -133,6 +133,7 @@ internal class LinkConfirmationActivityTest(private val nativeLinkEnabled: Boole
 
             assertThat(successResult.intent).isEqualTo(PAYMENT_INTENT.copy(paymentMethod = paymentMethod))
             assertThat(successResult.deferredIntentConfirmationType).isNull()
+            assertThat(successResult.completedFullPaymentFlow).isTrue()
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/shoppay/ShopPayConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/shoppay/ShopPayConfirmationDefinitionTest.kt
@@ -129,6 +129,7 @@ internal class ShopPayConfirmationDefinitionTest {
 
         assertThat(succeededResult.intent).isEqualTo(CONFIRMATION_PARAMETERS.intent)
         assertThat(succeededResult.deferredIntentConfirmationType).isNull()
+        assertThat(succeededResult.completedFullPaymentFlow).isFalse()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -215,6 +215,33 @@ internal class DefaultFlowControllerTest {
     }
 
     @Test
+    fun `successful payment should not clear viewmodel state if specified`() = confirmationTest {
+        val viewModel = createViewModel()
+        val flowController = createFlowController(viewModel = viewModel)
+
+        flowController.configureExpectingSuccess()
+
+        val paymentSelection = PaymentSelection.New.Card(
+            PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+            mock(),
+            mock()
+        )
+
+        viewModel.paymentSelection = paymentSelection
+
+        confirmationState.value = ConfirmationHandler.State.Complete(
+            ConfirmationHandler.Result.Succeeded(
+                intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+                deferredIntentConfirmationType = null,
+                completedFullPaymentFlow = false,
+            )
+        )
+
+        assertThat(viewModel.paymentSelection).isEqualTo(paymentSelection)
+        assertThat(viewModel.state).isNotNull()
+    }
+
+    @Test
     fun `failed payment should fire analytics event`() = runTest {
         val viewModel = createViewModel()
         val flowController = createFlowController(viewModel = viewModel)

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeIntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeIntentConfirmationInterceptor.kt
@@ -33,8 +33,9 @@ internal class FakeIntentConfirmationInterceptor : IntentConfirmationInterceptor
 
     fun enqueueCompleteStep(
         isForceSuccess: Boolean = false,
+        completedFullPaymentFlow: Boolean = true,
     ) {
-        channel.trySend(IntentConfirmationInterceptor.NextStep.Complete(isForceSuccess))
+        channel.trySend(IntentConfirmationInterceptor.NextStep.Complete(isForceSuccess, completedFullPaymentFlow))
     }
 
     fun enqueueNextActionStep(clientSecret: String) {


### PR DESCRIPTION
# Summary
Don't clear `FlowController` for `preparePaymentMethod` API

# Motivation
Since the `preparePaymentMethod` API effectively hands over the payment method for the merchant to handle, we don't want to reset the `FlowController` state in case of an external failure. Merchant feedback regarding the API.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified