### PR TITLE
Implement TermsDisplay configuration.

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,8 @@
 {
   "permissions": {
     "allow": [
-      "Bash(./gradlew:*)"
+      "Bash(./gradlew:*)",
+      "Bash(find:*)"
     ],
     "deny": []
   }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -538,6 +538,7 @@ internal class PlaygroundSettings private constructor(
                 FeatureFlags.forceEnableLinkPaymentSelectionHint,
                 listOf(PlaygroundConfigurationData.IntegrationType.LinkController)
             ),
+            TermsDisplaySettingsDefinition,
         )
 
         private val nonUiSettingDefinitions: List<PlaygroundSettingDefinition<*>> = listOf(

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/TermsDisplayDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/TermsDisplayDefinition.kt
@@ -1,0 +1,66 @@
+package com.stripe.android.paymentsheet.example.playground.settings
+
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.example.playground.PlaygroundState
+
+internal object TermsDisplaySettingsDefinition :
+    PlaygroundSettingDefinition<TermsDisplay>,
+    PlaygroundSettingDefinition.Saveable<TermsDisplay> by EnumSaveable(
+        key = "termsDisplay",
+        values = TermsDisplay.entries.toTypedArray(),
+        defaultValue = TermsDisplay.AUTOMATIC,
+    ),
+    PlaygroundSettingDefinition.Displayable<TermsDisplay> {
+    override val displayName: String = "Terms Display"
+
+    override fun createOptions(
+        configurationData: PlaygroundConfigurationData
+    ): List<PlaygroundSettingDefinition.Displayable.Option<TermsDisplay>> {
+        return TermsDisplay.entries.map { termsDisplay ->
+            option(name = termsDisplay.value, value = termsDisplay)
+        }
+    }
+
+    override fun applicable(configurationData: PlaygroundConfigurationData): Boolean {
+        return configurationData.integrationType.isPaymentFlow()
+    }
+
+    override fun configure(
+        value: TermsDisplay,
+        configurationBuilder: PaymentSheet.Configuration.Builder,
+        playgroundState: PlaygroundState.Payment,
+        configurationData: PlaygroundSettingDefinition.PaymentSheetConfigurationData
+    ) {
+        configurationBuilder.termsDisplay(value.termsDisplay)
+    }
+
+    override fun configure(
+        value: TermsDisplay,
+        configurationBuilder: EmbeddedPaymentElement.Configuration.Builder,
+        playgroundState: PlaygroundState.Payment,
+        configurationData: PlaygroundSettingDefinition.EmbeddedConfigurationData
+    ) {
+        configurationBuilder.termsDisplay(value.termsDisplay)
+    }
+}
+
+enum class TermsDisplay(
+    override val value: String,
+    val termsDisplay: Map<PaymentMethod.Type, PaymentSheet.TermsDisplay>
+) : ValueEnum {
+    AUTOMATIC("Auto", emptyMap()),
+    NEVER_CARDS("Never Cards", mapOf(PaymentMethod.Type.Card to PaymentSheet.TermsDisplay.NEVER)),
+    NEVER_US_BANK("Never US Bank", mapOf(PaymentMethod.Type.USBankAccount to PaymentSheet.TermsDisplay.NEVER)),
+    NEVER_CASH_APP("Never CashApp", mapOf(PaymentMethod.Type.CashAppPay to PaymentSheet.TermsDisplay.NEVER)),
+    NEVER_CASH_AUTO_OTHERS(
+        "Never CashApp Auto Others",
+        mapOf(
+            PaymentMethod.Type.CashAppPay to PaymentSheet.TermsDisplay.NEVER,
+            PaymentMethod.Type.Card to PaymentSheet.TermsDisplay.AUTOMATIC,
+            PaymentMethod.Type.Klarna to PaymentSheet.TermsDisplay.AUTOMATIC,
+            PaymentMethod.Type.AmazonPay to PaymentSheet.TermsDisplay.AUTOMATIC,
+        )
+    ),
+}

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -1018,6 +1018,7 @@ public final class com/stripe/android/paymentelement/EmbeddedPaymentElement$Conf
 	public final fun preferredNetworks (Ljava/util/List;)Lcom/stripe/android/paymentelement/EmbeddedPaymentElement$Configuration$Builder;
 	public final fun primaryButtonLabel (Ljava/lang/String;)Lcom/stripe/android/paymentelement/EmbeddedPaymentElement$Configuration$Builder;
 	public final fun shippingDetails (Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;)Lcom/stripe/android/paymentelement/EmbeddedPaymentElement$Configuration$Builder;
+	public final fun termsDisplay (Ljava/util/Map;)Lcom/stripe/android/paymentelement/EmbeddedPaymentElement$Configuration$Builder;
 }
 
 public final class com/stripe/android/paymentelement/EmbeddedPaymentElement$Configuration$Creator : android/os/Parcelable$Creator {
@@ -2137,6 +2138,7 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$Configuration$Bu
 	public final fun primaryButtonLabel (Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun shippingDetails (Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun shopPayConfiguration (Lcom/stripe/android/paymentsheet/PaymentSheet$ShopPayConfiguration;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
+	public final fun termsDisplay (Ljava/util/Map;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun walletButtons (Lcom/stripe/android/paymentsheet/PaymentSheet$WalletButtonsConfiguration;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 }
 
@@ -2915,6 +2917,14 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$Spacing$Creator 
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentSheet$Spacing;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/PaymentSheet$TermsDisplay : java/lang/Enum {
+	public static final field AUTOMATIC Lcom/stripe/android/paymentsheet/PaymentSheet$TermsDisplay;
+	public static final field NEVER Lcom/stripe/android/paymentsheet/PaymentSheet$TermsDisplay;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentSheet$TermsDisplay;
+	public static fun values ()[Lcom/stripe/android/paymentsheet/PaymentSheet$TermsDisplay;
 }
 
 public final class com/stripe/android/paymentsheet/PaymentSheet$Typography : android/os/Parcelable {

--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -6,6 +6,7 @@
     <ID>ConstructorParameterNaming:EmbeddedPaymentElement.kt$EmbeddedPaymentElement.PaymentOptionDisplayData$private val _shippingDetails: AddressDetails?</ID>
     <ID>ConstructorParameterNaming:PaymentOption.kt$PaymentOption$private val _labels: Labels</ID>
     <ID>ConstructorParameterNaming:PaymentOption.kt$PaymentOption$private val _shippingDetails: AddressDetails?</ID>
+    <ID>CyclomaticComplexMethod:CardDefinition.kt$CardUiDefinitionFactory$override fun createFormElements( metadata: PaymentMethodMetadata, arguments: UiDefinitionFactory.Arguments, ): List&lt;FormElement></ID>
     <ID>CyclomaticComplexMethod:CustomerSheetViewModel.kt$CustomerSheetViewModel$fun handleViewAction(viewAction: CustomerSheetViewAction)</ID>
     <ID>CyclomaticComplexMethod:PlaceholderHelper.kt$PlaceholderHelper$@VisibleForTesting internal fun specForPlaceholderField( field: PlaceholderField, placeholderOverrideList: List&lt;IdentifierSpec>, requiresMandate: Boolean, configuration: PaymentSheet.BillingDetailsCollectionConfiguration, )</ID>
     <ID>CyclomaticComplexMethod:TransformBankIconCodeToBankIcon.kt$internal fun transformBankIconCodeToBankIcon( iconCode: String?, fallbackIcon: Int, ): Int</ID>

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedFormPage.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedFormPage.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextReplacement
 import com.stripe.android.paymentelement.embedded.form.EMBEDDED_FORM_ACTIVITY_PRIMARY_BUTTON
 import com.stripe.android.paymentsheet.ui.FORM_ELEMENT_TEST_TAG
+import com.stripe.android.ui.core.elements.MANDATE_TEST_TAG
 import kotlin.time.Duration.Companion.seconds
 
 internal class EmbeddedFormPage(
@@ -87,5 +88,19 @@ internal class EmbeddedFormPage(
         }
 
         composeTestRule.waitForIdle()
+    }
+
+    fun assertMandateIsShown() {
+        waitUntilVisible()
+
+        composeTestRule.onNodeWithTag(MANDATE_TEST_TAG)
+            .assertExists()
+    }
+
+    fun assertMandateIsMissing() {
+        waitUntilVisible()
+
+        composeTestRule.onNodeWithTag(MANDATE_TEST_TAG)
+            .assertDoesNotExist()
     }
 }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetPage.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetPage.kt
@@ -38,6 +38,7 @@ import com.stripe.android.paymentsheet.ui.TEST_TAG_LIST
 import com.stripe.android.paymentsheet.ui.TEST_TAG_MODIFY_BADGE
 import com.stripe.android.paymentsheet.verticalmode.TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON
 import com.stripe.android.paymentsheet.verticalmode.TEST_TAG_PAYMENT_METHOD_VERTICAL_LAYOUT
+import com.stripe.android.ui.core.elements.MANDATE_TEST_TAG
 import com.stripe.android.ui.core.elements.SAVE_FOR_FUTURE_CHECKBOX_TEST_TAG
 import com.stripe.android.ui.core.elements.SET_AS_DEFAULT_PAYMENT_METHOD_TEST_TAG
 import com.stripe.android.uicore.elements.DROPDOWN_MENU_CLICKABLE_TEST_TAG
@@ -464,5 +465,13 @@ internal class PaymentSheetPage(
         composeTestRule
             .onNode(hasText(mandateText))
             .assertExists()
+    }
+
+    fun assertMandateIsMissing() {
+        waitUntilVisible()
+        assertIsOnFormPage()
+
+        composeTestRule.onNodeWithTag(MANDATE_TEST_TAG)
+            .assertDoesNotExist()
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodDefinition.kt
@@ -10,6 +10,9 @@ internal interface PaymentMethodDefinition {
 
     val supportedAsSavedPaymentMethod: Boolean
 
+    val supportsTermDisplayConfiguration: Boolean
+        get() = false
+
     fun requiresMandate(metadata: PaymentMethodMetadata): Boolean
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -68,13 +68,18 @@ internal data class PaymentMethodMetadata(
     val financialConnectionsAvailability: FinancialConnectionsAvailability?,
     val cardBrandFilter: CardBrandFilter,
     val elementsSessionId: String,
-    val shopPayConfiguration: PaymentSheet.ShopPayConfiguration?
+    val shopPayConfiguration: PaymentSheet.ShopPayConfiguration?,
+    val termsDisplay: Map<PaymentMethod.Type, PaymentSheet.TermsDisplay>,
 ) : Parcelable {
     fun hasIntentToSetup(code: PaymentMethodCode): Boolean {
         return when (stripeIntent) {
             is PaymentIntent -> stripeIntent.isSetupFutureUsageSet(code)
             is SetupIntent -> true
         }
+    }
+
+    fun mandateAllowed(paymentMethodType: PaymentMethod.Type): Boolean {
+        return termsDisplay[paymentMethodType] != PaymentSheet.TermsDisplay.NEVER
     }
 
     fun requiresMandate(paymentMethodCode: String): Boolean {
@@ -324,7 +329,8 @@ internal data class PaymentMethodMetadata(
                 cardBrandFilter = PaymentSheetCardBrandFilter(configuration.cardBrandAcceptance),
                 financialConnectionsAvailability = GetFinancialConnectionsAvailability(elementsSession),
                 elementsSessionId = elementsSession.elementsSessionId,
-                shopPayConfiguration = configuration.shopPayConfiguration
+                shopPayConfiguration = configuration.shopPayConfiguration,
+                termsDisplay = configuration.termsDisplay,
             )
         }
 
@@ -369,7 +375,8 @@ internal data class PaymentMethodMetadata(
                 cardBrandFilter = PaymentSheetCardBrandFilter(configuration.cardBrandAcceptance),
                 elementsSessionId = elementsSession.elementsSessionId,
                 financialConnectionsAvailability = GetFinancialConnectionsAvailability(elementsSession),
-                shopPayConfiguration = null
+                shopPayConfiguration = null,
+                termsDisplay = emptyMap(),
             )
         }
 
@@ -415,7 +422,8 @@ internal data class PaymentMethodMetadata(
                 cardBrandFilter = configuration.cardBrandFilter,
                 elementsSessionId = configuration.elementsSessionId,
                 financialConnectionsAvailability = GetFinancialConnectionsAvailability(elementsSession = null),
-                shopPayConfiguration = null
+                shopPayConfiguration = null,
+                termsDisplay = emptyMap(),
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AmazonPayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AmazonPayDefinition.kt
@@ -18,11 +18,15 @@ internal object AmazonPayDefinition : PaymentMethodDefinition {
 
     override val supportedAsSavedPaymentMethod: Boolean = false
 
+    override val supportsTermDisplayConfiguration: Boolean = true
+
     override fun requirementsToBeUsedAsNewPaymentMethod(
         hasIntentToSetup: Boolean
     ): Set<AddPaymentMethodRequirement> = setOf()
 
-    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = metadata.hasIntentToSetup(type.code)
+    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean {
+        return metadata.hasIntentToSetup(type.code) && metadata.mandateAllowed(type)
+    }
 
     override fun uiDefinitionFactory(): UiDefinitionFactory = AmazonPayUiDefinitionFactory
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -50,6 +50,8 @@ internal object CardDefinition : PaymentMethodDefinition {
 
     override val supportedAsSavedPaymentMethod: Boolean = true
 
+    override val supportsTermDisplayConfiguration: Boolean = true
+
     override fun requirementsToBeUsedAsNewPaymentMethod(
         hasIntentToSetup: Boolean
     ): Set<AddPaymentMethodRequirement> = setOf()
@@ -146,7 +148,8 @@ private object CardUiDefinitionFactory : UiDefinitionFactory.Simple {
                 null
             }
 
-            if (linkSignupOptInEnabled && signupMode != null) {
+            val mandateAllowed = metadata.mandateAllowed(CardDefinition.type)
+            if (linkSignupOptInEnabled && signupMode != null && mandateAllowed) {
                 add(
                     CombinedLinkMandateElement(
                         identifier = IdentifierSpec.Generic("card_mandate"),
@@ -156,7 +159,7 @@ private object CardUiDefinitionFactory : UiDefinitionFactory.Simple {
                         linkSignupStateFlow = arguments.linkInlineHandler?.linkInlineState ?: stateFlowOf(null)
                     )
                 )
-            } else if (metadata.hasIntentToSetup(CardDefinition.type.code)) {
+            } else if (metadata.hasIntentToSetup(CardDefinition.type.code) && mandateAllowed) {
                 add(
                     MandateTextElement(
                         identifier = IdentifierSpec.Generic("card_mandate"),

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CashAppPayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CashAppPayDefinition.kt
@@ -17,11 +17,15 @@ internal object CashAppPayDefinition : PaymentMethodDefinition {
 
     override val supportedAsSavedPaymentMethod: Boolean = false
 
+    override val supportsTermDisplayConfiguration: Boolean = true
+
     override fun requirementsToBeUsedAsNewPaymentMethod(
         hasIntentToSetup: Boolean
     ): Set<AddPaymentMethodRequirement> = setOf()
 
-    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = metadata.hasIntentToSetup(type.code)
+    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean {
+        return metadata.hasIntentToSetup(type.code) && metadata.mandateAllowed(type)
+    }
 
     override fun uiDefinitionFactory(): UiDefinitionFactory = CashAppPayUiDefinitionFactory
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KlarnaDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KlarnaDefinition.kt
@@ -18,11 +18,15 @@ internal object KlarnaDefinition : PaymentMethodDefinition {
 
     override val supportedAsSavedPaymentMethod: Boolean = false
 
+    override val supportsTermDisplayConfiguration: Boolean = true
+
     override fun requirementsToBeUsedAsNewPaymentMethod(
         hasIntentToSetup: Boolean
     ): Set<AddPaymentMethodRequirement> = setOf()
 
-    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = metadata.hasIntentToSetup(type.code)
+    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean {
+        return metadata.hasIntentToSetup(type.code) && metadata.mandateAllowed(type)
+    }
 
     override fun uiDefinitionFactory(): UiDefinitionFactory = KlarnaUiDefinitionFactory
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/PayPalDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/PayPalDefinition.kt
@@ -18,11 +18,15 @@ internal object PayPalDefinition : PaymentMethodDefinition {
 
     override val supportedAsSavedPaymentMethod: Boolean = false
 
+    override val supportsTermDisplayConfiguration: Boolean = true
+
     override fun requirementsToBeUsedAsNewPaymentMethod(
         hasIntentToSetup: Boolean
     ): Set<AddPaymentMethodRequirement> = setOf()
 
-    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = metadata.hasIntentToSetup(type.code)
+    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean {
+        return metadata.hasIntentToSetup(type.code) && metadata.mandateAllowed(type)
+    }
 
     override fun uiDefinitionFactory(): UiDefinitionFactory = PayPalUiDefinitionFactory
 }
@@ -44,7 +48,7 @@ private object PayPalUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDat
         sharedDataSpec: SharedDataSpec,
         transformSpecToElements: TransformSpecToElements
     ): List<FormElement> {
-        val localLayoutSpecs: List<FormItemSpec> = if (metadata.hasIntentToSetup(PayPalDefinition.type.code)) {
+        val localLayoutSpecs: List<FormItemSpec> = if (PayPalDefinition.requiresMandate(metadata)) {
             listOf(MandateTextSpec(stringResId = R.string.stripe_paypal_mandate))
         } else {
             emptyList()

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/RevolutPayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/RevolutPayDefinition.kt
@@ -18,11 +18,15 @@ internal object RevolutPayDefinition : PaymentMethodDefinition {
 
     override val supportedAsSavedPaymentMethod: Boolean = false
 
+    override val supportsTermDisplayConfiguration: Boolean = true
+
     override fun requirementsToBeUsedAsNewPaymentMethod(
         hasIntentToSetup: Boolean
     ): Set<AddPaymentMethodRequirement> = setOf()
 
-    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = metadata.hasIntentToSetup(type.code)
+    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean {
+        return metadata.hasIntentToSetup(type.code) && metadata.mandateAllowed(type)
+    }
 
     override fun uiDefinitionFactory(): UiDefinitionFactory = RevolutPayUiDefinitionFactory
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SatispayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SatispayDefinition.kt
@@ -17,11 +17,15 @@ internal object SatispayDefinition : PaymentMethodDefinition {
 
     override val supportedAsSavedPaymentMethod: Boolean = false
 
+    override val supportsTermDisplayConfiguration: Boolean = true
+
     override fun requirementsToBeUsedAsNewPaymentMethod(
         hasIntentToSetup: Boolean
     ): Set<AddPaymentMethodRequirement> = setOf()
 
-    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = metadata.hasIntentToSetup(type.code)
+    override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean {
+        return metadata.hasIntentToSetup(type.code) && metadata.mandateAllowed(type)
+    }
 
     override fun uiDefinitionFactory(): UiDefinitionFactory = SatispayUiDefinitionFactory
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
@@ -19,6 +19,7 @@ import com.stripe.android.common.configuration.ConfigurationDefaults
 import com.stripe.android.common.ui.DelegateDrawable
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.content.EmbeddedConfigurationCoordinator
@@ -32,6 +33,7 @@ import com.stripe.android.paymentelement.embedded.content.PaymentOptionDisplayDa
 import com.stripe.android.paymentsheet.CreateIntentCallback
 import com.stripe.android.paymentsheet.ExternalPaymentMethodConfirmHandler
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.PaymentSheet.TermsDisplay
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.paymentsheet.utils.applicationIsTaskOwner
@@ -235,6 +237,7 @@ class EmbeddedPaymentElement @Inject internal constructor(
         internal val embeddedViewDisplaysMandateText: Boolean,
         internal val link: PaymentSheet.LinkConfiguration,
         internal val formSheetAction: FormSheetAction,
+        internal val termsDisplay: Map<PaymentMethod.Type, TermsDisplay> = emptyMap(),
     ) : Parcelable {
         @Suppress("TooManyFunctions")
         class Builder(
@@ -266,6 +269,7 @@ class EmbeddedPaymentElement @Inject internal constructor(
                 ConfigurationDefaults.customPaymentMethods
             private var link: PaymentSheet.LinkConfiguration = ConfigurationDefaults.link
             private var formSheetAction: FormSheetAction = FormSheetAction.Continue
+            private var termsDisplay: Map<PaymentMethod.Type, TermsDisplay> = emptyMap()
 
             /**
              * If set, the customer can select a previously saved payment method.
@@ -464,6 +468,16 @@ class EmbeddedPaymentElement @Inject internal constructor(
                 this.formSheetAction = formSheetAction
             }
 
+            /**
+             * A map for specifying when legal agreements are displayed for each payment method type.
+             * If the payment method is not specified in the list, the TermsDisplay value will default to automatic.
+             *
+             * Valid payment method types include: amazon_pay, card, cashapp, klarna, paypal, revolut_pay, satispay.
+             */
+            fun termsDisplay(termsDisplay: Map<PaymentMethod.Type, TermsDisplay>) = apply {
+                this.termsDisplay = termsDisplay
+            }
+
             fun build() = Configuration(
                 merchantDisplayName = merchantDisplayName,
                 customer = customer,
@@ -484,6 +498,7 @@ class EmbeddedPaymentElement @Inject internal constructor(
                 embeddedViewDisplaysMandateText = embeddedViewDisplaysMandateText,
                 link = link,
                 formSheetAction = formSheetAction,
+                termsDisplay = termsDisplay,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -656,6 +656,19 @@ class PaymentSheet internal constructor(
         }
     }
 
+    /**
+     * [TermsDisplay] controls how mandates and legal agreements are displayed.
+     * Use [TermsDisplay.NEVER] to never display legal agreements.
+     * The default setting is [TermsDisplay.AUTOMATIC], which causes legal agreements to be shown only when necessary.
+     */
+    enum class TermsDisplay {
+        /** Show legal agreements only when necessary */
+        AUTOMATIC,
+
+        /** Never show legal agreements */
+        NEVER
+    }
+
     /** Configuration for [PaymentSheet] **/
     @Parcelize
     data class Configuration internal constructor(
@@ -791,6 +804,8 @@ class PaymentSheet internal constructor(
         internal val shopPayConfiguration: ShopPayConfiguration? = ConfigurationDefaults.shopPayConfiguration,
 
         internal val googlePlacesApiKey: String? = ConfigurationDefaults.googlePlacesApiKey,
+
+        internal val termsDisplay: Map<PaymentMethod.Type, TermsDisplay> = emptyMap(),
     ) : Parcelable {
 
         @JvmOverloads
@@ -946,6 +961,7 @@ class PaymentSheet internal constructor(
             private var walletButtons: WalletButtonsConfiguration = ConfigurationDefaults.walletButtons
             private var shopPayConfiguration: ShopPayConfiguration? = ConfigurationDefaults.shopPayConfiguration
             private var googlePlacesApiKey: String? = ConfigurationDefaults.googlePlacesApiKey
+            private var termsDisplay: Map<PaymentMethod.Type, TermsDisplay> = emptyMap()
 
             private var customPaymentMethods: List<CustomPaymentMethod> =
                 ConfigurationDefaults.customPaymentMethods
@@ -1102,6 +1118,16 @@ class PaymentSheet internal constructor(
                 this.googlePlacesApiKey = googlePlacesApiKey
             }
 
+            /**
+             * A map for specifying when legal agreements are displayed for each payment method type.
+             * If the payment method is not specified in the list, the TermsDisplay value will default to automatic.
+             *
+             * Valid payment method types include: amazon_pay, card, cashapp, klarna, paypal, revolut_pay, satispay.
+             */
+            fun termsDisplay(termsDisplay: Map<PaymentMethod.Type, TermsDisplay>) = apply {
+                this.termsDisplay = termsDisplay
+            }
+
             fun build() = Configuration(
                 merchantDisplayName = merchantDisplayName,
                 customer = customer,
@@ -1125,6 +1151,7 @@ class PaymentSheet internal constructor(
                 walletButtons = walletButtons,
                 shopPayConfiguration = shopPayConfiguration,
                 googlePlacesApiKey = googlePlacesApiKey,
+                termsDisplay = termsDisplay,
             )
         }
 

--- a/paymentsheet/src/test/java/com/stripe/android/common/model/CommonConfigurationFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/model/CommonConfigurationFactory.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.common.model
 
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 
@@ -24,6 +25,7 @@ internal object CommonConfigurationFactory {
         link: PaymentSheet.LinkConfiguration = PaymentSheet.LinkConfiguration(),
         shopPayConfiguration: PaymentSheet.ShopPayConfiguration? = null,
         googlePlacesApiKey: String? = null,
+        termsDisplay: Map<PaymentMethod.Type, PaymentSheet.TermsDisplay> = emptyMap(),
     ): CommonConfiguration = CommonConfiguration(
         merchantDisplayName = merchantDisplayName,
         customer = customer,
@@ -42,5 +44,6 @@ internal object CommonConfigurationFactory {
         link = link,
         shopPayConfiguration = shopPayConfiguration,
         googlePlacesApiKey = googlePlacesApiKey,
+        termsDisplay = termsDisplay,
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/common/model/CommonConfigurationTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/model/CommonConfigurationTest.kt
@@ -1,7 +1,9 @@
 package com.stripe.android.common.model
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet
+import org.junit.Assert.fail
 import org.junit.Test
 
 internal class CommonConfigurationTest {
@@ -41,5 +43,45 @@ internal class CommonConfigurationTest {
         )
 
         assertThat(configuration.containsVolatileDifferences(configWithBillingConfigChanges)).isTrue()
+    }
+
+    @Test
+    fun `validateTermsDisplay throws exception for unsupported payment method type`() {
+        val termsDisplay = mapOf(
+            PaymentMethod.Type.Affirm to PaymentSheet.TermsDisplay.NEVER
+        )
+
+        val configuration = CommonConfigurationFactory.create(termsDisplay = termsDisplay)
+
+        try {
+            configuration.validate(isLiveMode = true)
+            fail("Expected IllegalArgumentException to be thrown")
+        } catch (e: IllegalArgumentException) {
+            assertThat(e.message).isEqualTo("affirm does not support terms display configuration.")
+        }
+    }
+
+    @Test
+    fun `validateTermsDisplay works with empty termsDisplay map`() {
+        val configuration = CommonConfigurationFactory.create(termsDisplay = emptyMap())
+
+        configuration.validate(isLiveMode = true)
+    }
+
+    @Test
+    fun `validateTermsDisplay does not throw an exception for both TermsDisplay values`() {
+        val termsDisplayAutomatic = mapOf(
+            PaymentMethod.Type.Card to PaymentSheet.TermsDisplay.AUTOMATIC
+        )
+
+        val termsDisplayNever = mapOf(
+            PaymentMethod.Type.CashAppPay to PaymentSheet.TermsDisplay.NEVER
+        )
+
+        val configAutomatic = CommonConfigurationFactory.create(termsDisplay = termsDisplayAutomatic)
+        val configNever = CommonConfigurationFactory.create(termsDisplay = termsDisplayNever)
+
+        configAutomatic.validate(isLiveMode = true)
+        configNever.validate(isLiveMode = true)
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
@@ -5,6 +5,7 @@ import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.common.model.SHOP_PAY_CONFIGURATION
 import com.stripe.android.model.LinkMode
 import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -46,7 +47,8 @@ internal object PaymentMethodMetadataFactory {
         financialConnectionsAvailability: FinancialConnectionsAvailability? = FinancialConnectionsAvailability.Lite,
         customerMetadataPermissions: CustomerMetadata.Permissions =
             PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA_PERMISSIONS,
-        shopPayConfiguration: PaymentSheet.ShopPayConfiguration? = SHOP_PAY_CONFIGURATION
+        shopPayConfiguration: PaymentSheet.ShopPayConfiguration? = SHOP_PAY_CONFIGURATION,
+        termsDisplay: Map<PaymentMethod.Type, PaymentSheet.TermsDisplay> = emptyMap(),
     ): PaymentMethodMetadata {
         return PaymentMethodMetadata(
             stripeIntent = stripeIntent,
@@ -77,7 +79,8 @@ internal object PaymentMethodMetadataFactory {
             paymentMethodIncentive = paymentMethodIncentive,
             elementsSessionId = elementsSessionId,
             financialConnectionsAvailability = financialConnectionsAvailability,
-            shopPayConfiguration = shopPayConfiguration
+            shopPayConfiguration = shopPayConfiguration,
+            termsDisplay = termsDisplay,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -1148,7 +1148,8 @@ internal class PaymentMethodMetadataTest {
             paymentMethodIncentive = null,
             elementsSessionId = "session_1234",
             financialConnectionsAvailability = FinancialConnectionsAvailability.Full,
-            shopPayConfiguration = null
+            shopPayConfiguration = null,
+            termsDisplay = emptyMap(),
         )
 
         assertThat(metadata).isEqualTo(expectedMetadata)
@@ -1221,7 +1222,8 @@ internal class PaymentMethodMetadataTest {
             cardBrandFilter = PaymentSheetCardBrandFilter(cardBrandAcceptance),
             paymentMethodIncentive = null,
             elementsSessionId = "session_1234",
-            shopPayConfiguration = null
+            shopPayConfiguration = null,
+            termsDisplay = emptyMap(),
         )
         assertThat(metadata).isEqualTo(expectedMetadata)
     }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinitionTest.kt
@@ -11,6 +11,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.formElements
 import com.stripe.android.lpmfoundations.paymentmethod.link.LinkFormElement
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.model.SetupIntentFixtures
@@ -349,6 +350,68 @@ class CardDefinitionTest {
         assertThat(cardBillingAddressElements).hasSize(1)
         assertThat(cardBillingAddressElements.firstOrNull()?.sectionFieldErrorController())
             .isInstanceOf<AutocompleteAddressController>()
+    }
+
+    @Test
+    fun `createFormElements includes mandate when termsDisplay is AUTOMATIC`() {
+        val termsDisplay = mapOf(
+            PaymentMethod.Type.Card to PaymentSheet.TermsDisplay.AUTOMATIC
+        )
+        val metadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
+            termsDisplay = termsDisplay
+        )
+
+        val formElements = CardDefinition.formElements(
+            metadata,
+            linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
+        )
+
+        // Should include card_details, billing section, and mandate
+        assertThat(formElements).hasSize(3)
+        assertThat(formElements[0].identifier.v1).isEqualTo("card_details")
+        assertThat(formElements[1].identifier.v1).isEqualTo("credit_billing_section")
+        testStaticMandateElement(metadata, formElements[2])
+    }
+
+    @Test
+    fun `createFormElements excludes mandate when termsDisplay is NEVER`() {
+        val termsDisplay = mapOf(
+            PaymentMethod.Type.Card to PaymentSheet.TermsDisplay.NEVER
+        )
+        val metadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
+            termsDisplay = termsDisplay
+        )
+
+        val formElements = CardDefinition.formElements(
+            metadata,
+            linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
+        )
+
+        // Should only include card_details and billing section, no mandate
+        assertThat(formElements).hasSize(2)
+        assertThat(formElements[0].identifier.v1).isEqualTo("card_details")
+        assertThat(formElements[1].identifier.v1).isEqualTo("credit_billing_section")
+    }
+
+    @Test
+    fun `createFormElements includes mandate by default when termsDisplay not specified`() {
+        val metadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
+            termsDisplay = emptyMap(), // No terms display specified
+        )
+
+        val formElements = CardDefinition.formElements(
+            metadata,
+            linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
+        )
+
+        // Should include card_details, billing section, and mandate by default
+        assertThat(formElements).hasSize(3)
+        assertThat(formElements[0].identifier.v1).isEqualTo("card_details")
+        assertThat(formElements[1].identifier.v1).isEqualTo("credit_billing_section")
+        testStaticMandateElement(metadata, formElements[2])
     }
 
     private fun createLinkConfiguration(): LinkConfiguration {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Adds a new configuration option (`termsDisplay`) that allows merchants to hide mandates for specific payment methods.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-3892

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
