### PR TITLE
[Link-Attestation] Just launch web popup fallback on supported flows.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
@@ -158,9 +158,30 @@ internal class LinkActivityViewModel @Inject constructor(
     }
 
     fun moveToWeb() {
-        launchWebFlow?.let { launcher ->
-            navigate(LinkScreen.Loading, clearStack = true)
-            launcher.invoke(linkConfiguration)
+        when (linkLaunchMode) {
+            // Authentication flows with existing accounts -> dismiss with an error.
+            is LinkLaunchMode.Authentication -> dismissWithResult(
+                LinkActivityResult.Failed(
+                    error = IllegalStateException(
+                        "authentication only is not supported in web mode"
+                    ),
+                    linkAccountUpdate = LinkAccountUpdate.None
+                )
+            )
+            // Payment selection flows -> dismiss selecting Link with no selected payment method.
+            is LinkLaunchMode.PaymentMethodSelection -> dismissWithResult(
+                LinkActivityResult.Completed(
+                    linkAccountUpdate = LinkAccountUpdate.None,
+                    selectedPayment = null,
+                    shippingAddress = null
+                )
+            )
+            // Flows that end up in confirmation -> we can launch the web flow.
+            is LinkLaunchMode.Confirmation,
+            LinkLaunchMode.Full -> launchWebFlow?.let { launcher ->
+                navigate(LinkScreen.Loading, clearStack = true)
+                launcher.invoke(linkConfiguration)
+            }
         }
     }
 
@@ -227,7 +248,7 @@ internal class LinkActivityViewModel @Inject constructor(
             val attestationCheckResult = linkAttestationCheck.invoke()
             when (attestationCheckResult) {
                 is LinkAttestationCheck.Result.AttestationFailed -> {
-                    launchWebFlow?.invoke(linkConfiguration)
+                    moveToWeb()
                 }
                 LinkAttestationCheck.Result.Successful -> {
                     updateScreenState()


### PR DESCRIPTION
# Summary
The web popup does not support Link _fractioned_ flows, so we cannot fall back to it on all scenarios, just on the ones that end up in payment confirmation. 

- Full mode: supported, we keep using the fallback
- Payment selection mode: we just close marking link as selected, with no defined payment method. 

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
