### PR TITLE
Fix the inability to scroll page/scroll while continue option is disabled in consent screen in Identity

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/ui/ConsentScreen.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/ConsentScreen.kt
@@ -1,8 +1,10 @@
 package com.stripe.android.identity.ui
 
 import android.net.Uri
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -150,19 +152,24 @@ private fun SuccessUI(
             )
             ConsentLines(lines = consentPage.lines, bottomSheets = bottomSheets)
 
-            Html(
-                html = consentPage.privacyPolicy,
-                modifier = Modifier
-                    .padding(vertical = dimensionResource(id = R.dimen.stripe_item_vertical_margin))
-                    .semantics {
-                        testTag = PRIVACY_POLICY_TAG
-                    },
-                color = colorResource(id = R.color.stripe_html_line),
-                urlSpanStyle = SpanStyle(
-                    textDecoration = TextDecoration.Underline,
-                    color = colorResource(id = R.color.stripe_html_line)
+            Box(
+                modifier = Modifier.fillMaxWidth(),
+                contentAlignment = Alignment.Center
+            ) {
+                Html(
+                    html = consentPage.privacyPolicy,
+                    modifier = Modifier
+                        .padding(vertical = dimensionResource(id = R.dimen.stripe_item_vertical_margin))
+                        .semantics {
+                            testTag = PRIVACY_POLICY_TAG
+                        },
+                    color = colorResource(id = R.color.stripe_html_line),
+                    urlSpanStyle = SpanStyle(
+                        textDecoration = TextDecoration.Underline,
+                        color = colorResource(id = R.color.stripe_html_line)
+                    )
                 )
-            )
+            }
         }
 
         var acceptState by remember { mutableStateOf(LoadingButtonState.Idle) }
@@ -174,7 +181,7 @@ private fun SuccessUI(
                 scrolledToBottom = scrollState.value == scrollState.maxValue
             }
         }
-        
+
         LoadingButton(
             modifier = Modifier
                 .padding(bottom = 10.dp)


### PR DESCRIPTION
## Summary 

Fixes [#9052](https://github.com/stripe/stripe-android/issues/9052) 


This fixes the issue by moving the privacy policy links into the scroll view. This way it can not interfere with scrolling.

## Testing

- Launched the identity example app
- Began an identity flow
- Verified the privacy policy is hugging the other information and is inside the scroll view

After:

<img width="508" height="902" alt="Screenshot 2025-08-12 at 11 24 38 AM" src="https://github.com/user-attachments/assets/a50ffed7-a0bc-4141-9639-3e9896658c7b" />

