### PR TITLE
Call the result callback when the form sheet is cancelled as well.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
@@ -77,6 +77,10 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
                 } else {
                     result.selection?.let { rowSelectionImmediateActionHandler.invoke() }
                 }
+            } else if (result is FormResult.Cancelled) {
+                embeddedResultCallbackHelper.setResult(
+                    EmbeddedPaymentElement.Result.Canceled()
+                )
             }
         }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
@@ -212,7 +212,8 @@ internal class DefaultEmbeddedSheetLauncherTest {
         assertThat(selectionHolder.selection.value).isEqualTo(null)
         assertThat(sheetStateHolder.sheetIsOpen).isFalse()
         assertThat(selectionHolder.temporarySelection.value).isNull()
-        callbackHelper.callbackTurbine.expectNoEvents()
+        assertThat(callbackHelper.callbackTurbine.awaitItem())
+            .isInstanceOf<EmbeddedPaymentElement.Result.Canceled>()
     }
 
     @Test
@@ -226,6 +227,8 @@ internal class DefaultEmbeddedSheetLauncherTest {
             val callback = formRegisterCall.callback.asCallbackFor<FormResult>()
 
             callback.onActivityResult(result)
+            assertThat(callbackHelper.callbackTurbine.awaitItem())
+                .isInstanceOf<EmbeddedPaymentElement.Result.Canceled>()
         }
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
The behavior of not calling the result callback was confusing. This gives the merchant more information about what the user is doing.
