### PR TITLE
Fixes FlowController `walletCanBeUsed` logic.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandler.kt
@@ -132,7 +132,7 @@ internal class FlowControllerConfigurationHandler @Inject constructor(
         )
 
         viewModel.paymentSelection = paymentSelectionUpdater(
-            currentSelection = viewModel.paymentSelection,
+            existingSelection = viewModel.paymentSelection,
             previousConfig = viewModel.state?.config,
             newState = state,
             newConfig = configuration,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandler.kt
@@ -132,7 +132,7 @@ internal class FlowControllerConfigurationHandler @Inject constructor(
         )
 
         viewModel.paymentSelection = paymentSelectionUpdater(
-            existingSelection = viewModel.paymentSelection,
+            selection = viewModel.paymentSelection,
             previousConfig = viewModel.state?.config,
             newState = state,
             newConfig = configuration,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdater.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdater.kt
@@ -109,7 +109,10 @@ internal class DefaultPaymentSelectionUpdater @Inject constructor() : PaymentSel
 
         // If this selection is the existing selection (likely selected externally)
         // AND specific wallets are configured externally, preserve it
-        if (potentialSelection == selection && walletType in walletTypesDisplayedExternally) {
+        if (potentialSelection == selection &&
+            walletType in walletTypesDisplayedExternally &&
+            configuration.walletButtons.walletsToShow.isNotEmpty()
+        ) {
             return true
         }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdaterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdaterTest.kt
@@ -38,7 +38,7 @@ class PaymentSelectionUpdaterTest {
         val newState = mockPaymentSheetStateWithPaymentIntent(paymentSelection = PaymentSelection.GooglePay)
         val updater = createUpdater()
         val result = updater(
-            currentSelection = null,
+            existingSelection = null,
             previousConfig = null,
             newState = newState,
             newConfig = defaultPaymentSheetConfiguration,
@@ -70,7 +70,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            currentSelection = existingSelection,
+            existingSelection = existingSelection,
             previousConfig = PaymentSheet.Configuration(
                 merchantDisplayName = "Example, Inc.",
                 allowsDelayedPaymentMethods = true,
@@ -94,7 +94,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            currentSelection = existingSelection,
+            existingSelection = existingSelection,
             previousConfig = defaultPaymentSheetConfiguration,
             newState = newState,
             newConfig = defaultPaymentSheetConfiguration,
@@ -110,7 +110,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            currentSelection = existing,
+            existingSelection = existing,
             previousConfig = null,
             newState = newState,
             newConfig = defaultPaymentSheetConfiguration,
@@ -128,7 +128,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            currentSelection = existing,
+            existingSelection = existing,
             previousConfig = null,
             newState = newState,
             newConfig = defaultPaymentSheetConfiguration,
@@ -149,7 +149,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            currentSelection = existingSelection,
+            existingSelection = existingSelection,
             previousConfig = null,
             newState = newState,
             newConfig = defaultPaymentSheetConfiguration,
@@ -169,7 +169,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            currentSelection = paymentSelection,
+            existingSelection = paymentSelection,
             previousConfig = null,
             newState = newState,
             newConfig = defaultPaymentSheetConfiguration,
@@ -189,7 +189,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            currentSelection = paymentSelection,
+            existingSelection = paymentSelection,
             previousConfig = null,
             newState = newState,
             newConfig = defaultPaymentSheetConfiguration,
@@ -209,7 +209,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            currentSelection = paymentSelection,
+            existingSelection = paymentSelection,
             previousConfig = null,
             newState = newState,
             newConfig = defaultPaymentSheetConfiguration,
@@ -229,7 +229,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            currentSelection = paymentSelection,
+            existingSelection = paymentSelection,
             previousConfig = null,
             newState = newState,
             newConfig = defaultPaymentSheetConfiguration,
@@ -258,7 +258,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            currentSelection = existingSelection,
+            existingSelection = existingSelection,
             previousConfig = null,
             newState = newState,
             newConfig = defaultPaymentSheetConfiguration,
@@ -290,7 +290,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            currentSelection = existingSelection,
+            existingSelection = existingSelection,
             previousConfig = defaultPaymentSheetConfiguration,
             newState = newState,
             newConfig = defaultPaymentSheetConfiguration,
@@ -322,7 +322,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            currentSelection = existingSelection,
+            existingSelection = existingSelection,
             previousConfig = defaultPaymentSheetConfiguration,
             newState = newState,
             newConfig = defaultPaymentSheetConfiguration,
@@ -362,7 +362,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            currentSelection = existingSelection,
+            existingSelection = existingSelection,
             previousConfig = defaultPaymentSheetConfiguration.newBuilder()
                 .googlePay(
                     PaymentSheet.GooglePayConfiguration(
@@ -396,7 +396,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            currentSelection = existingSelection,
+            existingSelection = existingSelection,
             previousConfig = defaultPaymentSheetConfiguration,
             newState = newState,
             newConfig = newConfig,
@@ -411,7 +411,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            currentSelection = PaymentSelection.GooglePay,
+            existingSelection = PaymentSelection.GooglePay,
             previousConfig = null,
             newState = mockPaymentSheetStateWithPaymentIntent(),
             newConfig = defaultPaymentSheetConfiguration,
@@ -426,7 +426,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            currentSelection = PaymentSelection.Link(useLinkExpress = false),
+            existingSelection = PaymentSelection.Link(useLinkExpress = false),
             previousConfig = null,
             newState = mockPaymentSheetStateWithPaymentIntent(),
             newConfig = defaultPaymentSheetConfiguration,
@@ -442,7 +442,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            currentSelection = PaymentSelection.GooglePay,
+            existingSelection = PaymentSelection.GooglePay,
             previousConfig = null,
             newState = mockPaymentSheetStateWithPaymentIntent(),
             newConfig = defaultPaymentSheetConfiguration.newBuilder()
@@ -463,7 +463,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            currentSelection = PaymentSelection.Link(useLinkExpress = false),
+            existingSelection = PaymentSelection.Link(useLinkExpress = false),
             previousConfig = null,
             newState = mockPaymentSheetStateWithPaymentIntent(),
             newConfig = defaultPaymentSheetConfiguration.newBuilder()
@@ -484,7 +484,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            currentSelection = PaymentSelection.Link(useLinkExpress = false),
+            existingSelection = PaymentSelection.Link(useLinkExpress = false),
             previousConfig = null,
             newState = mockPaymentSheetStateWithPaymentIntent(),
             newConfig = defaultPaymentSheetConfiguration.newBuilder()
@@ -506,7 +506,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            currentSelection = PaymentSelection.GooglePay,
+            existingSelection = PaymentSelection.GooglePay,
             previousConfig = null,
             newState = mockPaymentSheetStateWithPaymentIntent(),
             newConfig = defaultPaymentSheetConfiguration.newBuilder()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdaterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdaterTest.kt
@@ -38,7 +38,7 @@ class PaymentSelectionUpdaterTest {
         val newState = mockPaymentSheetStateWithPaymentIntent(paymentSelection = PaymentSelection.GooglePay)
         val updater = createUpdater()
         val result = updater(
-            existingSelection = null,
+            selection = null,
             previousConfig = null,
             newState = newState,
             newConfig = defaultPaymentSheetConfiguration,
@@ -70,7 +70,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            existingSelection = existingSelection,
+            selection = existingSelection,
             previousConfig = PaymentSheet.Configuration(
                 merchantDisplayName = "Example, Inc.",
                 allowsDelayedPaymentMethods = true,
@@ -94,7 +94,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            existingSelection = existingSelection,
+            selection = existingSelection,
             previousConfig = defaultPaymentSheetConfiguration,
             newState = newState,
             newConfig = defaultPaymentSheetConfiguration,
@@ -110,7 +110,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            existingSelection = existing,
+            selection = existing,
             previousConfig = null,
             newState = newState,
             newConfig = defaultPaymentSheetConfiguration,
@@ -128,7 +128,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            existingSelection = existing,
+            selection = existing,
             previousConfig = null,
             newState = newState,
             newConfig = defaultPaymentSheetConfiguration,
@@ -149,7 +149,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            existingSelection = existingSelection,
+            selection = existingSelection,
             previousConfig = null,
             newState = newState,
             newConfig = defaultPaymentSheetConfiguration,
@@ -169,7 +169,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            existingSelection = paymentSelection,
+            selection = paymentSelection,
             previousConfig = null,
             newState = newState,
             newConfig = defaultPaymentSheetConfiguration,
@@ -189,7 +189,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            existingSelection = paymentSelection,
+            selection = paymentSelection,
             previousConfig = null,
             newState = newState,
             newConfig = defaultPaymentSheetConfiguration,
@@ -209,7 +209,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            existingSelection = paymentSelection,
+            selection = paymentSelection,
             previousConfig = null,
             newState = newState,
             newConfig = defaultPaymentSheetConfiguration,
@@ -229,7 +229,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            existingSelection = paymentSelection,
+            selection = paymentSelection,
             previousConfig = null,
             newState = newState,
             newConfig = defaultPaymentSheetConfiguration,
@@ -258,7 +258,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            existingSelection = existingSelection,
+            selection = existingSelection,
             previousConfig = null,
             newState = newState,
             newConfig = defaultPaymentSheetConfiguration,
@@ -290,7 +290,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            existingSelection = existingSelection,
+            selection = existingSelection,
             previousConfig = defaultPaymentSheetConfiguration,
             newState = newState,
             newConfig = defaultPaymentSheetConfiguration,
@@ -322,7 +322,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            existingSelection = existingSelection,
+            selection = existingSelection,
             previousConfig = defaultPaymentSheetConfiguration,
             newState = newState,
             newConfig = defaultPaymentSheetConfiguration,
@@ -362,7 +362,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            existingSelection = existingSelection,
+            selection = existingSelection,
             previousConfig = defaultPaymentSheetConfiguration.newBuilder()
                 .googlePay(
                     PaymentSheet.GooglePayConfiguration(
@@ -396,7 +396,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            existingSelection = existingSelection,
+            selection = existingSelection,
             previousConfig = defaultPaymentSheetConfiguration,
             newState = newState,
             newConfig = newConfig,
@@ -411,7 +411,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            existingSelection = PaymentSelection.GooglePay,
+            selection = PaymentSelection.GooglePay,
             previousConfig = null,
             newState = mockPaymentSheetStateWithPaymentIntent(),
             newConfig = defaultPaymentSheetConfiguration,
@@ -426,7 +426,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            existingSelection = PaymentSelection.Link(useLinkExpress = false),
+            selection = PaymentSelection.Link(useLinkExpress = false),
             previousConfig = null,
             newState = mockPaymentSheetStateWithPaymentIntent(),
             newConfig = defaultPaymentSheetConfiguration,
@@ -442,7 +442,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            existingSelection = PaymentSelection.GooglePay,
+            selection = PaymentSelection.GooglePay,
             previousConfig = null,
             newState = mockPaymentSheetStateWithPaymentIntent(),
             newConfig = defaultPaymentSheetConfiguration.newBuilder()
@@ -463,7 +463,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            existingSelection = PaymentSelection.Link(useLinkExpress = false),
+            selection = PaymentSelection.Link(useLinkExpress = false),
             previousConfig = null,
             newState = mockPaymentSheetStateWithPaymentIntent(),
             newConfig = defaultPaymentSheetConfiguration.newBuilder()
@@ -484,7 +484,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            existingSelection = PaymentSelection.Link(useLinkExpress = false),
+            selection = PaymentSelection.Link(useLinkExpress = false),
             previousConfig = null,
             newState = mockPaymentSheetStateWithPaymentIntent(),
             newConfig = defaultPaymentSheetConfiguration.newBuilder()
@@ -506,7 +506,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            existingSelection = PaymentSelection.GooglePay,
+            selection = PaymentSelection.GooglePay,
             previousConfig = null,
             newState = mockPaymentSheetStateWithPaymentIntent(),
             newConfig = defaultPaymentSheetConfiguration.newBuilder()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdaterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdaterTest.kt
@@ -522,6 +522,28 @@ class PaymentSelectionUpdaterTest {
         assertThat(result).isEqualTo(PaymentSelection.GooglePay)
     }
 
+    @OptIn(WalletButtonsPreview::class)
+    @Test
+    fun `If using wallet buttons config with specific wallet and existing selection matches, should preserve it`() {
+        val updater = createUpdater()
+
+        val result = updater(
+            selection = PaymentSelection.Link(useLinkExpress = false),
+            previousConfig = null,
+            newState = mockPaymentSheetStateWithPaymentIntent(),
+            newConfig = defaultPaymentSheetConfiguration.newBuilder()
+                .walletButtons(
+                    PaymentSheet.WalletButtonsConfiguration(
+                        willDisplayExternally = true,
+                        walletsToShow = listOf("link"),
+                    ),
+                ).build(),
+            walletButtonsAlreadyShown = false,
+        )
+
+        assertThat(result).isEqualTo(PaymentSelection.Link(useLinkExpress = false))
+    }
+
     private fun mockPaymentSheetStateWithPaymentIntent(
         paymentMethodTypes: List<String>? = null,
         paymentSelection: PaymentSelection? = null,


### PR DESCRIPTION
### Problem
When using `WalletButtonsConfiguration` with `willDisplayExternally = true` and specific `walletsToShow` (e.g., `["link"]`), wallet selections made through external wallet buttons were incorrectly cleared during validation.

**Steps to reproduce:**

_I used `carlosmuvi/merchant-demo` to test this. Could not reproduce on the playground._

1. Configure PaymentSheet with `WalletButtonsConfiguration(willDisplayExternally = true, walletsToShow = ["link"])`
2. User selects Link from external wallet buttons
3. Link selection gets cleared ❌

The `PaymentSelectionUpdater.walletCanBeUsed()` validation logic was designed for avoiding duplication but incorrectly rejected external wallet selections that should be preserved.

### Solution
Preserve wallet selections that match the current selection when specific wallets are configured externally