### PR TITLE
Add MOTO and User Key support to Setup Intents

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -2136,11 +2136,12 @@ public final class com/stripe/android/model/ConfirmSetupIntentParams : com/strip
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/model/ConfirmSetupIntentParams$Companion;
 	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Lcom/stripe/android/model/PaymentMethodOptionsParams;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component6 ()Ljava/lang/String;
 	public final fun component7 ()Lcom/stripe/android/model/MandateDataParams;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;ZLjava/lang/String;Lcom/stripe/android/model/MandateDataParams;Ljava/lang/Boolean;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/ConfirmSetupIntentParams;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;ZLjava/lang/String;Lcom/stripe/android/model/MandateDataParams;Ljava/lang/Boolean;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;ZLjava/lang/String;Lcom/stripe/android/model/MandateDataParams;Ljava/lang/Boolean;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethodOptionsParams;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/ConfirmSetupIntentParams;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;ZLjava/lang/String;Lcom/stripe/android/model/MandateDataParams;Ljava/lang/Boolean;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethodOptionsParams;ILjava/lang/Object;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
@@ -2154,6 +2155,7 @@ public final class com/stripe/android/model/ConfirmSetupIntentParams : com/strip
 	public synthetic fun getClientSecret ()Ljava/lang/String;
 	public final fun getMandateData ()Lcom/stripe/android/model/MandateDataParams;
 	public final fun getMandateId ()Ljava/lang/String;
+	public final fun getPaymentMethodOptions ()Lcom/stripe/android/model/PaymentMethodOptionsParams;
 	public fun getReturnUrl ()Ljava/lang/String;
 	public fun hashCode ()I
 	public final fun setMandateData (Lcom/stripe/android/model/MandateDataParams;)V

--- a/payments-core/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
@@ -39,6 +39,13 @@ constructor(
     private val useStripeSdk: Boolean = false,
 
     /**
+     * Payment-method-specific configuration for this SetupIntent.
+     *
+     * See [payment_method_options](https://docs.stripe.com/api/setup_intents/confirm#confirm_setup_intent-payment_method_options).
+     */
+    var paymentMethodOptions: PaymentMethodOptionsParams? = null,
+
+    /**
      * ID of the mandate to be used for this payment.
      */
     var mandateId: String? = null,
@@ -250,6 +257,25 @@ constructor(
                 mandateData = mandateData,
                 setAsDefaultPaymentMethod = setAsDefaultPaymentMethod,
                 paymentMethodCode = paymentMethodCode,
+            )
+        }
+
+        internal fun createForDashboard(
+            clientSecret: String,
+            paymentMethodId: String,
+            paymentMethodOptions: PaymentMethodOptionsParams?,
+        ): ConfirmSetupIntentParams {
+            // Dashboard only supports a specific payment flow today.
+            return ConfirmSetupIntentParams(
+                clientSecret = clientSecret,
+                paymentMethodId = paymentMethodId,
+                paymentMethodOptions = PaymentMethodOptionsParams.Card(
+                    moto = true,
+                    setupFutureUsage =
+                        (paymentMethodOptions as? PaymentMethodOptionsParams.Card)?.setupFutureUsage
+                ),
+                useStripeSdk = true,
+                paymentMethodCode = PaymentMethod.Type.Card.code,
             )
         }
     }

--- a/payments-core/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
@@ -39,15 +39,6 @@ constructor(
     private val useStripeSdk: Boolean = false,
 
     /**
-     * Payment-method-specific configuration for this SetupIntent.
-     *
-     * See [payment_method_options](
-     *   https://docs.stripe.com/api/setup_intents/confirm#confirm_setup_intent-payment_method_options
-     * ).
-     */
-    val paymentMethodOptions: PaymentMethodOptionsParams? = null,
-
-    /**
      * ID of the mandate to be used for this payment.
      */
     var mandateId: String? = null,
@@ -65,7 +56,16 @@ constructor(
     internal val setAsDefaultPaymentMethod: Boolean? = null,
 
     internal val paymentMethodCode: PaymentMethodCode? = paymentMethodCreateParams?.code,
-) : ConfirmStripeIntentParams {
+
+    /**
+     * Payment-method-specific configuration for this SetupIntent.
+     *
+     * See [payment_method_options](
+     *   https://docs.stripe.com/api/setup_intents/confirm#confirm_setup_intent-payment_method_options
+     * ).
+     */
+    val paymentMethodOptions: PaymentMethodOptionsParams? = null,
+    ) : ConfirmStripeIntentParams {
 
     override fun shouldUseStripeSdk(): Boolean {
         return useStripeSdk

--- a/payments-core/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
@@ -41,9 +41,11 @@ constructor(
     /**
      * Payment-method-specific configuration for this SetupIntent.
      *
-     * See [payment_method_options](https://docs.stripe.com/api/setup_intents/confirm#confirm_setup_intent-payment_method_options).
+     * See [payment_method_options](
+     *   https://docs.stripe.com/api/setup_intents/confirm#confirm_setup_intent-payment_method_options
+     * ).
      */
-    var paymentMethodOptions: PaymentMethodOptionsParams? = null,
+    val paymentMethodOptions: PaymentMethodOptionsParams? = null,
 
     /**
      * ID of the mandate to be used for this payment.
@@ -271,8 +273,7 @@ constructor(
                 paymentMethodId = paymentMethodId,
                 paymentMethodOptions = PaymentMethodOptionsParams.Card(
                     moto = true,
-                    setupFutureUsage =
-                        (paymentMethodOptions as? PaymentMethodOptionsParams.Card)?.setupFutureUsage
+                    setupFutureUsage = (paymentMethodOptions as? PaymentMethodOptionsParams.Card)?.setupFutureUsage
                 ),
                 useStripeSdk = true,
                 paymentMethodCode = PaymentMethod.Type.Card.code,

--- a/payments-core/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
@@ -64,8 +64,8 @@ constructor(
      *   https://docs.stripe.com/api/setup_intents/confirm#confirm_setup_intent-payment_method_options
      * ).
      */
-    val paymentMethodOptions: PaymentMethodOptionsParams? = null,
-    ) : ConfirmStripeIntentParams {
+    val paymentMethodOptions: PaymentMethodOptionsParams? = null
+) : ConfirmStripeIntentParams {
 
     override fun shouldUseStripeSdk(): Boolean {
         return useStripeSdk

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -418,8 +418,6 @@ class StripeApiRepository @JvmOverloads internal constructor(
             )
         }
     }
-
-
     private suspend fun confirmSetupIntentInternal(
         confirmSetupIntentParams: ConfirmSetupIntentParams,
         options: ApiRequest.Options,

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -410,6 +410,21 @@ class StripeApiRepository @JvmOverloads internal constructor(
         options: ApiRequest.Options,
         expandFields: List<String>
     ): Result<SetupIntent> {
+        return confirmSetupIntentParams.maybeForDashboard(options).mapResult {
+            confirmSetupIntentInternal(
+                confirmSetupIntentParams = it,
+                options = options,
+                expandFields = expandFields
+            )
+        }
+    }
+
+
+    private suspend fun confirmSetupIntentInternal(
+        confirmSetupIntentParams: ConfirmSetupIntentParams,
+        options: ApiRequest.Options,
+        expandFields: List<String>
+    ): Result<SetupIntent> {
         val setupIntentId = runCatching {
             SetupIntent.ClientSecret(confirmSetupIntentParams.clientSecret).setupIntentId
         }.getOrElse {
@@ -425,7 +440,9 @@ class StripeApiRepository @JvmOverloads internal constructor(
                 fraudDetectionDataParamsUtils.addFraudDetectionData(
                     // Add payment_user_agent if the Payment Method is being created on this call
                     maybeAddPaymentUserAgent(
-                        confirmSetupIntentParams.toParamMap(),
+                        confirmSetupIntentParams.toParamMap()
+                            // Omit client_secret with user key auth.
+                            .let { if (options.apiKeyIsUserKey) it.minus(PARAM_CLIENT_SECRET) else it },
                         confirmSetupIntentParams.paymentMethodCreateParams
                     ).plus(createExpandParam(expandFields)),
                     fraudDetectionData
@@ -459,6 +476,12 @@ class StripeApiRepository @JvmOverloads internal constructor(
         }.getOrElse {
             return Result.failure(it)
         }
+        val params: Map<String, Any?> =
+            if (options.apiKeyIsUserKey) {
+                createExpandParam(expandFields)
+            } else {
+                createClientSecretParam(clientSecret, expandFields)
+            }
 
         fireFraudDetectionDataRequest()
 
@@ -466,7 +489,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
             apiRequest = apiRequestFactory.createGet(
                 url = getRetrieveSetupIntentUrl(setupIntentId),
                 options = options,
-                params = createClientSecretParam(clientSecret, expandFields),
+                params = params,
             ),
             jsonParser = SetupIntentJsonParser(),
         ) {
@@ -1883,6 +1906,28 @@ class StripeApiRepository @JvmOverloads internal constructor(
 
         return paymentMethodResult.mapCatching { paymentMethod ->
             ConfirmPaymentIntentParams.createForDashboard(
+                clientSecret = clientSecret,
+                paymentMethodId = paymentMethod.id!!,
+                paymentMethodOptions = paymentMethodOptions,
+            )
+        }
+    }
+
+    private suspend fun ConfirmSetupIntentParams.maybeForDashboard(
+        options: ApiRequest.Options
+    ): Result<ConfirmSetupIntentParams> {
+        if (!options.apiKeyIsUserKey || paymentMethodCreateParams == null) {
+            return Result.success(this)
+        }
+
+        // For user key auth, we must create the PM first.
+        val paymentMethodResult = createPaymentMethod(
+            paymentMethodCreateParams = paymentMethodCreateParams,
+            options = options,
+        )
+
+        return paymentMethodResult.mapCatching { paymentMethod ->
+            ConfirmSetupIntentParams.createForDashboard(
                 clientSecret = clientSecret,
                 paymentMethodId = paymentMethod.id!!,
                 paymentMethodOptions = paymentMethodOptions,

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -795,6 +795,39 @@ internal class StripeApiRepositoryTest {
         }
 
     @Test
+    fun confirmSetupIntent_withApiUserKey_sendsValidRequest() =
+        runTest {
+            val apiKey = "uk_12345"
+            val clientSecret = "seti_12345_secret_fake"
+            whenever(stripeNetworkClient.executeRequest(any<ApiRequest>()))
+                .thenReturn(
+                    StripeResponse(
+                        200,
+                        SetupIntentFixtures.SI_3DS2_SUCCEEDED_JSON.toString(),
+                        emptyMap()
+                    )
+                )
+
+            val confirmSetupIntentParams =
+                ConfirmSetupIntentParams.createWithoutPaymentMethod(
+                    clientSecret
+                )
+
+
+            create().confirmSetupIntent(
+                confirmSetupIntentParams = confirmSetupIntentParams,
+                options = ApiRequest.Options(apiKey)
+            )
+
+            verify(stripeNetworkClient).executeRequest(apiRequestArgumentCaptor.capture())
+            val apiRequest = apiRequestArgumentCaptor.firstValue
+            assertThat(apiRequest.baseUrl)
+                .contains("seti_12345/confirm")
+            assertThat(apiRequest.params)
+                .doesNotContainKey(ConfirmStripeIntentParams.PARAM_CLIENT_SECRET)
+        }
+
+    @Test
     fun confirmSetupIntent_setsCorrectPaymentUserAgent() =
         runTest {
             // put a private key here to simulate the backend

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -812,8 +812,6 @@ internal class StripeApiRepositoryTest {
                 ConfirmSetupIntentParams.createWithoutPaymentMethod(
                     clientSecret
                 )
-
-
             create().confirmSetupIntent(
                 confirmSetupIntentParams = confirmSetupIntentParams,
                 options = ApiRequest.Options(apiKey)


### PR DESCRIPTION
# Summary
Adds MOTO and User Key support when confirming Setup Intents

Changes were made copying the way they were done for confirming Payment Intents: https://github.com/stripe/stripe-android/pull/4481

<!-- Simple summary of what was changed. -->

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Needed for the Stripe Dashboard Android app

# Testing
<!-- How was the code tested? Be as specific as possible. -->
I wrote a similar automated test that checks that the client secret is removed from the request, although this is not sufficient. I wanted to try if this _actually_ works but I'm struggling to compile the app due to java memory issues.

Changes need to be manually tested before merging this PR.

- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Changelog
This change is internal.