### PR TITLE
Send top level and PMO SFU in ConfirmPaymentIntentParams

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
@@ -255,7 +255,13 @@ constructor(
          * Use `` if you want to clear reusable from the payment intent.  Note: this
          * only works if the PaymentIntent was created with no setup_future_usage.
          */
-        Blank("")
+        Blank(""),
+
+        /**
+         * Use `none` to override top level setup_future_usage in payment_method_options.
+         */
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        None("none")
     }
 
     /**

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentIntent.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentIntent.kt
@@ -235,6 +235,24 @@ constructor(
             !isPaymentMethodOptionsSetupFutureUsageNone(code)
     }
 
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    fun getPaymentMethodOptionsSetupFutureUsage(code: PaymentMethodCode): ConfirmPaymentIntentParams.SetupFutureUsage? {
+        return paymentMethodOptionsJsonString?.let { json ->
+            when (JSONObject(json).optJSONObject(code)?.optString(SETUP_FUTURE_USAGE)) {
+                ConfirmPaymentIntentParams.SetupFutureUsage.OffSession.code -> {
+                    ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
+                }
+                ConfirmPaymentIntentParams.SetupFutureUsage.OnSession.code -> {
+                    ConfirmPaymentIntentParams.SetupFutureUsage.OnSession
+                }
+                ConfirmPaymentIntentParams.SetupFutureUsage.None.code -> {
+                    ConfirmPaymentIntentParams.SetupFutureUsage.None
+                }
+                else -> null
+            }
+        }
+    }
+
     internal fun withUnredactedClientSecret(clientSecret: String): PaymentIntent {
         if (!isRedacted) {
             return this

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethodOptionsParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethodOptionsParams.kt
@@ -80,16 +80,19 @@ sealed class PaymentMethodOptionsParams(
 
     @Parcelize
     data class Blik(
-        var code: String
+        var code: String,
+        var setupFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage? = null,
     ) : PaymentMethodOptionsParams(PaymentMethod.Type.Blik) {
         override fun createTypeParams(): List<Pair<String, Any?>> {
             return listOf(
-                PARAM_CODE to code
+                PARAM_CODE to code,
+                PARAM_SETUP_FUTURE_USAGE to setupFutureUsage?.code
             )
         }
 
         internal companion object {
             const val PARAM_CODE = "code"
+            const val PARAM_SETUP_FUTURE_USAGE = "setup_future_usage"
         }
     }
 
@@ -112,41 +115,57 @@ sealed class PaymentMethodOptionsParams(
     @Parcelize
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     data class Konbini(
-        private val confirmationNumber: String
+        private val confirmationNumber: String,
+        var setupFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage? = null,
     ) : PaymentMethodOptionsParams(PaymentMethod.Type.Konbini) {
         override fun createTypeParams(): List<Pair<String, Any?>> {
             return listOf(
-                PARAM_CONFIRMATION_NUMBER to confirmationNumber
+                PARAM_CONFIRMATION_NUMBER to confirmationNumber,
+                PARAM_SETUP_FUTURE_USAGE to setupFutureUsage?.code
             )
         }
 
         internal companion object {
             const val PARAM_CONFIRMATION_NUMBER = "confirmation_number"
+            const val PARAM_SETUP_FUTURE_USAGE = "setup_future_usage"
         }
     }
 
     @Parcelize
     data class WeChatPay(
-        var appId: String
+        var appId: String,
+        var setupFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage? = null,
     ) : PaymentMethodOptionsParams(PaymentMethod.Type.WeChatPay) {
         override fun createTypeParams(): List<Pair<String, Any?>> {
             return listOf(
                 PARAM_CLIENT to "android",
-                PARAM_APP_ID to appId
+                PARAM_APP_ID to appId,
+                PARAM_SETUP_FUTURE_USAGE to setupFutureUsage?.code
             )
         }
 
         internal companion object {
             const val PARAM_CLIENT = "client"
             const val PARAM_APP_ID = "app_id"
+            const val PARAM_SETUP_FUTURE_USAGE = "setup_future_usage"
         }
     }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Parcelize
-    object WeChatPayH5 : PaymentMethodOptionsParams(PaymentMethod.Type.WeChatPay) {
+    data class WeChatPayH5(
+        var setupFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage? = null
+    ) : PaymentMethodOptionsParams(PaymentMethod.Type.WeChatPay) {
         override fun createTypeParams(): List<Pair<String, Any?>> {
-            return listOf("client" to "mobile_web")
+            return listOf(
+                PARAM_CLIENT to "mobile_web",
+                PARAM_SETUP_FUTURE_USAGE to setupFutureUsage?.code
+            )
+        }
+
+        internal companion object {
+            const val PARAM_SETUP_FUTURE_USAGE = "setup_future_usage"
+            const val PARAM_CLIENT = "client"
         }
     }
 
@@ -164,18 +183,65 @@ sealed class PaymentMethodOptionsParams(
             const val PARAM_SETUP_FUTURE_USAGE = "setup_future_usage"
         }
     }
+
+    /**
+     * Generic SetupFutureUsage PMO object for deferred intents.
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @Parcelize
+    data class SetupFutureUsage(
+        var paymentMethodType: PaymentMethod.Type,
+        var setupFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage
+    ) : PaymentMethodOptionsParams(paymentMethodType) {
+        override fun createTypeParams(): List<Pair<String, Any?>> {
+            return listOf(
+                PARAM_SETUP_FUTURE_USAGE to setupFutureUsage.code
+            )
+        }
+
+        internal companion object {
+            const val PARAM_SETUP_FUTURE_USAGE = "setup_future_usage"
+        }
+    }
 }
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun PaymentMethodOptionsParams.setupFutureUsage(): ConfirmPaymentIntentParams.SetupFutureUsage? {
     return when (this) {
-        is PaymentMethodOptionsParams.Blik -> null
+        is PaymentMethodOptionsParams.Blik -> setupFutureUsage
         is PaymentMethodOptionsParams.Card -> setupFutureUsage
         is PaymentMethodOptionsParams.SepaDebit -> setupFutureUsage
-        is PaymentMethodOptionsParams.Konbini -> null
+        is PaymentMethodOptionsParams.Konbini -> setupFutureUsage
         is PaymentMethodOptionsParams.Link -> setupFutureUsage
         is PaymentMethodOptionsParams.USBankAccount -> setupFutureUsage
-        is PaymentMethodOptionsParams.WeChatPay -> null
-        is PaymentMethodOptionsParams.WeChatPayH5 -> null
+        is PaymentMethodOptionsParams.WeChatPay -> setupFutureUsage
+        is PaymentMethodOptionsParams.WeChatPayH5 -> setupFutureUsage
+        is PaymentMethodOptionsParams.SetupFutureUsage -> setupFutureUsage
+    }
+}
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun PaymentMethodOptionsParams?.updateSetupFutureUsageWithPmoSfu(
+    pmoSfu: ConfirmPaymentIntentParams.SetupFutureUsage
+): PaymentMethodOptionsParams? {
+    val currentSfu = this?.setupFutureUsage()
+    val sfuValueToSet = if (currentSfu === ConfirmPaymentIntentParams.SetupFutureUsage.OffSession) {
+        // If currentSfu is off_session, it was set through the save checkbox and should not be changed.
+        currentSfu
+    } else {
+        pmoSfu
+    }
+
+    return when (this) {
+        is PaymentMethodOptionsParams.Blik -> this.copy(setupFutureUsage = sfuValueToSet)
+        is PaymentMethodOptionsParams.Card -> this.copy(setupFutureUsage = sfuValueToSet)
+        is PaymentMethodOptionsParams.SepaDebit -> this.copy(setupFutureUsage = sfuValueToSet)
+        is PaymentMethodOptionsParams.Konbini -> this.copy(setupFutureUsage = sfuValueToSet)
+        is PaymentMethodOptionsParams.Link -> this.copy(setupFutureUsage = sfuValueToSet)
+        is PaymentMethodOptionsParams.USBankAccount -> this.copy(setupFutureUsage = sfuValueToSet)
+        is PaymentMethodOptionsParams.WeChatPay -> this.copy(setupFutureUsage = sfuValueToSet)
+        is PaymentMethodOptionsParams.WeChatPayH5 -> this.copy(setupFutureUsage = sfuValueToSet)
+        is PaymentMethodOptionsParams.SetupFutureUsage -> this.copy(setupFutureUsage = sfuValueToSet)
+        null -> null
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/utils/SetupFutureUsageUtils.kt
+++ b/payments-core/src/main/java/com/stripe/android/utils/SetupFutureUsageUtils.kt
@@ -1,0 +1,11 @@
+package com.stripe.android.utils
+
+import androidx.annotation.RestrictTo
+import com.stripe.android.model.ConfirmPaymentIntentParams
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun ConfirmPaymentIntentParams.SetupFutureUsage?.hasIntentToSetup() = when (this) {
+    ConfirmPaymentIntentParams.SetupFutureUsage.OnSession,
+    ConfirmPaymentIntentParams.SetupFutureUsage.OffSession -> true
+    else -> false
+}

--- a/payments-core/src/test/java/com/stripe/android/ConfirmPaymentIntentParamsFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/ConfirmPaymentIntentParamsFactoryTest.kt
@@ -120,7 +120,8 @@ class ConfirmPaymentIntentParamsFactoryTest {
             ),
             extraParams = PaymentMethodExtraParams.Card(
                 setAsDefault = true
-            )
+            ),
+            intentConfigSetupFutureUsage = null
         )
         assertThat(paymentIntentParams.setAsDefaultPaymentMethod).isTrue()
     }
@@ -134,7 +135,8 @@ class ConfirmPaymentIntentParamsFactoryTest {
             ),
             extraParams = PaymentMethodExtraParams.Card(
                 setAsDefault = false
-            )
+            ),
+            intentConfigSetupFutureUsage = null
         )
         assertThat(paymentIntentParams.setAsDefaultPaymentMethod).isFalse()
     }
@@ -170,7 +172,8 @@ class ConfirmPaymentIntentParamsFactoryTest {
             optionsParams = null,
             extraParams = PaymentMethodExtraParams.SepaDebit(
                 setAsDefault = true
-            )
+            ),
+            intentConfigSetupFutureUsage = null
         )
         assertThat(paymentIntentParams.setAsDefaultPaymentMethod).isTrue()
     }
@@ -182,7 +185,8 @@ class ConfirmPaymentIntentParamsFactoryTest {
             optionsParams = null,
             extraParams = PaymentMethodExtraParams.SepaDebit(
                 setAsDefault = false
-            )
+            ),
+            intentConfigSetupFutureUsage = null
         )
         assertThat(paymentIntentParams.setAsDefaultPaymentMethod).isFalse()
     }
@@ -207,7 +211,8 @@ class ConfirmPaymentIntentParamsFactoryTest {
         val result = factoryWithConfig.create(
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             optionsParams = null,
-            extraParams = null
+            extraParams = null,
+            intentConfigSetupFutureUsage = null
         )
         assertThat(result.shipping).isEqualTo(shippingDetails)
     }
@@ -250,6 +255,7 @@ class ConfirmPaymentIntentParamsFactoryTest {
                 setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.Blank
             ),
             extraParams = null,
+            intentConfigSetupFutureUsage = null
         )
 
         assertThat(result.paymentMethodOptions).isEqualTo(
@@ -273,6 +279,7 @@ class ConfirmPaymentIntentParamsFactoryTest {
                 setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
             ),
             extraParams = null,
+            intentConfigSetupFutureUsage = null
         )
 
         assertThat(result.paymentMethodOptions).isEqualTo(
@@ -340,11 +347,21 @@ class ConfirmPaymentIntentParamsFactoryTest {
         )
     }
 
+    @Test
+    fun `create() with intentConfig SFU 'OffSession' should contain mandate data`() {
+        mandateDataTest(
+            setupFutureUsage = StripeIntent.Usage.OffSession,
+            expectedMandateDataParams = MandateDataParams(MandateDataParams.Type.Online.DEFAULT),
+            intentConfigSetupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
+        )
+    }
+
     private fun mandateDataTest(
         setupFutureUsage: StripeIntent.Usage?,
         expectedMandateDataParams: MandateDataParams?,
         paymentMethod: PaymentMethod = PaymentMethodFactory.cashAppPay(),
-        paymentMethodOptionsJsonString: String? = null
+        paymentMethodOptionsJsonString: String? = null,
+        intentConfigSetupFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage? = null
     ) {
         val factoryWithConfig = ConfirmPaymentIntentParamsFactory(
             clientSecret = CLIENT_SECRET,
@@ -359,6 +376,7 @@ class ConfirmPaymentIntentParamsFactoryTest {
             paymentMethod = paymentMethod,
             optionsParams = null,
             extraParams = null,
+            intentConfigSetupFutureUsage = intentConfigSetupFutureUsage
         )
 
         assertThat(result).isInstanceOf(ConfirmPaymentIntentParams::class.java)

--- a/payments-core/src/test/java/com/stripe/android/ConfirmSetupIntentParamsFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/ConfirmSetupIntentParamsFactoryTest.kt
@@ -146,6 +146,7 @@ class ConfirmSetupIntentParamsFactoryTest {
             paymentMethod = PaymentMethodFactory.cashAppPay(),
             optionsParams = null,
             extraParams = null,
+            intentConfigSetupFutureUsage = null
         )
     }
 
@@ -162,6 +163,7 @@ class ConfirmSetupIntentParamsFactoryTest {
             paymentMethod = paymentMethod,
             optionsParams = null,
             extraParams = extraParams,
+            intentConfigSetupFutureUsage = null
         )
     }
 

--- a/payments-core/src/test/java/com/stripe/android/model/PaymentMethodOptionsParamsTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/PaymentMethodOptionsParamsTest.kt
@@ -37,6 +37,24 @@ class PaymentMethodOptionsParamsTest {
     }
 
     @Test
+    fun blikToParamMap_withSfu_includesSfu() {
+        val blikCode = "123456"
+        assertThat(
+            PaymentMethodOptionsParams.Blik(
+                code = blikCode,
+                setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.None
+            ).toParamMap()
+        ).isEqualTo(
+            mapOf(
+                PaymentMethod.Type.Blik.code to mapOf(
+                    PaymentMethodOptionsParams.Blik.PARAM_CODE to blikCode,
+                    PaymentMethodOptionsParams.Blik.PARAM_SETUP_FUTURE_USAGE to "none"
+                )
+            )
+        )
+    }
+
+    @Test
     fun cardToParamMap_withNoData_shouldHaveEmptyParams() {
         assertThat(
             PaymentMethodOptionsParams.Card()
@@ -85,6 +103,73 @@ class PaymentMethodOptionsParamsTest {
             mapOf(
                 "sepa_debit" to mapOf(
                     "setup_future_usage" to "on_session"
+                )
+            )
+        )
+    }
+
+    @Test
+    fun weChatPayToParamMap_hasCorrectValues() {
+        assertThat(
+            PaymentMethodOptionsParams.WeChatPay(
+                appId = "some_id",
+                setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.None
+            ).toParamMap()
+        ).isEqualTo(
+            mapOf(
+                "wechat_pay" to mapOf(
+                    PaymentMethodOptionsParams.WeChatPay.PARAM_CLIENT to "android",
+                    PaymentMethodOptionsParams.WeChatPay.PARAM_APP_ID to "some_id",
+                    PaymentMethodOptionsParams.WeChatPay.PARAM_SETUP_FUTURE_USAGE to "none"
+                )
+            )
+        )
+    }
+
+    @Test
+    fun weChatPayH5ToParamMap_hasCorrectValues() {
+        assertThat(
+            PaymentMethodOptionsParams.WeChatPayH5(
+                setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.None
+            ).toParamMap()
+        ).isEqualTo(
+            mapOf(
+                "wechat_pay" to mapOf(
+                    PaymentMethodOptionsParams.WeChatPay.PARAM_CLIENT to "mobile_web",
+                    PaymentMethodOptionsParams.WeChatPay.PARAM_SETUP_FUTURE_USAGE to "none"
+                )
+            )
+        )
+    }
+
+    @Test
+    fun konbiniToParamMap_hasCorrectValues() {
+        assertThat(
+            PaymentMethodOptionsParams.Konbini(
+                confirmationNumber = "12345",
+                setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.None
+            ).toParamMap()
+        ).isEqualTo(
+            mapOf(
+                "konbini" to mapOf(
+                    PaymentMethodOptionsParams.Konbini.PARAM_CONFIRMATION_NUMBER to "12345",
+                    PaymentMethodOptionsParams.Konbini.PARAM_SETUP_FUTURE_USAGE to "none"
+                )
+            )
+        )
+    }
+
+    @Test
+    fun setupFutureUsageToParamMap_hasCorrectValues() {
+        assertThat(
+            PaymentMethodOptionsParams.SetupFutureUsage(
+                paymentMethodType = PaymentMethod.Type.Klarna,
+                setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.None
+            ).toParamMap()
+        ).isEqualTo(
+            mapOf(
+                "klarna" to mapOf(
+                    PaymentMethodOptionsParams.SetupFutureUsage.PARAM_SETUP_FUTURE_USAGE to "none"
                 )
             )
         )

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverter.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverter.kt
@@ -116,7 +116,7 @@ class FieldValuesToParamsMapConverter {
                     }
                 }
                 PaymentMethod.Type.WeChatPay.code -> {
-                    PaymentMethodOptionsParams.WeChatPayH5
+                    PaymentMethodOptionsParams.WeChatPayH5()
                 }
                 PaymentMethod.Type.SepaDebit.code -> {
                     PaymentMethodOptionsParams.SepaDebit(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DeferredIntentValidator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DeferredIntentValidator.kt
@@ -19,6 +19,7 @@ internal object DeferredIntentValidator {
         stripeIntent: StripeIntent,
         intentConfiguration: PaymentSheet.IntentConfiguration,
         allowsManualConfirmation: Boolean,
+        paymentMethod: PaymentMethod
     ): StripeIntent {
         val params = intentConfiguration.toDeferredIntentParams()
 
@@ -35,12 +36,6 @@ internal object DeferredIntentValidator {
                         "(${paymentMode.currency.lowercase()})."
                 }
 
-                require(paymentMode.setupFutureUsage.isNull() == stripeIntent.setupFutureUsage.isNull()) {
-                    "Your PaymentIntent setupFutureUsage (${stripeIntent.setupFutureUsage}) " +
-                        "does not match the PaymentSheet.IntentConfiguration " +
-                        "setupFutureUsage (${paymentMode.setupFutureUsage})."
-                }
-
                 // Manual confirmation is only available using FlowController because merchants own
                 // the final step of confirmation. Showing a successful payment in the complete flow
                 // may be misleading when merchants still need to do a final confirmation which
@@ -50,17 +45,11 @@ internal object DeferredIntentValidator {
                         "can only be used with PaymentSheet.FlowController."
                 }
 
-                require(
-                    validatePaymentMethodOptionsSetupFutureUsage(
-                        paramsPaymentMethodOptionsJsonString = paymentMode.paymentMethodOptionsJsonString,
-                        stripeIntent = stripeIntent
-                    )
-                ) {
-                    "Your PaymentIntent payment_method_options setup_future_usage values " +
-                        "(${stripeIntent.getPaymentMethodOptions()} do not match the values provided in " +
-                        "PaymentSheet.IntentConfiguration.Mode.Payment.PaymentMethodOptions " +
-                        "(${paymentMode.paymentMethodOptionsJsonString})"
-                }
+                validateSfuAndPmoSfu(
+                    intent = stripeIntent,
+                    paymentMode = paymentMode,
+                    paymentMethod = paymentMethod
+                )
             }
             is SetupIntent -> {
                 val setupMode = requireNotNull(params.mode as? DeferredIntentParams.Mode.Setup) {
@@ -140,19 +129,54 @@ internal object DeferredIntentValidator {
         return firstFingerprint == secondFingerprint
     }
 
-    private fun validatePaymentMethodOptionsSetupFutureUsage(
-        paramsPaymentMethodOptionsJsonString: String?,
-        stripeIntent: StripeIntent,
-    ): Boolean {
-        val paramsMap = paramsPaymentMethodOptionsJsonString?.let {
+    private fun validateSfuAndPmoSfu(
+        intent: PaymentIntent,
+        paymentMode: DeferredIntentParams.Mode.Payment,
+        paymentMethod: PaymentMethod
+    ) {
+        val paymentIntentPmoSfu = paymentMethod.type?.code?.let {
+            (intent.getPaymentMethodOptions()[it] as? Map<*, *>?)?.get("setup_future_usage") as? String
+        }
+
+        val intentConfigPmoSfu = paymentMode.paymentMethodOptionsJsonString?.let {
             StripeJsonUtils.jsonObjectToMap(JSONObject(it))
         } ?: emptyMap()
 
-        return paramsMap.entries.all { (key, value) ->
-            val paramsSfu = (value as? Map<*, *>?)?.get("setup_future_usage") as? String
-            val intentSfu = (stripeIntent.getPaymentMethodOptions()[key] as? Map<*, *>?)?.get("setup_future_usage")
-            val isPaymentMethodInIntent = stripeIntent.paymentMethodTypes.contains(key)
-            if (isPaymentMethodInIntent) intentSfu == paramsSfu else true
+        // If using PMO SFU, not setting values on PaymentIntent is valid because the SDK will set them in the
+        // confirm params based on the IntentConfiguration
+        if (intentConfigPmoSfu.isNotEmpty() && intent.setupFutureUsage.isNull() && paymentIntentPmoSfu.isNull()) {
+            return
+        }
+
+        // If PI has top level SFU set, validate SFU is also set on IntentConfiguration
+        require(paymentMode.setupFutureUsage.isNull() == intent.setupFutureUsage.isNull()) {
+            "Your PaymentIntent setupFutureUsage (${intent.setupFutureUsage}) " +
+                "does not match the PaymentSheet.IntentConfiguration " +
+                "setupFutureUsage (${paymentMode.setupFutureUsage})."
+        }
+
+        val intentConfigurationPmoSfuForPaymentMethod = paymentMethod.type?.code?.let { code ->
+            intentConfigPmoSfu[code]?.let { value ->
+                (value as? Map<*, *>?)?.get("setup_future_usage") as? String
+            }
+        }
+
+        val intentAndConfigPmoSfuMatch = when (paymentIntentPmoSfu) {
+            // Allow on_session/off_session mismatch as there is no difference in behavior client side.
+            "on_session",
+            "off_session" -> {
+                intentConfigurationPmoSfuForPaymentMethod == "on_session" ||
+                    intentConfigurationPmoSfuForPaymentMethod == "off_session"
+            }
+            "none" -> intentConfigurationPmoSfuForPaymentMethod == "none"
+            null -> intentConfigurationPmoSfuForPaymentMethod.isNull()
+            else -> false
+        }
+
+        require(intentAndConfigPmoSfuMatch) {
+            "Your PaymentIntent payment_method_options[${paymentMethod.type?.code}][setup_future_usage] value " +
+                "$paymentIntentPmoSfu does not match the IntentConfiguration value " +
+                "$intentConfigurationPmoSfuForPaymentMethod"
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -489,23 +489,5 @@ internal fun PaymentSelection.Saved.mandateTextFromPaymentMethodMetadata(
     metadata.hasIntentToSetup(paymentMethod.type?.code ?: "")
 )
 
-/**
- * If setup_future_usage is set at the top level to "off_session" the payment method will
- * inherit this value so sending [ConfirmPaymentIntentParams.SetupFutureUsage.OnSession] and
- * [ConfirmPaymentIntentParams.SetupFutureUsage.Blank] have no effect.
- * If setup_future_usage is set to "on_session" at either the top level or payment_method_options level it can
- * only be updated to "off_session". This method will always return the [ConfirmPaymentIntentParams.SetupFutureUsage]
- * value if it is [ConfirmPaymentIntentParams.SetupFutureUsage.OffSession]. Otherwise it will return null if
- * @param hasIntentToSetup is true
- */
-internal fun PaymentSelection.CustomerRequestedSave.getSetupFutureUseValue(
-    hasIntentToSetup: Boolean
-): ConfirmPaymentIntentParams.SetupFutureUsage? {
-    return when (setupFutureUsage) {
-        ConfirmPaymentIntentParams.SetupFutureUsage.OffSession -> setupFutureUsage
-        else -> setupFutureUsage.takeIf { !hasIntentToSetup }
-    }
-}
-
 private val PaymentMethod.isLinkCardBrand: Boolean
     get() = type == PaymentMethod.Type.Card && linkPaymentDetails is LinkPaymentDetails.BankAccount

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -39,7 +39,6 @@ import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.addresselement.toIdentifierMap
 import com.stripe.android.paymentsheet.model.PaymentMethodIncentive
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.model.getSetupFutureUseValue
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.BankFormScreenState.ResultIdentifier
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormViewModel.AnalyticsEvent.Finished
@@ -706,7 +705,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
 
         val paymentMethodOptionsParams = if (resultIdentifier is ResultIdentifier.Session) {
             PaymentMethodOptionsParams.USBankAccount(
-                setupFutureUsage = customerRequestedSave.getSetupFutureUseValue(args.formArgs.hasIntentToSetup)
+                setupFutureUsage = customerRequestedSave.setupFutureUsage
             )
         } else {
             null

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -17,7 +17,6 @@ import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.model.getSetupFutureUseValue
 import com.stripe.android.ui.core.FieldValuesToParamsMapConverter
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.utils.collectAsState
@@ -99,12 +98,8 @@ internal fun FormFieldValues.transformToPaymentSelection(
     paymentMethod: SupportedPaymentMethod,
     paymentMethodMetadata: PaymentMethodMetadata,
 ): PaymentSelection {
-    val setupFutureUsage = userRequestedReuse.getSetupFutureUseValue(
-        paymentMethodMetadata.hasIntentToSetup(PaymentMethod.Type.Card.code)
-    )
-
     val params = transformToPaymentMethodCreateParams(paymentMethod.code, paymentMethodMetadata)
-    val options = transformToPaymentMethodOptionsParams(paymentMethod.code, setupFutureUsage)
+    val options = transformToPaymentMethodOptionsParams(paymentMethod.code, userRequestedReuse.setupFutureUsage)
     val extras = transformToExtraParams(paymentMethod.code)
     return if (paymentMethod.code == PaymentMethod.Type.Card.code) {
         PaymentSelection.New.Card(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultIntentConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultIntentConfirmationInterceptorTest.kt
@@ -21,6 +21,7 @@ import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.model.RadarSessionWithHCaptcha
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.StripeRepository
+import com.stripe.android.paymentelement.PaymentMethodOptionsSetupFutureUsagePreview
 import com.stripe.android.paymentelement.PreparePaymentMethodHandler
 import com.stripe.android.paymentelement.confirmation.intent.CreateIntentCallbackFailureException
 import com.stripe.android.paymentelement.confirmation.intent.DefaultIntentConfirmationInterceptor
@@ -1088,6 +1089,150 @@ class DefaultIntentConfirmationInterceptorTest {
             createSavedPaymentMethodRadarSessionCalls.verify()
 
             eventReporter.verifyCreateSavedPaymentMethodRadarSessionCall(error)
+        }
+
+    @OptIn(PaymentMethodOptionsSetupFutureUsagePreview::class)
+    @Test
+    fun `Returns confirm params with top level 'setup_future_usage' set to 'off_session' when set on configuration`() =
+        runTest {
+            val interceptor = DefaultIntentConfirmationInterceptor(
+                stripeRepository = object : AbsFakeStripeRepository() {
+                    override suspend fun retrieveStripeIntent(
+                        clientSecret: String,
+                        options: ApiRequest.Options,
+                        expandFields: List<String>
+                    ): Result<StripeIntent> {
+                        return Result.success(PaymentIntentFactory.create())
+                    }
+
+                    override suspend fun createPaymentMethod(
+                        paymentMethodCreateParams: PaymentMethodCreateParams,
+                        options: ApiRequest.Options
+                    ): Result<PaymentMethod> {
+                        return Result.success(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+                    }
+                },
+                publishableKeyProvider = { "pk" },
+                stripeAccountIdProvider = { null },
+                errorReporter = FakeErrorReporter(),
+                allowsManualConfirmation = false,
+                intentCreationCallbackProvider = {
+                    CreateIntentCallback { _, _ ->
+                        CreateIntentResult.Success("pi_123_secret_456")
+                    }
+                },
+                preparePaymentMethodHandlerProvider = {
+                    null
+                },
+            )
+
+            val nextStep = interceptor.intercept(
+                confirmationOption = PaymentMethodConfirmationOption.New(
+                    createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                    optionsParams = PaymentMethodOptionsParams.Card(
+                        setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
+                    ),
+                    extraParams = null,
+                    shouldSave = false,
+                ),
+                intent = PaymentIntentFactory.create(),
+                initializationMode = InitializationMode.DeferredIntent(
+                    PaymentSheet.IntentConfiguration(
+                        mode = PaymentSheet.IntentConfiguration.Mode.Payment(
+                            currency = "usd",
+                            amount = 5000,
+                            setupFutureUse = PaymentSheet.IntentConfiguration.SetupFutureUse.OffSession,
+                            paymentMethodOptions = PaymentSheet.IntentConfiguration.Mode.Payment.PaymentMethodOptions(
+                                setupFutureUsageValues = mapOf(
+                                    PaymentMethod.Type.Affirm to PaymentSheet.IntentConfiguration.SetupFutureUse.None
+                                )
+                            )
+                        ),
+                    )
+                ),
+                shippingDetails = null,
+            )
+
+            val confirmNextStep = nextStep as? IntentConfirmationInterceptor.NextStep.Confirm
+            val confirmParams = confirmNextStep?.confirmParams as? ConfirmPaymentIntentParams
+
+            assertThat(
+                confirmParams?.setupFutureUsage
+            ).isEqualTo(
+                ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
+            )
+        }
+
+    @OptIn(PaymentMethodOptionsSetupFutureUsagePreview::class)
+    @Test
+    fun `Returns confirm params with pmo 'setup_future_usage' set to 'off_session' when set on configuration`() =
+        runTest {
+            val interceptor = DefaultIntentConfirmationInterceptor(
+                stripeRepository = object : AbsFakeStripeRepository() {
+                    override suspend fun retrieveStripeIntent(
+                        clientSecret: String,
+                        options: ApiRequest.Options,
+                        expandFields: List<String>
+                    ): Result<StripeIntent> {
+                        return Result.success(PaymentIntentFactory.create())
+                    }
+
+                    override suspend fun createPaymentMethod(
+                        paymentMethodCreateParams: PaymentMethodCreateParams,
+                        options: ApiRequest.Options
+                    ): Result<PaymentMethod> {
+                        return Result.success(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+                    }
+                },
+                publishableKeyProvider = { "pk" },
+                stripeAccountIdProvider = { null },
+                errorReporter = FakeErrorReporter(),
+                allowsManualConfirmation = false,
+                intentCreationCallbackProvider = {
+                    CreateIntentCallback { _, _ ->
+                        CreateIntentResult.Success("pi_123_secret_456")
+                    }
+                },
+                preparePaymentMethodHandlerProvider = {
+                    null
+                },
+            )
+
+            val nextStep = interceptor.intercept(
+                confirmationOption = PaymentMethodConfirmationOption.New(
+                    createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                    optionsParams = null,
+                    extraParams = null,
+                    shouldSave = false,
+                ),
+                intent = PaymentIntentFactory.create(),
+                initializationMode = InitializationMode.DeferredIntent(
+                    PaymentSheet.IntentConfiguration(
+                        mode = PaymentSheet.IntentConfiguration.Mode.Payment(
+                            currency = "usd",
+                            amount = 5000,
+                            paymentMethodOptions = PaymentSheet.IntentConfiguration.Mode.Payment.PaymentMethodOptions(
+                                setupFutureUsageValues = mapOf(
+                                    PaymentMethod.Type.Card to
+                                        PaymentSheet.IntentConfiguration.SetupFutureUse.OffSession
+                                )
+                            )
+                        ),
+                    )
+                ),
+                shippingDetails = null,
+            )
+
+            val confirmNextStep = nextStep as? IntentConfirmationInterceptor.NextStep.Confirm
+            val confirmParams = confirmNextStep?.confirmParams as? ConfirmPaymentIntentParams
+
+            assertThat(
+                confirmParams?.paymentMethodOptions
+            ).isEqualTo(
+                PaymentMethodOptionsParams.Card(
+                    setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
+                )
+            )
         }
 
     private fun testNoProvider(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DeferredIntentValidatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DeferredIntentValidatorTest.kt
@@ -7,11 +7,11 @@ import com.stripe.android.isInstanceOf
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentelement.PaymentMethodOptionsSetupFutureUsagePreview
 import com.stripe.android.paymentsheet.PaymentSheet.IntentConfiguration
-import com.stripe.android.paymentsheet.paymentmethodoptions.setupfutureusage.toJsonObjectString
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.testing.PaymentMethodFactory.update
@@ -31,6 +31,7 @@ internal class DeferredIntentValidatorTest {
                 stripeIntent = paymentIntent,
                 intentConfiguration = intentConfiguration,
                 allowsManualConfirmation = false,
+                paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
             )
         }
 
@@ -50,6 +51,7 @@ internal class DeferredIntentValidatorTest {
                 stripeIntent = paymentIntent,
                 intentConfiguration = intentConfiguration,
                 allowsManualConfirmation = false,
+                paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
             )
         }
 
@@ -73,6 +75,7 @@ internal class DeferredIntentValidatorTest {
                 stripeIntent = paymentIntent,
                 intentConfiguration = intentConfiguration,
                 allowsManualConfirmation = false,
+                paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
             )
         ).isEqualTo(paymentIntent)
     }
@@ -91,6 +94,7 @@ internal class DeferredIntentValidatorTest {
                 stripeIntent = paymentIntent,
                 intentConfiguration = intentConfiguration,
                 allowsManualConfirmation = false,
+                paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
             )
         }
 
@@ -111,6 +115,7 @@ internal class DeferredIntentValidatorTest {
             stripeIntent = paymentIntent,
             intentConfiguration = intentConfiguration,
             allowsManualConfirmation = false,
+            paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
         )
 
         assertThat(result).isEqualTo(paymentIntent)
@@ -129,6 +134,7 @@ internal class DeferredIntentValidatorTest {
                 stripeIntent = paymentIntent,
                 intentConfiguration = intentConfiguration,
                 allowsManualConfirmation = false,
+                paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
             )
         }
 
@@ -150,6 +156,7 @@ internal class DeferredIntentValidatorTest {
             stripeIntent = paymentIntent,
             intentConfiguration = intentConfiguration,
             allowsManualConfirmation = true,
+            paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
         )
 
         assertThat(result).isEqualTo(paymentIntent)
@@ -164,6 +171,7 @@ internal class DeferredIntentValidatorTest {
             stripeIntent = paymentIntent,
             intentConfiguration = intentConfiguration,
             allowsManualConfirmation = true,
+            paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
         )
 
         assertThat(result).isEqualTo(paymentIntent)
@@ -180,6 +188,7 @@ internal class DeferredIntentValidatorTest {
             stripeIntent = paymentIntent,
             intentConfiguration = intentConfiguration,
             allowsManualConfirmation = true,
+            paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
         )
 
         assertThat(result).isEqualTo(paymentIntent)
@@ -195,6 +204,7 @@ internal class DeferredIntentValidatorTest {
                 stripeIntent = setupIntent,
                 intentConfiguration = intentConfiguration,
                 allowsManualConfirmation = false,
+                paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
             )
         }
 
@@ -218,6 +228,7 @@ internal class DeferredIntentValidatorTest {
                 stripeIntent = setupIntent,
                 intentConfiguration = intentConfiguration,
                 allowsManualConfirmation = false,
+                paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
             )
         ).isEqualTo(setupIntent)
     }
@@ -231,6 +242,7 @@ internal class DeferredIntentValidatorTest {
             stripeIntent = setupIntent,
             intentConfiguration = intentConfiguration,
             allowsManualConfirmation = true,
+            paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
         )
 
         assertThat(result).isEqualTo(setupIntent)
@@ -353,27 +365,25 @@ internal class DeferredIntentValidatorTest {
         }
 
     @Test
-    fun `PMO validation succeeds if intent and config PMO match`() {
+    fun `PMO validation succeeds if intent and config PMO match for PaymentMethod`() {
         val paymentIntent = PaymentIntentFactory.create(
             paymentMethodOptionsJsonString = PaymentIntentFixtures.PMO_SETUP_FUTURE_USAGE,
-            paymentMethodTypes = listOf("card", "affirm", "amazon_pay")
         )
         val paymentMethodOptions = IntentConfiguration.Mode.Payment.PaymentMethodOptions(
             setupFutureUsageValues = mapOf(
                 PaymentMethod.Type.Card to IntentConfiguration.SetupFutureUse.OffSession,
-                PaymentMethod.Type.Affirm to IntentConfiguration.SetupFutureUse.None,
-                PaymentMethod.Type.AmazonPay to IntentConfiguration.SetupFutureUse.OffSession,
             )
         )
         paymentMethodOptionsSetupFutureUsageTest(
             intent = paymentIntent,
             paymentMethodOptions = paymentMethodOptions,
-            shouldValidateSucceed = true
+            shouldValidateSucceed = true,
+            paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
         )
     }
 
     @Test
-    fun `PMO validation fails if Config PMO does not contain entry from Intent PMO`() {
+    fun `PMO validation succeeds if Config PMO and intent PMO do not match for PM not being used`() {
         val paymentIntent = PaymentIntentFactory.create(
             paymentMethodOptionsJsonString = PaymentIntentFixtures.PMO_SETUP_FUTURE_USAGE,
             paymentMethodTypes = listOf("card", "affirm", "amazon_pay")
@@ -382,13 +392,54 @@ internal class DeferredIntentValidatorTest {
         val paymentMethodOptions = IntentConfiguration.Mode.Payment.PaymentMethodOptions(
             setupFutureUsageValues = mapOf(
                 PaymentMethod.Type.Card to IntentConfiguration.SetupFutureUse.OnSession,
-                PaymentMethod.Type.Affirm to IntentConfiguration.SetupFutureUse.None,
+                PaymentMethod.Type.AmazonPay to IntentConfiguration.SetupFutureUse.None,
             )
         )
         paymentMethodOptionsSetupFutureUsageTest(
             intent = paymentIntent,
             paymentMethodOptions = paymentMethodOptions,
-            shouldValidateSucceed = false
+            shouldValidateSucceed = true,
+            paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
+        )
+    }
+
+    @Test
+    fun `SFU validation succeeds if not set on intent and using PMO SFU`() {
+        val paymentIntent = PaymentIntentFactory.create()
+
+        val paymentMethodOptions = IntentConfiguration.Mode.Payment.PaymentMethodOptions(
+            setupFutureUsageValues = mapOf(
+                PaymentMethod.Type.Card to IntentConfiguration.SetupFutureUse.OnSession,
+                PaymentMethod.Type.Affirm to IntentConfiguration.SetupFutureUse.None,
+            )
+        )
+
+        paymentMethodOptionsSetupFutureUsageTest(
+            intent = paymentIntent,
+            paymentMethodOptions = paymentMethodOptions,
+            shouldValidateSucceed = true,
+            topLevelUsage = IntentConfiguration.SetupFutureUse.OffSession,
+            paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
+        )
+    }
+
+    @Test
+    fun `PMO SFU validation succeeds if only set in intent configuration`() {
+        val paymentIntent = PaymentIntentFactory.create()
+
+        val paymentMethodOptions = IntentConfiguration.Mode.Payment.PaymentMethodOptions(
+            setupFutureUsageValues = mapOf(
+                PaymentMethod.Type.Card to IntentConfiguration.SetupFutureUse.OnSession,
+                PaymentMethod.Type.Affirm to IntentConfiguration.SetupFutureUse.None,
+            )
+        )
+
+        paymentMethodOptionsSetupFutureUsageTest(
+            intent = paymentIntent,
+            paymentMethodOptions = paymentMethodOptions,
+            shouldValidateSucceed = true,
+            topLevelUsage = IntentConfiguration.SetupFutureUse.OffSession,
+            paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
         )
     }
 
@@ -396,81 +447,21 @@ internal class DeferredIntentValidatorTest {
     fun `PMO validation fails if SFU values are not the same`() {
         val paymentIntent = PaymentIntentFactory.create(
             paymentMethodOptionsJsonString = PaymentIntentFixtures.PMO_SETUP_FUTURE_USAGE,
-            paymentMethodTypes = listOf("card", "affirm", "amazon_pay")
         )
 
         val paymentMethodOptions = IntentConfiguration.Mode.Payment.PaymentMethodOptions(
             setupFutureUsageValues = mapOf(
-                PaymentMethod.Type.Card to IntentConfiguration.SetupFutureUse.OnSession,
-                PaymentMethod.Type.Affirm to IntentConfiguration.SetupFutureUse.None,
-                PaymentMethod.Type.AmazonPay to IntentConfiguration.SetupFutureUse.OffSession,
+                PaymentMethod.Type.Card to IntentConfiguration.SetupFutureUse.None,
             )
         )
 
         paymentMethodOptionsSetupFutureUsageTest(
             intent = paymentIntent,
             paymentMethodOptions = paymentMethodOptions,
-            shouldValidateSucceed = false
-        )
-    }
-
-    @Test
-    fun `PMO validation fails if config PMO not in intent PMO and PM in paymentMethodTypes`() {
-        val paymentIntent = PaymentIntentFactory.create(
-            paymentMethodTypes = listOf("card", "amazon_pay", "affirm"),
-            paymentMethodOptionsJsonString = """
-                {
-                    "card": {
-                        "setup_future_usage": "off_session"
-                    },
-                    "affirm": {
-                        "setup_future_usage": "none"
-                    }
-                }
-            """.trimIndent()
-        )
-
-        val paymentMethodOptions = IntentConfiguration.Mode.Payment.PaymentMethodOptions(
-            setupFutureUsageValues = mapOf(
-                PaymentMethod.Type.Card to IntentConfiguration.SetupFutureUse.OffSession,
-                PaymentMethod.Type.Affirm to IntentConfiguration.SetupFutureUse.None,
-                PaymentMethod.Type.AmazonPay to IntentConfiguration.SetupFutureUse.OffSession,
-            )
-        )
-        paymentMethodOptionsSetupFutureUsageTest(
-            intent = paymentIntent,
-            paymentMethodOptions = paymentMethodOptions,
-            shouldValidateSucceed = false
-        )
-    }
-
-    @Test
-    fun `PMO validation succeeds if config PMO not in intent PMO and PM not in paymentMethodTypes`() {
-        val paymentIntent = PaymentIntentFactory.create(
-            paymentMethodTypes = listOf("card", "affirm"),
-            paymentMethodOptionsJsonString = """
-                {
-                    "card": {
-                        "setup_future_usage": "off_session"
-                    },
-                    "affirm": {
-                        "setup_future_usage": "none"
-                    }
-                }
-            """.trimIndent()
-        )
-
-        val paymentMethodOptions = IntentConfiguration.Mode.Payment.PaymentMethodOptions(
-            setupFutureUsageValues = mapOf(
-                PaymentMethod.Type.Card to IntentConfiguration.SetupFutureUse.OffSession,
-                PaymentMethod.Type.Affirm to IntentConfiguration.SetupFutureUse.None,
-                PaymentMethod.Type.AmazonPay to IntentConfiguration.SetupFutureUse.OffSession,
-            )
-        )
-        paymentMethodOptionsSetupFutureUsageTest(
-            intent = paymentIntent,
-            paymentMethodOptions = paymentMethodOptions,
-            shouldValidateSucceed = true
+            shouldValidateSucceed = false,
+            paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+            failureMessage = "Your PaymentIntent payment_method_options[card][setup_future_usage] value " +
+                "off_session does not match the IntentConfiguration value none"
         )
     }
 
@@ -537,11 +528,15 @@ internal class DeferredIntentValidatorTest {
 
     private fun paymentMethodOptionsSetupFutureUsageTest(
         intent: StripeIntent,
-        paymentMethodOptions: IntentConfiguration.Mode.Payment.PaymentMethodOptions,
-        shouldValidateSucceed: Boolean
+        paymentMethodOptions: IntentConfiguration.Mode.Payment.PaymentMethodOptions?,
+        shouldValidateSucceed: Boolean,
+        topLevelUsage: IntentConfiguration.SetupFutureUse? = null,
+        paymentMethod: PaymentMethod,
+        failureMessage: String? = null
     ) {
         val configuration = makeIntentConfigurationForPayment(
-            paymentMethodOptions = paymentMethodOptions
+            paymentMethodOptions = paymentMethodOptions,
+            setupFutureUse = topLevelUsage
         )
 
         if (shouldValidateSucceed) {
@@ -549,6 +544,7 @@ internal class DeferredIntentValidatorTest {
                 stripeIntent = intent,
                 intentConfiguration = configuration,
                 allowsManualConfirmation = false,
+                paymentMethod = paymentMethod
             )
 
             assertThat(result).isNotNull()
@@ -558,15 +554,11 @@ internal class DeferredIntentValidatorTest {
                     stripeIntent = intent,
                     intentConfiguration = configuration,
                     allowsManualConfirmation = false,
+                    paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
                 )
             }
 
-            assertThat(failure).hasMessageThat().isEqualTo(
-                "Your PaymentIntent payment_method_options setup_future_usage values " +
-                    "(${intent.getPaymentMethodOptions()} do not match the values provided in " +
-                    "PaymentSheet.IntentConfiguration.Mode.Payment.PaymentMethodOptions " +
-                    "(${paymentMethodOptions.toJsonObjectString()})"
-            )
+            assertThat(failure).hasMessageThat().isEqualTo(failureMessage)
         }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentSelectionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentSelectionTest.kt
@@ -8,7 +8,6 @@ import com.stripe.android.link.LinkPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.Address
 import com.stripe.android.model.CardBrand
-import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.CvcCheck
 import com.stripe.android.model.PaymentIntentFixtures
@@ -239,41 +238,5 @@ class PaymentSelectionTest {
                 isSetupFlow = true
             )
         )
-    }
-
-    @Test
-    fun `getSetupFutureUseValue returns correct value when hasIntentToSetup is true`() {
-        val noRequestSfu = PaymentSelection.CustomerRequestedSave.NoRequest.getSetupFutureUseValue(
-            hasIntentToSetup = true
-        )
-        assertThat(noRequestSfu).isNull()
-
-        val noReuseSfu = PaymentSelection.CustomerRequestedSave.RequestNoReuse.getSetupFutureUseValue(
-            hasIntentToSetup = true
-        )
-        assertThat(noReuseSfu).isNull()
-
-        val reuseSfu = PaymentSelection.CustomerRequestedSave.RequestReuse.getSetupFutureUseValue(
-            hasIntentToSetup = true
-        )
-        assertThat(reuseSfu).isEqualTo(ConfirmPaymentIntentParams.SetupFutureUsage.OffSession)
-    }
-
-    @Test
-    fun `getSetupFutureUseValue returns correct value when hasIntentToSetup is false`() {
-        val noRequestSfu = PaymentSelection.CustomerRequestedSave.NoRequest.getSetupFutureUseValue(
-            hasIntentToSetup = false
-        )
-        assertThat(noRequestSfu).isNull()
-
-        val noReuseSfu = PaymentSelection.CustomerRequestedSave.RequestNoReuse.getSetupFutureUseValue(
-            hasIntentToSetup = false
-        )
-        assertThat(noReuseSfu).isEqualTo(ConfirmPaymentIntentParams.SetupFutureUsage.Blank)
-
-        val reuseSfu = PaymentSelection.CustomerRequestedSave.RequestReuse.getSetupFutureUseValue(
-            hasIntentToSetup = false
-        )
-        assertThat(reuseSfu).isEqualTo(ConfirmPaymentIntentParams.SetupFutureUsage.OffSession)
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
@@ -225,30 +225,6 @@ class USBankAccountFormViewModelTest {
     }
 
     @Test
-    fun `when hasIntentToSetup, paymentMethodOptionsParams does not send SFU`() = runTest {
-        val viewModel = createViewModel(
-            defaultArgs.copy(
-                formArgs = defaultArgs.formArgs.copy(
-                    hasIntentToSetup = true
-                ),
-                showCheckbox = true,
-            )
-        )
-        val bankAccount = mockVerifiedBankAccount()
-
-        viewModel.linkedAccount.test {
-            skipItems(1)
-            viewModel.handleCollectBankAccountResult(bankAccount)
-
-            assertThat(awaitItem()?.paymentMethodOptionsParams).isEqualTo(
-                PaymentMethodOptionsParams.USBankAccount(
-                    setupFutureUsage = null
-                )
-            )
-        }
-    }
-
-    @Test
     fun `when reset, primary button launches bank account collection`() =
         runTest(UnconfinedTestDispatcher()) {
             val viewModel = createViewModel()
@@ -1348,43 +1324,6 @@ class USBankAccountFormViewModelTest {
 
             viewModel.saveForFutureUseElement.controller.onValueChange(false)
             assertThat(awaitItem()?.customerRequestedSave).isEqualTo(CustomerRequestedSave.RequestNoReuse)
-        }
-    }
-
-    @Test
-    fun `PaymentMethodOptionsParams does not contain SFU for RequestNoReuse if hasIntentToSetup`() = runTest {
-        val viewModel = createViewModel(
-            args = defaultArgs.copy(
-                showCheckbox = true,
-                formArgs = defaultArgs.formArgs.copy(
-                    hasIntentToSetup = true
-                )
-            )
-        )
-
-        viewModel.linkedAccount.test {
-            assertThat(awaitItem()).isNull()
-
-            viewModel.nameController.onValueChange("Some Name")
-            viewModel.emailController.onValueChange("email@email.com")
-            viewModel.handleCollectBankAccountResult(mockVerifiedBankAccount())
-
-            val initialAccount = awaitItem()
-            assertThat(initialAccount?.customerRequestedSave).isEqualTo(CustomerRequestedSave.RequestNoReuse)
-            assertThat(initialAccount?.paymentMethodOptionsParams).isEqualTo(
-                PaymentMethodOptionsParams.USBankAccount(
-                    setupFutureUsage = null
-                )
-            )
-
-            viewModel.saveForFutureUseElement.controller.onValueChange(true)
-            val updatedAccount = awaitItem()
-            assertThat(updatedAccount?.customerRequestedSave).isEqualTo(CustomerRequestedSave.RequestReuse)
-            assertThat(updatedAccount?.paymentMethodOptionsParams).isEqualTo(
-                PaymentMethodOptionsParams.USBankAccount(
-                    setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
-                )
-            )
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodTest.kt
@@ -10,14 +10,12 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
-import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.PaymentMethodCreateParams.Companion.getNameFromParams
 import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.PaymentMethodFixtures
-import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.ViewActionRecorder
@@ -77,84 +75,6 @@ internal class AddPaymentMethodTest {
         assertThat(cardPaymentSelection.brand.code).isEqualTo(cardBrand)
         assertThat(cardPaymentSelection.customerRequestedSave).isEqualTo(customerRequestedSave)
         assertThat(getNameFromParams(cardPaymentSelection.paymentMethodCreateParams)).isEqualTo(name)
-    }
-
-    @Test
-    fun `transformToPaymentSelection transforms cards with PMO SFU correctly for RequestNoReuse`() {
-        val cardBrand = "visa"
-        val customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestNoReuse
-        val formFieldValues = FormFieldValues(
-            fieldValuePairs = mapOf(
-                IdentifierSpec.CardBrand to FormFieldEntry(cardBrand, true),
-            ),
-            userRequestedReuse = customerRequestedSave,
-        )
-
-        val metadataWithPmoSfu = metadata.copy(
-            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
-                paymentMethodOptionsJsonString = PaymentIntentFixtures.PMO_SETUP_FUTURE_USAGE
-            )
-        )
-        val cardPaymentMethod = metadataWithPmoSfu.supportedPaymentMethodForCode("card")!!
-        val cardPaymentSelection = formFieldValues.transformToPaymentSelection(
-            cardPaymentMethod,
-            metadataWithPmoSfu
-        ) as PaymentSelection.New.Card
-        val options = cardPaymentSelection.paymentMethodOptionsParams as? PaymentMethodOptionsParams.Card
-        assertThat(cardPaymentSelection.customerRequestedSave).isEqualTo(customerRequestedSave)
-        assertThat(options?.setupFutureUsage).isNull()
-    }
-
-    @Test
-    fun `transformToPaymentSelection transforms cards with PMO SFU correctly for RequestReuse`() {
-        val cardBrand = "visa"
-        val customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestReuse
-        val formFieldValues = FormFieldValues(
-            fieldValuePairs = mapOf(
-                IdentifierSpec.CardBrand to FormFieldEntry(cardBrand, true),
-            ),
-            userRequestedReuse = customerRequestedSave,
-        )
-
-        val metadataWithPmoSfu = metadata.copy(
-            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
-                paymentMethodOptionsJsonString = PaymentIntentFixtures.PMO_SETUP_FUTURE_USAGE
-            )
-        )
-        val cardPaymentMethod = metadataWithPmoSfu.supportedPaymentMethodForCode("card")!!
-        val cardPaymentSelection = formFieldValues.transformToPaymentSelection(
-            cardPaymentMethod,
-            metadataWithPmoSfu
-        ) as PaymentSelection.New.Card
-        val options = cardPaymentSelection.paymentMethodOptionsParams as? PaymentMethodOptionsParams.Card
-        assertThat(cardPaymentSelection.customerRequestedSave).isEqualTo(customerRequestedSave)
-        assertThat(options?.setupFutureUsage).isEqualTo(ConfirmPaymentIntentParams.SetupFutureUsage.OffSession)
-    }
-
-    @Test
-    fun `transformToPaymentSelection transforms cards with PMO SFU correctly for NoRequest`() {
-        val cardBrand = "visa"
-        val customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest
-        val formFieldValues = FormFieldValues(
-            fieldValuePairs = mapOf(
-                IdentifierSpec.CardBrand to FormFieldEntry(cardBrand, true),
-            ),
-            userRequestedReuse = customerRequestedSave,
-        )
-
-        val metadataWithPmoSfu = metadata.copy(
-            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
-                paymentMethodOptionsJsonString = PaymentIntentFixtures.PMO_SETUP_FUTURE_USAGE
-            )
-        )
-        val cardPaymentMethod = metadataWithPmoSfu.supportedPaymentMethodForCode("card")!!
-        val cardPaymentSelection = formFieldValues.transformToPaymentSelection(
-            cardPaymentMethod,
-            metadataWithPmoSfu
-        ) as PaymentSelection.New.Card
-        val options = cardPaymentSelection.paymentMethodOptionsParams as? PaymentMethodOptionsParams.Card
-        assertThat(cardPaymentSelection.customerRequestedSave).isEqualTo(customerRequestedSave)
-        assertThat(options?.setupFutureUsage).isNull()
     }
 
     @Test
@@ -438,85 +358,6 @@ internal class AddPaymentMethodTest {
         )
 
         assertThat(params.toParamMap()).containsEntry("allow_redisplay", "always")
-    }
-
-    @Test
-    fun `transformToPaymentSelection transforms SepaDebit with PMO setupFutureUsage correctly for RequestReuse`() {
-        val customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestReuse
-        val formFieldValues = FormFieldValues(
-            fieldValuePairs = mapOf(
-                IdentifierSpec.Generic("sepa_debit[iban]") to FormFieldEntry("DE89370400440532013000", true),
-            ),
-            userRequestedReuse = customerRequestedSave,
-        )
-
-        val metadataWithSepaDebit = metadata.copy(
-            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
-                paymentMethodTypes = listOf("sepa_debit")
-            )
-        )
-        val sepaDebitPaymentMethod = metadataWithSepaDebit.supportedPaymentMethodForCode("sepa_debit")!!
-        val sepaDebitPaymentSelection = formFieldValues.transformToPaymentSelection(
-            sepaDebitPaymentMethod,
-            metadataWithSepaDebit
-        ) as PaymentSelection.New.GenericPaymentMethod
-
-        val options = sepaDebitPaymentSelection.paymentMethodOptionsParams as? PaymentMethodOptionsParams.SepaDebit
-        assertThat(sepaDebitPaymentSelection.customerRequestedSave).isEqualTo(customerRequestedSave)
-        assertThat(options?.setupFutureUsage).isEqualTo(ConfirmPaymentIntentParams.SetupFutureUsage.OffSession)
-    }
-
-    @Test
-    fun `transformToPaymentSelection transforms SepaDebit with PMO setupFutureUsage correctly for RequestNoReuse`() {
-        val customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestNoReuse
-        val formFieldValues = FormFieldValues(
-            fieldValuePairs = mapOf(
-                IdentifierSpec.Generic("sepa_debit[iban]") to
-                    FormFieldEntry("DE89370400440532013000", true),
-            ),
-            userRequestedReuse = customerRequestedSave,
-        )
-
-        val metadataWithSepaDebit = metadata.copy(
-            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
-                paymentMethodTypes = listOf("sepa_debit")
-            )
-        )
-        val sepaDebitPaymentMethod = metadataWithSepaDebit.supportedPaymentMethodForCode("sepa_debit")!!
-        val sepaDebitPaymentSelection = formFieldValues.transformToPaymentSelection(
-            sepaDebitPaymentMethod,
-            metadataWithSepaDebit
-        ) as PaymentSelection.New.GenericPaymentMethod
-
-        val options = sepaDebitPaymentSelection.paymentMethodOptionsParams as? PaymentMethodOptionsParams.SepaDebit
-        assertThat(sepaDebitPaymentSelection.customerRequestedSave).isEqualTo(customerRequestedSave)
-        assertThat(options?.setupFutureUsage).isEqualTo(ConfirmPaymentIntentParams.SetupFutureUsage.Blank)
-    }
-
-    @Test
-    fun `transformToPaymentSelection transforms SepaDebit with PMO setupFutureUsage correctly for NoRequest`() {
-        val customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest
-        val formFieldValues = FormFieldValues(
-            fieldValuePairs = mapOf(
-                IdentifierSpec.Generic("sepa_debit[iban]") to FormFieldEntry("DE89370400440532013000", true),
-            ),
-            userRequestedReuse = customerRequestedSave,
-        )
-
-        val metadataWithSepaDebit = metadata.copy(
-            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
-                paymentMethodTypes = listOf("sepa_debit")
-            )
-        )
-        val sepaDebitPaymentMethod = metadataWithSepaDebit.supportedPaymentMethodForCode("sepa_debit")!!
-        val sepaDebitPaymentSelection = formFieldValues.transformToPaymentSelection(
-            sepaDebitPaymentMethod,
-            metadataWithSepaDebit
-        ) as PaymentSelection.New.GenericPaymentMethod
-
-        val options = sepaDebitPaymentSelection.paymentMethodOptionsParams as? PaymentMethodOptionsParams.SepaDebit
-        assertThat(sepaDebitPaymentSelection.customerRequestedSave).isEqualTo(customerRequestedSave)
-        assertThat(options?.setupFutureUsage).isNull()
     }
 
     @Test


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add PMO SFU to `PaymentMethodOptionsParams`
Add top level SFU to `ConfirmPaymentIntentParams`
Update `DeferredIntentValidator` to allow top level/PMO SFU not being present on the intent if using PMO SFU

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
[Allow](https://docs.google.com/document/d/1AW8j-cJ9ZW5h-LapzXOYrrE2b1XtmVo_SnvbNf-asOU/edit?tab=t.0) 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [X] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
