### PR TITLE
Update account onboarding component to accept new requirements param 

### DIFF
--- a/connect-example/src/main/java/com/stripe/android/connect/example/data/SettingsService.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/data/SettingsService.kt
@@ -193,29 +193,33 @@ data class OnboardingSettings(
                     FutureRequirement.OMIT -> AccountOnboardingProps.FutureRequirementOption.OMIT
                     FutureRequirement.INCLUDE -> AccountOnboardingProps.FutureRequirementOption.INCLUDE
                 },
-                requirements = when (requirementsMode) {
-                    RequirementsMode.DEFAULT -> null
-                    RequirementsMode.ONLY -> requirementsText?.let { text ->
-                        if (text.isNotBlank()) {
-                            AccountOnboardingProps.RequirementsOption.only(
-                                text.split(",").map { it.trim() }.filter { it.isNotEmpty() }
-                            )
-                        } else {
-                            null
-                        }
-                    }
-                    RequirementsMode.EXCLUDE -> requirementsText?.let { text ->
-                        if (text.isNotBlank()) {
-                            AccountOnboardingProps.RequirementsOption.exclude(
-                                text.split(",").map { it.trim() }.filter { it.isNotEmpty() }
-                            )
-                        } else {
-                            null
-                        }
-                    }
-                }
+                requirements = buildRequirementsOption()
             ),
         )
+    }
+
+    private fun buildRequirementsOption(): AccountOnboardingProps.RequirementsOption? {
+        return when (requirementsMode) {
+            RequirementsMode.DEFAULT -> null
+            RequirementsMode.ONLY -> requirementsText?.let { text ->
+                if (text.isNotBlank()) {
+                    AccountOnboardingProps.RequirementsOption.only(
+                        text.split(",").map { it.trim() }.filter { it.isNotEmpty() }
+                    )
+                } else {
+                    null
+                }
+            }
+            RequirementsMode.EXCLUDE -> requirementsText?.let { text ->
+                if (text.isNotBlank()) {
+                    AccountOnboardingProps.RequirementsOption.exclude(
+                        text.split(",").map { it.trim() }.filter { it.isNotEmpty() }
+                    )
+                } else {
+                    null
+                }
+            }
+        }
     }
 }
 

--- a/connect-example/src/main/java/com/stripe/android/connect/example/data/SettingsService.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/data/SettingsService.kt
@@ -200,14 +200,18 @@ data class OnboardingSettings(
                             AccountOnboardingProps.RequirementsOption.only(
                                 text.split(",").map { it.trim() }.filter { it.isNotEmpty() }
                             )
-                        } else null
+                        } else {
+                            null
+                        }
                     }
                     RequirementsMode.EXCLUDE -> requirementsText?.let { text ->
                         if (text.isNotBlank()) {
                             AccountOnboardingProps.RequirementsOption.exclude(
                                 text.split(",").map { it.trim() }.filter { it.isNotEmpty() }
                             )
-                        } else null
+                        } else {
+                            null
+                        }
                     }
                 }
             ),

--- a/connect-example/src/main/java/com/stripe/android/connect/example/data/SettingsService.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/data/SettingsService.kt
@@ -71,6 +71,11 @@ class SettingsService @Inject constructor(@ApplicationContext context: Context) 
                 sharedPreferences.getString(ONBOARDING_FUTURE_REQUIREMENTS, FutureRequirement.DEFAULT.name)
                     ?: FutureRequirement.DEFAULT.name,
             ),
+            requirementsMode = RequirementsMode.valueOf(
+                sharedPreferences.getString(ONBOARDING_REQUIREMENTS_MODE, RequirementsMode.DEFAULT.name)
+                    ?: RequirementsMode.DEFAULT.name,
+            ),
+            requirementsText = sharedPreferences.getString(ONBOARDING_REQUIREMENTS_TEXT, null),
         )
     }
 
@@ -82,6 +87,8 @@ class SettingsService @Inject constructor(@ApplicationContext context: Context) 
             putString(ONBOARDING_SKIP_TERMS_OF_SERVICE, value.skipTermsOfService.name)
             putString(ONBOARDING_FIELD_OPTION, value.fieldOption.name)
             putString(ONBOARDING_FUTURE_REQUIREMENTS, value.futureRequirement.name)
+            putString(ONBOARDING_REQUIREMENTS_MODE, value.requirementsMode.name)
+            putString(ONBOARDING_REQUIREMENTS_TEXT, value.requirementsText)
         }
     }
 
