### PR TITLE
Populate billing address in passthrough

### DIFF
--- a/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
@@ -315,7 +315,7 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         id: String,
         extraParams: Map<String, *>?,
         requestOptions: ApiRequest.Options
-    ): Result<String> {
+    ): Result<PaymentMethod> {
         TODO("Not yet implemented")
     }
 

--- a/payments-core/src/main/java/com/stripe/android/model/ConsumerPaymentDetailsShare.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConsumerPaymentDetailsShare.kt
@@ -4,4 +4,4 @@ import com.stripe.android.core.model.StripeModel
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-internal data class ConsumerPaymentDetailsShare(val id: String) : StripeModel
+internal data class ConsumerPaymentDetailsShare(val paymentMethod: PaymentMethod) : StripeModel

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/ConsumerPaymentDetailsShareJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/ConsumerPaymentDetailsShareJsonParser.kt
@@ -1,15 +1,15 @@
 package com.stripe.android.model.parsers
 
-import com.stripe.android.core.model.StripeJsonUtils
 import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.model.ConsumerPaymentDetailsShare
 import org.json.JSONObject
 
 internal object ConsumerPaymentDetailsShareJsonParser : ModelJsonParser<ConsumerPaymentDetailsShare> {
-    private const val FIELD_ID = "payment_method"
+    private const val FIELD_PAYMENT_METHOD = "payment_method"
 
     override fun parse(json: JSONObject): ConsumerPaymentDetailsShare? {
-        val id = StripeJsonUtils.optString(json, FIELD_ID) ?: return null
-        return ConsumerPaymentDetailsShare(id)
+        val paymentMethodJson = json.optJSONObject(FIELD_PAYMENT_METHOD) ?: return null
+        val paymentMethod = PaymentMethodJsonParser().parse(paymentMethodJson)
+        return ConsumerPaymentDetailsShare(paymentMethod)
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -1181,7 +1181,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
         id: String,
         extraParams: Map<String, *>?,
         requestOptions: ApiRequest.Options
-    ): Result<String> {
+    ): Result<PaymentMethod> {
         return fetchStripeModelResult(
             apiRequest = apiRequestFactory.createPost(
                 url = sharePaymentDetailsUrl,
@@ -1196,7 +1196,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
                 ).plus(extraParams ?: emptyMap())
             ),
             jsonParser = ConsumerPaymentDetailsShareJsonParser,
-        ).map { it.id }
+        ).map { it.paymentMethod }
     }
 
     override suspend fun logOut(

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -303,7 +303,7 @@ interface StripeRepository {
         id: String,
         extraParams: Map<String, *>?,
         requestOptions: ApiRequest.Options
-    ): Result<String>
+    ): Result<PaymentMethod>
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     suspend fun logOut(

--- a/payments-core/src/test/java/com/stripe/android/model/ConsumerFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/ConsumerFixtures.kt
@@ -268,7 +268,42 @@ object ConsumerFixtures {
         """
         {
             "object": "payment_method",
-            "payment_method": "pm_1NsnWALu5o3P18Zp36Q7YfWW"
+            "payment_method": {
+                "id": "pm_1NsnWALu5o3P18Zp36Q7YfWW",
+                "object": "payment_method",
+                "created": 1550757934255,
+                "customer": "cus_AQsHpvKfKwJDrF",
+                "livemode": true,
+                "type": "card",
+                "billing_details": {
+                    "address": {
+                        "city": "San Francisco",
+                        "country": "US",
+                        "line1": "1234 Main Street",
+                        "postal_code": "94111",
+                        "state": "CA"
+                    },
+                    "email": "jenny.rosen@example.com",
+                    "name": "Jenny Rosen",
+                    "phone": "123-456-7890"
+                },
+                "card": {
+                    "brand": "visa",
+                    "checks": {
+                        "address_line1_check": "unchecked",
+                        "cvc_check": "unchecked"
+                    },
+                    "country": "US",
+                    "exp_month": 8,
+                    "exp_year": 2022,
+                    "funding": "credit",
+                    "fingerprint": "fingerprint123",
+                    "last4": "4242",
+                    "three_d_secure_usage": {
+                        "supported": true
+                    }
+                }
+            }
         }
         """.trimIndent()
     )

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/ConsumerPaymentDetailsShareJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/ConsumerPaymentDetailsShareJsonParserTest.kt
@@ -51,7 +51,7 @@ internal class ConsumerPaymentDetailsShareJsonParserTest {
                 code = "card"
             )
         )
