### PR TITLE
Update Embedded RowStyle constructor usage with Builder pattern

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutUI.kt
@@ -101,10 +101,10 @@ internal fun PaymentMethodVerticalLayoutUI(
         val textColor = MaterialTheme.stripeColors.onComponent
 
         val rowStyle = PaymentSheet.Appearance.Embedded.RowStyle.FloatingButton.default.run {
-            PaymentSheet.Appearance.Embedded.RowStyle.FloatingButton(
-                spacingDp = spacingDp,
-                additionalInsetsDp = StripeTheme.verticalModeRowPadding,
-            )
+            PaymentSheet.Appearance.Embedded.RowStyle.FloatingButton.Builder()
+                .spacingDp(spacingDp)
+                .additionalInsetsDp(StripeTheme.verticalModeRowPadding)
+                .build()
         }
 
         if (displayedSavedPaymentMethod != null) {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodRowCheckmarkButtonScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodRowCheckmarkButtonScreenshotTest.kt
@@ -77,24 +77,28 @@ internal class PaymentMethodRowCheckmarkButtonScreenshotTest {
 
     @Test
     fun testStyleAppearance() {
-        val style = FlatWithCheckmark(
-            separatorThicknessDp = StripeThemeDefaults.flat.separatorThickness,
-            startSeparatorInsetDp = StripeThemeDefaults.flat.separatorInsets,
-            endSeparatorInsetDp = StripeThemeDefaults.flat.separatorInsets,
-            topSeparatorEnabled = StripeThemeDefaults.flat.topSeparatorEnabled,
-            bottomSeparatorEnabled = StripeThemeDefaults.flat.bottomSeparatorEnabled,
-            checkmarkInsetDp = 20f,
-            additionalVerticalInsetsDp = 40f,
-            horizontalInsetsDp = 40f,
-            colorsLight = FlatWithCheckmark.Colors(
-                separatorColor = StripeThemeDefaults.colorsLight.componentBorder.toArgb(),
-                checkmarkColor = StripeThemeDefaults.colorsLight.materialColors.error.toArgb()
-            ),
-            colorsDark = FlatWithCheckmark.Colors(
-                separatorColor = StripeThemeDefaults.colorsDark.componentBorder.toArgb(),
-                checkmarkColor = StripeThemeDefaults.colorsDark.materialColors.error.toArgb()
+        val style = FlatWithCheckmark.Builder()
+            .separatorThicknessDp(StripeThemeDefaults.flat.separatorThickness)
+            .startSeparatorInsetDp(StripeThemeDefaults.flat.separatorInsets)
+            .endSeparatorInsetDp(StripeThemeDefaults.flat.separatorInsets)
+            .topSeparatorEnabled(StripeThemeDefaults.flat.topSeparatorEnabled)
+            .bottomSeparatorEnabled(StripeThemeDefaults.flat.bottomSeparatorEnabled)
+            .checkmarkInsetDp(20f)
+            .additionalVerticalInsetsDp(40f)
+            .horizontalInsetsDp(40f)
+            .colorsLight(
+                FlatWithCheckmark.Colors(
+                    separatorColor = StripeThemeDefaults.colorsLight.componentBorder.toArgb(),
+                    checkmarkColor = StripeThemeDefaults.colorsLight.materialColors.error.toArgb()
+                )
             )
-        )
+            .colorsDark(
+                FlatWithCheckmark.Colors(
+                    separatorColor = StripeThemeDefaults.colorsDark.componentBorder.toArgb(),
+                    checkmarkColor = StripeThemeDefaults.colorsDark.materialColors.error.toArgb()
+                )
+            )
+            .build()
 
         testPaymentMethodRowButton_Checkmark(
             appearance = PaymentSheet.Appearance.Embedded(style),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodRowFloatingButtonScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodRowFloatingButtonScreenshotTest.kt
@@ -121,10 +121,10 @@ internal class PaymentMethodRowFloatingButtonScreenshotTest {
 
     @Test
     fun testStyleAppearance() {
-        val style = FloatingButton(
-            spacingDp = StripeThemeDefaults.floating.spacing,
-            additionalInsetsDp = 40f
-        )
+        val style = FloatingButton.Builder()
+            .spacingDp(StripeThemeDefaults.floating.spacing)
+            .additionalInsetsDp(40f)
+            .build()
         testPaymentMethodRowButton_FloatingButton(
             trailingContent = {
                 TrailingContent()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodRowRadioButtonScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodRowRadioButtonScreenshotTest.kt
@@ -88,25 +88,29 @@ internal class PaymentMethodRowRadioButtonScreenshotTest {
 
     @Test
     fun testStyleAppearance() {
-        val style = FlatWithRadio(
-            separatorThicknessDp = StripeThemeDefaults.flat.separatorThickness,
-            startSeparatorInsetDp = StripeThemeDefaults.flat.separatorInsets,
-            endSeparatorInsetDp = StripeThemeDefaults.flat.separatorInsets,
-            topSeparatorEnabled = StripeThemeDefaults.flat.topSeparatorEnabled,
-            bottomSeparatorEnabled = StripeThemeDefaults.flat.bottomSeparatorEnabled,
-            additionalVerticalInsetsDp = 40f,
-            horizontalInsetsDp = 40f,
-            colorsLight = FlatWithRadio.Colors(
-                separatorColor = StripeThemeDefaults.colorsLight.componentBorder.toArgb(),
-                selectedColor = StripeThemeDefaults.colorsLight.materialColors.error.toArgb(),
-                unselectedColor = StripeThemeDefaults.colorsLight.materialColors.primary.toArgb()
-            ),
-            colorsDark = FlatWithRadio.Colors(
-                separatorColor = StripeThemeDefaults.colorsDark.componentBorder.toArgb(),
-                selectedColor = StripeThemeDefaults.colorsDark.materialColors.error.toArgb(),
-                unselectedColor = StripeThemeDefaults.colorsDark.materialColors.primary.toArgb()
+        val style = FlatWithRadio.Builder()
+            .separatorThicknessDp(StripeThemeDefaults.flat.separatorThickness)
+            .startSeparatorInsetDp(StripeThemeDefaults.flat.separatorInsets)
+            .endSeparatorInsetDp(StripeThemeDefaults.flat.separatorInsets)
+            .topSeparatorEnabled(StripeThemeDefaults.flat.topSeparatorEnabled)
+            .bottomSeparatorEnabled(StripeThemeDefaults.flat.bottomSeparatorEnabled)
+            .additionalVerticalInsetsDp(40f)
+            .horizontalInsetsDp(40f)
+            .colorsLight(
+                FlatWithRadio.Colors(
+                    separatorColor = StripeThemeDefaults.colorsLight.componentBorder.toArgb(),
+                    selectedColor = StripeThemeDefaults.colorsLight.materialColors.error.toArgb(),
+                    unselectedColor = StripeThemeDefaults.colorsLight.materialColors.primary.toArgb()
+                )
             )
-        )
+            .colorsDark(
+                FlatWithRadio.Colors(
+                    separatorColor = StripeThemeDefaults.colorsDark.componentBorder.toArgb(),
+                    selectedColor = StripeThemeDefaults.colorsDark.materialColors.error.toArgb(),
+                    unselectedColor = StripeThemeDefaults.colorsDark.materialColors.primary.toArgb()
+                )
+            )
+            .build()
 
         testPaymentMethodRowButton_RadioButton(
             trailingContent = {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
These files might lose access to internal constructors after v25 renaming. Migrate the constructor usages to builders.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
[MOBILESDK-3845](https://jira.corp.stripe.com/browse/MOBILESDK-3845)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
