### PR TITLE
[Inline OTP] Add killswitch and remove client flag.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/ElementsSession.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ElementsSession.kt
@@ -61,6 +61,9 @@ data class ElementsSession(
     val linkEnableDisplayableDefaultValuesInEce: Boolean
         get() = linkSettings?.linkEnableDisplayableDefaultValuesInEce ?: false
 
+    val linkMobileExpressCheckoutElementInlineOtpKillswitch: Boolean
+        get() = linkSettings?.linkMobileExpressCheckoutElementInlineOtpKillswitch ?: false
+
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Parcelize
     data class LinkSettings(
@@ -73,7 +76,8 @@ data class ElementsSession(
         val useAttestationEndpoints: Boolean,
         val suppress2faModal: Boolean,
         val disableLinkRuxInFlowController: Boolean,
-        val linkEnableDisplayableDefaultValuesInEce: Boolean
+        val linkEnableDisplayableDefaultValuesInEce: Boolean,
+        val linkMobileExpressCheckoutElementInlineOtpKillswitch: Boolean
     ) : StripeModel
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/ElementsSessionJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/ElementsSessionJsonParser.kt
@@ -173,6 +173,9 @@ internal class ElementsSessionJsonParser(
         val linkEnableDisplayableDefaultValuesInEce = json?.optBoolean(
             FIELD_LINK_ENABLE_DISPLAYABLE_DEFAULT_VALUES_IN_ECE
         ) == true
+        val linkMobileExpressCheckoutElementInlineOtpKillswitch = json?.optBoolean(
+            FIELD_LINK_MOBILE_EXPRESS_CHECKOUT_ELEMENT_INLINE_OTP_KILLSWITCH
+        ) == true
 
         val linkMode = json?.optString(FIELD_LINK_MODE)?.let { mode ->
             LinkMode.entries.firstOrNull { it.value == mode }
@@ -199,7 +202,8 @@ internal class ElementsSessionJsonParser(
             useAttestationEndpoints = useLinkAttestationEndpoints,
             suppress2faModal = suppressLink2faModal,
             disableLinkRuxInFlowController = disableLinkRuxInFlowController,
-            linkEnableDisplayableDefaultValuesInEce = linkEnableDisplayableDefaultValuesInEce
+            linkEnableDisplayableDefaultValuesInEce = linkEnableDisplayableDefaultValuesInEce,
+            linkMobileExpressCheckoutElementInlineOtpKillswitch = linkMobileExpressCheckoutElementInlineOtpKillswitch
         )
     }
 
@@ -451,6 +455,8 @@ internal class ElementsSessionJsonParser(
         private const val FIELD_LINK_SUPPRESS_2FA_MODAL = "link_mobile_suppress_2fa_modal"
         private const val FIELD_LINK_ENABLE_DISPLAYABLE_DEFAULT_VALUES_IN_ECE =
             "link_enable_displayable_default_values_in_ece"
+        private const val FIELD_LINK_MOBILE_EXPRESS_CHECKOUT_ELEMENT_INLINE_OTP_KILLSWITCH =
+            "link_mobile_express_checkout_element_inline_otp_killswitch"
         private const val FIELD_MERCHANT_COUNTRY = "merchant_country"
         private const val FIELD_PAYMENT_METHOD_PREFERENCE = "payment_method_preference"
         private const val FIELD_UNACTIVATED_PAYMENT_METHOD_TYPES = "unactivated_payment_method_types"

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -527,11 +527,7 @@ internal class PlaygroundSettings private constructor(
             PaymentMethodOptionsSetupFutureUsageSettingsDefinition,
             PaymentMethodOptionsSetupFutureUsageOverrideSettingsDefinition,
             WalletButtonsSettingsDefinition,
-            FeatureFlagSettingsDefinition(
-                FeatureFlags.showInlineOtpInWalletButtons,
-                allowedIntegrationTypes = PlaygroundConfigurationData.IntegrationType.paymentFlows().toList() +
-                    PlaygroundConfigurationData.IntegrationType.sptFlows().toList(),
-            ),
+
             ShopPaySettingsDefinition,
             LinkControllerAllowUserEmailEditsSettingsDefinition,
         )

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkConfiguration.kt
@@ -35,6 +35,7 @@ internal data class LinkConfiguration(
     val collectMissingBillingDetailsForExistingPaymentMethods: Boolean,
     val allowUserEmailEdits: Boolean,
     val enableDisplayableDefaultValuesInEce: Boolean,
+    val linkMobileExpressCheckoutElementInlineOtpKillswitch: Boolean,
     private val customerId: String?
 ) : Parcelable {
 

--- a/paymentsheet/src/main/java/com/stripe/android/link/gate/DefaultLinkGate.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/gate/DefaultLinkGate.kt
@@ -37,9 +37,6 @@ internal class DefaultLinkGate @Inject constructor(
             return useNativeLink.not() || configuration.suppress2faModal
         }
 
-    override val useInlineOtpInWalletButtons: Boolean
-        get() = FeatureFlags.showInlineOtpInWalletButtons.isEnabled && useNativeLink
-
     override val showRuxInFlowController: Boolean
         get() = useNativeLink && configuration.disableRuxInFlowController == false
 

--- a/paymentsheet/src/main/java/com/stripe/android/link/gate/LinkGate.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/gate/LinkGate.kt
@@ -11,7 +11,7 @@ internal interface LinkGate {
     val useNativeLink: Boolean
     val useAttestationEndpoints: Boolean
     val suppress2faModal: Boolean
-    val useInlineOtpInWalletButtons: Boolean
+
     val showRuxInFlowController: Boolean
 
     fun interface Factory {

--- a/paymentsheet/src/main/java/com/stripe/android/link/verification/DefaultLinkInlineInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/verification/DefaultLinkInlineInteractor.kt
@@ -55,7 +55,13 @@ internal class DefaultLinkInlineInteractor @Inject constructor(
             return
         }
 
-        if (linkConfigurationCoordinator.linkGate(linkConfiguration).useInlineOtpInWalletButtons.not()) {
+        if (linkConfiguration.linkMobileExpressCheckoutElementInlineOtpKillswitch) {
+            // If the killswitch is enabled, skip inline OTP verification.
+            updateState { it.copy(verificationState = VerificationState.RenderButton) }
+            return
+        }
+
+        if (linkConfigurationCoordinator.linkGate(linkConfiguration).useNativeLink.not()) {
             // If the feature flag is disabled, do not start Link verification.
             updateState { it.copy(verificationState = VerificationState.RenderButton) }
             return

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -594,6 +594,8 @@ internal class DefaultPaymentElementLoader @Inject constructor(
             suppress2faModal = elementsSession.suppressLink2faModal,
             disableRuxInFlowController = elementsSession.disableRuxInFlowController,
             enableDisplayableDefaultValuesInEce = elementsSession.linkEnableDisplayableDefaultValuesInEce,
+            linkMobileExpressCheckoutElementInlineOtpKillswitch = elementsSession
+                .linkMobileExpressCheckoutElementInlineOtpKillswitch,
             elementsSessionId = elementsSession.elementsSessionId,
             initializationMode = initializationMode,
             linkMode = elementsSession.linkSettings?.linkMode,

--- a/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
@@ -225,6 +225,7 @@ internal object TestFactory {
         collectMissingBillingDetailsForExistingPaymentMethods = true,
         allowUserEmailEdits = true,
         enableDisplayableDefaultValuesInEce = false,
+        linkMobileExpressCheckoutElementInlineOtpKillswitch = false,
         customerId = null
     )
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/gate/FakeLinkGate.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/gate/FakeLinkGate.kt
@@ -13,10 +13,6 @@ internal class FakeLinkGate : LinkGate {
     override val suppress2faModal: Boolean
         get() = _suppress2faModal
 
-    private var _useInlineOtpInWalletButtons: Boolean = false
-    override val useInlineOtpInWalletButtons: Boolean
-        get() = _useInlineOtpInWalletButtons
-
     private var _showRuxInFlowController: Boolean = true
     override val showRuxInFlowController: Boolean
         get() = _showRuxInFlowController
@@ -31,10 +27,6 @@ internal class FakeLinkGate : LinkGate {
 
     fun setSuppress2faModal(value: Boolean) {
         _suppress2faModal = value
-    }
-
-    fun setUseInlineOtpInWalletButtons(value: Boolean) {
-        _useInlineOtpInWalletButtons = value
     }
 
     fun setShowRuxInFlowController(value: Boolean) {

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenStateTest.kt
@@ -102,6 +102,7 @@ class SignUpScreenStateTest {
             collectMissingBillingDetailsForExistingPaymentMethods = true,
             allowUserEmailEdits = true,
             enableDisplayableDefaultValuesInEce = false,
+            linkMobileExpressCheckoutElementInlineOtpKillswitch = false,
             customerId = null
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -1963,6 +1963,7 @@ internal class PaymentMethodMetadataTest {
             collectMissingBillingDetailsForExistingPaymentMethods = true,
             allowUserEmailEdits = true,
             enableDisplayableDefaultValuesInEce = false,
+            linkMobileExpressCheckoutElementInlineOtpKillswitch = false,
             customerId = null
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElementTest.kt
@@ -156,6 +156,7 @@ class LinkFormElementTest {
             collectMissingBillingDetailsForExistingPaymentMethods = true,
             allowUserEmailEdits = true,
             enableDisplayableDefaultValuesInEce = false,
+            linkMobileExpressCheckoutElementInlineOtpKillswitch = false,
             customerId = null
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
@@ -617,6 +617,7 @@ class ConfirmationHandlerOptionKtxTest {
             collectMissingBillingDetailsForExistingPaymentMethods = true,
             allowUserEmailEdits = true,
             enableDisplayableDefaultValuesInEce = false,
+            linkMobileExpressCheckoutElementInlineOtpKillswitch = false,
             customerId = null
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
@@ -699,6 +699,7 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
                 collectMissingBillingDetailsForExistingPaymentMethods = true,
                 allowUserEmailEdits = true,
                 enableDisplayableDefaultValuesInEce = false,
+                linkMobileExpressCheckoutElementInlineOtpKillswitch = false,
                 customerId = null
             ),
             userInput = userInput,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -750,7 +750,8 @@ internal class DefaultPaymentElementLoaderTest {
                 useAttestationEndpoints = false,
                 suppress2faModal = false,
                 disableLinkRuxInFlowController = false,
-                linkEnableDisplayableDefaultValuesInEce = false
+                linkEnableDisplayableDefaultValuesInEce = false,
+                linkMobileExpressCheckoutElementInlineOtpKillswitch = false
             )
         )
 
@@ -788,7 +789,8 @@ internal class DefaultPaymentElementLoaderTest {
                 useAttestationEndpoints = false,
                 suppress2faModal = false,
                 disableLinkRuxInFlowController = false,
-                linkEnableDisplayableDefaultValuesInEce = false
+                linkEnableDisplayableDefaultValuesInEce = false,
+                linkMobileExpressCheckoutElementInlineOtpKillswitch = false
             )
         )
 
@@ -874,7 +876,8 @@ internal class DefaultPaymentElementLoaderTest {
                 useAttestationEndpoints = false,
                 suppress2faModal = false,
                 disableLinkRuxInFlowController = false,
-                linkEnableDisplayableDefaultValuesInEce = false
+                linkEnableDisplayableDefaultValuesInEce = false,
+                linkMobileExpressCheckoutElementInlineOtpKillswitch = false
             ),
             linkStore = mock {
                 on { hasUsedLink() } doReturn true
@@ -906,7 +909,8 @@ internal class DefaultPaymentElementLoaderTest {
                 useAttestationEndpoints = false,
                 suppress2faModal = false,
                 disableLinkRuxInFlowController = false,
-                linkEnableDisplayableDefaultValuesInEce = false
+                linkEnableDisplayableDefaultValuesInEce = false,
+                linkMobileExpressCheckoutElementInlineOtpKillswitch = false
             )
         )
 
@@ -1426,7 +1430,8 @@ internal class DefaultPaymentElementLoaderTest {
                 useAttestationEndpoints = false,
                 suppress2faModal = false,
                 disableLinkRuxInFlowController = false,
-                linkEnableDisplayableDefaultValuesInEce = false
+                linkEnableDisplayableDefaultValuesInEce = false,
+                linkMobileExpressCheckoutElementInlineOtpKillswitch = false
             ),
             linkStore = linkStore,
         )
@@ -3202,7 +3207,8 @@ internal class DefaultPaymentElementLoaderTest {
             useAttestationEndpoints = false,
             suppress2faModal = false,
             disableLinkRuxInFlowController = false,
-            linkEnableDisplayableDefaultValuesInEce = false
+            linkEnableDisplayableDefaultValuesInEce = false,
+            linkMobileExpressCheckoutElementInlineOtpKillswitch = false
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
@@ -92,6 +92,7 @@ internal object LinkTestUtils {
             collectMissingBillingDetailsForExistingPaymentMethods = true,
             allowUserEmailEdits = true,
             enableDisplayableDefaultValuesInEce = false,
+            linkMobileExpressCheckoutElementInlineOtpKillswitch = false,
             customerId = null
         )
     }

--- a/stripe-core/src/main/java/com/stripe/android/core/utils/FeatureFlags.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/FeatureFlags.kt
@@ -11,7 +11,6 @@ object FeatureFlags {
     val instantDebitsIncentives = FeatureFlag("Instant Bank Payments Incentives")
     val financialConnectionsFullSdkUnavailable = FeatureFlag("FC Full SDK Unavailable")
     val forceEnableNativeFinancialConnections = FeatureFlag("Force enable FC Native")
-    val showInlineOtpInWalletButtons = FeatureFlag("Show Inline Signup in Wallet Buttons")
 }
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)


### PR DESCRIPTION
# Summary

- Adds mobile killswitch for inline OTP
- Removes client feature flag

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
