### PR TITLE
Always log Link AB test exposures

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -273,15 +273,11 @@ internal class DefaultPaymentElementLoader @Inject constructor(
             state = state
         )
 
-        // Only log Link AB Test if Link is enabled
-        val linkEnabled = state.paymentMethodMetadata.linkState != null
-        if (linkEnabled) {
-            logLinkHoldbackExperiment(
-                elementsSession = elementsSession,
-                state = state,
-                experimentAssignment = ElementsSession.ExperimentAssignment.LINK_AB_TEST
-            )
-        }
+        logLinkHoldbackExperiment(
+            elementsSession = elementsSession,
+            state = state,
+            experimentAssignment = ElementsSession.ExperimentAssignment.LINK_AB_TEST
+        )
     }
 
     private suspend fun retrieveElementsSession(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -3190,7 +3190,7 @@ internal class DefaultPaymentElementLoaderTest {
     }
 
     @Test
-    fun `Just Link holdback experiment is triggered when loading PaymentSheet and Link unavailable`() = runTest {
+    fun `Both Link holdback experiments are triggered when loading PaymentSheet when Link is unavailable`() = runTest {
         val logLinkHoldbackExperiment = FakeLogLinkHoldbackExperiment()
 
         val loader = createPaymentElementLoader(
@@ -3208,13 +3208,14 @@ internal class DefaultPaymentElementLoaderTest {
             ),
         )
 
-        val item = logLinkHoldbackExperiment.calls.awaitItem()
-        assertThat(item.experiment).isEqualTo(ElementsSession.ExperimentAssignment.LINK_GLOBAL_HOLD_BACK)
-        logLinkHoldbackExperiment.calls.expectNoEvents()
+        val globalHoldback = logLinkHoldbackExperiment.calls.awaitItem()
+        assertThat(globalHoldback.experiment).isEqualTo(ElementsSession.ExperimentAssignment.LINK_GLOBAL_HOLD_BACK)
+        val abTest = logLinkHoldbackExperiment.calls.awaitItem()
+        assertThat(abTest.experiment).isEqualTo(ElementsSession.ExperimentAssignment.LINK_AB_TEST)
     }
 
     @Test
-    fun `Both Link holdback experiments are triggered when loading PaymentSheet`() = runTest {
+    fun `Both Link holdback experiments are triggered when loading PaymentSheet when Link is available`() = runTest {
         val logLinkHoldbackExperiment = FakeLogLinkHoldbackExperiment()
 
         val loader = createPaymentElementLoader(


### PR DESCRIPTION
# Summary

Always log Link AB test exposures, instead of only when Link is enabled.

# Motivation

https://stripe.slack.com/archives/C08P60QCL1W/p1754362038470109

# Testing

Unit tests updated

# Changelog

N/a