### PR TITLE
Keep Link mandate irregardless of the `TermsDisplay` value

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -149,7 +149,7 @@ private object CardUiDefinitionFactory : UiDefinitionFactory.Simple {
             }
 
             val mandateAllowed = metadata.mandateAllowed(CardDefinition.type)
-            if (linkSignupOptInEnabled && signupMode != null && mandateAllowed) {
+            if (linkSignupOptInEnabled && signupMode != null) {
                 add(
                     CombinedLinkMandateElement(
                         identifier = IdentifierSpec.Generic("card_mandate"),

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinitionTest.kt
@@ -396,6 +396,37 @@ class CardDefinitionTest {
     }
 
     @Test
+    fun `createFormElements retains Link mandate when termsDisplay is NEVER`() {
+        val termsDisplay = mapOf(
+            PaymentMethod.Type.Card to PaymentSheet.TermsDisplay.NEVER
+        )
+        val metadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
+            termsDisplay = termsDisplay,
+            linkState = LinkState(
+                configuration = TestFactory.LINK_CONFIGURATION.copy(
+                    linkSignUpOptInFeatureEnabled = true,
+                ),
+                loginState = LinkState.LoginState.LoggedOut,
+                signupMode = LinkSignupMode.AlongsideSaveForFutureUse,
+            )
+        )
+
+        val formElements = CardDefinition.formElements(
+            metadata,
+            linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
+        )
+
+        // Should only include card_details and billing section, no mandate
+        assertThat(formElements).hasSize(4)
+        assertThat(formElements[0].identifier.v1).isEqualTo("card_details")
+        assertThat(formElements[1].identifier.v1).isEqualTo("credit_billing_section")
+        assertThat(formElements[2].identifier.v1).isEqualTo("link_form")
+        assertThat(formElements[3].identifier.v1).isEqualTo("card_mandate")
+        assertThat(formElements[3]).isInstanceOf<CombinedLinkMandateElement>()
+    }
+
+    @Test
     fun `createFormElements includes mandate by default when termsDisplay not specified`() {
         val metadata = PaymentMethodMetadataFactory.create(
             stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,


### PR DESCRIPTION
# Summary
Keep Link mandate irregardless of the `TermsDisplay` value

# Motivation
Link team wants this mandate shown all the time since it revolves around Link legal terms.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified