### PR TITLE
Fix UI glitch with Link signup opt-in toggle

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -133,15 +133,17 @@ private object CardUiDefinitionFactory : UiDefinitionFactory.Simple {
             val signupMode = if (
                 metadata.linkState?.signupMode != null && arguments.linkConfigurationCoordinator != null
             ) {
-                add(
-                    LinkFormElement(
-                        signupMode = metadata.linkState.signupMode,
-                        configuration = metadata.linkState.configuration,
-                        linkConfigurationCoordinator = arguments.linkConfigurationCoordinator,
-                        initialLinkUserInput = arguments.initialLinkUserInput,
-                        onLinkInlineSignupStateChanged = arguments.onLinkInlineSignupStateChanged,
+                if (!linkSignupOptInEnabled) {
+                    add(
+                        LinkFormElement(
+                            signupMode = metadata.linkState.signupMode,
+                            configuration = metadata.linkState.configuration,
+                            linkConfigurationCoordinator = arguments.linkConfigurationCoordinator,
+                            initialLinkUserInput = arguments.initialLinkUserInput,
+                            onLinkInlineSignupStateChanged = arguments.onLinkInlineSignupStateChanged,
+                        )
                     )
-                )
+                }
 
                 metadata.linkState.signupMode
             } else {

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinitionTest.kt
@@ -309,28 +309,6 @@ class CardDefinitionTest {
     }
 
     @Test
-    fun `createFormElements returns mandate below link_form when has intent to setup`() {
-        val metadata = PaymentMethodMetadataFactory.create(
-            stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
-            linkState = LinkState(
-                signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
-                configuration = createLinkConfiguration().copy(linkSignUpOptInFeatureEnabled = true),
-                loginState = LinkState.LoginState.LoggedOut,
-            ),
-        )
-
-        val formElements = CardDefinition.formElements(
-            metadata,
-            linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
-        )
-
-        assertThat(formElements).hasSize(4)
-        assertThat(formElements[2].identifier.v1).isEqualTo("link_form")
-
-        testCombinedLinkMandateElement(formElements[3])
-    }
-
-    @Test
     fun `createFormElements should have autocomplete element if factory is used`() {
         val formElements = CardDefinition.formElements(
             metadata = PaymentMethodMetadataFactory.create(
@@ -418,12 +396,11 @@ class CardDefinitionTest {
         )
 
         // Should only include card_details and billing section, no mandate
-        assertThat(formElements).hasSize(4)
+        assertThat(formElements).hasSize(3)
         assertThat(formElements[0].identifier.v1).isEqualTo("card_details")
         assertThat(formElements[1].identifier.v1).isEqualTo("credit_billing_section")
-        assertThat(formElements[2].identifier.v1).isEqualTo("link_form")
-        assertThat(formElements[3].identifier.v1).isEqualTo("card_mandate")
-        assertThat(formElements[3]).isInstanceOf<CombinedLinkMandateElement>()
+        assertThat(formElements[2].identifier.v1).isEqualTo("card_mandate")
+        assertThat(formElements[2]).isInstanceOf<CombinedLinkMandateElement>()
     }
 
     @Test


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where both the Link inline signup and the signup opt-in toggle mandate (but not the toggle) would be shown.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
