### PR TITLE
Introduce hCaptcha service for passive hcaptcha

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/hcaptcha/DefaultHCaptchaService.kt
+++ b/payments-core/src/main/java/com/stripe/android/hcaptcha/DefaultHCaptchaService.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.hcaptcha
+
+import androidx.fragment.app.FragmentActivity
+import com.stripe.hcaptcha.HCaptchaError
+import com.stripe.hcaptcha.HCaptchaException
+import com.stripe.hcaptcha.HCaptchaTokenResponse
+import com.stripe.hcaptcha.config.HCaptchaConfig
+import com.stripe.hcaptcha.config.HCaptchaSize
+import com.stripe.hcaptcha.task.OnFailureListener
+import com.stripe.hcaptcha.task.OnSuccessListener
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+
+internal class DefaultHCaptchaService(
+    private val hCaptchaProvider: HCaptchaProvider
+) : HCaptchaService {
+
+    override suspend fun performPassiveHCaptcha(activity: FragmentActivity): HCaptchaService.Result {
+        return suspendCoroutine { coroutine ->
+            val hcaptcha = hCaptchaProvider.get(activity).apply {
+                addOnSuccessListener(object : OnSuccessListener<HCaptchaTokenResponse> {
+                    override fun onSuccess(result: HCaptchaTokenResponse) {
+                        coroutine.resume(HCaptchaService.Result.Success(result.tokenResult))
+                    }
+                })
+                addOnFailureListener(object : OnFailureListener {
+                    override fun onFailure(exception: HCaptchaException) {
+                        coroutine.resume(HCaptchaService.Result.Failure(exception))
+                    }
+                })
+            }
+
+            val config = HCaptchaConfig(
+                siteKey = SITE_KEY,
+                size = HCaptchaSize.INVISIBLE,
+                rqdata = null,
+                loading = false,
+                hideDialog = true,
+                disableHardwareAcceleration = true,
+                retryPredicate = { _, exception -> exception.hCaptchaError == HCaptchaError.SESSION_TIMEOUT }
+            )
+
+            hcaptcha.setup(config).verifyWithHCaptcha()
+        }
+    }
+
+    companion object {
+        private const val SITE_KEY = "143aadb6-fb60-4ab6-b128-f7fe53426d4a"
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/hcaptcha/HCaptchaModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/hcaptcha/HCaptchaModule.kt
@@ -1,0 +1,21 @@
+package com.stripe.android.hcaptcha
+
+import androidx.annotation.RestrictTo
+import dagger.Module
+import dagger.Provides
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Module
+object HCaptchaModule {
+    @Provides
+    internal fun provideHCaptchaProvider(): HCaptchaProvider {
+        return DefaultHCaptchaProvider()
+    }
+
+    @Provides
+    fun provideHCaptchaService(
+        hCaptchaProvider: HCaptchaProvider
+    ): HCaptchaService {
+        return DefaultHCaptchaService(hCaptchaProvider)
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/hcaptcha/HCaptchaProvider.kt
+++ b/payments-core/src/main/java/com/stripe/android/hcaptcha/HCaptchaProvider.kt
@@ -1,0 +1,16 @@
+package com.stripe.android.hcaptcha
+
+import androidx.annotation.RestrictTo
+import androidx.fragment.app.FragmentActivity
+import com.stripe.hcaptcha.HCaptcha
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun interface HCaptchaProvider {
+    fun get(activity: FragmentActivity): HCaptcha
+}
+
+internal class DefaultHCaptchaProvider : HCaptchaProvider {
+    override fun get(activity: FragmentActivity): HCaptcha {
+        return HCaptcha.getClient(activity)
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/hcaptcha/HCaptchaService.kt
+++ b/payments-core/src/main/java/com/stripe/android/hcaptcha/HCaptchaService.kt
@@ -1,0 +1,18 @@
+package com.stripe.android.hcaptcha
+
+import androidx.annotation.RestrictTo
+import androidx.fragment.app.FragmentActivity
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+interface HCaptchaService {
+    suspend fun performPassiveHCaptcha(activity: FragmentActivity): Result
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    sealed interface Result {
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        data class Success(val token: String) : Result
+
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        data class Failure(val error: Throwable) : Result
+    }
+}

--- a/payments-core/src/test/java/com/stripe/android/hcaptcha/DefaultHCaptchaServiceTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/hcaptcha/DefaultHCaptchaServiceTest.kt
@@ -1,0 +1,142 @@
+package com.stripe.android.hcaptcha
+
+import android.os.Handler
+import androidx.fragment.app.FragmentActivity
+import com.google.common.truth.Truth.assertThat
+import com.stripe.hcaptcha.HCaptcha
+import com.stripe.hcaptcha.HCaptchaError
+import com.stripe.hcaptcha.HCaptchaException
+import com.stripe.hcaptcha.HCaptchaTokenResponse
+import com.stripe.hcaptcha.config.HCaptchaConfig
+import com.stripe.hcaptcha.config.HCaptchaSize
+import com.stripe.hcaptcha.task.OnFailureListener
+import com.stripe.hcaptcha.task.OnSuccessListener
+import kotlinx.coroutines.test.runTest
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import kotlin.test.Test
+
+internal class DefaultHCaptchaServiceTest {
+
+    @Test
+    fun `performPassiveHCaptcha calls hCaptchaProvider with activity`() = runTest {
+        val testContext = createTestContext()
+        testContext.setupSuccessfulHCaptcha("test-token")
+
+        testContext.service.performPassiveHCaptcha(testContext.activity)
+
+        assertThat(testContext.hCaptchaProvider.getInvocations).containsExactly(testContext.activity)
+    }
+
+    @Test
+    fun `performPassiveHCaptcha configures HCaptcha with correct settings`() = runTest {
+        val testContext = createTestContext()
+        testContext.setupSuccessfulHCaptcha()
+
+        testContext.service.performPassiveHCaptcha(testContext.activity)
+
+        val configCaptor = argumentCaptor<HCaptchaConfig>()
+        verify(testContext.hCaptcha).setup(configCaptor.capture())
+
+        with(configCaptor.firstValue) {
+            assertThat(siteKey).isEqualTo("143aadb6-fb60-4ab6-b128-f7fe53426d4a")
+            assertThat(size).isEqualTo(HCaptchaSize.INVISIBLE)
+            assertThat(rqdata).isNull()
+            assertThat(loading).isFalse()
+            assertThat(hideDialog).isTrue()
+            assertThat(disableHardwareAcceleration).isTrue()
+        }
+    }
+
+    @Test
+    fun `performPassiveHCaptcha returns success when HCaptcha succeeds`() = runTest {
+        val testContext = createTestContext()
+        val expectedToken = "success-token"
+        testContext.setupSuccessfulHCaptcha(expectedToken)
+
+        val result = testContext.service.performPassiveHCaptcha(testContext.activity)
+
+        assertThat(result).isInstanceOf(HCaptchaService.Result.Success::class.java)
+        assertThat((result as HCaptchaService.Result.Success).token).isEqualTo(expectedToken)
+    }
+
+    @Test
+    fun `performPassiveHCaptcha returns failure when HCaptcha fails`() = runTest {
+        val testContext = createTestContext()
+        val exception = HCaptchaException(HCaptchaError.NETWORK_ERROR)
+        testContext.setupFailedHCaptcha(exception)
+
+        val result = testContext.service.performPassiveHCaptcha(testContext.activity)
+
+        assertThat(result).isInstanceOf(HCaptchaService.Result.Failure::class.java)
+        assertThat((result as HCaptchaService.Result.Failure).error).isEqualTo(exception)
+    }
+
+    private fun createTestContext(): TestContext {
+        val activity = mock<FragmentActivity>()
+        val hCaptcha = mock<HCaptcha>()
+        val hCaptchaProvider = FakeHCaptchaProvider(hCaptcha)
+        val service = DefaultHCaptchaService(hCaptchaProvider)
+
+        return TestContext(
+            activity = activity,
+            hCaptcha = hCaptcha,
+            hCaptchaProvider = hCaptchaProvider,
+            service = service
+        )
+    }
+
+    private fun TestContext.setupHCaptchaChaining() {
+        whenever(hCaptcha.addOnSuccessListener(any())).doReturn(hCaptcha)
+        whenever(hCaptcha.addOnFailureListener(any())).doReturn(hCaptcha)
+        whenever(hCaptcha.setup(any())).doReturn(hCaptcha)
+    }
+
+    private fun TestContext.setupSuccessfulHCaptcha(token: String = "test-token") {
+        setupHCaptchaChaining()
+
+        whenever(hCaptcha.verifyWithHCaptcha()).then {
+            val successCaptor = argumentCaptor<OnSuccessListener<HCaptchaTokenResponse>>()
+            verify(hCaptcha).addOnSuccessListener(successCaptor.capture())
+            successCaptor.firstValue.onSuccess(createHCaptchaTokenResponse(token))
+            hCaptcha
+        }
+    }
+
+    private fun TestContext.setupFailedHCaptcha(exception: HCaptchaException) {
+        setupHCaptchaChaining()
+
+        whenever(hCaptcha.verifyWithHCaptcha()).then {
+            val failureCaptor = argumentCaptor<OnFailureListener>()
+            verify(hCaptcha).addOnFailureListener(failureCaptor.capture())
+            failureCaptor.firstValue.onFailure(exception)
+            hCaptcha
+        }
+    }
+
+    private fun createHCaptchaTokenResponse(token: String): HCaptchaTokenResponse {
+        return HCaptchaTokenResponse(token, mock<Handler>())
+    }
+
+    private data class TestContext(
+        val activity: FragmentActivity,
+        val hCaptcha: HCaptcha,
+        val hCaptchaProvider: FakeHCaptchaProvider,
+        val service: DefaultHCaptchaService
+    )
+
+    private class FakeHCaptchaProvider(
+        private val hCaptcha: HCaptcha
+    ) : HCaptchaProvider {
+        val getInvocations = mutableListOf<FragmentActivity>()
+
+        override fun get(activity: FragmentActivity): HCaptcha {
+            getInvocations.add(activity)
+            return hCaptcha
+        }
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Introduce hCaptcha service for passive hcaptcha. We currently have a [top-level function](https://github.com/stripe/stripe-android/blob/68700b868917118b0efc14b407c1dc34aa453770/payments-core/src/main/java/com/stripe/android/hcaptcha/HCaptchaInterface.kt#L22) that performs passive hCaptcha, but I needed something testable for this use-case. I will tackle removing the existing passive hCaptcha as a separate issue.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-3842
https://docs.google.com/document/d/1VDwjpPnKxxZo9liOC4k9ccrO-fLgFaplNAuplYm2HDY/edit?usp=sharing

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