-        
+
         assertThat(
             ConsumerPaymentDetailsShareJsonParser
                 .parse(ConsumerFixtures.PAYMENT_DETAILS_SHARE_JSON)

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/ConsumerPaymentDetailsShareJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/ConsumerPaymentDetailsShareJsonParserTest.kt
@@ -1,16 +1,60 @@
 package com.stripe.android.model.parsers
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.Address
+import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConsumerFixtures
 import com.stripe.android.model.ConsumerPaymentDetailsShare
+import com.stripe.android.model.PaymentMethod
 import org.junit.Test
 
 internal class ConsumerPaymentDetailsShareJsonParserTest {
     @Test
     fun `parse result`() {
+        val expected = ConsumerPaymentDetailsShare(
+            paymentMethod = PaymentMethod(
+                id = "pm_1NsnWALu5o3P18Zp36Q7YfWW",
+                created = 1550757934255L,
+                liveMode = true,
+                type = PaymentMethod.Type.Card,
+                billingDetails = PaymentMethod.BillingDetails(
+                    address = Address(
+                        city = "San Francisco",
+                        country = "US",
+                        line1 = "1234 Main Street",
+                        postalCode = "94111",
+                        state = "CA"
+                    ),
+                    email = "jenny.rosen@example.com",
+                    name = "Jenny Rosen",
+                    phone = "123-456-7890"
+                ),
+                customerId = "cus_AQsHpvKfKwJDrF",
+                card = PaymentMethod.Card(
+                    brand = CardBrand.Visa,
+                    checks = PaymentMethod.Card.Checks(
+                        addressLine1Check = "unchecked",
+                        addressPostalCodeCheck = null,
+                        cvcCheck = "unchecked"
+                    ),
+                    country = "US",
+                    expiryMonth = 8,
+                    expiryYear = 2022,
+                    funding = "credit",
+                    fingerprint = "fingerprint123",
+                    last4 = "4242",
+                    threeDSecureUsage = PaymentMethod.Card.ThreeDSecureUsage(
+                        isSupported = true
+                    ),
+                    wallet = null
+                ),
+                code = "card"
+            )
+        )
+        
         assertThat(
             ConsumerPaymentDetailsShareJsonParser
                 .parse(ConsumerFixtures.PAYMENT_DETAILS_SHARE_JSON)
-        ).isEqualTo(ConsumerPaymentDetailsShare("pm_1NsnWALu5o3P18Zp36Q7YfWW"))
+        ).isEqualTo(expected)
     }
 }

