### PR TITLE
Don't use wallets are initial payment selections if using `walletButtons` option.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
@@ -35,6 +35,7 @@ internal data class CommonConfiguration(
     val googlePlacesApiKey: String?,
     val linkAppearance: LinkAppearance? = null,
     val termsDisplay: Map<PaymentMethod.Type, TermsDisplay>,
+    val walletButtons: PaymentSheet.WalletButtonsConfiguration?,
 ) : Parcelable {
 
     fun validate(isLiveMode: Boolean) {
@@ -178,6 +179,7 @@ internal fun PaymentSheet.Configuration.asCommonConfiguration(): CommonConfigura
     shopPayConfiguration = shopPayConfiguration,
     googlePlacesApiKey = googlePlacesApiKey,
     termsDisplay = termsDisplay,
+    walletButtons = walletButtons,
 )
 
 internal fun EmbeddedPaymentElement.Configuration.asCommonConfiguration(): CommonConfiguration = CommonConfiguration(
@@ -199,6 +201,7 @@ internal fun EmbeddedPaymentElement.Configuration.asCommonConfiguration(): Commo
     shopPayConfiguration = null,
     googlePlacesApiKey = null,
     termsDisplay = termsDisplay,
+    walletButtons = null,
 )
 
 internal fun LinkController.Configuration.asCommonConfiguration(): CommonConfiguration = CommonConfiguration(
@@ -225,6 +228,7 @@ internal fun LinkController.Configuration.asCommonConfiguration(): CommonConfigu
     googlePlacesApiKey = null,
     linkAppearance = linkAppearance,
     termsDisplay = emptyMap(),
+    walletButtons = null,
 )
 
 private fun String.isEKClientSecretValid(): Boolean {

--- a/paymentsheet/src/test/java/com/stripe/android/common/model/CommonConfigurationFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/model/CommonConfigurationFactory.kt
@@ -26,6 +26,7 @@ internal object CommonConfigurationFactory {
         shopPayConfiguration: PaymentSheet.ShopPayConfiguration? = null,
         googlePlacesApiKey: String? = null,
         termsDisplay: Map<PaymentMethod.Type, PaymentSheet.TermsDisplay> = emptyMap(),
+        walletButtons: PaymentSheet.WalletButtonsConfiguration? = null,
     ): CommonConfiguration = CommonConfiguration(
         merchantDisplayName = merchantDisplayName,
         customer = customer,
@@ -45,5 +46,6 @@ internal object CommonConfigurationFactory {
         shopPayConfiguration = shopPayConfiguration,
         googlePlacesApiKey = googlePlacesApiKey,
         termsDisplay = termsDisplay,
+        walletButtons = walletButtons,
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -285,7 +285,7 @@ internal class DefaultPaymentElementLoaderTest {
         }
 
     @Test
-    fun `Should default to no payment method google pay is not ready`() =
+    fun `Should default to no payment method when google pay is not ready`() =
         runTest {
             prefsRepository.savePaymentSelection(null)
 
@@ -309,7 +309,7 @@ internal class DefaultPaymentElementLoaderTest {
         }
 
     @Test
-    fun `Should default to no payment method if saved selection is Google Pay & its not ready`() =
+    fun `Should default to no payment method when saved selection is Google Pay & its not ready`() =
         runTest {
             prefsRepository.savePaymentSelection(PaymentSelection.GooglePay)
 
@@ -334,7 +334,7 @@ internal class DefaultPaymentElementLoaderTest {
 
     @OptIn(WalletButtonsPreview::class)
     @Test
-    fun `Should default to no payment method is using wallet buttons`() =
+    fun `Should default to no payment method when using wallet buttons`() =
         runTest {
             prefsRepository.savePaymentSelection(null)
 
@@ -365,7 +365,7 @@ internal class DefaultPaymentElementLoaderTest {
 
     @OptIn(WalletButtonsPreview::class)
     @Test
-    fun `Should default to no payment method is using wallet buttons & google is saved selection`() =
+    fun `Should default to no payment method when using wallet buttons & google is saved selection`() =
         runTest {
             prefsRepository.savePaymentSelection(PaymentSelection.GooglePay)
 
@@ -396,7 +396,7 @@ internal class DefaultPaymentElementLoaderTest {
 
     @OptIn(WalletButtonsPreview::class)
     @Test
-    fun `Should default to no payment method is using wallet buttons & link is saved selection`() =
+    fun `Should default to no payment method when using wallet buttons & link is saved selection`() =
         runTest {
             prefsRepository.savePaymentSelection(PaymentSelection.Link())
 
@@ -426,7 +426,7 @@ internal class DefaultPaymentElementLoaderTest {
         }
 
     @Test
-    fun `Should default to no payment method google pay is not configured`() =
+    fun `Should default to no payment method when google pay is not configured`() =
         runTest {
             prefsRepository.savePaymentSelection(null)
 


### PR DESCRIPTION
# Summary
Don't use wallets are initial payment selections if using `walletButtons` option.

# Motivation
Merchant ask to have no wallets as initial payment selection with wallet buttons

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified