### PR TITLE
StripeCryptoOnramp: Updates OnrampCoordinator To Use Builder

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/callbacks/PaymentElementCallbackIdentifier.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/callbacks/PaymentElementCallbackIdentifier.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.paymentelement.callbacks
 
+import androidx.annotation.RestrictTo
 import javax.inject.Qualifier
 
 @Qualifier
-internal annotation class PaymentElementCallbackIdentifier
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+annotation class PaymentElementCallbackIdentifier

--- a/stripe-crypto-onramp/build.gradle
+++ b/stripe-crypto-onramp/build.gradle
@@ -2,6 +2,7 @@ apply from: configs.androidLibrary
 
 apply plugin: 'org.jetbrains.kotlin.plugin.parcelize'
 apply plugin: 'dev.drewhamilton.poko'
+apply plugin: 'com.google.devtools.ksp'
 
 dependencies {
     implementation project(':stripe-core')
@@ -15,6 +16,8 @@ dependencies {
     implementation libs.kotlin.serialization
 
     implementation libs.dagger
+
+    ksp libs.daggerCompiler
 
     testImplementation testLibs.androidx.junit
 

--- a/stripe-crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampCoordinator.kt
+++ b/stripe-crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampCoordinator.kt
@@ -4,12 +4,8 @@ import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultRegistryOwner
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.SavedStateHandle
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
-import androidx.lifecycle.createSavedStateHandle
-import androidx.lifecycle.viewmodel.CreationExtras
 import com.stripe.android.crypto.onramp.di.DaggerOnrampComponent
 import com.stripe.android.crypto.onramp.di.OnrampComponent
 import com.stripe.android.crypto.onramp.model.ConfigurationCallback
@@ -180,4 +176,3 @@ internal class OnrampCoordinator @Inject internal constructor(
         }
     }
 }
-

--- a/stripe-crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampCoordinator.kt
+++ b/stripe-crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampCoordinator.kt
@@ -15,6 +15,7 @@ import com.stripe.android.crypto.onramp.di.OnrampComponent
 import com.stripe.android.crypto.onramp.model.ConfigurationCallback
 import com.stripe.android.crypto.onramp.model.LinkUserInfo
 import com.stripe.android.crypto.onramp.model.OnrampConfiguration
+import com.stripe.android.crypto.onramp.viewmodels.OnrampCoordinatorViewModel
 import com.stripe.android.link.LinkController
 import javax.inject.Inject
 
@@ -109,9 +110,19 @@ internal class OnrampCoordinator @Inject internal constructor(
         TODO("Not yet implemented")
     }
 
