### PR TITLE
Add new radar session creation type for payment methods for `PreparePaymentMethod` API.

### DIFF
--- a/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
@@ -294,6 +294,13 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         TODO("Not yet implemented")
     }
 
+    override suspend fun createSavedPaymentMethodRadarSession(
+        paymentMethodId: String,
+        requestOptions: ApiRequest.Options
+    ): Result<RadarSessionWithHCaptcha> {
+        TODO("Not yet implemented")
+    }
+
     override suspend fun attachHCaptchaToRadarSession(
         radarSessionToken: String,
         hcaptchaToken: String,

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -282,6 +282,12 @@ interface StripeRepository {
     ): Result<RadarSessionWithHCaptcha>
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    suspend fun createSavedPaymentMethodRadarSession(
+        paymentMethodId: String,
+        requestOptions: ApiRequest.Options
+    ): Result<RadarSessionWithHCaptcha>
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     suspend fun attachHCaptchaToRadarSession(
         radarSessionToken: String,
         hcaptchaToken: String,

--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -158,6 +158,9 @@ interface ErrorReporter : FraudDetectionErrorReporter {
         FRAUD_DETECTION_API_FAILURE(
             eventName = "fraud_detection_data_repository.api_failure"
         ),
+        SAVED_PAYMENT_METHOD_RADAR_SESSION_FAILURE(
+            eventName = "stripe_android.saved_payment_method_radar_session_failure"
+        ),
         EXTERNAL_PAYMENT_METHOD_CONFIRM_HANDLER_NULL(
             eventName = "paymentsheet.external_payment_method.confirm_handler_is_null"
         ),

--- a/paymentsheet/src/main/java/com/stripe/android/shoppay/di/ShopPayModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/shoppay/di/ShopPayModule.kt
@@ -4,16 +4,21 @@ import com.stripe.android.BuildConfig
 import com.stripe.android.SharedPaymentTokenSessionPreview
 import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.model.parsers.ModelJsonParser
+import com.stripe.android.core.networking.AnalyticsRequestExecutor
+import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.core.utils.DefaultDurationProvider
 import com.stripe.android.core.utils.DurationProvider
 import com.stripe.android.core.utils.RealUserFacingLogger
 import com.stripe.android.core.utils.UserFacingLogger
+import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.paymentelement.AnalyticEventCallback
 import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
 import com.stripe.android.paymentelement.PreparePaymentMethodHandler
 import com.stripe.android.paymentelement.ShopPayPreview
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
+import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.payments.core.analytics.RealErrorReporter
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.ShopPayHandlers
@@ -77,6 +82,11 @@ internal interface ShopPayModule {
         parser: ECEShippingRateJsonParser
     ): ModelJsonParser<ECEShippingRate>
 
+    @Binds
+    fun bindsAnalyticsRequestFactory(
+        paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory
+    ): AnalyticsRequestFactory
+
     companion object {
         @OptIn(ShopPayPreview::class)
         @Provides
@@ -110,6 +120,15 @@ internal interface ShopPayModule {
 
         @Provides
         fun provideDurationProvider(): DurationProvider = DefaultDurationProvider.instance
+
+        @Provides
+        internal fun providesErrorReporter(
+            analyticsRequestFactory: AnalyticsRequestFactory,
+            analyticsRequestExecutor: AnalyticsRequestExecutor
+        ): ErrorReporter = RealErrorReporter(
+            analyticsRequestFactory = analyticsRequestFactory,
+            analyticsRequestExecutor = analyticsRequestExecutor,
+        )
 
         @OptIn(ExperimentalAnalyticEventCallbackApi::class)
         @Provides

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultIntentConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultIntentConfirmationInterceptorTest.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentelement.confirmation
 
+import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.SharedPaymentTokenSessionPreview
 import com.stripe.android.core.exception.APIException
@@ -15,6 +16,7 @@ import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodOptionsParams
+import com.stripe.android.model.RadarSessionWithHCaptcha
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.paymentelement.PreparePaymentMethodHandler
@@ -876,6 +878,7 @@ class DefaultIntentConfirmationInterceptorTest {
         runTest {
             val completablePaymentMethod = CompletableDeferred<PaymentMethod>()
             val completableShippingAddress = CompletableDeferred<AddressDetails?>()
+            val createSavedPaymentMethodRadarSessionCalls = Turbine<CreateSavedPaymentMethodRadarSessionCall>()
 
             val providedPaymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
             val providedShippingAddress = SHIPPING_ADDRESS
@@ -883,7 +886,8 @@ class DefaultIntentConfirmationInterceptorTest {
             val interceptor = DefaultIntentConfirmationInterceptor(
                 stripeRepository = stripeRepositoryReturning(
                     onCreatePaymentMethodId = "pm_1234",
-                    onRetrievePaymentMethodId = "pm_5678"
+                    onRetrievePaymentMethodId = "pm_5678",
+                    createSavedPaymentMethodRadarSessionCalls = createSavedPaymentMethodRadarSessionCalls,
                 ),
                 publishableKeyProvider = { "pk" },
                 stripeAccountIdProvider = { null },
@@ -931,14 +935,15 @@ class DefaultIntentConfirmationInterceptorTest {
 
             val shippingAddress = completableShippingAddress.await()
 
-            assertThat(shippingAddress?.name).isEqualTo(providedShippingAddress.getName())
-            assertThat(shippingAddress?.phoneNumber).isEqualTo(providedShippingAddress.getPhone())
-            assertThat(shippingAddress?.address?.line1).isEqualTo(providedShippingAddress.getAddress().line1)
-            assertThat(shippingAddress?.address?.line2).isEqualTo(providedShippingAddress.getAddress().line2)
-            assertThat(shippingAddress?.address?.city).isEqualTo(providedShippingAddress.getAddress().city)
-            assertThat(shippingAddress?.address?.state).isEqualTo(providedShippingAddress.getAddress().state)
-            assertThat(shippingAddress?.address?.country)
-                .isEqualTo(providedShippingAddress.getAddress().country)
+            verifyShipping(providedShippingAddress, shippingAddress)
+
+            val createRadarSessionCall = createSavedPaymentMethodRadarSessionCalls.awaitItem()
+
+            assertThat(createRadarSessionCall.paymentMethodId).isEqualTo("pm_123456789")
+            assertThat(createRadarSessionCall.requestOptions.apiKey).isEqualTo("pk")
+            assertThat(createRadarSessionCall.requestOptions.stripeAccount).isNull()
+
+            createSavedPaymentMethodRadarSessionCalls.ensureAllEventsConsumed()
         }
 
     @Test
@@ -946,11 +951,13 @@ class DefaultIntentConfirmationInterceptorTest {
         runTest {
             val completablePaymentMethod = CompletableDeferred<PaymentMethod>()
             val completableShippingAddress = CompletableDeferred<AddressDetails?>()
+            val createSavedPaymentMethodRadarSessionCalls = Turbine<CreateSavedPaymentMethodRadarSessionCall>()
 
             val interceptor = DefaultIntentConfirmationInterceptor(
                 stripeRepository = stripeRepositoryReturning(
                     onCreatePaymentMethodId = "pm_1234",
-                    onRetrievePaymentMethodId = "pm_5678"
+                    onRetrievePaymentMethodId = "pm_5678",
+                    createSavedPaymentMethodRadarSessionCalls = createSavedPaymentMethodRadarSessionCalls,
                 ),
                 publishableKeyProvider = { "pk" },
                 stripeAccountIdProvider = { null },
@@ -1002,6 +1009,78 @@ class DefaultIntentConfirmationInterceptorTest {
             val shippingAddress = completableShippingAddress.await()
 
             assertThat(shippingAddress).isNull()
+
+            createSavedPaymentMethodRadarSessionCalls.verify()
+        }
+
+    @Test
+    fun `If failed to make radar session, should still continue with preparing payment method`() =
+        runTest {
+            val completablePaymentMethod = CompletableDeferred<PaymentMethod>()
+            val completableShippingAddress = CompletableDeferred<AddressDetails?>()
+            val createSavedPaymentMethodRadarSessionCalls = Turbine<CreateSavedPaymentMethodRadarSessionCall>()
+
+            val error = IllegalStateException("Failed to make radar session!")
+            val eventReporter = FakeErrorReporter()
+
+            val interceptor = DefaultIntentConfirmationInterceptor(
+                stripeRepository = stripeRepositoryReturning(
+                    onCreatePaymentMethodId = "pm_1234",
+                    onRetrievePaymentMethodId = "pm_5678",
+                    createSavedPaymentMethodRadarSessionResult = Result.failure(error),
+                    createSavedPaymentMethodRadarSessionCalls = createSavedPaymentMethodRadarSessionCalls,
+                ),
+                publishableKeyProvider = { "pk" },
+                stripeAccountIdProvider = { null },
+                errorReporter = eventReporter,
+                allowsManualConfirmation = false,
+                intentCreationCallbackProvider = {
+                    null
+                },
+                preparePaymentMethodHandlerProvider = {
+                    PreparePaymentMethodHandler { paymentMethod, shippingAddress ->
+                        completablePaymentMethod.complete(paymentMethod)
+                        completableShippingAddress.complete(shippingAddress)
+                    }
+                },
+            )
+
+            val nextStep = interceptor.intercept(
+                initializationMode = InitializationMode.DeferredIntent(
+                    intentConfiguration = PaymentSheet.IntentConfiguration(
+                        sharedPaymentTokenSessionWithMode = PaymentSheet.IntentConfiguration.Mode.Payment(
+                            amount = 1099L,
+                            currency = "usd",
+                        ),
+                        sellerDetails = PaymentSheet.IntentConfiguration.SellerDetails(
+                            networkId = "network_id",
+                            externalId = "external_id"
+                        )
+                    ),
+                ),
+                intent = PaymentIntentFactory.create(),
+                paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                paymentMethodOptionsParams = null,
+                paymentMethodExtraParams = null,
+                shippingValues = null,
+                customerRequestedSave = false,
+            )
+
+            assertThat(nextStep).isEqualTo(
+                IntentConfirmationInterceptor.NextStep.Complete(isForceSuccess = true)
+            )
+
+            val paymentMethod = completablePaymentMethod.await()
+
+            assertThat(paymentMethod.id).isEqualTo("pm_1234")
+
+            val shippingAddress = completableShippingAddress.await()
+
+            assertThat(shippingAddress).isNull()
+
+            createSavedPaymentMethodRadarSessionCalls.verify()
+
+            eventReporter.verifyCreateSavedPaymentMethodRadarSessionCall(error)
         }
 
     private fun testNoProvider(
@@ -1085,6 +1164,14 @@ class DefaultIntentConfirmationInterceptorTest {
     private fun stripeRepositoryReturning(
         onCreatePaymentMethodId: String,
         onRetrievePaymentMethodId: String,
+        createSavedPaymentMethodRadarSessionCalls: Turbine<CreateSavedPaymentMethodRadarSessionCall> = Turbine(),
+        createSavedPaymentMethodRadarSessionResult: Result<RadarSessionWithHCaptcha> = Result.success(
+            RadarSessionWithHCaptcha(
+                id = "rse_123",
+                passiveCaptchaSiteKey = "1234",
+                passiveCaptchaRqdata = "123456789",
+            )
+        ),
     ): StripeRepository {
         return object : AbsFakeStripeRepository() {
             override suspend fun createPaymentMethod(
@@ -1109,7 +1196,54 @@ class DefaultIntentConfirmationInterceptorTest {
                     )
                 )
             }
+
+            override suspend fun createSavedPaymentMethodRadarSession(
+                paymentMethodId: String,
+                requestOptions: ApiRequest.Options
+            ): Result<RadarSessionWithHCaptcha> {
+                createSavedPaymentMethodRadarSessionCalls.add(
+                    CreateSavedPaymentMethodRadarSessionCall(paymentMethodId, requestOptions)
+                )
+
+                return createSavedPaymentMethodRadarSessionResult
+            }
         }
+    }
+
+    private fun verifyShipping(
+        expectedShippingAddress: ConfirmPaymentIntentParams.Shipping,
+        actualShippingAddress: AddressDetails?
+    ) {
+        assertThat(actualShippingAddress?.name).isEqualTo(expectedShippingAddress.getName())
+        assertThat(actualShippingAddress?.phoneNumber).isEqualTo(expectedShippingAddress.getPhone())
+        assertThat(actualShippingAddress?.address?.line1).isEqualTo(expectedShippingAddress.getAddress().line1)
+        assertThat(actualShippingAddress?.address?.line2).isEqualTo(expectedShippingAddress.getAddress().line2)
+        assertThat(actualShippingAddress?.address?.city).isEqualTo(expectedShippingAddress.getAddress().city)
+        assertThat(actualShippingAddress?.address?.state).isEqualTo(expectedShippingAddress.getAddress().state)
+        assertThat(actualShippingAddress?.address?.country)
+            .isEqualTo(expectedShippingAddress.getAddress().country)
+    }
+
+    private suspend fun Turbine<CreateSavedPaymentMethodRadarSessionCall>.verify() {
+        val createRadarSessionCall = awaitItem()
+
+        assertThat(createRadarSessionCall.paymentMethodId).isEqualTo("pm_1234")
+        assertThat(createRadarSessionCall.requestOptions.apiKey).isEqualTo("pk")
+        assertThat(createRadarSessionCall.requestOptions.stripeAccount).isNull()
+
+        ensureAllEventsConsumed()
+    }
+
+    private suspend fun FakeErrorReporter.verifyCreateSavedPaymentMethodRadarSessionCall(
+        error: Exception,
+    ) {
+        val failedRadarEvent = awaitCall()
+
+        assertThat(failedRadarEvent.errorEvent)
+            .isEqualTo(ErrorReporter.ExpectedErrorEvent.SAVED_PAYMENT_METHOD_RADAR_SESSION_FAILURE)
+        assertThat(failedRadarEvent.stripeException?.cause).isEqualTo(error)
+
+        ensureAllEventsConsumed()
     }
 
     private fun IntentConfirmationInterceptor.NextStep.asFail(): IntentConfirmationInterceptor.NextStep.Fail {
@@ -1126,6 +1260,11 @@ class DefaultIntentConfirmationInterceptorTest {
             return other is TestException && other.message == message
         }
     }
+
+    private data class CreateSavedPaymentMethodRadarSessionCall(
+        val paymentMethodId: String,
+        val requestOptions: ApiRequest.Options
+    )
 
     private companion object {
         const val CREATE_INTENT_CALLBACK_MESSAGE =

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultIntentConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultIntentConfirmationInterceptorTest.kt
@@ -1034,9 +1034,7 @@ class DefaultIntentConfirmationInterceptorTest {
                 stripeAccountIdProvider = { null },
                 errorReporter = eventReporter,
                 allowsManualConfirmation = false,
-                intentCreationCallbackProvider = {
-                    null
-                },
+                intentCreationCallbackProvider = { null },
                 preparePaymentMethodHandlerProvider = {
                     PreparePaymentMethodHandler { paymentMethod, shippingAddress ->
                         completablePaymentMethod.complete(paymentMethod)
@@ -1067,7 +1065,10 @@ class DefaultIntentConfirmationInterceptorTest {
             )
 
             assertThat(nextStep).isEqualTo(
-                IntentConfirmationInterceptor.NextStep.Complete(isForceSuccess = true)
+                IntentConfirmationInterceptor.NextStep.Complete(
+                    isForceSuccess = true,
+                    completedFullPaymentFlow = false,
+                )
             )
 
             val paymentMethod = completablePaymentMethod.await()

--- a/paymentsheet/src/test/java/com/stripe/android/shoppay/ShopPayActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/shoppay/ShopPayActivityTest.kt
@@ -33,6 +33,7 @@ import com.stripe.android.shoppay.bridge.ShopPayBridgeHandler
 import com.stripe.android.shoppay.bridge.ShopPayConfirmationState
 import com.stripe.android.testing.AbsFakeStripeRepository
 import com.stripe.android.testing.CoroutineTestRule
+import com.stripe.android.testing.FakeErrorReporter
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -350,6 +351,7 @@ internal class ShopPayActivityTest {
                         preparePaymentMethodHandler
                     },
                     workContext = dispatcher,
+                    errorReporter = FakeErrorReporter(),
                     eventReporter = FakeEventReporter(),
                 ) as T
             }


### PR DESCRIPTION
# Summary
Add new radar session creation type for payment methods for `PreparePaymentMethod` API.

# Motivation
Risk ask for merchant

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified