### PR TITLE
Support terms display configuration for sepa family payment methods.

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestSepaDebit.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestSepaDebit.kt
@@ -22,6 +22,8 @@ import com.stripe.android.paymentsheet.example.playground.settings.GooglePaySett
 import com.stripe.android.paymentsheet.example.playground.settings.InitializationType
 import com.stripe.android.paymentsheet.example.playground.settings.InitializationTypeSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.PaymentMethodOptionsSetupFutureUsageOverrideSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.TermsDisplay
+import com.stripe.android.paymentsheet.example.playground.settings.TermsDisplaySettingsDefinition
 import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_OPTION_TEST_TAG
 import com.stripe.android.test.core.DEFAULT_UI_TIMEOUT
 import com.stripe.android.test.core.TestParameters
@@ -60,6 +62,7 @@ internal class TestSepaDebit : BasePlaygroundTest() {
             testParameters = testParameters.copyPlaygroundSettings { settings ->
                 settings[AutomaticPaymentMethodsSettingsDefinition] = true
                 settings[CheckoutModeSettingsDefinition] = CheckoutMode.PAYMENT_WITH_SETUP
+                settings[TermsDisplaySettingsDefinition] = TermsDisplay.NEVER_SEPA_FAMILY
             },
         ) {
             fillOutIban()

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/TermsDisplayDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/TermsDisplayDefinition.kt
@@ -63,4 +63,13 @@ enum class TermsDisplay(
             PaymentMethod.Type.AmazonPay to PaymentSheet.TermsDisplay.AUTOMATIC,
         )
     ),
+    NEVER_SEPA_FAMILY(
+        "Never Sepa Family",
+        mapOf(
+            PaymentMethod.Type.SepaDebit to PaymentSheet.TermsDisplay.NEVER,
+            PaymentMethod.Type.Ideal to PaymentSheet.TermsDisplay.NEVER,
+            PaymentMethod.Type.Bancontact to PaymentSheet.TermsDisplay.NEVER,
+            PaymentMethod.Type.Sofort to PaymentSheet.TermsDisplay.NEVER,
+        )
+    ),
 }

--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -6,11 +6,10 @@
     <ID>ConstructorParameterNaming:EmbeddedPaymentElement.kt$EmbeddedPaymentElement.PaymentOptionDisplayData$private val _shippingDetails: AddressDetails?</ID>
     <ID>ConstructorParameterNaming:PaymentOption.kt$PaymentOption$private val _labels: Labels</ID>
     <ID>ConstructorParameterNaming:PaymentOption.kt$PaymentOption$private val _shippingDetails: AddressDetails?</ID>
-    <ID>CyclomaticComplexMethod:CardDefinition.kt$CardUiDefinitionFactory$override fun createFormElements( metadata: PaymentMethodMetadata, arguments: UiDefinitionFactory.Arguments, ): List&lt;FormElement></ID>
     <ID>CyclomaticComplexMethod:CustomerSheetViewModel.kt$CustomerSheetViewModel$fun handleViewAction(viewAction: CustomerSheetViewAction)</ID>
-    <ID>CyclomaticComplexMethod:PlaceholderHelper.kt$PlaceholderHelper$@VisibleForTesting internal fun specForPlaceholderField( field: PlaceholderField, placeholderOverrideList: List&lt;IdentifierSpec>, requiresMandate: Boolean, configuration: PaymentSheet.BillingDetailsCollectionConfiguration, )</ID>
+    <ID>CyclomaticComplexMethod:PlaceholderHelper.kt$PlaceholderHelper$@VisibleForTesting internal fun specForPlaceholderField( field: PlaceholderField, placeholderOverrideList: List&lt;IdentifierSpec>, requiresMandate: Boolean, configuration: PaymentSheet.BillingDetailsCollectionConfiguration, termsDisplay: PaymentSheet.TermsDisplay, )</ID>
     <ID>CyclomaticComplexMethod:TransformBankIconCodeToBankIcon.kt$internal fun transformBankIconCodeToBankIcon( iconCode: String?, fallbackIcon: Int, ): Int</ID>
-    <ID>CyclomaticComplexMethod:TransformSpecToElements.kt$TransformSpecToElements$fun transform( metadata: PaymentMethodMetadata?, specs: List&lt;FormItemSpec>, placeholderOverrideList: List&lt;IdentifierSpec> = emptyList(), ): List&lt;FormElement></ID>
+    <ID>CyclomaticComplexMethod:TransformSpecToElements.kt$TransformSpecToElements$fun transform( metadata: PaymentMethodMetadata?, specs: List&lt;FormItemSpec>, placeholderOverrideList: List&lt;IdentifierSpec> = emptyList(), termsDisplay: PaymentSheet.TermsDisplay, ): List&lt;FormElement></ID>
     <ID>EmptyFunctionBlock:PrimaryButtonAnimator.kt$PrimaryButtonAnimator.&lt;no name provided>${ }</ID>
     <ID>EmptyFunctionBlock:VerticalModeFormUITest.kt$VerticalModeFormUITest.&lt;no name provided>${}</ID>
     <ID>FunctionNaming:PaymentSheetTopBar.kt$@Preview @Composable internal fun PaymentSheetTopBar_Preview()</ID>
@@ -58,6 +57,7 @@
     <ID>LongMethod:PaymentSheetViewModelTest.kt$PaymentSheetViewModelTest$@Test fun `Can complete payment after switching to another LPM from card selection with inline Link signup state`()</ID>
     <ID>LongMethod:PaymentSheetViewModelTest.kt$PaymentSheetViewModelTest$@Test fun `On inline link payment, should process with primary button`()</ID>
     <ID>LongMethod:PlaceholderHelperTest.kt$PlaceholderHelperTest$@Test fun `Test correct placeholder is removed for placeholder spec`()</ID>
+    <ID>LongMethod:PlaceholderHelperTest.kt$PlaceholderHelperTest$@Test fun `Test correct spec is returned for placeholder fields`()</ID>
     <ID>LongMethod:SignUpScreen.kt$@Composable internal fun SignUpBody( emailController: TextFieldController, phoneNumberController: PhoneNumberController, nameController: TextFieldController, signUpScreenState: SignUpScreenState, onSignUpClick: () -> Unit )</ID>
     <ID>LongMethod:USBankAccountForm.kt$@Composable private fun BankAccountDetails( bankName: String?, enabled: Boolean, last4: String?, promoBadgeState: PromoBadgeState?, onIconButtonClick: () -> Unit, )</ID>
     <ID>LongMethod:USBankAccountForm.kt$@Composable private fun BillingDetailsForm( instantDebits: Boolean, formArgs: FormArguments, enabled: Boolean, isPaymentFlow: Boolean, nameController: TextFieldController, emailController: TextFieldController, phoneController: PhoneNumberController, addressController: AddressController, lastTextFieldIdentifier: IdentifierSpec?, sameAsShippingElement: SameAsShippingElement?, )</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElements.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElements.kt
@@ -2,6 +2,7 @@ package com.stripe.android.lpmfoundations.luxe
 
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.forms.PlaceholderHelper.specsForConfiguration
 import com.stripe.android.paymentsheet.model.currency
 import com.stripe.android.ui.core.elements.AddressSpec
@@ -47,12 +48,14 @@ internal class TransformSpecToElements(
         metadata: PaymentMethodMetadata?,
         specs: List<FormItemSpec>,
         placeholderOverrideList: List<IdentifierSpec> = emptyList(),
+        termsDisplay: PaymentSheet.TermsDisplay,
     ): List<FormElement> {
         return specsForConfiguration(
             configuration = arguments.billingDetailsCollectionConfiguration,
             placeholderOverrideList = placeholderOverrideList,
             requiresMandate = arguments.requiresMandate,
             specs = specs,
+            termsDisplay = termsDisplay,
         ).flatMap { spec ->
             when (spec) {
                 is StaticTextSpec -> listOf(spec.transform())

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -78,8 +78,17 @@ internal data class PaymentMethodMetadata(
         }
     }
 
-    fun mandateAllowed(paymentMethodType: PaymentMethod.Type): Boolean {
+    fun mandateAllowed(paymentMethodType: PaymentMethod.Type?): Boolean {
         return termsDisplay[paymentMethodType] != PaymentSheet.TermsDisplay.NEVER
+    }
+
+    fun termsDisplayForCode(paymentMethodCode: String): PaymentSheet.TermsDisplay {
+        val paymentMethodDefinition = PaymentMethodRegistry.definitionsByCode[paymentMethodCode]
+        return termsDisplayForType(paymentMethodDefinition?.type)
+    }
+
+    fun termsDisplayForType(paymentMethodType: PaymentMethod.Type?): PaymentSheet.TermsDisplay {
+        return termsDisplay[paymentMethodType] ?: PaymentSheet.TermsDisplay.AUTOMATIC
     }
 
     fun requiresMandate(paymentMethodCode: String): Boolean {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionFactory.kt
@@ -133,6 +133,7 @@ internal sealed interface UiDefinitionFactory {
             return transformSpecToElements.transform(
                 metadata = metadata,
                 specs = sharedDataSpec.fields,
+                termsDisplay = metadata.termsDisplayForCode(sharedDataSpec.type),
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AmazonPayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AmazonPayDefinition.kt
@@ -56,6 +56,7 @@ private object AmazonPayUiDefinitionFactory : UiDefinitionFactory.RequiresShared
         return transformSpecToElements.transform(
             metadata = metadata,
             specs = sharedDataSpec.fields + localLayoutSpecs,
+            termsDisplay = metadata.termsDisplayForType(AmazonPayDefinition.type),
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BacsDebitDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BacsDebitDefinition.kt
@@ -78,7 +78,8 @@ private object BacsDebitUiDefinitionFactory : UiDefinitionFactory.RequiresShared
                 IdentifierSpec.Name,
                 IdentifierSpec.Email,
                 IdentifierSpec.BillingAddress
-            )
+            ),
+            termsDisplay = metadata.termsDisplayForType(BacsDebitDefinition.type),
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BancontactDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BancontactDefinition.kt
@@ -17,6 +17,8 @@ internal object BancontactDefinition : PaymentMethodDefinition {
 
     override val supportedAsSavedPaymentMethod: Boolean = false
 
+    override val supportsTermDisplayConfiguration: Boolean = true
+
     override fun requirementsToBeUsedAsNewPaymentMethod(
         hasIntentToSetup: Boolean
     ): Set<AddPaymentMethodRequirement> = setOfNotNull(
@@ -52,7 +54,8 @@ private object BancontactUiDefinitionFactory : UiDefinitionFactory.RequiresShare
                 listOf(IdentifierSpec.Name, IdentifierSpec.Email)
             } else {
                 emptyList()
-            }
+            },
+            termsDisplay = metadata.termsDisplayForType(BancontactDefinition.type),
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CashAppPayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CashAppPayDefinition.kt
@@ -54,7 +54,8 @@ private object CashAppPayUiDefinitionFactory : UiDefinitionFactory.RequiresShare
         }
         return transformSpecToElements.transform(
             metadata = metadata,
-            specs = sharedDataSpec.fields + localLayoutSpecs
+            specs = sharedDataSpec.fields + localLayoutSpecs,
+            termsDisplay = metadata.termsDisplayForType(CashAppPayDefinition.type),
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/IdealDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/IdealDefinition.kt
@@ -17,6 +17,8 @@ internal object IdealDefinition : PaymentMethodDefinition {
 
     override val supportedAsSavedPaymentMethod: Boolean = false
 
+    override val supportsTermDisplayConfiguration: Boolean = true
+
     override fun requirementsToBeUsedAsNewPaymentMethod(
         hasIntentToSetup: Boolean
     ): Set<AddPaymentMethodRequirement> = setOfNotNull(
@@ -53,6 +55,7 @@ private object IdealUiDefinitionFactory : UiDefinitionFactory.RequiresSharedData
             } else {
                 emptyList()
             },
+            termsDisplay = metadata.termsDisplayForType(IdealDefinition.type),
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KlarnaDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KlarnaDefinition.kt
@@ -56,7 +56,8 @@ private object KlarnaUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDat
         }
         return transformSpecToElements.transform(
             metadata = metadata,
-            specs = sharedDataSpec.fields + localLayoutSpecs
+            specs = sharedDataSpec.fields + localLayoutSpecs,
+            termsDisplay = metadata.termsDisplayForType(KlarnaDefinition.type),
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/PayPalDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/PayPalDefinition.kt
@@ -57,6 +57,7 @@ private object PayPalUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDat
         return transformSpecToElements.transform(
             metadata = metadata,
             specs = sharedDataSpec.fields + localLayoutSpecs,
+            termsDisplay = metadata.termsDisplayForType(PayPalDefinition.type),
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/RevolutPayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/RevolutPayDefinition.kt
@@ -57,6 +57,7 @@ private object RevolutPayUiDefinitionFactory : UiDefinitionFactory.RequiresShare
         return transformSpecToElements.transform(
             metadata = metadata,
             specs = sharedDataSpec.fields + localLayoutSpecs,
+            termsDisplay = metadata.termsDisplayForType(RevolutPayDefinition.type),
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SatispayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SatispayDefinition.kt
@@ -54,7 +54,8 @@ private object SatispayUiDefinitionFactory : UiDefinitionFactory.RequiresSharedD
         }
         return transformSpecToElements.transform(
             metadata = metadata,
-            specs = sharedDataSpec.fields + localLayoutSpecs
+            specs = sharedDataSpec.fields + localLayoutSpecs,
+            termsDisplay = metadata.termsDisplayForType(SatispayDefinition.type),
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SepaDebitDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SepaDebitDefinition.kt
@@ -19,6 +19,8 @@ internal object SepaDebitDefinition : PaymentMethodDefinition {
 
     override val supportedAsSavedPaymentMethod: Boolean = true
 
+    override val supportsTermDisplayConfiguration: Boolean = true
+
     override fun requirementsToBeUsedAsNewPaymentMethod(
         hasIntentToSetup: Boolean
     ): Set<AddPaymentMethodRequirement> = setOf(

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SofortDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SofortDefinition.kt
@@ -17,6 +17,8 @@ internal object SofortDefinition : PaymentMethodDefinition {
 
     override val supportedAsSavedPaymentMethod: Boolean = false
 
+    override val supportsTermDisplayConfiguration: Boolean = true
+
     override fun requirementsToBeUsedAsNewPaymentMethod(
         hasIntentToSetup: Boolean
     ): Set<AddPaymentMethodRequirement> = setOf(
@@ -52,7 +54,8 @@ private object SofortUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDat
                 listOf(IdentifierSpec.Name, IdentifierSpec.Email)
             } else {
                 emptyList()
-            }
+            },
+            termsDisplay = metadata.termsDisplayForType(SofortDefinition.type),
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
@@ -471,8 +471,6 @@ class EmbeddedPaymentElement @Inject internal constructor(
             /**
              * A map for specifying when legal agreements are displayed for each payment method type.
              * If the payment method is not specified in the list, the TermsDisplay value will default to automatic.
-             *
-             * Valid payment method types include: amazon_pay, card, cashapp, klarna, paypal, revolut_pay, satispay.
              */
             fun termsDisplay(termsDisplay: Map<PaymentMethod.Type, TermsDisplay>) = apply {
                 this.termsDisplay = termsDisplay

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -1121,8 +1121,6 @@ class PaymentSheet internal constructor(
             /**
              * A map for specifying when legal agreements are displayed for each payment method type.
              * If the payment method is not specified in the list, the TermsDisplay value will default to automatic.
-             *
-             * Valid payment method types include: amazon_pay, card, cashapp, klarna, paypal, revolut_pay, satispay.
              */
             fun termsDisplay(termsDisplay: Map<PaymentMethod.Type, TermsDisplay>) = apply {
                 this.termsDisplay = termsDisplay

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/PlaceholderHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/PlaceholderHelper.kt
@@ -31,6 +31,7 @@ internal object PlaceholderHelper {
         placeholderOverrideList: List<IdentifierSpec>,
         requiresMandate: Boolean,
         configuration: PaymentSheet.BillingDetailsCollectionConfiguration,
+        termsDisplay: PaymentSheet.TermsDisplay,
     ): List<FormItemSpec> {
         val billingDetailsPlaceholders = mutableListOf(
             PlaceholderField.Name,
@@ -59,11 +60,16 @@ internal object PlaceholderHelper {
                 }
 
                 is PlaceholderSpec -> specForPlaceholderField(
-                    it.field,
-                    placeholderOverrideList,
-                    requiresMandate,
-                    configuration
+                    field = it.field,
+                    placeholderOverrideList = placeholderOverrideList,
+                    requiresMandate = requiresMandate,
+                    configuration = configuration,
+                    termsDisplay = termsDisplay,
                 )
+
+                is SepaMandateTextSpec -> it.takeUnless {
+                    termsDisplay == PaymentSheet.TermsDisplay.NEVER
+                }
 
                 else -> it
             }
@@ -71,10 +77,11 @@ internal object PlaceholderHelper {
             // Add additional fields that don't have a placeholder, if necessary.
             billingDetailsPlaceholders.mapNotNull {
                 specForPlaceholderField(
-                    it,
-                    placeholderOverrideList,
-                    requiresMandate,
-                    configuration
+                    field = it,
+                    placeholderOverrideList = placeholderOverrideList,
+                    requiresMandate = requiresMandate,
+                    configuration = configuration,
+                    termsDisplay = termsDisplay,
                 )
             }
         )
@@ -120,6 +127,7 @@ internal object PlaceholderHelper {
         placeholderOverrideList: List<IdentifierSpec>,
         requiresMandate: Boolean,
         configuration: PaymentSheet.BillingDetailsCollectionConfiguration,
+        termsDisplay: PaymentSheet.TermsDisplay,
     ) = when (field) {
         PlaceholderField.Name -> NameSpec().takeIf {
             configuration.name == CollectionMode.Always ||
@@ -163,7 +171,7 @@ internal object PlaceholderHelper {
             }
 
         PlaceholderField.SepaMandate -> SepaMandateTextSpec().takeIf {
-            requiresMandate
+            requiresMandate && termsDisplay != PaymentSheet.TermsDisplay.NEVER
         }
 
         else -> null

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -487,7 +487,7 @@ internal fun PaymentSelection.Saved.mandateTextFromPaymentMethodMetadata(
 ): ResolvableString? = mandateText(
     metadata.merchantName,
     metadata.hasIntentToSetup(paymentMethod.type?.code ?: "")
-)
+).takeIf { metadata.mandateAllowed(paymentMethod.type) }
 
 /**
  * If setup_future_usage is set at the top level to "off_session" the payment method will

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElementsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElementsTest.kt
@@ -71,8 +71,9 @@ internal class TransformSpecToElementsTest {
         runBlocking {
             val countrySection = CountrySpec(allowedCountryCodes = setOf("AT"))
             val formElement = transformSpecToElements.transform(
-                PaymentMethodMetadataFactory.create(),
-                listOf(countrySection),
+                metadata = PaymentMethodMetadataFactory.create(),
+                specs = listOf(element = countrySection),
+                termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
             )
 
             val countrySectionElement = formElement.first() as SectionElement
@@ -94,8 +95,9 @@ internal class TransformSpecToElementsTest {
         runBlocking {
             val idealSection = IDEAL_BANK_CONFIG
             val formElement = transformSpecToElements.transform(
-                PaymentMethodMetadataFactory.create(),
-                listOf(idealSection),
+                metadata = PaymentMethodMetadataFactory.create(),
+                specs = listOf(idealSection),
+                termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
             )
 
             val idealSectionElement = formElement.first() as SectionElement
@@ -112,8 +114,9 @@ internal class TransformSpecToElementsTest {
     @Test
     fun `Add a name section spec sets up the name element correctly`() = runBlocking {
         val formElement = transformSpecToElements.transform(
-            PaymentMethodMetadataFactory.create(),
-            listOf(nameSection),
+            metadata = PaymentMethodMetadataFactory.create(),
+            specs = listOf(nameSection),
+            termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
         )
 
         val nameElement = (formElement.first() as SectionElement)
@@ -134,8 +137,8 @@ internal class TransformSpecToElementsTest {
     @Test
     fun `Add a simple text section spec sets up the text element correctly`() = runBlocking {
         val formElement = transformSpecToElements.transform(
-            PaymentMethodMetadataFactory.create(),
-            listOf(
+            metadata = PaymentMethodMetadataFactory.create(),
+            specs = listOf(
                 SimpleTextSpec(
                     IdentifierSpec.Generic("simple"),
                     TranslationId.AddressName.resourceId,
@@ -144,6 +147,7 @@ internal class TransformSpecToElementsTest {
                     capitalization = Capitalization.Words
                 )
             ),
+            termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
         )
 
         val nameElement = (formElement.first() as SectionElement).fields[0]
@@ -160,8 +164,9 @@ internal class TransformSpecToElementsTest {
     @Test
     fun `Add a email section spec sets up the email element correctly`() = runBlocking {
         val formElement = transformSpecToElements.transform(
-            PaymentMethodMetadataFactory.create(),
-            listOf(emailSection),
+            metadata = PaymentMethodMetadataFactory.create(),
+            specs = listOf(emailSection),
+            termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
         )
 
         val emailSectionElement = formElement.first() as SectionElement
@@ -179,8 +184,9 @@ internal class TransformSpecToElementsTest {
             stringResId = R.string.stripe_sepa_mandate
         )
         val formElement = transformSpecToElements.transform(
-            PaymentMethodMetadataFactory.create(),
-            listOf(staticText),
+            metadata = PaymentMethodMetadataFactory.create(),
+            specs = listOf(staticText),
+            termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
         )
 
         val staticTextElement = formElement.first() as StaticTextElement
@@ -194,8 +200,9 @@ internal class TransformSpecToElementsTest {
     fun `Add a phone section spec sets up the phone element correctly`() = runBlocking {
         val phoneSpec = PhoneSpec()
         val formElement = transformSpecToElements.transform(
-            PaymentMethodMetadataFactory.create(),
-            listOf(phoneSpec),
+            metadata = PaymentMethodMetadataFactory.create(),
+            specs = listOf(phoneSpec),
+            termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
         )
 
         val phoneSectionElement = formElement.first() as SectionElement
@@ -216,8 +223,9 @@ internal class TransformSpecToElementsTest {
                 address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full
             )
         ).transform(
-            PaymentMethodMetadataFactory.create(),
-            listOf(placeholderSpec),
+            metadata = PaymentMethodMetadataFactory.create(),
+            specs = listOf(placeholderSpec),
+            termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
         )
 
         assertThat(formElement).hasSize(1)
@@ -238,8 +246,9 @@ internal class TransformSpecToElementsTest {
                 phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
             )
         ).transform(
-            PaymentMethodMetadataFactory.create(),
-            listOf(placeholderSpec),
+            metadata = PaymentMethodMetadataFactory.create(),
+            specs = listOf(placeholderSpec),
+            termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
         )
 
         assertThat(formElement).hasSize(1)
@@ -260,8 +269,9 @@ internal class TransformSpecToElementsTest {
                 name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
             )
         ).transform(
-            PaymentMethodMetadataFactory.create(),
-            listOf(placeholderSpec),
+            metadata = PaymentMethodMetadataFactory.create(),
+            specs = listOf(placeholderSpec),
+            termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
         )
 
         assertThat(formElement).hasSize(1)
@@ -282,8 +292,9 @@ internal class TransformSpecToElementsTest {
                 email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
             )
         ).transform(
-            PaymentMethodMetadataFactory.create(),
-            listOf(placeholderSpec),
+            metadata = PaymentMethodMetadataFactory.create(),
+            specs = listOf(placeholderSpec),
+            termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
         )
 
         assertThat(formElement).hasSize(1)
@@ -302,8 +313,9 @@ internal class TransformSpecToElementsTest {
         val formElement = TransformSpecToElementsFactory.create(
             requiresMandate = true
         ).transform(
-            PaymentMethodMetadataFactory.create(),
-            listOf(placeholderSpec),
+            metadata = PaymentMethodMetadataFactory.create(),
+            specs = listOf(placeholderSpec),
+            termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
         )
 
         assertThat(formElement).hasSize(1)
@@ -320,8 +332,9 @@ internal class TransformSpecToElementsTest {
         val formElement = TransformSpecToElementsFactory.create(
             requiresMandate = false
         ).transform(
-            PaymentMethodMetadataFactory.create(),
-            listOf(placeholderSpec),
+            metadata = PaymentMethodMetadataFactory.create(),
+            specs = listOf(placeholderSpec),
+            termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
         )
 
         assertThat(formElement).isEmpty()
@@ -335,8 +348,9 @@ internal class TransformSpecToElementsTest {
                 TestAutocompleteAddressInteractor.noOp()
             }
         ).transform(
-            PaymentMethodMetadataFactory.create(),
-            listOf(AddressSpec()),
+            metadata = PaymentMethodMetadataFactory.create(),
+            specs = listOf(AddressSpec()),
+            termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
         )
 
         assertThat(formElement).hasSize(1)

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -1895,6 +1895,13 @@ internal class PaymentMethodMetadataTest {
     }
 
     @Test
+    fun `mandateAllowed returns true when payment method is null`() {
+        val termsDisplay = mapOf(PaymentMethod.Type.USBankAccount to PaymentSheet.TermsDisplay.NEVER)
+        val metadata = PaymentMethodMetadataFactory.create(termsDisplay = termsDisplay)
+        assertThat(metadata.mandateAllowed(null)).isTrue()
+    }
+
+    @Test
     fun `mandateAllowed works with multiple payment method types`() {
         val termsDisplay = mapOf(
             PaymentMethod.Type.Card to PaymentSheet.TermsDisplay.NEVER,
@@ -1907,6 +1914,70 @@ internal class PaymentMethodMetadataTest {
         assertThat(metadata.mandateAllowed(PaymentMethod.Type.USBankAccount)).isTrue()
         assertThat(metadata.mandateAllowed(PaymentMethod.Type.CashAppPay)).isFalse()
         assertThat(metadata.mandateAllowed(PaymentMethod.Type.Klarna)).isTrue() // Not in map
+    }
+
+    @Test
+    fun termsDisplayForType_returnsConfiguredValues_whenPresentInMap() {
+        val metadata = PaymentMethodMetadataFactory.create(
+            termsDisplay = mapOf(
+                PaymentMethod.Type.Card to PaymentSheet.TermsDisplay.AUTOMATIC,
+                PaymentMethod.Type.Klarna to PaymentSheet.TermsDisplay.NEVER,
+            )
+        )
+
+        assertThat(metadata.termsDisplayForType(PaymentMethod.Type.Card))
+            .isEqualTo(PaymentSheet.TermsDisplay.AUTOMATIC)
+        assertThat(metadata.termsDisplayForType(PaymentMethod.Type.Klarna))
+            .isEqualTo(PaymentSheet.TermsDisplay.NEVER)
+    }
+
+    @Test
+    fun termsDisplayForType_returnsAutomatic_whenTypeMissingFromMap() {
+        val metadata = PaymentMethodMetadataFactory.create(
+            termsDisplay = mapOf(
+                PaymentMethod.Type.Card to PaymentSheet.TermsDisplay.AUTOMATIC,
+            )
+        )
+
+        assertThat(metadata.termsDisplayForType(PaymentMethod.Type.Ideal))
+            .isEqualTo(PaymentSheet.TermsDisplay.AUTOMATIC)
+    }
+
+    @Test
+    fun termsDisplayForType_returnsAutomatic_whenTypeIsNull() {
+        val metadata = PaymentMethodMetadataFactory.create(
+            termsDisplay = emptyMap()
+        )
+
+        assertThat(metadata.termsDisplayForType(null))
+            .isEqualTo(PaymentSheet.TermsDisplay.AUTOMATIC)
+    }
+
+    @Test
+    fun termsDisplayForCode_mapsCodeToType_andReturnsConfiguredValue() {
+        val metadata = PaymentMethodMetadataFactory.create(
+            termsDisplay = mapOf(
+                PaymentMethod.Type.Card to PaymentSheet.TermsDisplay.AUTOMATIC,
+                PaymentMethod.Type.Klarna to PaymentSheet.TermsDisplay.NEVER,
+            )
+        )
+
+        assertThat(metadata.termsDisplayForCode("card"))
+            .isEqualTo(PaymentSheet.TermsDisplay.AUTOMATIC)
+        assertThat(metadata.termsDisplayForCode("klarna"))
+            .isEqualTo(PaymentSheet.TermsDisplay.NEVER)
+    }
+
+    @Test
+    fun termsDisplayForCode_returnsAutomatic_forUnknownCode() {
+        val metadata = PaymentMethodMetadataFactory.create(
+            termsDisplay = mapOf(
+                PaymentMethod.Type.Card to PaymentSheet.TermsDisplay.AUTOMATIC,
+            )
+        )
+
+        assertThat(metadata.termsDisplayForCode("made_up_code"))
+            .isEqualTo(PaymentSheet.TermsDisplay.AUTOMATIC)
     }
 
     private fun availableWalletsTest(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/PlaceholderHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/PlaceholderHelperTest.kt
@@ -44,6 +44,7 @@ class PlaceholderHelperTest {
                 PhoneSpec(),
                 AddressSpec(),
             ),
+            termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
         )
         assertThat(specs).isEmpty()
     }
@@ -68,6 +69,7 @@ class PlaceholderHelperTest {
                 PlaceholderSpec(field = PlaceholderSpec.PlaceholderField.Phone),
                 PlaceholderSpec(field = PlaceholderSpec.PlaceholderField.BillingAddress),
             ),
+            termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
         )
         assertThat(specs).isEmpty()
     }
@@ -96,6 +98,7 @@ class PlaceholderHelperTest {
                     label = StripeR.string.stripe_affirm_buy_now_pay_later,
                 ),
             ),
+            termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
         )
 
         // Email should replace the placeholder, phone and address should be added at the end.
@@ -120,6 +123,7 @@ class PlaceholderHelperTest {
             specs = listOf(
                 NameSpec(),
             ),
+            termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
         )
 
         assertThat(specs).containsExactly(
@@ -134,6 +138,7 @@ class PlaceholderHelperTest {
                 NameSpec(),
                 SepaMandateTextSpec()
             ),
+            termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
         )
 
         assertThat(specsWithSepa).containsExactly(
@@ -151,11 +156,47 @@ class PlaceholderHelperTest {
                     field = PlaceholderSpec.PlaceholderField.SepaMandate,
                 )
             ),
+            termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
         )
 
         assertThat(specsWithSepaPlaceholder).containsExactly(
             NameSpec(),
             SepaMandateTextSpec()
+        )
+    }
+
+    @Test
+    fun `Test when termsDisplay=NEVER, SepaMandateSpec is not added`() {
+        val specsWithSepa = specsForConfiguration(
+            configuration = PaymentSheet.BillingDetailsCollectionConfiguration(),
+            placeholderOverrideList = emptyList(),
+            requiresMandate = true,
+            specs = listOf(
+                NameSpec(),
+                SepaMandateTextSpec()
+            ),
+            termsDisplay = PaymentSheet.TermsDisplay.NEVER,
+        )
+
+        assertThat(specsWithSepa).containsExactly(
+            NameSpec(),
+        )
+
+        val specsWithSepaPlaceholder = specsForConfiguration(
+            configuration = PaymentSheet.BillingDetailsCollectionConfiguration(),
+            placeholderOverrideList = emptyList(),
+            requiresMandate = true,
+            specs = listOf(
+                NameSpec(),
+                PlaceholderSpec(
+                    field = PlaceholderSpec.PlaceholderField.SepaMandate,
+                )
+            ),
+            termsDisplay = PaymentSheet.TermsDisplay.NEVER,
+        )
+
+        assertThat(specsWithSepaPlaceholder).containsExactly(
+            NameSpec(),
         )
     }
 
@@ -175,6 +216,7 @@ class PlaceholderHelperTest {
                 placeholderOverrideList = emptyList(),
                 requiresMandate = false,
                 configuration = billingDetailsCollectionConfiguration,
+                termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
             )
         ).isEqualTo(NameSpec())
         assertThat(
@@ -183,6 +225,7 @@ class PlaceholderHelperTest {
                 placeholderOverrideList = emptyList(),
                 requiresMandate = false,
                 configuration = billingDetailsCollectionConfiguration,
+                termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
             )
         ).isEqualTo(EmailSpec())
         assertThat(
@@ -191,6 +234,7 @@ class PlaceholderHelperTest {
                 placeholderOverrideList = emptyList(),
                 requiresMandate = false,
                 configuration = billingDetailsCollectionConfiguration,
+                termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
             )
         ).isEqualTo(PhoneSpec())
         assertThat(
@@ -199,6 +243,7 @@ class PlaceholderHelperTest {
                 placeholderOverrideList = emptyList(),
                 requiresMandate = false,
                 configuration = billingDetailsCollectionConfiguration,
+                termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
             )
         ).isEqualTo(AddressSpec())
         assertThat(
@@ -207,6 +252,7 @@ class PlaceholderHelperTest {
                 placeholderOverrideList = emptyList(),
                 requiresMandate = false,
                 configuration = billingDetailsCollectionConfiguration,
+                termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
             )
         ).isEqualTo(AddressSpec(hideCountry = true))
         assertThat(
@@ -215,6 +261,7 @@ class PlaceholderHelperTest {
                 placeholderOverrideList = emptyList(),
                 requiresMandate = true,
                 configuration = billingDetailsCollectionConfiguration,
+                termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
             )
         ).isEqualTo(SepaMandateTextSpec())
     }
@@ -235,6 +282,7 @@ class PlaceholderHelperTest {
                 placeholderOverrideList = emptyList(),
                 requiresMandate = false,
                 configuration = billingDetailsCollectionConfiguration,
+                termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
             )
         ).isNull()
         assertThat(
@@ -243,6 +291,7 @@ class PlaceholderHelperTest {
                 placeholderOverrideList = emptyList(),
                 requiresMandate = false,
                 configuration = billingDetailsCollectionConfiguration,
+                termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
             )
         ).isNull()
         assertThat(
@@ -251,6 +300,7 @@ class PlaceholderHelperTest {
                 placeholderOverrideList = emptyList(),
                 requiresMandate = false,
                 configuration = billingDetailsCollectionConfiguration,
+                termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
             )
         ).isNull()
         assertThat(
@@ -259,6 +309,7 @@ class PlaceholderHelperTest {
                 placeholderOverrideList = emptyList(),
                 requiresMandate = false,
                 configuration = billingDetailsCollectionConfiguration,
+                termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
             )
         ).isNull()
         assertThat(
@@ -267,6 +318,7 @@ class PlaceholderHelperTest {
                 placeholderOverrideList = emptyList(),
                 requiresMandate = false,
                 configuration = billingDetailsCollectionConfiguration,
+                termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
             )
         ).isNull()
     }
@@ -399,6 +451,7 @@ class PlaceholderHelperTest {
                 placeholderOverrideList = emptyList(),
                 requiresMandate = false,
                 configuration = PaymentSheet.BillingDetailsCollectionConfiguration(),
+                termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
             )
         ).isNull()
         assertThat(
@@ -407,6 +460,7 @@ class PlaceholderHelperTest {
                 placeholderOverrideList = emptyList(),
                 requiresMandate = true,
                 configuration = PaymentSheet.BillingDetailsCollectionConfiguration(),
+                termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
             )
         ).isInstanceOf<
             SepaMandateTextSpec
@@ -429,6 +483,7 @@ class PlaceholderHelperTest {
                 placeholderOverrideList = listOf(IdentifierSpec.Name),
                 requiresMandate = false,
                 configuration = billingDetailsCollectionConfiguration,
+                termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
             )
         ).isInstanceOf<
             NameSpec
@@ -439,6 +494,7 @@ class PlaceholderHelperTest {
                 placeholderOverrideList = listOf(IdentifierSpec.Email),
                 requiresMandate = false,
                 configuration = billingDetailsCollectionConfiguration,
+                termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
             )
         ).isInstanceOf<
             EmailSpec
@@ -449,6 +505,7 @@ class PlaceholderHelperTest {
                 placeholderOverrideList = listOf(IdentifierSpec.Phone),
                 requiresMandate = false,
                 configuration = billingDetailsCollectionConfiguration,
+                termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
             )
         ).isInstanceOf<
             PhoneSpec
@@ -459,6 +516,7 @@ class PlaceholderHelperTest {
                 placeholderOverrideList = listOf(IdentifierSpec.Generic("billing_details[address]")),
                 requiresMandate = false,
                 configuration = billingDetailsCollectionConfiguration,
+                termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
             )
         ).isInstanceOf<
             AddressSpec
@@ -488,6 +546,7 @@ class PlaceholderHelperTest {
                 exampleTextSpec,
                 mandateTextSpec,
             ),
+            termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
         )
 
         assertThat(specs).containsExactly(
@@ -523,6 +582,7 @@ class PlaceholderHelperTest {
                 exampleTextSpec,
                 mandateTextSpec,
             ),
+            termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
         )
 
         assertThat(specs).containsExactly(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentSelectionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentSelectionTest.kt
@@ -13,6 +13,7 @@ import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.CvcCheck
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountTextBuilder
 import com.stripe.android.testing.PaymentMethodFactory
 import org.junit.Test
@@ -239,6 +240,22 @@ class PaymentSelectionTest {
                 isSetupFlow = true
             )
         )
+    }
+
+    @Test
+    fun `mandateTextFromPaymentMethodMetadata returns mandate for Saved SepaDebit`() {
+        val selection = PaymentSelection.Saved(PaymentMethodFactory.sepaDebit())
+        val metadata = PaymentMethodMetadataFactory.create()
+        assertThat(selection.mandateTextFromPaymentMethodMetadata(metadata)).isNotNull()
+    }
+
+    @Test
+    fun `mandateTextFromPaymentMethodMetadata returns correct mandate for Saved SepaDebit with TermsDisplay=NEVER`() {
+        val selection = PaymentSelection.Saved(PaymentMethodFactory.sepaDebit())
+        val metadata = PaymentMethodMetadataFactory.create(
+            termsDisplay = mapOf(PaymentMethod.Type.SepaDebit to PaymentSheet.TermsDisplay.NEVER)
+        )
+        assertThat(selection.mandateTextFromPaymentMethodMetadata(metadata)).isNull()
     }
 
     @Test


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Adds support for hiding terms display for sepa family payment methods.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-3929

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

