### PR TITLE
Expose image loader to library group

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
@@ -526,7 +526,8 @@ class EmbeddedPaymentElement @Inject internal constructor(
 
     @Poko
     class PaymentOptionDisplayData internal constructor(
-        private val imageLoader: suspend () -> Drawable,
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        val imageLoader: suspend () -> Drawable,
 
         /**
          * A user facing string representing the payment method; e.g. "Google Pay" or "···· 4242" for a card.

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
@@ -5,6 +5,7 @@ import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.os.Parcelable
 import androidx.activity.result.ActivityResultCaller
+import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.graphics.painter.Painter
@@ -526,7 +527,7 @@ class EmbeddedPaymentElement @Inject internal constructor(
 
     @Poko
     class PaymentOptionDisplayData internal constructor(
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         val imageLoader: suspend () -> Drawable,
 
         /**


### PR DESCRIPTION
# Summary
- Deciding to go w/ the image encoding approach for RN display data for images, for a few reasons (will document this in the RN PR)

   - Merchants get full control over styling - rounded corners, color filters, opacity, etc. If we give them a native view, they're stuck with whatever styling props we decide to expose. E.g. we'd need to expose a border radius, opacity, etc. 
   - They can drop these images into literally component, like lists, modals, custom cards, overlays. Native views would force merchants into a more limiting specific component structure.


# Motivation
- Expose image on payment option display data

# Testing
N/A