@@ -150,6 +157,8 @@ class SettingsService @Inject constructor(@ApplicationContext context: Context) 
         private const val ONBOARDING_SKIP_TERMS_OF_SERVICE = "OnboardingSkipTermsOfService"
         private const val ONBOARDING_FIELD_OPTION = "OnboardingFieldOption"
         private const val ONBOARDING_FUTURE_REQUIREMENTS = "OnboardingFutureRequirements"
+        private const val ONBOARDING_REQUIREMENTS_MODE = "OnboardingRequirementsMode"
+        private const val ONBOARDING_REQUIREMENTS_TEXT = "OnboardingRequirementsText"
     }
 }
 
@@ -160,6 +169,8 @@ data class OnboardingSettings(
     val skipTermsOfService: SkipTermsOfService = SkipTermsOfService.DEFAULT,
     val fieldOption: FieldOption = FieldOption.DEFAULT,
     val futureRequirement: FutureRequirement = FutureRequirement.DEFAULT,
+    val requirementsMode: RequirementsMode = RequirementsMode.DEFAULT,
+    val requirementsText: String? = null,
 ) {
     fun toProps(): AccountOnboardingProps {
         return AccountOnboardingProps(
@@ -181,6 +192,23 @@ data class OnboardingSettings(
                     FutureRequirement.DEFAULT -> null
                     FutureRequirement.OMIT -> AccountOnboardingProps.FutureRequirementOption.OMIT
                     FutureRequirement.INCLUDE -> AccountOnboardingProps.FutureRequirementOption.INCLUDE
+                },
+                requirements = when (requirementsMode) {
+                    RequirementsMode.DEFAULT -> null
+                    RequirementsMode.ONLY -> requirementsText?.let { text ->
+                        if (text.isNotBlank()) {
+                            AccountOnboardingProps.RequirementsOption.only(
+                                text.split(",").map { it.trim() }.filter { it.isNotEmpty() }
+                            )
+                        } else null
+                    }
+                    RequirementsMode.EXCLUDE -> requirementsText?.let { text ->
+                        if (text.isNotBlank()) {
+                            AccountOnboardingProps.RequirementsOption.exclude(
+                                text.split(",").map { it.trim() }.filter { it.isNotEmpty() }
+                            )
+                        } else null
+                    }
                 }
             ),
         )
@@ -197,3 +225,4 @@ data class PresentationSettings(
 enum class SkipTermsOfService { DEFAULT, SKIP, SHOW }
 enum class FieldOption { DEFAULT, CURRENTLY_DUE, EVENTUALLY_DUE }
 enum class FutureRequirement { DEFAULT, OMIT, INCLUDE }
+enum class RequirementsMode { DEFAULT, ONLY, EXCLUDE }

--- a/connect-example/src/main/java/com/stripe/android/connect/example/ui/settings/AccountOnboardingSettingsView.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/ui/settings/AccountOnboardingSettingsView.kt
@@ -165,7 +165,7 @@ private fun AccountOnboardingSettingsView(
                         RequirementsMode.EXCLUDE -> "Requirements to exclude (comma-separated)"
                         RequirementsMode.DEFAULT -> ""
                     },
-                    placeholder = "e.g., business_profile.mcc, business_profile.url",
+                    placeholder = "e.g., external_account, business_profile.url",
                     value = requirementsText,
                     onValueChange = { requirementsText = it },
                 )

--- a/connect-example/src/main/java/com/stripe/android/connect/example/ui/settings/AccountOnboardingSettingsView.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/ui/settings/AccountOnboardingSettingsView.kt
@@ -24,6 +24,7 @@ import com.stripe.android.connect.example.R
 import com.stripe.android.connect.example.data.FieldOption
 import com.stripe.android.connect.example.data.FutureRequirement
 import com.stripe.android.connect.example.data.OnboardingSettings
+import com.stripe.android.connect.example.data.RequirementsMode
 import com.stripe.android.connect.example.data.SkipTermsOfService
 import com.stripe.android.connect.example.ui.common.BackIconButton
 import com.stripe.android.connect.example.ui.common.ConnectExampleScaffold
@@ -68,6 +69,12 @@ private fun AccountOnboardingSettingsView(
     var futureRequirement by rememberSaveable {
         mutableStateOf(onboardingSettings.futureRequirement)
     }
+    var requirementsMode by rememberSaveable {
+        mutableStateOf(onboardingSettings.requirementsMode)
+    }
+    var requirementsText by rememberSaveable {
+        mutableStateOf(onboardingSettings.requirementsText ?: "")
+    }
     ConnectExampleScaffold(
         title = stringResource(R.string.onboarding_settings),
         navigationIcon = { BackIconButton(onBack) },
@@ -82,6 +89,8 @@ private fun AccountOnboardingSettingsView(
                             skipTermsOfService = skipTermsOfService,
                             fieldOption = fieldOption,
                             futureRequirement = futureRequirement,
+                            requirementsMode = requirementsMode,
+                            requirementsText = requirementsText.trim().takeIf { it.isNotEmpty() },
                         )
                     )
                     onBack()
@@ -141,6 +150,26 @@ private fun AccountOnboardingSettingsView(
                 selectedOption = futureRequirement,
                 onSelectOption = { futureRequirement = it }
             )
+            Spacer(Modifier.requiredHeight(8.dp))
+            SettingsDropdownField(
+                label = "Requirements mode",
+                options = RequirementsMode.entries.toList(),
+                selectedOption = requirementsMode,
+                onSelectOption = { requirementsMode = it }
+            )
+            if (requirementsMode != RequirementsMode.DEFAULT) {
+                Spacer(Modifier.requiredHeight(8.dp))
+                SettingsTextField(
+                    label = when (requirementsMode) {
+                        RequirementsMode.ONLY -> "Requirements to include (comma-separated)"
+                        RequirementsMode.EXCLUDE -> "Requirements to exclude (comma-separated)"
+                        RequirementsMode.DEFAULT -> ""
+                    },
+                    placeholder = "e.g., business_profile.mcc, business_profile.url",
+                    value = requirementsText,
+                    onValueChange = { requirementsText = it },
+                )
+            }
         }
     }
 }

