### PR TITLE
Attach radar_options to payment method create params in PassiveChallengeConfirmationDefinition

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinition.kt
@@ -6,6 +6,7 @@ import com.stripe.android.challenge.PassiveChallengeActivityContract
 import com.stripe.android.challenge.PassiveChallengeActivityResult
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.model.RadarOptions
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
@@ -40,12 +41,27 @@ internal class PassiveChallengeConfirmationDefinition @Inject constructor(
         deferredIntentConfirmationType: DeferredIntentConfirmationType?,
         result: PassiveChallengeActivityResult
     ): ConfirmationDefinition.Result {
-        return ConfirmationDefinition.Result.NextStep(
-            confirmationOption = confirmationOption.copy(
-                passiveCaptchaParams = null
-            ),
-            parameters = confirmationParameters
-        )
+        return when (result) {
+            is PassiveChallengeActivityResult.Failed -> {
+                ConfirmationDefinition.Result.NextStep(
+                    confirmationOption = confirmationOption.copy(
+                        passiveCaptchaParams = null
+                    ),
+                    parameters = confirmationParameters
+                )
+            }
+            is PassiveChallengeActivityResult.Success -> {
+                ConfirmationDefinition.Result.NextStep(
+                    confirmationOption = confirmationOption.copy(
+                        passiveCaptchaParams = null,
+                        createParams = confirmationOption.createParams.copy(
+                            radarOptions = RadarOptions(result.token)
+                        )
+                    ),
+                    parameters = confirmationParameters
+                )
+            }
+        }
     }
 
     override fun createLauncher(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinitionTest.kt
@@ -7,6 +7,7 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.isInstanceOf
 import com.stripe.android.model.PassiveCaptchaParams
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
+import com.stripe.android.model.RadarOptions
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationOption
@@ -228,21 +229,27 @@ internal class PassiveChallengeConfirmationDefinitionTest {
     @Test
     fun `'toResult' should return 'NextStep' with passiveCaptchaParams removed for Success result`() {
         val definition = createPassiveChallengeConfirmationDefinition()
+        val testToken = "test_token"
 
         val result = definition.toResult(
             confirmationOption = PAYMENT_METHOD_CONFIRMATION_OPTION_NEW,
             confirmationParameters = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
-            result = PassiveChallengeActivityResult.Success("test_token"),
+            result = PassiveChallengeActivityResult.Success(testToken),
         )
 
         assertThat(result).isInstanceOf<ConfirmationDefinition.Result.NextStep>()
 
         val nextStepResult = result.asNextStep()
 
-        assertThat(nextStepResult.confirmationOption).isEqualTo(
-            PAYMENT_METHOD_CONFIRMATION_OPTION_NEW.copy(passiveCaptchaParams = null)
+        val expectedOption = PAYMENT_METHOD_CONFIRMATION_OPTION_NEW.copy(
+            passiveCaptchaParams = null,
+            createParams = PAYMENT_METHOD_CONFIRMATION_OPTION_NEW.createParams.copy(
+                radarOptions = RadarOptions(testToken)
+            )
         )
+
+        assertThat(nextStepResult.confirmationOption).isEqualTo(expectedOption)
         assertThat(nextStepResult.parameters).isEqualTo(CONFIRMATION_PARAMETERS)
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Attach radar_options to payment method create params in PassiveChallengeConfirmationDefinition

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-3844

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
