### PR TITLE
Improve `request_surface` configurability

### DIFF
--- a/payment-method-messaging/src/main/java/com/stripe/android/paymentmethodmessaging/view/injection/PaymentMethodMessagingComponent.kt
+++ b/payment-method-messaging/src/main/java/com/stripe/android/paymentmethodmessaging/view/injection/PaymentMethodMessagingComponent.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentmethodmessaging.view.injection
 import android.app.Application
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
+import com.stripe.android.networking.PaymentElementRequestSurfaceModule
 import com.stripe.android.paymentmethodmessaging.view.PaymentMethodMessagingView
 import com.stripe.android.paymentmethodmessaging.view.PaymentMethodMessagingViewModel
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
@@ -16,6 +17,7 @@ import javax.inject.Singleton
         CoroutineContextModule::class,
         PaymentMethodMessagingModule::class,
         StripeRepositoryModule::class,
+        PaymentElementRequestSurfaceModule::class,
         CoreCommonModule::class
     ]
 )

--- a/payments-core/src/main/java/com/stripe/android/IssuingCardPinService.kt
+++ b/payments-core/src/main/java/com/stripe/android/IssuingCardPinService.kt
@@ -368,9 +368,10 @@ class IssuingCardPinService @VisibleForTesting internal constructor(
             return IssuingCardPinService(
                 keyProvider,
                 StripeApiRepository(
-                    context,
-                    { publishableKey },
-                    appInfo,
+                    context = context,
+                    publishableKeyProvider = { publishableKey },
+                    requestSurface = StripeRepository.DEFAULT_REQUEST_SURFACE,
+                    appInfo = appInfo,
                     paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
                         context,
                         { publishableKey },

--- a/payments-core/src/main/java/com/stripe/android/Stripe.kt
+++ b/payments-core/src/main/java/com/stripe/android/Stripe.kt
@@ -102,10 +102,11 @@ class Stripe internal constructor(
     ) : this(
         context.applicationContext,
         StripeApiRepository(
-            context.applicationContext,
-            { publishableKey },
-            appInfo,
-            Logger.getInstance(enableLogging),
+            context = context.applicationContext,
+            publishableKeyProvider = { publishableKey },
+            requestSurface = StripeRepository.DEFAULT_REQUEST_SURFACE,
+            appInfo = appInfo,
+            logger = Logger.getInstance(enableLogging),
             betas = betas
         ),
         ApiKeyValidator.get().requireValid(publishableKey),

--- a/payments-core/src/main/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryFactory.kt
@@ -9,6 +9,7 @@ import com.stripe.android.core.networking.DefaultAnalyticsRequestExecutor
 import com.stripe.android.model.AccountRange
 import com.stripe.android.networking.PaymentAnalyticsEvent
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
+import com.stripe.android.networking.RequestSurface
 import com.stripe.android.networking.StripeApiRepository
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
@@ -26,6 +27,7 @@ import javax.inject.Named
 class DefaultCardAccountRangeRepositoryFactory @Inject constructor(
     context: Context,
     @Named(PRODUCT_USAGE) private val productUsageTokens: Set<String>,
+    private val requestSurface: RequestSurface,
     private val analyticsRequestExecutor: AnalyticsRequestExecutor,
 ) : CardAccountRangeRepository.Factory {
     private val appContext = context.applicationContext
@@ -44,9 +46,10 @@ class DefaultCardAccountRangeRepositoryFactory @Inject constructor(
         context: Context,
         productUsageTokens: Set<String> = emptySet()
     ) : this(
-        context,
-        productUsageTokens,
-        DefaultAnalyticsRequestExecutor(),
+        context = context,
+        productUsageTokens = productUsageTokens,
+        requestSurface = StripeRepository.DEFAULT_REQUEST_SURFACE,
+        analyticsRequestExecutor = DefaultAnalyticsRequestExecutor(),
     )
 
     @Throws(IllegalStateException::class)
@@ -96,8 +99,9 @@ class DefaultCardAccountRangeRepositoryFactory @Inject constructor(
             onSuccess = { publishableKey ->
                 RemoteCardAccountRangeSource(
                     StripeApiRepository(
-                        appContext,
-                        { publishableKey }
+                        context = appContext,
+                        publishableKeyProvider = { publishableKey },
+                        requestSurface = requestSurface,
                     ),
                     ApiRequest.Options(
                         publishableKey

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModel.kt
@@ -268,7 +268,7 @@ internal class GooglePayLauncherViewModel(
         private val workContext: CoroutineContext = Dispatchers.IO,
     ) : ViewModelProvider.Factory {
 
-        @Suppress("UNCHECKED_CAST")
+        @Suppress("UNCHECKED_CAST", "LongMethod")
         override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
             val application = extras.requireApplication()
 
@@ -287,8 +287,9 @@ internal class GooglePayLauncherViewModel(
             )
 
             val stripeRepository = StripeApiRepository(
-                application,
-                { publishableKey },
+                context = application,
+                publishableKeyProvider = { publishableKey },
+                requestSurface = StripeRepository.DEFAULT_REQUEST_SURFACE,
                 logger = logger,
                 workContext = workContext,
                 productUsageTokens = productUsageTokens,

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherViewModelFactoryComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherViewModelFactoryComponent.kt
@@ -10,6 +10,7 @@ import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherViewModel
+import com.stripe.android.networking.PaymentElementRequestSurfaceModule
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import dagger.BindsInstance
@@ -27,6 +28,7 @@ import javax.inject.Singleton
     modules = [
         GooglePayPaymentMethodLauncherModule::class,
         StripeRepositoryModule::class,
+        PaymentElementRequestSurfaceModule::class,
         CoroutineContextModule::class,
         CoreCommonModule::class
     ]

--- a/payments-core/src/main/java/com/stripe/android/networking/PaymentElementRequestSurfaceModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/PaymentElementRequestSurfaceModule.kt
@@ -1,0 +1,12 @@
+package com.stripe.android.networking
+
+import androidx.annotation.RestrictTo
+import dagger.Module
+import dagger.Provides
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
+@Module
+class PaymentElementRequestSurfaceModule {
+    @Provides
+    fun providesRequestSurface(): RequestSurface = RequestSurface.PaymentElement
+}

--- a/payments-core/src/main/java/com/stripe/android/networking/RequestSurface.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/RequestSurface.kt
@@ -1,0 +1,12 @@
+package com.stripe.android.networking
+
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+enum class RequestSurface(val value: String) {
+    PaymentElement("android_payment_element"),
+    CryptoOnramp("android_crypto_onramp"),
+    ;
+
+    override fun toString(): String = value
+}

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -121,6 +121,7 @@ import kotlin.coroutines.CoroutineContext
 class StripeApiRepository @JvmOverloads internal constructor(
     private val context: Context,
     private val publishableKeyProvider: () -> String,
+    private val requestSurface: RequestSurface,
     private val appInfo: AppInfo? = Stripe.appInfo,
     private val logger: Logger = Logger.noop(),
     private val workContext: CoroutineContext = Dispatchers.IO,
@@ -134,7 +135,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
     private val fraudDetectionDataRepository: FraudDetectionDataRepository =
         DefaultFraudDetectionDataRepository(context, workContext),
     private val cardAccountRangeRepositoryFactory: CardAccountRangeRepository.Factory =
-        DefaultCardAccountRangeRepositoryFactory(context, productUsageTokens, analyticsRequestExecutor),
+        DefaultCardAccountRangeRepositoryFactory(context, productUsageTokens, requestSurface, analyticsRequestExecutor),
     private val paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory =
         PaymentAnalyticsRequestFactory(context, publishableKeyProvider, productUsageTokens),
     private val fraudDetectionDataParamsUtils: FraudDetectionDataParamsUtils = FraudDetectionDataParamsUtils(),
@@ -147,6 +148,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
     constructor(
         appContext: Context,
         @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
+        requestSurface: RequestSurface,
         @IOContext workContext: CoroutineContext,
         @Named(PRODUCT_USAGE) productUsageTokens: Set<String>,
         paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory,
@@ -155,6 +157,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
     ) : this(
         context = appContext,
         publishableKeyProvider = publishableKeyProvider,
+        requestSurface = requestSurface,
         logger = logger,
         workContext = workContext,
         productUsageTokens = productUsageTokens,
@@ -418,6 +421,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
             )
         }
     }
+
     private suspend fun confirmSetupIntentInternal(
         confirmSetupIntentParams: ConfirmSetupIntentParams,
         options: ApiRequest.Options,
@@ -1187,7 +1191,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
                 url = sharePaymentDetailsUrl,
                 options = requestOptions,
                 params = mapOf(
-                    "request_surface" to "android_payment_element",
+                    "request_surface" to requestSurface.value,
                     "credentials" to mapOf(
                         "consumer_session_client_secret" to consumerSessionClientSecret
                     ),
@@ -1209,7 +1213,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
                 url = logoutConsumerUrl,
                 options = requestOptions,
                 params = mapOf(
-                    "request_surface" to "android_payment_element",
+                    "request_surface" to requestSurface.value,
                     "credentials" to mapOf(
                         "consumer_session_client_secret" to consumerSessionClientSecret
                     ),
@@ -1564,7 +1568,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
                 listConsumerPaymentDetailsUrl,
                 requestOptions,
                 mapOf(
-                    "request_surface" to "android_payment_element",
+                    "request_surface" to requestSurface.value,
                     "credentials" to mapOf(
                         "consumer_session_client_secret" to clientSecret
                     ),
@@ -1584,7 +1588,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
                 listShippingAddresses,
                 requestOptions,
                 mapOf(
-                    "request_surface" to "android_payment_element",
+                    "request_surface" to requestSurface.value,
                     "credentials" to mapOf(
                         "consumer_session_client_secret" to clientSecret
                     ),
@@ -1605,7 +1609,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
                     getConsumerPaymentDetailsUrl(paymentDetailsId),
                     requestOptions,
                     mapOf(
-                        "request_surface" to "android_payment_element",
+                        "request_surface" to requestSurface.value,
                         "credentials" to mapOf(
                             "consumer_session_client_secret" to clientSecret
                         )
@@ -1626,7 +1630,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
                 getConsumerPaymentDetailsUrl(paymentDetailsUpdateParams.id),
                 requestOptions,
                 mapOf(
-                    "request_surface" to "android_payment_element",
+                    "request_surface" to requestSurface.value,
                     "credentials" to mapOf(
                         "consumer_session_client_secret" to clientSecret
                     )

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -440,4 +440,10 @@ interface StripeRepository {
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     fun buildPaymentUserAgent(attribution: Set<String> = emptySet()): String
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    companion object {
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        val DEFAULT_REQUEST_SURFACE = RequestSurface.PaymentElement
+    }
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/di/CollectBankAccountComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/di/CollectBankAccountComponent.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
+import com.stripe.android.networking.PaymentElementRequestSurfaceModule
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountContract
 import com.stripe.android.payments.bankaccount.ui.CollectBankAccountViewEffect
 import com.stripe.android.payments.bankaccount.ui.CollectBankAccountViewModel
@@ -19,6 +20,7 @@ import javax.inject.Singleton
         CoroutineContextModule::class,
         CollectBankAccountModule::class,
         StripeRepositoryModule::class,
+        PaymentElementRequestSurfaceModule::class,
         CoreCommonModule::class
     ]
 )

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherViewModelFactoryComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherViewModelFactoryComponent.kt
@@ -6,6 +6,7 @@ import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
+import com.stripe.android.networking.PaymentElementRequestSurfaceModule
 import dagger.BindsInstance
 import dagger.Component
 import javax.inject.Named
@@ -16,6 +17,7 @@ import javax.inject.Singleton
     modules = [
         PaymentLauncherModule::class,
         StripeRepositoryModule::class,
+        PaymentElementRequestSurfaceModule::class,
         CoroutineContextModule::class,
         CoreCommonModule::class
     ]

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/Stripe3ds2TransactionViewModelFactoryComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/Stripe3ds2TransactionViewModelFactoryComponent.kt
@@ -6,6 +6,7 @@ import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.injection.RetryDelayModule
+import com.stripe.android.networking.PaymentElementRequestSurfaceModule
 import dagger.BindsInstance
 import dagger.Component
 import javax.inject.Named
@@ -15,6 +16,7 @@ import javax.inject.Singleton
 @Component(
     modules = [
         StripeRepositoryModule::class,
+        PaymentElementRequestSurfaceModule::class,
         Stripe3ds2TransactionModule::class,
         CoroutineContextModule::class,
         CoreCommonModule::class,

--- a/payments-core/src/main/java/com/stripe/android/view/CardWidgetViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardWidgetViewModel.kt
@@ -77,6 +77,7 @@ internal class CardWidgetViewModel(
             val stripeRepository = StripeApiRepository(
                 context = context,
                 publishableKeyProvider = { PaymentConfiguration.getInstance(context).publishableKey },
+                requestSurface = StripeRepository.DEFAULT_REQUEST_SURFACE,
             )
 
             @Suppress("UNCHECKED_CAST")

--- a/payments-core/src/test/java/com/stripe/android/PaymentMethodEndToEndTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/PaymentMethodEndToEndTest.kt
@@ -8,6 +8,7 @@ import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
+import com.stripe.android.networking.RequestSurface
 import com.stripe.android.networking.StripeApiRepository
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -266,8 +267,9 @@ internal class PaymentMethodEndToEndTest {
     @Test
     fun createPaymentMethod_withGrabPay_shouldCreateObject() = runTest {
         val repository = StripeApiRepository(
-            context,
-            { ApiKeyFixtures.GRABPAY_PUBLISHABLE_KEY },
+            context = context,
+            publishableKeyProvider = { ApiKeyFixtures.GRABPAY_PUBLISHABLE_KEY },
+            requestSurface = RequestSurface.PaymentElement,
             workContext = testDispatcher
         )
 
@@ -283,8 +285,9 @@ internal class PaymentMethodEndToEndTest {
     @Test
     fun `createPaymentMethod() with PayPal PaymentMethod should create expected object`() = runTest {
         val paymentMethod = StripeApiRepository(
-            context,
-            { ApiKeyFixtures.PAYPAL_PUBLISHABLE_KEY },
+            context = context,
+            publishableKeyProvider = { ApiKeyFixtures.PAYPAL_PUBLISHABLE_KEY },
+            requestSurface = RequestSurface.PaymentElement,
             workContext = testDispatcher
         ).createPaymentMethod(
             PaymentMethodCreateParams.createPayPal(),

--- a/payments-core/src/test/java/com/stripe/android/StripeEndToEndTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/StripeEndToEndTest.kt
@@ -19,6 +19,7 @@ import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.SourceParams
 import com.stripe.android.model.SourceTypeModel
 import com.stripe.android.model.Token
+import com.stripe.android.networking.RequestSurface
 import com.stripe.android.networking.StripeApiRepository
 import com.stripe.android.utils.TestUtils.idleLooper
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -221,8 +222,9 @@ internal class StripeEndToEndTest {
         publishableKey: String = ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY
     ): Stripe {
         val stripeRepository = StripeApiRepository(
-            context,
-            { publishableKey },
+            context = context,
+            publishableKeyProvider = { publishableKey },
+            requestSurface = RequestSurface.PaymentElement,
             workContext = testDispatcher
         )
         return Stripe(

--- a/payments-core/src/test/java/com/stripe/android/StripePaymentAuthTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/StripePaymentAuthTest.kt
@@ -8,6 +8,7 @@ import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.model.Source
 import com.stripe.android.model.SourceFixtures
+import com.stripe.android.networking.RequestSurface
 import com.stripe.android.networking.StripeApiRepository
 import com.stripe.android.utils.TestUtils.idleLooper
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -196,8 +197,9 @@ internal class StripePaymentAuthTest {
     private fun createStripe(): Stripe {
         return Stripe(
             StripeApiRepository(
-                ApplicationProvider.getApplicationContext(),
-                { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY },
+                context = ApplicationProvider.getApplicationContext(),
+                publishableKeyProvider = { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY },
+                requestSurface = RequestSurface.PaymentElement,
                 stripeNetworkClient = DefaultStripeNetworkClient(
                     workContext = testDispatcher
                 ),

--- a/payments-core/src/test/java/com/stripe/android/StripeTest.java
+++ b/payments-core/src/test/java/com/stripe/android/StripeTest.java
@@ -38,6 +38,7 @@ import com.stripe.android.model.Source;
 import com.stripe.android.model.SourceParams;
 import com.stripe.android.model.Token;
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory;
+import com.stripe.android.networking.RequestSurface;
 import com.stripe.android.networking.StripeApiRepository;
 import com.stripe.android.networking.StripeRepository;
 import com.stripe.android.testing.FakeLogger;
@@ -954,6 +955,7 @@ public class StripeTest {
         return new StripeApiRepository(
                 context,
                 () -> publishableKey,
+                RequestSurface.PaymentElement,
                 null,
                 new FakeLogger(),
                 workDispatcher,

--- a/payments-core/src/test/java/com/stripe/android/cards/CardAccountRangeServiceTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/cards/CardAccountRangeServiceTest.kt
@@ -17,6 +17,7 @@ import com.stripe.android.model.AccountRange
 import com.stripe.android.model.BinRange
 import com.stripe.android.model.CardBrand
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
+import com.stripe.android.networking.RequestSurface
 import com.stripe.android.networking.StripeApiRepository
 import com.stripe.android.uicore.utils.stateFlowOf
 import com.stripe.android.utils.TestUtils
@@ -316,7 +317,7 @@ class CardAccountRangeServiceTest {
 
     private fun createRemoteCardAccountRangeSource(): CardAccountRangeSource {
         return RemoteCardAccountRangeSource(
-            StripeApiRepository(applicationContext, { publishableKey }),
+            StripeApiRepository(applicationContext, { publishableKey }, RequestSurface.PaymentElement),
             ApiRequest.Options(publishableKey),
             DefaultCardAccountRangeStore(applicationContext),
             DefaultAnalyticsRequestExecutor(),

--- a/payments-core/src/test/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryFactoryTest.kt
@@ -6,6 +6,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.networking.AnalyticsRequest
+import com.stripe.android.networking.StripeRepository
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.BeforeTest
@@ -18,9 +19,9 @@ class DefaultCardAccountRangeRepositoryFactoryTest {
     private val factory = DefaultCardAccountRangeRepositoryFactory(
         context = context,
         productUsageTokens = setOf("SomeProduct"),
-    ) {
-        analyticsRequests.add(it)
-    }
+        requestSurface = StripeRepository.DEFAULT_REQUEST_SURFACE,
+        analyticsRequestExecutor = { analyticsRequests.add(it) }
+    )
 
     @BeforeTest
     fun setup() {

--- a/payments-core/src/test/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryTest.kt
@@ -14,6 +14,7 @@ import com.stripe.android.model.BinRange
 import com.stripe.android.model.CardBrand
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.networking.StripeApiRepository
+import com.stripe.android.networking.StripeRepository
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatchers.header
 import com.stripe.android.networktesting.RequestMatchers.method
@@ -299,8 +300,9 @@ internal class DefaultCardAccountRangeRepositoryTest {
         publishableKey: String = ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY
     ): CardAccountRangeSource {
         val stripeRepository = StripeApiRepository(
-            application,
-            { publishableKey }
+            context = application,
+            publishableKeyProvider = { publishableKey },
+            requestSurface = StripeRepository.DEFAULT_REQUEST_SURFACE,
         )
         return RemoteCardAccountRangeSource(
             stripeRepository,

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -91,8 +91,9 @@ internal class StripeApiRepositoryTest {
 
     private val context: Context = ApplicationProvider.getApplicationContext()
     private val stripeApiRepository = StripeApiRepository(
-        context,
-        { DEFAULT_OPTIONS.apiKey },
+        context = context,
+        publishableKeyProvider = { DEFAULT_OPTIONS.apiKey },
+        requestSurface = StripeRepository.DEFAULT_REQUEST_SURFACE,
         workContext = testDispatcher
     )
     private val fileFactory = FileFactory(context)
@@ -1016,8 +1017,9 @@ internal class StripeApiRepositoryTest {
     @Test
     fun createSource_createsObjectAndLogs() = runTest {
         val stripeApiRepository = StripeApiRepository(
-            context,
-            { DEFAULT_OPTIONS.apiKey },
+            context = context,
+            publishableKeyProvider = { DEFAULT_OPTIONS.apiKey },
+            requestSurface = StripeRepository.DEFAULT_REQUEST_SURFACE,
             workContext = testDispatcher,
             stripeNetworkClient = DefaultStripeNetworkClient(
                 workContext = testDispatcher
@@ -1394,8 +1396,9 @@ internal class StripeApiRepositoryTest {
             Locale.setDefault(Locale.JAPAN)
 
             val stripeRepository = StripeApiRepository(
-                context,
-                { DEFAULT_OPTIONS.apiKey },
+                context = context,
+                publishableKeyProvider = { DEFAULT_OPTIONS.apiKey },
+                requestSurface = StripeRepository.DEFAULT_REQUEST_SURFACE,
                 workContext = testDispatcher,
                 sdkVersion = "AndroidBindings/13.0.0"
             )
@@ -1716,8 +1719,9 @@ internal class StripeApiRepositoryTest {
     fun `createRadarSession() with FraudDetectionData should return expected value`() =
         runTest {
             val stripeRepository = StripeApiRepository(
-                context,
-                { DEFAULT_OPTIONS.apiKey },
+                context = context,
+                publishableKeyProvider = { DEFAULT_OPTIONS.apiKey },
+                requestSurface = StripeRepository.DEFAULT_REQUEST_SURFACE,
                 analyticsRequestExecutor = analyticsRequestExecutor,
                 fraudDetectionDataRepository = FakeFraudDetectionDataRepository(
                     FraudDetectionData(
@@ -1740,8 +1744,9 @@ internal class StripeApiRepositoryTest {
     fun `createRadarSession() with null FraudDetectionData should throw an exception`() =
         runTest {
             val stripeRepository = StripeApiRepository(
-                context,
-                { DEFAULT_OPTIONS.apiKey },
+                context = context,
+                publishableKeyProvider = { DEFAULT_OPTIONS.apiKey },
+                requestSurface = StripeRepository.DEFAULT_REQUEST_SURFACE,
                 fraudDetectionDataRepository = FakeFraudDetectionDataRepository(
                     null
                 ),
@@ -1789,8 +1794,9 @@ internal class StripeApiRepositoryTest {
             )
 
             val stripeRepository = StripeApiRepository(
-                context,
-                { DEFAULT_OPTIONS.apiKey },
+                context = context,
+                publishableKeyProvider = { DEFAULT_OPTIONS.apiKey },
+                requestSurface = StripeRepository.DEFAULT_REQUEST_SURFACE,
                 stripeNetworkClient = stripeNetworkClient,
                 analyticsRequestExecutor = analyticsRequestExecutor,
                 fraudDetectionDataRepository = FakeFraudDetectionDataRepository(
@@ -1833,8 +1839,9 @@ internal class StripeApiRepositoryTest {
     fun `createSavedPaymentMethodRadarSession() with null FraudDetectionData should throw an exception`() =
         runTest {
             val stripeRepository = StripeApiRepository(
-                context,
-                { DEFAULT_OPTIONS.apiKey },
+                context = context,
+                publishableKeyProvider = { DEFAULT_OPTIONS.apiKey },
+                requestSurface = StripeRepository.DEFAULT_REQUEST_SURFACE,
                 fraudDetectionDataRepository = FakeFraudDetectionDataRepository(
                     null
                 ),
@@ -3308,8 +3315,9 @@ internal class StripeApiRepositoryTest {
 
     private fun create(productUsage: Set<String> = emptySet()): StripeApiRepository {
         return StripeApiRepository(
-            context,
-            { DEFAULT_OPTIONS.apiKey },
+            context = context,
+            publishableKeyProvider = { DEFAULT_OPTIONS.apiKey },
+            requestSurface = StripeRepository.DEFAULT_REQUEST_SURFACE,
             workContext = testDispatcher,
             productUsageTokens = productUsage,
             stripeNetworkClient = stripeNetworkClient,

--- a/payments-model/src/main/java/com/stripe/android/repository/ConsumersApiService.kt
+++ b/payments-model/src/main/java/com/stripe/android/repository/ConsumersApiService.kt
@@ -48,6 +48,7 @@ interface ConsumersApiService {
     suspend fun lookupConsumerSession(
         email: String,
         requestSurface: String,
+        sessionId: String,
         doNotLogConsumerFunnelEvent: Boolean,
         requestOptions: ApiRequest.Options,
         customerId: String?
@@ -180,6 +181,7 @@ class ConsumersApiServiceImpl(
     override suspend fun lookupConsumerSession(
         email: String,
         requestSurface: String,
+        sessionId: String,
         doNotLogConsumerFunnelEvent: Boolean,
         requestOptions: ApiRequest.Options,
         customerId: String?
@@ -197,6 +199,7 @@ class ConsumersApiServiceImpl(
                 requestOptions,
                 mapOf(
                     "request_surface" to requestSurface,
+                    "session_id" to sessionId,
                     "email_address" to email.lowercase(),
                     "customer_id" to customerId
                 ).filterValues { it != null } + avoidConsumerLoggingParams

--- a/payments-model/src/test/java/com/stripe/android/repository/ConsumersApiServiceImplTest.kt
+++ b/payments-model/src/test/java/com/stripe/android/repository/ConsumersApiServiceImplTest.kt
@@ -96,6 +96,7 @@ class ConsumersApiServiceImplTest {
             header("User-Agent", "Stripe/v1 ${StripeSdkVersion.VERSION}"),
             bodyPart("email_address", "email%40example.com"),
             bodyPart("request_surface", requestSurface),
+            bodyPart("session_id", DEFAULT_SESSION_ID),
         ) { response ->
             response.setBody(ConsumerFixtures.EXISTING_CONSUMER_JSON.toString())
         }
@@ -103,6 +104,7 @@ class ConsumersApiServiceImplTest {
         val lookup = consumersApiService.lookupConsumerSession(
             email = email,
             requestSurface = requestSurface,
+            sessionId = DEFAULT_SESSION_ID,
             requestOptions = DEFAULT_OPTIONS,
             doNotLogConsumerFunnelEvent = false,
             customerId = null
@@ -134,6 +136,7 @@ class ConsumersApiServiceImplTest {
             consumersApiService.lookupConsumerSession(
                 email = email,
                 requestSurface = requestSurface,
+                sessionId = DEFAULT_SESSION_ID,
                 doNotLogConsumerFunnelEvent = false,
                 requestOptions = DEFAULT_OPTIONS,
                 customerId = null
@@ -343,5 +346,6 @@ class ConsumersApiServiceImplTest {
 
     private companion object {
         private val DEFAULT_OPTIONS = ApiRequest.Options("pk_test_vOo1umqsYxSrP5UXfOeL3ecm")
+        private const val DEFAULT_SESSION_ID = "sess_123"
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerAdapterDataSourceComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerAdapterDataSourceComponent.kt
@@ -11,6 +11,7 @@ import com.stripe.android.customersheet.data.CustomerSheetIntentDataSource
 import com.stripe.android.customersheet.data.CustomerSheetPaymentMethodDataSource
 import com.stripe.android.customersheet.data.CustomerSheetSavedSelectionDataSource
 import com.stripe.android.customersheet.injection.CustomerSheetDataCommonModule
+import com.stripe.android.networking.PaymentElementRequestSurfaceModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import dagger.BindsInstance
 import dagger.Component
@@ -23,6 +24,7 @@ import javax.inject.Singleton
         CustomerSheetDataSourceCommonModule::class,
         CustomerSheetDataCommonModule::class,
         StripeRepositoryModule::class,
+        PaymentElementRequestSurfaceModule::class,
         CoroutineContextModule::class,
         CoreCommonModule::class,
         ApplicationIdModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerSessionDataSourceComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerSessionDataSourceComponent.kt
@@ -11,6 +11,7 @@ import com.stripe.android.customersheet.data.CustomerSheetIntentDataSource
 import com.stripe.android.customersheet.data.CustomerSheetPaymentMethodDataSource
 import com.stripe.android.customersheet.data.CustomerSheetSavedSelectionDataSource
 import com.stripe.android.customersheet.injection.CustomerSheetDataCommonModule
+import com.stripe.android.networking.PaymentElementRequestSurfaceModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.ExperimentalCustomerSessionApi
 import dagger.BindsInstance
@@ -25,6 +26,7 @@ import javax.inject.Singleton
         CustomerSheetDataSourceCommonModule::class,
         CustomerSheetDataCommonModule::class,
         StripeRepositoryModule::class,
+        PaymentElementRequestSurfaceModule::class,
         CoroutineContextModule::class,
         CoreCommonModule::class,
         ApplicationIdModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelComponent.kt
@@ -6,6 +6,7 @@ import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.customersheet.CustomerSheetIntegration
 import com.stripe.android.customersheet.CustomerSheetViewModel
 import com.stripe.android.googlepaylauncher.injection.GooglePayLauncherModule
+import com.stripe.android.networking.PaymentElementRequestSurfaceModule
 import com.stripe.android.paymentelement.confirmation.injection.DefaultConfirmationModule
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
@@ -19,6 +20,7 @@ import javax.inject.Named
         DefaultConfirmationModule::class,
         CustomerSheetViewModelModule::class,
         StripeRepositoryModule::class,
+        PaymentElementRequestSurfaceModule::class,
         GooglePayLauncherModule::class,
     ],
 )

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/StripeCustomerAdapterComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/StripeCustomerAdapterComponent.kt
@@ -8,6 +8,7 @@ import com.stripe.android.customersheet.CustomerEphemeralKey
 import com.stripe.android.customersheet.CustomerEphemeralKeyProvider
 import com.stripe.android.customersheet.SetupIntentClientSecretProvider
 import com.stripe.android.customersheet.StripeCustomerAdapter
+import com.stripe.android.networking.PaymentElementRequestSurfaceModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.PrefsRepository
@@ -24,6 +25,7 @@ import kotlin.coroutines.CoroutineContext
         StripeCustomerAdapterModule::class,
         CustomerSheetDataCommonModule::class,
         StripeRepositoryModule::class,
+        PaymentElementRequestSurfaceModule::class,
         CoroutineContextModule::class,
         CoreCommonModule::class,
     ]

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
@@ -393,6 +393,7 @@ internal class LinkActivityViewModel @Inject constructor(
                 DaggerNativeLinkComponent
                     .builder()
                     .configuration(args.configuration)
+                    .requestSurface(args.requestSurface)
                     .publishableKeyProvider { args.publishableKey }
                     .stripeAccountIdProvider { args.stripeAccountId }
                     .paymentElementCallbackIdentifier(args.paymentElementCallbackIdentifier)

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkController.kt
@@ -12,6 +12,7 @@ import com.stripe.android.link.injection.DaggerLinkControllerComponent
 import com.stripe.android.link.injection.LinkControllerPresenterComponent
 import com.stripe.android.link.model.LinkAppearance
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.networking.RequestSurface
 import com.stripe.android.paymentsheet.PaymentSheet
 import dev.drewhamilton.poko.Poko
 import kotlinx.coroutines.flow.StateFlow
@@ -558,11 +559,29 @@ class LinkController @Inject internal constructor(
             application: Application,
             savedStateHandle: SavedStateHandle
         ): LinkController {
+            return create(
+                application = application,
+                savedStateHandle = savedStateHandle,
+                // Temporarily "android_crypto_onramp" until backend is ready.
+                // Should be "android_link_controller" instead.
+                requestSurface = RequestSurface.CryptoOnramp,
+            )
+        }
+
+        // Internal use only.
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        @JvmStatic
+        fun create(
+            application: Application,
+            savedStateHandle: SavedStateHandle,
+            requestSurface: RequestSurface,
+        ): LinkController {
             return DaggerLinkControllerComponent.factory()
                 .build(
                     application = application,
                     savedStateHandle = savedStateHandle,
                     paymentElementCallbackIdentifier = "LinkController",
+                    requestSurface = requestSurface,
                 )
                 .linkController
         }

--- a/paymentsheet/src/main/java/com/stripe/android/link/NativeLinkActivityContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/NativeLinkActivityContract.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.core.os.BundleCompat
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.networking.RequestSurface
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import javax.inject.Inject
 
@@ -13,7 +14,8 @@ import javax.inject.Inject
  * Contract used to explicitly launch Link natively.
  */
 internal class NativeLinkActivityContract @Inject constructor(
-    @PaymentElementCallbackIdentifier private val paymentElementCallbackIdentifier: String
+    @PaymentElementCallbackIdentifier private val paymentElementCallbackIdentifier: String,
+    private val requestSurface: RequestSurface,
 ) :
     ActivityResultContract<LinkActivityContract.Args, LinkActivityResult>() {
     override fun createIntent(context: Context, input: LinkActivityContract.Args): Intent {
@@ -22,12 +24,13 @@ internal class NativeLinkActivityContract @Inject constructor(
             context = context,
             args = NativeLinkArgs(
                 configuration = input.configuration,
+                requestSurface = requestSurface,
                 stripeAccountId = paymentConfiguration.stripeAccountId,
                 publishableKey = paymentConfiguration.publishableKey,
                 linkExpressMode = input.linkExpressMode,
                 launchMode = input.launchMode,
                 paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
-                linkAccountInfo = input.linkAccountInfo,
+                linkAccountInfo = input.linkAccountInfo
             )
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/link/NativeLinkArgs.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/NativeLinkArgs.kt
@@ -1,11 +1,13 @@
 package com.stripe.android.link
 
 import android.os.Parcelable
+import com.stripe.android.networking.RequestSurface
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
 internal data class NativeLinkArgs(
     val configuration: LinkConfiguration,
+    val requestSurface: RequestSurface,
     val publishableKey: String,
     val stripeAccountId: String?,
     val linkExpressMode: LinkExpressMode,

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
@@ -79,7 +79,11 @@ internal class DefaultLinkAccountManager @Inject constructor(
         startSession: Boolean,
         customerId: String?
     ): Result<LinkAccount?> =
-        linkRepository.lookupConsumer(email, customerId)
+        linkRepository.lookupConsumer(
+            email = email,
+            sessionId = config.elementsSessionId,
+            customerId = customerId
+        )
             .onFailure { error ->
                 linkEventsReporter.onAccountLookupFailure(error)
             }.map { consumerSessionLookup ->

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerComponent.kt
@@ -3,6 +3,7 @@ package com.stripe.android.link.injection
 import android.app.Application
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.link.LinkController
+import com.stripe.android.networking.RequestSurface
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import dagger.BindsInstance
 import dagger.Component
@@ -24,6 +25,7 @@ internal interface LinkControllerComponent {
             @BindsInstance savedStateHandle: SavedStateHandle,
             @BindsInstance @PaymentElementCallbackIdentifier
             paymentElementCallbackIdentifier: String,
+            @BindsInstance requestSurface: RequestSurface,
         ): LinkControllerComponent
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkComponent.kt
@@ -19,6 +19,7 @@ import com.stripe.android.link.account.LinkAccountManager
 import com.stripe.android.link.account.LinkAuth
 import com.stripe.android.link.analytics.LinkEventsReporter
 import com.stripe.android.link.confirmation.LinkConfirmationHandler
+import com.stripe.android.networking.RequestSurface
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.paymentelement.confirmation.injection.DefaultConfirmationModule
 import com.stripe.android.paymentelement.confirmation.link.LinkPassthroughConfirmationModule
@@ -104,6 +105,11 @@ internal interface NativeLinkComponent {
 
         @BindsInstance
         fun linkAccountUpdate(linkAccountUpdate: LinkAccountUpdate.Value): Builder
+
+        @BindsInstance
+        fun requestSurface(
+            requestSurface: RequestSurface
+        ): Builder
 
         fun build(): NativeLinkComponent
     }

--- a/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
@@ -31,6 +31,7 @@ import com.stripe.android.model.SharePaymentDetails
 import com.stripe.android.model.SignUpParams
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.VerificationType
+import com.stripe.android.networking.RequestSurface
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.repository.ConsumersApiService
@@ -46,6 +47,7 @@ import kotlin.coroutines.CoroutineContext
 @SuppressWarnings("TooManyFunctions")
 internal class LinkApiRepository @Inject constructor(
     application: Application,
+    private val requestSurface: RequestSurface,
     @Named(PUBLISHABLE_KEY) private val publishableKeyProvider: () -> String,
     @Named(STRIPE_ACCOUNT_ID) private val stripeAccountIdProvider: () -> String?,
     private val stripeRepository: StripeRepository,
@@ -70,7 +72,7 @@ internal class LinkApiRepository @Inject constructor(
             requireNotNull(
                 consumersApiService.lookupConsumerSession(
                     email = email,
-                    requestSurface = REQUEST_SURFACE,
+                    requestSurface = requestSurface.value,
                     doNotLogConsumerFunnelEvent = false,
                     requestOptions = buildRequestOptions(),
                     customerId = customerId
@@ -86,7 +88,7 @@ internal class LinkApiRepository @Inject constructor(
             requireNotNull(
                 consumersApiService.lookupConsumerSession(
                     email = email,
-                    requestSurface = REQUEST_SURFACE,
+                    requestSurface = requestSurface.value,
                     doNotLogConsumerFunnelEvent = true,
                     requestOptions = buildRequestOptions(),
                     customerId = null
@@ -107,7 +109,7 @@ internal class LinkApiRepository @Inject constructor(
             consumersApiService.mobileLookupConsumerSession(
                 email = email,
                 emailSource = emailSource,
-                requestSurface = REQUEST_SURFACE,
+                requestSurface = requestSurface.value,
                 verificationToken = verificationToken,
                 appId = appId,
                 requestOptions = buildRequestOptions(),
@@ -135,7 +137,7 @@ internal class LinkApiRepository @Inject constructor(
                 currency = null,
                 incentiveEligibilitySession = null,
                 consentAction = consentAction,
-                requestSurface = REQUEST_SURFACE
+                requestSurface = requestSurface.value
             ),
             requestOptions = buildRequestOptions(),
         )
@@ -164,7 +166,7 @@ internal class LinkApiRepository @Inject constructor(
                 currency = currency,
                 incentiveEligibilitySession = incentiveEligibilitySession,
                 consentAction = consentAction,
-                requestSurface = REQUEST_SURFACE,
+                requestSurface = requestSurface.value,
                 verificationToken = verificationToken,
                 appId = appId
             ),
@@ -185,7 +187,7 @@ internal class LinkApiRepository @Inject constructor(
                 cardPaymentMethodCreateParamsMap = paymentMethodCreateParams.toParamMap(),
                 email = userEmail,
             ),
-            requestSurface = REQUEST_SURFACE,
+            requestSurface = requestSurface.value,
             requestOptions = buildRequestOptions(consumerPublishableKey),
         ).mapCatching {
             val paymentDetails = it.paymentDetails.first()
@@ -223,7 +225,7 @@ internal class LinkApiRepository @Inject constructor(
                 billingEmailAddress = userEmail,
                 billingAddress = null
             ),
-            requestSurface = REQUEST_SURFACE,
+            requestSurface = requestSurface.value,
             requestOptions = buildRequestOptions(),
         ).mapCatching {
             it.paymentDetails.first()
@@ -296,7 +298,7 @@ internal class LinkApiRepository @Inject constructor(
             paymentDetailsId = paymentDetailsId,
             expectedPaymentMethodType = expectedPaymentMethodType,
             requestOptions = buildRequestOptions(),
-            requestSurface = REQUEST_SURFACE,
+            requestSurface = requestSurface.value,
             extraParams = paymentMethodParams + fraudParams + optionsParams,
             billingPhone = billingPhone,
         )
@@ -341,7 +343,7 @@ internal class LinkApiRepository @Inject constructor(
                 consumersApiService.startConsumerVerification(
                     consumerSessionClientSecret = consumerSessionClientSecret,
                     locale = locale ?: Locale.US,
-                    requestSurface = REQUEST_SURFACE,
+                    requestSurface = requestSurface.value,
                     type = VerificationType.SMS,
                     customEmailType = null,
                     connectionsMerchantName = null,
@@ -366,7 +368,7 @@ internal class LinkApiRepository @Inject constructor(
                 consumersApiService.confirmConsumerVerification(
                     consumerSessionClientSecret = consumerSessionClientSecret,
                     verificationCode = verificationCode,
-                    requestSurface = REQUEST_SURFACE,
+                    requestSurface = requestSurface.value,
                     type = VerificationType.SMS,
                     requestOptions = consumerPublishableKey?.let {
                         ApiRequest.Options(it)
@@ -455,7 +457,7 @@ internal class LinkApiRepository @Inject constructor(
             consumerSessionClientSecret = consumerSessionClientSecret,
             intentToken = stripeIntent.clientSecret,
             linkMode = linkMode,
-            requestSurface = REQUEST_SURFACE,
+            requestSurface = requestSurface.value,
             requestOptions = consumerPublishableKey?.let {
                 ApiRequest.Options(it)
             } ?: ApiRequest.Options(
@@ -475,7 +477,6 @@ internal class LinkApiRepository @Inject constructor(
     }
 
     private companion object {
-        const val REQUEST_SURFACE = "android_payment_element"
         const val ALLOW_REDISPLAY_PARAM = "allow_redisplay"
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
@@ -66,6 +66,7 @@ internal class LinkApiRepository @Inject constructor(
 
     override suspend fun lookupConsumer(
         email: String,
+        sessionId: String,
         customerId: String?
     ): Result<ConsumerSessionLookup> = withContext(workContext) {
         runCatching {
@@ -73,6 +74,7 @@ internal class LinkApiRepository @Inject constructor(
                 consumersApiService.lookupConsumerSession(
                     email = email,
                     requestSurface = requestSurface.value,
+                    sessionId = sessionId,
                     doNotLogConsumerFunnelEvent = false,
                     requestOptions = buildRequestOptions(),
                     customerId = customerId
@@ -82,13 +84,15 @@ internal class LinkApiRepository @Inject constructor(
     }
 
     override suspend fun lookupConsumerWithoutBackendLoggingForExposure(
-        email: String
+        email: String,
+        sessionId: String,
     ): Result<ConsumerSessionLookup> = withContext(workContext) {
         runCatching {
             requireNotNull(
                 consumersApiService.lookupConsumerSession(
                     email = email,
                     requestSurface = requestSurface.value,
+                    sessionId = sessionId,
                     doNotLogConsumerFunnelEvent = true,
                     requestOptions = buildRequestOptions(),
                     customerId = null

--- a/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
@@ -32,6 +32,7 @@ internal interface LinkRepository {
      */
     suspend fun lookupConsumer(
         email: String,
+        sessionId: String,
         customerId: String?
     ): Result<ConsumerSessionLookup>
 
@@ -41,7 +42,8 @@ internal interface LinkRepository {
      * Link global holdback to look up consumers in the event Link is disabled.
      */
     suspend fun lookupConsumerWithoutBackendLoggingForExposure(
-        email: String
+        email: String,
+        sessionId: String,
     ): Result<ConsumerSessionLookup>
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedCommonModule.kt
@@ -15,6 +15,7 @@ import com.stripe.android.core.utils.DurationProvider
 import com.stripe.android.link.injection.PaymentsIntegrityModule
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
+import com.stripe.android.networking.PaymentElementRequestSurfaceModule
 import com.stripe.android.paymentelement.AnalyticEventCallback
 import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
@@ -46,6 +47,7 @@ import kotlin.coroutines.CoroutineContext
         StripeRepositoryModule::class,
         CoreCommonModule::class,
         PaymentsIntegrityModule::class,
+        PaymentElementRequestSurfaceModule::class,
     ],
 )
 internal interface EmbeddedCommonModule {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerStateComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerStateComponent.kt
@@ -8,6 +8,7 @@ import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.googlepaylauncher.injection.GooglePayLauncherModule
 import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.link.verification.DefaultLinkInlineInteractor
+import com.stripe.android.networking.PaymentElementRequestSurfaceModule
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.injection.ExtendedPaymentElementConfirmationModule
@@ -32,6 +33,7 @@ import javax.inject.Singleton
         StripeRepositoryModule::class,
         ExtendedPaymentElementConfirmationModule::class,
         PaymentSheetCommonModule::class,
+        PaymentElementRequestSurfaceModule::class,
         FlowControllerModule::class,
         GooglePayLauncherModule::class,
         CoroutineContextModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelFactoryComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelFactoryComponent.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.injection
 import android.content.Context
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
+import com.stripe.android.networking.PaymentElementRequestSurfaceModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.addresselement.AddressElementActivityContract
 import com.stripe.android.paymentsheet.addresselement.AddressElementViewModel
@@ -15,6 +16,7 @@ import javax.inject.Singleton
 @Component(
     modules = [
         PaymentSheetCommonModule::class,
+        PaymentElementRequestSurfaceModule::class,
         CoroutineContextModule::class,
         StripeRepositoryModule::class,
         CoreCommonModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/LinkHoldbackExposureModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/LinkHoldbackExposureModule.kt
@@ -12,6 +12,7 @@ import com.stripe.android.core.networking.DefaultStripeNetworkClient
 import com.stripe.android.core.version.StripeSdkVersion
 import com.stripe.android.link.repositories.LinkApiRepository
 import com.stripe.android.link.repositories.LinkRepository
+import com.stripe.android.networking.RequestSurface
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.repository.ConsumersApiServiceImpl
@@ -53,6 +54,7 @@ internal class LinkHoldbackExposureModule {
         application: Application,
         @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
         @Named(STRIPE_ACCOUNT_ID) stripeAccountIdProvider: () -> String?,
+        requestSurface: RequestSurface,
         stripeRepository: StripeRepository,
         @IOContext workContext: CoroutineContext,
         logger: Logger,
@@ -69,14 +71,15 @@ internal class LinkHoldbackExposureModule {
             )
         )
         return LinkApiRepository(
-            application,
-            publishableKeyProvider,
-            stripeAccountIdProvider,
-            stripeRepository,
-            consumersApiService,
-            workContext,
-            locale,
-            errorReporter,
+            application = application,
+            requestSurface = requestSurface,
+            publishableKeyProvider = publishableKeyProvider,
+            stripeAccountIdProvider = stripeAccountIdProvider,
+            stripeRepository = stripeRepository,
+            consumersApiService = consumersApiService,
+            workContext = workContext,
+            locale = locale,
+            errorReporter = errorReporter,
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelFactoryComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelFactoryComponent.kt
@@ -5,10 +5,10 @@ import android.content.Context
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
+import com.stripe.android.networking.PaymentElementRequestSurfaceModule
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
-import com.stripe.android.paymentsheet.injection.PaymentSheetLauncherComponent.Builder
 import com.stripe.android.ui.core.di.CardScanModule
 import com.stripe.android.ui.core.forms.resources.injection.ResourceRepositoryModule
 import dagger.BindsInstance
@@ -21,6 +21,7 @@ import javax.inject.Singleton
     modules = [
         StripeRepositoryModule::class,
         PaymentSheetCommonModule::class,
+        PaymentElementRequestSurfaceModule::class,
         PaymentOptionsViewModelModule::class,
         CoroutineContextModule::class,
         CoreCommonModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherComponent.kt
@@ -7,6 +7,7 @@ import com.stripe.android.common.di.MobileSessionIdModule
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.googlepaylauncher.injection.GooglePayLauncherModule
+import com.stripe.android.networking.PaymentElementRequestSurfaceModule
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.ui.core.di.CardScanModule
@@ -20,6 +21,7 @@ import javax.inject.Singleton
     modules = [
         StripeRepositoryModule::class,
         PaymentSheetCommonModule::class,
+        PaymentElementRequestSurfaceModule::class,
         PaymentSheetLauncherModule::class,
         GooglePayLauncherModule::class,
         CoroutineContextModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/di/PollingComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/di/PollingComponent.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.paymentdatacollection.polling.di
 import android.app.Application
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
+import com.stripe.android.networking.PaymentElementRequestSurfaceModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.polling.IntentStatusPoller
 import dagger.BindsInstance
@@ -16,6 +17,7 @@ import javax.inject.Singleton
         CoroutineContextModule::class,
         PollingViewModelModule::class,
         StripeRepositoryModule::class,
+        PaymentElementRequestSurfaceModule::class,
         CoreCommonModule::class
     ]
 )

--- a/paymentsheet/src/main/java/com/stripe/android/shoppay/di/ShopPayModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/shoppay/di/ShopPayModule.kt
@@ -11,6 +11,7 @@ import com.stripe.android.core.utils.DurationProvider
 import com.stripe.android.core.utils.RealUserFacingLogger
 import com.stripe.android.core.utils.UserFacingLogger
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
+import com.stripe.android.networking.PaymentElementRequestSurfaceModule
 import com.stripe.android.paymentelement.AnalyticEventCallback
 import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
 import com.stripe.android.paymentelement.PreparePaymentMethodHandler
@@ -45,6 +46,7 @@ import javax.inject.Named
 @Module(
     includes = [
         StripeRepositoryModule::class,
+        PaymentElementRequestSurfaceModule::class,
     ]
 )
 internal interface ShopPayModule {

--- a/paymentsheet/src/test/java/com/stripe/android/link/FakeConsumersApiService.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/FakeConsumersApiService.kt
@@ -58,6 +58,7 @@ internal open class FakeConsumersApiService : ConsumersApiService {
     override suspend fun lookupConsumerSession(
         email: String,
         requestSurface: String,
+        sessionId: String,
         doNotLogConsumerFunnelEvent: Boolean,
         requestOptions: ApiRequest.Options,
         customerId: String?
@@ -66,7 +67,8 @@ internal open class FakeConsumersApiService : ConsumersApiService {
             LookupCall(
                 email = email,
                 requestOptions = requestOptions,
-                requestSurface = requestSurface
+                requestSurface = requestSurface,
+                sessionId = sessionId,
             )
         )
         return lookupConsumerSessionResult
@@ -171,6 +173,7 @@ internal open class FakeConsumersApiService : ConsumersApiService {
     data class LookupCall(
         val email: String,
         val requestSurface: String,
+        val sessionId: String,
         val requestOptions: ApiRequest.Options
     )
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
@@ -31,6 +31,7 @@ import com.stripe.android.link.injection.NativeLinkComponent
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.ui.signup.SignUpViewModel
 import com.stripe.android.link.utils.TestNavigationManager
+import com.stripe.android.networking.RequestSurface
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentsheet.addresselement.AutocompleteActivityLauncher
@@ -136,6 +137,7 @@ internal class LinkActivityViewModelTest {
     fun `initializer creates ViewModel when args are valid`() {
         val mockArgs = NativeLinkArgs(
             configuration = mock(),
+            requestSurface = RequestSurface.PaymentElement,
             publishableKey = "",
             stripeAccountId = null,
             linkExpressMode = LinkExpressMode.DISABLED,

--- a/paymentsheet/src/test/java/com/stripe/android/link/NativeLinkActivityContractTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/NativeLinkActivityContractTest.kt
@@ -8,6 +8,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.networking.RequestSurface
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -32,7 +33,10 @@ class NativeLinkActivityContractTest {
 
     @Test
     fun `intent is created correctly`() {
-        val contract = NativeLinkActivityContract(paymentElementCallbackIdentifier = LINK_CALLBACK_TEST_IDENTIFIER)
+        val contract = NativeLinkActivityContract(
+            paymentElementCallbackIdentifier = LINK_CALLBACK_TEST_IDENTIFIER,
+            requestSurface = REQUEST_SURFACE
+        )
         val args = LinkActivityContract.Args(
             configuration = TestFactory.LINK_CONFIGURATION,
             linkExpressMode = LinkExpressMode.DISABLED,
@@ -50,6 +54,7 @@ class NativeLinkActivityContractTest {
         assertThat(actualArg).isEqualTo(
             NativeLinkArgs(
                 configuration = TestFactory.LINK_CONFIGURATION,
+                requestSurface = REQUEST_SURFACE,
                 publishableKey = "pk_test_abcdefg",
                 stripeAccountId = null,
                 linkExpressMode = LinkExpressMode.DISABLED,
@@ -66,7 +71,10 @@ class NativeLinkActivityContractTest {
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
         )
 
-        val contract = NativeLinkActivityContract(paymentElementCallbackIdentifier = LINK_CALLBACK_TEST_IDENTIFIER)
+        val contract = NativeLinkActivityContract(
+            paymentElementCallbackIdentifier = LINK_CALLBACK_TEST_IDENTIFIER,
+            requestSurface = REQUEST_SURFACE
+        )
 
         val result = contract.parseResult(
             resultCode = LinkActivity.RESULT_COMPLETE,
@@ -78,7 +86,10 @@ class NativeLinkActivityContractTest {
 
     @Test
     fun `complete with canceled result when result not found`() {
-        val contract = NativeLinkActivityContract(paymentElementCallbackIdentifier = LINK_CALLBACK_TEST_IDENTIFIER)
+        val contract = NativeLinkActivityContract(
+            paymentElementCallbackIdentifier = LINK_CALLBACK_TEST_IDENTIFIER,
+            requestSurface = REQUEST_SURFACE
+        )
 
         val result = contract.parseResult(
             resultCode = LinkActivity.RESULT_COMPLETE,
@@ -95,7 +106,10 @@ class NativeLinkActivityContractTest {
 
     @Test
     fun `unknown result code results in canceled`() {
-        val contract = NativeLinkActivityContract(paymentElementCallbackIdentifier = LINK_CALLBACK_TEST_IDENTIFIER)
+        val contract = NativeLinkActivityContract(
+            paymentElementCallbackIdentifier = LINK_CALLBACK_TEST_IDENTIFIER,
+            requestSurface = REQUEST_SURFACE
+        )
 
         val result = contract.parseResult(42, Intent())
 
@@ -109,7 +123,10 @@ class NativeLinkActivityContractTest {
 
     @Test
     fun `canceled result code is handled correctly`() {
-        val contract = NativeLinkActivityContract(paymentElementCallbackIdentifier = LINK_CALLBACK_TEST_IDENTIFIER)
+        val contract = NativeLinkActivityContract(
+            paymentElementCallbackIdentifier = LINK_CALLBACK_TEST_IDENTIFIER,
+            requestSurface = REQUEST_SURFACE
+        )
 
         val result = contract.parseResult(Activity.RESULT_CANCELED, Intent())
 
@@ -132,5 +149,6 @@ class NativeLinkActivityContractTest {
 
     private companion object {
         const val LINK_CALLBACK_TEST_IDENTIFIER = "LinkTestIdentifier"
+        val REQUEST_SURFACE = RequestSurface.PaymentElement
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
@@ -26,6 +26,7 @@ import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.SharePaymentDetails
+import com.stripe.android.networking.RequestSurface
 import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
@@ -262,6 +263,7 @@ internal object TestFactory {
 
     val NATIVE_LINK_ARGS = NativeLinkArgs(
         configuration = LINK_CONFIGURATION,
+        requestSurface = RequestSurface.PaymentElement,
         publishableKey = "",
         stripeAccountId = "",
         linkExpressMode = LinkExpressMode.DISABLED,

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAccountManagerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAccountManagerTest.kt
@@ -58,9 +58,13 @@ class DefaultLinkAccountManagerTest {
     fun `When customerEmail is set in arguments then it is looked up`() = runSuspendTest {
         val linkRepository = object : FakeLinkRepository() {
             var callCount = 0
-            override suspend fun lookupConsumer(email: String, customerId: String?): Result<ConsumerSessionLookup> {
+            override suspend fun lookupConsumer(
+                email: String,
+                sessionId: String,
+                customerId: String?
+            ): Result<ConsumerSessionLookup> {
                 if (email == TestFactory.EMAIL) callCount += 1
-                return super.lookupConsumer(email, customerId)
+                return super.lookupConsumer(email = email, sessionId = sessionId, customerId = customerId)
             }
         }
         assertThat(
@@ -174,9 +178,13 @@ class DefaultLinkAccountManagerTest {
     fun `signInWithUserInput sends correct parameters and starts session for existing user`() = runSuspendTest {
         val linkRepository = object : FakeLinkRepository() {
             var callCount = 0
-            override suspend fun lookupConsumer(email: String, customerId: String?): Result<ConsumerSessionLookup> {
+            override suspend fun lookupConsumer(
+                email: String,
+                sessionId: String,
+                customerId: String?
+            ): Result<ConsumerSessionLookup> {
                 if (email == TestFactory.EMAIL) callCount += 1
-                return super.lookupConsumer(email, customerId)
+                return super.lookupConsumer(email = email, sessionId = sessionId, customerId = customerId)
             }
         }
         val accountManager = accountManager(linkRepository = linkRepository)
@@ -490,9 +498,13 @@ class DefaultLinkAccountManagerTest {
                 return details
             }
 
-            override suspend fun lookupConsumer(email: String, customerId: String?): Result<ConsumerSessionLookup> {
+            override suspend fun lookupConsumer(
+                email: String,
+                sessionId: String,
+                customerId: String?
+            ): Result<ConsumerSessionLookup> {
                 callCount += 1
-                return super.lookupConsumer(email, customerId)
+                return super.lookupConsumer(email = email, sessionId = sessionId, customerId = customerId)
             }
         }
         val accountManager = accountManager(linkRepository = linkRepository)

--- a/paymentsheet/src/test/java/com/stripe/android/link/repositories/FakeLinkRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/repositories/FakeLinkRepository.kt
@@ -45,6 +45,7 @@ internal open class FakeLinkRepository : LinkRepository {
 
     override suspend fun lookupConsumer(
         email: String,
+        sessionId: String,
         customerId: String?
     ): Result<ConsumerSessionLookup> {
         lookupConsumerCalls.add(
@@ -56,7 +57,8 @@ internal open class FakeLinkRepository : LinkRepository {
     }
 
     override suspend fun lookupConsumerWithoutBackendLoggingForExposure(
-        email: String
+        email: String,
+        sessionId: String
     ): Result<ConsumerSessionLookup> {
         lookupConsumerWithoutBackendLoggingCalls.add(
             item = LookupCall(

--- a/paymentsheet/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
@@ -20,6 +20,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.VerificationType
+import com.stripe.android.networking.RequestSurface
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.repository.ConsumersApiService
@@ -54,16 +55,7 @@ class LinkApiRepositoryTest {
         whenever(clientSecret).thenReturn("secret")
     }
 
-    private val linkRepository = LinkApiRepository(
-        application = ApplicationProvider.getApplicationContext(),
-        publishableKeyProvider = { PUBLISHABLE_KEY },
-        stripeAccountIdProvider = { STRIPE_ACCOUNT_ID },
-        stripeRepository = stripeRepository,
-        consumersApiService = consumersApiService,
-        workContext = Dispatchers.IO,
-        locale = Locale.US,
-        errorReporter = errorReporter
-    )
+    private val linkRepository = linkRepository(consumersApiService = consumersApiService)
 
     @Before
     fun clearErrorReporter() {
@@ -816,6 +808,7 @@ class LinkApiRepositoryTest {
     ): LinkApiRepository {
         return LinkApiRepository(
             application = ApplicationProvider.getApplicationContext(),
+            requestSurface = RequestSurface.PaymentElement,
             publishableKeyProvider = { PUBLISHABLE_KEY },
             stripeAccountIdProvider = { STRIPE_ACCOUNT_ID },
             stripeRepository = stripeRepository,

--- a/paymentsheet/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
@@ -67,13 +67,18 @@ class LinkApiRepositoryTest {
         val consumersApiService = FakeConsumersApiService()
         val linkRepository = linkRepository(consumersApiService)
 
-        val result = linkRepository.lookupConsumer(TestFactory.EMAIL, customerId = null)
+        val result = linkRepository.lookupConsumer(
+            email = TestFactory.EMAIL,
+            sessionId = SESSION_ID,
+            customerId = null,
+        )
 
         assertThat(result).isEqualTo(Result.success(TestFactory.CONSUMER_SESSION_LOOKUP))
         assertThat(consumersApiService.lookupCalls.size).isEqualTo(1)
         val lookup = consumersApiService.lookupCalls.first()
         assertThat(lookup.email).isEqualTo(TestFactory.EMAIL)
         assertThat(lookup.requestSurface).isEqualTo(CONSUMER_SURFACE)
+        assertThat(lookup.sessionId).isEqualTo(SESSION_ID)
         assertThat(lookup.requestOptions.apiKey).isEqualTo(PUBLISHABLE_KEY)
         assertThat(lookup.requestOptions.stripeAccount).isEqualTo(STRIPE_ACCOUNT_ID)
     }
@@ -85,6 +90,7 @@ class LinkApiRepositoryTest {
             override suspend fun lookupConsumerSession(
                 email: String,
                 requestSurface: String,
+                sessionId: String,
                 doNotLogConsumerFunnelEvent: Boolean,
                 requestOptions: ApiRequest.Options,
                 customerId: String?
@@ -94,7 +100,7 @@ class LinkApiRepositoryTest {
         }
         val linkRepository = linkRepository(consumersApiService)
 
-        val result = linkRepository.lookupConsumer("email", customerId = null)
+        val result = linkRepository.lookupConsumer("email", sessionId = SESSION_ID, customerId = null)
 
         assertThat(result).isEqualTo(Result.failure<ConsumerSessionLookup>(error))
     }
@@ -837,5 +843,6 @@ class LinkApiRepositoryTest {
         const val PUBLISHABLE_KEY = "publishableKey"
         const val STRIPE_ACCOUNT_ID = "stripeAccountId"
         const val CONSUMER_SURFACE = "android_payment_element"
+        const val SESSION_ID = "sess_123"
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ExtendedPaymentElementConfirmationTestActivity.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ExtendedPaymentElementConfirmationTestActivity.kt
@@ -29,6 +29,7 @@ import com.stripe.android.link.analytics.FakeLinkEventsReporter
 import com.stripe.android.link.analytics.LinkEventsReporter
 import com.stripe.android.link.gate.DefaultLinkGate
 import com.stripe.android.link.gate.LinkGate
+import com.stripe.android.networking.PaymentElementRequestSurfaceModule
 import com.stripe.android.networking.StripeApiRepository
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
@@ -117,7 +118,7 @@ internal interface ExtendedPaymentElementConfirmationTestComponent {
     }
 }
 
-@Module
+@Module(includes = [PaymentElementRequestSurfaceModule::class])
 internal interface ExtendedPaymentElementConfirmationTestModule {
     @Binds
     fun bindsStripeRepository(repository: StripeApiRepository): StripeRepository

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/PaymentElementConfirmationTestActivity.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/PaymentElementConfirmationTestActivity.kt
@@ -29,6 +29,7 @@ import com.stripe.android.link.analytics.FakeLinkEventsReporter
 import com.stripe.android.link.analytics.LinkEventsReporter
 import com.stripe.android.link.gate.DefaultLinkGate
 import com.stripe.android.link.gate.LinkGate
+import com.stripe.android.networking.PaymentElementRequestSurfaceModule
 import com.stripe.android.networking.StripeApiRepository
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
@@ -117,7 +118,7 @@ internal interface PaymentElementConfirmationTestComponent {
     }
 }
 
-@Module
+@Module(includes = [PaymentElementRequestSurfaceModule::class])
 internal interface PaymentElementConfirmationTestModule {
     @Binds
     fun bindsStripeRepository(repository: StripeApiRepository): StripeRepository

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationActivityTest.kt
@@ -22,6 +22,7 @@ import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.link.LinkLaunchMode
 import com.stripe.android.link.NativeLinkArgs
 import com.stripe.android.link.TestFactory
+import com.stripe.android.networking.RequestSurface
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.PaymentElementConfirmationTestActivity
@@ -203,6 +204,7 @@ internal class LinkConfirmationActivityTest(private val nativeLinkEnabled: Boole
                         "native_link_args",
                         NativeLinkArgs(
                             configuration = TestFactory.LINK_CONFIGURATION,
+                            requestSurface = RequestSurface.PaymentElement,
                             publishableKey = PUBLISHABLE_KEY,
                             stripeAccountId = null,
                             linkExpressMode = LinkExpressMode.ENABLED,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/foundations/LpmNetworkTestActivity.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/foundations/LpmNetworkTestActivity.kt
@@ -19,6 +19,7 @@ import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.core.utils.requireApplication
+import com.stripe.android.networking.PaymentElementRequestSurfaceModule
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.paymentelement.confirmation.ALLOWS_MANUAL_CONFIRMATION
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
@@ -119,6 +120,7 @@ internal class LpmNetworkTestActivity : AppCompatActivity() {
 @Component(
     modules = [
         StripeRepositoryModule::class,
+        PaymentElementRequestSurfaceModule::class,
         DefaultConfirmationModule::class,
         LpmNetworkTestModule::class,
     ]

--- a/stripe-crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/di/OnrampModule.kt
+++ b/stripe-crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/di/OnrampModule.kt
@@ -3,6 +3,7 @@ package com.stripe.android.crypto.onramp.di
 import android.app.Application
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.link.LinkController
+import com.stripe.android.networking.RequestSurface
 import dagger.Module
 import dagger.Provides
 import javax.inject.Singleton
@@ -20,7 +21,8 @@ internal class OnrampModule {
     ): LinkController {
         return LinkController.create(
             application = application,
-            savedStateHandle = savedStateHandle
+            savedStateHandle = savedStateHandle,
+            requestSurface = RequestSurface.CryptoOnramp
         )
     }
 }


### PR DESCRIPTION
# Summary
Send `request_surface="android_crypto_onramp"` from the crypto-onramp and link-controller SDKs.

Major changes to support this include:
 * introducing enum `RequestSurface`
 * adding `RequestSurface` dependency in `StripeApiRepository`
 * adding `RequestSurface` to our many DI graphs, hardcoding to `android_payment_element` to avoid changing behavior
 * adding `StripeRepository.DEFAULT_REQUEST_SURFACE` (i.e. `android_payment_element`) where dagger isn't available
 * add `session_id` param to `/lookup` requests (iOS already does this)

# Motivation
👻 

# Testing
- [x] Added tests
- [x] Modified tests
- [x] Manually verified