--- a/connect/api/connect.api
+++ b/connect/api/connect.api
@@ -34,8 +34,8 @@ public final class com/stripe/android/connect/AccountOnboardingProps$CollectionO
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> ()V
-	public fun <init> (Lcom/stripe/android/connect/AccountOnboardingProps$FieldOption;Lcom/stripe/android/connect/AccountOnboardingProps$FutureRequirementOption;)V
-	public synthetic fun <init> (Lcom/stripe/android/connect/AccountOnboardingProps$FieldOption;Lcom/stripe/android/connect/AccountOnboardingProps$FutureRequirementOption;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/stripe/android/connect/AccountOnboardingProps$FieldOption;Lcom/stripe/android/connect/AccountOnboardingProps$FutureRequirementOption;Lcom/stripe/android/connect/AccountOnboardingProps$RequirementsOption;)V
+	public synthetic fun <init> (Lcom/stripe/android/connect/AccountOnboardingProps$FieldOption;Lcom/stripe/android/connect/AccountOnboardingProps$FutureRequirementOption;Lcom/stripe/android/connect/AccountOnboardingProps$RequirementsOption;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFields ()Lcom/stripe/android/connect/AccountOnboardingProps$FieldOption;
@@ -75,6 +75,34 @@ public final class com/stripe/android/connect/AccountOnboardingProps$FutureRequi
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/connect/AccountOnboardingProps$FutureRequirementOption;
 	public static fun values ()[Lcom/stripe/android/connect/AccountOnboardingProps$FutureRequirementOption;
+}
+
+public abstract class com/stripe/android/connect/AccountOnboardingProps$RequirementsOption : android/os/Parcelable {
+	public static final field $stable I
+	public static final field Companion Lcom/stripe/android/connect/AccountOnboardingProps$RequirementsOption$Companion;
+	public static final fun exclude (Ljava/util/List;)Lcom/stripe/android/connect/AccountOnboardingProps$RequirementsOption;
+	public static final fun only (Ljava/util/List;)Lcom/stripe/android/connect/AccountOnboardingProps$RequirementsOption;
+}
+
+public final class com/stripe/android/connect/AccountOnboardingProps$RequirementsOption$Companion {
+	public final fun exclude (Ljava/util/List;)Lcom/stripe/android/connect/AccountOnboardingProps$RequirementsOption;
+	public final fun only (Ljava/util/List;)Lcom/stripe/android/connect/AccountOnboardingProps$RequirementsOption;
+}
+
+public final class com/stripe/android/connect/AccountOnboardingProps$RequirementsOption$Exclude$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/connect/AccountOnboardingProps$RequirementsOption$Exclude;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/connect/AccountOnboardingProps$RequirementsOption$Exclude;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/connect/AccountOnboardingProps$RequirementsOption$Only$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/connect/AccountOnboardingProps$RequirementsOption$Only;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/connect/AccountOnboardingProps$RequirementsOption$Only;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public final class com/stripe/android/connect/BuildConfig {

--- a/connect/src/main/java/com/stripe/android/connect/AccountOnboardingView.kt
+++ b/connect/src/main/java/com/stripe/android/connect/AccountOnboardingView.kt
@@ -99,6 +99,7 @@ class AccountOnboardingProps(
      * Customizes collecting `currently_due` or `eventually_due` requirements and controls whether to include
      * [future requirements](https://docs.stripe.com/api/accounts/object#account_object-future_requirements).
      * Specifying `eventually_due` collects both `eventually_due` and `currently_due` requirements.
+     * Additionally, `requirements` can be used to collect only some requirements or exclude them.
      */
     val collectionOptions: CollectionOptions? = null,
 ) : Parcelable {
@@ -108,6 +109,7 @@ class AccountOnboardingProps(
     class CollectionOptions(
         val fields: FieldOption? = null,
         val futureRequirements: FutureRequirementOption? = null,
+        internal val requirements: RequirementsOption? = null,
     ) : Parcelable
 
     enum class FieldOption(internal val value: String) {
@@ -118,6 +120,25 @@ class AccountOnboardingProps(
     enum class FutureRequirementOption(internal val value: String) {
         OMIT("omit"),
         INCLUDE("include"),
+    }
+
+    @Parcelize
+    sealed class RequirementsOption : Parcelable {
+        @Poko
+        @Parcelize
+        internal class Only(val only: List<String>) : RequirementsOption()
+
+        @Poko
+        @Parcelize
+        internal class Exclude(val exclude: List<String>) : RequirementsOption()
+
+        companion object {
+            @JvmStatic
+            fun only(only: List<String>): RequirementsOption = Only(only)
+
+            @JvmStatic
+            fun exclude(exclude: List<String>): RequirementsOption = Exclude(exclude)
+        }
     }
 }
 

--- a/connect/src/main/java/com/stripe/android/connect/webview/serialization/AccountOnboardingPropsJs.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/serialization/AccountOnboardingPropsJs.kt
@@ -15,6 +15,13 @@ internal data class AccountOnboardingPropsJs(
     data class CollectionOptionsJs(
         val fields: String?,
         val futureRequirements: String?,
+        val requirements: RequirementsJs?,
+    )
+
+    @Serializable
+    data class RequirementsJs(
+        val only: List<String>?,
+        val exclude: List<String>?,
     )
 }
 
@@ -28,6 +35,14 @@ internal fun AccountOnboardingProps.toJs(): AccountOnboardingPropsJs {
             AccountOnboardingPropsJs.CollectionOptionsJs(
                 fields = it.fields?.value,
                 futureRequirements = it.futureRequirements?.value,
+                requirements = it.requirements?.let { req ->
+                    when (req) {
+                        is AccountOnboardingProps.RequirementsOption.Only ->
+                            AccountOnboardingPropsJs.RequirementsJs(only = req.only, exclude = null)
+                        is AccountOnboardingProps.RequirementsOption.Exclude ->
+                            AccountOnboardingPropsJs.RequirementsJs(only = null, exclude = req.exclude)
+                    }
+                }
             )
         }
     )


### PR DESCRIPTION
# Summary
Adds the `requirement` prop to onboarding as outlined in this [API Review](https://docs.google.com/document/d/13U9tcqSQTK5bV8NTy3i6YErvrr5LEl9wz3IbnYOeLuc/edit?tab=t.0#bookmark=id.67i2kmsnlize). 

Allows the onboarding component to include only the requirements in the only field or to exclude requirements in the exclude field.

# Motivation
https://jira.corp.stripe.com/browse/CAX-4476
https://jira.corp.stripe.com/browse/CRE-2002

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots

https://github.com/user-attachments/assets/7b358000-67be-4c4e-a626-55e721cad16e

In the video, I first show what happens if you don't specify any params, then I changed it to "only" "external_account". Since this account has already completed onboarding, it closes as expected. 

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
