### PR TITLE
Link signup toggle in FlowController

### DIFF
--- a/payments-model/src/main/java/com/stripe/android/model/SignUpParams.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/SignUpParams.kt
@@ -6,8 +6,8 @@ import java.util.Locale
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
 data class SignUpParams(
     val email: String,
-    val phoneNumber: String,
-    val country: String,
+    val phoneNumber: String?,
+    val country: String?,
     val name: String?,
     val locale: Locale?,
     val amount: Long?,
@@ -21,9 +21,6 @@ data class SignUpParams(
     fun toParamMap(): Map<String, *> {
         val params = mutableMapOf(
             "email_address" to email.lowercase(),
-            "phone_number" to phoneNumber,
-            "country" to country,
-            "country_inferring_method" to "PHONE_NUMBER",
             "amount" to amount,
             "currency" to currency,
             "consent_action" to consentAction.value,
@@ -32,6 +29,15 @@ data class SignUpParams(
 
         locale?.let {
             params["locale"] = it.toLanguageTag()
+        }
+
+        phoneNumber?.takeIf { it.isNotBlank() }?.let {
+            params["phone_number"] = it
+            params["country_inferring_method"] = "PHONE_NUMBER"
+        }
+
+        country?.takeIf { it.isNotBlank() }?.let {
+            params["country"] = it
         }
 
         name?.takeIf { it.isNotBlank() }?.let {

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
@@ -376,7 +376,6 @@ internal class PaymentSheetPlaygroundActivity :
                 }
             }
             PaymentSheet.LinkSignupOptInState.Hidden -> {
-                Text("not shown.")
                 // Don't display anything when hidden
             }
         }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
@@ -10,11 +10,15 @@ import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Switch
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -325,6 +329,43 @@ internal class PaymentSheetPlaygroundActivity :
     }
 
     @Composable
+    private fun LinkSignupToggle(flowController: PaymentSheet.FlowController) {
+        val linkSignupToggleState by flowController.linkSignupToggleState.collectAsState()
+        var isChecked by remember { mutableStateOf(false) }
+
+        if (linkSignupToggleState.shouldDisplay) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 8.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = androidx.compose.ui.Alignment.CenterVertically
+            ) {
+                Column(
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Text(
+                        text = linkSignupToggleState.title,
+                        style = MaterialTheme.typography.body1
+                    )
+                    Text(
+                        text = linkSignupToggleState.subtitle,
+                        style = MaterialTheme.typography.caption,
+                        color = MaterialTheme.colors.onSurface.copy(alpha = 0.6f)
+                    )
+                }
+                Switch(
+                    checked = isChecked,
+                    onCheckedChange = { checked ->
+                        isChecked = checked
+                        flowController.setLinkSignupToggleValue(checked)
+                    }
+                )
+            }
+        }
+    }
+
+    @Composable
     private fun ReloadButton(playgroundSettings: PlaygroundSettings) {
         Button(
             onClick = {
@@ -449,6 +490,8 @@ internal class PaymentSheetPlaygroundActivity :
         if (playgroundState.snapshot[WalletButtonsSettingsDefinition] != WalletButtonsPlaygroundType.Disabled) {
             flowController.WalletButtons()
         }
+
+        LinkSignupToggle(flowController = flowController)
 
         PaymentMethodSelector(
             isEnabled = flowControllerState != null,

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -2127,11 +2127,11 @@ public abstract interface class com/stripe/android/paymentsheet/PaymentSheet$Flo
 	public static fun create (Landroidx/fragment/app/Fragment;Lcom/stripe/android/paymentsheet/PaymentOptionCallback;Lcom/stripe/android/paymentsheet/CreateIntentCallback;Lcom/stripe/android/paymentsheet/ExternalPaymentMethodConfirmHandler;Lcom/stripe/android/paymentsheet/PaymentSheetResultCallback;)Lcom/stripe/android/paymentsheet/PaymentSheet$FlowController;
 	public static fun create (Landroidx/fragment/app/Fragment;Lcom/stripe/android/paymentsheet/PaymentOptionCallback;Lcom/stripe/android/paymentsheet/CreateIntentCallback;Lcom/stripe/android/paymentsheet/PaymentSheetResultCallback;)Lcom/stripe/android/paymentsheet/PaymentSheet$FlowController;
 	public static fun create (Landroidx/fragment/app/Fragment;Lcom/stripe/android/paymentsheet/PaymentOptionCallback;Lcom/stripe/android/paymentsheet/PaymentSheetResultCallback;)Lcom/stripe/android/paymentsheet/PaymentSheet$FlowController;
-	public abstract fun getLinkSignupToggleState ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getLinkSignupOptInState ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getLinkSignupOptInValue ()Lkotlinx/coroutines/flow/MutableStateFlow;
 	public abstract fun getPaymentOption ()Lcom/stripe/android/paymentsheet/model/PaymentOption;
 	public abstract fun getShippingDetails ()Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;
 	public abstract fun presentPaymentOptions ()V
-	public abstract fun setLinkSignupToggleValue (Z)V
 	public abstract fun setShippingDetails (Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;)V
 }
 
@@ -2486,17 +2486,29 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$LinkConfiguratio
 	public static fun values ()[Lcom/stripe/android/paymentsheet/PaymentSheet$LinkConfiguration$Display;
 }
 
-public final class com/stripe/android/paymentsheet/PaymentSheet$LinkSignupToggleState {
+public abstract class com/stripe/android/paymentsheet/PaymentSheet$LinkSignupOptInState {
 	public static final field $stable I
-	public fun <init> (ZLjava/lang/String;Ljava/lang/String;)V
-	public final fun component1 ()Z
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (ZLjava/lang/String;Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentSheet$LinkSignupToggleState;
-	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$LinkSignupToggleState;ZLjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$LinkSignupToggleState;
+}
+
+public final class com/stripe/android/paymentsheet/PaymentSheet$LinkSignupOptInState$Hidden : com/stripe/android/paymentsheet/PaymentSheet$LinkSignupOptInState {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/stripe/android/paymentsheet/PaymentSheet$LinkSignupOptInState$Hidden;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getShouldDisplay ()Z
-	public final fun getSubtitle ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/paymentsheet/PaymentSheet$LinkSignupOptInState$Visible : com/stripe/android/paymentsheet/PaymentSheet$LinkSignupOptInState {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Landroidx/compose/ui/text/AnnotatedString;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Landroidx/compose/ui/text/AnnotatedString;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Landroidx/compose/ui/text/AnnotatedString;)Lcom/stripe/android/paymentsheet/PaymentSheet$LinkSignupOptInState$Visible;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$LinkSignupOptInState$Visible;Ljava/lang/String;Ljava/lang/String;Landroidx/compose/ui/text/AnnotatedString;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$LinkSignupOptInState$Visible;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getTermsAndConditions ()Landroidx/compose/ui/text/AnnotatedString;
 	public final fun getTitle ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -558,6 +558,14 @@ public final class com/stripe/android/link/ui/inline/UserInput$SignUp$Creator : 
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/link/ui/inline/UserInput$SignUpOptionalPhone$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/link/ui/inline/UserInput$SignUpOptionalPhone;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/link/ui/inline/UserInput$SignUpOptionalPhone;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/link/ui/signup/ComposableSingletons$SignUpScreenKt {
 	public static final field INSTANCE Lcom/stripe/android/link/ui/signup/ComposableSingletons$SignUpScreenKt;
 	public fun <init> ()V

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -2119,9 +2119,11 @@ public abstract interface class com/stripe/android/paymentsheet/PaymentSheet$Flo
 	public static fun create (Landroidx/fragment/app/Fragment;Lcom/stripe/android/paymentsheet/PaymentOptionCallback;Lcom/stripe/android/paymentsheet/CreateIntentCallback;Lcom/stripe/android/paymentsheet/ExternalPaymentMethodConfirmHandler;Lcom/stripe/android/paymentsheet/PaymentSheetResultCallback;)Lcom/stripe/android/paymentsheet/PaymentSheet$FlowController;
 	public static fun create (Landroidx/fragment/app/Fragment;Lcom/stripe/android/paymentsheet/PaymentOptionCallback;Lcom/stripe/android/paymentsheet/CreateIntentCallback;Lcom/stripe/android/paymentsheet/PaymentSheetResultCallback;)Lcom/stripe/android/paymentsheet/PaymentSheet$FlowController;
 	public static fun create (Landroidx/fragment/app/Fragment;Lcom/stripe/android/paymentsheet/PaymentOptionCallback;Lcom/stripe/android/paymentsheet/PaymentSheetResultCallback;)Lcom/stripe/android/paymentsheet/PaymentSheet$FlowController;
+	public abstract fun getLinkSignupToggleState ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun getPaymentOption ()Lcom/stripe/android/paymentsheet/model/PaymentOption;
 	public abstract fun getShippingDetails ()Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;
 	public abstract fun presentPaymentOptions ()V
+	public abstract fun setLinkSignupToggleValue (Z)V
 	public abstract fun setShippingDetails (Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;)V
 }
 
@@ -2474,6 +2476,22 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$LinkConfiguratio
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentSheet$LinkConfiguration$Display;
 	public static fun values ()[Lcom/stripe/android/paymentsheet/PaymentSheet$LinkConfiguration$Display;
+}
+
+public final class com/stripe/android/paymentsheet/PaymentSheet$LinkSignupToggleState {
+	public static final field $stable I
+	public fun <init> (ZLjava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (ZLjava/lang/String;Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentSheet$LinkSignupToggleState;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$LinkSignupToggleState;ZLjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$LinkSignupToggleState;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getShouldDisplay ()Z
+	public final fun getSubtitle ()Ljava/lang/String;
+	public final fun getTitle ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/stripe/android/paymentsheet/PaymentSheet$PaymentMethodLayout : java/lang/Enum {

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -558,14 +558,6 @@ public final class com/stripe/android/link/ui/inline/UserInput$SignUp$Creator : 
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/stripe/android/link/ui/inline/UserInput$SignUpOptionalPhone$Creator : android/os/Parcelable$Creator {
-	public fun <init> ()V
-	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/link/ui/inline/UserInput$SignUpOptionalPhone;
-	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
-	public final fun newArray (I)[Lcom/stripe/android/link/ui/inline/UserInput$SignUpOptionalPhone;
-	public synthetic fun newArray (I)[Ljava/lang/Object;
-}
-
 public final class com/stripe/android/link/ui/signup/ComposableSingletons$SignUpScreenKt {
 	public static final field INSTANCE Lcom/stripe/android/link/ui/signup/ComposableSingletons$SignUpScreenKt;
 	public fun <init> ()V

--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -16,10 +16,12 @@
     <ID>FunctionNaming:PaymentSheetTopBar.kt$@Preview @Composable internal fun TestModeBadge_Preview()</ID>
     <ID>FunctionOnlyReturningConstant:FlowControllerModule.kt$FlowControllerModule$@Provides @Singleton @Named(ALLOWS_MANUAL_CONFIRMATION) fun provideAllowsManualConfirmation()</ID>
     <ID>FunctionOnlyReturningConstant:PaymentSheetLauncherModule.kt$PaymentSheetLauncherModule.Companion$@Provides @Singleton @Named(ALLOWS_MANUAL_CONFIRMATION) fun provideAllowsManualConfirmation()</ID>
+    <ID>Indentation:FakeSignupToLinkToggleInteractor.kt$FakeSignupToLinkToggleInteractor$ </ID>
     <ID>LargeClass:CustomerAdapterTest.kt$CustomerAdapterTest</ID>
     <ID>LargeClass:CustomerSheetViewModel.kt$CustomerSheetViewModel : ViewModel</ID>
     <ID>LargeClass:CustomerSheetViewModelTest.kt$CustomerSheetViewModelTest</ID>
     <ID>LargeClass:DefaultConfirmationHandlerTest.kt$DefaultConfirmationHandlerTest</ID>
+    <ID>LargeClass:DefaultEventReporter.kt$DefaultEventReporter : EventReporter</ID>
     <ID>LargeClass:DefaultEventReporterTest.kt$DefaultEventReporterTest</ID>
     <ID>LargeClass:DefaultFlowControllerTest.kt$DefaultFlowControllerTest</ID>
     <ID>LargeClass:DefaultIntentConfirmationInterceptorTest.kt$DefaultIntentConfirmationInterceptorTest</ID>
@@ -92,9 +94,12 @@
     <ID>MaxLineLength:PaymentSheet.kt$PaymentSheet.IntentConfiguration.Mode.Setup$*</ID>
     <ID>MaxLineLength:PaymentSheet.kt$PaymentSheet.IntentConfiguration.SetupFutureUse$*</ID>
     <ID>MaxLineLength:PrimaryButtonTest.kt$PrimaryButtonTest$primaryButton.setAppearanceConfiguration(StripeThemeDefaults.primaryButtonStyle, ColorStateList.valueOf(Color.BLACK))</ID>
+    <ID>MaxLineLength:SignupToLinkToggleInteractorTest.kt$SignupToLinkToggleInteractorTest$.</ID>
+    <ID>MaxLineLength:SignupToLinkToggleInteractorTest.kt$SignupToLinkToggleInteractorTest$val linkAnnotations = visibleState.termsAndConditions.getStringAnnotations("URL", 0, visibleState.termsAndConditions.length)</ID>
     <ID>MaxLineLength:SupportedPaymentMethod.kt$SupportedPaymentMethod$/** This describes the image in the LPM selector. These can be found internally [here](https://www.figma.com/file/2b9r3CJbyeVAmKi1VHV2h9/Mobile-Payment-Element?node-id=1128%3A0) */</ID>
     <ID>MaxLineLength:USBankAccountFormViewModelTest.kt$USBankAccountFormViewModelTest$fun</ID>
     <ID>MaximumLineLength:CardDefinition.kt$internal</ID>
+    <ID>NoUnusedImports:FakeSignupToLinkToggleInteractor.kt$com.stripe.android.paymentsheet.ui.FakeSignupToLinkToggleInteractor.kt</ID>
     <ID>TooGenericExceptionCaught:IntentConfirmationInterceptor.kt$DefaultIntentConfirmationInterceptor$exception: Exception</ID>
     <ID>TooManyFunctions:CustomerSheetEventReporter.kt$CustomerSheetEventReporter</ID>
     <ID>TooManyFunctions:DefaultCustomerSheetEventReporter.kt$DefaultCustomerSheetEventReporter : CustomerSheetEventReporter</ID>
@@ -116,5 +121,6 @@
     <ID>TooManyFunctions:PaymentSheet.kt$PaymentSheet.Appearance.Embedded.RowStyle.FlatWithDisclosure$Builder</ID>
     <ID>TooManyFunctions:WalletViewModel.kt$WalletViewModel : ViewModel</ID>
     <ID>UnusedPrivateClass:PaymentOptionsViewModelTest.kt$PaymentOptionsViewModelTest$MyHostActivity : AppCompatActivity</ID>
+    <ID>Wrapping:FakeSignupToLinkToggleInteractor.kt$FakeSignupToLinkToggleInteractor$(</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -16,7 +16,6 @@
     <ID>FunctionNaming:PaymentSheetTopBar.kt$@Preview @Composable internal fun TestModeBadge_Preview()</ID>
     <ID>FunctionOnlyReturningConstant:FlowControllerModule.kt$FlowControllerModule$@Provides @Singleton @Named(ALLOWS_MANUAL_CONFIRMATION) fun provideAllowsManualConfirmation()</ID>
     <ID>FunctionOnlyReturningConstant:PaymentSheetLauncherModule.kt$PaymentSheetLauncherModule.Companion$@Provides @Singleton @Named(ALLOWS_MANUAL_CONFIRMATION) fun provideAllowsManualConfirmation()</ID>
-    <ID>Indentation:FakeSignupToLinkToggleInteractor.kt$FakeSignupToLinkToggleInteractor$ </ID>
     <ID>LargeClass:CustomerAdapterTest.kt$CustomerAdapterTest</ID>
     <ID>LargeClass:CustomerSheetViewModel.kt$CustomerSheetViewModel : ViewModel</ID>
     <ID>LargeClass:CustomerSheetViewModelTest.kt$CustomerSheetViewModelTest</ID>
@@ -94,12 +93,9 @@
     <ID>MaxLineLength:PaymentSheet.kt$PaymentSheet.IntentConfiguration.Mode.Setup$*</ID>
     <ID>MaxLineLength:PaymentSheet.kt$PaymentSheet.IntentConfiguration.SetupFutureUse$*</ID>
     <ID>MaxLineLength:PrimaryButtonTest.kt$PrimaryButtonTest$primaryButton.setAppearanceConfiguration(StripeThemeDefaults.primaryButtonStyle, ColorStateList.valueOf(Color.BLACK))</ID>
-    <ID>MaxLineLength:SignupToLinkToggleInteractorTest.kt$SignupToLinkToggleInteractorTest$.</ID>
-    <ID>MaxLineLength:SignupToLinkToggleInteractorTest.kt$SignupToLinkToggleInteractorTest$val linkAnnotations = visibleState.termsAndConditions.getStringAnnotations("URL", 0, visibleState.termsAndConditions.length)</ID>
     <ID>MaxLineLength:SupportedPaymentMethod.kt$SupportedPaymentMethod$/** This describes the image in the LPM selector. These can be found internally [here](https://www.figma.com/file/2b9r3CJbyeVAmKi1VHV2h9/Mobile-Payment-Element?node-id=1128%3A0) */</ID>
     <ID>MaxLineLength:USBankAccountFormViewModelTest.kt$USBankAccountFormViewModelTest$fun</ID>
     <ID>MaximumLineLength:CardDefinition.kt$internal</ID>
-    <ID>NoUnusedImports:FakeSignupToLinkToggleInteractor.kt$com.stripe.android.paymentsheet.ui.FakeSignupToLinkToggleInteractor.kt</ID>
     <ID>TooGenericExceptionCaught:IntentConfirmationInterceptor.kt$DefaultIntentConfirmationInterceptor$exception: Exception</ID>
     <ID>TooManyFunctions:CustomerSheetEventReporter.kt$CustomerSheetEventReporter</ID>
     <ID>TooManyFunctions:DefaultCustomerSheetEventReporter.kt$DefaultCustomerSheetEventReporter : CustomerSheetEventReporter</ID>
@@ -121,6 +117,5 @@
     <ID>TooManyFunctions:PaymentSheet.kt$PaymentSheet.Appearance.Embedded.RowStyle.FlatWithDisclosure$Builder</ID>
     <ID>TooManyFunctions:WalletViewModel.kt$WalletViewModel : ViewModel</ID>
     <ID>UnusedPrivateClass:PaymentOptionsViewModelTest.kt$PaymentOptionsViewModelTest$MyHostActivity : AppCompatActivity</ID>
-    <ID>Wrapping:FakeSignupToLinkToggleInteractor.kt$FakeSignupToLinkToggleInteractor$(</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -49,6 +49,10 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_link_sign_up_message">Save your payment information with Link, and securely check out in 1-click on Link-supported sites.</string>
   <!-- Legal text shown when creating a Link account. -->
   <string name="stripe_link_sign_up_terms"><![CDATA[By continuing you agree to the <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.]]></string>
+  <!-- Title for the Link signup toggle that merchants can render -->
+  <string name="stripe_link_signup_toggle_title">Save my info for faster checkout with Link</string>
+  <!-- Description for the Link signup toggle that merchants can render -->
+  <string name="stripe_link_signup_toggle_description">Pay faster everywhere Link is accepted.</string>
   <!-- Confirm CTA for the update card screen in Link native -->
   <string name="stripe_link_update_card_confirm_cta">Update card</string>
   <!-- Text informing the user that the card to be updated is their default -->

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkConfiguration.kt
@@ -54,4 +54,10 @@ internal data class LinkConfiguration(
         val eligible: Boolean,
         val preferredNetworks: List<String>,
     ) : Parcelable
+
+    val enableNewUserSignupAPI: Boolean
+        get() = flags["link_enable_new_user_signup_api"] ?: false
+
+    val newUserSignupInitialValue: Boolean
+        get() = flags["link_new_user_signup_api_initial_value"] ?: false
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
@@ -142,6 +142,13 @@ internal class DefaultLinkAccountManager @Inject constructor(
                 name = userInput.name,
                 consentAction = userInput.consentAction,
             )
+            is UserInput.SignUpOptionalPhone -> signUpIfValidSessionState(
+                email = userInput.email,
+                country = userInput.country,
+                phone = userInput.phone,
+                name = userInput.name,
+                consentAction = userInput.consentAction,
+            )
         }
 
     override suspend fun logOut(): Result<ConsumerSession> {
@@ -171,8 +178,8 @@ internal class DefaultLinkAccountManager @Inject constructor(
      */
     private suspend fun signUpIfValidSessionState(
         email: String,
-        phone: String,
-        country: String,
+        phone: String?,
+        country: String?,
         name: String?,
         consentAction: SignUpConsentAction
     ): Result<LinkAccount> {
@@ -220,8 +227,8 @@ internal class DefaultLinkAccountManager @Inject constructor(
 
     override suspend fun signUp(
         email: String,
-        phone: String,
-        country: String,
+        phone: String?,
+        country: String?,
         name: String?,
         consentAction: SignUpConsentAction
     ): Result<LinkAccount> =

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
@@ -142,13 +142,6 @@ internal class DefaultLinkAccountManager @Inject constructor(
                 name = userInput.name,
                 consentAction = userInput.consentAction,
             )
-            is UserInput.SignUpOptionalPhone -> signUpIfValidSessionState(
-                email = userInput.email,
-                country = userInput.country,
-                phone = userInput.phone,
-                name = userInput.name,
-                consentAction = userInput.consentAction,
-            )
         }
 
     override suspend fun logOut(): Result<ConsumerSession> {
@@ -243,8 +236,8 @@ internal class DefaultLinkAccountManager @Inject constructor(
 
     override suspend fun mobileSignUp(
         email: String,
-        phone: String,
-        country: String,
+        phone: String?,
+        country: String?,
         name: String?,
         verificationToken: String,
         appId: String,

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAuth.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAuth.kt
@@ -22,8 +22,8 @@ internal class DefaultLinkAuth @Inject constructor(
 ) : LinkAuth {
     override suspend fun signUp(
         email: String,
-        phoneNumber: String,
-        country: String,
+        phoneNumber: String?,
+        country: String?,
         name: String?,
         consentAction: SignUpConsentAction
     ): LinkAuthResult {
@@ -72,8 +72,8 @@ internal class DefaultLinkAuth @Inject constructor(
 
     private suspend fun mobileSignUp(
         email: String,
-        phoneNumber: String,
-        country: String,
+        phoneNumber: String?,
+        country: String?,
         name: String?,
         consentAction: SignUpConsentAction
     ): Result<LinkAccount> {

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
@@ -85,8 +85,8 @@ internal interface LinkAccountManager {
      */
     suspend fun mobileSignUp(
         email: String,
-        phone: String,
-        country: String,
+        phone: String?,
+        country: String?,
         name: String?,
         verificationToken: String,
         appId: String,

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
@@ -74,8 +74,8 @@ internal interface LinkAccountManager {
      */
     suspend fun signUp(
         email: String,
-        phone: String,
-        country: String,
+        phone: String?,
+        country: String?,
         name: String?,
         consentAction: SignUpConsentAction
     ): Result<LinkAccount>

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAuth.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAuth.kt
@@ -6,8 +6,8 @@ import com.stripe.android.model.EmailSource
 internal interface LinkAuth {
     suspend fun signUp(
         email: String,
-        phoneNumber: String,
-        country: String,
+        phoneNumber: String?,
+        country: String?,
         name: String?,
         consentAction: SignUpConsentAction
     ): LinkAuthResult

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkComponent.kt
@@ -4,6 +4,7 @@ import com.stripe.android.common.di.ApplicationIdModule
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.account.LinkAccountManager
+import com.stripe.android.link.account.LinkAuth
 import com.stripe.android.link.attestation.LinkAttestationCheck
 import com.stripe.android.link.gate.LinkGate
 import dagger.BindsInstance
@@ -29,6 +30,7 @@ internal abstract class LinkComponent {
     internal abstract val linkAccountManager: LinkAccountManager
     internal abstract val configuration: LinkConfiguration
     internal abstract val linkGate: LinkGate
+    internal abstract val linkAuth: LinkAuth
     internal abstract val linkAttestationCheck: LinkAttestationCheck
     internal abstract val inlineSignupViewModelFactory: LinkInlineSignupAssistedViewModelFactory
 

--- a/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
@@ -143,8 +143,8 @@ internal class LinkApiRepository @Inject constructor(
     override suspend fun mobileSignUp(
         name: String?,
         email: String,
-        phoneNumber: String,
-        country: String,
+        phoneNumber: String?,
+        country: String?,
         consentAction: ConsumerSignUpConsentAction,
         amount: Long?,
         currency: String?,

--- a/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
@@ -118,8 +118,8 @@ internal class LinkApiRepository @Inject constructor(
 
     override suspend fun consumerSignUp(
         email: String,
-        phone: String,
-        country: String,
+        phone: String?,
+        country: String?,
         name: String?,
         consentAction: ConsumerSignUpConsentAction
     ): Result<ConsumerSessionSignup> = withContext(workContext) {

--- a/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
@@ -64,8 +64,8 @@ internal interface LinkRepository {
      */
     suspend fun consumerSignUp(
         email: String,
-        phone: String,
-        country: String,
+        phone: String?,
+        country: String?,
         name: String?,
         consentAction: ConsumerSignUpConsentAction
     ): Result<ConsumerSessionSignup>

--- a/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
@@ -73,8 +73,8 @@ internal interface LinkRepository {
     suspend fun mobileSignUp(
         name: String?,
         email: String,
-        phoneNumber: String,
-        country: String,
+        phoneNumber: String?,
+        country: String?,
         consentAction: ConsumerSignUpConsentAction,
         amount: Long?,
         currency: String?,

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/LinkTerms.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/LinkTerms.kt
@@ -72,7 +72,7 @@ internal fun LinkTerms(
     )
 }
 
-private fun String.replaceHyperlinks() = this.replace(
+internal fun String.replaceHyperlinks() = this.replace(
     "<terms>",
     "<a href=\"https://link.co/terms\">"
 ).replace("</terms>", "</a>").replace(

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/inline/InlineSignupViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/inline/InlineSignupViewModel.kt
@@ -13,6 +13,7 @@ import com.stripe.android.link.injection.LinkComponent
 import com.stripe.android.link.ui.inline.LinkSignupField.Email
 import com.stripe.android.link.ui.inline.LinkSignupField.Name
 import com.stripe.android.link.ui.inline.LinkSignupField.Phone
+import com.stripe.android.link.ui.inline.UserInput.SignUpOptionalPhone
 import com.stripe.android.link.ui.signup.SignUpState
 import com.stripe.android.link.utils.errorMessage
 import com.stripe.android.uicore.elements.EmailConfig
@@ -290,12 +291,14 @@ internal class InlineSignupViewModel(
         return when (this) {
             is UserInput.SignUp -> email
             is UserInput.SignIn -> email
+            is SignUpOptionalPhone -> email
         }
     }
 
     private fun UserInput.phone(): String? {
         return when (this) {
             is UserInput.SignUp -> phone
+            is SignUpOptionalPhone -> phone
             is UserInput.SignIn -> null
         }
     }
@@ -303,6 +306,7 @@ internal class InlineSignupViewModel(
     private fun UserInput.name(): String? {
         return when (this) {
             is UserInput.SignUp -> name
+            is SignUpOptionalPhone -> name
             is UserInput.SignIn -> null
         }
     }
@@ -310,6 +314,7 @@ internal class InlineSignupViewModel(
     private fun UserInput.country(): String? {
         return when (this) {
             is UserInput.SignUp -> country
+            is SignUpOptionalPhone -> country
             is UserInput.SignIn -> null
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/inline/InlineSignupViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/inline/InlineSignupViewModel.kt
@@ -13,7 +13,6 @@ import com.stripe.android.link.injection.LinkComponent
 import com.stripe.android.link.ui.inline.LinkSignupField.Email
 import com.stripe.android.link.ui.inline.LinkSignupField.Name
 import com.stripe.android.link.ui.inline.LinkSignupField.Phone
-import com.stripe.android.link.ui.inline.UserInput.SignUpOptionalPhone
 import com.stripe.android.link.ui.signup.SignUpState
 import com.stripe.android.link.utils.errorMessage
 import com.stripe.android.uicore.elements.EmailConfig
@@ -291,14 +290,12 @@ internal class InlineSignupViewModel(
         return when (this) {
             is UserInput.SignUp -> email
             is UserInput.SignIn -> email
-            is SignUpOptionalPhone -> email
         }
     }
 
     private fun UserInput.phone(): String? {
         return when (this) {
             is UserInput.SignUp -> phone
-            is SignUpOptionalPhone -> phone
             is UserInput.SignIn -> null
         }
     }
@@ -306,7 +303,6 @@ internal class InlineSignupViewModel(
     private fun UserInput.name(): String? {
         return when (this) {
             is UserInput.SignUp -> name
-            is SignUpOptionalPhone -> name
             is UserInput.SignIn -> null
         }
     }
@@ -314,7 +310,6 @@ internal class InlineSignupViewModel(
     private fun UserInput.country(): String? {
         return when (this) {
             is UserInput.SignUp -> country
-            is SignUpOptionalPhone -> country
             is UserInput.SignIn -> null
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/inline/UserInput.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/inline/UserInput.kt
@@ -21,25 +21,11 @@ internal sealed class UserInput : Parcelable {
     @Parcelize
     data class SignUp(
         val email: String,
-        val phone: String,
-        val country: String,
-        val name: String?,
-        val consentAction: SignUpConsentAction
-    ) : UserInput()
-
-    /**
-     * Represents an input that is valid for looking up a link account.
-     *
-     * Intended only for login via the link login toggle.
-     *
-     * @see [com.stripe.android.paymentsheet.ui.SignupToLinkToggleInteractor]
-     */
-    @Parcelize
-    data class SignUpOptionalPhone(
-        val email: String,
         val phone: String?,
         val country: String?,
         val name: String?,
         val consentAction: SignUpConsentAction
     ) : UserInput()
+
+
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/inline/UserInput.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/inline/UserInput.kt
@@ -26,4 +26,20 @@ internal sealed class UserInput : Parcelable {
         val name: String?,
         val consentAction: SignUpConsentAction
     ) : UserInput()
+
+    /**
+     * Represents an input that is valid for looking up a link account.
+     *
+     * Intended only for login via the link login toggle.
+     *
+     * @see [com.stripe.android.paymentsheet.ui.SignupToLinkToggleInteractor]
+     */
+    @Parcelize
+    data class SignUpOptionalPhone(
+        val email: String,
+        val phone: String?,
+        val country: String?,
+        val name: String?,
+        val consentAction: SignUpConsentAction
+    ) : UserInput()
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/inline/UserInput.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/inline/UserInput.kt
@@ -26,6 +26,4 @@ internal sealed class UserInput : Parcelable {
         val name: String?,
         val consentAction: SignUpConsentAction
     ) : UserInput()
-
-
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -48,6 +48,7 @@ import com.stripe.android.uicore.PRIMARY_BUTTON_SUCCESS_BACKGROUND_COLOR
 import com.stripe.android.uicore.StripeThemeDefaults
 import com.stripe.android.uicore.getRawValueFromDimenResource
 import dev.drewhamilton.poko.Poko
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 
@@ -3293,6 +3294,15 @@ class PaymentSheet internal constructor(
     }
 
     /**
+     * State information for the Link signup toggle that merchants can observe to render their own UI.
+     */
+    data class LinkSignupToggleState(
+        val shouldDisplay: Boolean,
+        val title: String,
+        val subtitle: String
+    )
+
+    /**
      * A class that presents the individual steps of a payment sheet flow.
      */
     interface FlowController {
@@ -3305,6 +3315,12 @@ class PaymentSheet internal constructor(
         @WalletButtonsPreview
         @Composable
         fun WalletButtons()
+
+        /**
+         * StateFlow that provides information about the Link signup toggle display state and content.
+         * Merchants can observe this to render their own Link signup toggle UI.
+         */
+        val linkSignupToggleState: StateFlow<PaymentSheet.LinkSignupToggleState>
 
         /**
          * Configure the FlowController to process a [PaymentIntent].
@@ -3350,6 +3366,13 @@ class PaymentSheet internal constructor(
          * You can use this to e.g. display the payment option in your UI.
          */
         fun getPaymentOption(): PaymentOption?
+
+        /**
+         * Set the value of the Link signup toggle.
+         * This allows merchants to programmatically control whether the customer has opted in to Link signup.
+         * @param isChecked true if the customer has opted in to Link signup, false otherwise
+         */
+        fun setLinkSignupToggleValue(isChecked: Boolean)
 
         /**
          * Present a sheet where the customer chooses how to pay, either by selecting an existing

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -635,6 +635,41 @@ internal class DefaultEventReporter @Inject internal constructor(
         )
     }
 
+    override fun onLinkUserSignupSucceeded() {
+        fireEvent(
+            PaymentSheetEvent.LinkUserSignupSucceeded(
+                isDeferred = isDeferred,
+                isSpt = isSpt,
+                linkEnabled = linkEnabled,
+                googlePaySupported = googlePaySupported,
+            )
+        )
+    }
+
+    override fun onLinkUserSignupFailed(error: Throwable) {
+        fireEvent(
+            PaymentSheetEvent.LinkUserSignupFailed(
+                isDeferred = isDeferred,
+                isSpt = isSpt,
+                linkEnabled = linkEnabled,
+                googlePaySupported = googlePaySupported,
+                error = error,
+            )
+        )
+    }
+
+    override fun onLinkUserPaymentDetailCreationCompleted(error: Throwable?) {
+        fireEvent(
+            PaymentSheetEvent.LinkUserPaymentDetailCreationCompleted(
+                isDeferred = isDeferred,
+                isSpt = isSpt,
+                linkEnabled = linkEnabled,
+                googlePaySupported = googlePaySupported,
+                error = error,
+            )
+        )
+    }
+
     private fun fireEvent(event: PaymentSheetEvent) {
         CoroutineScope(workContext).launch {
             analyticsRequestExecutor.executeAsync(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
@@ -251,6 +251,21 @@ internal interface EventReporter {
      */
     fun onShopPayWebViewCancelled(didReceiveECEClick: Boolean)
 
+    /**
+     * Link user signup via API has succeeded.
+     */
+    fun onLinkUserSignupSucceeded()
+
+    /**
+     * Link user signup via API has failed.
+     */
+    fun onLinkUserSignupFailed(error: Throwable)
+
+    /**
+     * Link user payment detail creation via API has completed (success or failure).
+     */
+    fun onLinkUserPaymentDetailCreationCompleted(error: Throwable?)
+
     enum class Mode(val code: String) {
         Complete("complete"),
         Custom("custom"),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -706,6 +706,50 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         )
     }
 
+    class LinkUserSignupSucceeded(
+        override val isDeferred: Boolean,
+        override val isSpt: Boolean,
+        override val linkEnabled: Boolean,
+        override val googlePaySupported: Boolean,
+    ) : PaymentSheetEvent() {
+        override val eventName: String = "link.new_user_signup_api.signup_success"
+        override val additionalParams: Map<String, Any?> = emptyMap()
+    }
+
+    class LinkUserSignupFailed(
+        override val isDeferred: Boolean,
+        override val isSpt: Boolean,
+        override val linkEnabled: Boolean,
+        override val googlePaySupported: Boolean,
+        error: Throwable,
+    ) : PaymentSheetEvent() {
+        override val eventName: String = "link.new_user_signup_api.signup_failure"
+        override val additionalParams: Map<String, Any?> = buildMap {
+            val errorParams = ErrorReporter.getAdditionalParamsFromError(error)
+            putAll(errorParams)
+        }
+    }
+
+    class LinkUserPaymentDetailCreationCompleted(
+        override val isDeferred: Boolean,
+        override val isSpt: Boolean,
+        override val linkEnabled: Boolean,
+        override val googlePaySupported: Boolean,
+        error: Throwable?,
+    ) : PaymentSheetEvent() {
+        override val eventName: String = if (error == null) {
+            "link.new_user_signup_api.payment_detail_creation_success"
+        } else {
+            "link.new_user_signup_api.payment_detail_creation_failure"
+        }
+        override val additionalParams: Map<String, Any?> = buildMap {
+            error?.let { err ->
+                val errorParams = ErrorReporter.getAdditionalParamsFromError(err)
+                putAll(errorParams)
+            }
+        }
+    }
+
     private fun standardParams(
         isDecoupled: Boolean,
         isSpt: Boolean,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -65,6 +65,7 @@ import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.paymentsheet.state.PaymentSheetState
 import com.stripe.android.paymentsheet.ui.SepaMandateContract
 import com.stripe.android.paymentsheet.ui.SepaMandateResult
+import com.stripe.android.paymentsheet.ui.SignupToLinkToggleInteractor
 import com.stripe.android.paymentsheet.utils.canSave
 import com.stripe.android.paymentsheet.utils.toConfirmationError
 import com.stripe.android.uicore.utils.AnimationConstants
@@ -102,6 +103,7 @@ internal class DefaultFlowController @Inject internal constructor(
     @Named(ENABLE_LOGGING) private val enableLogging: Boolean,
     @Named(PRODUCT_USAGE) private val productUsage: Set<String>,
     private val configurationHandler: FlowControllerConfigurationHandler,
+    private val signupToLinkToggleInteractor: SignupToLinkToggleInteractor,
     private val errorReporter: ErrorReporter,
     private val signupForLink: SignupForLink,
     @InitializedViaCompose private val initializedViaCompose: Boolean,
@@ -186,10 +188,10 @@ internal class DefaultFlowController @Inject internal constructor(
     }
 
     override val linkSignupOptInState: StateFlow<PaymentSheet.LinkSignupOptInState> =
-        viewModel.flowControllerStateComponent.signupToLinkToggleInteractor.state
+        signupToLinkToggleInteractor.state
 
     override val linkSignupOptInValue: MutableStateFlow<Boolean> =
-        viewModel.flowControllerStateComponent.signupToLinkToggleInteractor.toggleValue
+        signupToLinkToggleInteractor.toggleValue
 
     override fun configureWithPaymentIntent(
         paymentIntentClientSecret: String,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -68,8 +68,8 @@ import com.stripe.android.paymentsheet.ui.SepaMandateResult
 import com.stripe.android.paymentsheet.utils.canSave
 import com.stripe.android.paymentsheet.utils.toConfirmationError
 import com.stripe.android.uicore.utils.AnimationConstants
-import com.stripe.android.uicore.utils.mapAsStateFlow
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -185,15 +185,11 @@ internal class DefaultFlowController @Inject internal constructor(
         viewModel.flowControllerStateComponent.walletButtonsContent.Content()
     }
 
-    override val linkSignupToggleState: StateFlow<PaymentSheet.LinkSignupToggleState> =
+    override val linkSignupOptInState: StateFlow<PaymentSheet.LinkSignupOptInState> =
         viewModel.flowControllerStateComponent.signupToLinkToggleInteractor.state
-            .mapAsStateFlow {
-                PaymentSheet.LinkSignupToggleState(
-                    shouldDisplay = it.shouldDisplay,
-                    title = it.title,
-                    subtitle = it.subtitle
-                )
-            }
+
+    override val linkSignupOptInValue: MutableStateFlow<Boolean> =
+        viewModel.flowControllerStateComponent.signupToLinkToggleInteractor.toggleValue
 
     override fun configureWithPaymentIntent(
         paymentIntentClientSecret: String,
@@ -249,10 +245,6 @@ internal class DefaultFlowController @Inject internal constructor(
         return viewModel.paymentSelection?.let {
             paymentOptionFactory.create(it)
         }
-    }
-
-    override fun setLinkSignupToggleValue(isChecked: Boolean) {
-        viewModel.flowControllerStateComponent.signupToLinkToggleInteractor.handleToggleChange(isChecked)
     }
 
     private fun withCurrentState(block: (State) -> Unit) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -3,7 +3,6 @@ package com.stripe.android.paymentsheet.flowcontroller
 import android.app.Activity
 import android.content.Context
 import android.os.Parcelable
-import android.util.Log
 import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.ActivityResultRegistryOwner
@@ -30,8 +29,6 @@ import com.stripe.android.link.account.updateLinkAccount
 import com.stripe.android.link.gate.LinkGate
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.model.toLoginState
-import com.stripe.android.link.ui.inline.SignUpConsentAction
-import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.WalletType
 import com.stripe.android.model.PaymentMethod
@@ -62,7 +59,6 @@ import com.stripe.android.paymentsheet.model.PaymentOption
 import com.stripe.android.paymentsheet.model.PaymentOptionFactory
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.PaymentSelection.Link
-import com.stripe.android.paymentsheet.model.billingDetails
 import com.stripe.android.paymentsheet.model.isLink
 import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
@@ -107,6 +103,7 @@ internal class DefaultFlowController @Inject internal constructor(
     @Named(PRODUCT_USAGE) private val productUsage: Set<String>,
     private val configurationHandler: FlowControllerConfigurationHandler,
     private val errorReporter: ErrorReporter,
+    private val signupForLink: SignupForLink,
     @InitializedViaCompose private val initializedViaCompose: Boolean,
     @PaymentElementCallbackIdentifier private val paymentElementCallbackIdentifier: String,
 ) : PaymentSheet.FlowController {
@@ -256,10 +253,6 @@ internal class DefaultFlowController @Inject internal constructor(
 
     override fun setLinkSignupToggleValue(isChecked: Boolean) {
         viewModel.flowControllerStateComponent.signupToLinkToggleInteractor.handleToggleChange(isChecked)
-    }
-
-    private fun getSignupToLinkValue(): Boolean {
-        return viewModel.flowControllerStateComponent.signupToLinkToggleInteractor.getSignupToLinkValue()
     }
 
     private fun withCurrentState(block: (State) -> Unit) {
@@ -495,40 +488,6 @@ internal class DefaultFlowController @Inject internal constructor(
         }
     }
 
-    private suspend fun createLinkAccountIfNeeded() {
-        try {
-            val state = viewModel.state?.paymentSheetState ?: return
-            val paymentSelection = viewModel.paymentSelection
-
-            // Check if we should sign up to Link
-            if (!getSignupToLinkValue()) return
-            if (linkAccountHolder.linkAccountInfo.value.account != null) return
-            if (state.linkConfiguration == null) return
-
-            val billing = paymentSelection?.billingDetails
-            val email = billing?.email
-            val phone = billing?.phone
-            if (email == null || phone == null) return
-
-            // Attempt Link signup
-            val linkConfiguration = state.linkConfiguration ?: return
-            val linkAccountManager = linkHandler.linkConfigurationCoordinator
-                .getComponent(linkConfiguration).linkAccountManager
-
-            val userInput = UserInput.SignUp(
-                email = email,
-                country = billing.address?.country ?: "US",
-                phone = phone,
-                name = billing.name,
-                consentAction = SignUpConsentAction.Implied
-            )
-            Log.d("DefaultFlowController", "Creating Link account with user input: $userInput")
-            linkAccountManager.signInWithUserInput(userInput)
-        } catch (e: StripeException) {
-            Log.d("DefaultFlowController", "Failed to create Link account: ${e.message}", e)
-        }
-    }
-
     private fun confirmSavedPaymentMethod(
         paymentSelection: PaymentSelection.Saved,
         state: PaymentSheetState.Full,
@@ -559,7 +518,10 @@ internal class DefaultFlowController @Inject internal constructor(
         initializationMode: PaymentElementLoader.InitializationMode,
     ) {
         viewModelScope.launch {
-            createLinkAccountIfNeeded()
+            signupForLink(
+                linkConfiguration = state.linkConfiguration,
+                paymentSelection = paymentSelection
+            )
 
             val confirmationOption = paymentSelection?.toConfirmationOption(
                 configuration = state.config,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerModule.kt
@@ -117,8 +117,13 @@ internal object FlowControllerModule {
     @Singleton
     fun providesSignupToLinkToggleInteractor(
         viewModel: FlowControllerViewModel,
+        application: Application,
     ): SignupToLinkToggleInteractor {
-        return DefaultSignupToLinkToggleInteractor.create(viewModel)
+        return DefaultSignupToLinkToggleInteractor(
+            flowControllerState = viewModel.stateFlow,
+            linkAccountHolder = viewModel.flowControllerStateComponent.linkAccountHolder,
+            application = application,
+        )
     }
 
     @Provides

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerModule.kt
@@ -18,7 +18,9 @@ import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.flowcontroller.DefaultFlowController.Companion.FLOW_CONTROLLER_LINK_LAUNCHER
 import com.stripe.android.paymentsheet.flowcontroller.DefaultFlowController.Companion.WALLETS_BUTTON_LINK_LAUNCHER
 import com.stripe.android.paymentsheet.injection.PaymentOptionsViewModelSubcomponent
+import com.stripe.android.paymentsheet.ui.DefaultSignupToLinkToggleInteractor
 import com.stripe.android.paymentsheet.ui.DefaultWalletButtonsInteractor
+import com.stripe.android.paymentsheet.ui.SignupToLinkToggleInteractor
 import com.stripe.android.paymentsheet.ui.WalletButtonsContent
 import com.stripe.android.uicore.image.StripeImageLoader
 import dagger.Module
@@ -109,6 +111,14 @@ internal object FlowControllerModule {
         return WalletButtonsContent(
             interactor = DefaultWalletButtonsInteractor.create(viewModel, walletsButtonLinkLauncher)
         )
+    }
+
+    @Provides
+    @Singleton
+    fun providesSignupToLinkToggleInteractor(
+        viewModel: FlowControllerViewModel,
+    ): SignupToLinkToggleInteractor {
+        return DefaultSignupToLinkToggleInteractor.create(viewModel)
     }
 
     @Provides

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerModule.kt
@@ -19,6 +19,7 @@ import com.stripe.android.paymentsheet.flowcontroller.DefaultFlowController.Comp
 import com.stripe.android.paymentsheet.flowcontroller.DefaultFlowController.Companion.WALLETS_BUTTON_LINK_LAUNCHER
 import com.stripe.android.paymentsheet.injection.PaymentOptionsViewModelSubcomponent
 import com.stripe.android.paymentsheet.ui.DefaultSignupToLinkToggleInteractor
+import com.stripe.android.paymentsheet.ui.DefaultSignupToLinkToggleStringProvider
 import com.stripe.android.paymentsheet.ui.DefaultWalletButtonsInteractor
 import com.stripe.android.paymentsheet.ui.SignupToLinkToggleInteractor
 import com.stripe.android.paymentsheet.ui.WalletButtonsContent
@@ -122,7 +123,7 @@ internal object FlowControllerModule {
         return DefaultSignupToLinkToggleInteractor(
             flowControllerState = viewModel.stateFlow,
             linkAccountHolder = viewModel.flowControllerStateComponent.linkAccountHolder,
-            application = application,
+            stringProvider = DefaultSignupToLinkToggleStringProvider(application),
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerStateComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerStateComponent.kt
@@ -45,6 +45,7 @@ import javax.inject.Singleton
     ]
 )
 internal interface FlowControllerStateComponent {
+    val application: Application
     val flowControllerComponentBuilder: FlowControllerComponent.Builder
     val confirmationHandler: ConfirmationHandler
     val linkHandler: LinkHandler

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerStateComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerStateComponent.kt
@@ -18,6 +18,7 @@ import com.stripe.android.paymentsheet.LinkHandler
 import com.stripe.android.paymentsheet.PaymentOptionsViewModel
 import com.stripe.android.paymentsheet.injection.LinkHoldbackExposureModule
 import com.stripe.android.paymentsheet.injection.PaymentSheetCommonModule
+import com.stripe.android.paymentsheet.ui.SignupToLinkToggleInteractor
 import com.stripe.android.paymentsheet.ui.WalletButtonsContent
 import com.stripe.android.ui.core.di.CardScanModule
 import com.stripe.android.ui.core.forms.resources.injection.ResourceRepositoryModule
@@ -49,6 +50,7 @@ internal interface FlowControllerStateComponent {
     val linkHandler: LinkHandler
     val errorReporter: ErrorReporter
     val walletButtonsContent: WalletButtonsContent
+    val signupToLinkToggleInteractor: SignupToLinkToggleInteractor
     val linkInlineInteractor: DefaultLinkInlineInteractor
     val linkAccountHolder: LinkAccountHolder
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerStateComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerStateComponent.kt
@@ -18,7 +18,6 @@ import com.stripe.android.paymentsheet.LinkHandler
 import com.stripe.android.paymentsheet.PaymentOptionsViewModel
 import com.stripe.android.paymentsheet.injection.LinkHoldbackExposureModule
 import com.stripe.android.paymentsheet.injection.PaymentSheetCommonModule
-import com.stripe.android.paymentsheet.ui.SignupToLinkToggleInteractor
 import com.stripe.android.paymentsheet.ui.WalletButtonsContent
 import com.stripe.android.ui.core.di.CardScanModule
 import com.stripe.android.ui.core.forms.resources.injection.ResourceRepositoryModule
@@ -45,13 +44,11 @@ import javax.inject.Singleton
     ]
 )
 internal interface FlowControllerStateComponent {
-    val application: Application
     val flowControllerComponentBuilder: FlowControllerComponent.Builder
     val confirmationHandler: ConfirmationHandler
     val linkHandler: LinkHandler
     val errorReporter: ErrorReporter
     val walletButtonsContent: WalletButtonsContent
-    val signupToLinkToggleInteractor: SignupToLinkToggleInteractor
     val linkInlineInteractor: DefaultLinkInlineInteractor
     val linkAccountHolder: LinkAccountHolder
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/SignupForLink.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/SignupForLink.kt
@@ -1,0 +1,83 @@
+package com.stripe.android.paymentsheet.flowcontroller
+
+import com.stripe.android.core.Logger
+import com.stripe.android.core.exception.StripeException
+import com.stripe.android.link.LinkConfiguration
+import com.stripe.android.link.account.LinkAccountHolder
+import com.stripe.android.link.account.LinkAccountManager
+import com.stripe.android.link.ui.inline.SignUpConsentAction
+import com.stripe.android.link.ui.inline.UserInput
+import com.stripe.android.paymentsheet.LinkHandler
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.model.billingDetails
+import com.stripe.android.paymentsheet.ui.SignupToLinkToggleInteractor
+import javax.inject.Inject
+
+internal class SignupForLink @Inject constructor(
+    private val linkAccountHolder: LinkAccountHolder,
+    private val linkHandler: LinkHandler,
+    private val signupToLinkToggleInteractor: SignupToLinkToggleInteractor,
+    private val logger: Logger
+) {
+
+    suspend operator fun invoke(
+        linkConfiguration: LinkConfiguration?,
+        paymentSelection: PaymentSelection?
+    ) {
+        try {
+            // Check if we should sign up to Link
+            if (!signupToLinkToggleInteractor.getSignupToLinkValue()) return
+            if (linkAccountHolder.linkAccountInfo.value.account != null) return
+            if (linkConfiguration == null) return
+
+            val billing = paymentSelection?.billingDetails
+            val email = billing?.email
+            val phone = billing?.phone
+            if (email == null) return
+
+            // Attempt Link signup
+            val linkAccountManager = linkHandler.linkConfigurationCoordinator
+                .getComponent(linkConfiguration).linkAccountManager
+
+            val userInput = UserInput.SignUpOptionalPhone(
+                email = email,
+                country = billing.address?.country ?: "US",
+                phone = phone,
+                name = billing.name,
+                consentAction = SignUpConsentAction.Implied
+            )
+            logger.debug("Creating Link account with user input: $userInput")
+
+            // Create Link account
+            val accountResult = linkAccountManager.signInWithUserInput(userInput)
+            if (accountResult.isSuccess) {
+                logger.debug("Link account created successfully")
+                createCardPaymentDetailsIfNeeded(paymentSelection, linkAccountManager)
+            } else {
+                val errorMessage = accountResult.exceptionOrNull()?.message
+                logger.debug("Failed to create Link account: $errorMessage")
+            }
+        } catch (e: StripeException) {
+            logger.debug("Failed to create Link account: ${e.message}")
+        }
+    }
+
+    private suspend fun createCardPaymentDetailsIfNeeded(
+        paymentSelection: PaymentSelection?,
+        linkAccountManager: LinkAccountManager
+    ) {
+        // Create payment method in Link if we have card payment selection
+        if (paymentSelection is PaymentSelection.New) {
+            val paymentMethodCreateParams = paymentSelection.paymentMethodCreateParams
+            val cardPaymentDetailsResult = linkAccountManager.createCardPaymentDetails(
+                paymentMethodCreateParams
+            )
+            if (cardPaymentDetailsResult.isSuccess) {
+                logger.debug("Card payment details created in Link successfully")
+            } else {
+                val errorMessage = cardPaymentDetailsResult.exceptionOrNull()?.message
+                logger.debug("Failed to create card payment details: $errorMessage")
+            }
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/SignupForLink.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/SignupForLink.kt
@@ -30,7 +30,7 @@ internal class SignupForLink @Inject constructor(
             // Link is disabled
             if (linkConfiguration == null) return
             // Signup toggle wasn't shown
-            if (signupToLinkToggleInteractor.state == LinkSignupOptInState.Hidden) return
+            if (signupToLinkToggleInteractor.state.value == LinkSignupOptInState.Hidden) return
             // Signup is disabled from backend
             if (linkConfiguration.enableNewUserSignupAPI.not()) return
             // Signup toggle is off
@@ -46,7 +46,7 @@ internal class SignupForLink @Inject constructor(
 
             val userInput = UserInput.SignUpOptionalPhone(
                 email = email,
-                country = billing.address?.country,
+                country = billing.address?.country ?: "US",
                 phone = billing.phone,
                 name = billing.name,
                 consentAction = SignUpConsentAction.Implied

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/SignupForLink.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/SignupForLink.kt
@@ -42,9 +42,9 @@ internal class SignupForLink @Inject constructor(
 
             val userInput = UserInput.SignUpOptionalPhone(
                 email = email,
-                country = billing?.address?.country ?: "US",
-                phone = billing?.phone,
-                name = billing?.name,
+                country = billing.address?.country,
+                phone = billing.phone,
+                name = billing.name,
                 consentAction = SignUpConsentAction.Implied
             )
             logger.debug("Creating Link account with user input: $userInput")
@@ -74,7 +74,7 @@ internal class SignupForLink @Inject constructor(
         linkAccountManager: LinkAccountManager
     ) {
         // Create payment method in Link if we have card payment selection
-        if (paymentSelection is PaymentSelection.New) {
+        if (paymentSelection is PaymentSelection.New.Card) {
             val paymentMethodCreateParams = paymentSelection.paymentMethodCreateParams
             val cardPaymentDetailsResult = linkAccountManager.createCardPaymentDetails(
                 paymentMethodCreateParams

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/SignupForLink.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/SignupForLink.kt
@@ -32,7 +32,6 @@ internal class SignupForLink @Inject constructor(
 
             val billing = paymentSelection?.billingDetails
             val email = billing?.email
-            val phone = billing?.phone
             if (email == null) return
 
             // Attempt Link signup
@@ -41,9 +40,9 @@ internal class SignupForLink @Inject constructor(
 
             val userInput = UserInput.SignUpOptionalPhone(
                 email = email,
-                country = billing.address?.country ?: "US",
-                phone = phone,
-                name = billing.name,
+                country = billing?.address?.country ?: "US",
+                phone = billing?.phone,
+                name = billing?.name,
                 consentAction = SignUpConsentAction.Implied
             )
             logger.debug("Creating Link account with user input: $userInput")

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/SignupForLink.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/SignupForLink.kt
@@ -6,6 +6,7 @@ import com.stripe.android.link.account.LinkAccountManager
 import com.stripe.android.link.ui.inline.SignUpConsentAction
 import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.paymentsheet.LinkHandler
+import com.stripe.android.paymentsheet.PaymentSheet.LinkSignupOptInState
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.billingDetails
@@ -28,8 +29,12 @@ internal class SignupForLink @Inject constructor(
             val email = billing?.email
             // Link is disabled
             if (linkConfiguration == null) return
+            // Signup toggle wasn't shown
+            if (signupToLinkToggleInteractor.state == LinkSignupOptInState.Hidden) return
+            // Signup is disabled from backend
+            if (linkConfiguration.enableNewUserSignupAPI.not()) return
             // Signup toggle is off
-            if (!signupToLinkToggleInteractor.toggleValue.value) return
+            if (signupToLinkToggleInteractor.toggleValue.value.not()) return
             // Link account already exists
             if (linkAccountHolder.linkAccountInfo.value.account != null) return
             // No email provided

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SignupToLinkToggleInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SignupToLinkToggleInteractor.kt
@@ -1,69 +1,72 @@
 package com.stripe.android.paymentsheet.ui
 
-import androidx.compose.runtime.Immutable
-import androidx.compose.runtime.Stable
+import android.app.Application
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.fromHtml
 import com.stripe.android.link.account.LinkAccountHolder
+import com.stripe.android.link.ui.replaceHyperlinks
+import com.stripe.android.lpmfoundations.paymentmethod.WalletType
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.flowcontroller.DefaultFlowController
-import com.stripe.android.paymentsheet.flowcontroller.FlowControllerViewModel
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 internal interface SignupToLinkToggleInteractor {
-    val state: StateFlow<State>
-
-    @Immutable
-    @Stable
-    data class State(
-        val shouldDisplay: Boolean,
-        val title: String,
-        val subtitle: String,
-        val isChecked: Boolean,
-    )
+    val state: StateFlow<PaymentSheet.LinkSignupOptInState>
+    val toggleValue: MutableStateFlow<Boolean>
 
     fun handleToggleChange(checked: Boolean)
     fun getSignupToLinkValue(): Boolean
 }
 
 internal class DefaultSignupToLinkToggleInteractor(
-    private val flowControllerState: StateFlow<DefaultFlowController.State?>,
-    private val linkAccountHolder: LinkAccountHolder,
+    flowControllerState: StateFlow<DefaultFlowController.State?>,
+    linkAccountHolder: LinkAccountHolder,
+    application: Application,
 ) : SignupToLinkToggleInteractor {
+
+    val title = application.getString(R.string.stripe_link_signup_toggle_title)
+    val description = application.getString(R.string.stripe_link_signup_toggle_description)
+    val termsAndConditions = AnnotatedString
+        .fromHtml(application.getString(R.string.stripe_link_sign_up_terms).replaceHyperlinks())
 
     private val _isChecked = MutableStateFlow(false)
 
-    override val state: StateFlow<SignupToLinkToggleInteractor.State> = combineAsStateFlow(
+    override val toggleValue: MutableStateFlow<Boolean> = _isChecked
+
+    override val state: StateFlow<PaymentSheet.LinkSignupOptInState> = combineAsStateFlow(
         flowControllerState,
         _isChecked,
         linkAccountHolder.linkAccountInfo
     ) { state, isChecked, linkAccountInfo ->
-        val metadata = state?.paymentSheetState?.paymentMethodMetadata
-        val shouldDisplay = metadata?.linkState != null && linkAccountInfo.account == null
+        val paymentMethodMetadata = state?.paymentSheetState?.paymentMethodMetadata
+        val linkState = paymentMethodMetadata?.linkState
 
-        SignupToLinkToggleInteractor.State(
-            shouldDisplay = shouldDisplay,
-            title = "Save my info for faster checkout with Link",
-            subtitle = "Pay faster everywhere Link is accepted.",
-            isChecked = isChecked,
-        )
+        // We don't recognize the Link account
+        val hasNoExistingAccount = linkAccountInfo.account == null
+        // Shop Pay is available in the available wallets list
+        val shopPayAvailable = paymentMethodMetadata?.availableWallets?.contains(WalletType.ShopPay) == true
+
+        val shouldDisplay = linkState != null && hasNoExistingAccount && shopPayAvailable.not()
+
+        if (shouldDisplay) {
+            PaymentSheet.LinkSignupOptInState.Visible(
+                title = title,
+                description = description,
+                termsAndConditions = termsAndConditions
+            )
+        } else {
+            PaymentSheet.LinkSignupOptInState.Hidden
+        }
     }
 
     override fun handleToggleChange(checked: Boolean) {
-        _isChecked.value = checked
+        toggleValue.value = checked
     }
 
     override fun getSignupToLinkValue(): Boolean {
-        return _isChecked.value
-    }
-
-    companion object {
-        fun create(
-            flowControllerViewModel: FlowControllerViewModel,
-        ): SignupToLinkToggleInteractor {
-            return DefaultSignupToLinkToggleInteractor(
-                flowControllerState = flowControllerViewModel.stateFlow,
-                linkAccountHolder = flowControllerViewModel.flowControllerStateComponent.linkAccountHolder,
-            )
-        }
+        return toggleValue.value
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SignupToLinkToggleInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SignupToLinkToggleInteractor.kt
@@ -12,7 +12,6 @@ internal interface SignupToLinkToggleInteractor {
     val state: StateFlow<PaymentSheet.LinkSignupOptInState>
     val toggleValue: MutableStateFlow<Boolean>
 
-    fun handleToggleChange(checked: Boolean)
     fun getSignupToLinkValue(): Boolean
 }
 
@@ -50,10 +49,6 @@ internal class DefaultSignupToLinkToggleInteractor(
         } else {
             PaymentSheet.LinkSignupOptInState.Hidden
         }
-    }
-
-    override fun handleToggleChange(checked: Boolean) {
-        toggleValue.value = checked
     }
 
     override fun getSignupToLinkValue(): Boolean {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SignupToLinkToggleInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SignupToLinkToggleInteractor.kt
@@ -1,13 +1,8 @@
 package com.stripe.android.paymentsheet.ui
 
-import android.app.Application
-import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.fromHtml
 import com.stripe.android.link.account.LinkAccountHolder
-import com.stripe.android.link.ui.replaceHyperlinks
 import com.stripe.android.lpmfoundations.paymentmethod.WalletType
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.flowcontroller.DefaultFlowController
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -24,13 +19,8 @@ internal interface SignupToLinkToggleInteractor {
 internal class DefaultSignupToLinkToggleInteractor(
     flowControllerState: StateFlow<DefaultFlowController.State?>,
     linkAccountHolder: LinkAccountHolder,
-    application: Application,
+    private val stringProvider: SignupToLinkToggleStringProvider,
 ) : SignupToLinkToggleInteractor {
-
-    val title = application.getString(R.string.stripe_link_signup_toggle_title)
-    val description = application.getString(R.string.stripe_link_signup_toggle_description)
-    val termsAndConditions = AnnotatedString
-        .fromHtml(application.getString(R.string.stripe_link_sign_up_terms).replaceHyperlinks())
 
     private val _isChecked = MutableStateFlow(false)
 
@@ -53,9 +43,9 @@ internal class DefaultSignupToLinkToggleInteractor(
 
         if (shouldDisplay) {
             PaymentSheet.LinkSignupOptInState.Visible(
-                title = title,
-                description = description,
-                termsAndConditions = termsAndConditions
+                title = stringProvider.title,
+                description = stringProvider.description,
+                termsAndConditions = stringProvider.termsAndConditions
             )
         } else {
             PaymentSheet.LinkSignupOptInState.Hidden

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SignupToLinkToggleInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SignupToLinkToggleInteractor.kt
@@ -1,0 +1,100 @@
+package com.stripe.android.paymentsheet.ui
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
+import androidx.lifecycle.viewModelScope
+import com.stripe.android.common.model.CommonConfiguration
+import com.stripe.android.link.account.LinkAccountHolder
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.flowcontroller.FlowControllerViewModel
+import com.stripe.android.paymentsheet.state.PaymentElementLoader
+import com.stripe.android.uicore.utils.combineAsStateFlow
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+internal interface SignupToLinkToggleInteractor {
+    val state: StateFlow<State>
+
+    @Immutable
+    @Stable
+    data class State(
+        val shouldDisplay: Boolean,
+        val title: String,
+        val subtitle: String,
+        val isChecked: Boolean,
+    )
+
+    fun handleToggleChange(checked: Boolean)
+    fun getSignupToLinkValue(): Boolean
+}
+
+internal class DefaultSignupToLinkToggleInteractor(
+    private val arguments: StateFlow<Arguments?>,
+    private val linkAccountHolder: LinkAccountHolder,
+    private val coroutineScope: CoroutineScope,
+) : SignupToLinkToggleInteractor {
+
+    private val _isChecked = MutableStateFlow(false)
+
+    override val state: StateFlow<SignupToLinkToggleInteractor.State> = combineAsStateFlow(
+        arguments,
+        _isChecked,
+        linkAccountHolder.linkAccountInfo
+    ) { arguments, isChecked, linkAccountInfo ->
+        val shouldDisplay = arguments?.run {
+            paymentMethodMetadata.linkState != null &&
+                configuration.link.shouldDisplay &&
+                linkAccountInfo.account == null
+        } ?: false
+
+        SignupToLinkToggleInteractor.State(
+            shouldDisplay = shouldDisplay,
+            title = "Save my info for faster checkout with Link",
+            subtitle = "Pay faster everywhere Link is accepted.",
+            isChecked = isChecked,
+        )
+    }
+
+    override fun handleToggleChange(checked: Boolean) {
+        _isChecked.value = checked
+    }
+
+    override fun getSignupToLinkValue(): Boolean {
+        return _isChecked.value
+    }
+
+    data class Arguments(
+        val paymentMethodMetadata: PaymentMethodMetadata,
+        val configuration: CommonConfiguration,
+        val appearance: PaymentSheet.Appearance,
+        val initializationMode: PaymentElementLoader.InitializationMode,
+    )
+
+    companion object {
+        fun create(
+            flowControllerViewModel: FlowControllerViewModel,
+        ): SignupToLinkToggleInteractor {
+            return DefaultSignupToLinkToggleInteractor(
+                arguments = combineAsStateFlow(
+                    flowControllerViewModel.stateFlow,
+                    flowControllerViewModel.configureRequest,
+                ) { flowControllerState, configureRequest ->
+                    if (flowControllerState != null && configureRequest != null) {
+                        Arguments(
+                            configuration = flowControllerState.paymentSheetState.config,
+                            paymentMethodMetadata = flowControllerState.paymentSheetState.paymentMethodMetadata,
+                            appearance = configureRequest.configuration.appearance,
+                            initializationMode = configureRequest.initializationMode,
+                        )
+                    } else {
+                        null
+                    }
+                },
+                linkAccountHolder = flowControllerViewModel.flowControllerStateComponent.linkAccountHolder,
+                coroutineScope = flowControllerViewModel.viewModelScope,
+            )
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SignupToLinkToggleInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SignupToLinkToggleInteractor.kt
@@ -45,7 +45,6 @@ internal class DefaultSignupToLinkToggleInteractor(
     ) { arguments, isChecked, linkAccountInfo ->
         val shouldDisplay = arguments?.run {
             paymentMethodMetadata.linkState != null &&
-                configuration.link.shouldDisplay &&
                 linkAccountInfo.account == null
         } ?: false
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SignupToLinkToggleStringProvider.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SignupToLinkToggleStringProvider.kt
@@ -1,0 +1,32 @@
+package com.stripe.android.paymentsheet.ui
+
+import android.app.Application
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.fromHtml
+import com.stripe.android.link.ui.replaceHyperlinks
+
+internal interface SignupToLinkToggleStringProvider {
+    val title: String
+    val description: String
+    val termsAndConditions: AnnotatedString
+}
+
+internal class DefaultSignupToLinkToggleStringProvider(
+    private val application: Application
+) : SignupToLinkToggleStringProvider {
+
+    override val title: String by lazy {
+        application.getString(com.stripe.android.paymentsheet.R.string.stripe_link_signup_toggle_title)
+    }
+
+    override val description: String by lazy {
+        application.getString(com.stripe.android.paymentsheet.R.string.stripe_link_signup_toggle_description)
+    }
+
+    override val termsAndConditions: AnnotatedString by lazy {
+        AnnotatedString.fromHtml(
+            application.getString(com.stripe.android.paymentsheet.R.string.stripe_link_sign_up_terms)
+                .replaceHyperlinks()
+        )
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SignupToLinkToggleStringProvider.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SignupToLinkToggleStringProvider.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.fromHtml
 import com.stripe.android.link.ui.replaceHyperlinks
+import com.stripe.android.paymentsheet.R
 
 internal interface SignupToLinkToggleStringProvider {
     val title: String
@@ -16,17 +17,16 @@ internal class DefaultSignupToLinkToggleStringProvider(
 ) : SignupToLinkToggleStringProvider {
 
     override val title: String by lazy {
-        application.getString(com.stripe.android.paymentsheet.R.string.stripe_link_signup_toggle_title)
+        application.getString(R.string.stripe_link_signup_toggle_title)
     }
 
     override val description: String by lazy {
-        application.getString(com.stripe.android.paymentsheet.R.string.stripe_link_signup_toggle_description)
+        application.getString(R.string.stripe_link_signup_toggle_description)
     }
 
     override val termsAndConditions: AnnotatedString by lazy {
         AnnotatedString.fromHtml(
-            application.getString(com.stripe.android.paymentsheet.R.string.stripe_link_sign_up_terms)
-                .replaceHyperlinks()
+            application.getString(R.string.stripe_link_sign_up_terms).replaceHyperlinks()
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAccountManagerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAccountManagerTest.kt
@@ -196,8 +196,8 @@ class DefaultLinkAccountManagerTest {
             var callCount = 0
             override suspend fun consumerSignUp(
                 actualEmail: String,
-                actualPhone: String,
-                actualCountry: String,
+                actualPhone: String?,
+                actualCountry: String?,
                 actualName: String?,
                 actualConsentAction: ConsumerSignUpConsentAction
             ): Result<ConsumerSessionSignup> {
@@ -239,8 +239,8 @@ class DefaultLinkAccountManagerTest {
             var callCount = 0
             override suspend fun consumerSignUp(
                 email: String,
-                phone: String,
-                country: String,
+                phone: String?,
+                country: String?,
                 name: String?,
                 consentAction: ConsumerSignUpConsentAction
             ): Result<ConsumerSessionSignup> {
@@ -264,8 +264,8 @@ class DefaultLinkAccountManagerTest {
                 var callCount = 0
                 override suspend fun consumerSignUp(
                     email: String,
-                    phone: String,
-                    country: String,
+                    phone: String?,
+                    country: String?,
                     name: String?,
                     consentAction: ConsumerSignUpConsentAction
                 ): Result<ConsumerSessionSignup> {
@@ -291,8 +291,8 @@ class DefaultLinkAccountManagerTest {
                 var callCount = 0
                 override suspend fun consumerSignUp(
                     email: String,
-                    phone: String,
-                    country: String,
+                    phone: String?,
+                    country: String?,
                     name: String?,
                     consentAction: ConsumerSignUpConsentAction
                 ): Result<ConsumerSessionSignup> {
@@ -317,8 +317,8 @@ class DefaultLinkAccountManagerTest {
             var callCount = 0
             override suspend fun consumerSignUp(
                 email: String,
-                phone: String,
-                country: String,
+                phone: String?,
+                country: String?,
                 name: String?,
                 consentAction: ConsumerSignUpConsentAction
             ): Result<ConsumerSessionSignup> {
@@ -344,8 +344,8 @@ class DefaultLinkAccountManagerTest {
                 val consentActions = arrayListOf<ConsumerSignUpConsentAction>()
                 override suspend fun consumerSignUp(
                     email: String,
-                    phone: String,
-                    country: String,
+                    phone: String?,
+                    country: String?,
                     name: String?,
                     consentAction: ConsumerSignUpConsentAction
                 ): Result<ConsumerSessionSignup> {

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/FakeLinkAccountManager.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/FakeLinkAccountManager.kt
@@ -166,8 +166,8 @@ internal open class FakeLinkAccountManager(
 
     override suspend fun mobileSignUp(
         email: String,
-        phone: String,
-        country: String,
+        phone: String?,
+        country: String?,
         name: String?,
         verificationToken: String,
         appId: String,
@@ -349,8 +349,8 @@ internal open class FakeLinkAccountManager(
 
     data class MobileSignUpCall(
         val email: String,
-        val phone: String,
-        val country: String,
+        val phone: String?,
+        val country: String?,
         val name: String?,
         val verificationToken: String,
         val appId: String,

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/FakeLinkAuth.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/FakeLinkAuth.kt
@@ -15,8 +15,8 @@ internal class FakeLinkAuth : LinkAuth {
 
     override suspend fun signUp(
         email: String,
-        phoneNumber: String,
-        country: String,
+        phoneNumber: String?,
+        country: String?,
         name: String?,
         consentAction: SignUpConsentAction
     ): LinkAuthResult {
@@ -65,8 +65,8 @@ internal class FakeLinkAuth : LinkAuth {
 
     data class SignUpCall(
         val email: String,
-        val phone: String,
-        val country: String,
+        val phone: String?,
+        val country: String?,
         val name: String?,
         val consentAction: SignUpConsentAction
     )

--- a/paymentsheet/src/test/java/com/stripe/android/link/repositories/FakeLinkRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/repositories/FakeLinkRepository.kt
@@ -88,8 +88,8 @@ internal open class FakeLinkRepository : LinkRepository {
 
     override suspend fun consumerSignUp(
         email: String,
-        phone: String,
-        country: String,
+        phone: String?,
+        country: String?,
         name: String?,
         consentAction: ConsumerSignUpConsentAction
     ) = consumerSignUpResult

--- a/paymentsheet/src/test/java/com/stripe/android/link/repositories/FakeLinkRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/repositories/FakeLinkRepository.kt
@@ -97,8 +97,8 @@ internal open class FakeLinkRepository : LinkRepository {
     override suspend fun mobileSignUp(
         name: String?,
         email: String,
-        phoneNumber: String,
-        country: String,
+        phoneNumber: String?,
+        country: String?,
         consentAction: ConsumerSignUpConsentAction,
         amount: Long?,
         currency: String?,
@@ -239,8 +239,8 @@ internal open class FakeLinkRepository : LinkRepository {
     data class MobileSignUpCall(
         val name: String?,
         val email: String,
-        val phoneNumber: String,
-        val country: String,
+        val phoneNumber: String?,
+        val country: String?,
         val consentAction: ConsumerSignUpConsentAction,
         val amount: Long?,
         val currency: String?,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeEventReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeEventReporter.kt
@@ -275,6 +275,15 @@ internal class FakeEventReporter : EventReporter {
     override fun onShopPayWebViewCancelled(didReceiveECEClick: Boolean) {
     }
 
+    override fun onLinkUserSignupSucceeded() {
+    }
+
+    override fun onLinkUserSignupFailed(error: Throwable) {
+    }
+
+    override fun onLinkUserPaymentDetailCreationCompleted(error: Throwable?) {
+    }
+
     data class PaymentFailureCall(
         val paymentSelection: PaymentSelection,
         val error: PaymentSheetConfirmationError

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -2486,6 +2486,7 @@ internal class DefaultFlowControllerTest {
                 isLiveModeProvider = { false },
             ),
             errorReporter = errorReporter,
+            signupForLink = mock(),
             initializedViaCompose = false,
             linkHandler = mock(),
             paymentElementCallbackIdentifier = FLOW_CONTROLLER_CALLBACK_TEST_IDENTIFIER,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -2494,6 +2494,7 @@ internal class DefaultFlowControllerTest {
             flowControllerLinkLauncher = flowControllerLinkPaymentLauncher,
             walletsButtonLinkLauncher = walletsButtonLinkPaymentLauncher,
             activityResultRegistryOwner = mock(),
+            signupToLinkToggleInteractor = mock(),
             linkGateFactory = { linkGate },
             confirmationHandler = confirmationHandler ?: FakeConfirmationHandler(),
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/SignupForLinkTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/SignupForLinkTest.kt
@@ -19,7 +19,6 @@ import com.stripe.android.paymentsheet.LinkHandler
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.FakeSignupToLinkToggleInteractor
-import com.stripe.android.testing.FakeLogger
 import com.stripe.android.utils.FakeLinkComponent
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
 import kotlinx.coroutines.test.runTest
@@ -30,7 +29,6 @@ class SignupForLinkTest {
 
     private val linkAccountHolder = LinkAccountHolder(SavedStateHandle())
     private val signupToLinkToggleInteractor = FakeSignupToLinkToggleInteractor()
-    private val logger = FakeLogger()
     private val linkAccountManager = FakeLinkAccountManager()
     private val linkComponent = FakeLinkComponent(linkAccountManager = linkAccountManager)
     private val linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(component = linkComponent)
@@ -42,7 +40,6 @@ class SignupForLinkTest {
         linkAccountHolder = linkAccountHolder,
         linkHandler = linkHandler,
         signupToLinkToggleInteractor = signupToLinkToggleInteractor,
-        logger = logger,
         eventReporter = eventReporter
     )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/SignupForLinkTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/SignupForLinkTest.kt
@@ -157,7 +157,7 @@ class SignupForLinkTest {
         // Given
         setupSuccessfulSignupMocks()
 
-        val expectedUserInput = UserInput.SignUpOptionalPhone(
+        val expectedUserInput = UserInput.SignUp(
             email = testEmail,
             country = testCountry,
             phone = testPhone,
@@ -194,7 +194,7 @@ class SignupForLinkTest {
             customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest
         )
 
-        val expectedUserInput = UserInput.SignUpOptionalPhone(
+        val expectedUserInput = UserInput.SignUp(
             email = testEmail,
             country = "US", // Default country
             phone = testPhone,
@@ -257,7 +257,7 @@ class SignupForLinkTest {
         )
         val savedPaymentSelection = PaymentSelection.Saved(paymentMethodWithBillingDetails)
 
-        val expectedUserInput = UserInput.SignUpOptionalPhone(
+        val expectedUserInput = UserInput.SignUp(
             email = testEmail,
             country = testCountry,
             phone = testPhone,
@@ -314,9 +314,9 @@ class SignupForLinkTest {
             customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest
         )
 
-        val expectedUserInput = UserInput.SignUpOptionalPhone(
+        val expectedUserInput = UserInput.SignUp(
             email = testEmail,
-            country = "US", // Default
+            country = null,
             phone = null,
             name = null,
             consentAction = SignUpConsentAction.Implied

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/SignupForLinkTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/SignupForLinkTest.kt
@@ -16,6 +16,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.LinkHandler
+import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.FakeSignupToLinkToggleInteractor
 import com.stripe.android.testing.FakeLogger
@@ -35,11 +36,14 @@ class SignupForLinkTest {
     private val linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(component = linkComponent)
     private val linkHandler = LinkHandler(linkConfigurationCoordinator)
 
+    private val eventReporter = FakeEventReporter()
+
     private val signupForLink = SignupForLink(
         linkAccountHolder = linkAccountHolder,
         linkHandler = linkHandler,
         signupToLinkToggleInteractor = signupToLinkToggleInteractor,
-        logger = logger
+        logger = logger,
+        eventReporter = eventReporter
     )
 
     private val testEmail = "test@example.com"

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/SignupForLinkTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/SignupForLinkTest.kt
@@ -1,0 +1,348 @@
+package com.stripe.android.paymentsheet.flowcontroller
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.link.LinkAccountUpdate
+import com.stripe.android.link.LinkConfiguration
+import com.stripe.android.link.LinkConfigurationCoordinator
+import com.stripe.android.link.TestFactory
+import com.stripe.android.link.account.FakeLinkAccountManager
+import com.stripe.android.link.account.LinkAccountHolder
+import com.stripe.android.link.injection.LinkComponent
+import com.stripe.android.link.model.LinkAccount
+import com.stripe.android.link.ui.inline.SignUpConsentAction
+import com.stripe.android.link.ui.inline.UserInput
+import com.stripe.android.model.Address
+import com.stripe.android.model.CardBrand
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodCreateParamsFixtures
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.paymentsheet.LinkHandler
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.ui.SignupToLinkToggleInteractor
+import com.stripe.android.testing.FakeLogger
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+
+class SignupForLinkTest {
+
+    private val linkAccountHolder = mock<LinkAccountHolder>()
+    private val linkHandler = mock<LinkHandler>()
+    private val signupToLinkToggleInteractor = mock<SignupToLinkToggleInteractor>()
+    private val logger = FakeLogger()
+    private val linkConfigurationCoordinator = mock<LinkConfigurationCoordinator>()
+    private val linkComponent = mock<LinkComponent>()
+    private val linkAccountManager = FakeLinkAccountManager()
+
+    private val signupForLink = SignupForLink(
+        linkAccountHolder = linkAccountHolder,
+        linkHandler = linkHandler,
+        signupToLinkToggleInteractor = signupToLinkToggleInteractor,
+        logger = logger
+    )
+
+    private val testEmail = "test@example.com"
+    private val testPhone = "+1234567890"
+    private val testName = "John Doe"
+    private val testCountry = "US"
+
+    private val testAddress = Address(
+        line1 = "123 Main St",
+        line2 = null,
+        city = "San Francisco",
+        state = "CA",
+        postalCode = "94105",
+        country = testCountry
+    )
+
+    private val testBillingDetails = PaymentMethod.BillingDetails(
+        address = testAddress,
+        email = testEmail,
+        name = testName,
+        phone = testPhone
+    )
+
+    private val testPaymentSelection = PaymentSelection.New.Card(
+        paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD.copy(
+            billingDetails = testBillingDetails
+        ),
+        brand = CardBrand.Visa,
+        customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest
+    )
+
+    private val testLinkConfiguration = mock<LinkConfiguration>()
+
+    @Test
+    fun `invoke should return early when signup toggle is disabled`() = runTest {
+        // Given
+        whenever(signupToLinkToggleInteractor.getSignupToLinkValue()).thenReturn(false)
+
+        // When
+        signupForLink(testLinkConfiguration, testPaymentSelection)
+
+        // Then
+        verifyNoInteractions(linkAccountHolder, linkHandler)
+    }
+
+    @Test
+    fun `invoke should return early when link account already exists`() = runTest {
+        // Given
+        whenever(signupToLinkToggleInteractor.getSignupToLinkValue()).thenReturn(true)
+        val existingAccount = mock<LinkAccount>()
+        val accountInfo = LinkAccountUpdate.Value(existingAccount)
+        whenever(linkAccountHolder.linkAccountInfo).thenReturn(MutableStateFlow(accountInfo))
+
+        // When
+        signupForLink(testLinkConfiguration, testPaymentSelection)
+
+        // Then
+        verifyNoInteractions(linkHandler)
+    }
+
+    @Test
+    fun `invoke should return early when linkConfiguration is null`() = runTest {
+        // Given
+        whenever(signupToLinkToggleInteractor.getSignupToLinkValue()).thenReturn(true)
+        whenever(linkAccountHolder.linkAccountInfo).thenReturn(
+            MutableStateFlow(LinkAccountUpdate.Value(null))
+        )
+
+        // When
+        signupForLink(null, testPaymentSelection)
+
+        // Then
+        verifyNoInteractions(linkHandler)
+    }
+
+    @Test
+    fun `invoke should return early when email is null`() = runTest {
+        // Given
+        whenever(signupToLinkToggleInteractor.getSignupToLinkValue()).thenReturn(true)
+        whenever(linkAccountHolder.linkAccountInfo).thenReturn(
+            MutableStateFlow(LinkAccountUpdate.Value(null))
+        )
+
+        val paymentSelectionWithoutEmail = PaymentSelection.New.Card(
+            paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD.copy(
+                billingDetails = testBillingDetails.copy(email = null)
+            ),
+            brand = CardBrand.Visa,
+            customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest
+        )
+
+        // When
+        signupForLink(testLinkConfiguration, paymentSelectionWithoutEmail)
+
+        // Then
+        verifyNoInteractions(linkHandler)
+    }
+
+    @Test
+    fun `invoke should return early when paymentSelection is null`() = runTest {
+        // Given
+        whenever(signupToLinkToggleInteractor.getSignupToLinkValue()).thenReturn(true)
+        whenever(linkAccountHolder.linkAccountInfo).thenReturn(
+            MutableStateFlow(LinkAccountUpdate.Value(null))
+        )
+
+        // When
+        signupForLink(testLinkConfiguration, null)
+
+        // Then
+        verifyNoInteractions(linkHandler)
+    }
+
+    @Test
+    fun `invoke should successfully sign up to Link and create card payment details`() = runTest {
+        // Given
+        setupSuccessfulSignupMocks()
+
+        val expectedUserInput = UserInput.SignUpOptionalPhone(
+            email = testEmail,
+            country = testCountry,
+            phone = testPhone,
+            name = testName,
+            consentAction = SignUpConsentAction.Implied
+        )
+
+        linkAccountManager.signInWithUserInputResult = Result.success(TestFactory.LINK_ACCOUNT)
+        linkAccountManager.createCardPaymentDetailsResult = Result.success(TestFactory.LINK_NEW_PAYMENT_DETAILS)
+
+        // When
+        signupForLink(testLinkConfiguration, testPaymentSelection)
+
+        // Then
+        val signInCall = linkAccountManager.awaitSignInWithUserInputCall()
+        assertThat(signInCall).isEqualTo(expectedUserInput)
+        
+        val createCardCall = linkAccountManager.awaitCreateCardPaymentDetailsCall()
+        assertThat(createCardCall).isEqualTo(testPaymentSelection.paymentMethodCreateParams)
+    }
+
+    @Test
+    fun `invoke should use default country US when billing address country is null`() = runTest {
+        // Given
+        setupSuccessfulSignupMocks()
+
+        val paymentSelectionWithoutCountry = PaymentSelection.New.Card(
+            paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD.copy(
+                billingDetails = testBillingDetails.copy(
+                    address = testAddress.copy(country = null)
+                )
+            ),
+            brand = CardBrand.Visa,
+            customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest
+        )
+
+        val expectedUserInput = UserInput.SignUpOptionalPhone(
+            email = testEmail,
+            country = "US", // Default country
+            phone = testPhone,
+            name = testName,
+            consentAction = SignUpConsentAction.Implied
+        )
+
+        linkAccountManager.signInWithUserInputResult = Result.success(TestFactory.LINK_ACCOUNT)
+
+        // When
+        signupForLink(testLinkConfiguration, paymentSelectionWithoutCountry)
+
+        // Then
+        val signInCall = linkAccountManager.awaitSignInWithUserInputCall()
+        assertThat(signInCall).isEqualTo(expectedUserInput)
+    }
+
+    @Test
+    fun `invoke should handle signup failure gracefully`() = runTest {
+        // Given
+        setupSuccessfulSignupMocks()
+
+        val error = com.stripe.android.core.exception.APIException(message = "Signup failed")
+        linkAccountManager.signInWithUserInputResult = Result.failure(error)
+
+        // When
+        signupForLink(testLinkConfiguration, testPaymentSelection)
+
+        // Then
+        linkAccountManager.awaitSignInWithUserInputCall()
+    }
+
+    @Test
+    fun `invoke should handle card payment details creation failure gracefully`() = runTest {
+        // Given
+        setupSuccessfulSignupMocks()
+
+        linkAccountManager.signInWithUserInputResult = Result.success(TestFactory.LINK_ACCOUNT)
+        val error = com.stripe.android.core.exception.APIException(message = "Card creation failed")
+        linkAccountManager.createCardPaymentDetailsResult = Result.failure(error)
+
+        // When
+        signupForLink(testLinkConfiguration, testPaymentSelection)
+
+        // Then
+        linkAccountManager.awaitSignInWithUserInputCall()
+        linkAccountManager.awaitCreateCardPaymentDetailsCall()
+    }
+
+    @Test
+    fun `invoke should not create card payment details for non-New payment selections`() = runTest {
+        // Given
+        setupSuccessfulSignupMocks()
+
+        linkAccountManager.signInWithUserInputResult = Result.success(TestFactory.LINK_ACCOUNT)
+
+        // Use TestFactory to create a saved payment method with proper billing details
+        val paymentMethodWithBillingDetails = PaymentMethodFixtures.CARD_PAYMENT_METHOD.copy(
+            billingDetails = testBillingDetails
+        )
+        val savedPaymentSelection = PaymentSelection.Saved(paymentMethodWithBillingDetails)
+
+        val expectedUserInput = UserInput.SignUpOptionalPhone(
+            email = testEmail,
+            country = testCountry,
+            phone = testPhone,
+            name = testName,
+            consentAction = SignUpConsentAction.Implied
+        )
+
+        // When
+        signupForLink(testLinkConfiguration, savedPaymentSelection)
+
+        // Then
+        // Should still sign up to Link with user input (since we have email)
+        val signInCall = linkAccountManager.awaitSignInWithUserInputCall()
+        assertThat(signInCall).isEqualTo(expectedUserInput)
+        
+        // But should NOT create card payment details since it's not a New payment selection
+        // No more invocations should be made to createCardPaymentDetails
+    }
+
+    @Test
+    fun `invoke should handle exceptions during linkAccountManager operations`() = runTest {
+        // Given
+        setupSuccessfulSignupMocks()
+
+        // Make the linkAccountManager throw an exception during signInWithUserInput
+        linkAccountManager.signInWithUserInputResult = Result.failure(
+            com.stripe.android.core.exception.APIException(message = "Network error")
+        )
+
+        // When
+        signupForLink(testLinkConfiguration, testPaymentSelection)
+
+        // Then
+        linkAccountManager.awaitSignInWithUserInputCall()
+    }
+
+    @Test
+    fun `invoke should work with minimal billing details`() = runTest {
+        // Given
+        setupSuccessfulSignupMocks()
+
+        val minimalBillingDetails = PaymentMethod.BillingDetails(
+            email = testEmail,
+            address = null,
+            name = null,
+            phone = null
+        )
+
+        val paymentSelectionMinimal = PaymentSelection.New.Card(
+            paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD.copy(
+                billingDetails = minimalBillingDetails
+            ),
+            brand = CardBrand.Visa,
+            customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest
+        )
+
+        val expectedUserInput = UserInput.SignUpOptionalPhone(
+            email = testEmail,
+            country = "US", // Default
+            phone = null,
+            name = null,
+            consentAction = SignUpConsentAction.Implied
+        )
+
+        linkAccountManager.signInWithUserInputResult = Result.success(TestFactory.LINK_ACCOUNT)
+
+        // When
+        signupForLink(testLinkConfiguration, paymentSelectionMinimal)
+
+        // Then
+        val signInCall = linkAccountManager.awaitSignInWithUserInputCall()
+        assertThat(signInCall).isEqualTo(expectedUserInput)
+    }
+
+    private fun setupSuccessfulSignupMocks() {
+        whenever(signupToLinkToggleInteractor.getSignupToLinkValue()).thenReturn(true)
+        whenever(linkAccountHolder.linkAccountInfo).thenReturn(
+            MutableStateFlow(LinkAccountUpdate.Value(null))
+        )
+        whenever(linkHandler.linkConfigurationCoordinator).thenReturn(linkConfigurationCoordinator)
+        whenever(linkConfigurationCoordinator.getComponent(testLinkConfiguration))
+            .thenReturn(linkComponent)
+        whenever(linkComponent.linkAccountManager).thenReturn(linkAccountManager)
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeSignupToLinkToggleInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeSignupToLinkToggleInteractor.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.paymentsheet.ui
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+internal class FakeSignupToLinkToggleInteractor : SignupToLinkToggleInteractor {
+
+    private val _state = MutableStateFlow(
+        SignupToLinkToggleInteractor.State(
+            shouldDisplay = true,
+            title = "Save my info for faster checkout with Link",
+            subtitle = "Pay faster everywhere Link is accepted.",
+            isChecked = false,
+        )
+    )
+
+    override val state: StateFlow<SignupToLinkToggleInteractor.State> = _state
+
+    private var _signupToLinkValue = false
+
+    override fun handleToggleChange(checked: Boolean) {
+        _signupToLinkValue = checked
+        _state.value = _state.value.copy(isChecked = checked)
+    }
+
+    override fun getSignupToLinkValue(): Boolean {
+        return _signupToLinkValue
+    }
+
+    fun setSignupToLinkValue(value: Boolean) {
+        _signupToLinkValue = value
+        _state.value = _state.value.copy(isChecked = value)
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeSignupToLinkToggleInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeSignupToLinkToggleInteractor.kt
@@ -1,26 +1,37 @@
 package com.stripe.android.paymentsheet.ui
 
+import androidx.compose.ui.text.buildAnnotatedString
+import com.stripe.android.paymentsheet.PaymentSheet
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 internal class FakeSignupToLinkToggleInteractor : SignupToLinkToggleInteractor {
 
-    private val _state = MutableStateFlow(
-        SignupToLinkToggleInteractor.State(
-            shouldDisplay = true,
+    private val _state = MutableStateFlow<PaymentSheet.LinkSignupOptInState>(
+        PaymentSheet.LinkSignupOptInState.Visible(
             title = "Save my info for faster checkout with Link",
-            subtitle = "Pay faster everywhere Link is accepted.",
-            isChecked = false,
+            description = "Pay faster everywhere Link is accepted.",
+            termsAndConditions = buildAnnotatedString {
+                append(
+                    """
+                    By saving my payment information to Link, I agree to Link's 
+                    <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.
+                    """.trimIndent()
+                )
+            }
         )
     )
 
-    override val state: StateFlow<SignupToLinkToggleInteractor.State> = _state
+    override val state: StateFlow<PaymentSheet.LinkSignupOptInState> = _state
+
+    private val _toggleValue = MutableStateFlow(false)
+    override val toggleValue: MutableStateFlow<Boolean> = _toggleValue
 
     private var _signupToLinkValue = false
 
     override fun handleToggleChange(checked: Boolean) {
         _signupToLinkValue = checked
-        _state.value = _state.value.copy(isChecked = checked)
+        _toggleValue.value = checked
     }
 
     override fun getSignupToLinkValue(): Boolean {
@@ -29,6 +40,10 @@ internal class FakeSignupToLinkToggleInteractor : SignupToLinkToggleInteractor {
 
     fun setSignupToLinkValue(value: Boolean) {
         _signupToLinkValue = value
-        _state.value = _state.value.copy(isChecked = value)
+        _toggleValue.value = value
+    }
+
+    fun setState(newState: PaymentSheet.LinkSignupOptInState) {
+        _state.value = newState
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeSignupToLinkToggleInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeSignupToLinkToggleInteractor.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.paymentsheet.ui
 
-import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.AnnotatedString
 import com.stripe.android.paymentsheet.PaymentSheet
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -11,14 +11,9 @@ internal class FakeSignupToLinkToggleInteractor : SignupToLinkToggleInteractor {
         PaymentSheet.LinkSignupOptInState.Visible(
             title = "Save my info for faster checkout with Link",
             description = "Pay faster everywhere Link is accepted.",
-            termsAndConditions = buildAnnotatedString {
-                append(
-                    """
-                    By saving my payment information to Link, I agree to Link's 
-                    <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.
-                    """.trimIndent()
-                )
-            }
+            termsAndConditions = AnnotatedString(
+                "By saving my payment information to Link, I agree to Link's Terms and Privacy Policy."
+            )
         )
     )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeSignupToLinkToggleInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeSignupToLinkToggleInteractor.kt
@@ -24,11 +24,6 @@ internal class FakeSignupToLinkToggleInteractor : SignupToLinkToggleInteractor {
 
     private var _signupToLinkValue = false
 
-    override fun handleToggleChange(checked: Boolean) {
-        _signupToLinkValue = checked
-        _toggleValue.value = checked
-    }
-
     override fun getSignupToLinkValue(): Boolean {
         return _signupToLinkValue
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/SignupToLinkToggleInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/SignupToLinkToggleInteractorTest.kt
@@ -1,0 +1,320 @@
+package com.stripe.android.paymentsheet.ui
+
+import android.app.Application
+import androidx.lifecycle.SavedStateHandle
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.common.model.asCommonConfiguration
+import com.stripe.android.link.LinkAccountUpdate
+import com.stripe.android.link.TestFactory
+import com.stripe.android.link.account.LinkAccountHolder
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.lpmfoundations.paymentmethod.WalletType
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.PaymentSheetFixtures
+import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.flowcontroller.DefaultFlowController
+import com.stripe.android.paymentsheet.state.LinkState
+import com.stripe.android.paymentsheet.state.PaymentSheetState
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SignupToLinkToggleInteractorTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val linkAccountHolder = LinkAccountHolder(SavedStateHandle())
+    private val flowControllerState = MutableStateFlow<DefaultFlowController.State?>(null)
+    private val mockApplication = mock<Application>()
+
+    private val titleText = "title"
+    private val descriptionText = "description"
+    private val termsText = "terms"
+
+    private val interactor = DefaultSignupToLinkToggleInteractor(
+        flowControllerState = flowControllerState,
+        linkAccountHolder = linkAccountHolder,
+        application = mockApplication
+    )
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        whenever(mockApplication.getString(R.string.stripe_link_signup_toggle_title))
+            .thenReturn(titleText)
+        whenever(mockApplication.getString(R.string.stripe_link_signup_toggle_description))
+            .thenReturn(descriptionText)
+        whenever(mockApplication.getString(R.string.stripe_sign_up_terms))
+            .thenReturn(termsText)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `state is Visible when Link available, no account, and ShopPay not available`() = runTest {
+        // Given
+        setupLinkAvailable()
+        setupNoExistingAccount()
+        setupWalletButtonsConfiguration(walletTypesToShow = listOf("google_pay")) // No ShopPay
+
+        // When
+        val state = interactor.state.value
+
+        // Then
+        assertThat(state is PaymentSheet.LinkSignupOptInState.Visible).isTrue()
+        val visibleState = state as PaymentSheet.LinkSignupOptInState.Visible
+        assertThat(visibleState.title).isEqualTo(titleText)
+        assertThat(visibleState.description).isEqualTo(descriptionText)
+    }
+
+    @Test
+    fun `state is Hidden when ShopPay is available`() = runTest {
+        // Given
+        setupLinkAvailable()
+        setupNoExistingAccount()
+        setupWalletButtonsConfiguration(walletTypesToShow = listOf("shop_pay", "google_pay")) // ShopPay present
+
+        // When
+        val state = interactor.state.value
+
+        // Then
+        assertThat(state).isEqualTo(PaymentSheet.LinkSignupOptInState.Hidden)
+    }
+
+    @Test
+    fun `state is Hidden when Link state is null`() = runTest {
+        // Given
+        setupLinkNotAvailable() // No Link state
+        setupNoExistingAccount()
+        setupWalletButtonsConfiguration(walletTypesToShow = listOf("google_pay")) // No ShopPay
+
+        // When
+        val state = interactor.state.value
+
+        // Then
+        assertThat(state).isEqualTo(PaymentSheet.LinkSignupOptInState.Hidden)
+    }
+
+    @Test
+    fun `state is Hidden when Link account already exists`() = runTest {
+        // Given
+        setupLinkAvailable()
+        setupExistingAccount() // Account exists
+        setupWalletButtonsConfiguration(walletTypesToShow = listOf("google_pay")) // No ShopPay
+
+        // When
+        val state = interactor.state.value
+
+        // Then
+        assertThat(state).isEqualTo(PaymentSheet.LinkSignupOptInState.Hidden)
+    }
+
+    @Test
+    fun `state is Hidden when flowControllerState is null`() = runTest {
+        // Given
+        flowControllerState.value = null // No state
+        setupNoExistingAccount()
+        setupWalletButtonsConfiguration(walletTypesToShow = listOf("google_pay"))
+
+        // When
+        val state = interactor.state.value
+
+        // Then
+        assertThat(state).isEqualTo(PaymentSheet.LinkSignupOptInState.Hidden)
+    }
+
+    @Test
+    fun `state is Visible when no ShopPay in available wallets and Link available and no account`() = runTest {
+        // Given
+        setupLinkAvailable()
+        setupNoExistingAccount()
+        setupWalletButtonsConfiguration(walletTypesToShow = listOf("google_pay")) // No ShopPay in available wallets
+
+        // When
+        val state = interactor.state.value
+
+        // Then
+        // When ShopPay is not in availableWallets, so ShopPay is not considered available
+        // Therefore state should be Visible (Link available + no account + no ShopPay restriction)
+        assertThat(state is PaymentSheet.LinkSignupOptInState.Visible).isTrue()
+    }
+
+    @Test
+    fun `handleToggleChange updates toggle value`() = runTest {
+        // When
+        interactor.handleToggleChange(true)
+
+        // Then
+        assertThat(interactor.getSignupToLinkValue()).isTrue()
+
+        // When
+        interactor.handleToggleChange(false)
+
+        // Then
+        assertThat(interactor.getSignupToLinkValue()).isFalse()
+    }
+
+    @Test
+    fun `getSignupToLinkValue returns current toggle state`() = runTest {
+        // Given
+        assertThat(interactor.getSignupToLinkValue()).isFalse()
+
+        // When
+        interactor.handleToggleChange(true)
+
+        // Then
+        assertThat(interactor.getSignupToLinkValue()).isTrue()
+
+        // When
+        interactor.handleToggleChange(false)
+
+        // Then
+        assertThat(interactor.getSignupToLinkValue()).isFalse()
+    }
+
+    @Test
+    fun `state updates when Link account status changes`() = runTest {
+        // Given
+        setupLinkAvailable()
+        setupWalletButtonsConfiguration(walletTypesToShow = listOf("google_pay"))
+
+        // Initially no account
+        setupNoExistingAccount()
+        assertThat(interactor.state.value is PaymentSheet.LinkSignupOptInState.Visible).isTrue()
+
+        // When account is created
+        setupExistingAccount()
+
+        // Then
+        assertThat(interactor.state.value).isEqualTo(PaymentSheet.LinkSignupOptInState.Hidden)
+
+        // When account is removed
+        setupNoExistingAccount()
+
+        // Then
+        assertThat(interactor.state.value is PaymentSheet.LinkSignupOptInState.Visible).isTrue()
+    }
+
+    @Test
+    fun `state updates when wallet configuration changes`() = runTest {
+        // Given
+        setupLinkAvailable()
+        setupNoExistingAccount()
+
+        // Initially no ShopPay
+        setupWalletButtonsConfiguration(walletTypesToShow = listOf("google_pay"))
+        assertThat(interactor.state.value is PaymentSheet.LinkSignupOptInState.Visible).isTrue()
+
+        // When ShopPay is added
+        setupWalletButtonsConfiguration(walletTypesToShow = listOf("google_pay", "shop_pay"))
+
+        // Then
+        assertThat(interactor.state.value).isEqualTo(PaymentSheet.LinkSignupOptInState.Hidden)
+
+        // When ShopPay is removed
+        setupWalletButtonsConfiguration(walletTypesToShow = listOf("google_pay"))
+
+        // Then
+        assertThat(interactor.state.value is PaymentSheet.LinkSignupOptInState.Visible).isTrue()
+    }
+
+    // Helper methods
+    private fun setupLinkAvailable() {
+        val linkState = LinkState(
+            configuration = TestFactory.LINK_CONFIGURATION,
+            loginState = LinkState.LoginState.LoggedOut,
+            signupMode = com.stripe.android.link.ui.inline.LinkSignupMode.InsteadOfSaveForFutureUse
+        )
+
+        // Use PaymentMethodMetadataFactory instead of mocks
+        val paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            linkState = linkState
+        )
+
+        val paymentSheetState = createPaymentSheetState(paymentMethodMetadata)
+        val flowControllerState = createFlowControllerState(paymentSheetState)
+
+        this.flowControllerState.value = flowControllerState
+    }
+
+    private fun setupLinkNotAvailable() {
+        // Use PaymentMethodMetadataFactory with null linkState instead of mocks
+        val paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            linkState = null
+        )
+
+        val paymentSheetState = createPaymentSheetState(paymentMethodMetadata)
+        val flowControllerState = createFlowControllerState(paymentSheetState)
+
+        this.flowControllerState.value = flowControllerState
+    }
+
+    private fun setupNoExistingAccount() {
+        linkAccountHolder.set(LinkAccountUpdate.Value(null))
+    }
+
+    private fun setupExistingAccount() {
+        linkAccountHolder.set(LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT))
+    }
+
+    private fun setupWalletButtonsConfiguration(walletTypesToShow: List<String>) {
+        // Convert wallet type strings to WalletType enum
+        val availableWallets = walletTypesToShow.mapNotNull { walletTypeString ->
+            when (walletTypeString) {
+                "google_pay" -> WalletType.GooglePay
+                "link" -> WalletType.Link
+                "shop_pay" -> WalletType.ShopPay
+                else -> null
+            }
+        }
+
+        // Get the current state to preserve Link state
+        val currentState = flowControllerState.value
+        val currentLinkState = currentState?.paymentSheetState?.paymentMethodMetadata?.linkState
+
+        // Create new PaymentMethodMetadata with updated availableWallets
+        val paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            linkState = currentLinkState,
+            availableWallets = availableWallets
+        )
+
+        val paymentSheetState = createPaymentSheetState(paymentMethodMetadata)
+        val flowControllerState = createFlowControllerState(paymentSheetState)
+
+        this.flowControllerState.value = flowControllerState
+    }
+
+    private fun createPaymentSheetState(
+        paymentMethodMetadata: PaymentMethodMetadata
+    ): PaymentSheetState.Full {
+        return PaymentSheetState.Full(
+            customer = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE,
+            config = PaymentSheetFixtures.CONFIG_MINIMUM.asCommonConfiguration(),
+            paymentSelection = null,
+            validationError = null,
+            paymentMethodMetadata = paymentMethodMetadata
+        )
+    }
+
+    private fun createFlowControllerState(
+        paymentSheetState: PaymentSheetState.Full
+    ): DefaultFlowController.State {
+        return DefaultFlowController.State(
+            paymentSheetState = paymentSheetState,
+            config = PaymentSheetFixtures.CONFIG_MINIMUM
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/SignupToLinkToggleInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/SignupToLinkToggleInteractorTest.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.paymentsheet.ui
 
-import android.app.Application
+import androidx.compose.ui.text.AnnotatedString
 import androidx.lifecycle.SavedStateHandle
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.common.model.asCommonConfiguration
@@ -12,7 +12,6 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFact
 import com.stripe.android.lpmfoundations.paymentmethod.WalletType
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
-import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.flowcontroller.DefaultFlowController
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.PaymentSheetState
@@ -26,8 +25,6 @@ import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SignupToLinkToggleInteractorTest {
@@ -35,27 +32,26 @@ class SignupToLinkToggleInteractorTest {
     private val testDispatcher = StandardTestDispatcher()
     private val linkAccountHolder = LinkAccountHolder(SavedStateHandle())
     private val flowControllerState = MutableStateFlow<DefaultFlowController.State?>(null)
-    private val mockApplication = mock<Application>()
 
     private val titleText = "title"
     private val descriptionText = "description"
-    private val termsText = "terms"
+    private val termsText = AnnotatedString("terms")
+
+    private val mockStringProvider = object : SignupToLinkToggleStringProvider {
+        override val title: String = titleText
+        override val description: String = descriptionText
+        override val termsAndConditions: AnnotatedString = termsText
+    }
 
     private val interactor = DefaultSignupToLinkToggleInteractor(
         flowControllerState = flowControllerState,
         linkAccountHolder = linkAccountHolder,
-        application = mockApplication
+        stringProvider = mockStringProvider
     )
 
     @Before
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
-        whenever(mockApplication.getString(R.string.stripe_link_signup_toggle_title))
-            .thenReturn(titleText)
-        whenever(mockApplication.getString(R.string.stripe_link_signup_toggle_description))
-            .thenReturn(descriptionText)
-        whenever(mockApplication.getString(R.string.stripe_sign_up_terms))
-            .thenReturn(termsText)
     }
 
     @After

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/SignupToLinkToggleInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/SignupToLinkToggleInteractorTest.kt
@@ -149,39 +149,6 @@ class SignupToLinkToggleInteractorTest {
     }
 
     @Test
-    fun `handleToggleChange updates toggle value`() = runTest {
-        // When
-        interactor.handleToggleChange(true)
-
-        // Then
-        assertThat(interactor.getSignupToLinkValue()).isTrue()
-
-        // When
-        interactor.handleToggleChange(false)
-
-        // Then
-        assertThat(interactor.getSignupToLinkValue()).isFalse()
-    }
-
-    @Test
-    fun `getSignupToLinkValue returns current toggle state`() = runTest {
-        // Given
-        assertThat(interactor.getSignupToLinkValue()).isFalse()
-
-        // When
-        interactor.handleToggleChange(true)
-
-        // Then
-        assertThat(interactor.getSignupToLinkValue()).isTrue()
-
-        // When
-        interactor.handleToggleChange(false)
-
-        // Then
-        assertThat(interactor.getSignupToLinkValue()).isFalse()
-    }
-
-    @Test
     fun `state updates when Link account status changes`() = runTest {
         // Given
         setupLinkAvailable()

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeLinkComponent.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeLinkComponent.kt
@@ -2,7 +2,9 @@ package com.stripe.android.utils
 
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.account.FakeLinkAccountManager
+import com.stripe.android.link.account.FakeLinkAuth
 import com.stripe.android.link.account.LinkAccountManager
+import com.stripe.android.link.account.LinkAuth
 import com.stripe.android.link.attestation.FakeLinkAttestationCheck
 import com.stripe.android.link.attestation.LinkAttestationCheck
 import com.stripe.android.link.gate.FakeLinkGate
@@ -18,6 +20,7 @@ import org.mockito.kotlin.mock
 internal class FakeLinkComponent(
     override val configuration: LinkConfiguration = createLinkConfiguration(),
     override val linkAccountManager: LinkAccountManager = FakeLinkAccountManager(),
+    override val linkAuth: LinkAuth = FakeLinkAuth(),
     override val linkGate: LinkGate = FakeLinkGate(),
     override val linkAttestationCheck: LinkAttestationCheck = FakeLinkAttestationCheck(),
     override val inlineSignupViewModelFactory: LinkInlineSignupAssistedViewModelFactory = object :


### PR DESCRIPTION
# Summary

- Adds `SignupToLink` toggle state to `FlowController`
- Adds `SignupForLink` usecase that creates account + adds payment details if toggle enabled

[record1.webm](https://github.com/user-attachments/assets/a54f2124-2ec5-420f-8e69-2ff4f152b97b)

<img width="1396" height="502" alt="image" src="https://github.com/user-attachments/assets/1aa1916f-dfe6-4bdc-8e5d-02962f4c79a7" />

<img width="1418" height="699" alt="image" src="https://github.com/user-attachments/assets/35e55ca2-0f6a-40f5-b8b1-b4b321828285" />

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
