### PR TITLE
Fix SepaDebit with PMO SFU

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestSepaDebit.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestSepaDebit.kt
@@ -14,10 +14,14 @@ import com.stripe.android.paymentsheet.example.playground.settings.CheckoutMode
 import com.stripe.android.paymentsheet.example.playground.settings.CheckoutModeSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.Country
 import com.stripe.android.paymentsheet.example.playground.settings.CountrySettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.CustomerSessionSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.CustomerSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.CustomerType
 import com.stripe.android.paymentsheet.example.playground.settings.DelayedPaymentMethodsSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.GooglePaySettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.InitializationType
 import com.stripe.android.paymentsheet.example.playground.settings.InitializationTypeSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.PaymentMethodOptionsSetupFutureUsageOverrideSettingsDefinition
 import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_OPTION_TEST_TAG
 import com.stripe.android.test.core.DEFAULT_UI_TIMEOUT
 import com.stripe.android.test.core.TestParameters
@@ -169,6 +173,19 @@ internal class TestSepaDebit : BasePlaygroundTest() {
                 selectors.continueButton.click()
             }
         )
+    }
+
+    @Test
+    fun testSepaDebitWithPmoSfuAndCustomerSession() {
+        testDriver.confirmNewOrGuestComplete(
+            testParameters = testParameters.copyPlaygroundSettings { settings ->
+                settings[CustomerSessionSettingsDefinition] = true
+                settings[CustomerSettingsDefinition] = CustomerType.NEW
+                settings[PaymentMethodOptionsSetupFutureUsageOverrideSettingsDefinition] = "sepa_debit:off_session"
+            }.copy(saveForFutureUseCheckboxVisible = true),
+        ) {
+            fillOutIban()
+        }
     }
 
     @OptIn(ExperimentalTestApi::class)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -100,7 +100,7 @@ internal fun FormFieldValues.transformToPaymentSelection(
     paymentMethodMetadata: PaymentMethodMetadata,
 ): PaymentSelection {
     val setupFutureUsage = userRequestedReuse.getSetupFutureUseValue(
-        paymentMethodMetadata.hasIntentToSetup(PaymentMethod.Type.Card.code)
+        paymentMethodMetadata.hasIntentToSetup(paymentMethod.code)
     )
 
     val params = transformToPaymentMethodCreateParams(paymentMethod.code, paymentMethodMetadata)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodTest.kt
@@ -452,7 +452,11 @@ internal class AddPaymentMethodTest {
 
         val metadataWithSepaDebit = metadata.copy(
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
-                paymentMethodTypes = listOf("sepa_debit")
+                paymentMethodTypes = listOf("sepa_debit"),
+                paymentMethodOptionsJsonString = PaymentIntentFixtures.getPaymentMethodOptionsJsonString(
+                    code = "sepa_debit",
+                    sfuValue = "off_session"
+                )
             )
         )
         val sepaDebitPaymentMethod = metadataWithSepaDebit.supportedPaymentMethodForCode("sepa_debit")!!
@@ -479,7 +483,11 @@ internal class AddPaymentMethodTest {
 
         val metadataWithSepaDebit = metadata.copy(
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
-                paymentMethodTypes = listOf("sepa_debit")
+                paymentMethodTypes = listOf("sepa_debit"),
+                paymentMethodOptionsJsonString = PaymentIntentFixtures.getPaymentMethodOptionsJsonString(
+                    code = "sepa_debit",
+                    sfuValue = "off_session"
+                )
             )
         )
         val sepaDebitPaymentMethod = metadataWithSepaDebit.supportedPaymentMethodForCode("sepa_debit")!!
@@ -490,7 +498,7 @@ internal class AddPaymentMethodTest {
 
         val options = sepaDebitPaymentSelection.paymentMethodOptionsParams as? PaymentMethodOptionsParams.SepaDebit
         assertThat(sepaDebitPaymentSelection.customerRequestedSave).isEqualTo(customerRequestedSave)
-        assertThat(options?.setupFutureUsage).isEqualTo(ConfirmPaymentIntentParams.SetupFutureUsage.Blank)
+        assertThat(options?.setupFutureUsage).isNull()
     }
 
     @Test
@@ -505,7 +513,11 @@ internal class AddPaymentMethodTest {
 
         val metadataWithSepaDebit = metadata.copy(
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
-                paymentMethodTypes = listOf("sepa_debit")
+                paymentMethodTypes = listOf("sepa_debit"),
+                paymentMethodOptionsJsonString = PaymentIntentFixtures.getPaymentMethodOptionsJsonString(
+                    code = "sepa_debit",
+                    sfuValue = "off_session"
+                )
             )
         )
         val sepaDebitPaymentMethod = metadataWithSepaDebit.supportedPaymentMethodForCode("sepa_debit")!!


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Update `FormFieldValues.transformToPaymentSelection` to check `PaymentMethodMetadata.hasIntentToSetup` for the specified payment method instead of always checking card.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
If PMO SFU is set for sepa debit to on/off_session, customer session is enabled, and the user does not check the SFU checkbox, the payment will fail with because the PaymentMethodOptionsParams will have setup_future_usage set to blank but the PaymentIntent payment_method_options will have SFU set to on/off_session.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [X] Manually verified