+    /**
+     * A Builder utility type to create an [OnrampCoordinator] with appropriate parameters.
+     *
+     * @param isLinkUserCallback A callback for handling if a given user has a link account.
+     */
     class Builder(
         private val isLinkUserCallback: (Boolean) -> Unit
     ) {
+        /**
+         * Constructs an [OnrampCoordinator] for the given parameters.
+         *
+         * @param activity The Activity that is using the [OnrampCoordinator].
+         */
         fun build(activity: ComponentActivity): OnrampCoordinator {
             return create(
                 viewModelStoreOwner = activity,
@@ -120,6 +131,11 @@ internal class OnrampCoordinator @Inject internal constructor(
             )
         }
 
+        /**
+         * Constructs an [OnrampCoordinator] for the given parameters.
+         *
+         * @param fragment The Fragment that is using the [OnrampCoordinator].
+         */
         fun build(fragment: Fragment): OnrampCoordinator {
             return create(
                 viewModelStoreOwner = fragment,
@@ -144,7 +160,6 @@ internal class OnrampCoordinator @Inject internal constructor(
                 modelClass = OnrampCoordinatorViewModel::class.java
             )
 
-            // Get Application from the lifecycle owner (which should be an Activity or Fragment)
             val application = when (lifecycleOwner) {
                 is Fragment -> lifecycleOwner.requireActivity().application
                 is ComponentActivity -> lifecycleOwner.application
@@ -166,29 +181,3 @@ internal class OnrampCoordinator @Inject internal constructor(
     }
 }
 
-/**
- * ViewModel that stores Onramp configuration in a SavedStateHandle for
- * process death restoration.
- *
- * @property handle SavedStateHandle backing persistent state.
- */
-internal class OnrampCoordinatorViewModel(
-    private val handle: SavedStateHandle
-) : ViewModel() {
-
-    /**
-     * The current OnrampConfiguration, persisted across process restarts.
-     */
-    var onRampConfiguration: OnrampConfiguration?
-        get() = handle["configuration"]
-        set(value) = handle.set("configuration", value)
-
-    class Factory : ViewModelProvider.Factory {
-        @Suppress("UNCHECKED_CAST")
-        override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
-            return OnrampCoordinatorViewModel(
-                handle = extras.createSavedStateHandle(),
-            ) as T
-        }
-    }
-}

--- a/stripe-crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/di/OnrampComponent.kt
+++ b/stripe-crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/di/OnrampComponent.kt
@@ -1,0 +1,51 @@
+package com.stripe.android.crypto.onramp.di
+
+import android.app.Application
+import androidx.activity.result.ActivityResultRegistryOwner
+import com.stripe.android.core.injection.CoreCommonModule
+import com.stripe.android.core.injection.CoroutineContextModule
+import com.stripe.android.crypto.onramp.OnrampCoordinator
+import com.stripe.android.crypto.onramp.OnrampCoordinatorViewModel
+import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
+import com.stripe.android.payments.core.injection.StripeRepositoryModule
+import com.stripe.android.ui.core.forms.resources.injection.ResourceRepositoryModule
+import dagger.BindsInstance
+import dagger.Component
+import javax.inject.Singleton
+
+@Singleton
+@Component(
+    modules = [
+        StripeRepositoryModule::class,
+        ResourceRepositoryModule::class,
+        CoreCommonModule::class,
+        CoroutineContextModule::class,
+    ]
+)
+internal interface OnrampComponent {
+    val onrampCoordinator: OnrampCoordinator
+
+    @Component.Builder
+    interface Builder {
+        @BindsInstance
+        fun application(application: Application): Builder
+
+        @BindsInstance
+        fun onRampCoordinatorViewModel(viewModel: OnrampCoordinatorViewModel): Builder
+
+        @BindsInstance
+        fun linkElementCallbackIdentifier(
+            @PaymentElementCallbackIdentifier linkElementCallbackIdentifier: String
+        ): Builder
+
+        @BindsInstance
+        fun activityResultRegistryOwner(
+            activityResultRegistryOwner: ActivityResultRegistryOwner
+        ): Builder
+
+        @BindsInstance
+        fun isLinkUserCallback(isLinkUserCallback: (Boolean) -> Unit): Builder
+
+        fun build(): OnrampComponent
+    }
+}

--- a/stripe-crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/di/OnrampComponent.kt
+++ b/stripe-crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/di/OnrampComponent.kt
@@ -5,7 +5,7 @@ import androidx.activity.result.ActivityResultRegistryOwner
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.crypto.onramp.OnrampCoordinator
-import com.stripe.android.crypto.onramp.OnrampCoordinatorViewModel
+import com.stripe.android.crypto.onramp.viewmodels.OnrampCoordinatorViewModel
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.ui.core.forms.resources.injection.ResourceRepositoryModule

--- a/stripe-crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/viewmodels/OnrampCoordinatorViewModel.kt
+++ b/stripe-crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/viewmodels/OnrampCoordinatorViewModel.kt
@@ -1,0 +1,35 @@
+package com.stripe.android.crypto.onramp.viewmodels
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.createSavedStateHandle
+import androidx.lifecycle.viewmodel.CreationExtras
+import com.stripe.android.crypto.onramp.model.OnrampConfiguration
+
+/**
+ * ViewModel that stores Onramp configuration in a SavedStateHandle for
+ * process death restoration.
+ *
+ * @property handle SavedStateHandle backing persistent state.
+ */
+internal class OnrampCoordinatorViewModel(
+    private val handle: SavedStateHandle
+) : ViewModel() {
+
+    /**
+     * The current OnrampConfiguration, persisted across process restarts.
+     */
+    var onRampConfiguration: OnrampConfiguration?
+        get() = handle["configuration"]
+        set(value) = handle.set("configuration", value)
+
+    class Factory : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
+            return OnrampCoordinatorViewModel(
+                handle = extras.createSavedStateHandle(),
+            ) as T
+        }
+    }
+}


### PR DESCRIPTION
# Summary
* Updates the `OnrampCoordinator` to utilize a Builder utility for initialization through a new Component addition.

# Motivation
Clients of the Coordinator need a good way to construct it, this is the currently proposed way.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

Added the following to the payment sheet example `Reload` button to test the success of construction via the `Builder`.

```kotlin
val coordinator = OnrampCoordinator.Builder(isLinkUserCallback = { success ->
    // Check success
}).build(this)

coordinator.isLinkUser("test")
```

# Screenshots
N/A

# Changelog
N/A
