### PR TITLE
Remove unsupported device.

### DIFF
--- a/scripts/browserstack.py
+++ b/scripts/browserstack.py
@@ -274,7 +274,6 @@ def executeTests(appUrl, testUrl, isNightly):
             "Google Pixel 4 XL-10.0",
             "Google Pixel 3-9.0",
             "Samsung Galaxy S9-8.0",
-            "Samsung Galaxy S8-7.0",
         ]
     else:
         devices = [


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Our nightly tests are failing, with an error saying this device doesn't exist.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fix nightly builds.


https://github.com/stripe/stripe-android/actions/runs/16388511280/job/46311365246


{'message': "[BROWSERSTACK_INVALID_DEVICE] The device 'Samsung Galaxy S8-7.0' specified in the 'devices' param is invalid. Specify a device using its display name and os_version, such as 'Samsung Galaxy S9-8.0'.  To view the list of available devices and os versions, visit our documentation - https://www.browserstack.com/list-of-browsers-and-platforms/app_automate"}
