### PR TITLE
[link] Fix selecting a newly added card in LinkController

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/CreateInstantDebitsResult.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/CreateInstantDebitsResult.kt
@@ -47,7 +47,7 @@ internal class RealCreateInstantDebitsResult @Inject constructor(
                 paymentDetailsId = paymentDetails.id,
                 consumerSessionClientSecret = clientSecret,
                 expectedPaymentMethodType = linkMode.expectedPaymentMethodType,
-                billingPhone = elementsSessionContext.billingDetails?.phone,
+                billingPhone = elementsSessionContext?.billingDetails?.phone,
             )
 
             sharePaymentDetails.encodedPaymentMethod

--- a/payments-model/src/main/java/com/stripe/android/model/ConsumerPaymentDetails.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/ConsumerPaymentDetails.kt
@@ -73,6 +73,7 @@ data class ConsumerPaymentDetails(
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     data class Passthrough(
         override val id: String,
+        val paymentMethodId: String,
         override val last4: String,
         override val billingAddress: BillingAddress? = null,
         override val billingEmailAddress: String? = null,

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkConfigurationCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkConfigurationCoordinator.kt
@@ -108,10 +108,7 @@ internal class RealLinkConfigurationCoordinator @Inject internal constructor(
         val linkPaymentDetailsResult = accountManager.createCardPaymentDetails(paymentMethodCreateParams)
         return linkPaymentDetailsResult.mapCatching { linkPaymentDetails ->
             if (configuration.passthroughModeEnabled) {
-                accountManager.shareCardPaymentDetails(
-                    paymentDetailsId = linkPaymentDetails.paymentDetails.id,
-                    paymentMethodCreateParams = paymentMethodCreateParams
-                ).getOrThrow()
+                accountManager.shareCardPaymentDetails(linkPaymentDetails).getOrThrow()
             } else {
                 linkPaymentDetails
             }

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerViewModel.kt
@@ -116,7 +116,7 @@ internal class LinkControllerViewModel @Inject constructor(
             getLaunchMode = { _, state ->
                 LinkLaunchMode.PaymentMethodSelection(
                     selectedPayment = state.selectedPaymentMethod?.details,
-                    shareAfterCreatingInPassthroughMode = false,
+                    sharePaymentDetailsImmediatelyAfterCreation = false,
                 )
             }
         )

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerViewModel.kt
@@ -115,7 +115,8 @@ internal class LinkControllerViewModel @Inject constructor(
             },
             getLaunchMode = { _, state ->
                 LinkLaunchMode.PaymentMethodSelection(
-                    selectedPayment = state.selectedPaymentMethod?.details
+                    selectedPayment = state.selectedPaymentMethod?.details,
+                    shareAfterCreatingInPassthroughMode = false,
                 )
             }
         )

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkLaunchMode.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkLaunchMode.kt
@@ -16,7 +16,12 @@ internal sealed interface LinkLaunchMode : Parcelable {
         /**
          * A previously selected payment that will be preselected at launch
          */
-        val selectedPayment: ConsumerPaymentDetails.PaymentDetails?
+        val selectedPayment: ConsumerPaymentDetails.PaymentDetails?,
+
+        /**
+         * If true, shares the payment method after creating it in passthrough mode.
+         */
+        val shareAfterCreatingInPassthroughMode: Boolean = true,
     ) : LinkLaunchMode
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkLaunchMode.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkLaunchMode.kt
@@ -19,9 +19,9 @@ internal sealed interface LinkLaunchMode : Parcelable {
         val selectedPayment: ConsumerPaymentDetails.PaymentDetails?,
 
         /**
-         * If true, shares the payment method after creating it in passthrough mode.
+         * If true, shares the payment details immediately after creating it in passthrough mode.
          */
-        val shareAfterCreatingInPassthroughMode: Boolean = true,
+        val sharePaymentDetailsImmediatelyAfterCreation: Boolean = true,
     ) : LinkLaunchMode
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkPaymentDetails.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkPaymentDetails.kt
@@ -24,7 +24,7 @@ internal sealed class LinkPaymentDetails(
      */
     @Parcelize
     class Saved(
-        override val paymentDetails: ConsumerPaymentDetails.PaymentDetails,
+        override val paymentDetails: ConsumerPaymentDetails.Passthrough,
         override val paymentMethodCreateParams: PaymentMethodCreateParams
     ) : LinkPaymentDetails(paymentDetails, paymentMethodCreateParams)
 

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
@@ -256,7 +256,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
 
     override suspend fun createCardPaymentDetails(
         paymentMethodCreateParams: PaymentMethodCreateParams
-    ): Result<LinkPaymentDetails> {
+    ): Result<LinkPaymentDetails.New> {
         val linkAccountValue = linkAccountHolder.linkAccountInfo.value.account
         return if (linkAccountValue != null) {
             linkAccountValue.let { account ->
@@ -267,19 +267,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
                     consumerSessionClientSecret = account.clientSecret,
                     consumerPublishableKey = account.consumerPublishableKey.takeIf { !config.passthroughModeEnabled },
                     active = config.passthroughModeEnabled,
-                ).mapCatching {
-                    if (config.passthroughModeEnabled) {
-                        linkRepository.shareCardPaymentDetails(
-                            id = it.paymentDetails.id,
-                            last4 = paymentMethodCreateParams.cardLast4().orEmpty(),
-                            consumerSessionClientSecret = account.clientSecret,
-                            paymentMethodCreateParams = paymentMethodCreateParams,
-                            allowRedisplay = paymentMethodCreateParams.allowRedisplay,
-                        ).getOrThrow()
-                    } else {
-                        it
-                    }
-                }.onSuccess {
+                ).onSuccess {
                     errorReporter.report(ErrorReporter.SuccessEvent.LINK_CREATE_CARD_SUCCESS)
                 }
             }
@@ -288,6 +276,23 @@ internal class DefaultLinkAccountManager @Inject constructor(
             Result.failure(
                 IllegalStateException("A non-null Link account is needed to create payment details")
             )
+        }
+    }
+
+    override suspend fun shareCardPaymentDetails(
+        paymentDetailsId: String,
+        paymentMethodCreateParams: PaymentMethodCreateParams
+    ): Result<LinkPaymentDetails.Saved> {
+        return runCatching {
+            requireNotNull(linkAccountHolder.linkAccountInfo.value.account)
+        }.mapCatching { account ->
+            linkRepository.shareCardPaymentDetails(
+                id = paymentDetailsId,
+                last4 = paymentMethodCreateParams.cardLast4().orEmpty(),
+                consumerSessionClientSecret = account.clientSecret,
+                paymentMethodCreateParams = paymentMethodCreateParams,
+                allowRedisplay = paymentMethodCreateParams.allowRedisplay,
+            ).getOrThrow()
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
@@ -280,18 +280,17 @@ internal class DefaultLinkAccountManager @Inject constructor(
     }
 
     override suspend fun shareCardPaymentDetails(
-        paymentDetailsId: String,
-        paymentMethodCreateParams: PaymentMethodCreateParams
+        cardPaymentDetails: LinkPaymentDetails.New
     ): Result<LinkPaymentDetails.Saved> {
         return runCatching {
             requireNotNull(linkAccountHolder.linkAccountInfo.value.account)
         }.mapCatching { account ->
+            val paymentDetails = cardPaymentDetails.paymentDetails
+            val paymentMethodCreateParams = cardPaymentDetails.originalParams
             linkRepository.shareCardPaymentDetails(
-                id = paymentDetailsId,
-                last4 = paymentMethodCreateParams.cardLast4().orEmpty(),
+                id = paymentDetails.id,
                 consumerSessionClientSecret = account.clientSecret,
                 paymentMethodCreateParams = paymentMethodCreateParams,
-                allowRedisplay = paymentMethodCreateParams.allowRedisplay,
             ).getOrThrow()
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
@@ -100,11 +100,16 @@ internal interface LinkAccountManager {
 
     suspend fun createCardPaymentDetails(
         paymentMethodCreateParams: PaymentMethodCreateParams
-    ): Result<LinkPaymentDetails>
+    ): Result<LinkPaymentDetails.New>
 
     suspend fun createBankAccountPaymentDetails(
         bankAccountId: String,
     ): Result<ConsumerPaymentDetails.PaymentDetails>
+
+    suspend fun shareCardPaymentDetails(
+        paymentDetailsId: String,
+        paymentMethodCreateParams: PaymentMethodCreateParams
+    ): Result<LinkPaymentDetails.Saved>
 
     suspend fun sharePaymentDetails(
         paymentDetailsId: String,

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
@@ -107,8 +107,7 @@ internal interface LinkAccountManager {
     ): Result<ConsumerPaymentDetails.PaymentDetails>
 
     suspend fun shareCardPaymentDetails(
-        paymentDetailsId: String,
-        paymentMethodCreateParams: PaymentMethodCreateParams
+        cardPaymentDetails: LinkPaymentDetails.New,
     ): Result<LinkPaymentDetails.Saved>
 
     suspend fun sharePaymentDetails(

--- a/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
@@ -152,14 +152,14 @@ internal class DefaultLinkConfirmationHandler @Inject constructor(
     }
 
     private fun savedConfirmationArgs(
-        paymentDetails: LinkPaymentDetails,
+        paymentDetails: LinkPaymentDetails.Saved,
         cvc: String?
     ): ConfirmationHandler.Args {
         return ConfirmationHandler.Args(
             intent = configuration.stripeIntent,
             confirmationOption = PaymentMethodConfirmationOption.Saved(
                 paymentMethod = PaymentMethod.Builder()
-                    .setId(paymentDetails.paymentDetails.id)
+                    .setId(paymentDetails.paymentDetails.paymentMethodId)
                     .setCode(paymentDetails.paymentMethodCreateParams.typeCode)
                     .setCard(
                         PaymentMethod.Card(

--- a/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
@@ -258,8 +258,9 @@ internal class LinkApiRepository @Inject constructor(
         }.map { passthroughModePaymentMethodId ->
             LinkPaymentDetails.Saved(
                 paymentDetails = ConsumerPaymentDetails.Passthrough(
-                    id = passthroughModePaymentMethodId,
+                    id = id,
                     last4 = last4,
+                    paymentMethodId = passthroughModePaymentMethodId,
                 ),
                 paymentMethodCreateParams = PaymentMethodCreateParams.createLink(
                     paymentDetailsId = passthroughModePaymentMethodId,

--- a/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
@@ -234,11 +234,9 @@ internal class LinkApiRepository @Inject constructor(
     override suspend fun shareCardPaymentDetails(
         paymentMethodCreateParams: PaymentMethodCreateParams,
         id: String,
-        last4: String,
         consumerSessionClientSecret: String,
-        allowRedisplay: PaymentMethod.AllowRedisplay?,
     ): Result<LinkPaymentDetails.Saved> = withContext(workContext) {
-        val allowRedisplay = allowRedisplay?.let {
+        val allowRedisplay = paymentMethodCreateParams.allowRedisplay?.let {
             mapOf(ALLOW_REDISPLAY_PARAM to it.value)
         } ?: emptyMap()
 
@@ -259,7 +257,7 @@ internal class LinkApiRepository @Inject constructor(
             LinkPaymentDetails.Saved(
                 paymentDetails = ConsumerPaymentDetails.Passthrough(
                     id = id,
-                    last4 = last4,
+                    last4 = paymentMethodCreateParams.cardLast4().orEmpty(),
                     paymentMethodId = passthroughModePaymentMethodId,
                 ),
                 paymentMethodCreateParams = PaymentMethodCreateParams.createLink(

--- a/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
@@ -237,7 +237,7 @@ internal class LinkApiRepository @Inject constructor(
         last4: String,
         consumerSessionClientSecret: String,
         allowRedisplay: PaymentMethod.AllowRedisplay?,
-    ): Result<LinkPaymentDetails> = withContext(workContext) {
+    ): Result<LinkPaymentDetails.Saved> = withContext(workContext) {
         val allowRedisplay = allowRedisplay?.let {
             mapOf(ALLOW_REDISPLAY_PARAM to it.value)
         } ?: emptyMap()

--- a/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
@@ -96,7 +96,7 @@ internal interface LinkRepository {
         last4: String,
         consumerSessionClientSecret: String,
         allowRedisplay: PaymentMethod.AllowRedisplay?,
-    ): Result<LinkPaymentDetails>
+    ): Result<LinkPaymentDetails.Saved>
 
     suspend fun sharePaymentDetails(
         consumerSessionClientSecret: String,

--- a/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
@@ -93,9 +93,7 @@ internal interface LinkRepository {
     suspend fun shareCardPaymentDetails(
         paymentMethodCreateParams: PaymentMethodCreateParams,
         id: String,
-        last4: String,
         consumerSessionClientSecret: String,
-        allowRedisplay: PaymentMethod.AllowRedisplay?,
     ): Result<LinkPaymentDetails.Saved>
 
     suspend fun sharePaymentDetails(

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
@@ -98,7 +98,7 @@ internal class PaymentMethodViewModel @Inject constructor(
                         if (shouldShare) {
                             linkAccountManager.shareCardPaymentDetails(
                                 paymentDetailsId = linkPaymentDetails.paymentDetails.id,
-                                paymentMethodCreateParams = linkPaymentDetails.paymentMethodCreateParams,
+                                paymentMethodCreateParams = paymentMethodCreateParams,
                             ).getOrThrow()
                         } else {
                             linkPaymentDetails

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
@@ -96,10 +96,7 @@ internal class PaymentMethodViewModel @Inject constructor(
                             (linkLaunchMode as? LinkLaunchMode.PaymentMethodSelection)
                                 ?.sharePaymentDetailsImmediatelyAfterCreation != false
                         if (shouldShare) {
-                            linkAccountManager.shareCardPaymentDetails(
-                                paymentDetailsId = linkPaymentDetails.paymentDetails.id,
-                                paymentMethodCreateParams = paymentMethodCreateParams,
-                            ).getOrThrow()
+                            linkAccountManager.shareCardPaymentDetails(linkPaymentDetails).getOrThrow()
                         } else {
                             linkPaymentDetails
                         }

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
@@ -92,7 +92,10 @@ internal class PaymentMethodViewModel @Inject constructor(
             dismissalCoordinator.withDismissalDisabled {
                 linkAccountManager.createCardPaymentDetails(paymentMethodCreateParams)
                     .mapCatching { linkPaymentDetails ->
-                        if (configuration.passthroughModeEnabled) {
+                        val shouldShare = configuration.passthroughModeEnabled &&
+                            (linkLaunchMode as? LinkLaunchMode.PaymentMethodSelection)
+                                ?.shareAfterCreatingInPassthroughMode != false
+                        if (shouldShare) {
                             linkAccountManager.shareCardPaymentDetails(
                                 paymentDetailsId = linkPaymentDetails.paymentDetails.id,
                                 paymentMethodCreateParams = linkPaymentDetails.paymentMethodCreateParams,

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
@@ -91,6 +91,16 @@ internal class PaymentMethodViewModel @Inject constructor(
 
             dismissalCoordinator.withDismissalDisabled {
                 linkAccountManager.createCardPaymentDetails(paymentMethodCreateParams)
+                    .mapCatching { linkPaymentDetails ->
+                        if (configuration.passthroughModeEnabled) {
+                            linkAccountManager.shareCardPaymentDetails(
+                                paymentDetailsId = linkPaymentDetails.paymentDetails.id,
+                                paymentMethodCreateParams = linkPaymentDetails.paymentMethodCreateParams,
+                            ).getOrThrow()
+                        } else {
+                            linkPaymentDetails
+                        }
+                    }
                     .fold(
                         onSuccess = { linkPaymentDetails ->
                             val params = paymentMethodCreateParams.toParamMap()

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
@@ -94,7 +94,7 @@ internal class PaymentMethodViewModel @Inject constructor(
                     .mapCatching { linkPaymentDetails ->
                         val shouldShare = configuration.passthroughModeEnabled &&
                             (linkLaunchMode as? LinkLaunchMode.PaymentMethodSelection)
-                                ?.shareAfterCreatingInPassthroughMode != false
+                                ?.sharePaymentDetailsImmediatelyAfterCreation != false
                         if (shouldShare) {
                             linkAccountManager.shareCardPaymentDetails(
                                 paymentDetailsId = linkPaymentDetails.paymentDetails.id,

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
@@ -96,7 +96,7 @@ internal class PaymentMethodViewModel @Inject constructor(
                             val params = paymentMethodCreateParams.toParamMap()
                             val cardMap = params["card"] as? Map<*, *>?
                             val billingDetailsMap = params["billing_details"] as? Map<*, *>?
-                            performConfirmation(
+                            attemptCompletion(
                                 paymentDetails = linkPaymentDetails,
                                 cvc = cardMap?.get("cvc") as? String?,
                                 billingPhone = billingDetailsMap?.get("phone") as? String?
@@ -120,7 +120,7 @@ internal class PaymentMethodViewModel @Inject constructor(
         }
     }
 
-    private suspend fun performConfirmation(
+    private suspend fun attemptCompletion(
         paymentDetails: LinkPaymentDetails,
         cvc: String?,
         billingPhone: String?

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinition.kt
@@ -151,7 +151,7 @@ internal class LinkInlineSignupConfirmationDefinition(
 
         return PaymentMethodConfirmationOption.Saved(
             paymentMethod = PaymentMethod.Builder()
-                .setId(paymentDetails.id)
+                .setId(paymentDetails.paymentMethodId)
                 .setCode(createParams.typeCode)
                 .setCard(
                     PaymentMethod.Card(

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerViewModelTest.kt
@@ -360,7 +360,13 @@ class LinkControllerViewModelTest {
         val args = call.input
         assertThat(args.startWithVerificationDialog).isTrue()
         assertThat(args.linkAccountInfo.account).isNull()
-        assertThat(args.launchMode).isEqualTo(LinkLaunchMode.PaymentMethodSelection(null))
+        assertThat(args.launchMode)
+            .isEqualTo(
+                LinkLaunchMode.PaymentMethodSelection(
+                    selectedPayment = null,
+                    shareAfterCreatingInPassthroughMode = false
+                )
+            )
 
         val state = viewModel.state(application).first()
         assertThat(state.isConsumerVerified).isNull()

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerViewModelTest.kt
@@ -364,7 +364,7 @@ class LinkControllerViewModelTest {
             .isEqualTo(
                 LinkLaunchMode.PaymentMethodSelection(
                     selectedPayment = null,
-                    shareAfterCreatingInPassthroughMode = false
+                    sharePaymentDetailsImmediatelyAfterCreation = false
                 )
             )
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
@@ -99,7 +99,7 @@ internal object TestFactory {
     )
 
     val CONSUMER_PAYMENT_DETAILS_CARD = ConsumerPaymentDetails.Card(
-        id = "pm_123",
+        id = "csmrpd_123",
         last4 = "4242",
         expiryYear = 2999,
         expiryMonth = 12,
@@ -121,7 +121,7 @@ internal object TestFactory {
     )
 
     val CONSUMER_PAYMENT_DETAILS_BANK_ACCOUNT = ConsumerPaymentDetails.BankAccount(
-        id = "pm_124",
+        id = "csmrpd_124",
         last4 = "4242",
         isDefault = false,
         bankName = "Stripe Test Bank",
@@ -132,8 +132,9 @@ internal object TestFactory {
     )
 
     val CONSUMER_PAYMENT_DETAILS_PASSTHROUGH = ConsumerPaymentDetails.Passthrough(
-        id = "pm_125",
+        id = "csmrpd_125",
         last4 = "4242",
+        paymentMethodId = "pm_123"
     )
 
     val LINK_ACCOUNT_SESSION = LinkAccountSession(
@@ -153,7 +154,7 @@ internal object TestFactory {
     )
 
     val LINK_SAVED_PAYMENT_DETAILS = LinkPaymentDetails.Saved(
-        paymentDetails = CONSUMER_PAYMENT_DETAILS_CARD,
+        paymentDetails = CONSUMER_PAYMENT_DETAILS_PASSTHROUGH,
         paymentMethodCreateParams = PAYMENT_METHOD_CREATE_PARAMS,
     )
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAccountManagerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAccountManagerTest.kt
@@ -518,6 +518,7 @@ class DefaultLinkAccountManagerTest {
 
     @Test
     fun `createCardPaymentDetails makes correct calls in passthrough mode`() = runSuspendTest {
+        val newPaymentDetails = TestFactory.LINK_NEW_PAYMENT_DETAILS
         val linkRepository = object : FakeLinkRepository() {
             var createCardPaymentDetailsCallCount = 0
             var shareCardPaymentDetailsCallCount = 0
@@ -530,7 +531,7 @@ class DefaultLinkAccountManagerTest {
                 active: Boolean
             ): Result<LinkPaymentDetails.New> {
                 createCardPaymentDetailsCallCount += 1
-                return Result.success(TestFactory.LINK_NEW_PAYMENT_DETAILS)
+                return Result.success(newPaymentDetails)
             }
 
             override suspend fun shareCardPaymentDetails(
@@ -539,10 +540,10 @@ class DefaultLinkAccountManagerTest {
                 last4: String,
                 consumerSessionClientSecret: String,
                 allowRedisplay: PaymentMethod.AllowRedisplay?,
-            ): Result<LinkPaymentDetails.New> {
+            ): Result<LinkPaymentDetails.Saved> {
                 val paymentDetailsMatch = paymentMethodCreateParams == TestFactory.PAYMENT_METHOD_CREATE_PARAMS &&
-                    id == TestFactory.LINK_NEW_PAYMENT_DETAILS.paymentDetails.id &&
-                    last4 == TestFactory.LINK_NEW_PAYMENT_DETAILS.paymentDetails.last4
+                    id == newPaymentDetails.paymentDetails.id &&
+                    last4 == newPaymentDetails.paymentDetails.last4
                 if (paymentDetailsMatch && consumerSessionClientSecret == TestFactory.CLIENT_SECRET) {
                     shareCardPaymentDetailsCallCount += 1
                 }
@@ -567,7 +568,7 @@ class DefaultLinkAccountManagerTest {
         assertThat(result.isSuccess).isTrue()
         val linkPaymentDetails = result.getOrThrow()
         assertThat(linkPaymentDetails.paymentDetails.id)
-            .isEqualTo(TestFactory.LINK_NEW_PAYMENT_DETAILS.paymentDetails.id)
+            .isEqualTo(TestFactory.LINK_SAVED_PAYMENT_DETAILS.paymentDetails.id)
 
         assertThat(linkRepository.createCardPaymentDetailsCallCount).isEqualTo(1)
         assertThat(linkRepository.shareCardPaymentDetailsCallCount).isEqualTo(1)
@@ -1137,10 +1138,10 @@ class DefaultLinkAccountManagerTest {
                 last4: String,
                 consumerSessionClientSecret: String,
                 allowRedisplay: PaymentMethod.AllowRedisplay?,
-            ): Result<LinkPaymentDetails.New> {
+            ): Result<LinkPaymentDetails.Saved> {
                 actualAllowRedisplay = allowRedisplay
 
-                return Result.success(TestFactory.LINK_NEW_PAYMENT_DETAILS)
+                return Result.success(TestFactory.LINK_SAVED_PAYMENT_DETAILS)
             }
         }
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/FakeLinkAccountManager.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/FakeLinkAccountManager.kt
@@ -196,8 +196,7 @@ internal open class FakeLinkAccountManager(
     }
 
     override suspend fun shareCardPaymentDetails(
-        paymentDetailsId: String,
-        paymentMethodCreateParams: PaymentMethodCreateParams
+        cardPaymentDetails: LinkPaymentDetails.New
     ): Result<LinkPaymentDetails.Saved> {
         return shareCardPaymentDetailsResult
     }

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/FakeLinkAccountManager.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/FakeLinkAccountManager.kt
@@ -57,7 +57,7 @@ internal open class FakeLinkAccountManager(
     var createCardPaymentDetailsResult: Result<LinkPaymentDetails.New> = Result.success(
         value = TestFactory.LINK_NEW_PAYMENT_DETAILS
     )
-    var shareNewPaymentDetailsResult: Result<LinkPaymentDetails.Saved> = Result.success(
+    var shareCardPaymentDetailsResult: Result<LinkPaymentDetails.Saved> = Result.success(
         value = TestFactory.LINK_SAVED_PAYMENT_DETAILS
     )
     var createBankAccountPaymentDetailsResult: Result<ConsumerPaymentDetails.BankAccount> = Result.success(
@@ -199,7 +199,7 @@ internal open class FakeLinkAccountManager(
         paymentDetailsId: String,
         paymentMethodCreateParams: PaymentMethodCreateParams
     ): Result<LinkPaymentDetails.Saved> {
-        return shareNewPaymentDetailsResult
+        return shareCardPaymentDetailsResult
     }
 
     override suspend fun createBankAccountPaymentDetails(

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/FakeLinkAccountManager.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/FakeLinkAccountManager.kt
@@ -54,8 +54,11 @@ internal open class FakeLinkAccountManager(
     var mobileSignUpResult: Result<LinkAccount> = Result.success(TestFactory.LINK_ACCOUNT)
     var signInWithUserInputResult: Result<LinkAccount> = Result.success(TestFactory.LINK_ACCOUNT)
     var logOutResult: Result<ConsumerSession> = Result.success(ConsumerSession("", "", "", ""))
-    var createCardPaymentDetailsResult: Result<LinkPaymentDetails> = Result.success(
+    var createCardPaymentDetailsResult: Result<LinkPaymentDetails.New> = Result.success(
         value = TestFactory.LINK_NEW_PAYMENT_DETAILS
+    )
+    var shareNewPaymentDetailsResult: Result<LinkPaymentDetails.Saved> = Result.success(
+        value = TestFactory.LINK_SAVED_PAYMENT_DETAILS
     )
     var createBankAccountPaymentDetailsResult: Result<ConsumerPaymentDetails.BankAccount> = Result.success(
         value = TestFactory.CONSUMER_PAYMENT_DETAILS_BANK_ACCOUNT
@@ -188,8 +191,15 @@ internal open class FakeLinkAccountManager(
 
     override suspend fun createCardPaymentDetails(
         paymentMethodCreateParams: PaymentMethodCreateParams
-    ): Result<LinkPaymentDetails> {
+    ): Result<LinkPaymentDetails.New> {
         return createCardPaymentDetailsResult
+    }
+
+    override suspend fun shareCardPaymentDetails(
+        paymentDetailsId: String,
+        paymentMethodCreateParams: PaymentMethodCreateParams
+    ): Result<LinkPaymentDetails.Saved> {
+        return shareNewPaymentDetailsResult
     }
 
     override suspend fun createBankAccountPaymentDetails(

--- a/paymentsheet/src/test/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandlerTest.kt
@@ -455,7 +455,7 @@ internal class DefaultLinkConfirmationHandlerTest {
     ) {
         assertThat(intent).isEqualTo(configuration.stripeIntent)
         val option = confirmationOption as PaymentMethodConfirmationOption.Saved
-        assertThat(option.paymentMethod.id).isEqualTo(paymentDetails.paymentDetails.id)
+        assertThat(option.paymentMethod.id).isEqualTo(paymentDetails.paymentDetails.paymentMethodId)
 
         val optionsCard = option.optionsParams as? PaymentMethodOptionsParams.Card
         assertThat(optionsCard?.cvc).isEqualTo(cvc)

--- a/paymentsheet/src/test/java/com/stripe/android/link/repositories/FakeLinkRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/repositories/FakeLinkRepository.kt
@@ -27,7 +27,7 @@ internal open class FakeLinkRepository : LinkRepository {
     var createLinkAccountSessionResult = Result.success(TestFactory.LINK_ACCOUNT_SESSION)
     var createCardPaymentDetailsResult = Result.success(TestFactory.LINK_NEW_PAYMENT_DETAILS)
     var createBankAccountPaymentDetailsResult = Result.success(TestFactory.CONSUMER_PAYMENT_DETAILS_BANK_ACCOUNT)
-    var shareCardPaymentDetailsResult = Result.success(TestFactory.LINK_NEW_PAYMENT_DETAILS)
+    var shareCardPaymentDetailsResult = Result.success(TestFactory.LINK_SAVED_PAYMENT_DETAILS)
     var sharePaymentDetails = Result.success(TestFactory.LINK_SHARE_PAYMENT_DETAILS)
     var createPaymentMethod = Result.success(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
     var logOutResult = Result.success(TestFactory.CONSUMER_SESSION)

--- a/paymentsheet/src/test/java/com/stripe/android/link/repositories/FakeLinkRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/repositories/FakeLinkRepository.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.link.repositories
 
 import app.cash.turbine.Turbine
+import com.stripe.android.link.LinkPaymentDetails
 import com.stripe.android.link.LinkPaymentMethod
 import com.stripe.android.link.TestFactory
 import com.stripe.android.model.ConsumerPaymentDetails
@@ -13,7 +14,6 @@ import com.stripe.android.model.EmailSource
 import com.stripe.android.model.IncentiveEligibilitySession
 import com.stripe.android.model.LinkAccountSession
 import com.stripe.android.model.LinkMode
-import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.StripeIntent
@@ -135,10 +135,8 @@ internal open class FakeLinkRepository : LinkRepository {
     override suspend fun shareCardPaymentDetails(
         paymentMethodCreateParams: PaymentMethodCreateParams,
         id: String,
-        last4: String,
-        consumerSessionClientSecret: String,
-        allowRedisplay: PaymentMethod.AllowRedisplay?
-    ) = shareCardPaymentDetailsResult
+        consumerSessionClientSecret: String
+    ): Result<LinkPaymentDetails.Saved> = shareCardPaymentDetailsResult
 
     override suspend fun sharePaymentDetails(
         consumerSessionClientSecret: String,

--- a/paymentsheet/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
@@ -488,8 +488,6 @@ class LinkApiRepositoryTest {
             paymentMethodCreateParams = cardPaymentMethodCreateParams,
             consumerSessionClientSecret = consumerSessionSecret,
             id = paymentDetailsId,
-            last4 = "4242",
-            allowRedisplay = null,
         )
 
         assertThat(result.isSuccess).isTrue()
@@ -505,7 +503,7 @@ class LinkApiRepositoryTest {
             .isEqualTo(
                 ConsumerPaymentDetails.Passthrough(
                     id = paymentDetailsId,
-                    last4 = "4242",
+                    last4 = cardPaymentMethodCreateParams.cardLast4().orEmpty(),
                     paymentMethodId = "pm_123"
                 )
             )
@@ -536,8 +534,6 @@ class LinkApiRepositoryTest {
             paymentMethodCreateParams = cardPaymentMethodCreateParams,
             consumerSessionClientSecret = consumerSessionSecret,
             id = "csmrpd*AYq4D_sXdAAAAOQ0",
-            last4 = "4242",
-            allowRedisplay = null,
         )
         val loggedErrors = errorReporter.getLoggedErrors()
 
@@ -774,11 +770,9 @@ class LinkApiRepositoryTest {
         ).thenReturn(Result.success("pm_123"))
 
         val result = linkRepository.shareCardPaymentDetails(
-            paymentMethodCreateParams = cardPaymentMethodCreateParams,
+            paymentMethodCreateParams = cardPaymentMethodCreateParams.copy(allowRedisplay = allowRedisplay),
             consumerSessionClientSecret = "consumer_session_secret",
             id = "csmrpd*AYq4D_sXdAAAAOQ0",
-            last4 = "4242",
-            allowRedisplay = allowRedisplay,
         )
 
         assertThat(result).isNotNull()

--- a/paymentsheet/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
@@ -473,7 +473,7 @@ class LinkApiRepositoryTest {
     @Test
     fun `shareCardPaymentDetails returns LinkPaymentDetails_Saved`() = runTest {
         val consumerSessionSecret = "consumer_session_secret"
-        val id = "csmrpd*AYq4D_sXdAAAAOQ0"
+        val paymentDetailsId = "csmrpd*AYq4D_sXdAAAAOQ0"
 
         whenever(
             stripeRepository.sharePaymentDetails(
@@ -487,7 +487,7 @@ class LinkApiRepositoryTest {
         val result = linkRepository.shareCardPaymentDetails(
             paymentMethodCreateParams = cardPaymentMethodCreateParams,
             consumerSessionClientSecret = consumerSessionSecret,
-            id = id,
+            id = paymentDetailsId,
             last4 = "4242",
             allowRedisplay = null,
         )
@@ -497,12 +497,18 @@ class LinkApiRepositoryTest {
 
         verify(stripeRepository).sharePaymentDetails(
             consumerSessionClientSecret = consumerSessionSecret,
-            id = id,
+            id = paymentDetailsId,
             extraParams = mapOf("payment_method_options" to mapOf("card" to mapOf("cvc" to "123"))),
             requestOptions = ApiRequest.Options(apiKey = PUBLISHABLE_KEY, stripeAccount = STRIPE_ACCOUNT_ID)
         )
         assertThat(savedLinkPaymentDetails.paymentDetails)
-            .isEqualTo(ConsumerPaymentDetails.Passthrough(id = "pm_123", last4 = "4242"))
+            .isEqualTo(
+                ConsumerPaymentDetails.Passthrough(
+                    id = paymentDetailsId,
+                    last4 = "4242",
+                    paymentMethodId = "pm_123"
+                )
+            )
         assertThat(savedLinkPaymentDetails.paymentMethodCreateParams)
             .isEqualTo(
                 PaymentMethodCreateParams.createLink(

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/PaymentDetailsListItemScreenShotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/PaymentDetailsListItemScreenShotTest.kt
@@ -239,8 +239,9 @@ internal class PaymentDetailsListItemScreenShotTest {
         snapshot(
             state = State(
                 details = ConsumerPaymentDetails.Passthrough(
-                    id = "wAAACGA",
+                    id = "csmrpd_wAAACGA",
                     last4 = "6789",
+                    paymentMethodId = "pm_123",
                 ),
                 enabled = true,
                 isSelected = false,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
@@ -220,18 +220,10 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
     fun `'action' should return 'Launch' after successful sign-in & attach`() = test(
         attachNewCardToAccountResult = Result.success(
             LinkPaymentDetails.Saved(
-                paymentDetails = ConsumerPaymentDetails.Card(
-                    id = "pm_1",
+                paymentDetails = ConsumerPaymentDetails.Passthrough(
+                    id = "csmrpd_123",
                     last4 = "4242",
-                    isDefault = false,
-                    expiryYear = 2030,
-                    expiryMonth = 4,
-                    brand = CardBrand.Visa,
-                    cvcCheck = CvcCheck.Pass,
-                    networks = emptyList(),
-                    funding = "CREDIT",
-                    nickname = null,
-                    billingAddress = null,
+                    paymentMethodId = "pm_123",
                 ),
                 paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
             )
@@ -486,18 +478,10 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
         actionTest(
             attachNewCardToAccountResult = Result.success(
                 LinkPaymentDetails.Saved(
-                    paymentDetails = ConsumerPaymentDetails.Card(
-                        id = "pm_1",
+                    paymentDetails = ConsumerPaymentDetails.Passthrough(
+                        id = "csmrpd_123",
                         last4 = "4242",
-                        isDefault = false,
-                        expiryYear = 2030,
-                        expiryMonth = 4,
-                        brand = CardBrand.Visa,
-                        cvcCheck = CvcCheck.Pass,
-                        networks = emptyList(),
-                        funding = "CREDIT",
-                        nickname = null,
-                        billingAddress = null,
+                        paymentMethodId = "pm_1",
                     ),
                     paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                 )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
@@ -223,7 +223,7 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
                 paymentDetails = ConsumerPaymentDetails.Passthrough(
                     id = "csmrpd_123",
                     last4 = "4242",
-                    paymentMethodId = "pm_123",
+                    paymentMethodId = "pm_1",
                 ),
                 paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
             )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -1125,7 +1125,7 @@ internal class PaymentOptionsViewModelTest {
 
     private fun createLinkViewModel(): PaymentOptionsViewModel {
         val linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(
-            attachNewCardToAccountResult = Result.success(LinkTestUtils.LINK_NEW_PAYMENT_DETAILS),
+            attachNewCardToAccountResult = Result.success(LinkTestUtils.LINK_SAVED_PAYMENT_DETAILS),
             accountStatus = AccountStatus.Verified,
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
@@ -18,17 +18,10 @@ import org.mockito.kotlin.mock
 
 internal object LinkTestUtils {
     val LINK_SAVED_PAYMENT_DETAILS = LinkPaymentDetails.Saved(
-        paymentDetails = ConsumerPaymentDetails.Card(
-            id = "pm_123",
+        paymentDetails = ConsumerPaymentDetails.Passthrough(
+            id = "csmrpd_123",
             last4 = "4242",
-            expiryYear = 2024,
-            expiryMonth = 4,
-            brand = CardBrand.DinersClub,
-            cvcCheck = CvcCheck.Fail,
-            isDefault = false,
-            networks = emptyList(),
-            funding = "CREDIT",
-            nickname = null,
+            paymentMethodId = "pm_123",
             billingAddress = ConsumerPaymentDetails.BillingAddress(
                 name = null,
                 line1 = null,


### PR DESCRIPTION
# Summary

💡 See [individual commits](https://github.com/stripe/stripe-android/pull/11177/commits) for easier review.

Fix a bug where a selecting a newly added card in LinkController in passthrough mode immediately shares it, creating the payment method prematurely.

Note that there is a similar bug in FlowController (new card is shared **immediately after** selecting but **before** confirmation has started) which this PR does not address in order to limit its scope. However, this PR _does_ include some refactoring that will be part of [a larger effort to clean up Link payment confirmation](https://github.com/stripe/stripe-android/pull/11064/files).

# Motivation
👻 

# Testing
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots

https://github.com/user-attachments/assets/fd214af2-ab03-4751-917f-f74b4246b5ed

