### PR TITLE
Direct to card scan: Launching CardScanActivity from CardDetailsSectionController preview

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/NamedConstants.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/NamedConstants.kt
@@ -27,3 +27,8 @@ const val IS_INSTANT_APP = "isInstantApp"
 const val STATUS_BAR_COLOR = "STATUS_BAR_COLOR"
 
 internal const val INCLUDE_PAYMENT_SHEET_NEXT_ACTION_HANDLERS = "INCLUDE_PAYMENT_SHEET_NEXT_ACTION_HANDLERS"
+
+/**
+ * Name to indicate whether the user has seen direct-to-card-scan.
+ */
+const val HAS_SEEN_DIRECT_TO_CARD_SCAN = "HAS_SEEN_DIRECT_TO_CARD_SCAN"

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/cardscan/CardScanContract.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/cardscan/CardScanContract.kt
@@ -4,13 +4,15 @@ import android.content.Context
 import android.content.Intent
 import android.os.Parcelable
 import androidx.activity.result.contract.ActivityResultContract
+import androidx.annotation.RestrictTo
 import androidx.core.os.BundleCompat
 import com.stripe.android.stripecardscan.cardscan.CardScanConfiguration
 import com.stripe.android.stripecardscan.cardscan.CardScanSheetResult
 import com.stripe.android.stripecardscan.cardscan.exception.UnknownScanException
 import kotlinx.parcelize.Parcelize
 
