### PR TITLE
Reduce the number of autocomplete characters required.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModel.kt
@@ -180,7 +180,7 @@ internal class AutocompleteViewModel @Inject constructor(
                 queryFlow.collect { query ->
                     query?.let {
                         searchJob?.cancel()
-                        if (query.length > MIN_CHARS_AUTOCOMPLETE) {
+                        if (query.length >= MIN_CHARS_AUTOCOMPLETE) {
                             searchJob = launch {
                                 delay(SEARCH_DEBOUNCE_MS)
                                 if (isActive) {
@@ -265,6 +265,6 @@ internal class AutocompleteViewModel @Inject constructor(
     companion object {
         const val SEARCH_DEBOUNCE_MS = 400L
         const val MAX_DISPLAYED_RESULTS = 4
-        const val MIN_CHARS_AUTOCOMPLETE = 3
+        const val MIN_CHARS_AUTOCOMPLETE = 2
     }
 }


### PR DESCRIPTION
# Summary
Reduce the number of autocomplete characters required.

# Motivation
Needed to enter 4 characters before a search was performed. 4 felt like too many characters for users to have to enter. There exists a large number of 2-digit/3-digit home numbers which can be used to query. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified