### PR TITLE
Fix android tests not found

### DIFF
--- a/paymentsheet-example/build.gradle
+++ b/paymentsheet-example/build.gradle
@@ -113,6 +113,8 @@ android {
         applicationId "com.stripe.android.paymentsheet.example"
         versionCode 11
 
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+
         buildConfigField "boolean", "IS_RUNNING_IN_CI", "$gradle.ext.isCi"
         buildConfigField "boolean", "IS_NIGHTLY_BUILD", "$gradle.ext.isNightlyBuild"
         buildConfigField "boolean", "IS_BROWSERSTACK_BUILD", "$gradle.ext.isBrowserstackBuild"

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -30,6 +30,7 @@ import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.espresso.web.sugar.Web.onWebView
 import androidx.test.espresso.web.webdriver.DriverAtoms.webClick
+import androidx.test.runner.AndroidJUnitRunner
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiSelector
 import com.google.common.truth.Truth.assertThat
@@ -87,7 +88,7 @@ import kotlin.time.Duration.Companion.seconds
 internal class PlaygroundTestDriver(
     private val device: UiDevice,
     private val composeTestRule: ComposeTestRule,
-) {
+) : AndroidJUnitRunner() {
     @Volatile
     private var resultCountDownLatch: CountDownLatch? = null
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
In #11050, `PlaygroundTestDriver` does not inherit `ScreenshotTest` anymore, causing the tests failed to run. 

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://stripe.slack.com/archives/C02CCKZSB9R/p1753729402511609?thread_ts=1753719326.774549&cid=C02CCKZSB9R
Android tests like `TestFpx` was failling.
```
junit.framework.AssertionFailedError: No tests found in com.stripe.android.lpm.TestGooglePay
at android.test.AndroidTestRunner.runTest(AndroidTestRunner.java:195)
at android.test.AndroidTestRunner.runTest(AndroidTestRunner.java:181)
at android.test.InstrumentationTestRunner.onStart(InstrumentationTestRunner.java:563)
at android.app.Instrumentation$InstrumentationThread.run(Instrumentation.java:2594)
```

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
