### PR TITLE
Fix AppearanceStore initializing Font with null values

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/AppearanceStore.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/AppearanceStore.kt
@@ -167,8 +167,7 @@ internal object AppearanceStore {
 
             @OptIn(AppearanceAPIAdditionsPreview::class)
             fun getEmbeddedAppearance(): PaymentSheet.Appearance.Embedded {
-                // paymentMethodIconMargins will override default spacing in PaymentMethodRowButton so we only
-                // want to init them if they were set in the playground
+                // paymentMethodIconMargins and font will override defaults so only init if set in playground
                 val insets = if (horizontalPaymentMethodIconMargin != null || verticalPaymentMethodIconMargin != null) {
                     PaymentSheet.Insets(
                         horizontalDp = horizontalPaymentMethodIconMargin ?: 0f,
@@ -178,17 +177,21 @@ internal object AppearanceStore {
                     null
                 }
 
+                val font = if (listOfNotNull(fontWeight, fontFamilyRes, fontSizeSp, letterSpacingSp).isNotEmpty()) {
+                    PaymentSheet.Typography.Font(
+                        fontFamily = fontFamilyRes,
+                        fontSizeSp = fontSizeSp,
+                        fontWeight = fontWeight,
+                        letterSpacingSp = letterSpacingSp
+                    )
+                } else {
+                    null
+                }
+
                 return PaymentSheet.Appearance.Embedded.Builder()
                     .rowStyle(getRow())
                     .paymentMethodIconMargins(insets)
-                    .titleFont(
-                        PaymentSheet.Typography.Font(
-                            fontFamily = fontFamilyRes,
-                            fontSizeSp = fontSizeSp,
-                            fontWeight = fontWeight,
-                            letterSpacingSp = letterSpacingSp
-                        )
-                    )
+                    .titleFont(font)
                     .build()
             }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Only init Font in AppearanceStore if a value has been set through playground UI

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Font with null values was being added to Embedded appearance causing text to look off

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

