### PR TITLE
Add `is_spt` to `PaymentSheet` events

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -49,6 +49,7 @@ internal class DefaultEventReporter @Inject internal constructor(
 ) : EventReporter {
 
     private var isDeferred: Boolean = false
+    private var isSpt: Boolean = false
     private var linkEnabled: Boolean = false
     private var linkMode: LinkMode? = null
     private var googlePaySupported: Boolean = false
@@ -78,6 +79,7 @@ internal class DefaultEventReporter @Inject internal constructor(
                 primaryButtonColor = primaryButtonColor,
                 configurationSpecificPayload = configurationSpecificPayload,
                 isDeferred = isDeferred,
+                isSpt = isSpt,
                 linkEnabled = linkEnabled,
                 googlePaySupported = googlePaySupported,
                 isStripeCardScanAvailable = isStripeCardScanAvailable(),
@@ -88,7 +90,15 @@ internal class DefaultEventReporter @Inject internal constructor(
 
     override fun onLoadStarted(initializedViaCompose: Boolean) {
         durationProvider.start(DurationProvider.Key.Loading)
-        fireEvent(PaymentSheetEvent.LoadStarted(isDeferred, linkEnabled, googlePaySupported, initializedViaCompose))
+        fireEvent(
+            PaymentSheetEvent.LoadStarted(
+                isDeferred = isDeferred,
+                linkEnabled = linkEnabled,
+                googlePaySupported = googlePaySupported,
+                isSpt = isSpt,
+                initializedViaCompose = initializedViaCompose
+            )
+        )
     }
 
     override fun onLoadSucceeded(
@@ -110,6 +120,9 @@ internal class DefaultEventReporter @Inject internal constructor(
         this.currency = currency
         this.linkEnabled = linkEnabled
         this.linkMode = linkMode
+        this.isSpt = initializationMode is PaymentElementLoader.InitializationMode.DeferredIntent &&
+            initializationMode.intentConfiguration.intentBehavior is
+            PaymentSheet.IntentConfiguration.IntentBehavior.SharedPaymentToken
         this.googlePaySupported = googlePaySupported
         this.financialConnectionsAvailability = financialConnectionsAvailability
 
@@ -122,6 +135,7 @@ internal class DefaultEventReporter @Inject internal constructor(
                 paymentSelection = paymentSelection,
                 duration = duration,
                 isDeferred = isDeferred,
+                isSpt = isSpt,
                 linkEnabled = linkEnabled,
                 linkMode = linkMode,
                 googlePaySupported = googlePaySupported,
@@ -147,6 +161,7 @@ internal class DefaultEventReporter @Inject internal constructor(
                 duration = duration,
                 error = error,
                 isDeferred = isDeferred,
+                isSpt = isSpt,
                 linkEnabled = linkEnabled,
                 googlePaySupported = googlePaySupported,
             )
@@ -158,6 +173,7 @@ internal class DefaultEventReporter @Inject internal constructor(
             PaymentSheetEvent.ElementsSessionLoadFailed(
                 error = error,
                 isDeferred = isDeferred,
+                isSpt = isSpt,
                 linkEnabled = linkEnabled,
                 googlePaySupported = googlePaySupported,
             )
@@ -168,6 +184,7 @@ internal class DefaultEventReporter @Inject internal constructor(
         fireEvent(
             PaymentSheetEvent.Dismiss(
                 isDeferred = isDeferred,
+                isSpt = isSpt,
                 linkEnabled = linkEnabled,
                 googlePaySupported = googlePaySupported,
             )
@@ -183,6 +200,7 @@ internal class DefaultEventReporter @Inject internal constructor(
                 googlePaySupported = googlePaySupported,
                 currency = currency,
                 isDeferred = isDeferred,
+                isSpt = isSpt,
             )
         )
     }
@@ -195,6 +213,7 @@ internal class DefaultEventReporter @Inject internal constructor(
                 googlePaySupported = googlePaySupported,
                 currency = currency,
                 isDeferred = isDeferred,
+                isSpt = isSpt,
             )
         )
     }
@@ -208,6 +227,7 @@ internal class DefaultEventReporter @Inject internal constructor(
                 googlePaySupported = googlePaySupported,
                 currency = currency,
                 isDeferred = isDeferred,
+                isSpt = isSpt,
             )
         )
     }
@@ -220,6 +240,7 @@ internal class DefaultEventReporter @Inject internal constructor(
             PaymentSheetEvent.SelectPaymentMethod(
                 code = code,
                 isDeferred = isDeferred,
+                isSpt = isSpt,
                 currency = currency,
                 linkEnabled = linkEnabled,
                 linkContext = determineLinkContextForPaymentMethodType(code),
@@ -237,6 +258,7 @@ internal class DefaultEventReporter @Inject internal constructor(
                 code = code,
                 currency = currency,
                 isDeferred = isDeferred,
+                isSpt = isSpt,
                 linkEnabled = linkEnabled,
                 googlePaySupported = googlePaySupported,
             )
@@ -251,6 +273,7 @@ internal class DefaultEventReporter @Inject internal constructor(
             PaymentSheetEvent.ShowPaymentOptionForm(
                 code = code,
                 isDeferred = isDeferred,
+                isSpt = isSpt,
                 linkEnabled = linkEnabled,
                 googlePaySupported = googlePaySupported,
             )
@@ -265,6 +288,7 @@ internal class DefaultEventReporter @Inject internal constructor(
                 isDeferred = isDeferred,
                 linkEnabled = linkEnabled,
                 googlePaySupported = googlePaySupported,
+                isSpt = isSpt,
             )
         )
     }
@@ -281,6 +305,7 @@ internal class DefaultEventReporter @Inject internal constructor(
                 isDeferred = isDeferred,
                 linkEnabled = linkEnabled,
                 googlePaySupported = googlePaySupported,
+                isSpt = isSpt,
             )
         )
     }
@@ -289,6 +314,7 @@ internal class DefaultEventReporter @Inject internal constructor(
         fireEvent(
             PaymentSheetEvent.CardNumberCompleted(
                 isDeferred = isDeferred,
+                isSpt = isSpt,
                 linkEnabled = linkEnabled,
                 googlePaySupported = googlePaySupported,
             )
@@ -309,6 +335,7 @@ internal class DefaultEventReporter @Inject internal constructor(
                 paymentSelection = paymentSelection,
                 currency = currency,
                 isDeferred = isDeferred,
+                isSpt = isSpt,
                 linkEnabled = linkEnabled,
                 googlePaySupported = googlePaySupported,
             )
@@ -320,6 +347,7 @@ internal class DefaultEventReporter @Inject internal constructor(
             PaymentSheetEvent.CardBrandDisallowed(
                 cardBrand = brand,
                 isDeferred = isDeferred,
+                isSpt = isSpt,
                 linkEnabled = linkEnabled,
                 googlePaySupported = googlePaySupported,
             )
@@ -337,6 +365,7 @@ internal class DefaultEventReporter @Inject internal constructor(
                 selectedLpm = paymentSelection.code(),
                 linkContext = paymentSelection.linkContext(),
                 isDeferred = isDeferred,
+                isSpt = isSpt,
                 linkEnabled = linkEnabled,
                 googlePaySupported = googlePaySupported,
                 financialConnectionsAvailability = financialConnectionsAvailability,
@@ -363,6 +392,7 @@ internal class DefaultEventReporter @Inject internal constructor(
                 result = PaymentSheetEvent.Payment.Result.Success,
                 currency = currency,
                 isDeferred = deferredIntentConfirmationType != null,
+                isSpt = isSpt,
                 linkEnabled = linkEnabled,
                 googlePaySupported = googlePaySupported,
                 deferredIntentConfirmationType = deferredIntentConfirmationType,
@@ -384,6 +414,7 @@ internal class DefaultEventReporter @Inject internal constructor(
                 result = PaymentSheetEvent.Payment.Result.Failure(error),
                 currency = currency,
                 isDeferred = isDeferred,
+                isSpt = isSpt,
                 linkEnabled = linkEnabled,
                 googlePaySupported = googlePaySupported,
                 deferredIntentConfirmationType = null,
@@ -395,6 +426,7 @@ internal class DefaultEventReporter @Inject internal constructor(
         fireEvent(
             PaymentSheetEvent.LpmSerializeFailureEvent(
                 isDeferred = isDeferred,
+                isSpt = isSpt,
                 linkEnabled = linkEnabled,
                 googlePaySupported = googlePaySupported,
                 errorMessage = errorMessage
@@ -409,6 +441,7 @@ internal class DefaultEventReporter @Inject internal constructor(
             PaymentSheetEvent.AutofillEvent(
                 type = type,
                 isDeferred = isDeferred,
+                isSpt = isSpt,
                 linkEnabled = linkEnabled,
                 googlePaySupported = googlePaySupported,
             )
@@ -419,6 +452,7 @@ internal class DefaultEventReporter @Inject internal constructor(
         fireEvent(
             PaymentSheetEvent.ShowEditablePaymentOption(
                 isDeferred = isDeferred,
+                isSpt = isSpt,
                 linkEnabled = linkEnabled,
                 googlePaySupported = googlePaySupported,
             )
@@ -429,6 +463,7 @@ internal class DefaultEventReporter @Inject internal constructor(
         fireEvent(
             PaymentSheetEvent.HideEditablePaymentOption(
                 isDeferred = isDeferred,
+                isSpt = isSpt,
                 linkEnabled = linkEnabled,
                 googlePaySupported = googlePaySupported,
             )
@@ -448,6 +483,7 @@ internal class DefaultEventReporter @Inject internal constructor(
                 },
                 selectedBrand = selectedBrand,
                 isDeferred = isDeferred,
+                isSpt = isSpt,
                 linkEnabled = linkEnabled,
                 googlePaySupported = googlePaySupported
             )
@@ -461,6 +497,7 @@ internal class DefaultEventReporter @Inject internal constructor(
             PaymentSheetEvent.UpdatePaymentOptionSucceeded(
                 selectedBrand = selectedBrand,
                 isDeferred = isDeferred,
+                isSpt = isSpt,
                 linkEnabled = linkEnabled,
                 googlePaySupported = googlePaySupported,
             )
@@ -476,6 +513,7 @@ internal class DefaultEventReporter @Inject internal constructor(
                 selectedBrand = selectedBrand,
                 error = error,
                 isDeferred = isDeferred,
+                isSpt = isSpt,
                 linkEnabled = linkEnabled,
                 googlePaySupported = googlePaySupported,
             )
@@ -488,6 +526,7 @@ internal class DefaultEventReporter @Inject internal constructor(
         fireEvent(
             PaymentSheetEvent.SetAsDefaultPaymentMethodSucceeded(
                 isDeferred = isDeferred,
+                isSpt = isSpt,
                 linkEnabled = linkEnabled,
                 googlePaySupported = googlePaySupported,
                 paymentMethodType = paymentMethodType,
@@ -502,6 +541,7 @@ internal class DefaultEventReporter @Inject internal constructor(
             PaymentSheetEvent.ExperimentExposure(
                 experiment = experiment,
                 isDeferred = isDeferred,
+                isSpt = isSpt,
                 linkEnabled = linkEnabled,
                 googlePaySupported = googlePaySupported,
             )
@@ -516,6 +556,7 @@ internal class DefaultEventReporter @Inject internal constructor(
             PaymentSheetEvent.SetAsDefaultPaymentMethodFailed(
                 error = error,
                 isDeferred = isDeferred,
+                isSpt = isSpt,
                 linkEnabled = linkEnabled,
                 googlePaySupported = googlePaySupported,
                 paymentMethodType = paymentMethodType,
@@ -531,6 +572,7 @@ internal class DefaultEventReporter @Inject internal constructor(
         val analyticsEvent = when (event) {
             is USBankAccountFormViewModel.AnalyticsEvent.Started -> BankAccountCollectorStarted(
                 isDeferred = isDeferred,
+                isSpt = isSpt,
                 linkEnabled = linkEnabled,
                 googlePaySupported = googlePaySupported,
                 financialConnectionsAvailability = financialConnectionsAvailability
@@ -538,6 +580,7 @@ internal class DefaultEventReporter @Inject internal constructor(
 
             is USBankAccountFormViewModel.AnalyticsEvent.Finished -> BankAccountCollectorFinished(
                 isDeferred = isDeferred,
+                isSpt = isSpt,
                 linkEnabled = linkEnabled,
                 googlePaySupported = googlePaySupported,
                 event = event,
@@ -562,6 +605,7 @@ internal class DefaultEventReporter @Inject internal constructor(
         fireEvent(
             PaymentSheetEvent.ShopPayWebviewLoadAttempt(
                 isDeferred = isDeferred,
+                isSpt = isSpt,
                 linkEnabled = linkEnabled,
                 googlePaySupported = googlePaySupported,
             )
@@ -572,6 +616,7 @@ internal class DefaultEventReporter @Inject internal constructor(
         fireEvent(
             PaymentSheetEvent.ShopPayWebviewConfirmSuccess(
                 isDeferred = isDeferred,
+                isSpt = isSpt,
                 linkEnabled = linkEnabled,
                 googlePaySupported = googlePaySupported,
             )
@@ -582,6 +627,7 @@ internal class DefaultEventReporter @Inject internal constructor(
         fireEvent(
             PaymentSheetEvent.ShopPayWebviewCancelled(
                 isDeferred = isDeferred,
+                isSpt = isSpt,
                 linkEnabled = linkEnabled,
                 googlePaySupported = googlePaySupported,
                 didReceiveECEClick = didReceiveECEClick,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -64,15 +64,17 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
     }
 
     val params: Map<String, Any?>
-        get() = standardParams(isDeferred, linkEnabled, googlePaySupported) + additionalParams
+        get() = standardParams(isDeferred, isSpt, linkEnabled, googlePaySupported) + additionalParams
 
     protected abstract val isDeferred: Boolean
+    protected abstract val isSpt: Boolean
     protected abstract val linkEnabled: Boolean
     protected abstract val googlePaySupported: Boolean
     protected abstract val additionalParams: Map<String, Any?>
 
     class LoadStarted(
         override val isDeferred: Boolean,
+        override val isSpt: Boolean,
         override val linkEnabled: Boolean,
         override val googlePaySupported: Boolean,
         initializedViaCompose: Boolean,
@@ -89,6 +91,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         linkMode: LinkMode?,
         override val linkEnabled: Boolean,
         override val isDeferred: Boolean,
+        override val isSpt: Boolean,
         override val googlePaySupported: Boolean,
         linkDisplay: PaymentSheet.LinkConfiguration.Display,
         financialConnectionsAvailability: FinancialConnectionsAvailability?,
@@ -146,6 +149,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         error: Throwable,
         override val isDeferred: Boolean,
         override val linkEnabled: Boolean,
+        override val isSpt: Boolean,
         override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
         override val eventName: String = "mc_load_failed"
@@ -158,6 +162,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
     class ElementsSessionLoadFailed(
         error: Throwable,
         override val isDeferred: Boolean,
+        override val isSpt: Boolean,
         override val linkEnabled: Boolean,
         override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
@@ -176,6 +181,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         override val linkEnabled: Boolean,
         override val googlePaySupported: Boolean,
         override val isDeferred: Boolean,
+        override val isSpt: Boolean,
         private val isStripeCardScanAvailable: Boolean,
         private val isAnalyticEventCallbackSet: Boolean,
     ) : PaymentSheetEvent() {
@@ -227,6 +233,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
     class Dismiss(
         override val isDeferred: Boolean,
         override val linkEnabled: Boolean,
+        override val isSpt: Boolean,
         override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
         override val eventName: String = "mc_dismiss"
@@ -237,6 +244,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         mode: EventReporter.Mode,
         currency: String?,
         override val isDeferred: Boolean,
+        override val isSpt: Boolean,
         override val linkEnabled: Boolean,
         override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
@@ -250,6 +258,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         mode: EventReporter.Mode,
         currency: String?,
         override val isDeferred: Boolean,
+        override val isSpt: Boolean,
         override val linkEnabled: Boolean,
         override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
@@ -263,6 +272,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         mode: EventReporter.Mode,
         currency: String?,
         override val isDeferred: Boolean,
+        override val isSpt: Boolean,
         override val linkEnabled: Boolean,
         override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
@@ -278,6 +288,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         linkContext: String?,
         financialConnectionsAvailability: FinancialConnectionsAvailability?,
         override val isDeferred: Boolean,
+        override val isSpt: Boolean,
         override val linkEnabled: Boolean,
         override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
@@ -295,6 +306,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         code: String,
         currency: String?,
         override val isDeferred: Boolean,
+        override val isSpt: Boolean,
         override val linkEnabled: Boolean,
         override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
@@ -311,6 +323,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         paymentSelection: PaymentSelection?,
         currency: String?,
         override val isDeferred: Boolean,
+        override val isSpt: Boolean,
         override val linkEnabled: Boolean,
         override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
@@ -324,6 +337,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
     class ShowPaymentOptionForm(
         code: String,
         override val isDeferred: Boolean,
+        override val isSpt: Boolean,
         override val linkEnabled: Boolean,
         override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
@@ -336,6 +350,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
     class PaymentOptionFormInteraction(
         code: String,
         override val isDeferred: Boolean,
+        override val isSpt: Boolean,
         override val linkEnabled: Boolean,
         override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
@@ -348,6 +363,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
     class PaymentMethodFormCompleted(
         code: String,
         override val isDeferred: Boolean,
+        override val isSpt: Boolean,
         override val linkEnabled: Boolean,
         override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
@@ -359,6 +375,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
 
     class CardNumberCompleted(
         override val isDeferred: Boolean,
+        override val isSpt: Boolean,
         override val linkEnabled: Boolean,
         override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
@@ -369,6 +386,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
     class CardBrandDisallowed(
         cardBrand: CardBrand,
         override val isDeferred: Boolean,
+        override val isSpt: Boolean,
         override val linkEnabled: Boolean,
         override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
@@ -386,6 +404,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         linkContext: String?,
         financialConnectionsAvailability: FinancialConnectionsAvailability?,
         override val isDeferred: Boolean,
+        override val isSpt: Boolean,
         override val linkEnabled: Boolean,
         override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
@@ -406,6 +425,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         paymentSelection: PaymentSelection,
         currency: String?,
         override val isDeferred: Boolean,
+        override val isSpt: Boolean,
         override val linkEnabled: Boolean,
         override val googlePaySupported: Boolean,
         private val deferredIntentConfirmationType: DeferredIntentConfirmationType?,
@@ -453,6 +473,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
 
     class LpmSerializeFailureEvent(
         override val isDeferred: Boolean,
+        override val isSpt: Boolean,
         override val linkEnabled: Boolean,
         override val googlePaySupported: Boolean,
         val errorMessage: String?
@@ -464,6 +485,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
     class AutofillEvent(
         type: String,
         override val isDeferred: Boolean,
+        override val isSpt: Boolean,
         override val linkEnabled: Boolean,
         override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
@@ -478,6 +500,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
 
     class ShowEditablePaymentOption(
         override val isDeferred: Boolean,
+        override val isSpt: Boolean,
         override val linkEnabled: Boolean,
         override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
@@ -488,6 +511,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
 
     class HideEditablePaymentOption(
         override val isDeferred: Boolean,
+        override val isSpt: Boolean,
         override val linkEnabled: Boolean,
         override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
@@ -500,6 +524,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         source: Source,
         selectedBrand: CardBrand,
         override val isDeferred: Boolean,
+        override val isSpt: Boolean,
         override val linkEnabled: Boolean,
         override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
@@ -517,6 +542,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
 
     class SetAsDefaultPaymentMethodSucceeded(
         override val isDeferred: Boolean,
+        override val isSpt: Boolean,
         override val linkEnabled: Boolean,
         override val googlePaySupported: Boolean,
         val paymentMethodType: String?,
@@ -531,6 +557,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
     class SetAsDefaultPaymentMethodFailed(
         error: Throwable,
         override val isDeferred: Boolean,
+        override val isSpt: Boolean,
         override val linkEnabled: Boolean,
         override val googlePaySupported: Boolean,
         paymentMethodType: String?,
@@ -546,6 +573,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
     class UpdatePaymentOptionSucceeded(
         selectedBrand: CardBrand?,
         override val isDeferred: Boolean,
+        override val isSpt: Boolean,
         override val linkEnabled: Boolean,
         override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
@@ -562,6 +590,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         selectedBrand: CardBrand?,
         error: Throwable,
         override val isDeferred: Boolean,
+        override val isSpt: Boolean,
         override val linkEnabled: Boolean,
         override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
@@ -581,6 +610,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         override val linkEnabled: Boolean = false
         override val isDeferred: Boolean = false
         override val googlePaySupported: Boolean = false
+        override val isSpt: Boolean = false
 
         override val eventName: String = formatEventName(mode, "cannot_return_from_link_and_lpms")
 
@@ -589,6 +619,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
 
     class BankAccountCollectorStarted(
         override val isDeferred: Boolean,
+        override val isSpt: Boolean,
         override val linkEnabled: Boolean,
         override val googlePaySupported: Boolean,
         financialConnectionsAvailability: FinancialConnectionsAvailability?
@@ -603,6 +634,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
     class BankAccountCollectorFinished(
         event: Finished,
         override val isDeferred: Boolean,
+        override val isSpt: Boolean,
         override val linkEnabled: Boolean,
         override val googlePaySupported: Boolean,
         financialConnectionsAvailability: FinancialConnectionsAvailability?
@@ -628,6 +660,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
 
     class ExperimentExposure(
         override val isDeferred: Boolean,
+        override val isSpt: Boolean,
         override val linkEnabled: Boolean,
         override val googlePaySupported: Boolean,
         experiment: LoggableExperiment
@@ -642,6 +675,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
 
     class ShopPayWebviewLoadAttempt(
         override val isDeferred: Boolean,
+        override val isSpt: Boolean,
         override val linkEnabled: Boolean,
         override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
@@ -651,6 +685,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
 
     class ShopPayWebviewConfirmSuccess(
         override val isDeferred: Boolean,
+        override val isSpt: Boolean,
         override val linkEnabled: Boolean,
         override val googlePaySupported: Boolean,
     ) : PaymentSheetEvent() {
@@ -660,6 +695,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
 
     class ShopPayWebviewCancelled(
         override val isDeferred: Boolean,
+        override val isSpt: Boolean,
         override val linkEnabled: Boolean,
         override val googlePaySupported: Boolean,
         didReceiveECEClick: Boolean,
@@ -672,10 +708,12 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
 
     private fun standardParams(
         isDecoupled: Boolean,
+        isSpt: Boolean,
         linkEnabled: Boolean,
         googlePaySupported: Boolean,
     ): Map<String, Any?> = mapOf(
         FIELD_IS_DECOUPLED to isDecoupled,
+        FIELD_IS_SPT to isSpt,
         FIELD_LINK_ENABLED to linkEnabled,
         FIELD_GOOGLE_PAY_ENABLED to googlePaySupported,
     )
@@ -718,6 +756,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         const val FIELD_CUSTOM_PAYMENT_METHODS = "custom_payment_methods"
         const val FIELD_PAYMENT_METHOD_ORDER = "payment_method_order"
         const val FIELD_IS_DECOUPLED = "is_decoupled"
+        const val FIELD_IS_SPT = "is_spt"
         const val FIELD_DEFERRED_INTENT_CONFIRMATION_TYPE = "deferred_intent_confirmation_type"
         const val FIELD_DURATION = "duration"
         const val FIELD_LINK_ENABLED = "link_enabled"

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
@@ -41,6 +41,7 @@ class PaymentSheetEventTest {
             primaryButtonColor = config.primaryButtonColorUsage(),
             configurationSpecificPayload = PaymentSheetEvent.ConfigurationSpecificPayload.PaymentSheet(config),
             isDeferred = false,
+            isSpt = false,
             linkEnabled = false,
             googlePaySupported = false,
             isStripeCardScanAvailable = true,
@@ -77,6 +78,7 @@ class PaymentSheetEventTest {
             primaryButtonColor = config.primaryButtonColorUsage(),
             configurationSpecificPayload = PaymentSheetEvent.ConfigurationSpecificPayload.PaymentSheet(config),
             isDeferred = false,
+            isSpt = false,
             linkEnabled = false,
             googlePaySupported = false,
             isStripeCardScanAvailable = true,
@@ -113,6 +115,7 @@ class PaymentSheetEventTest {
             primaryButtonColor = config.primaryButtonColorUsage(),
             configurationSpecificPayload = PaymentSheetEvent.ConfigurationSpecificPayload.PaymentSheet(config),
             isDeferred = false,
+            isSpt = false,
             linkEnabled = false,
             googlePaySupported = false,
             isStripeCardScanAvailable = true,
@@ -151,6 +154,7 @@ class PaymentSheetEventTest {
             primaryButtonColor = config.primaryButtonColorUsage(),
             configurationSpecificPayload = PaymentSheetEvent.ConfigurationSpecificPayload.PaymentSheet(config),
             isDeferred = false,
+            isSpt = false,
             linkEnabled = false,
             googlePaySupported = false,
             isStripeCardScanAvailable = true,
@@ -187,6 +191,7 @@ class PaymentSheetEventTest {
             primaryButtonColor = config.primaryButtonColorUsage(),
             configurationSpecificPayload = PaymentSheetEvent.ConfigurationSpecificPayload.PaymentSheet(config),
             isDeferred = false,
+            isSpt = false,
             linkEnabled = false,
             googlePaySupported = false,
             isStripeCardScanAvailable = true,
@@ -221,6 +226,7 @@ class PaymentSheetEventTest {
             primaryButtonColor = config.primaryButtonColorUsage(),
             configurationSpecificPayload = PaymentSheetEvent.ConfigurationSpecificPayload.PaymentSheet(config),
             isDeferred = false,
+            isSpt = false,
             linkEnabled = false,
             googlePaySupported = false,
             isStripeCardScanAvailable = true,
@@ -305,6 +311,7 @@ class PaymentSheetEventTest {
                 isRowSelectionImmediateAction = false
             ),
             isDeferred = true,
+            isSpt = false,
             linkEnabled = false,
             googlePaySupported = false,
             isStripeCardScanAvailable = true,
@@ -364,6 +371,7 @@ class PaymentSheetEventTest {
                 isRowSelectionImmediateAction = false
             ),
             isDeferred = true,
+            isSpt = false,
             linkEnabled = false,
             googlePaySupported = false,
             isStripeCardScanAvailable = true,
@@ -423,6 +431,7 @@ class PaymentSheetEventTest {
                 isRowSelectionImmediateAction = true
             ),
             isDeferred = true,
+            isSpt = false,
             linkEnabled = false,
             googlePaySupported = false,
             isStripeCardScanAvailable = true,
@@ -468,6 +477,7 @@ class PaymentSheetEventTest {
             mapOf(
                 "is_decoupled" to false,
                 "link_enabled" to false,
+                "is_spt" to false,
                 "google_pay_enabled" to false,
                 "duration" to 5f,
                 "selected_lpm" to "none",
@@ -664,6 +674,7 @@ class PaymentSheetEventTest {
                 "currency" to "usd",
                 "duration" to 0.001F,
                 "is_decoupled" to false,
+                "is_spt" to false,
                 "link_enabled" to false,
                 "google_pay_enabled" to false,
                 "selected_lpm" to "card",
@@ -720,6 +731,7 @@ class PaymentSheetEventTest {
                 "currency" to "usd",
                 "duration" to 0.001F,
                 "is_decoupled" to false,
+                "is_spt" to false,
                 "link_enabled" to false,
                 "google_pay_enabled" to false,
                 "selected_lpm" to "card",
@@ -745,6 +757,7 @@ class PaymentSheetEventTest {
                 "currency" to "usd",
                 "duration" to 0.001F,
                 "is_decoupled" to false,
+                "is_spt" to false,
                 "link_enabled" to false,
                 "google_pay_enabled" to false,
                 "selected_lpm" to "google_pay",
@@ -770,6 +783,7 @@ class PaymentSheetEventTest {
                 "currency" to "usd",
                 "duration" to 0.001F,
                 "is_decoupled" to false,
+                "is_spt" to false,
                 "link_enabled" to false,
                 "google_pay_enabled" to false,
                 "selected_lpm" to "link",
@@ -796,6 +810,7 @@ class PaymentSheetEventTest {
                 "currency" to "usd",
                 "duration" to 0.001F,
                 "is_decoupled" to false,
+                "is_spt" to false,
                 "link_enabled" to false,
                 "selected_lpm" to "card",
                 "google_pay_enabled" to false,
@@ -828,6 +843,7 @@ class PaymentSheetEventTest {
                 "currency" to "usd",
                 "duration" to 0.001F,
                 "is_decoupled" to false,
+                "is_spt" to false,
                 "link_enabled" to false,
                 "google_pay_enabled" to false,
                 "selected_lpm" to "external_fawry",
@@ -859,6 +875,7 @@ class PaymentSheetEventTest {
                 "currency" to "usd",
                 "duration" to 0.001F,
                 "is_decoupled" to false,
+                "is_spt" to false,
                 "link_enabled" to false,
                 "google_pay_enabled" to false,
                 "selected_lpm" to "cpmt_1",
@@ -893,6 +910,7 @@ class PaymentSheetEventTest {
                 "currency" to "usd",
                 "duration" to 0.001F,
                 "is_decoupled" to false,
+                "is_spt" to false,
                 "link_enabled" to false,
                 "google_pay_enabled" to false,
                 "selected_lpm" to "external_fawry",
@@ -929,6 +947,7 @@ class PaymentSheetEventTest {
                 "currency" to "usd",
                 "duration" to 0.001F,
                 "is_decoupled" to false,
+                "is_spt" to false,
                 "link_enabled" to false,
                 "google_pay_enabled" to false,
                 "selected_lpm" to "cpmt_1",
@@ -956,6 +975,7 @@ class PaymentSheetEventTest {
                 "currency" to "usd",
                 "duration" to 0.001F,
                 "is_decoupled" to false,
+                "is_spt" to false,
                 "link_enabled" to false,
                 "google_pay_enabled" to false,
                 "selected_lpm" to "card",
@@ -1019,6 +1039,7 @@ class PaymentSheetEventTest {
                 "currency" to "usd",
                 "duration" to 0.001F,
                 "is_decoupled" to false,
+                "is_spt" to false,
                 "link_enabled" to false,
                 "google_pay_enabled" to false,
                 "selected_lpm" to "card",
@@ -1047,6 +1068,7 @@ class PaymentSheetEventTest {
                 "currency" to "usd",
                 "duration" to 0.001F,
                 "is_decoupled" to false,
+                "is_spt" to false,
                 "link_enabled" to false,
                 "google_pay_enabled" to false,
                 "selected_lpm" to "google_pay",
@@ -1075,6 +1097,7 @@ class PaymentSheetEventTest {
                 "currency" to "usd",
                 "duration" to 0.001F,
                 "is_decoupled" to false,
+                "is_spt" to false,
                 "link_enabled" to false,
                 "google_pay_enabled" to false,
                 "selected_lpm" to "link",
@@ -1104,6 +1127,7 @@ class PaymentSheetEventTest {
                 "currency" to "usd",
                 "duration" to 0.001F,
                 "is_decoupled" to false,
+                "is_spt" to false,
                 "link_enabled" to false,
                 "selected_lpm" to "card",
                 "google_pay_enabled" to false,
@@ -1119,6 +1143,7 @@ class PaymentSheetEventTest {
             code = "card",
             currency = "usd",
             isDeferred = false,
+            isSpt = false,
             linkEnabled = false,
             googlePaySupported = false,
         )
@@ -1134,6 +1159,7 @@ class PaymentSheetEventTest {
                 "selected_lpm" to "card",
                 "currency" to "usd",
                 "is_decoupled" to false,
+                "is_spt" to false,
                 "link_enabled" to false,
                 "google_pay_enabled" to false,
             )
@@ -1147,6 +1173,7 @@ class PaymentSheetEventTest {
             paymentSelection = PaymentSelection.GooglePay,
             currency = "usd",
             isDeferred = false,
+            isSpt = false,
             linkEnabled = false,
             googlePaySupported = false,
         )
@@ -1161,6 +1188,7 @@ class PaymentSheetEventTest {
             mapOf(
                 "currency" to "usd",
                 "is_decoupled" to false,
+                "is_spt" to false,
                 "link_enabled" to false,
                 "google_pay_enabled" to false,
             )
@@ -1172,6 +1200,7 @@ class PaymentSheetEventTest {
         val event = PaymentSheetEvent.ShowPaymentOptionForm(
             code = "card",
             isDeferred = false,
+            isSpt = false,
             linkEnabled = false,
             googlePaySupported = false,
         )
@@ -1186,6 +1215,7 @@ class PaymentSheetEventTest {
             mapOf(
                 "selected_lpm" to "card",
                 "is_decoupled" to false,
+                "is_spt" to false,
                 "link_enabled" to false,
                 "google_pay_enabled" to false,
             )
@@ -1197,6 +1227,7 @@ class PaymentSheetEventTest {
         val event = PaymentSheetEvent.PaymentOptionFormInteraction(
             code = "card",
             isDeferred = false,
+            isSpt = false,
             linkEnabled = false,
             googlePaySupported = false,
         )
@@ -1211,6 +1242,7 @@ class PaymentSheetEventTest {
             mapOf(
                 "selected_lpm" to "card",
                 "is_decoupled" to false,
+                "is_spt" to false,
                 "link_enabled" to false,
                 "google_pay_enabled" to false,
             )
@@ -1222,6 +1254,7 @@ class PaymentSheetEventTest {
         val event = PaymentSheetEvent.PaymentMethodFormCompleted(
             code = "card",
             isDeferred = false,
+            isSpt = false,
             linkEnabled = false,
             googlePaySupported = false,
         )
@@ -1236,6 +1269,7 @@ class PaymentSheetEventTest {
             mapOf(
                 "selected_lpm" to "card",
                 "is_decoupled" to false,
+                "is_spt" to false,
                 "link_enabled" to false,
                 "google_pay_enabled" to false,
             )
@@ -1246,6 +1280,7 @@ class PaymentSheetEventTest {
     fun `CardNumberCompleted event should return expected toString()`() {
         val event = PaymentSheetEvent.CardNumberCompleted(
             isDeferred = false,
+            isSpt = false,
             linkEnabled = false,
             googlePaySupported = false,
         )
@@ -1259,6 +1294,7 @@ class PaymentSheetEventTest {
         ).isEqualTo(
             mapOf(
                 "is_decoupled" to false,
+                "is_spt" to false,
                 "link_enabled" to false,
                 "google_pay_enabled" to false,
             )
@@ -1269,6 +1305,7 @@ class PaymentSheetEventTest {
     fun `ShowEditablePaymentOption event should return expected toString()`() {
         val event = PaymentSheetEvent.ShowEditablePaymentOption(
             isDeferred = false,
+            isSpt = false,
             linkEnabled = false,
             googlePaySupported = false,
         )
@@ -1282,6 +1319,7 @@ class PaymentSheetEventTest {
         ).isEqualTo(
             mapOf(
                 "is_decoupled" to false,
+                "is_spt" to false,
                 "link_enabled" to false,
                 "google_pay_enabled" to false,
             )
@@ -1292,6 +1330,7 @@ class PaymentSheetEventTest {
     fun `HideEditablePaymentOption event should return expected toString()`() {
         val event = PaymentSheetEvent.HideEditablePaymentOption(
             isDeferred = false,
+            isSpt = false,
             linkEnabled = false,
             googlePaySupported = false,
         )
@@ -1305,6 +1344,7 @@ class PaymentSheetEventTest {
         ).isEqualTo(
             mapOf(
                 "is_decoupled" to false,
+                "is_spt" to false,
                 "link_enabled" to false,
                 "google_pay_enabled" to false,
             )
@@ -1317,6 +1357,7 @@ class PaymentSheetEventTest {
             selectedBrand = CardBrand.CartesBancaires,
             source = PaymentSheetEvent.CardBrandSelected.Source.Add,
             isDeferred = false,
+            isSpt = false,
             linkEnabled = false,
             googlePaySupported = false,
         )
@@ -1332,6 +1373,7 @@ class PaymentSheetEventTest {
                 "cbc_event_source" to "add",
                 "selected_card_brand" to "cartes_bancaires",
                 "is_decoupled" to false,
+                "is_spt" to false,
                 "link_enabled" to false,
                 "google_pay_enabled" to false,
             )
@@ -1344,6 +1386,7 @@ class PaymentSheetEventTest {
             selectedBrand = CardBrand.CartesBancaires,
             source = PaymentSheetEvent.CardBrandSelected.Source.Edit,
             isDeferred = false,
+            isSpt = false,
             linkEnabled = false,
             googlePaySupported = false,
         )
@@ -1359,6 +1402,7 @@ class PaymentSheetEventTest {
                 "cbc_event_source" to "edit",
                 "selected_card_brand" to "cartes_bancaires",
                 "is_decoupled" to false,
+                "is_spt" to false,
                 "link_enabled" to false,
                 "google_pay_enabled" to false,
             )
@@ -1370,6 +1414,7 @@ class PaymentSheetEventTest {
         val event = PaymentSheetEvent.UpdatePaymentOptionSucceeded(
             selectedBrand = CardBrand.CartesBancaires,
             isDeferred = false,
+            isSpt = false,
             linkEnabled = false,
             googlePaySupported = false,
         )
@@ -1384,6 +1429,7 @@ class PaymentSheetEventTest {
             mapOf(
                 "selected_card_brand" to "cartes_bancaires",
                 "is_decoupled" to false,
+                "is_spt" to false,
                 "link_enabled" to false,
                 "google_pay_enabled" to false,
             )
@@ -1400,6 +1446,7 @@ class PaymentSheetEventTest {
                 message = "No network available!"
             ),
             isDeferred = false,
+            isSpt = false,
             linkEnabled = false,
             googlePaySupported = false,
         )
@@ -1415,6 +1462,7 @@ class PaymentSheetEventTest {
                 "selected_card_brand" to "cartes_bancaires",
                 "error_message" to "No network available!",
                 "is_decoupled" to false,
+                "is_spt" to false,
                 "link_enabled" to false,
                 "google_pay_enabled" to false,
                 "analytics_value" to "apiError",
@@ -1429,6 +1477,7 @@ class PaymentSheetEventTest {
     fun `SetAsDefaultPaymentMethodSucceeded event with setAsDefaultPaymentMethod should return expected toString()`() {
         val event = PaymentSheetEvent.SetAsDefaultPaymentMethodSucceeded(
             isDeferred = false,
+            isSpt = false,
             linkEnabled = false,
             googlePaySupported = false,
             paymentMethodType = PaymentMethod.Type.Card.code,
@@ -1443,6 +1492,7 @@ class PaymentSheetEventTest {
         ).isEqualTo(
             mapOf(
                 "is_decoupled" to false,
+                "is_spt" to false,
                 "link_enabled" to false,
                 "google_pay_enabled" to false,
                 "payment_method_type" to "card",
@@ -1459,6 +1509,7 @@ class PaymentSheetEventTest {
                 message = "No network available!"
             ),
             isDeferred = false,
+            isSpt = false,
             linkEnabled = false,
             googlePaySupported = false,
             paymentMethodType = PaymentMethod.Type.Card.code,
@@ -1474,6 +1525,7 @@ class PaymentSheetEventTest {
             mapOf(
                 "error_message" to "No network available!",
                 "is_decoupled" to false,
+                "is_spt" to false,
                 "link_enabled" to false,
                 "google_pay_enabled" to false,
                 "payment_method_type" to "card",
@@ -1497,6 +1549,7 @@ class PaymentSheetEventTest {
                 primaryButtonColor = config.primaryButtonColorUsage(),
                 configurationSpecificPayload = PaymentSheetEvent.ConfigurationSpecificPayload.PaymentSheet(config),
                 isDeferred = false,
+                isSpt = false,
                 linkEnabled = false,
                 googlePaySupported = false,
                 isStripeCardScanAvailable = true,
@@ -1506,6 +1559,7 @@ class PaymentSheetEventTest {
             mapOf(
                 "mpe_config" to expectedConfigMap,
                 "is_decoupled" to false,
+                "is_spt" to false,
                 "link_enabled" to false,
                 "google_pay_enabled" to false,
             )
@@ -1543,6 +1597,7 @@ class PaymentSheetEventTest {
                 primaryButtonColor = config.primaryButtonColorUsage(),
                 configurationSpecificPayload = PaymentSheetEvent.ConfigurationSpecificPayload.PaymentSheet(config),
                 isDeferred = false,
+                isSpt = false,
                 linkEnabled = false,
                 googlePaySupported = false,
                 isStripeCardScanAvailable = true,
@@ -1552,6 +1607,7 @@ class PaymentSheetEventTest {
             mapOf(
                 "mpe_config" to expectedConfigMap,
                 "is_decoupled" to false,
+                "is_spt" to false,
                 "link_enabled" to false,
                 "google_pay_enabled" to false,
             )
@@ -1569,6 +1625,7 @@ class PaymentSheetEventTest {
                 configurationSpecificPayload = PaymentSheetEvent.ConfigurationSpecificPayload.PaymentSheet(config),
                 primaryButtonColor = config.primaryButtonColorUsage(),
                 isDeferred = false,
+                isSpt = false,
                 linkEnabled = false,
                 googlePaySupported = false,
                 isStripeCardScanAvailable = true,
@@ -1588,6 +1645,7 @@ class PaymentSheetEventTest {
                 configurationSpecificPayload = PaymentSheetEvent.ConfigurationSpecificPayload.PaymentSheet(config),
                 primaryButtonColor = config.primaryButtonColorUsage(),
                 isDeferred = false,
+                isSpt = false,
                 linkEnabled = false,
                 googlePaySupported = false,
                 isStripeCardScanAvailable = false,
@@ -1607,6 +1665,7 @@ class PaymentSheetEventTest {
                 configurationSpecificPayload = PaymentSheetEvent.ConfigurationSpecificPayload.PaymentSheet(config),
                 primaryButtonColor = config.primaryButtonColorUsage(),
                 isDeferred = false,
+                isSpt = false,
                 linkEnabled = false,
                 googlePaySupported = false,
                 isStripeCardScanAvailable = true,
@@ -1626,6 +1685,7 @@ class PaymentSheetEventTest {
                 configurationSpecificPayload = PaymentSheetEvent.ConfigurationSpecificPayload.PaymentSheet(config),
                 primaryButtonColor = config.primaryButtonColorUsage(),
                 isDeferred = false,
+                isSpt = false,
                 linkEnabled = false,
                 googlePaySupported = false,
                 isStripeCardScanAvailable = false,
@@ -1641,6 +1701,7 @@ class PaymentSheetEventTest {
             currency = "USD",
             duration = 60.seconds,
             isDeferred = false,
+            isSpt = false,
             linkEnabled = false,
             googlePaySupported = false,
             linkContext = null,
@@ -1657,6 +1718,7 @@ class PaymentSheetEventTest {
             mapOf(
                 "selected_lpm" to "card",
                 "is_decoupled" to false,
+                "is_spt" to false,
                 "link_enabled" to false,
                 "google_pay_enabled" to false,
                 "duration" to 60f,
@@ -1673,6 +1735,7 @@ class PaymentSheetEventTest {
             currency = null,
             duration = null,
             isDeferred = false,
+            isSpt = false,
             linkEnabled = false,
             googlePaySupported = false,
             linkContext = null,
@@ -1688,6 +1751,7 @@ class PaymentSheetEventTest {
         ).isEqualTo(
             mapOf(
                 "is_decoupled" to false,
+                "is_spt" to false,
                 "link_enabled" to false,
                 "google_pay_enabled" to false,
                 "fc_sdk_availability" to "LITE"
@@ -1712,6 +1776,7 @@ class PaymentSheetEventTest {
         ).isEqualTo(
             mapOf(
                 "is_decoupled" to false,
+                "is_spt" to false,
                 "link_enabled" to false,
                 "google_pay_enabled" to false,
             )
@@ -1732,6 +1797,7 @@ class PaymentSheetEventTest {
         ).isEqualTo(
             mapOf(
                 "is_decoupled" to false,
+                "is_spt" to false,
                 "link_enabled" to false,
                 "google_pay_enabled" to false,
             )
@@ -1742,6 +1808,7 @@ class PaymentSheetEventTest {
     fun `ShopPayWebviewLoadAttempt event should return expected event name and params`() {
         val event = PaymentSheetEvent.ShopPayWebviewLoadAttempt(
             isDeferred = false,
+            isSpt = false,
             linkEnabled = false,
             googlePaySupported = false,
         )
@@ -1750,6 +1817,7 @@ class PaymentSheetEventTest {
         assertThat(event.params).isEqualTo(
             mapOf(
                 "is_decoupled" to false,
+                "is_spt" to false,
                 "link_enabled" to false,
                 "google_pay_enabled" to false,
             )
@@ -1760,6 +1828,7 @@ class PaymentSheetEventTest {
     fun `ShopPayWebviewConfirmSuccess event should return expected event name and params`() {
         val event = PaymentSheetEvent.ShopPayWebviewConfirmSuccess(
             isDeferred = false,
+            isSpt = false,
             linkEnabled = false,
             googlePaySupported = false,
         )
@@ -1768,6 +1837,7 @@ class PaymentSheetEventTest {
         assertThat(event.params).isEqualTo(
             mapOf(
                 "is_decoupled" to false,
+                "is_spt" to false,
                 "link_enabled" to false,
                 "google_pay_enabled" to false,
             )
@@ -1778,6 +1848,7 @@ class PaymentSheetEventTest {
     fun `ShopPayWebviewCancelled event with ECE click should return expected event name and params`() {
         val event = PaymentSheetEvent.ShopPayWebviewCancelled(
             isDeferred = false,
+            isSpt = false,
             linkEnabled = false,
             googlePaySupported = false,
             didReceiveECEClick = true,
@@ -1787,6 +1858,7 @@ class PaymentSheetEventTest {
         assertThat(event.params).isEqualTo(
             mapOf(
                 "is_decoupled" to false,
+                "is_spt" to false,
                 "link_enabled" to false,
                 "google_pay_enabled" to false,
                 "did_receive_ece_click" to true,
@@ -1798,6 +1870,7 @@ class PaymentSheetEventTest {
     fun `ShopPayWebviewCancelled event without ECE click should return expected event name and params`() {
         val event = PaymentSheetEvent.ShopPayWebviewCancelled(
             isDeferred = false,
+            isSpt = false,
             linkEnabled = false,
             googlePaySupported = false,
             didReceiveECEClick = false,
@@ -1810,6 +1883,7 @@ class PaymentSheetEventTest {
     fun `ShopPay events with different deferred and link states should return expected params`() {
         val loadAttemptEvent = PaymentSheetEvent.ShopPayWebviewLoadAttempt(
             isDeferred = true,
+            isSpt = false,
             linkEnabled = true,
             googlePaySupported = true,
         )
@@ -1817,6 +1891,7 @@ class PaymentSheetEventTest {
         assertThat(loadAttemptEvent.params).isEqualTo(
             mapOf(
                 "is_decoupled" to true,
+                "is_spt" to false,
                 "link_enabled" to true,
                 "google_pay_enabled" to true,
             )
@@ -1846,6 +1921,7 @@ class PaymentSheetEventTest {
             result = result,
             currency = "usd",
             isDeferred = false,
+            isSpt = false,
             linkEnabled = false,
             googlePaySupported = false,
             deferredIntentConfirmationType = null,
@@ -1867,6 +1943,7 @@ class PaymentSheetEventTest {
             configurationSpecificPayload = PaymentSheetEvent.ConfigurationSpecificPayload.PaymentSheet(configuration),
             googlePaySupported = true,
             isDeferred = false,
+            isSpt = false,
             linkEnabled = false,
             isStripeCardScanAvailable = true,
             isAnalyticEventCallbackSet = false,
@@ -1879,6 +1956,7 @@ class PaymentSheetEventTest {
 
     private fun createLoadSucceededEvent(
         isDeferred: Boolean = false,
+        isSpt: Boolean = false,
         linkEnabled: Boolean = false,
         linkMode: LinkMode? = null,
         googlePaySupported: Boolean = false,
@@ -1895,6 +1973,7 @@ class PaymentSheetEventTest {
     ): PaymentSheetEvent.LoadSucceeded {
         return PaymentSheetEvent.LoadSucceeded(
             isDeferred = isDeferred,
+            isSpt = isSpt,
             linkEnabled = linkEnabled,
             linkMode = linkMode,
             googlePaySupported = googlePaySupported,


### PR DESCRIPTION
# Summary
Add `is_spt` to `PaymentSheet` events

# Motivation
Want to track shared payment token usage.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified