### PR TITLE
Fix hCaptcha memory leak

### DIFF
--- a/hcaptcha/src/main/java/com/stripe/hcaptcha/HCaptcha.kt
+++ b/hcaptcha/src/main/java/com/stripe/hcaptcha/HCaptcha.kt
@@ -51,7 +51,10 @@ interface IHCaptcha {
      * @param config Config to customize: size, theme, locale, endpoint, rqdata, etc.
      * @return new [HCaptcha] object
      */
-    fun setup(config: HCaptchaConfig): HCaptcha?
+    fun setup(
+        activity: FragmentActivity,
+        config: HCaptchaConfig
+    ): HCaptcha?
 
     /**
      * Presents a captcha challenge. Depending on the configuration passed in setup, this will be either a passive
@@ -59,7 +62,7 @@ interface IHCaptcha {
      *
      * @return [HCaptcha]
      */
-    fun verifyWithHCaptcha(): HCaptcha?
+    fun verifyWithHCaptcha(activity: FragmentActivity): HCaptcha?
 
     /**
      * Force stop verification and release resources.
@@ -69,12 +72,11 @@ interface IHCaptcha {
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class HCaptcha private constructor(
-    private val activity: FragmentActivity,
-    private val internalConfig: HCaptchaInternalConfig
+    private val internalConfig: HCaptchaInternalConfig,
 ) : Task<HCaptchaTokenResponse>(), IHCaptcha {
     private var captchaVerifier: IHCaptchaVerifier? = null
 
-    override fun setup(config: HCaptchaConfig): HCaptcha {
+    override fun setup(activity: FragmentActivity, config: HCaptchaConfig): HCaptcha {
         val listener = HCaptchaStateListener(
             onOpen = { captchaOpened() },
             onSuccess = { token ->
@@ -102,7 +104,7 @@ class HCaptcha private constructor(
         return this
     }
 
-    override fun verifyWithHCaptcha(): HCaptcha {
+    override fun verifyWithHCaptcha(activity: FragmentActivity): HCaptcha? {
         val captchaVerifier = captchaVerifier
             ?: // Cold start at verification time.
             throw IllegalStateException("verifyWithHCaptcha must not be called before setup.")
@@ -123,14 +125,12 @@ class HCaptcha private constructor(
         /**
          * Constructs a new client which allows to display a challenge dialog
          *
-         * @param activity The current activity
          * @return new [HCaptcha] object
          */
         fun getClient(
-            activity: FragmentActivity,
             internalConfig: HCaptchaInternalConfig = HCaptchaInternalConfig()
         ): HCaptcha {
-            return HCaptcha(activity, internalConfig)
+            return HCaptcha(internalConfig)
         }
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/hcaptcha/HCaptchaInterface.kt
+++ b/payments-core/src/main/java/com/stripe/android/hcaptcha/HCaptchaInterface.kt
@@ -27,7 +27,7 @@ suspend fun performPassiveHCaptcha(
     // TODO(awush): in the future, we should convert the hCaptcha SDK to use a suspend interface instead of callbacks,
     //  then we can eliminate the {{suspendCancelableCoroutine}} here.
     return suspendCancellableCoroutine { coroutine ->
-        val hcaptcha = HCaptcha.getClient(activity).apply {
+        val hcaptcha = HCaptcha.getClient().apply {
             addOnSuccessListener(object : OnSuccessListener<HCaptchaTokenResponse> {
                 override fun onSuccess(result: HCaptchaTokenResponse) {
                     coroutine.resume(result.tokenResult) { _ -> }
@@ -50,6 +50,6 @@ suspend fun performPassiveHCaptcha(
             retryPredicate = { _, exception -> exception.hCaptchaError == HCaptchaError.SESSION_TIMEOUT }
         )
 
-        hcaptcha.setup(config).verifyWithHCaptcha()
+        hcaptcha.setup(activity, config).verifyWithHCaptcha(activity)
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/hcaptcha/HCaptchaProvider.kt
+++ b/payments-core/src/main/java/com/stripe/android/hcaptcha/HCaptchaProvider.kt
@@ -1,16 +1,15 @@
 package com.stripe.android.hcaptcha
 
 import androidx.annotation.RestrictTo
-import androidx.fragment.app.FragmentActivity
 import com.stripe.hcaptcha.HCaptcha
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun interface HCaptchaProvider {
-    fun get(activity: FragmentActivity): HCaptcha
+    fun get(): HCaptcha
 }
 
 internal class DefaultHCaptchaProvider : HCaptchaProvider {
-    override fun get(activity: FragmentActivity): HCaptcha {
-        return HCaptcha.getClient(activity)
+    override fun get(): HCaptcha {
+        return HCaptcha.getClient()
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
hCaptcha is retaining an instance of the host activity even after its destroyed. This change fixes that.
I used the latest version the hCaptcha library on a fresh project and the issue still exists. `HCaptcha.reset()` does not fix the issue when called after verification or in `onDestroy`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
