### PR TITLE
Allow redisplay when confirming from Link wallet

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkConfiguration.kt
@@ -2,6 +2,7 @@ package com.stripe.android.link
 
 import android.os.Parcelable
 import com.stripe.android.CardBrandFilter
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.model.LinkMode
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
@@ -39,7 +40,8 @@ internal data class LinkConfiguration(
     val linkAppearance: LinkAppearance?,
     val linkSignUpOptInFeatureEnabled: Boolean,
     val linkSignUpOptInInitialValue: Boolean,
-    private val customerId: String?
+    private val customerId: String?,
+    val saveConsentBehavior: PaymentMethodSaveConsentBehavior,
 ) : Parcelable {
 
     val customerIdForEceDefaultValues: String?

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkConfiguration.kt
@@ -44,6 +44,13 @@ internal data class LinkConfiguration(
     val saveConsentBehavior: PaymentMethodSaveConsentBehavior,
 ) : Parcelable {
 
+    val alwaysSaveForFutureUse: Boolean
+        get() {
+            // When this (now poorly named) feature flag is enabled for a merchant, we always show the reuse mandate,
+            // since the merchant will save the payment method for future use.
+            return linkSignUpOptInFeatureEnabled
+        }
+
     val customerIdForEceDefaultValues: String?
         get() = if (enableDisplayableDefaultValuesInEce) customerId else null
 

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
@@ -343,6 +343,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
         expectedPaymentMethodType: String,
         billingPhone: String?,
         cvc: String?,
+        allowRedisplay: String?,
     ): Result<SharePaymentDetails> {
         return runCatching {
             requireNotNull(linkAccountHolder.linkAccountInfo.value.account)
@@ -353,6 +354,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
                 expectedPaymentMethodType = expectedPaymentMethodType,
                 billingPhone = billingPhone,
                 cvc = cvc,
+                allowRedisplay = allowRedisplay,
             ).getOrThrow()
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
@@ -126,6 +126,7 @@ internal interface LinkAccountManager {
         expectedPaymentMethodType: String,
         billingPhone: String?,
         cvc: String?,
+        allowRedisplay: String? = null,
     ): Result<SharePaymentDetails>
 
     suspend fun setLinkAccountFromLookupResult(

--- a/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
@@ -173,9 +173,7 @@ internal class DefaultLinkConfirmationHandler @Inject constructor(
             is SetupIntent -> true
         }
 
-        val isAlwaysShowingMandate = configuration.linkSignUpOptInFeatureEnabled
-
-        return if (isSettingUp || isAlwaysShowingMandate) {
+        return if (isSettingUp || configuration.alwaysSaveForFutureUse) {
             configuration.saveConsentBehavior.overrideAllowRedisplay ?: PaymentMethod.AllowRedisplay.LIMITED
         } else {
             PaymentMethod.AllowRedisplay.UNSPECIFIED

--- a/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
@@ -5,14 +5,17 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkPaymentDetails
 import com.stripe.android.link.model.LinkAccount
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.model.Address
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.LinkMode
+import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethod.Type.USBankAccount
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodOptionsParams
+import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.wallets.Wallet
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
@@ -26,6 +29,7 @@ internal class DefaultLinkConfirmationHandler @Inject constructor(
     private val logger: Logger,
     private val confirmationHandler: ConfirmationHandler,
 ) : LinkConfirmationHandler {
+
     override suspend fun confirm(
         paymentDetails: ConsumerPaymentDetails.PaymentDetails,
         linkAccount: LinkAccount,
@@ -123,12 +127,21 @@ internal class DefaultLinkConfirmationHandler @Inject constructor(
         cvc: String?,
         billingPhone: String?
     ): ConfirmationHandler.Args {
+        val paymentMethodType = if (configuration.passthroughModeEnabled) {
+            computeExpectedPaymentMethodType(configuration, paymentDetails)
+        } else {
+            PaymentMethod.Type.Link.code
+        }
+
+        val allowRedisplay = allowRedisplay(paymentMethodType = paymentMethodType)
+
         val confirmationOption = if (configuration.passthroughModeEnabled) {
             LinkPassthroughConfirmationOption(
                 paymentDetailsId = paymentDetails.id,
                 expectedPaymentMethodType = computeExpectedPaymentMethodType(configuration, paymentDetails),
                 cvc = cvc,
-                billingPhone = billingPhone
+                billingPhone = billingPhone,
+                allowRedisplay = allowRedisplay,
             )
         } else {
             PaymentMethodConfirmationOption.New(
@@ -137,6 +150,7 @@ internal class DefaultLinkConfirmationHandler @Inject constructor(
                     consumerSessionClientSecret = linkAccount.clientSecret,
                     cvc = cvc,
                     billingPhone = billingPhone,
+                    allowRedisplay = allowRedisplay,
                 ),
                 extraParams = null,
                 optionsParams = null,
@@ -151,6 +165,21 @@ internal class DefaultLinkConfirmationHandler @Inject constructor(
             initializationMode = configuration.initializationMode,
             shippingDetails = configuration.shippingDetails
         )
+    }
+
+    private fun allowRedisplay(paymentMethodType: String): PaymentMethod.AllowRedisplay? {
+        val isSettingUp = when (val intent = configuration.stripeIntent) {
+            is PaymentIntent -> intent.isSetupFutureUsageSet(paymentMethodType)
+            is SetupIntent -> true
+        }
+
+        val isAlwaysShowingMandate = configuration.linkSignUpOptInFeatureEnabled
+
+        return if (isSettingUp || isAlwaysShowingMandate) {
+            configuration.saveConsentBehavior.overrideAllowRedisplay ?: PaymentMethod.AllowRedisplay.LIMITED
+        } else {
+            PaymentMethod.AllowRedisplay.UNSPECIFIED
+        }
     }
 
     private fun savedConfirmationArgs(
@@ -203,6 +232,7 @@ internal fun createPaymentMethodCreateParams(
     consumerSessionClientSecret: String,
     cvc: String?,
     billingPhone: String?,
+    allowRedisplay: PaymentMethod.AllowRedisplay? = null,
 ): PaymentMethodCreateParams {
     val billingDetails = PaymentMethod.BillingDetails(
         address = selectedPaymentDetails.billingAddress?.let {
@@ -225,6 +255,7 @@ internal fun createPaymentMethodCreateParams(
         consumerSessionClientSecret = consumerSessionClientSecret,
         billingDetails = billingDetails.takeIf { it != PaymentMethod.BillingDetails() },
         extraParams = cvc?.let { mapOf("card" to mapOf("cvc" to cvc)) },
+        allowRedisplay = allowRedisplay,
     )
 }
 
@@ -249,3 +280,9 @@ private fun computeBankAccountExpectedPaymentMethodType(configuration: LinkConfi
         ConsumerPaymentDetails.BankAccount.TYPE
     }
 }
+
+private val PaymentMethodSaveConsentBehavior.overrideAllowRedisplay: PaymentMethod.AllowRedisplay?
+    get() = when (this) {
+        is PaymentMethodSaveConsentBehavior.Disabled -> overrideAllowRedisplay
+        is PaymentMethodSaveConsentBehavior.Enabled, PaymentMethodSaveConsentBehavior.Legacy -> null
+    }

--- a/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
@@ -138,7 +138,7 @@ internal class DefaultLinkConfirmationHandler @Inject constructor(
         val confirmationOption = if (configuration.passthroughModeEnabled) {
             LinkPassthroughConfirmationOption(
                 paymentDetailsId = paymentDetails.id,
-                expectedPaymentMethodType = computeExpectedPaymentMethodType(configuration, paymentDetails),
+                expectedPaymentMethodType = paymentMethodType,
                 cvc = cvc,
                 billingPhone = billingPhone,
                 allowRedisplay = allowRedisplay,

--- a/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
@@ -290,11 +290,15 @@ internal class LinkApiRepository @Inject constructor(
         expectedPaymentMethodType: String,
         billingPhone: String?,
         cvc: String?,
+        allowRedisplay: String?,
     ): Result<SharePaymentDetails> = withContext(workContext) {
         val fraudParams = fraudDetectionDataRepository.getCached()?.params.orEmpty()
         val paymentMethodParams = mapOf("expand" to listOf("payment_method"))
         val optionsParams = cvc?.let {
             mapOf("payment_method_options" to mapOf("card" to mapOf("cvc" to it)))
+        } ?: emptyMap()
+        val allowRedisplayParams = allowRedisplay?.let {
+            mapOf("allow_redisplay" to allowRedisplay)
         } ?: emptyMap()
 
         consumersApiService.sharePaymentDetails(
@@ -303,7 +307,7 @@ internal class LinkApiRepository @Inject constructor(
             expectedPaymentMethodType = expectedPaymentMethodType,
             requestOptions = buildRequestOptions(),
             requestSurface = requestSurface.value,
-            extraParams = paymentMethodParams + fraudParams + optionsParams,
+            extraParams = paymentMethodParams + fraudParams + optionsParams + allowRedisplayParams,
             billingPhone = billingPhone,
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
@@ -114,6 +114,7 @@ internal interface LinkRepository {
         expectedPaymentMethodType: String,
         billingPhone: String?,
         cvc: String?,
+        allowRedisplay: String?,
     ): Result<SharePaymentDetails>
 
     suspend fun createPaymentMethod(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkPassthroughConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkPassthroughConfirmationDefinition.kt
@@ -87,6 +87,7 @@ internal class LinkPassthroughConfirmationDefinition @Inject constructor(
             expectedPaymentMethodType = confirmationOption.expectedPaymentMethodType,
             billingPhone = confirmationOption.billingPhone,
             cvc = confirmationOption.cvc,
+            allowRedisplay = confirmationOption.allowRedisplay?.value,
         ).mapCatching {
             requireNotNull(it.encodedPaymentMethod.parsePaymentMethod())
         }.map { paymentMethod ->

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkPassthroughConfirmationOption.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkPassthroughConfirmationOption.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentelement.confirmation.link
 
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import kotlinx.parcelize.Parcelize
 
@@ -9,4 +10,5 @@ internal data class LinkPassthroughConfirmationOption(
     val expectedPaymentMethodType: String,
     val cvc: String?,
     val billingPhone: String?,
+    val allowRedisplay: PaymentMethod.AllowRedisplay? = null,
 ) : ConfirmationHandler.Option

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -645,7 +645,8 @@ internal class DefaultPaymentElementLoader @Inject constructor(
             allowUserEmailEdits = configuration.link.allowUserEmailEdits,
             skipWalletInFlowController = elementsSession.linkMobileSkipWalletInFlowController,
             customerId = elementsSession.customer?.session?.customerId,
-            linkAppearance = linkAppearance
+            linkAppearance = linkAppearance,
+            saveConsentBehavior = elementsSession.toPaymentSheetSaveConsentBehavior(),
         )
 
         // CBF isn't currently supported in the web flow.

--- a/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
@@ -230,7 +230,8 @@ internal object TestFactory {
         linkAppearance = null,
         linkSignUpOptInFeatureEnabled = false,
         linkSignUpOptInInitialValue = false,
-        customerId = null
+        customerId = null,
+        saveConsentBehavior = PaymentMethodSaveConsentBehavior.Disabled(null),
     )
 
     val LINK_WALLET_PRIMARY_BUTTON_LABEL = Amount(

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/FakeLinkAccountManager.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/FakeLinkAccountManager.kt
@@ -221,7 +221,8 @@ internal open class FakeLinkAccountManager(
         paymentDetailsId: String,
         expectedPaymentMethodType: String,
         cvc: String?,
-        billingPhone: String?
+        billingPhone: String?,
+        allowRedisplay: String?,
     ): Result<SharePaymentDetails> {
         return sharePaymentDetails
     }

--- a/paymentsheet/src/test/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandlerTest.kt
@@ -80,6 +80,7 @@ internal class DefaultLinkConfirmationHandlerTest {
                     country = "US",
                 ),
             ),
+            allowRedisplay = PaymentMethod.AllowRedisplay.UNSPECIFIED,
         )
     }
 
@@ -120,6 +121,7 @@ internal class DefaultLinkConfirmationHandlerTest {
                     country = "US",
                 ),
             ),
+            allowRedisplay = PaymentMethod.AllowRedisplay.LIMITED,
         )
     }
 
@@ -234,6 +236,7 @@ internal class DefaultLinkConfirmationHandlerTest {
                     country = "US",
                 ),
             ),
+            allowRedisplay = PaymentMethod.AllowRedisplay.UNSPECIFIED,
         )
     }
 
@@ -516,6 +519,7 @@ internal class DefaultLinkConfirmationHandlerTest {
         linkAccount: LinkAccount,
         cvc: String?,
         billingDetails: PaymentMethod.BillingDetails?,
+        allowRedisplay: PaymentMethod.AllowRedisplay?,
     ) {
         assertThat(intent).isEqualTo(configuration.stripeIntent)
         val option = confirmationOption as PaymentMethodConfirmationOption.New
@@ -525,6 +529,7 @@ internal class DefaultLinkConfirmationHandlerTest {
                 consumerSessionClientSecret = linkAccount.clientSecret,
                 extraParams = cvc?.let { mapOf("card" to mapOf("cvc" to cvc)) },
                 billingDetails = billingDetails,
+                allowRedisplay = allowRedisplay,
             )
         )
         assertThat(shippingDetails).isEqualTo(configuration.shippingDetails)

--- a/paymentsheet/src/test/java/com/stripe/android/link/repositories/FakeLinkRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/repositories/FakeLinkRepository.kt
@@ -150,7 +150,8 @@ internal open class FakeLinkRepository : LinkRepository {
         paymentDetailsId: String,
         expectedPaymentMethodType: String,
         cvc: String?,
-        billingPhone: String?
+        billingPhone: String?,
+        allowRedisplay: String?,
     ) = sharePaymentDetails
 
     override suspend fun createPaymentMethod(

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenStateTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.link.ui.signup
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.link.LinkConfiguration
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.model.LinkMode
 import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -106,7 +107,8 @@ class SignUpScreenStateTest {
             linkSignUpOptInFeatureEnabled = false,
             linkSignUpOptInInitialValue = false,
             skipWalletInFlowController = false,
-            customerId = null
+            customerId = null,
+            saveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -2084,7 +2084,8 @@ internal class PaymentMethodMetadataTest {
             linkAppearance = null,
             linkSignUpOptInFeatureEnabled = false,
             linkSignUpOptInInitialValue = false,
-            customerId = null
+            customerId = null,
+            saveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElementTest.kt
@@ -25,6 +25,7 @@ import com.stripe.android.link.ui.inline.LINK_INLINE_SIGNUP_REMAINING_FIELDS_TES
 import com.stripe.android.link.ui.inline.LinkSignupMode
 import com.stripe.android.link.ui.inline.SignUpConsentAction
 import com.stripe.android.link.ui.inline.UserInput
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.model.ConsumerSession
 import com.stripe.android.model.LinkMode
 import com.stripe.android.model.PaymentMethodCreateParams
@@ -160,7 +161,8 @@ class LinkFormElementTest {
             linkAppearance = null,
             linkSignUpOptInFeatureEnabled = false,
             linkSignUpOptInInitialValue = false,
-            customerId = null
+            customerId = null,
+            saveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
@@ -10,6 +10,7 @@ import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.link.ui.inline.SignUpConsentAction
 import com.stripe.android.link.ui.inline.UserInput
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilter
 import com.stripe.android.model.Address
 import com.stripe.android.model.CardBrand
@@ -622,7 +623,8 @@ class ConfirmationHandlerOptionKtxTest {
             linkAppearance = null,
             linkSignUpOptInFeatureEnabled = false,
             linkSignUpOptInInitialValue = false,
-            customerId = null
+            customerId = null,
+            saveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
@@ -18,6 +18,7 @@ import com.stripe.android.link.injection.LinkComponent
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.ui.inline.SignUpConsentAction
 import com.stripe.android.link.ui.inline.UserInput
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.CardParams
 import com.stripe.android.model.ConfirmPaymentIntentParams
@@ -703,7 +704,8 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
                 linkAppearance = null,
                 linkSignUpOptInFeatureEnabled = false,
                 linkSignUpOptInInitialValue = false,
-                customerId = null
+                customerId = null,
+                saveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
             ),
             userInput = userInput,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
@@ -5,6 +5,7 @@ import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.core.model.CountryCode
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkPaymentDetails
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.CvcCheck
@@ -96,7 +97,8 @@ internal object LinkTestUtils {
             linkSignUpOptInFeatureEnabled = false,
             linkSignUpOptInInitialValue = false,
             skipWalletInFlowController = false,
-            customerId = null
+            customerId = null,
+            saveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
         )
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request uses the `payment_method_save_allow_redisplay_override` field for payment methods confirmed through the Link wallet.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
