### PR TITLE
Move & rename address element components

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/EmailSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/EmailSpec.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.uicore.elements.EmailElement
 import com.stripe.android.uicore.elements.IdentifierSpec
 import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AddressControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AddressControllerTest.kt
@@ -4,6 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ui.core.R
 import com.stripe.android.uicore.elements.AddressController
 import com.stripe.android.uicore.elements.EmailConfig
+import com.stripe.android.uicore.elements.EmailElement
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SimpleTextFieldController
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AddressElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AddressElementTest.kt
@@ -347,10 +347,10 @@ class AddressElementTest {
             IdentifierSpec.Generic("address"),
             countryElement = countryElement,
             addressInputMode = AddressInputMode.AutocompleteCondensed(
-                "some key",
-                setOf("US", "CA"),
-                AddressFieldConfiguration.OPTIONAL,
-                AddressFieldConfiguration.OPTIONAL
+                googleApiKey = "some key",
+                autocompleteCountries = setOf("US", "CA"),
+                nameConfig = AddressFieldConfiguration.OPTIONAL,
+                phoneNumberConfig = AddressFieldConfiguration.OPTIONAL
             ) { throw AssertionError("Not Expected") },
             sameAsShippingElement = null,
             shippingValuesMap = null
@@ -368,10 +368,10 @@ class AddressElementTest {
             IdentifierSpec.Generic("address"),
             countryElement = countryElement,
             addressInputMode = AddressInputMode.AutocompleteCondensed(
-                "some key",
-                setOf("US", "CA"),
-                AddressFieldConfiguration.OPTIONAL,
-                AddressFieldConfiguration.OPTIONAL
+                googleApiKey = "some key",
+                autocompleteCountries = setOf("US", "CA"),
+                nameConfig = AddressFieldConfiguration.OPTIONAL,
+                phoneNumberConfig = AddressFieldConfiguration.OPTIONAL
             ) { throw AssertionError("Not Expected") },
             sameAsShippingElement = null,
             shippingValuesMap = null,
@@ -395,10 +395,10 @@ class AddressElementTest {
                 controller = countryDropdownFieldController,
             ),
             addressInputMode = AddressInputMode.AutocompleteCondensed(
-                "some key",
-                setOf("US", "CA"),
-                AddressFieldConfiguration.OPTIONAL,
-                AddressFieldConfiguration.OPTIONAL
+                googleApiKey = "some key",
+                autocompleteCountries = setOf("US", "CA"),
+                nameConfig = AddressFieldConfiguration.OPTIONAL,
+                phoneNumberConfig = AddressFieldConfiguration.OPTIONAL
             ) { throw AssertionError("Not Expected") },
             sameAsShippingElement = null,
             shippingValuesMap = null,
@@ -423,10 +423,10 @@ class AddressElementTest {
                 controller = countryDropdownFieldController,
             ),
             addressInputMode = AddressInputMode.AutocompleteExpanded(
-                "some key",
-                setOf("US", "CA"),
-                AddressFieldConfiguration.OPTIONAL,
-                AddressFieldConfiguration.OPTIONAL
+                googleApiKey = "some key",
+                autocompleteCountries = setOf("US", "CA"),
+                nameConfig = AddressFieldConfiguration.OPTIONAL,
+                phoneNumberConfig = AddressFieldConfiguration.OPTIONAL
             ) { onNavigationCounter.getAndIncrement() },
             sameAsShippingElement = null,
             shippingValuesMap = null,
@@ -450,10 +450,10 @@ class AddressElementTest {
                 IdentifierSpec.Generic("address"),
                 countryElement = countryElement,
                 addressInputMode = AddressInputMode.AutocompleteCondensed(
-                    null,
-                    setOf(),
-                    AddressFieldConfiguration.OPTIONAL,
-                    AddressFieldConfiguration.OPTIONAL
+                    googleApiKey = null,
+                    autocompleteCountries = setOf(),
+                    nameConfig = AddressFieldConfiguration.OPTIONAL,
+                    phoneNumberConfig = AddressFieldConfiguration.OPTIONAL
                 ) { throw AssertionError("Not Expected") },
                 sameAsShippingElement = null,
                 shippingValuesMap = null

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AddressElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AddressElementTest.kt
@@ -2,12 +2,12 @@ package com.stripe.android.ui.core.elements
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.uicore.elements.AddressElement
+import com.stripe.android.uicore.elements.AddressFieldConfiguration
 import com.stripe.android.uicore.elements.AddressInputMode
 import com.stripe.android.uicore.elements.CountryConfig
 import com.stripe.android.uicore.elements.CountryElement
 import com.stripe.android.uicore.elements.DropdownFieldController
 import com.stripe.android.uicore.elements.IdentifierSpec
-import com.stripe.android.uicore.elements.PhoneNumberState
 import com.stripe.android.uicore.elements.RowElement
 import com.stripe.android.uicore.elements.SameAsShippingController
 import com.stripe.android.uicore.elements.SameAsShippingElement
@@ -149,9 +149,9 @@ class AddressElementTest {
             addressInputMode = AddressInputMode.AutocompleteCondensed(
                 googleApiKey = null,
                 autocompleteCountries = setOf(),
-                phoneNumberState = PhoneNumberState.REQUIRED
+                nameConfig = AddressFieldConfiguration.REQUIRED,
+                phoneNumberConfig = AddressFieldConfiguration.REQUIRED
             ) { throw AssertionError("Not Expected") },
-            hideName = false,
             sameAsShippingElement = null,
             shippingValuesMap = null
         )
@@ -164,14 +164,15 @@ class AddressElementTest {
     }
 
     @Test
-    fun `hidden phone number field is not shown`() = runTest {
+    fun `hidden name & phone number field is not shown`() = runTest {
         val addressElement = AddressElement(
             IdentifierSpec.Generic("address"),
             countryElement = countryElement,
             addressInputMode = AddressInputMode.AutocompleteCondensed(
                 googleApiKey = null,
                 autocompleteCountries = setOf(),
-                phoneNumberState = PhoneNumberState.HIDDEN
+                nameConfig = AddressFieldConfiguration.HIDDEN,
+                phoneNumberConfig = AddressFieldConfiguration.HIDDEN
             ) { throw AssertionError("Not Expected") },
             sameAsShippingElement = null,
             shippingValuesMap = null
@@ -180,18 +181,20 @@ class AddressElementTest {
         val identifierSpecs = addressElement.fields.first().map {
             it.identifier
         }
+        assertThat(identifierSpecs.contains(IdentifierSpec.Name)).isFalse()
         assertThat(identifierSpecs.contains(IdentifierSpec.Phone)).isFalse()
     }
 
     @Test
-    fun `optional phone number field is shown`() = runTest {
+    fun `optional name & phone number field is shown`() = runTest {
         val addressElement = AddressElement(
             IdentifierSpec.Generic("address"),
             countryElement = countryElement,
             addressInputMode = AddressInputMode.AutocompleteCondensed(
                 googleApiKey = null,
                 autocompleteCountries = setOf(),
-                phoneNumberState = PhoneNumberState.OPTIONAL
+                nameConfig = AddressFieldConfiguration.OPTIONAL,
+                phoneNumberConfig = AddressFieldConfiguration.OPTIONAL
             ) { throw AssertionError("Not Expected") },
             sameAsShippingElement = null,
             shippingValuesMap = null
@@ -200,6 +203,7 @@ class AddressElementTest {
         val identifierSpecs = addressElement.fields.first().map {
             it.identifier
         }
+        assertThat(identifierSpecs.contains(IdentifierSpec.Name)).isTrue()
         assertThat(identifierSpecs.contains(IdentifierSpec.Phone)).isTrue()
     }
 
@@ -247,9 +251,9 @@ class AddressElementTest {
             addressInputMode = AddressInputMode.AutocompleteExpanded(
                 googleApiKey = null,
                 autocompleteCountries = null,
-                phoneNumberState = PhoneNumberState.REQUIRED,
+                nameConfig = AddressFieldConfiguration.REQUIRED,
+                phoneNumberConfig = AddressFieldConfiguration.REQUIRED,
             ) { throw AssertionError("Not Expected") },
-            hideName = false,
             sameAsShippingElement = null,
             shippingValuesMap = null
         )
@@ -262,14 +266,15 @@ class AddressElementTest {
     }
 
     @Test
-    fun `expanded shipping address element should hide phone number when state is hidden`() = runTest {
+    fun `expanded shipping address element should hide name and phone number when state is hidden`() = runTest {
         val addressElement = AddressElement(
             IdentifierSpec.Generic("address"),
             countryElement = countryElement,
             addressInputMode = AddressInputMode.AutocompleteExpanded(
                 googleApiKey = null,
                 autocompleteCountries = null,
-                phoneNumberState = PhoneNumberState.HIDDEN,
+                nameConfig = AddressFieldConfiguration.HIDDEN,
+                phoneNumberConfig = AddressFieldConfiguration.HIDDEN,
             ) { throw AssertionError("Not Expected") },
             sameAsShippingElement = null,
             shippingValuesMap = null
@@ -278,6 +283,7 @@ class AddressElementTest {
         val identifierSpecs = addressElement.fields.first().map {
             it.identifier
         }
+        assertThat(identifierSpecs.contains(IdentifierSpec.Name)).isFalse()
         assertThat(identifierSpecs.contains(IdentifierSpec.Phone)).isFalse()
     }
 
@@ -289,7 +295,8 @@ class AddressElementTest {
             addressInputMode = AddressInputMode.AutocompleteExpanded(
                 googleApiKey = null,
                 autocompleteCountries = null,
-                phoneNumberState = PhoneNumberState.OPTIONAL,
+                nameConfig = AddressFieldConfiguration.HIDDEN,
+                phoneNumberConfig = AddressFieldConfiguration.OPTIONAL,
             ) { throw AssertionError("Not Expected") },
             sameAsShippingElement = null,
             shippingValuesMap = null
@@ -342,7 +349,8 @@ class AddressElementTest {
             addressInputMode = AddressInputMode.AutocompleteCondensed(
                 "some key",
                 setOf("US", "CA"),
-                PhoneNumberState.OPTIONAL
+                AddressFieldConfiguration.OPTIONAL,
+                AddressFieldConfiguration.OPTIONAL
             ) { throw AssertionError("Not Expected") },
             sameAsShippingElement = null,
             shippingValuesMap = null
@@ -362,7 +370,8 @@ class AddressElementTest {
             addressInputMode = AddressInputMode.AutocompleteCondensed(
                 "some key",
                 setOf("US", "CA"),
-                PhoneNumberState.OPTIONAL
+                AddressFieldConfiguration.OPTIONAL,
+                AddressFieldConfiguration.OPTIONAL
             ) { throw AssertionError("Not Expected") },
             sameAsShippingElement = null,
             shippingValuesMap = null,
@@ -388,7 +397,8 @@ class AddressElementTest {
             addressInputMode = AddressInputMode.AutocompleteCondensed(
                 "some key",
                 setOf("US", "CA"),
-                PhoneNumberState.OPTIONAL
+                AddressFieldConfiguration.OPTIONAL,
+                AddressFieldConfiguration.OPTIONAL
             ) { throw AssertionError("Not Expected") },
             sameAsShippingElement = null,
             shippingValuesMap = null,
@@ -415,7 +425,8 @@ class AddressElementTest {
             addressInputMode = AddressInputMode.AutocompleteExpanded(
                 "some key",
                 setOf("US", "CA"),
-                PhoneNumberState.OPTIONAL
+                AddressFieldConfiguration.OPTIONAL,
+                AddressFieldConfiguration.OPTIONAL
             ) { onNavigationCounter.getAndIncrement() },
             sameAsShippingElement = null,
             shippingValuesMap = null,
@@ -441,7 +452,8 @@ class AddressElementTest {
                 addressInputMode = AddressInputMode.AutocompleteCondensed(
                     null,
                     setOf(),
-                    PhoneNumberState.OPTIONAL
+                    AddressFieldConfiguration.OPTIONAL,
+                    AddressFieldConfiguration.OPTIONAL
                 ) { throw AssertionError("Not Expected") },
                 sameAsShippingElement = null,
                 shippingValuesMap = null
@@ -461,7 +473,8 @@ class AddressElementTest {
             addressInputMode = AddressInputMode.AutocompleteExpanded(
                 googleApiKey = null,
                 autocompleteCountries = null,
-                phoneNumberState = PhoneNumberState.OPTIONAL,
+                nameConfig = AddressFieldConfiguration.OPTIONAL,
+                phoneNumberConfig = AddressFieldConfiguration.OPTIONAL,
             ) { throw AssertionError("Not Expected") },
             sameAsShippingElement = null,
             shippingValuesMap = null
@@ -517,7 +530,7 @@ class AddressElementTest {
             ),
             countryElement = countryElement,
             addressInputMode = AddressInputMode.NoAutocomplete(
-                phoneNumberState = PhoneNumberState.REQUIRED
+                phoneNumberConfig = AddressFieldConfiguration.REQUIRED
             ),
             sameAsShippingElement = null,
             shippingValuesMap = null,
@@ -543,7 +556,8 @@ class AddressElementTest {
             addressInputMode = AddressInputMode.AutocompleteCondensed(
                 googleApiKey = null,
                 autocompleteCountries = setOf(),
-                phoneNumberState = PhoneNumberState.OPTIONAL
+                nameConfig = AddressFieldConfiguration.OPTIONAL,
+                phoneNumberConfig = AddressFieldConfiguration.OPTIONAL
             ) { throw AssertionError("Not Expected") },
             sameAsShippingElement = null,
             shippingValuesMap = null,

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AutocompleteCapableAddressInputModeTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AutocompleteCapableAddressInputModeTest.kt
@@ -2,8 +2,8 @@ package com.stripe.android.ui.core.elements
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.uicore.address.AutocompleteCapableInputMode
+import com.stripe.android.uicore.elements.AddressFieldConfiguration
 import com.stripe.android.uicore.elements.AddressInputMode
-import com.stripe.android.uicore.elements.PhoneNumberState
 import org.junit.Test
 
 internal class AutocompleteCapableAddressInputModeTest {
@@ -70,7 +70,8 @@ internal class AutocompleteCapableAddressInputModeTest {
         return AddressInputMode.AutocompleteExpanded(
             googleApiKey = googleApiKey,
             autocompleteCountries = autocompleteCountries,
-            phoneNumberState = PhoneNumberState.REQUIRED
+            nameConfig = AddressFieldConfiguration.REQUIRED,
+            phoneNumberConfig = AddressFieldConfiguration.REQUIRED
         ) {}
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -26,11 +26,11 @@ import com.stripe.android.paymentsheet.model.PaymentMethodIncentive
 import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
 import com.stripe.android.ui.core.elements.CardBillingAddressElement
 import com.stripe.android.ui.core.elements.CardDetailsSectionElement
-import com.stripe.android.ui.core.elements.EmailElement
 import com.stripe.android.ui.core.elements.Mandate
 import com.stripe.android.ui.core.elements.MandateTextElement
 import com.stripe.android.ui.core.elements.RenderableFormElement
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
+import com.stripe.android.uicore.elements.EmailElement
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.PhoneNumberController

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressFormController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressFormController.kt
@@ -1,11 +1,11 @@
 package com.stripe.android.paymentsheet.addresselement
 
 import com.stripe.android.core.model.CountryUtils
+import com.stripe.android.uicore.elements.AddressFieldConfiguration
 import com.stripe.android.uicore.elements.AutocompleteAddressElement
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
-import com.stripe.android.uicore.elements.PhoneNumberState
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.utils.mapAsStateFlow
 
@@ -18,10 +18,10 @@ internal class AddressFormController(
         identifier = IdentifierSpec.Generic("address"),
         initialValues = initialValues,
         countryCodes = config?.allowedCountries ?: CountryUtils.supportedBillingCountries,
-        phoneNumberState = parsePhoneNumberConfig(config?.additionalFields?.phone),
+        nameConfig = AddressFieldConfiguration.REQUIRED,
+        phoneNumberConfig = parsePhoneNumberConfig(config?.additionalFields?.phone),
         shippingValuesMap = null,
         sameAsShippingElement = null,
-        hideName = false,
         interactorFactory = { interactor },
     )
 
@@ -49,15 +49,15 @@ internal class AddressFormController(
 
     private fun parsePhoneNumberConfig(
         configuration: AddressLauncher.AdditionalFieldsConfiguration.FieldConfiguration?
-    ): PhoneNumberState {
+    ): AddressFieldConfiguration {
         return when (configuration) {
             AddressLauncher.AdditionalFieldsConfiguration.FieldConfiguration.HIDDEN ->
-                PhoneNumberState.HIDDEN
+                AddressFieldConfiguration.HIDDEN
             AddressLauncher.AdditionalFieldsConfiguration.FieldConfiguration.OPTIONAL ->
-                PhoneNumberState.OPTIONAL
+                AddressFieldConfiguration.OPTIONAL
             AddressLauncher.AdditionalFieldsConfiguration.FieldConfiguration.REQUIRED ->
-                PhoneNumberState.REQUIRED
-            null -> PhoneNumberState.OPTIONAL
+                AddressFieldConfiguration.REQUIRED
+            null -> AddressFieldConfiguration.OPTIONAL
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BillingDetailsForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BillingDetailsForm.kt
@@ -7,7 +7,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.CardBillingAddressElement
-import com.stripe.android.ui.core.elements.EmailElement
+import com.stripe.android.uicore.elements.EmailElement
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.NameConfig
 import com.stripe.android.uicore.elements.PhoneNumberController

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElementsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElementsTest.kt
@@ -19,7 +19,6 @@ import com.stripe.android.ui.core.elements.Capitalization
 import com.stripe.android.ui.core.elements.CountrySpec
 import com.stripe.android.ui.core.elements.DropdownItemSpec
 import com.stripe.android.ui.core.elements.DropdownSpec
-import com.stripe.android.ui.core.elements.EmailElement
 import com.stripe.android.ui.core.elements.EmailSpec
 import com.stripe.android.ui.core.elements.KeyboardType
 import com.stripe.android.ui.core.elements.MandateTextElement
@@ -37,6 +36,7 @@ import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.CountryConfig
 import com.stripe.android.uicore.elements.CountryElement
 import com.stripe.android.uicore.elements.EmailConfig
+import com.stripe.android.uicore.elements.EmailElement
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.NameConfig
 import com.stripe.android.uicore.elements.PhoneNumberElement

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -33,12 +33,12 @@ import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
-import com.stripe.android.ui.core.elements.EmailElement
 import com.stripe.android.ui.core.elements.MandateTextElement
 import com.stripe.android.ui.core.elements.SharedDataSpec
 import com.stripe.android.uicore.IconStyle
 import com.stripe.android.uicore.elements.AddressElement
 import com.stripe.android.uicore.elements.CountryElement
+import com.stripe.android.uicore.elements.EmailElement
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.PhoneNumberElement
 import com.stripe.android.uicore.elements.SectionElement

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/CompleteFormFieldValueFilterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/CompleteFormFieldValueFilterTest.kt
@@ -3,8 +3,8 @@ package com.stripe.android.paymentsheet.forms
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.ui.core.elements.EmailElement
 import com.stripe.android.uicore.elements.EmailConfig
+import com.stripe.android.uicore.elements.EmailElement
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SectionController
 import com.stripe.android.uicore.elements.SectionElement

--- a/stripe-ui-core/api/stripe-ui-core.api
+++ b/stripe-ui-core/api/stripe-ui-core.api
@@ -62,6 +62,10 @@ public final class com/stripe/android/uicore/address/StateSchema$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class com/stripe/android/uicore/elements/AddressFieldConfiguration$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class com/stripe/android/uicore/elements/AddressInputMode$AutocompleteCondensed$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/uicore/elements/AddressInputMode$AutocompleteCondensed;
@@ -163,10 +167,6 @@ public final class com/stripe/android/uicore/elements/ParameterDestination$Local
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/uicore/elements/ParameterDestination$Local;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
-}
-
-public final class com/stripe/android/uicore/elements/PhoneNumberState$Companion {
-	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class com/stripe/android/uicore/elements/SameAsShippingElementUIKt {

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressElement.kt
@@ -31,7 +31,6 @@ class AddressElement(
     shippingValuesMap: Map<IdentifierSpec, String?>?,
     private val isPlacesAvailable: Boolean = DefaultIsPlacesAvailable().invoke(),
     private val hideCountry: Boolean = false,
-    private val hideName: Boolean = true,
 ) : SectionMultiFieldElement(_identifier), AddressFieldsElement {
 
     override val allowsUserInteraction: Boolean = true
@@ -43,6 +42,7 @@ class AddressElement(
             textFieldConfig = SimpleTextFieldConfig(
                 label = resolvableString(CoreR.string.stripe_address_label_full_name)
             ),
+            showOptionalLabel = addressInputMode.nameConfig == AddressFieldConfiguration.OPTIONAL,
             initialValue = rawValuesMap[IdentifierSpec.Name]
         )
     )
@@ -58,8 +58,8 @@ class AddressElement(
         IdentifierSpec.Phone,
         PhoneNumberController.createPhoneNumberController(
             initialValue = rawValuesMap[IdentifierSpec.Phone] ?: "",
-            showOptionalLabel = addressInputMode.phoneNumberState == PhoneNumberState.OPTIONAL,
-            acceptAnyInput = addressInputMode.phoneNumberState != PhoneNumberState.REQUIRED,
+            showOptionalLabel = addressInputMode.phoneNumberConfig == AddressFieldConfiguration.OPTIONAL,
+            acceptAnyInput = addressInputMode.phoneNumberConfig != AddressFieldConfiguration.REQUIRED,
         )
     )
 
@@ -160,6 +160,8 @@ class AddressElement(
         sameAsShippingUpdatedFlow,
         fieldsUpdatedFlow
     ) { country, otherFields, _, _ ->
+        val hideName = addressInputMode.nameConfig == AddressFieldConfiguration.HIDDEN
+
         val condensed = listOfNotNull(
             nameElement.takeUnless { hideName },
             countryElement.takeUnless { hideCountry },
@@ -190,7 +192,7 @@ class AddressElement(
             }
         }
 
-        val fields = if (addressInputMode.phoneNumberState != PhoneNumberState.HIDDEN) {
+        val fields = if (addressInputMode.phoneNumberConfig != AddressFieldConfiguration.HIDDEN) {
             baseElements.plus(phoneNumberElement)
         } else {
             baseElements

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressFieldConfiguration.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressFieldConfiguration.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.Serializable
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Serializable
-enum class PhoneNumberState {
+enum class AddressFieldConfiguration {
     @SerialName("hidden")
     HIDDEN,
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressInputMode.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressInputMode.kt
@@ -7,14 +7,16 @@ import kotlinx.parcelize.Parcelize
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
 sealed class AddressInputMode : Parcelable {
-    abstract val phoneNumberState: PhoneNumberState
+    abstract val phoneNumberConfig: AddressFieldConfiguration
+    abstract val nameConfig: AddressFieldConfiguration
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
     @Parcelize
     data class AutocompleteCondensed(
         override val googleApiKey: String?,
         override val autocompleteCountries: Set<String>?,
-        override val phoneNumberState: PhoneNumberState,
+        override val phoneNumberConfig: AddressFieldConfiguration,
+        override val nameConfig: AddressFieldConfiguration,
         override val onNavigation: () -> Unit
     ) : AddressInputMode(), AutocompleteCapableInputMode
 
@@ -23,14 +25,17 @@ sealed class AddressInputMode : Parcelable {
     data class AutocompleteExpanded(
         override val googleApiKey: String?,
         override val autocompleteCountries: Set<String>?,
-        override val phoneNumberState: PhoneNumberState,
+        override val phoneNumberConfig: AddressFieldConfiguration,
+        override val nameConfig: AddressFieldConfiguration,
         override val onNavigation: () -> Unit,
     ) : AddressInputMode(), AutocompleteCapableInputMode
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
     @Parcelize
     data class NoAutocomplete(
-        override val phoneNumberState: PhoneNumberState =
-            PhoneNumberState.HIDDEN
+        override val phoneNumberConfig: AddressFieldConfiguration =
+            AddressFieldConfiguration.HIDDEN,
+        override val nameConfig: AddressFieldConfiguration =
+            AddressFieldConfiguration.HIDDEN,
     ) : AddressInputMode()
 }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressController.kt
@@ -20,11 +20,11 @@ class AutocompleteAddressController(
         CountryConfig(countryCodes),
         initialValues[IdentifierSpec.Country]
     ),
-    private val phoneNumberState: PhoneNumberState,
+    private val phoneNumberConfig: AddressFieldConfiguration,
+    private val nameConfig: AddressFieldConfiguration,
     private val sameAsShippingElement: SameAsShippingElement?,
     private val shippingValuesMap: Map<IdentifierSpec, String?>?,
     private val hideCountry: Boolean = false,
-    private val hideName: Boolean = true,
 ) : SectionFieldErrorController, SectionFieldComposable {
     private val interactor = interactorFactory.create()
 
@@ -91,7 +91,6 @@ class AutocompleteAddressController(
             shippingValuesMap = shippingValuesMap,
             isPlacesAvailable = config.isPlacesAvailable,
             hideCountry = hideCountry,
-            hideName = hideName,
         )
     }
 
@@ -102,12 +101,13 @@ class AutocompleteAddressController(
         val googlePlacesApiKey = config.googlePlacesApiKey
 
         return if (googlePlacesApiKey == null) {
-            AddressInputMode.NoAutocomplete(phoneNumberState)
+            AddressInputMode.NoAutocomplete(phoneNumberConfig, nameConfig)
         } else if (expandForm || values[IdentifierSpec.Line1] != null) {
             AddressInputMode.AutocompleteExpanded(
                 googleApiKey = googlePlacesApiKey,
                 autocompleteCountries = config.autocompleteCountries,
-                phoneNumberState = phoneNumberState,
+                phoneNumberConfig = phoneNumberConfig,
+                nameConfig = nameConfig,
                 onNavigation = {
                     interactor.onAutocomplete(
                         country = countryDropdownFieldController.rawFieldValue.value ?: ""
@@ -118,7 +118,8 @@ class AutocompleteAddressController(
             AddressInputMode.AutocompleteCondensed(
                 googleApiKey = googlePlacesApiKey,
                 autocompleteCountries = config.autocompleteCountries,
-                phoneNumberState = phoneNumberState,
+                phoneNumberConfig = phoneNumberConfig,
+                nameConfig = nameConfig,
                 onNavigation = {
                     interactor.onAutocomplete(
                         country = countryDropdownFieldController.rawFieldValue.value ?: ""

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressElement.kt
@@ -13,12 +13,12 @@ class AutocompleteAddressElement(
         CountryConfig(countryCodes),
         initialValues[IdentifierSpec.Country]
     ),
-    phoneNumberState: PhoneNumberState = PhoneNumberState.HIDDEN,
+    phoneNumberConfig: AddressFieldConfiguration = AddressFieldConfiguration.HIDDEN,
+    nameConfig: AddressFieldConfiguration = AddressFieldConfiguration.HIDDEN,
     sameAsShippingElement: SameAsShippingElement?,
     shippingValuesMap: Map<IdentifierSpec, String?>?,
     interactorFactory: AutocompleteAddressInteractor.Factory,
     hideCountry: Boolean = false,
-    hideName: Boolean = true,
 ) : AddressFieldsElement {
     private val controller by lazy {
         AutocompleteAddressController(
@@ -26,12 +26,12 @@ class AutocompleteAddressElement(
             initialValues = initialValues,
             countryCodes = countryCodes,
             countryDropdownFieldController = countryDropdownFieldController,
-            phoneNumberState = phoneNumberState,
+            phoneNumberConfig = phoneNumberConfig,
+            nameConfig = nameConfig,
             sameAsShippingElement = sameAsShippingElement,
             shippingValuesMap = shippingValuesMap,
             interactorFactory = interactorFactory,
             hideCountry = hideCountry,
-            hideName = hideName,
         )
     }
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/EmailElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/EmailElement.kt
@@ -1,12 +1,7 @@
-package com.stripe.android.ui.core.elements
+package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
 import com.stripe.android.core.strings.ResolvableString
-import com.stripe.android.uicore.elements.EmailConfig
-import com.stripe.android.uicore.elements.IdentifierSpec
-import com.stripe.android.uicore.elements.SectionSingleFieldElement
-import com.stripe.android.uicore.elements.SimpleTextFieldController
-import com.stripe.android.uicore.elements.TextFieldController
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
 data class EmailElement(

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/AutocompleteAddressControllerTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/AutocompleteAddressControllerTest.kt
@@ -30,7 +30,7 @@ class AutocompleteAddressControllerTest {
     }
 
     @Test
-    fun `Phone number field is shown when state iS REQUIRED`() = elementsTest(
+    fun `Phone number field is shown when state is REQUIRED`() = elementsTest(
         phoneNumberConfig = AddressFieldConfiguration.REQUIRED,
     ) { elements ->
         assertThat(elements.filterIsInstance<PhoneNumberElement>()).hasSize(1)
@@ -55,7 +55,7 @@ class AutocompleteAddressControllerTest {
     }
 
     @Test
-    fun `Name should be shown if 'hideName' is set to false`() = elementsTest(
+    fun `Name should be shown when state is REQUIRED`() = elementsTest(
         nameConfig = AddressFieldConfiguration.REQUIRED
     ) { elements ->
         assertThat(

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/AutocompleteAddressControllerTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/AutocompleteAddressControllerTest.kt
@@ -15,7 +15,7 @@ import org.junit.Test
 class AutocompleteAddressControllerTest {
     @Test
     fun `Phone number field is hidden when state is HIDDEN`() = elementsTest(
-        phoneNumberState = PhoneNumberState.HIDDEN,
+        phoneNumberConfig = AddressFieldConfiguration.HIDDEN,
         sameAsShippingElement = null,
         shippingValuesMap = emptyMap(),
     ) { elements ->
@@ -24,21 +24,21 @@ class AutocompleteAddressControllerTest {
 
     @Test
     fun `Phone number field is shown when state is OPTIONAL`() = elementsTest(
-        phoneNumberState = PhoneNumberState.OPTIONAL,
+        phoneNumberConfig = AddressFieldConfiguration.OPTIONAL,
     ) { elements ->
         assertThat(elements.filterIsInstance<PhoneNumberElement>()).hasSize(1)
     }
 
     @Test
     fun `Phone number field is shown when state iS REQUIRED`() = elementsTest(
-        phoneNumberState = PhoneNumberState.REQUIRED,
+        phoneNumberConfig = AddressFieldConfiguration.REQUIRED,
     ) { elements ->
         assertThat(elements.filterIsInstance<PhoneNumberElement>()).hasSize(1)
     }
 
     @Test
-    fun `Name should be hidden if 'hideName' is set to true`() = elementsTest(
-        hideName = true
+    fun `Name field is hidden when state is HIDDEN`() = elementsTest(
+        nameConfig = AddressFieldConfiguration.HIDDEN
     ) { elements ->
         assertThat(
             elements.any { it.identifier == IdentifierSpec.Name }
@@ -46,8 +46,17 @@ class AutocompleteAddressControllerTest {
     }
 
     @Test
+    fun `Name field is shown when state is OPTIONAL`() = elementsTest(
+        nameConfig = AddressFieldConfiguration.OPTIONAL
+    ) { elements ->
+        assertThat(
+            elements.any { it.identifier == IdentifierSpec.Name }
+        ).isTrue()
+    }
+
+    @Test
     fun `Name should be shown if 'hideName' is set to false`() = elementsTest(
-        hideName = false
+        nameConfig = AddressFieldConfiguration.REQUIRED
     ) { elements ->
         assertThat(
             elements.any { it.identifier == IdentifierSpec.Name }
@@ -526,7 +535,8 @@ class AutocompleteAddressControllerTest {
 
     private fun elementsTest(
         values: Map<IdentifierSpec, String?> = emptyMap(),
-        phoneNumberState: PhoneNumberState = PhoneNumberState.HIDDEN,
+        nameConfig: AddressFieldConfiguration = AddressFieldConfiguration.HIDDEN,
+        phoneNumberConfig: AddressFieldConfiguration = AddressFieldConfiguration.HIDDEN,
         sameAsShippingElement: SameAsShippingElement? = null,
         shippingValuesMap: Map<IdentifierSpec, String?> = emptyMap(),
         autocompleteConfig: AutocompleteAddressInteractor.Config = AutocompleteAddressInteractor.Config(
@@ -535,7 +545,6 @@ class AutocompleteAddressControllerTest {
         ),
         eventToEmit: AutocompleteAddressInteractor.Event? = null,
         hideCountry: Boolean = false,
-        hideName: Boolean = true,
         test: suspend TestAutocompleteAddressInteractor.Scenario.(elements: List<SectionFieldElement>) -> Unit
     ) = runTest {
         TestAutocompleteAddressInteractor.test(
@@ -543,12 +552,12 @@ class AutocompleteAddressControllerTest {
         ) {
             val controller = createAutocompleteAddressController(
                 values = values,
-                phoneNumberState = phoneNumberState,
+                nameConfig = nameConfig,
+                phoneNumberConfig = phoneNumberConfig,
                 sameAsShippingElement = sameAsShippingElement,
                 shippingValuesMap = shippingValuesMap,
                 interactor = interactor,
                 hideCountry = hideCountry,
-                hideName = hideName,
             )
 
             val registerCall = registerCalls.awaitItem()
@@ -568,13 +577,13 @@ class AutocompleteAddressControllerTest {
     }
 
     private fun formFieldsTest(
-        phoneNumberState: PhoneNumberState = PhoneNumberState.HIDDEN,
+        phoneNumberConfig: AddressFieldConfiguration = AddressFieldConfiguration.HIDDEN,
         sameAsShippingElement: SameAsShippingElement? = null,
         shippingValuesMap: Map<IdentifierSpec, String?> = emptyMap(),
         test: suspend TurbineTestContext<List<Pair<IdentifierSpec, FormFieldEntry>>>.() -> Unit
     ) = runTest {
         val controller = createAutocompleteAddressController(
-            phoneNumberState = phoneNumberState,
+            phoneNumberConfig = phoneNumberConfig,
             sameAsShippingElement = sameAsShippingElement,
             shippingValuesMap = shippingValuesMap,
         )
@@ -590,7 +599,8 @@ class AutocompleteAddressControllerTest {
 
     private fun createAutocompleteAddressController(
         values: Map<IdentifierSpec, String?> = emptyMap(),
-        phoneNumberState: PhoneNumberState = PhoneNumberState.HIDDEN,
+        phoneNumberConfig: AddressFieldConfiguration = AddressFieldConfiguration.HIDDEN,
+        nameConfig: AddressFieldConfiguration = AddressFieldConfiguration.HIDDEN,
         sameAsShippingElement: SameAsShippingElement? = null,
         shippingValuesMap: Map<IdentifierSpec, String?> = emptyMap(),
         autocompleteConfig: AutocompleteAddressInteractor.Config = AutocompleteAddressInteractor.Config(
@@ -598,7 +608,6 @@ class AutocompleteAddressControllerTest {
             googlePlacesApiKey = null,
         ),
         hideCountry: Boolean = false,
-        hideName: Boolean = true,
         interactor: AutocompleteAddressInteractor =
             TestAutocompleteAddressInteractor.noOp(
                 autocompleteConfig = autocompleteConfig,
@@ -609,9 +618,9 @@ class AutocompleteAddressControllerTest {
             initialValues = values,
             sameAsShippingElement = sameAsShippingElement,
             shippingValuesMap = shippingValuesMap,
-            phoneNumberState = phoneNumberState,
+            phoneNumberConfig = phoneNumberConfig,
+            nameConfig = nameConfig,
             hideCountry = hideCountry,
-            hideName = hideName,
             interactorFactory = { interactor },
         )
     }


### PR DESCRIPTION
# Summary
Move & rename address element components

# Motivation
We are moving phone number and email contact information into the billing details form now. This PR starts with some of the tedious refactors to make it possible.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified