### PR TITLE
Fix playground failing to load when both CS remove and remove last are disabled

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
@@ -189,7 +189,9 @@ class CheckoutRequest private constructor(
                 paymentMethodSaveFeature = paymentMethodSaveFeature,
                 paymentMethodRemoveFeature = paymentMethodRemoveFeature,
                 paymentMethodSetAsDefaultFeature = paymentMethodSetAsDefaultFeature,
-                paymentMethodRemoveLastFeature = paymentMethodRemoveLastFeature,
+                paymentMethodRemoveLastFeature = paymentMethodRemoveLastFeature.takeIf {
+                    paymentMethodRemoveLastFeature == FeatureState.Enabled
+                },
                 paymentMethodRedisplayFeature = paymentMethodRedisplayFeature,
                 paymentMethodRedisplayFilters = paymentMethodRedisplayFilters,
                 paymentMethodOverrideRedisplay = paymentMethodOverrideRedisplay,


### PR DESCRIPTION
# Summary
Fix playground failing to load when both CS remove and remove last are disabled

# Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-3122
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-4221

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified