### PR TITLE
[lc] Update PaymentMethodPreview icons and interface

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/LinkControllerUi.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/LinkControllerUi.kt
@@ -47,11 +47,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
 import com.stripe.android.link.LinkController
 import com.stripe.android.paymentsheet.example.samples.ui.shared.PaymentSheetExampleTheme
 import com.stripe.android.ui.core.R
@@ -363,7 +365,7 @@ private fun PaymentMethodButton(
                 if (preview != null) {
                     Image(
                         modifier = Modifier.size(iconSize),
-                        painter = painterResource(preview.iconRes),
+                        painter = preview.iconPainter,
                         contentDescription = null,
                     )
                     Column(
@@ -376,16 +378,12 @@ private fun PaymentMethodButton(
                             text = preview.label,
                             style = MaterialTheme.typography.h6,
                         )
-                        preview.sublabel?.let { sublabel ->
-                            Text(
-                                modifier = Modifier.padding(top = 2.dp),
-                                text = sublabel,
-                                style = MaterialTheme.typography.body2,
-                                color = MaterialTheme.colors.onSurface.copy(
-                                    alpha = 0.6f
-                                ),
-                            )
-                        }
+                        Text(
+                            modifier = Modifier.padding(top = 2.dp),
+                            text = preview.sublabel,
+                            style = MaterialTheme.typography.body2,
+                            color = MaterialTheme.colors.onSurface.copy(alpha = 0.6f),
+                        )
                     }
                 } else {
                     Icon(
@@ -419,6 +417,7 @@ private fun PaymentMethodButton(
 @Preview(showBackground = true)
 @Composable
 private fun PaymentMethodButtonPreview() {
+    val context = LocalContext.current
     PaymentSheetExampleTheme {
         Column {
             PaymentMethodButton(
@@ -429,9 +428,14 @@ private fun PaymentMethodButtonPreview() {
             PaymentMethodButton(
                 modifier = Modifier.padding(16.dp),
                 preview = LinkController.PaymentMethodPreview(
+                    imageLoader = {
+                        ContextCompat.getDrawable(
+                            context,
+                            com.stripe.android.paymentsheet.R.drawable.stripe_ic_paymentsheet_link_arrow,
+                        )!!
+                    },
                     label = "Link",
                     sublabel = "Visa (Personal) •••• 4242",
-                    iconRes = com.stripe.android.paymentsheet.R.drawable.stripe_ic_paymentsheet_link_arrow,
                 ),
                 onClick = {},
             )

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -384,22 +384,6 @@ public final class com/stripe/android/link/LinkController$LinkAccount$Creator : 
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/stripe/android/link/LinkController$PaymentMethodPreview$Creator : android/os/Parcelable$Creator {
-	public fun <init> ()V
-	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/link/LinkController$PaymentMethodPreview;
-	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
-	public final fun newArray (I)[Lcom/stripe/android/link/LinkController$PaymentMethodPreview;
-	public synthetic fun newArray (I)[Ljava/lang/Object;
-}
-
-public final class com/stripe/android/link/LinkController$State$Creator : android/os/Parcelable$Creator {
-	public fun <init> ()V
-	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/link/LinkController$State;
-	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
-	public final fun newArray (I)[Lcom/stripe/android/link/LinkController$State;
-	public synthetic fun newArray (I)[Ljava/lang/Object;
-}
-
 public final class com/stripe/android/link/LinkLaunchMode$Authentication$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/link/LinkLaunchMode$Authentication;

--- a/paymentsheet/src/main/java/com/stripe/android/common/ui/DelegateDrawable.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/ui/DelegateDrawable.kt
@@ -25,6 +25,11 @@ internal class DelegateDrawable(
 ) : Drawable() {
     @Volatile
     private var delegate: Drawable = ShapeDrawable()
+        .apply {
+            // Non-zero dimensions to avoid crashing before `delegate` has been initialized.
+            intrinsicHeight = 1
+            intrinsicWidth = 1
+        }
 
     init {
         @OptIn(DelicateCoroutinesApi::class)

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkController.kt
@@ -2,19 +2,24 @@ package com.stripe.android.link
 
 import android.app.Application
 import android.content.Context
+import android.graphics.drawable.Drawable
 import android.os.Parcelable
 import androidx.activity.ComponentActivity
-import androidx.annotation.DrawableRes
 import androidx.annotation.RestrictTo
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.common.configuration.ConfigurationDefaults
+import com.stripe.android.common.ui.DelegateDrawable
 import com.stripe.android.link.injection.DaggerLinkControllerComponent
 import com.stripe.android.link.injection.LinkControllerPresenterComponent
 import com.stripe.android.link.model.LinkAppearance
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.uicore.image.rememberDrawablePainter
 import dev.drewhamilton.poko.Poko
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -233,7 +238,6 @@ class LinkController @Inject internal constructor(
      * @param createdPaymentMethod The [PaymentMethod] created from the selected Link payment method, if any.
      */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    @Parcelize
     @Poko
     class State
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -243,7 +247,7 @@ class LinkController @Inject internal constructor(
         val internalLinkAccount: LinkAccount? = null,
         val selectedPaymentMethodPreview: PaymentMethodPreview? = null,
         val createdPaymentMethod: PaymentMethod? = null,
-    ) : Parcelable {
+    ) {
         /**
          * Whether the Link consumer account is verified. Null if no account is loaded.
          */
@@ -537,18 +541,33 @@ class LinkController @Inject internal constructor(
     /**
      * Preview information for a Link payment method.
      *
-     * @param iconRes The drawable resource ID for the payment method icon.
      * @param label The main label text (e.g., "Link").
-     * @param sublabel Additional descriptive text (e.g., "Card •••• 1234").
+     * @param sublabel Additional descriptive text (e.g., "Visa •••• 4242").
      */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    @Parcelize
     @Poko
-    class PaymentMethodPreview(
-        @DrawableRes val iconRes: Int,
+    class PaymentMethodPreview
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    constructor(
+        private val imageLoader: suspend () -> Drawable,
         val label: String,
-        val sublabel: String?
-    ) : Parcelable
+        val sublabel: String,
+    ) {
+        /**
+         * An image representing a payment method; e.g. the VISA logo.
+         */
+        @IgnoredOnParcel
+        val icon: Drawable by lazy {
+            DelegateDrawable(imageLoader)
+        }
+
+        /**
+         * An image representing a payment method; e.g. the VISA logo.
+         */
+        val iconPainter: Painter
+            @Composable
+            get() = rememberDrawablePainter(icon)
+    }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     companion object {

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
@@ -17,11 +17,17 @@ import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.link.model.toLoginState
 import com.stripe.android.link.ui.inline.SignUpConsentAction
 import com.stripe.android.link.ui.wallet.displayName
+import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.EmailSource
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.parsers.PaymentMethodJsonParser
 import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.paymentdatacollection.ach.TransformToBankIcon
 import com.stripe.android.paymentsheet.state.LinkState
+import com.stripe.android.paymentsheet.ui.getCardBrandIconForVerticalMode
+import com.stripe.android.paymentsheet.ui.getLinkIcon
+import com.stripe.android.uicore.image.StripeImageLoader
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -75,10 +81,12 @@ internal class LinkControllerInteractor @Inject constructor(
     val authenticationResultFlow = _authenticationResultFlow.asSharedFlow()
 
     fun state(context: Context): StateFlow<LinkController.State> {
+        val imageLoader = StripeImageLoader(context)
+        val iconLoader = PaymentSelection.IconLoader(context.resources, imageLoader)
         return combineAsStateFlow(_internalLinkAccount, _state) { account, state ->
             LinkController.State(
                 internalLinkAccount = account,
-                selectedPaymentMethodPreview = state.selectedPaymentMethod?.toPreview(context),
+                selectedPaymentMethodPreview = state.selectedPaymentMethod?.toPreview(context, iconLoader),
                 createdPaymentMethod = state.createdPaymentMethod,
             )
         }
@@ -417,16 +425,36 @@ internal class LinkControllerInteractor @Inject constructor(
         }
     }
 
-    private fun LinkPaymentMethod.toPreview(context: Context): LinkController.PaymentMethodPreview {
+    private fun LinkPaymentMethod.toPreview(
+        context: Context,
+        iconLoader: PaymentSelection.IconLoader
+    ): LinkController.PaymentMethodPreview {
+        val label = context.getString(com.stripe.android.R.string.stripe_link)
         val sublabel = buildString {
             append(details.displayName.resolve(context))
             append(" •••• ")
             append(details.last4)
         }
+        val drawableResourceId = when (val details = details) {
+            is ConsumerPaymentDetails.BankAccount -> {
+                TransformToBankIcon(bankName = details.bankName)
+            }
+            is ConsumerPaymentDetails.Card ->
+                details.brand.getCardBrandIconForVerticalMode()
+            is ConsumerPaymentDetails.Passthrough ->
+                getLinkIcon(iconOnly = true)
+        }
+
         return LinkController.PaymentMethodPreview(
-            iconRes = R.drawable.stripe_ic_paymentsheet_link_arrow,
-            label = context.getString(com.stripe.android.R.string.stripe_link),
-            sublabel = sublabel
+            imageLoader = {
+                iconLoader.load(
+                    drawableResourceId = drawableResourceId,
+                    lightThemeIconUrl = null,
+                    darkThemeIconUrl = null,
+                )
+            },
+            label = label,
+            sublabel = sublabel,
         )
     }
 


### PR DESCRIPTION
# Summary
Updates `LinkController.PaymentMethodPreview` to resemble `EmbeddedPaymentElement.PaymentOptionDisplayData` and return the PM icon instead of Link icon.

The bank icon isn't ideal, but we'll update in a follow-up.

# Motivation
👻 

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
https://github.com/user-attachments/assets/d3becc37-1b25-4d04-b29a-589c6e150ff7