-internal class CardScanContract : ActivityResultContract<CardScanContract.Args, CardScanSheetResult>() {
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class CardScanContract : ActivityResultContract<CardScanContract.Args, CardScanSheetResult>() {
     override fun createIntent(context: Context, input: Args): Intent {
         return Intent(context, CardScanActivity::class.java)
             .apply {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionController.kt
@@ -4,6 +4,7 @@ import androidx.annotation.RestrictTo
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.cards.CardAccountRangeRepository
+import com.stripe.android.stripecardscan.cardscan.CardScanSheetResult
 import com.stripe.android.ui.core.DefaultIsStripeCardScanAvailable
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.uicore.elements.IdentifierSpec
@@ -16,7 +17,8 @@ class CardDetailsSectionController(
     collectName: Boolean = false,
     cbcEligibility: CardBrandChoiceEligibility = CardBrandChoiceEligibility.Ineligible,
     cardBrandFilter: CardBrandFilter = DefaultCardBrandFilter,
-    val elementsSessionId: String? = null
+    val elementsSessionId: String? = null,
+    val directToCardScanData: DirectToCardScanData?,
 ) : SectionFieldErrorController {
 
     internal val cardDetailsElement = CardDetailsElement(
@@ -32,4 +34,8 @@ class CardDetailsSectionController(
     internal val isStripeCardScanAvailable = DefaultIsStripeCardScanAvailable()
 
     override val error = cardDetailsElement.controller.error
+
+    fun onCardScanResult(result: CardScanSheetResult) {
+        cardDetailsElement.controller.numberElement.controller.onCardScanResult(result)
+    }
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionElement.kt
@@ -16,6 +16,7 @@ class CardDetailsSectionElement(
     cardAccountRangeRepositoryFactory: CardAccountRangeRepository.Factory,
     initialValues: Map<IdentifierSpec, String?>,
     elementsSessionId: String? = null,
+    directToCardScanData: DirectToCardScanData?,
     private val collectName: Boolean = false,
     private val cbcEligibility: CardBrandChoiceEligibility = CardBrandChoiceEligibility.Ineligible,
     private val cardBrandFilter: CardBrandFilter = DefaultCardBrandFilter,
@@ -26,7 +27,8 @@ class CardDetailsSectionElement(
         collectName = collectName,
         cbcEligibility = cbcEligibility,
         cardBrandFilter = cardBrandFilter,
-        elementsSessionId = elementsSessionId
+        elementsSessionId = elementsSessionId,
+        directToCardScanData = directToCardScanData,
     )
 ) : FormElement {
     override val allowsUserInteraction: Boolean = true

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionElementUI.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.ui.core.elements
 
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.annotation.RestrictTo
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -7,18 +8,24 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
+import androidx.core.app.ActivityOptionsCompat
+import com.stripe.android.stripecardscan.cardscan.CardScanConfiguration
 import com.stripe.android.ui.core.R
+import com.stripe.android.ui.core.cardscan.CardScanContract
 import com.stripe.android.uicore.elements.H6Text
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SectionController
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.SectionElementUI
+import com.stripe.android.uicore.utils.AnimationConstants
 
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -29,6 +36,35 @@ fun CardDetailsSectionElementUI(
     lastTextFieldIdentifier: IdentifierSpec?,
     modifier: Modifier = Modifier,
 ) {
+    if (
+        controller.isCardScanEnabled &&
+        controller.isStripeCardScanAvailable() &&
+        controller.directToCardScanData?.shouldOpenCardScanAutomatically == true
+    ) {
+        val cardScanLauncher =
+            rememberLauncherForActivityResult(CardScanContract()) { result ->
+                controller.onCardScanResult(result)
+            }
+
+        val options = ActivityOptionsCompat.makeCustomAnimation(
+            LocalContext.current,
+            AnimationConstants.FADE_IN,
+            AnimationConstants.FADE_OUT,
+        )
+
+        SideEffect {
+            controller.directToCardScanData.shouldOpenCardScanAutomatically = false
+
+            cardScanLauncher.launch(
+                input = CardScanContract.Args(
+                    configuration = CardScanConfiguration(
+                        elementsSessionId = controller.elementsSessionId
+                    )
+                ),
+                options
+            )
+        }
+    }
     Column(modifier) {
         Row(
             horizontalArrangement = Arrangement.SpaceBetween,
@@ -48,7 +84,7 @@ fun CardDetailsSectionElementUI(
                     enabled = enabled,
                     elementsSessionId = controller.elementsSessionId
                 ) {
-                    controller.cardDetailsElement.controller.numberElement.controller.onCardScanResult(it)
+                    controller.onCardScanResult(it)
                 }
             }
         }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DirectToCardScanData.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DirectToCardScanData.kt
@@ -1,0 +1,19 @@
+package com.stripe.android.ui.core.elements
+
+import androidx.lifecycle.SavedStateHandle
+
+class DirectToCardScanData(
+    shouldOpenCardScanAutomaticallyInitialValue: Boolean,
+    private val savedStateHandle: SavedStateHandle
+) {
+    var shouldOpenCardScanAutomatically: Boolean
+        get() = savedStateHandle[KEY_SHOULD_OPEN_CARD_SCAN] ?: false
+        set(value) = savedStateHandle.set(KEY_SHOULD_OPEN_CARD_SCAN, value)
+    init {
+        shouldOpenCardScanAutomatically = shouldOpenCardScanAutomaticallyInitialValue
+    }
+
+    companion object {
+        const val KEY_SHOULD_OPEN_CARD_SCAN = "KEY_SHOULD_OPEN_CARD_SCAN"
+    }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/DirectToCardScanDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/DirectToCardScanDefinition.kt
@@ -1,0 +1,59 @@
+package com.stripe.android.paymentsheet.example.playground.settings
+
+import com.stripe.android.customersheet.CustomerSheet
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.example.Settings
+import com.stripe.android.paymentsheet.example.playground.PlaygroundState
+
+internal object DirectToCardScanDefinition: BooleanSettingsDefinition(
+    key = "directToCardScan",
+    displayName = "Direct To Card Scan",
+    defaultValue = false
+) {
+    override fun configure(
+        value: Boolean,
+        configurationBuilder: PaymentSheet.Configuration.Builder,
+        playgroundState: PlaygroundState.Payment,
+        configurationData: PlaygroundSettingDefinition.PaymentSheetConfigurationData,
+        settings: Settings
+    ) {
+        configurationBuilder.opensCardScannerAutomatically(value)
+    }
+
+    override fun configure(
+        value: Boolean,
+        configurationBuilder: CustomerSheet.Configuration.Builder,
+        playgroundState: PlaygroundState.Customer,
+        configurationData: PlaygroundSettingDefinition.CustomerSheetConfigurationData
+    ) {
+        configurationBuilder.opensCardScannerAutomatically(value)
+    }
+
+    override fun configure(
+        value: Boolean,
+        configurationBuilder: PaymentSheet.Configuration.Builder,
+        playgroundState: PlaygroundState.Payment,
+        configurationData: PlaygroundSettingDefinition.PaymentSheetConfigurationData
+    ) {
+        configurationBuilder.opensCardScannerAutomatically(value)
+    }
+
+    override fun configure(
+        value: Boolean,
+        configurationBuilder: PaymentSheet.Configuration.Builder,
+        playgroundState: PlaygroundState.SharedPaymentToken,
+        configurationData: PlaygroundSettingDefinition.PaymentSheetConfigurationData
+    ) {
+        configurationBuilder.opensCardScannerAutomatically(value)
+    }
+
+    override fun configure(
+        value: Boolean,
+        configurationBuilder: EmbeddedPaymentElement.Configuration.Builder,
+        playgroundState: PlaygroundState.Payment,
+        configurationData: PlaygroundSettingDefinition.EmbeddedConfigurationData
+    ) {
+        configurationBuilder.opensCardScannerAutomatically(value)
+    }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -511,6 +511,7 @@ internal class PlaygroundSettings private constructor(
             CustomPaymentMethodsSettingDefinition,
             LayoutSettingsDefinition,
             CardBrandAcceptanceSettingsDefinition,
+            DirectToCardScanDefinition,
             FeatureFlagSettingsDefinition(
                 FeatureFlags.instantDebitsIncentives,
                 PlaygroundConfigurationData.IntegrationType.paymentFlows().toList(),

--- a/paymentsheet/build.gradle
+++ b/paymentsheet/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     api project(":payments-core")
     implementation project(':payments-ui-core')
     implementation project(':stripe-ui-core')
+    compileOnly project(':stripecardscan')
     compileOnly project(':financial-connections')
     implementation project(":stripe-attestation")
 

--- a/paymentsheet/src/main/java/com/stripe/android/common/configuration/ConfigurationDefaults.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/configuration/ConfigurationDefaults.kt
@@ -31,6 +31,7 @@ internal object ConfigurationDefaults {
     val walletButtons: PaymentSheet.WalletButtonsConfiguration = PaymentSheet.WalletButtonsConfiguration()
     val shopPayConfiguration: PaymentSheet.ShopPayConfiguration? = null
     val googlePlacesApiKey: String? = null
+    const val opensCardScannerAutomatically: Boolean = false
 
     const val embeddedViewDisplaysMandateText: Boolean = true
 }

--- a/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
@@ -36,6 +36,7 @@ internal data class CommonConfiguration(
     val linkAppearance: LinkAppearance? = null,
     val termsDisplay: Map<PaymentMethod.Type, TermsDisplay>,
     val walletButtons: PaymentSheet.WalletButtonsConfiguration?,
+    val opensCardScannerAutomaticallyConfig: Boolean,
 ) : Parcelable {
 
     fun validate(isLiveMode: Boolean) {
@@ -180,6 +181,7 @@ internal fun PaymentSheet.Configuration.asCommonConfiguration(): CommonConfigura
     googlePlacesApiKey = googlePlacesApiKey,
     termsDisplay = termsDisplay,
     walletButtons = walletButtons,
+    opensCardScannerAutomaticallyConfig = opensCardScannerAutomatically,
 )
 
 internal fun EmbeddedPaymentElement.Configuration.asCommonConfiguration(): CommonConfiguration = CommonConfiguration(
@@ -202,6 +204,7 @@ internal fun EmbeddedPaymentElement.Configuration.asCommonConfiguration(): Commo
     googlePlacesApiKey = null,
     termsDisplay = termsDisplay,
     walletButtons = null,
+    opensCardScannerAutomaticallyConfig = opensCardScannerAutomatically,
 )
 
 internal fun LinkController.Configuration.asCommonConfiguration(): CommonConfiguration = CommonConfiguration(
@@ -229,6 +232,7 @@ internal fun LinkController.Configuration.asCommonConfiguration(): CommonConfigu
     linkAppearance = linkAppearance,
     termsDisplay = emptyMap(),
     walletButtons = null,
+    opensCardScannerAutomaticallyConfig = false,
 )
 
 private fun String.isEKClientSecretValid(): Boolean {

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
@@ -229,6 +229,8 @@ class CustomerSheet internal constructor(
         internal val paymentMethodOrder: List<String> = ConfigurationDefaults.paymentMethodOrder,
 
         internal val cardBrandAcceptance: CardBrandAcceptance = ConfigurationDefaults.cardBrandAcceptance,
+
+        internal val opensCardScannerAutomatically: Boolean = ConfigurationDefaults.opensCardScannerAutomatically
     ) : Parcelable {
 
         // Hide no-argument constructor init
@@ -266,6 +268,7 @@ class CustomerSheet internal constructor(
                 ConfigurationDefaults.allowsRemovalOfLastSavedPaymentMethod
             private var paymentMethodOrder: List<String> = ConfigurationDefaults.paymentMethodOrder
             private var cardBrandAcceptance: CardBrandAcceptance = ConfigurationDefaults.cardBrandAcceptance
+            private var opensCardScannerAutomatically: Boolean = ConfigurationDefaults.opensCardScannerAutomatically
 
             fun appearance(appearance: PaymentSheet.Appearance) = apply {
                 this.appearance = appearance
@@ -328,6 +331,15 @@ class CustomerSheet internal constructor(
                 this.cardBrandAcceptance = cardBrandAcceptance
             }
 
+            /**
+             * By default, the customer sheet offers a card scan button within the new card entry form.
+             * When opensCardScannerAutomatically is set to true, the card entry form will initialize with the card scanner already open.
+             * **Note**: The stripecardscan dependency must be added to set `opensCardScannerAutomatically` to true
+             */
+            fun opensCardScannerAutomatically(opensCardScannerAutomatically: Boolean) = apply {
+                this.opensCardScannerAutomatically = opensCardScannerAutomatically
+            }
+
             fun build() = Configuration(
                 appearance = appearance,
                 googlePayEnabled = googlePayEnabled,
@@ -338,7 +350,8 @@ class CustomerSheet internal constructor(
                 preferredNetworks = preferredNetworks,
                 allowsRemovalOfLastSavedPaymentMethod = allowsRemovalOfLastSavedPaymentMethod,
                 paymentMethodOrder = paymentMethodOrder,
-                cardBrandAcceptance = cardBrandAcceptance
+                cardBrandAcceptance = cardBrandAcceptance,
+                opensCardScannerAutomatically = opensCardScannerAutomatically,
             )
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -468,6 +468,7 @@ internal class CustomerSheetViewModel(
                             )
                         },
                         autocompleteAddressInteractorFactory = null,
+                        directToCardScanData = null,
                     ),
                 ) ?: listOf(),
                 primaryButtonLabel = if (
@@ -815,6 +816,7 @@ internal class CustomerSheetViewModel(
                     )
                 },
                 autocompleteAddressInteractorFactory = null,
+                directToCardScanData = null,
             )
         ) ?: emptyList()
 

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -70,6 +70,7 @@ internal data class PaymentMethodMetadata(
     val elementsSessionId: String,
     val shopPayConfiguration: PaymentSheet.ShopPayConfiguration?,
     val termsDisplay: Map<PaymentMethod.Type, PaymentSheet.TermsDisplay>,
+    val openCardScanAutomaticallyConfig: Boolean,
 ) : Parcelable {
     fun hasIntentToSetup(code: PaymentMethodCode): Boolean {
         return when (stripeIntent) {
@@ -331,6 +332,7 @@ internal data class PaymentMethodMetadata(
                 elementsSessionId = elementsSession.elementsSessionId,
                 shopPayConfiguration = configuration.shopPayConfiguration,
                 termsDisplay = configuration.termsDisplay,
+                openCardScanAutomaticallyConfig = configuration.opensCardScannerAutomaticallyConfig,
             )
         }
 
@@ -377,6 +379,7 @@ internal data class PaymentMethodMetadata(
                 financialConnectionsAvailability = GetFinancialConnectionsAvailability(elementsSession),
                 shopPayConfiguration = null,
                 termsDisplay = emptyMap(),
+                openCardScanAutomaticallyConfig = configuration.opensCardScannerAutomatically,
             )
         }
 
@@ -424,6 +427,7 @@ internal data class PaymentMethodMetadata(
                 financialConnectionsAvailability = GetFinancialConnectionsAvailability(elementsSession = null),
                 shopPayConfiguration = null,
                 termsDisplay = emptyMap(),
+                openCardScanAutomaticallyConfig = false,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionFactory.kt
@@ -19,6 +19,7 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.toIdentifierMap
 import com.stripe.android.paymentsheet.model.PaymentMethodIncentive
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
+import com.stripe.android.ui.core.elements.DirectToCardScanData
 import com.stripe.android.ui.core.elements.FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE
 import com.stripe.android.ui.core.elements.SharedDataSpec
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
@@ -42,6 +43,7 @@ internal sealed interface UiDefinitionFactory {
         val setAsDefaultMatchesSaveForFutureUse: Boolean,
         val autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
         val linkInlineHandler: LinkInlineHandler?,
+        val directToCardScanData: DirectToCardScanData?,
     ) {
         interface Factory {
             fun create(
@@ -61,6 +63,7 @@ internal sealed interface UiDefinitionFactory {
                 private val setAsDefaultMatchesSaveForFutureUse: Boolean =
                     FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE,
                 private val autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
+                private val directToCardScanData: DirectToCardScanData? = null,
             ) : Factory {
                 override fun create(
                     metadata: PaymentMethodMetadata,
@@ -86,6 +89,7 @@ internal sealed interface UiDefinitionFactory {
                         setAsDefaultMatchesSaveForFutureUse = setAsDefaultMatchesSaveForFutureUse,
                         autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
                         linkInlineHandler = linkInlineHandler,
+                        directToCardScanData = directToCardScanData,
                     )
                 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -105,7 +105,8 @@ private object CardUiDefinitionFactory : UiDefinitionFactory.Simple {
                     collectName = billingDetailsCollectionConfiguration.collectsName,
                     cbcEligibility = arguments.cbcEligibility,
                     cardBrandFilter = arguments.cardBrandFilter,
-                    elementsSessionId = metadata.elementsSessionId
+                    elementsSessionId = metadata.elementsSessionId,
+                    directToCardScanData = arguments.directToCardScanData,
                 )
             )
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
@@ -238,6 +238,7 @@ class EmbeddedPaymentElement @Inject internal constructor(
         internal val link: PaymentSheet.LinkConfiguration,
         internal val formSheetAction: FormSheetAction,
         internal val termsDisplay: Map<PaymentMethod.Type, TermsDisplay> = emptyMap(),
+        internal val opensCardScannerAutomatically: Boolean = ConfigurationDefaults.opensCardScannerAutomatically,
     ) : Parcelable {
         @Suppress("TooManyFunctions")
         class Builder(
@@ -270,6 +271,7 @@ class EmbeddedPaymentElement @Inject internal constructor(
             private var link: PaymentSheet.LinkConfiguration = ConfigurationDefaults.link
             private var formSheetAction: FormSheetAction = FormSheetAction.Continue
             private var termsDisplay: Map<PaymentMethod.Type, TermsDisplay> = emptyMap()
+            private var opensCardScannerAutomatically: Boolean = ConfigurationDefaults.opensCardScannerAutomatically
 
             /**
              * If set, the customer can select a previously saved payment method.
@@ -477,6 +479,14 @@ class EmbeddedPaymentElement @Inject internal constructor(
             fun termsDisplay(termsDisplay: Map<PaymentMethod.Type, TermsDisplay>) = apply {
                 this.termsDisplay = termsDisplay
             }
+            /**
+             * By default, the embedded payment element offers a card scan button within the new card entry form.
+             * When opensCardScannerAutomatically is set to true, the card entry form will initialize with the card scanner already open.
+             * **Note**: The stripecardscan dependency must be added to set `opensCardScannerAutomatically` to true
+             */
+            fun opensCardScannerAutomatically(opensCardScannerAutomatically: Boolean) = apply {
+                this.opensCardScannerAutomatically = opensCardScannerAutomatically
+            }
 
             fun build() = Configuration(
                 merchantDisplayName = merchantDisplayName,
@@ -499,6 +509,7 @@ class EmbeddedPaymentElement @Inject internal constructor(
                 link = link,
                 formSheetAction = formSheetAction,
                 termsDisplay = termsDisplay,
+                opensCardScannerAutomatically = opensCardScannerAutomatically,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedFormHelperFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedFormHelperFactory.kt
@@ -10,14 +10,18 @@ import com.stripe.android.paymentsheet.LinkInlineHandler
 import com.stripe.android.paymentsheet.NewPaymentOptionSelection
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.payments.core.injection.HAS_SEEN_DIRECT_TO_CARD_SCAN
+import com.stripe.android.ui.core.elements.DirectToCardScanData
 import kotlinx.coroutines.CoroutineScope
 import javax.inject.Inject
+import javax.inject.Named
 
 internal class EmbeddedFormHelperFactory @Inject constructor(
     private val linkConfigurationCoordinator: LinkConfigurationCoordinator,
     private val embeddedSelectionHolder: EmbeddedSelectionHolder,
     private val cardAccountRangeRepositoryFactory: CardAccountRangeRepository.Factory,
     private val savedStateHandle: SavedStateHandle,
+    @Named(HAS_SEEN_DIRECT_TO_CARD_SCAN) private val hasSeenDirectToCardScan: Boolean,
 ) {
     fun create(
         coroutineScope: CoroutineScope,
@@ -51,6 +55,11 @@ internal class EmbeddedFormHelperFactory @Inject constructor(
             eventReporter = eventReporter,
             savedStateHandle = savedStateHandle,
             autocompleteAddressInteractorFactory = null,
+            directToCardScanData = DirectToCardScanData(
+                shouldOpenCardScanAutomaticallyInitialValue =
+                    !hasSeenDirectToCardScan && paymentMethodMetadata.openCardScanAutomaticallyConfig,
+                savedStateHandle = savedStateHandle,
+            ),
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
@@ -46,6 +46,7 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
     private val rowSelectionImmediateActionHandler: EmbeddedRowSelectionImmediateActionHandler,
     private val customerStateHolder: CustomerStateHolder,
     private val sheetStateHolder: SheetStateHolder,
+    private val hasSeenDirectToCardScanHolder: EmbeddedHasSeenDirectToCardScanHolder,
     private val errorReporter: ErrorReporter,
     @Named(STATUS_BAR_COLOR) private val statusBarColor: Int?,
     @PaymentElementCallbackIdentifier private val paymentElementCallbackIdentifier: String,
@@ -82,6 +83,7 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
                     EmbeddedPaymentElement.Result.Canceled()
                 )
             }
+            hasSeenDirectToCardScanHolder.hasSeenDirectToCardScan = true
         }
 
     private val manageActivityLauncher: ActivityResultLauncher<ManageContract.Args> =
@@ -126,6 +128,7 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
             paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
             statusBarColor = statusBarColor,
             paymentSelection = currentSelection,
+            hasSeenDirectToCardScan = hasSeenDirectToCardScanHolder.hasSeenDirectToCardScan
         )
         formActivityLauncher.launch(args)
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
@@ -30,6 +30,7 @@ import com.stripe.android.paymentsheet.ui.WalletButtonsInteractor
 import com.stripe.android.paymentsheet.verticalmode.DefaultPaymentMethodVerticalLayoutInteractor
 import com.stripe.android.paymentsheet.verticalmode.PaymentMethodIncentiveInteractor
 import com.stripe.android.paymentsheet.verticalmode.PaymentMethodVerticalLayoutInteractor
+import com.stripe.android.ui.core.elements.DirectToCardScanData
 import com.stripe.android.ui.core.elements.FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedHasSeenDirectToCardScanHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedHasSeenDirectToCardScanHolder.kt
@@ -1,0 +1,18 @@
+package com.stripe.android.paymentelement.embedded.content
+
+import androidx.lifecycle.SavedStateHandle
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+internal class EmbeddedHasSeenDirectToCardScanHolder @Inject constructor(
+    private val savedStateHandle: SavedStateHandle,
+) {
+    var hasSeenDirectToCardScan: Boolean
+        get() = savedStateHandle.get<Boolean>(HAS_SEEN_DIRECT_TO_CARD_SCAN_KEY) == true
+        set(value) = savedStateHandle.set(HAS_SEEN_DIRECT_TO_CARD_SCAN_KEY, value)
+
+    companion object {
+        private const val HAS_SEEN_DIRECT_TO_CARD_SCAN_KEY = "HAS_SEEN_DIRECT_TO_CARD_SCAN_KEY"
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModelComponent.kt
@@ -42,6 +42,7 @@ import com.stripe.android.paymentsheet.state.RetrieveCustomerEmail
 import com.stripe.android.ui.core.di.CardScanModule
 import com.stripe.android.uicore.image.StripeImageLoader
 import com.stripe.android.uicore.utils.mapAsStateFlow
+import com.stripe.android.payments.core.injection.HAS_SEEN_DIRECT_TO_CARD_SCAN
 import dagger.Binds
 import dagger.BindsInstance
 import dagger.Component
@@ -232,6 +233,14 @@ internal interface EmbeddedPaymentElementViewModelModule {
             @PaymentElementCallbackIdentifier paymentElementCallbackIdentifier: String,
         ): InternalRowSelectionCallback? {
             return PaymentElementCallbackReferences[paymentElementCallbackIdentifier]?.rowSelectionCallback
+        }
+
+        @Provides
+        @Named(HAS_SEEN_DIRECT_TO_CARD_SCAN)
+        fun providesHasSeenDirectToCardScan(
+            hasSeenDirectToCardScanHolder: EmbeddedHasSeenDirectToCardScanHolder
+        ): Boolean {
+            return hasSeenDirectToCardScanHolder.hasSeenDirectToCardScan
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityViewModel.kt
@@ -28,6 +28,7 @@ internal class FormActivityViewModel @Inject constructor(
                 paymentMethodMetadata = args.paymentMethodMetadata,
                 selectedPaymentMethodCode = args.selectedPaymentMethodCode,
                 hasSavedPaymentMethods = args.hasSavedPaymentMethods,
+                hasSeenDirectToCardScan = args.hasSeenDirectToCardScan,
                 configuration = args.configuration,
                 initializationMode = args.initializationMode,
                 statusBarColor = args.statusBarColor,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityViewModelComponent.kt
@@ -21,6 +21,7 @@ import com.stripe.android.paymentelement.confirmation.injection.ExtendedPaymentE
 import com.stripe.android.paymentelement.embedded.EmbeddedCommonModule
 import com.stripe.android.paymentelement.embedded.EmbeddedLinkExtrasModule
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.payments.core.injection.HAS_SEEN_DIRECT_TO_CARD_SCAN
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.paymentsheet.verticalmode.DefaultVerticalModeFormInteractor
@@ -58,6 +59,8 @@ internal interface FormActivityViewModelComponent {
             @BindsInstance paymentMethodMetadata: PaymentMethodMetadata,
             @BindsInstance selectedPaymentMethodCode: PaymentMethodCode,
             @BindsInstance hasSavedPaymentMethods: Boolean,
+            @Named(HAS_SEEN_DIRECT_TO_CARD_SCAN)
+            @BindsInstance hasSeenDirectToCardScan: Boolean,
             @BindsInstance
             @Named(STATUS_BAR_COLOR)
             statusBarColor: Int?,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormContract.kt
@@ -57,6 +57,7 @@ internal object FormContract : ActivityResultContract<FormContract.Args, FormRes
         val selectedPaymentMethodCode: String,
         val paymentMethodMetadata: PaymentMethodMetadata,
         val hasSavedPaymentMethods: Boolean,
+        val hasSeenDirectToCardScan: Boolean,
         val configuration: EmbeddedPaymentElement.Configuration,
         val initializationMode: PaymentElementLoader.InitializationMode,
         val paymentElementCallbackIdentifier: String,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultFormHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultFormHelper.kt
@@ -20,6 +20,7 @@ import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.ui.transformToPaymentMethodCreateParams
 import com.stripe.android.paymentsheet.ui.transformToPaymentSelection
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
+import com.stripe.android.ui.core.elements.DirectToCardScanData
 import com.stripe.android.ui.core.elements.FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.FormElement
@@ -34,6 +35,7 @@ internal class DefaultFormHelper(
     private val linkInlineHandler: LinkInlineHandler,
     private val cardAccountRangeRepositoryFactory: CardAccountRangeRepository.Factory,
     private val paymentMethodMetadata: PaymentMethodMetadata,
+    private val directToCardScanData: DirectToCardScanData?,
     private val newPaymentSelectionProvider: () -> NewPaymentOptionSelection?,
     private val selectionUpdater: (PaymentSelection?) -> Unit,
     private val linkConfigurationCoordinator: LinkConfigurationCoordinator?,
@@ -65,6 +67,7 @@ internal class DefaultFormHelper(
                 eventReporter = viewModel.eventReporter,
                 savedStateHandle = viewModel.savedStateHandle,
                 autocompleteAddressInteractorFactory = viewModel.autocompleteAddressInteractorFactory,
+                directToCardScanData = viewModel.directToCardScanData,
             )
         }
 
@@ -88,6 +91,7 @@ internal class DefaultFormHelper(
                 eventReporter = eventReporter,
                 savedStateHandle = savedStateHandle,
                 autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
+                directToCardScanData = null,
             )
         }
     }
@@ -161,6 +165,7 @@ internal class DefaultFormHelper(
                 },
                 setAsDefaultMatchesSaveForFutureUse = setAsDefaultMatchesSaveForFutureUse,
                 autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
+                directToCardScanData = directToCardScanData,
             ),
         ) ?: emptyList()
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionContract.kt
@@ -32,6 +32,7 @@ internal class PaymentOptionContract :
         val configuration: PaymentSheet.Configuration,
         val linkAccountInfo: LinkAccountUpdate.Value,
         val enableLogging: Boolean,
+        val hasSeenDirectToCardScan: Boolean,
         val walletsToShow: List<WalletType>,
         val productUsage: Set<String>,
         val paymentElementCallbackIdentifier: String,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -302,6 +302,19 @@ internal class PaymentOptionsViewModel @Inject constructor(
             linkGateFactory.create(linkConfiguration).showRuxInFlowController
     }
 
+    override suspend fun initializeHasSeenDirectToCardScanValue() {
+        paymentMethodMetadata.collect { metadata ->
+            if (metadata != null) {
+                directToCardScanData.shouldOpenCardScanAutomatically =
+                    metadata.openCardScanAutomaticallyConfig && !args.hasSeenDirectToCardScan
+                // no saved PMs
+//            customerStateHolder?.paymentMethods?.value.isNullOrEmpty() &&
+//            paymentMethodMetadata.supportedPaymentMethodTypes().size == 1 &&
+//            paymentMethodMetadata.supportedPaymentMethodTypes()[0] == PaymentMethod.Type.Card.code
+            }
+        }
+    }
+
     override fun handlePaymentMethodSelected(selection: PaymentSelection?) {
         updateSelection(selection)
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -806,6 +806,8 @@ class PaymentSheet internal constructor(
         internal val googlePlacesApiKey: String? = ConfigurationDefaults.googlePlacesApiKey,
 
         internal val termsDisplay: Map<PaymentMethod.Type, TermsDisplay> = emptyMap(),
+
+        internal val opensCardScannerAutomatically: Boolean = ConfigurationDefaults.opensCardScannerAutomatically,
     ) : Parcelable {
 
         @JvmOverloads
@@ -962,6 +964,7 @@ class PaymentSheet internal constructor(
             private var shopPayConfiguration: ShopPayConfiguration? = ConfigurationDefaults.shopPayConfiguration
             private var googlePlacesApiKey: String? = ConfigurationDefaults.googlePlacesApiKey
             private var termsDisplay: Map<PaymentMethod.Type, TermsDisplay> = emptyMap()
+            private var opensCardScannerAutomatically: Boolean = ConfigurationDefaults.opensCardScannerAutomatically
 
             private var customPaymentMethods: List<CustomPaymentMethod> =
                 ConfigurationDefaults.customPaymentMethods
@@ -1128,6 +1131,16 @@ class PaymentSheet internal constructor(
                 this.termsDisplay = termsDisplay
             }
 
+            /**
+             * By default, the payment sheet offers a card scan button within the new card entry form.
+             * When opensCardScannerAutomatically is set to true, the card entry form will
+             * initialize with the card scanner already open.
+             * **Note**: The stripecardscan dependency must be added to set `opensCardScannerAutomatically` to true
+             */
+            fun opensCardScannerAutomatically(opensCardScannerAutomatically: Boolean) = apply {
+                this.opensCardScannerAutomatically = opensCardScannerAutomatically
+            }
+
             fun build() = Configuration(
                 merchantDisplayName = merchantDisplayName,
                 customer = customer,
@@ -1152,6 +1165,7 @@ class PaymentSheet internal constructor(
                 shopPayConfiguration = shopPayConfiguration,
                 googlePlacesApiKey = googlePlacesApiKey,
                 termsDisplay = termsDisplay,
+                opensCardScannerAutomatically = opensCardScannerAutomatically,
             )
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -647,6 +647,19 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         _paymentSheetResult.tryEmit(PaymentSheetResult.Canceled)
     }
 
+    override suspend fun initializeHasSeenDirectToCardScanValue() {
+        paymentMethodMetadata.collect { metadata ->
+            if (metadata != null) {
+                directToCardScanData.shouldOpenCardScanAutomatically =
+                    metadata.openCardScanAutomaticallyConfig
+                // no saved PMs
+//            customerStateHolder?.paymentMethods?.value.isNullOrEmpty() &&
+//            paymentMethodMetadata.supportedPaymentMethodTypes().size == 1 &&
+//            paymentMethodMetadata.supportedPaymentMethodTypes()[0] == PaymentMethod.Type.Card.code
+            }
+        }
+    }
+
     override fun onError(error: ResolvableString?) = resetViewState(error)
 
     private fun determineInitialBackStack(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -32,6 +32,7 @@ import com.stripe.android.paymentsheet.state.WalletsState
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.ui.core.elements.CvcConfig
 import com.stripe.android.ui.core.elements.CvcController
+import com.stripe.android.ui.core.elements.DirectToCardScanData
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.flatMapLatestAsStateFlow
@@ -64,6 +65,11 @@ internal abstract class BaseSheetViewModel(
 
     private val _paymentMethodMetadata = MutableStateFlow<PaymentMethodMetadata?>(null)
     internal val paymentMethodMetadata: StateFlow<PaymentMethodMetadata?> = _paymentMethodMetadata
+
+    val directToCardScanData = DirectToCardScanData(
+        shouldOpenCardScanAutomaticallyInitialValue = false,
+        savedStateHandle = savedStateHandle,
+    )
 
     val navigationHandler: NavigationHandler<PaymentSheetScreen> = NavigationHandler(
         coroutineScope = viewModelScope,
@@ -148,6 +154,10 @@ internal abstract class BaseSheetViewModel(
                 clearErrorMessages()
             }
         }
+
+        viewModelScope.launch {
+            initializeHasSeenDirectToCardScanValue()
+        }
     }
 
     fun registerForActivityResult(
@@ -215,6 +225,8 @@ internal abstract class BaseSheetViewModel(
             onUserCancel()
         }
     }
+
+    abstract suspend fun initializeHasSeenDirectToCardScanValue()
 
     abstract fun onUserCancel()
 


### PR DESCRIPTION
# Summary
This preview demos the launching of CardScanActivity from CardDetailsSectionController. 

We pass the update method and configuration data to CardDetailsSectionController through DefaultFormHelper.create and UiDefinitionFactory.Arguments.

# Motivation
I want feedback on the shape of this approach. If there are any qualms about passing the configuration through PaymentMethodMetadata and FormElements.

Pros
- We get navigation to/from card scan for free
- Passing data into the card details section controller is very easy
- Guarantees that in paymentsheet, card scan only gets launched after paymentElementData loads.

This would be in contrast to an approach where I launched the CardScanActivity in VerticalModeFormUI and AddPaymentMethod (the compose function)
# Testing
N.A.

# Screenshots
Demo: https://stripe.enterprise.slack.com/files/U07SQAP7LKC/F099KENMTQC/video_clip__2025-08-07_12_47_58_.mov

# Changelog
N.A.