### PR TITLE
[Link] Do not start with add payment method after relaunching.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
@@ -345,10 +345,12 @@ internal class LinkActivityViewModel @Inject constructor(
         return ScreenState.FullScreen(
             initialDestination = when (accountStatus) {
                 AccountStatus.Verified -> {
-                    if (linkAccount?.completedSignup == true) {
+                    if (linkAccount?.completedSignup == true && linkLaunchMode.selectedPayment() == null) {
                         // We just completed signup, but haven't added a payment method yet.
                         LinkScreen.PaymentMethod
                     } else {
+                        // We have a verified account, or we're relaunching after signing up and adding a payment,
+                        // then show the wallet.
                         LinkScreen.Wallet
                     }
                 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkLaunchMode.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkLaunchMode.kt
@@ -52,4 +52,11 @@ internal sealed interface LinkLaunchMode : Parcelable {
     data class Authentication(
         val existingOnly: Boolean = false,
     ) : LinkLaunchMode
+
+    fun selectedPayment(): ConsumerPaymentDetails.PaymentDetails? = when (this) {
+        is Authentication -> null
+        is Full -> null
+        is Confirmation -> selectedPayment.details
+        is PaymentMethodSelection -> selectedPayment
+    }
 }


### PR DESCRIPTION
# Summary

- User signs up to Link and adds a PM
- Then launches Link again
- **Before**: we’d show add payment method again, because consumer just signed up.
- **Now**: we show the wallet if the user selected a PM previously.

[record_bug.webm](https://github.com/user-attachments/assets/38215b0e-a9b5-42dd-aec7-8c6eac086d68)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
