### PR TITLE
Fix mandates for PS.

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetPage.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetPage.kt
@@ -32,12 +32,14 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.paymentsheet.ui.FORM_ELEMENT_TEST_TAG
 import com.stripe.android.paymentsheet.ui.GOOGLE_PAY_BUTTON_TEST_TAG
 import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_ERROR_TEXT_TEST_TAG
+import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_MANDATE_TEXT_TEST_TAG
 import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG
 import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_OPTION_TEST_TAG
 import com.stripe.android.paymentsheet.ui.TEST_TAG_LIST
 import com.stripe.android.paymentsheet.ui.TEST_TAG_MODIFY_BADGE
 import com.stripe.android.paymentsheet.verticalmode.TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON
 import com.stripe.android.paymentsheet.verticalmode.TEST_TAG_PAYMENT_METHOD_VERTICAL_LAYOUT
+import com.stripe.android.paymentsheet.verticalmode.TEST_TAG_SAVED_PAYMENT_METHOD_ROW_BUTTON
 import com.stripe.android.ui.core.elements.MANDATE_TEST_TAG
 import com.stripe.android.ui.core.elements.SAVE_FOR_FUTURE_CHECKBOX_TEST_TAG
 import com.stripe.android.ui.core.elements.SET_AS_DEFAULT_PAYMENT_METHOD_TEST_TAG
@@ -461,9 +463,9 @@ internal class PaymentSheetPage(
         composeTestRule.onNode(hasTestTag(GOOGLE_PAY_BUTTON_TEST_TAG)).assertIsDisplayed()
     }
 
-    fun assertHasMandate(mandateText: String) {
+    fun assertHasMandate(mandateText: String, substring: Boolean = false) {
         composeTestRule
-            .onNode(hasText(mandateText))
+            .onNode(hasText(mandateText, substring = substring))
             .assertExists()
     }
 
@@ -473,5 +475,20 @@ internal class PaymentSheetPage(
 
         composeTestRule.onNodeWithTag(MANDATE_TEST_TAG)
             .assertDoesNotExist()
+
+        composeTestRule.onNodeWithTag(PAYMENT_SHEET_MANDATE_TEXT_TEST_TAG)
+            .assertDoesNotExist()
+    }
+
+    fun assertSavedSelection(paymentMethodId: String) {
+        waitUntilVisible()
+
+        composeTestRule.waitUntil {
+            composeTestRule.onAllNodes(
+                hasTestTag("${TEST_TAG_SAVED_PAYMENT_METHOD_ROW_BUTTON}_$paymentMethodId")
+                    .and(isSelected())
+            ).fetchSemanticsNodes()
+                .isNotEmpty()
+        }
     }
 }

--- a/paymentsheet/src/androidTest/resources/payment-methods-get-success-us-bank.json
+++ b/paymentsheet/src/androidTest/resources/payment-methods-get-success-us-bank.json
@@ -1,0 +1,44 @@
+{
+  "object": "list",
+  "data": [{
+    "id": "pm_6789",
+    "object": "payment_method",
+    "allow_redisplay": "unspecified",
+    "billing_details": {
+      "address": {
+        "city": "South San Francisco",
+        "country": "US",
+        "line1": "354 Oyster Point Blvd",
+        "line2": null,
+        "postal_code": "94080",
+        "state": "CA"
+      },
+      "email": "email@email.com",
+      "name": "Jenny Rosen",
+      "phone": "+18008675309",
+      "tax_id": null
+    },
+    "created": 1755020663,
+    "customer": "cus_1",
+    "livemode": false,
+    "type": "us_bank_account",
+    "us_bank_account": {
+      "account_holder_type": "individual",
+      "account_type": "checking",
+      "bank_name": "STRIPE TEST BANK",
+      "financial_connections_account": "fca_a",
+      "fingerprint": "a",
+      "last4": "6789",
+      "linked_account": "fca_a",
+      "networks": {
+        "preferred": "ach",
+        "supported": [
+          "ach"]
+      },
+      "routing_number": "110000000",
+      "status_details": null
+    }
+  }],
+  "has_more": false,
+  "url": "/v1/payment_methods"
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -180,9 +180,9 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
                 displaysMandatesInFormScreen = false,
             ).also { interactor ->
                 viewModel.viewModelScope.launch {
-                    interactor.state.collect { state ->
+                    interactor.state.mapAsStateFlow { it.mandate }.collect { mandate ->
                         viewModel.mandateHandler.updateMandateText(
-                            mandateText = state.mandate,
+                            mandateText = mandate,
                             showAbove = true,
                         )
                     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Before:
https://github.com/user-attachments/assets/c6d4cb85-7d49-4156-8797-b6f57c66f768

The saved us bank mandate was being displayed while paying with a card. This change fixes it and adds a test to prevent regressions. The fix isn't perfect, but the way mandates are modeled in PS make this hard to fix without a hacky fix, or a complete rearchitecture. 


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-3919

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
