### PR TITLE
StripeCryptoOnramp: Minor Architecture Cleanup

### DIFF
--- a/stripe-crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampCoordinator.kt
+++ b/stripe-crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampCoordinator.kt
@@ -122,16 +122,18 @@ class OnrampCoordinator @Inject internal constructor(
                 modelClass = OnrampCoordinatorViewModel::class.java
             )
 
-            val application = when (lifecycleOwner) {
-                is Fragment -> lifecycleOwner.requireActivity().application
-                is ComponentActivity -> lifecycleOwner.application
-                else -> throw IllegalArgumentException("LifecycleOwner must be an Activity or Fragment")
+            val componentActivity: ComponentActivity = when {
+                lifecycleOwner is ComponentActivity -> lifecycleOwner
+                lifecycleOwner is Fragment -> lifecycleOwner.requireActivity()
+                activityResultRegistryOwner is ComponentActivity -> activityResultRegistryOwner
+                else -> throw IllegalStateException("Expected a ComponentActivity")
             }
 
             val onrampComponent: OnrampComponent =
                 DaggerOnrampComponent
                     .builder()
-                    .application(application)
+                    .application(componentActivity.application)
+                    .componentActivity(componentActivity)
                     .onRampCoordinatorViewModel(viewModel)
                     .linkElementCallbackIdentifier(linkElementCallbackIdentifier)
                     .activityResultRegistryOwner(activityResultRegistryOwner)

--- a/stripe-crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/di/OnrampComponent.kt
+++ b/stripe-crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/di/OnrampComponent.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.crypto.onramp.di
 
 import android.app.Application
+import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultRegistryOwner
 import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.core.injection.CoreCommonModule
@@ -35,6 +36,9 @@ internal interface OnrampComponent {
 
         @BindsInstance
         fun lifecycleOwner(lifecycleOwner: LifecycleOwner): Builder
+
+        @BindsInstance
+        fun componentActivity(activity: ComponentActivity): Builder
 
         @BindsInstance
         fun onRampCoordinatorViewModel(viewModel: OnrampCoordinatorViewModel): Builder


### PR DESCRIPTION
# Summary
* Removes unnecessary checks for a `ComponentActivity`
* Observes the LinkController.State changes and stores them in the VM instead of retrieving them from the `StateFlow`
* Removes unnecessary internal scoping

# Motivation
This works resolves remaining comments from https://github.com/stripe/stripe-android/pull/11208

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