--- a/paymentsheet/src/androidTest/resources/consumer-payment-details-share-success.json
+++ b/paymentsheet/src/androidTest/resources/consumer-payment-details-share-success.json
@@ -1,4 +1,39 @@
 {
   "object": "payment_method",
-  "payment_method": "pm_1234"
+  "payment_method": {
+    "id": "pm_1234",
+    "object": "payment_method",
+    "created": 1550757934255,
+    "customer": "cus_AQsHpvKfKwJDrF",
+    "livemode": true,
+    "type": "card",
+    "billing_details": {
+      "address": {
+        "city": "San Francisco",
+        "country": "US",
+        "line1": "1234 Main Street",
+        "postal_code": "94111",
+        "state": "CA"
+      },
+      "email": "jenny.rosen@example.com",
+      "name": "Jenny Rosen",
+      "phone": "123-456-7890"
+    },
+    "card": {
+      "brand": "visa",
+      "checks": {
+        "address_line1_check": "unchecked",
+        "cvc_check": "unchecked"
+      },
+      "country": "US",
+      "exp_month": 8,
+      "exp_year": 2022,
+      "funding": "credit",
+      "fingerprint": "fingerprint123",
+      "last4": "4242",
+      "three_d_secure_usage": {
+        "supported": true
+      }
+    }
+  }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
@@ -11,6 +11,7 @@ import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.link.LinkPaymentDetails
 import com.stripe.android.link.LinkPaymentMethod
 import com.stripe.android.link.confirmation.createPaymentMethodCreateParams
+import com.stripe.android.link.utils.toConsumerBillingAddress
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.ConsumerPaymentDetailsCreateParams
 import com.stripe.android.model.ConsumerPaymentDetailsCreateParams.Card.Companion.extraConfirmationParams
@@ -249,24 +250,29 @@ internal class LinkApiRepository @Inject constructor(
             mapOf("billing_phone" to it)
         } ?: emptyMap()
 
+        val paymentMethodParams = mapOf("expand" to listOf("payment_method"))
+
         stripeRepository.sharePaymentDetails(
             consumerSessionClientSecret = consumerSessionClientSecret,
             id = id,
             extraParams = mapOf(
                 "payment_method_options" to extraConfirmationParams(paymentMethodCreateParams.toParamMap()),
-            ) + allowRedisplay + billingPhone,
+            ) + allowRedisplay + billingPhone + paymentMethodParams,
             requestOptions = buildRequestOptions(),
         ).onFailure {
             errorReporter.report(ErrorReporter.ExpectedErrorEvent.LINK_SHARE_CARD_FAILURE, StripeException.create(it))
-        }.map { passthroughModePaymentMethodId ->
+        }.map { paymentMethod ->
+            val paymentMethodId = requireNotNull(paymentMethod.id)
             LinkPaymentDetails.Saved(
                 paymentDetails = ConsumerPaymentDetails.Passthrough(
                     id = id,
                     last4 = paymentMethodCreateParams.cardLast4().orEmpty(),
-                    paymentMethodId = passthroughModePaymentMethodId,
+                    paymentMethodId = paymentMethodId,
+                    billingEmailAddress = paymentMethod.billingDetails?.email,
+                    billingAddress = paymentMethod.billingDetails?.toConsumerBillingAddress(),
                 ),
                 paymentMethodCreateParams = PaymentMethodCreateParams.createLink(
-                    paymentDetailsId = passthroughModePaymentMethodId,
+                    paymentDetailsId = paymentMethodId,
                     consumerSessionClientSecret = consumerSessionClientSecret,
                     extraParams = extraConfirmationParams(paymentMethodCreateParams.toParamMap())
                 ),

--- a/paymentsheet/src/main/java/com/stripe/android/link/utils/LinkBillingDetailsUtils.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/utils/LinkBillingDetailsUtils.kt
@@ -5,8 +5,10 @@ import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.ConsumerPaymentDetails.PaymentDetails
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode
+import com.stripe.android.paymentsheet.model.toPaymentSheetBillingDetails
 
 /**
  * Returns the effective billing details, which refers to billing details that have been
@@ -106,4 +108,8 @@ private fun PaymentSheet.BillingDetails.toConsumerBillingAddress(): ConsumerPaym
         postalCode = billingAddress.postalCode,
         countryCode = billingAddress.country?.let { CountryCode.create(it) }
     )
+}
+
+internal fun PaymentMethod.BillingDetails.toConsumerBillingAddress(): ConsumerPaymentDetails.BillingAddress? {
+    return this.toPaymentSheetBillingDetails().toConsumerBillingAddress()
 }


### PR DESCRIPTION
# Summary
- Issue: we were not expanding the PM object when calling `/share`, and hence ignoring its payload (billingDetails)
- Fix: expand the PM object and populate details. 

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
