### PR TITLE
[Link] Add `ExpressLaunchMode`.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivity.kt
@@ -51,6 +51,7 @@ internal class LinkActivity : ComponentActivity() {
             vm.handleResult(result)
         }
 
+        vm.launchWebFlow = ::launchWebFlow
         lifecycle.addObserver(vm)
         observeBackPress()
 
@@ -63,12 +64,6 @@ internal class LinkActivity : ComponentActivity() {
                 vm.result.collect { result ->
                     bottomSheetState.hide()
                     dismissWithResult(result)
-                }
-            }
-
-            LaunchedEffect(Unit) {
-                vm.launchWebFlow.collect { configuration ->
-                    launchWebFlow(configuration)
                 }
             }
 
@@ -109,6 +104,7 @@ internal class LinkActivity : ComponentActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
+        viewModel?.unregisterActivity()
     }
 
     override fun finish() {

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivity.kt
@@ -120,7 +120,7 @@ internal class LinkActivity : ComponentActivity() {
         webLauncher?.launch(
             LinkActivityContract.Args(
                 configuration = configuration,
-                startWithVerificationDialog = false,
+                linkExpressMode = LinkExpressMode.DISABLED,
                 linkAccountInfo = LinkAccountUpdate.Value(
                     account = null,
                     lastUpdateReason = null

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityContract.kt
@@ -37,7 +37,7 @@ internal class LinkActivityContract @Inject internal constructor(
 
     data class Args internal constructor(
         internal val configuration: LinkConfiguration,
-        internal val startWithVerificationDialog: Boolean,
+        internal val linkExpressMode: LinkExpressMode,
         internal val linkAccountInfo: LinkAccountUpdate.Value,
         internal val launchMode: LinkLaunchMode
     )

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
@@ -245,7 +245,6 @@ internal class LinkActivityViewModel @Inject constructor(
                     LinkExpressMode.ENABLED -> moveToWeb(attestationCheckResult.error)
                     LinkExpressMode.ENABLED_NO_WEB_FALLBACK -> updateScreenState()
                 }
-
             }
             LinkAttestationCheck.Result.Successful -> {
                 updateScreenState()
@@ -255,7 +254,6 @@ internal class LinkActivityViewModel @Inject constructor(
                 handleAccountError()
             }
         }
-
     }
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
@@ -383,7 +383,7 @@ internal class LinkControllerInteractor @Inject constructor(
                 launcher.launch(
                     LinkActivityContract.Args(
                         configuration = configuration,
-                        startWithVerificationDialog = true,
+                        linkExpressMode = LinkExpressMode.ENABLED,
                         linkAccountInfo = linkAccountHolder.linkAccountInfo.value,
                         launchMode = launchMode,
                     )

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkExpressMode.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkExpressMode.kt
@@ -1,0 +1,21 @@
+package com.stripe.android.link
+
+/**
+ * Enum representing the different modes for Link Express functionality.
+ */
+internal enum class LinkExpressMode {
+    /**
+     * Link Express is disabled.
+     */
+    DISABLED,
+
+    /**
+     * Link Express is enabled.
+     */
+    ENABLED,
+
+    /**
+     * Link Express is enabled, but on attestation failures, we don't want to fall back to Link web
+     */
+    ENABLED_NO_WEB_FALLBACK
+}

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
@@ -77,13 +77,13 @@ internal class LinkPaymentLauncher @Inject internal constructor(
         configuration: LinkConfiguration,
         linkAccountInfo: LinkAccountUpdate.Value,
         launchMode: LinkLaunchMode,
-        useLinkExpress: Boolean
+        linkExpressMode: LinkExpressMode
     ) {
         val args = LinkActivityContract.Args(
             configuration = configuration,
+            linkExpressMode = linkExpressMode,
             linkAccountInfo = linkAccountInfo,
-            launchMode = launchMode,
-            startWithVerificationDialog = useLinkExpress
+            launchMode = launchMode
         )
         linkActivityResultLauncher?.launch(args)
         analyticsHelper.onLinkLaunched()

--- a/paymentsheet/src/main/java/com/stripe/android/link/NativeLinkActivityContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/NativeLinkActivityContract.kt
@@ -24,7 +24,7 @@ internal class NativeLinkActivityContract @Inject constructor(
                 configuration = input.configuration,
                 stripeAccountId = paymentConfiguration.stripeAccountId,
                 publishableKey = paymentConfiguration.publishableKey,
-                startWithVerificationDialog = input.startWithVerificationDialog,
+                linkExpressMode = input.linkExpressMode,
                 launchMode = input.launchMode,
                 paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
                 linkAccountInfo = input.linkAccountInfo,

--- a/paymentsheet/src/main/java/com/stripe/android/link/NativeLinkArgs.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/NativeLinkArgs.kt
@@ -8,7 +8,7 @@ internal data class NativeLinkArgs(
     val configuration: LinkConfiguration,
     val publishableKey: String,
     val stripeAccountId: String?,
-    val startWithVerificationDialog: Boolean,
+    val linkExpressMode: LinkExpressMode,
     val linkAccountInfo: LinkAccountUpdate.Value,
     val paymentElementCallbackIdentifier: String,
     val launchMode: LinkLaunchMode,

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkViewModelModule.kt
@@ -3,6 +3,7 @@ package com.stripe.android.link.injection
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.link.LinkActivityViewModel
 import com.stripe.android.link.LinkConfiguration
+import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.link.LinkLaunchMode
 import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.link.account.LinkAccountManager
@@ -33,7 +34,7 @@ internal object LinkViewModelModule {
         savedStateHandle: SavedStateHandle,
         linkLaunchMode: LinkLaunchMode,
         autocompleteLauncher: DefaultAutocompleteLauncher,
-        @Named(START_WITH_VERIFICATION_DIALOG) startWithVerificationDialog: Boolean
+        @Named(LINK_EXPRESS_MODE) linkExpressMode: LinkExpressMode
     ): LinkActivityViewModel {
         return LinkActivityViewModel(
             activityRetainedComponent = component,
@@ -45,7 +46,7 @@ internal object LinkViewModelModule {
             linkAttestationCheck = linkAttestationCheck,
             savedStateHandle = savedStateHandle,
             navigationManager = navigationManager,
-            startWithVerificationDialog = startWithVerificationDialog,
+            linkExpressMode = linkExpressMode,
             linkConfirmationHandlerFactory = linkConfirmationHandlerFactory,
             linkLaunchMode = linkLaunchMode,
             autocompleteLauncher = autocompleteLauncher,

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkComponent.kt
@@ -12,6 +12,7 @@ import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.LinkActivityViewModel
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkDismissalCoordinator
+import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.link.LinkLaunchMode
 import com.stripe.android.link.WebLinkActivityContract
 import com.stripe.android.link.account.LinkAccountManager
@@ -94,8 +95,8 @@ internal interface NativeLinkComponent {
         fun application(application: Application): Builder
 
         @BindsInstance
-        fun startWithVerificationDialog(
-            @Named(START_WITH_VERIFICATION_DIALOG) startWithVerificationDialog: Boolean
+        fun linkExpressMode(
+            @Named(LINK_EXPRESS_MODE) linkExpressMode: LinkExpressMode
         ): Builder
 
         @BindsInstance

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkDIConsts.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkDIConsts.kt
@@ -1,3 +1,3 @@
 package com.stripe.android.link.injection
 
-internal const val START_WITH_VERIFICATION_DIALOG = "start_with_verification_dialog"
+internal const val LINK_EXPRESS_MODE = "link_express_mode"

--- a/paymentsheet/src/main/java/com/stripe/android/link/verification/DefaultLinkInlineInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/verification/DefaultLinkInlineInteractor.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.core.Logger
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkConfigurationCoordinator
+import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.link.LinkLaunchMode
 import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.account.LinkAccountManager
@@ -106,7 +107,7 @@ internal class DefaultLinkInlineInteractor @Inject constructor(
                     configuration = verificationState.linkConfiguration,
                     linkAccountInfo = accountManager.linkAccountInfo.value,
                     launchMode = LinkLaunchMode.PaymentMethodSelection(null),
-                    useLinkExpress = true
+                    linkExpressMode = LinkExpressMode.ENABLED
                 )
                 // No UI changes - keep the 2FA until we get a result from the Link payment selection flow.
             }.onFailure { error ->

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationOptionKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationOptionKtx.kt
@@ -127,7 +127,7 @@ private fun PaymentSelection.Link.toConfirmationOption(
     return linkConfiguration?.let {
         LinkConfirmationOption(
             configuration = linkConfiguration,
-            useLinkExpress = useLinkExpress,
+            linkExpressMode = linkExpressMode,
             linkLaunchMode = when {
                 // If a payment is included in the confirmation option, launch confirmation right away
                 selectedPayment != null -> LinkLaunchMode.Confirmation(selectedPayment)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinition.kt
@@ -58,7 +58,7 @@ internal class LinkConfirmationDefinition @Inject constructor(
             configuration = confirmationOption.configuration,
             linkAccountInfo = linkAccountHolder.linkAccountInfo.value,
             launchMode = confirmationOption.linkLaunchMode,
-            useLinkExpress = confirmationOption.useLinkExpress,
+            linkExpressMode = confirmationOption.linkExpressMode,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationOption.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationOption.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentelement.confirmation.link
 
 import com.stripe.android.link.LinkConfiguration
+import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.link.LinkLaunchMode
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import kotlinx.parcelize.Parcelize
@@ -9,5 +10,5 @@ import kotlinx.parcelize.Parcelize
 internal data class LinkConfirmationOption(
     val configuration: LinkConfiguration,
     val linkLaunchMode: LinkLaunchMode = LinkLaunchMode.Full,
-    val useLinkExpress: Boolean
+    val linkExpressMode: LinkExpressMode
 ) : ConfirmationHandler.Option

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -16,6 +16,7 @@ import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.utils.requireApplication
 import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkConfiguration
+import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.link.LinkLaunchMode
 import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.account.LinkAccountHolder
@@ -261,7 +262,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
                     configuration = linkState!!.configuration,
                     launchMode = LinkLaunchMode.PaymentMethodSelection(selectedPayment = null),
                     linkAccountInfo = linkAccountHolder.linkAccountInfo.value,
-                    useLinkExpress = true
+                    linkExpressMode = LinkExpressMode.ENABLED
                 )
             } else {
                 _paymentOptionsActivityResult.tryEmit(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -21,6 +21,7 @@ import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.utils.requireApplication
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
+import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.model.SetupIntent
@@ -141,7 +142,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         }
 
     private val isConfirmingWithLinkExpress: Boolean
-        get() = (inProgressSelection as? PaymentSelection.Link)?.useLinkExpress == true
+        get() = (inProgressSelection as? PaymentSelection.Link)?.linkExpressMode != LinkExpressMode.DISABLED
 
     override var newPaymentSelection: NewPaymentOptionSelection? = null
 
@@ -372,11 +373,21 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     }
 
     fun checkoutWithLink() {
-        checkout(PaymentSelection.Link(useLinkExpress = false), CheckoutIdentifier.SheetTopWallet)
+        checkout(
+            PaymentSelection.Link(
+                linkExpressMode = LinkExpressMode.DISABLED
+            ),
+            CheckoutIdentifier.SheetTopWallet
+        )
     }
 
     private fun checkoutWithLinkExpress() {
-        checkout(PaymentSelection.Link(useLinkExpress = true), CheckoutIdentifier.SheetTopWallet)
+        checkout(
+            PaymentSelection.Link(
+                linkExpressMode = LinkExpressMode.ENABLED_NO_WEB_FALLBACK,
+            ),
+            CheckoutIdentifier.SheetTopWallet
+        )
     }
 
     private fun checkout(
@@ -749,7 +760,7 @@ private val ConfirmationHandler.State.contentVisible: Boolean
                 // Hide the payment sheet for these confirmation flows that render UI
                 // on top of the payment sheet to avoid weird visual overlap.
                 is GooglePayConfirmationOption -> false
-                is LinkConfirmationOption -> option.useLinkExpress
+                is LinkConfirmationOption -> option.linkExpressMode != LinkExpressMode.DISABLED
                 else -> true
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -142,7 +142,9 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         }
 
     private val isConfirmingWithLinkExpress: Boolean
-        get() = (inProgressSelection as? PaymentSelection.Link)?.linkExpressMode != LinkExpressMode.DISABLED
+        get() = (inProgressSelection as? PaymentSelection.Link)?.linkExpressMode?.let { 
+            it != LinkExpressMode.DISABLED 
+        } ?: false
 
     override var newPaymentSelection: NewPaymentOptionSelection? = null
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -382,6 +382,8 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     }
 
     private fun checkoutWithLinkExpress() {
+        // We don't want to fall back to web on express mode if attestation
+        // fails on payment sheet given the OTP shows on launch.
         checkout(
             PaymentSelection.Link(
                 linkExpressMode = LinkExpressMode.ENABLED_NO_WEB_FALLBACK,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -142,9 +142,9 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         }
 
     private val isConfirmingWithLinkExpress: Boolean
-        get() = (inProgressSelection as? PaymentSelection.Link)?.linkExpressMode?.let { 
-            it != LinkExpressMode.DISABLED 
-        } ?: false
+        get() = (inProgressSelection as? PaymentSelection.Link)?.linkExpressMode
+            ?.let { it != LinkExpressMode.DISABLED }
+            ?: false
 
     override var newPaymentSelection: NewPaymentOptionSelection? = null
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -21,6 +21,7 @@ import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkActivityResult.Canceled.Reason
 import com.stripe.android.link.LinkConfiguration
+import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.link.LinkLaunchMode
 import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.LinkPaymentMethod
@@ -280,7 +281,7 @@ internal class DefaultFlowController @Inject internal constructor(
                 flowControllerLinkLauncher.present(
                     configuration = linkConfiguration,
                     linkAccountInfo = linkAccountInfo,
-                    useLinkExpress = true,
+                    linkExpressMode = LinkExpressMode.ENABLED,
                     launchMode = LinkLaunchMode.PaymentMethodSelection(
                         selectedPayment = (paymentSelection as? Link)?.selectedPayment?.details
                     )
@@ -587,7 +588,7 @@ internal class DefaultFlowController @Inject internal constructor(
             }
             null,
             is PaymentOptionsActivityResult.Canceled -> {
-                viewModel.paymentSelection = (result as? PaymentOptionsActivityResult.Canceled)?.paymentSelection
+                viewModel.paymentSelection = result?.paymentSelection
                 onPaymentSelection(canceled = true)
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -12,6 +12,7 @@ import androidx.core.content.res.ResourcesCompat
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.orEmpty
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.link.LinkPaymentMethod
 import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
@@ -69,7 +70,7 @@ internal sealed class PaymentSelection : Parcelable {
 
     @Parcelize
     data class Link(
-        val useLinkExpress: Boolean = false,
+        val linkExpressMode: LinkExpressMode = LinkExpressMode.DISABLED,
         val selectedPayment: LinkPaymentMethod? = null,
         val shippingAddress: ConsumerShippingAddress? = null,
     ) : PaymentSelection() {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
@@ -7,6 +7,7 @@ import com.stripe.android.CardBrandFilter
 import com.stripe.android.GooglePayJsonFactory
 import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.common.model.asCommonConfiguration
+import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.link.LinkLaunchMode
 import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.account.LinkAccountHolder
@@ -71,7 +72,7 @@ internal interface WalletButtonsInteractor {
             val state: LinkButtonState,
         ) : WalletButton {
             override fun createSelection(): PaymentSelection {
-                return PaymentSelection.Link(useLinkExpress = false)
+                return PaymentSelection.Link(linkExpressMode = LinkExpressMode.DISABLED)
             }
         }
 
@@ -232,7 +233,7 @@ internal class DefaultWalletButtonsInteractor(
                 configuration = linkConfiguration,
                 linkAccountInfo = linkAccountHolder.linkAccountInfo.value,
                 launchMode = LinkLaunchMode.PaymentMethodSelection(selectedPayment?.details),
-                useLinkExpress = true
+                linkExpressMode = LinkExpressMode.ENABLED
             )
         } else {
             handleButtonPressed(

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityContractTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityContractTest.kt
@@ -7,7 +7,6 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.link.gate.FakeLinkGate
 import com.stripe.android.link.gate.LinkGate
-import com.stripe.android.link.LinkExpressMode
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityContractTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityContractTest.kt
@@ -7,6 +7,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.link.gate.FakeLinkGate
 import com.stripe.android.link.gate.LinkGate
+import com.stripe.android.link.LinkExpressMode
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
@@ -21,7 +22,7 @@ class LinkActivityContractTest {
     private val context: Context = ApplicationProvider.getApplicationContext()
     private val args = LinkActivityContract.Args(
         configuration = TestFactory.LINK_CONFIGURATION,
-        startWithVerificationDialog = false,
+        linkExpressMode = LinkExpressMode.DISABLED,
         linkAccountInfo = LinkAccountUpdate.Value(
             account = null,
             lastUpdateReason = null

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityTest.kt
@@ -120,17 +120,18 @@ internal class LinkActivityTest {
         use2faDialog: Boolean = true,
         linkAccountManager: LinkAccountManager = FakeLinkAccountManager()
     ): LinkActivity {
+        val linkExpressMode = if (use2faDialog) LinkExpressMode.ENABLED else LinkExpressMode.DISABLED
         val intent = LinkActivity.createIntent(
             context = context,
             args = TestFactory.NATIVE_LINK_ARGS.copy(
-                startWithVerificationDialog = use2faDialog
+                linkExpressMode = linkExpressMode,
             )
         )
 
         val activityController = Robolectric.buildActivity(LinkActivity::class.java, intent)
 
         activityController.get().viewModelFactory = linkViewModelFactory(
-            use2faDialog = use2faDialog,
+            linkExpressMode = linkExpressMode,
             linkAccountManager = linkAccountManager
         )
 
@@ -140,7 +141,7 @@ internal class LinkActivityTest {
     }
 
     private fun linkViewModelFactory(
-        use2faDialog: Boolean = true,
+        linkExpressMode: LinkExpressMode = LinkExpressMode.ENABLED,
         linkAccountManager: LinkAccountManager = FakeLinkAccountManager()
     ): ViewModelProvider.Factory = viewModelFactory {
         initializer {
@@ -153,7 +154,7 @@ internal class LinkActivityTest {
                 linkAttestationCheck = FakeLinkAttestationCheck(),
                 savedStateHandle = SavedStateHandle(),
                 linkConfiguration = TestFactory.LINK_CONFIGURATION,
-                startWithVerificationDialog = use2faDialog,
+                linkExpressMode = linkExpressMode,
                 navigationManager = TestNavigationManager(),
                 linkLaunchMode = LinkLaunchMode.Full,
                 linkConfirmationHandlerFactory = { FakeLinkConfirmationHandler() },

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
@@ -107,6 +107,8 @@ internal class LinkActivityViewModelTest {
                     }
                 )
 
+                vm.unregisterActivity()
+
                 val autocompleteRegisterCall = registerCalls.awaitItem()
                 val confirmationHandlerRegisterCall = confirmationHandler.registerTurbine.awaitItem()
 
@@ -450,44 +452,45 @@ internal class LinkActivityViewModelTest {
 
     @Test
     fun `onCreate should launch web when attestation check fails`() = runTest {
+        var launchWebConfig: LinkConfiguration? = null
         val error = Throwable("oops")
         val linkAttestationCheck = FakeLinkAttestationCheck()
         linkAttestationCheck.result = LinkAttestationCheck.Result.AttestationFailed(error)
 
         val vm = createViewModel(
-            linkAttestationCheck = linkAttestationCheck
+            linkAttestationCheck = linkAttestationCheck,
+            launchWeb = { config ->
+                launchWebConfig = config
+            }
         )
 
-        vm.launchWebFlow.test {
-            vm.onCreate(mock())
+        vm.onCreate(mock())
 
-            assertThat(vm.linkScreenState.value).isEqualTo(ScreenState.Loading)
+        assertThat(vm.linkScreenState.value).isEqualTo(ScreenState.Loading)
 
-            val launchWebConfig = awaitItem()
-            assertThat(launchWebConfig).isNotNull()
-        }
+        assertThat(launchWebConfig).isNotNull()
     }
 
     @Test
     fun `onCreate shouldn't launch web when attestationCheck fails`() =
         runTest {
+            var launchWebConfig: LinkConfiguration? = null
             val linkAttestationCheck = FakeLinkAttestationCheck()
 
             val vm = createViewModel(
-                linkAttestationCheck = linkAttestationCheck
+                linkAttestationCheck = linkAttestationCheck,
+                launchWeb = { config ->
+                    launchWebConfig = config
+                }
             )
 
-            vm.launchWebFlow.test {
-                vm.onCreate(mock())
+            vm.onCreate(mock())
 
-                advanceUntilIdle()
+            advanceUntilIdle()
 
-                val state = vm.linkScreenState.value as ScreenState.FullScreen
-                assertEquals(state.initialDestination, LinkScreen.SignUp)
-
-                // Should not emit any items since web shouldn't be launched
-                expectNoEvents()
-            }
+            val state = vm.linkScreenState.value as ScreenState.FullScreen
+            assertEquals(state.initialDestination, LinkScreen.SignUp)
+            assertThat(launchWebConfig).isNull()
         }
 
     @Test
@@ -520,8 +523,6 @@ internal class LinkActivityViewModelTest {
         linkAccountManager.setAccountStatus(AccountStatus.NeedsVerification)
 
         vm.onCreate(mock())
-
-        advanceUntilIdle()
 
         assertThat(vm.linkScreenState.value).isEqualTo(ScreenState.VerificationDialog(TestFactory.LINK_ACCOUNT))
         linkAttestationCheck.awaitInvokeCall()
@@ -733,6 +734,7 @@ internal class LinkActivityViewModelTest {
     private fun testAttestationCheckError(
         attestationCheckResult: LinkAttestationCheck.Result,
     ) = runTest {
+        var launchWebConfig: LinkConfiguration? = null
         val linkAccountHolder = LinkAccountHolder(SavedStateHandle())
         val linkAccountManager = FakeLinkAccountManager(
             linkAccountHolder = linkAccountHolder,
@@ -751,25 +753,24 @@ internal class LinkActivityViewModelTest {
             linkAccountManager = linkAccountManager,
             linkAccountHolder = linkAccountHolder,
             linkExpressMode = LinkExpressMode.DISABLED,
+            launchWeb = { config ->
+                launchWebConfig = config
+            },
         )
 
-        vm.launchWebFlow.test {
-            vm.result.test {
-                vm.onCreate(mock())
+        vm.result.test {
+            vm.onCreate(mock())
 
-                advanceUntilIdle()
+            advanceUntilIdle()
 
-                linkAccountManager.awaitLogoutCall()
-                assertThat(linkAccountHolder.linkAccountInfo.value.account).isNull()
+            linkAccountManager.awaitLogoutCall()
+            assertThat(linkAccountHolder.linkAccountInfo.value.account).isNull()
+            assertThat(launchWebConfig).isNull()
 
-                expectNoEvents()
-
-                val state = vm.linkScreenState.value as ScreenState.FullScreen
-                assertEquals(state.initialDestination, LinkScreen.SignUp)
-            }
-
-            // Should not emit any items since web shouldn't be launched for errors
             expectNoEvents()
+
+            val state = vm.linkScreenState.value as ScreenState.FullScreen
+            assertEquals(state.initialDestination, LinkScreen.SignUp)
         }
     }
 
@@ -785,6 +786,7 @@ internal class LinkActivityViewModelTest {
         savedStateHandle: SavedStateHandle = SavedStateHandle(),
         linkLaunchMode: LinkLaunchMode = LinkLaunchMode.Full,
         linkConfirmationHandler: LinkConfirmationHandler = FakeLinkConfirmationHandler(),
+        launchWeb: (LinkConfiguration) -> Unit = {},
         autocompleteLauncher: AutocompleteActivityLauncher = TestAutocompleteLauncher.noOp(),
         linkConfiguration: LinkConfiguration = TestFactory.LINK_CONFIGURATION,
     ): LinkActivityViewModel {
@@ -802,7 +804,9 @@ internal class LinkActivityViewModelTest {
             linkLaunchMode = linkLaunchMode,
             linkConfirmationHandlerFactory = { linkConfirmationHandler },
             autocompleteLauncher = autocompleteLauncher,
-        )
+        ).apply {
+            this.launchWebFlow = launchWeb
+        }
     }
 
     private fun creationExtras(): CreationExtras {

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
@@ -22,7 +22,6 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.link.LinkAccountUpdate.Value.UpdateReason.LoggedOut
 import com.stripe.android.link.account.FakeLinkAccountManager
 import com.stripe.android.link.account.LinkAccountHolder
-import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.link.attestation.FakeLinkAttestationCheck
 import com.stripe.android.link.attestation.LinkAttestationCheck
 import com.stripe.android.link.confirmation.FakeLinkConfirmationHandler

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
@@ -22,6 +22,7 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.link.LinkAccountUpdate.Value.UpdateReason.LoggedOut
 import com.stripe.android.link.account.FakeLinkAccountManager
 import com.stripe.android.link.account.LinkAccountHolder
+import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.link.attestation.FakeLinkAttestationCheck
 import com.stripe.android.link.attestation.LinkAttestationCheck
 import com.stripe.android.link.confirmation.FakeLinkConfirmationHandler
@@ -136,7 +137,7 @@ internal class LinkActivityViewModelTest {
             configuration = mock(),
             publishableKey = "",
             stripeAccountId = null,
-            startWithVerificationDialog = false,
+            linkExpressMode = LinkExpressMode.DISABLED,
             linkAccountInfo = LinkAccountUpdate.Value(
                 account = null,
                 lastUpdateReason = null
@@ -514,7 +515,7 @@ internal class LinkActivityViewModelTest {
         val vm = createViewModel(
             linkAccountManager = linkAccountManager,
             linkAttestationCheck = linkAttestationCheck,
-            startWithVerificationDialog = true
+            linkExpressMode = LinkExpressMode.ENABLED
         )
         linkAccountManager.setAccountStatus(AccountStatus.NeedsVerification)
 
@@ -534,7 +535,7 @@ internal class LinkActivityViewModelTest {
 
         val vm = createViewModel(
             linkAccountManager = linkAccountManager,
-            startWithVerificationDialog = true
+            linkExpressMode = LinkExpressMode.ENABLED
         )
         linkAccountManager.setAccountStatus(AccountStatus.NeedsVerification)
 
@@ -558,7 +559,7 @@ internal class LinkActivityViewModelTest {
 
         val vm = createViewModel(
             linkAccountManager = linkAccountManager,
-            startWithVerificationDialog = true,
+            linkExpressMode = LinkExpressMode.ENABLED
         )
 
         vm.result.test {
@@ -749,7 +750,7 @@ internal class LinkActivityViewModelTest {
             linkAttestationCheck = linkAttestationCheck,
             linkAccountManager = linkAccountManager,
             linkAccountHolder = linkAccountHolder,
-            startWithVerificationDialog = false,
+            linkExpressMode = LinkExpressMode.DISABLED,
         )
 
         vm.launchWebFlow.test {
@@ -780,7 +781,7 @@ internal class LinkActivityViewModelTest {
         eventReporter: EventReporter = FakeEventReporter(),
         navigationManager: NavigationManager = TestNavigationManager(),
         linkAttestationCheck: LinkAttestationCheck = FakeLinkAttestationCheck(),
-        startWithVerificationDialog: Boolean = false,
+        linkExpressMode: LinkExpressMode = LinkExpressMode.DISABLED,
         savedStateHandle: SavedStateHandle = SavedStateHandle(),
         linkLaunchMode: LinkLaunchMode = LinkLaunchMode.Full,
         linkConfirmationHandler: LinkConfirmationHandler = FakeLinkConfirmationHandler(),
@@ -795,7 +796,7 @@ internal class LinkActivityViewModelTest {
             confirmationHandlerFactory = { confirmationHandler },
             linkAttestationCheck = linkAttestationCheck,
             linkConfiguration = linkConfiguration,
-            startWithVerificationDialog = startWithVerificationDialog,
+            linkExpressMode = linkExpressMode,
             navigationManager = navigationManager,
             savedStateHandle = savedStateHandle,
             linkLaunchMode = linkLaunchMode,

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerCoordinatorTest.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.testing.TestLifecycleOwner
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.utils.FakeActivityResultRegistry
+import com.stripe.android.link.LinkExpressMode
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -131,7 +132,7 @@ internal class LinkControllerCoordinatorTest {
         coordinator.linkActivityResultLauncher.launch(
             LinkActivityContract.Args(
                 configuration = TestFactory.LINK_CONFIGURATION,
-                startWithVerificationDialog = false,
+                linkExpressMode = LinkExpressMode.DISABLED,
                 linkAccountInfo = LinkAccountUpdate.Value(null),
                 launchMode = LinkLaunchMode.PaymentMethodSelection(null),
             )

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerCoordinatorTest.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.testing.TestLifecycleOwner
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.utils.FakeActivityResultRegistry
-import com.stripe.android.link.LinkExpressMode
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerInteractorTest.kt
@@ -376,7 +376,7 @@ class LinkControllerInteractorTest {
 
         val call = launcher.calls.awaitItem()
         val args = call.input
-        assertThat(args.linkExpressMode).isEqualTo(LinkExpressMode.DISABLED)
+        assertThat(args.linkExpressMode).isEqualTo(LinkExpressMode.ENABLED)
         assertThat(args.linkAccountInfo.account).isNull()
         assertThat(args.launchMode)
             .isEqualTo(

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerInteractorTest.kt
@@ -376,7 +376,7 @@ class LinkControllerInteractorTest {
 
         val call = launcher.calls.awaitItem()
         val args = call.input
-        assertThat(args.startWithVerificationDialog).isTrue()
+        assertThat(args.linkExpressMode).isEqualTo(LinkExpressMode.DISABLED)
         assertThat(args.linkAccountInfo.account).isNull()
         assertThat(args.launchMode)
             .isEqualTo(
@@ -593,7 +593,7 @@ class LinkControllerInteractorTest {
         interactor.authenticate(launcher, "test@example.com")
 
         val args = launcher.calls.awaitItem().input
-        assertThat(args.startWithVerificationDialog).isTrue()
+        assertThat(args.linkExpressMode).isEqualTo(LinkExpressMode.ENABLED)
         assertThat(args.linkAccountInfo.account).isNull()
         assertThat(args.launchMode).isEqualTo(LinkLaunchMode.Authentication())
 
@@ -705,7 +705,7 @@ class LinkControllerInteractorTest {
         interactor.authenticateExistingConsumer(launcher, "test@example.com")
 
         val args = launcher.calls.awaitItem().input
-        assertThat(args.startWithVerificationDialog).isTrue()
+        assertThat(args.linkExpressMode).isEqualTo(LinkExpressMode.ENABLED)
         assertThat(args.linkAccountInfo.account).isNull()
         assertThat(args.launchMode).isEqualTo(LinkLaunchMode.Authentication(existingOnly = true))
     }

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkPaymentLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkPaymentLauncherTest.kt
@@ -7,6 +7,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.link.account.LinkStore
 import com.stripe.android.link.analytics.FakeLinkAnalyticsHelper
 import com.stripe.android.link.analytics.LinkAnalyticsHelper
+import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.link.injection.LinkAnalyticsComponent
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentelement.confirmation.asCallbackFor
@@ -90,7 +91,7 @@ internal class LinkPaymentLauncherTest {
             linkPaymentLauncher.present(
                 configuration = TestFactory.LINK_CONFIGURATION,
                 linkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
-                useLinkExpress = true,
+                linkExpressMode = LinkExpressMode.ENABLED,
                 launchMode = LinkLaunchMode.Full
             )
 
@@ -100,7 +101,7 @@ internal class LinkPaymentLauncherTest {
                 .isEqualTo(
                     LinkActivityContract.Args(
                         configuration = TestFactory.LINK_CONFIGURATION,
-                        startWithVerificationDialog = true,
+                        linkExpressMode = LinkExpressMode.ENABLED,
                         linkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
                         launchMode = LinkLaunchMode.Full,
                     )
@@ -123,12 +124,12 @@ internal class LinkPaymentLauncherTest {
             linkPaymentLauncher.present(
                 configuration = TestFactory.LINK_CONFIGURATION,
                 linkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
-                useLinkExpress = false,
+                linkExpressMode = LinkExpressMode.DISABLED,
                 launchMode = LinkLaunchMode.Full
             )
 
             val launchCall = awaitLaunchCall() as? LinkActivityContract.Args
-            assertThat(launchCall?.startWithVerificationDialog).isFalse()
+            assertThat(launchCall?.linkExpressMode).isEqualTo(LinkExpressMode.DISABLED)
             awaitNextRegisteredLauncher()
         }
     }
@@ -232,7 +233,7 @@ internal class LinkPaymentLauncherTest {
             linkPaymentLauncher.present(
                 configuration = TestFactory.LINK_CONFIGURATION,
                 linkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
-                useLinkExpress = true,
+                linkExpressMode = LinkExpressMode.ENABLED,
                 launchMode = LinkLaunchMode.Full
             )
 
@@ -264,7 +265,7 @@ internal class LinkPaymentLauncherTest {
                 linkPaymentLauncher.present(
                     configuration = TestFactory.LINK_CONFIGURATION,
                     linkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
-                    useLinkExpress = true,
+                    linkExpressMode = LinkExpressMode.ENABLED,
                     launchMode = LinkLaunchMode.Full
                 )
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkPaymentLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkPaymentLauncherTest.kt
@@ -7,7 +7,6 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.link.account.LinkStore
 import com.stripe.android.link.analytics.FakeLinkAnalyticsHelper
 import com.stripe.android.link.analytics.LinkAnalyticsHelper
-import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.link.injection.LinkAnalyticsComponent
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentelement.confirmation.asCallbackFor

--- a/paymentsheet/src/test/java/com/stripe/android/link/NativeLinkActivityContractTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/NativeLinkActivityContractTest.kt
@@ -35,7 +35,7 @@ class NativeLinkActivityContractTest {
         val contract = NativeLinkActivityContract(paymentElementCallbackIdentifier = LINK_CALLBACK_TEST_IDENTIFIER)
         val args = LinkActivityContract.Args(
             configuration = TestFactory.LINK_CONFIGURATION,
-            startWithVerificationDialog = false,
+            linkExpressMode = LinkExpressMode.DISABLED,
             linkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
             launchMode = LinkLaunchMode.Full
         )
@@ -52,7 +52,7 @@ class NativeLinkActivityContractTest {
                 configuration = TestFactory.LINK_CONFIGURATION,
                 publishableKey = "pk_test_abcdefg",
                 stripeAccountId = null,
-                startWithVerificationDialog = false,
+                linkExpressMode = LinkExpressMode.DISABLED,
                 linkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
                 paymentElementCallbackIdentifier = LINK_CALLBACK_TEST_IDENTIFIER,
                 launchMode = LinkLaunchMode.Full

--- a/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
@@ -5,7 +5,6 @@ import com.stripe.android.core.model.CountryCode
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.financialconnections.model.FinancialConnectionsAccount
 import com.stripe.android.link.model.LinkAccount
-import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.CardDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.formElements

--- a/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
@@ -5,6 +5,7 @@ import com.stripe.android.core.model.CountryCode
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.financialconnections.model.FinancialConnectionsAccount
 import com.stripe.android.link.model.LinkAccount
+import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.CardDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.formElements
@@ -264,7 +265,7 @@ internal object TestFactory {
         configuration = LINK_CONFIGURATION,
         publishableKey = "",
         stripeAccountId = "",
-        startWithVerificationDialog = false,
+        linkExpressMode = LinkExpressMode.DISABLED,
         linkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
         paymentElementCallbackIdentifier = "LinkNativeTestIdentifier",
         launchMode = LinkLaunchMode.Full,

--- a/paymentsheet/src/test/java/com/stripe/android/link/WebLinkActivityContractTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/WebLinkActivityContractTest.kt
@@ -41,7 +41,7 @@ class WebLinkActivityContractTest {
         val contract = contract(stripeRepository)
         val args = LinkActivityContract.Args(
             configuration = TestFactory.LINK_CONFIGURATION,
-            startWithVerificationDialog = false,
+            linkExpressMode = LinkExpressMode.DISABLED,
             linkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
             launchMode = LinkLaunchMode.Full
         )

--- a/paymentsheet/src/test/java/com/stripe/android/link/verification/DefaultLinkInlineInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/verification/DefaultLinkInlineInteractorTest.kt
@@ -6,6 +6,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.link.LinkAccountUpdate
+import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.link.LinkLaunchMode
 import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.TestFactory
@@ -159,7 +160,7 @@ class DefaultLinkInlineInteractorTest {
                 configuration = any(),
                 linkAccountInfo = any(),
                 launchMode = eq(LinkLaunchMode.PaymentMethodSelection(null)),
-                useLinkExpress = any()
+                linkExpressMode = any()
             )
         }
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/verification/DefaultLinkInlineInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/verification/DefaultLinkInlineInteractorTest.kt
@@ -6,7 +6,6 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.link.LinkAccountUpdate
-import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.link.LinkLaunchMode
 import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.TestFactory

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
@@ -7,6 +7,7 @@ import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.isInstanceOf
 import com.stripe.android.link.LinkConfiguration
+import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.link.ui.inline.SignUpConsentAction
 import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilter
@@ -280,7 +281,7 @@ class ConfirmationHandlerOptionKtxTest {
         ).isEqualTo(
             LinkConfirmationOption(
                 configuration = LINK_CONFIGURATION,
-                useLinkExpress = false
+                linkExpressMode = LinkExpressMode.DISABLED
             )
         )
     }
@@ -289,7 +290,7 @@ class ConfirmationHandlerOptionKtxTest {
     fun `On Link selection with express configuration, should return Link confirmation option with express enabled`() {
         assertThat(
             PaymentSelection.Link(
-                useLinkExpress = true
+                linkExpressMode = LinkExpressMode.ENABLED
             ).toConfirmationOption(
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
                 linkConfiguration = LINK_CONFIGURATION,
@@ -297,7 +298,7 @@ class ConfirmationHandlerOptionKtxTest {
         ).isEqualTo(
             LinkConfirmationOption(
                 configuration = LINK_CONFIGURATION,
-                useLinkExpress = true
+                linkExpressMode = LinkExpressMode.ENABLED
             )
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationActivityTest.kt
@@ -18,6 +18,7 @@ import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.link.LinkAccountUpdate
+import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.link.LinkLaunchMode
 import com.stripe.android.link.NativeLinkArgs
 import com.stripe.android.link.TestFactory
@@ -204,7 +205,7 @@ internal class LinkConfirmationActivityTest(private val nativeLinkEnabled: Boole
                             configuration = TestFactory.LINK_CONFIGURATION,
                             publishableKey = PUBLISHABLE_KEY,
                             stripeAccountId = null,
-                            startWithVerificationDialog = true,
+                            linkExpressMode = LinkExpressMode.ENABLED,
                             linkAccountInfo = LinkAccountUpdate.Value(null),
                             paymentElementCallbackIdentifier = "ConfirmationTestIdentifier",
                             launchMode = LinkLaunchMode.Full,
@@ -241,7 +242,7 @@ internal class LinkConfirmationActivityTest(private val nativeLinkEnabled: Boole
 
         val LINK_CONFIRMATION_OPTION = LinkConfirmationOption(
             configuration = TestFactory.LINK_CONFIGURATION,
-            useLinkExpress = true,
+            linkExpressMode = LinkExpressMode.ENABLED,
         )
 
         val CONFIRMATION_PARAMETERS = ConfirmationDefinition.Parameters(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinitionTest.kt
@@ -6,6 +6,7 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.isInstanceOf
 import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.LinkActivityResult
+import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.TestFactory
 import com.stripe.android.link.account.LinkAccountHolder
@@ -143,16 +144,16 @@ internal class LinkConfirmationDefinitionTest {
 
         val presentCall = launcherScenario.presentCalls.awaitItem()
 
-        assertThat(presentCall.useLinkExpress).isTrue()
+        assertThat(presentCall.linkExpressMode).isNotEqualTo(LinkExpressMode.DISABLED)
     }
 
     @Test
-    fun `'launch' should launch properly with provided parameters when useLinkExpress is false`() = test {
+    fun `'launch' should launch properly with provided parameters when linkExpressMode is disabled`() = test {
         val definition = createLinkConfirmationDefinition()
 
         definition.launch(
             confirmationOption = LINK_CONFIRMATION_OPTION.copy(
-                useLinkExpress = false
+                linkExpressMode = LinkExpressMode.DISABLED
             ),
             confirmationParameters = CONFIRMATION_PARAMETERS,
             launcher = launcherScenario.launcher,
@@ -163,7 +164,7 @@ internal class LinkConfirmationDefinitionTest {
 
         assertThat(presentCall.configuration).isEqualTo(LINK_CONFIRMATION_OPTION.configuration)
         assertThat(presentCall.linkAccount).isNull()
-        assertThat(presentCall.useLinkExpress).isFalse()
+        assertThat(presentCall.linkExpressMode).isEqualTo(LinkExpressMode.DISABLED)
     }
 
     @Test
@@ -355,7 +356,7 @@ internal class LinkConfirmationDefinitionTest {
 
         private val LINK_CONFIRMATION_OPTION = LinkConfirmationOption(
             configuration = TestFactory.LINK_CONFIGURATION,
-            useLinkExpress = true,
+            linkExpressMode = LinkExpressMode.ENABLED,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationFlowTest.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.isInstanceOf
 import com.stripe.android.link.LinkActivityResult
+import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.link.TestFactory
 import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
@@ -151,7 +152,7 @@ class LinkConfirmationFlowTest {
 
         private val LINK_CONFIRMATION_OPTION = LinkConfirmationOption(
             configuration = TestFactory.LINK_CONFIGURATION,
-            useLinkExpress = true,
+            linkExpressMode = LinkExpressMode.ENABLED,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -14,6 +14,7 @@ import com.stripe.android.isInstanceOf
 import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkConfigurationCoordinator
+import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.link.LinkLaunchMode
 import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.TestFactory
@@ -237,7 +238,7 @@ internal class PaymentOptionsViewModelTest {
             configuration = any(),
             linkAccountInfo = eq(LinkAccountUpdate.Value(unverifiedAccount)),
             launchMode = eq(LinkLaunchMode.PaymentMethodSelection(selectedPayment = null)),
-            useLinkExpress = eq(true)
+            linkExpressMode = eq(LinkExpressMode.ENABLED)
         )
     }
 
@@ -275,7 +276,7 @@ internal class PaymentOptionsViewModelTest {
             configuration = any(),
             linkAccountInfo = any(),
             launchMode = any(),
-            useLinkExpress = any()
+            linkExpressMode = any()
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -2845,7 +2845,7 @@ internal class PaymentSheetViewModelTest {
         val paymentSuccessCall = eventReporter.paymentSuccessCalls.awaitItem()
 
         assertThat(paymentSuccessCall.paymentSelection)
-            .isEqualTo(PaymentSelection.Link(linkExpressMode = LinkExpressMode.ENABLED))
+            .isEqualTo(PaymentSelection.Link(linkExpressMode = LinkExpressMode.ENABLED_NO_WEB_FALLBACK))
     }
 
     @Test
@@ -2883,7 +2883,7 @@ internal class PaymentSheetViewModelTest {
         val paymentFailureCall = eventReporter.paymentFailureCalls.awaitItem()
 
         assertThat(paymentFailureCall.paymentSelection)
-            .isEqualTo(PaymentSelection.Link(linkExpressMode = LinkExpressMode.ENABLED))
+            .isEqualTo(PaymentSelection.Link(linkExpressMode = LinkExpressMode.ENABLED_NO_WEB_FALLBACK))
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -1613,7 +1613,7 @@ internal class PaymentSheetViewModelTest {
             assertThat(arguments.confirmationOption).isEqualTo(
                 LinkConfirmationOption(
                     configuration = TestFactory.LINK_CONFIGURATION,
-                    linkExpressMode = LinkExpressMode.ENABLED,
+                    linkExpressMode = LinkExpressMode.ENABLED_NO_WEB_FALLBACK,
                 )
             )
 
@@ -2830,7 +2830,7 @@ internal class PaymentSheetViewModelTest {
 
         assertThat(arguments.confirmationOption).isEqualTo(
             LinkConfirmationOption(
-                linkExpressMode = LinkExpressMode.ENABLED,
+                linkExpressMode = LinkExpressMode.ENABLED_NO_WEB_FALLBACK,
                 configuration = LINK_CONFIG,
             )
         )
@@ -2867,7 +2867,7 @@ internal class PaymentSheetViewModelTest {
 
         assertThat(arguments.confirmationOption).isEqualTo(
             LinkConfirmationOption(
-                linkExpressMode = LinkExpressMode.ENABLED,
+                linkExpressMode = LinkExpressMode.ENABLED_NO_WEB_FALLBACK,
                 configuration = LINK_CONFIG,
             )
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -18,7 +18,9 @@ import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.isInstanceOf
+import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkConfigurationCoordinator
+import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.link.TestFactory
 import com.stripe.android.link.attestation.FakeLinkAttestationCheck
 import com.stripe.android.link.attestation.LinkAttestationCheck
@@ -658,7 +660,7 @@ internal class PaymentSheetViewModelTest {
         val confirmationArgs = startTurbine.awaitItem()
         assertThat(confirmationArgs.confirmationOption).isInstanceOf<LinkConfirmationOption>()
         val confirmationOption = confirmationArgs.confirmationOption as? LinkConfirmationOption
-        assertThat(confirmationOption?.useLinkExpress).isTrue()
+        assertThat(confirmationOption?.linkExpressMode).isNotEqualTo(LinkExpressMode.DISABLED)
     }
 
     @Test
@@ -689,7 +691,7 @@ internal class PaymentSheetViewModelTest {
         val confirmationArgs = startTurbine.awaitItem()
         assertThat(confirmationArgs.confirmationOption).isInstanceOf<LinkConfirmationOption>()
         val confirmationOption = confirmationArgs.confirmationOption as? LinkConfirmationOption
-        assertThat(confirmationOption?.useLinkExpress).isFalse()
+        assertThat(confirmationOption?.linkExpressMode).isEqualTo(LinkExpressMode.DISABLED)
     }
 
     @Test
@@ -967,7 +969,7 @@ internal class PaymentSheetViewModelTest {
 
             assertThat(arguments.confirmationOption).isEqualTo(
                 LinkConfirmationOption(
-                    useLinkExpress = false,
+                    linkExpressMode = LinkExpressMode.DISABLED,
                     configuration = TestFactory.LINK_CONFIGURATION,
                 )
             )
@@ -1612,7 +1614,7 @@ internal class PaymentSheetViewModelTest {
             assertThat(arguments.confirmationOption).isEqualTo(
                 LinkConfirmationOption(
                     configuration = TestFactory.LINK_CONFIGURATION,
-                    useLinkExpress = true,
+                    linkExpressMode = LinkExpressMode.ENABLED,
                 )
             )
 
@@ -2754,7 +2756,7 @@ internal class PaymentSheetViewModelTest {
 
         assertThat(arguments.confirmationOption).isEqualTo(
             LinkConfirmationOption(
-                useLinkExpress = false,
+                linkExpressMode = LinkExpressMode.DISABLED,
                 configuration = LINK_CONFIG,
             )
         )
@@ -2768,7 +2770,7 @@ internal class PaymentSheetViewModelTest {
 
         val paymentSuccessCall = eventReporter.paymentSuccessCalls.awaitItem()
 
-        assertThat(paymentSuccessCall.paymentSelection).isEqualTo(PaymentSelection.Link(useLinkExpress = false))
+        assertThat(paymentSuccessCall.paymentSelection).isEqualTo(PaymentSelection.Link(linkExpressMode = LinkExpressMode.DISABLED))
     }
 
     @Test
@@ -2790,7 +2792,7 @@ internal class PaymentSheetViewModelTest {
 
         assertThat(arguments.confirmationOption).isEqualTo(
             LinkConfirmationOption(
-                useLinkExpress = false,
+                linkExpressMode = LinkExpressMode.DISABLED,
                 configuration = LINK_CONFIG,
             )
         )
@@ -2805,7 +2807,7 @@ internal class PaymentSheetViewModelTest {
 
         val paymentFailureCall = eventReporter.paymentFailureCalls.awaitItem()
 
-        assertThat(paymentFailureCall.paymentSelection).isEqualTo(PaymentSelection.Link(useLinkExpress = false))
+        assertThat(paymentFailureCall.paymentSelection).isEqualTo(PaymentSelection.Link(linkExpressMode = LinkExpressMode.DISABLED))
     }
 
     @Test
@@ -2827,7 +2829,7 @@ internal class PaymentSheetViewModelTest {
 
         assertThat(arguments.confirmationOption).isEqualTo(
             LinkConfirmationOption(
-                useLinkExpress = true,
+                linkExpressMode = LinkExpressMode.ENABLED,
                 configuration = LINK_CONFIG,
             )
         )
@@ -2841,7 +2843,7 @@ internal class PaymentSheetViewModelTest {
 
         val paymentSuccessCall = eventReporter.paymentSuccessCalls.awaitItem()
 
-        assertThat(paymentSuccessCall.paymentSelection).isEqualTo(PaymentSelection.Link(useLinkExpress = true))
+        assertThat(paymentSuccessCall.paymentSelection).isEqualTo(PaymentSelection.Link(linkExpressMode = LinkExpressMode.ENABLED))
     }
 
     @Test
@@ -2863,7 +2865,7 @@ internal class PaymentSheetViewModelTest {
 
         assertThat(arguments.confirmationOption).isEqualTo(
             LinkConfirmationOption(
-                useLinkExpress = true,
+                linkExpressMode = LinkExpressMode.ENABLED,
                 configuration = LINK_CONFIG,
             )
         )
@@ -2878,7 +2880,7 @@ internal class PaymentSheetViewModelTest {
 
         val paymentFailureCall = eventReporter.paymentFailureCalls.awaitItem()
 
-        assertThat(paymentFailureCall.paymentSelection).isEqualTo(PaymentSelection.Link(useLinkExpress = true))
+        assertThat(paymentFailureCall.paymentSelection).isEqualTo(PaymentSelection.Link(linkExpressMode = LinkExpressMode.ENABLED))
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -18,7 +18,6 @@ import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.isInstanceOf
-import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.link.TestFactory
@@ -2770,7 +2769,8 @@ internal class PaymentSheetViewModelTest {
 
         val paymentSuccessCall = eventReporter.paymentSuccessCalls.awaitItem()
 
-        assertThat(paymentSuccessCall.paymentSelection).isEqualTo(PaymentSelection.Link(linkExpressMode = LinkExpressMode.DISABLED))
+        assertThat(paymentSuccessCall.paymentSelection)
+            .isEqualTo(PaymentSelection.Link(linkExpressMode = LinkExpressMode.DISABLED))
     }
 
     @Test
@@ -2807,7 +2807,8 @@ internal class PaymentSheetViewModelTest {
 
         val paymentFailureCall = eventReporter.paymentFailureCalls.awaitItem()
 
-        assertThat(paymentFailureCall.paymentSelection).isEqualTo(PaymentSelection.Link(linkExpressMode = LinkExpressMode.DISABLED))
+        assertThat(paymentFailureCall.paymentSelection)
+            .isEqualTo(PaymentSelection.Link(linkExpressMode = LinkExpressMode.DISABLED))
     }
 
     @Test
@@ -2843,7 +2844,8 @@ internal class PaymentSheetViewModelTest {
 
         val paymentSuccessCall = eventReporter.paymentSuccessCalls.awaitItem()
 
-        assertThat(paymentSuccessCall.paymentSelection).isEqualTo(PaymentSelection.Link(linkExpressMode = LinkExpressMode.ENABLED))
+        assertThat(paymentSuccessCall.paymentSelection)
+            .isEqualTo(PaymentSelection.Link(linkExpressMode = LinkExpressMode.ENABLED))
     }
 
     @Test
@@ -2880,7 +2882,8 @@ internal class PaymentSheetViewModelTest {
 
         val paymentFailureCall = eventReporter.paymentFailureCalls.awaitItem()
 
-        assertThat(paymentFailureCall.paymentSelection).isEqualTo(PaymentSelection.Link(linkExpressMode = LinkExpressMode.ENABLED))
+        assertThat(paymentFailureCall.paymentSelection)
+            .isEqualTo(PaymentSelection.Link(linkExpressMode = LinkExpressMode.ENABLED))
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -301,8 +301,8 @@ internal class DefaultFlowControllerTest {
                     createParams = selection.paymentMethodCreateParams,
                     optionsParams = selection.paymentMethodOptionsParams,
                     extraParams = selection.paymentMethodExtraParams,
-                    shouldSave =
-                    selection.customerRequestedSave == PaymentSelection.CustomerRequestedSave.RequestReuse,
+                    shouldSave = selection.customerRequestedSave == PaymentSelection
+                        .CustomerRequestedSave.RequestReuse,
                 )
             )
 
@@ -519,7 +519,7 @@ internal class DefaultFlowControllerTest {
             configuration = any(),
             linkAccountInfo = anyOrNull(),
             launchMode = any(),
-                            linkExpressMode = any()
+            linkExpressMode = any()
         )
 
         verify(paymentOptionActivityLauncher, never()).launch(any(), anyOrNull())
@@ -559,7 +559,7 @@ internal class DefaultFlowControllerTest {
             configuration = any(),
             linkAccountInfo = anyOrNull(),
             launchMode = any(),
-                            linkExpressMode = any()
+            linkExpressMode = any()
         )
 
         // Simulate user dismissing 2FA with back press
@@ -580,7 +580,7 @@ internal class DefaultFlowControllerTest {
         verify(flowControllerLinkPaymentLauncher, never()).present(
             configuration = any(),
             linkAccountInfo = anyOrNull(),
-                linkExpressMode = any(),
+            linkExpressMode = any(),
             launchMode = any()
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -21,6 +21,7 @@ import com.stripe.android.isInstanceOf
 import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkActivityResult.Canceled.Reason
+import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.LinkPaymentMethod
 import com.stripe.android.link.TestFactory
@@ -518,7 +519,7 @@ internal class DefaultFlowControllerTest {
             configuration = any(),
             linkAccountInfo = anyOrNull(),
             launchMode = any(),
-            useLinkExpress = any()
+                            linkExpressMode = any()
         )
 
         verify(paymentOptionActivityLauncher, never()).launch(any(), anyOrNull())
@@ -558,7 +559,7 @@ internal class DefaultFlowControllerTest {
             configuration = any(),
             linkAccountInfo = anyOrNull(),
             launchMode = any(),
-            useLinkExpress = any()
+                            linkExpressMode = any()
         )
 
         // Simulate user dismissing 2FA with back press
@@ -579,7 +580,7 @@ internal class DefaultFlowControllerTest {
         verify(flowControllerLinkPaymentLauncher, never()).present(
             configuration = any(),
             linkAccountInfo = anyOrNull(),
-            useLinkExpress = any(),
+                linkExpressMode = any(),
             launchMode = any()
         )
 
@@ -909,7 +910,7 @@ internal class DefaultFlowControllerTest {
 
         assertThat(arguments.confirmationOption).isEqualTo(
             LinkConfirmationOption(
-                useLinkExpress = false,
+                linkExpressMode = LinkExpressMode.DISABLED,
                 configuration = TestFactory.LINK_CONFIGURATION,
             )
         )
@@ -1320,7 +1321,7 @@ internal class DefaultFlowControllerTest {
 
         assertThat(arguments.confirmationOption).isEqualTo(
             LinkConfirmationOption(
-                useLinkExpress = false,
+                linkExpressMode = LinkExpressMode.DISABLED,
                 configuration = TestFactory.LINK_CONFIGURATION,
             )
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdaterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdaterTest.kt
@@ -6,6 +6,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.core.model.CountryCode
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.lpmfoundations.paymentmethod.DisplayableCustomPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.PaymentIntentFixtures
@@ -17,7 +18,6 @@ import com.stripe.android.paymentelement.WalletButtonsPreview
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.PaymentSheetState
 import com.stripe.android.testing.PaymentMethodFactory

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdaterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdaterTest.kt
@@ -17,6 +17,7 @@ import com.stripe.android.paymentelement.WalletButtonsPreview
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.PaymentSheetState
 import com.stripe.android.testing.PaymentMethodFactory
@@ -426,7 +427,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            selection = PaymentSelection.Link(useLinkExpress = false),
+            selection = PaymentSelection.Link(linkExpressMode = LinkExpressMode.DISABLED),
             previousConfig = null,
             newState = mockPaymentSheetStateWithPaymentIntent(),
             newConfig = defaultPaymentSheetConfiguration,
@@ -463,7 +464,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            selection = PaymentSelection.Link(useLinkExpress = false),
+            selection = PaymentSelection.Link(linkExpressMode = LinkExpressMode.DISABLED),
             previousConfig = null,
             newState = mockPaymentSheetStateWithPaymentIntent(),
             newConfig = defaultPaymentSheetConfiguration.newBuilder()
@@ -484,7 +485,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            selection = PaymentSelection.Link(useLinkExpress = false),
+            selection = PaymentSelection.Link(linkExpressMode = LinkExpressMode.DISABLED),
             previousConfig = null,
             newState = mockPaymentSheetStateWithPaymentIntent(),
             newConfig = defaultPaymentSheetConfiguration.newBuilder()
@@ -497,7 +498,7 @@ class PaymentSelectionUpdaterTest {
             walletButtonsAlreadyShown = false,
         )
 
-        assertThat(result).isEqualTo(PaymentSelection.Link(useLinkExpress = false))
+        assertThat(result).isEqualTo(PaymentSelection.Link(linkExpressMode = LinkExpressMode.DISABLED))
     }
 
     @OptIn(WalletButtonsPreview::class)
@@ -528,7 +529,7 @@ class PaymentSelectionUpdaterTest {
         val updater = createUpdater()
 
         val result = updater(
-            selection = PaymentSelection.Link(useLinkExpress = false),
+            selection = PaymentSelection.Link(linkExpressMode = LinkExpressMode.DISABLED),
             previousConfig = null,
             newState = mockPaymentSheetStateWithPaymentIntent(),
             newConfig = defaultPaymentSheetConfiguration.newBuilder()
@@ -541,7 +542,7 @@ class PaymentSelectionUpdaterTest {
             walletButtonsAlreadyShown = false,
         )
 
-        assertThat(result).isEqualTo(PaymentSelection.Link(useLinkExpress = false))
+        assertThat(result).isEqualTo(PaymentSelection.Link(linkExpressMode = LinkExpressMode.DISABLED))
     }
 
     private fun mockPaymentSheetStateWithPaymentIntent(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultWalletButtonsInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultWalletButtonsInteractorTest.kt
@@ -9,6 +9,7 @@ import com.stripe.android.common.model.CommonConfigurationFactory
 import com.stripe.android.isInstanceOf
 import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.LinkConfiguration
+import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.TestFactory
 import com.stripe.android.link.account.LinkAccountHolder
@@ -260,7 +261,7 @@ class DefaultWalletButtonsInteractorTest {
             confirmationHandler = FakeConfirmationHandler().apply {
                 state.value = ConfirmationHandler.State.Confirming(
                     LinkConfirmationOption(
-                        useLinkExpress = false,
+                        linkExpressMode = LinkExpressMode.DISABLED,
                         configuration = mock()
                     )
                 )
@@ -346,7 +347,7 @@ class DefaultWalletButtonsInteractorTest {
 
             val call = presentCalls.awaitItem()
             assertThat(call.configuration).isEqualTo(linkConfiguration)
-            assertThat(call.useLinkExpress).isTrue()
+            assertThat(call.linkExpressMode).isNotEqualTo(LinkExpressMode.DISABLED)
         }
     }
 
@@ -752,7 +753,7 @@ class DefaultWalletButtonsInteractorTest {
             confirmationHandler = FakeConfirmationHandler().apply {
                 state.value = ConfirmationHandler.State.Confirming(
                     LinkConfirmationOption(
-                        useLinkExpress = false,
+                        linkExpressMode = LinkExpressMode.DISABLED,
                         configuration = mock()
                     )
                 )

--- a/paymentsheet/src/test/java/com/stripe/android/utils/RecordingLinkPaymentLauncher.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/RecordingLinkPaymentLauncher.kt
@@ -5,6 +5,7 @@ import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
 import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkConfiguration
+import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.link.LinkLaunchMode
 import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.model.LinkAccount
@@ -48,7 +49,7 @@ internal object RecordingLinkPaymentLauncher {
                         configuration = arguments[0] as LinkConfiguration,
                         linkAccount = arguments[1] as? LinkAccount,
                         launchMode = arguments[2] as LinkLaunchMode,
-                        useLinkExpress = arguments[3] as Boolean
+                        linkExpressMode = arguments[3] as LinkExpressMode
                     )
                 )
             }
@@ -84,6 +85,6 @@ internal object RecordingLinkPaymentLauncher {
         val configuration: LinkConfiguration,
         val linkAccount: LinkAccount?,
         val launchMode: LinkLaunchMode,
-        val useLinkExpress: Boolean,
+        val linkExpressMode: LinkExpressMode,
     )
 }


### PR DESCRIPTION
# Summary

Replace useLinkExpress boolean with LinkExpressMode enum. We now have 3 states:

- DISABLED - Link Express is disabled
- ENABLED - Link Express is enabled with web fallback
- ENABLED_NO_WEB_FALLBACK - Link Express is enabled but skips web fallback on attestation errors.

The ENABLED_NO_WEB_FALLBACK mode is specifically for PaymentSheet flows that launch OTP verification immediately, where falling back to web would be invasive to the user experience.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
