### PR TITLE
Fix hCaptcha memory leak

### DIFF
--- a/hcaptcha/src/main/java/com/stripe/hcaptcha/HCaptcha.kt
+++ b/hcaptcha/src/main/java/com/stripe/hcaptcha/HCaptcha.kt
@@ -48,6 +48,7 @@ interface IHCaptcha {
     /**
      * Constructs a new client which allows to display a challenge dialog
      *
+     * @param activity The FragmentActivity context required for starting the challenge
      * @param config Config to customize: size, theme, locale, endpoint, rqdata, etc.
      * @return new [HCaptcha] object
      */
@@ -60,6 +61,7 @@ interface IHCaptcha {
      * Presents a captcha challenge. Depending on the configuration passed in setup, this will be either a passive
      * challenge or a dialog to be completed by the user.
      *
+     * @param activity The FragmentActivity context required for starting the challenge
      * @return [HCaptcha]
      */
     fun verifyWithHCaptcha(activity: FragmentActivity): HCaptcha?

--- a/hcaptcha/src/main/java/com/stripe/hcaptcha/HCaptcha.kt
+++ b/hcaptcha/src/main/java/com/stripe/hcaptcha/HCaptcha.kt
@@ -51,7 +51,10 @@ interface IHCaptcha {
      * @param config Config to customize: size, theme, locale, endpoint, rqdata, etc.
      * @return new [HCaptcha] object
      */
-    fun setup(config: HCaptchaConfig): HCaptcha?
+    fun setup(
+        activity: FragmentActivity,
+        config: HCaptchaConfig
+    ): HCaptcha?
 
     /**
      * Presents a captcha challenge. Depending on the configuration passed in setup, this will be either a passive
@@ -59,7 +62,7 @@ interface IHCaptcha {
      *
      * @return [HCaptcha]
      */
-    fun verifyWithHCaptcha(): HCaptcha?
+    fun verifyWithHCaptcha(activity: FragmentActivity): HCaptcha?
 
     /**
      * Force stop verification and release resources.
@@ -69,12 +72,11 @@ interface IHCaptcha {
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class HCaptcha private constructor(
-    private val activity: FragmentActivity,
-    private val internalConfig: HCaptchaInternalConfig
+    private val internalConfig: HCaptchaInternalConfig,
 ) : Task<HCaptchaTokenResponse>(), IHCaptcha {
     private var captchaVerifier: IHCaptchaVerifier? = null
 
-    override fun setup(config: HCaptchaConfig): HCaptcha {
+    override fun setup(activity: FragmentActivity, config: HCaptchaConfig): HCaptcha {
         val listener = HCaptchaStateListener(
             onOpen = { captchaOpened() },
             onSuccess = { token ->
@@ -102,7 +104,7 @@ class HCaptcha private constructor(
         return this
     }
 
-    override fun verifyWithHCaptcha(): HCaptcha {
+    override fun verifyWithHCaptcha(activity: FragmentActivity): HCaptcha? {
         val captchaVerifier = captchaVerifier
             ?: // Cold start at verification time.
             throw IllegalStateException("verifyWithHCaptcha must not be called before setup.")
@@ -112,6 +114,7 @@ class HCaptcha private constructor(
     }
 
     override fun reset() {
+        removeAllListeners()
         captchaVerifier?.let {
             it.reset()
             captchaVerifier = null
@@ -123,14 +126,12 @@ class HCaptcha private constructor(
         /**
          * Constructs a new client which allows to display a challenge dialog
          *
-         * @param activity The current activity
          * @return new [HCaptcha] object
          */
         fun getClient(
-            activity: FragmentActivity,
             internalConfig: HCaptchaInternalConfig = HCaptchaInternalConfig()
         ): HCaptcha {
-            return HCaptcha(activity, internalConfig)
+            return HCaptcha(internalConfig)
         }
     }
 }

--- a/hcaptcha/src/main/java/com/stripe/hcaptcha/webview/HCaptchaWebViewHelper.kt
+++ b/hcaptcha/src/main/java/com/stripe/hcaptcha/webview/HCaptchaWebViewHelper.kt
@@ -28,7 +28,7 @@ import com.stripe.hcaptcha.config.HCaptchaInternalConfig
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 internal class HCaptchaWebViewHelper(
     handler: Handler,
-    private val context: Context,
+    context: Context,
     internal val config: HCaptchaConfig,
     private val internalConfig: HCaptchaInternalConfig,
     private val captchaVerifier: IHCaptchaVerifier,
@@ -36,7 +36,7 @@ internal class HCaptchaWebViewHelper(
     internal val webView: WebView
 ) {
     init {
-        setupWebView(handler)
+        setupWebView(context, handler)
     }
 
     /**
@@ -45,7 +45,7 @@ internal class HCaptchaWebViewHelper(
      * * loads custom html page to display challenge and/or checkbox
      */
     @SuppressLint("SetJavaScriptEnabled", "AddJavascriptInterface")
-    private fun setupWebView(handler: Handler) {
+    private fun setupWebView(context: Context, handler: Handler) {
         val jsInterface = HCaptchaJSInterface(handler, config, captchaVerifier)
         val debugInfo = HCaptchaDebugInfo(context)
 

--- a/payments-core/src/main/java/com/stripe/android/hcaptcha/DefaultHCaptchaService.kt
+++ b/payments-core/src/main/java/com/stripe/android/hcaptcha/DefaultHCaptchaService.kt
@@ -15,25 +15,24 @@ import kotlin.coroutines.resume
 internal class DefaultHCaptchaService(
     private val hCaptchaProvider: HCaptchaProvider
 ) : HCaptchaService {
-    @SuppressWarnings("TooGenericExceptionCaught")
     override suspend fun performPassiveHCaptcha(
         activity: FragmentActivity,
         siteKey: String,
         rqData: String?
     ): HCaptchaService.Result {
         val hCaptcha = hCaptchaProvider.get()
-        return try {
+        val result = runCatching {
             startVerification(
                 activity = activity,
                 siteKey = siteKey,
                 rqData = rqData,
                 hCaptcha = hCaptcha
             )
-        } catch (e: Throwable) {
+        }.getOrElse { e ->
             HCaptchaService.Result.Failure(e)
-        } finally {
-            hCaptcha.reset()
         }
+        hCaptcha.reset()
+        return result
     }
 
     private suspend fun startVerification(

--- a/payments-core/src/main/java/com/stripe/android/hcaptcha/DefaultHCaptchaService.kt
+++ b/payments-core/src/main/java/com/stripe/android/hcaptcha/DefaultHCaptchaService.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.hcaptcha
 
 import androidx.fragment.app.FragmentActivity
+import com.stripe.hcaptcha.HCaptcha
 import com.stripe.hcaptcha.HCaptchaError
 import com.stripe.hcaptcha.HCaptchaException
 import com.stripe.hcaptcha.HCaptchaTokenResponse
@@ -14,43 +15,59 @@ import kotlin.coroutines.resume
 internal class DefaultHCaptchaService(
     private val hCaptchaProvider: HCaptchaProvider
 ) : HCaptchaService {
-
+    @SuppressWarnings("TooGenericExceptionCaught")
     override suspend fun performPassiveHCaptcha(
         activity: FragmentActivity,
         siteKey: String,
         rqData: String?
     ): HCaptchaService.Result {
         val hCaptcha = hCaptchaProvider.get()
-        try {
-            return suspendCancellableCoroutine { continuation ->
-                continuation.invokeOnCancellation {
-                    hCaptcha.reset()
-                }
-
-                hCaptcha.addOnSuccessListener(object : OnSuccessListener<HCaptchaTokenResponse> {
-                    override fun onSuccess(result: HCaptchaTokenResponse) {
-                        continuation.resume(HCaptchaService.Result.Success(result.tokenResult))
-                    }
-                }).addOnFailureListener(object : OnFailureListener {
-                    override fun onFailure(exception: HCaptchaException) {
-                        continuation.resume(HCaptchaService.Result.Failure(exception))
-                    }
-                })
-
-                val config = HCaptchaConfig(
-                    siteKey = siteKey,
-                    size = HCaptchaSize.INVISIBLE,
-                    rqdata = rqData,
-                    loading = false,
-                    hideDialog = true,
-                    disableHardwareAcceleration = true,
-                    retryPredicate = { _, exception -> exception.hCaptchaError == HCaptchaError.SESSION_TIMEOUT }
-                )
-
-                hCaptcha.setup(activity, config).verifyWithHCaptcha(activity)
-            }
+        return try {
+            startVerification(
+                activity = activity,
+                siteKey = siteKey,
+                rqData = rqData,
+                hCaptcha = hCaptcha
+            )
+        } catch (e: Throwable) {
+            HCaptchaService.Result.Failure(e)
         } finally {
             hCaptcha.reset()
+        }
+    }
+
+    private suspend fun startVerification(
+        activity: FragmentActivity,
+        siteKey: String,
+        rqData: String?,
+        hCaptcha: HCaptcha
+    ): HCaptchaService.Result {
+        return suspendCancellableCoroutine { continuation ->
+            continuation.invokeOnCancellation {
+                hCaptcha.reset()
+            }
+
+            hCaptcha.addOnSuccessListener(object : OnSuccessListener<HCaptchaTokenResponse> {
+                override fun onSuccess(result: HCaptchaTokenResponse) {
+                    continuation.resume(HCaptchaService.Result.Success(result.tokenResult))
+                }
+            }).addOnFailureListener(object : OnFailureListener {
+                override fun onFailure(exception: HCaptchaException) {
+                    continuation.resume(HCaptchaService.Result.Failure(exception))
+                }
+            })
+
+            val config = HCaptchaConfig(
+                siteKey = siteKey,
+                size = HCaptchaSize.INVISIBLE,
+                rqdata = rqData,
+                loading = false,
+                hideDialog = true,
+                disableHardwareAcceleration = true,
+                retryPredicate = { _, exception -> exception.hCaptchaError == HCaptchaError.SESSION_TIMEOUT }
+            )
+
+            hCaptcha.setup(activity, config).verifyWithHCaptcha(activity)
         }
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/hcaptcha/HCaptchaInterface.kt
+++ b/payments-core/src/main/java/com/stripe/android/hcaptcha/HCaptchaInterface.kt
@@ -27,7 +27,7 @@ suspend fun performPassiveHCaptcha(
     // TODO(awush): in the future, we should convert the hCaptcha SDK to use a suspend interface instead of callbacks,
     //  then we can eliminate the {{suspendCancelableCoroutine}} here.
     return suspendCancellableCoroutine { coroutine ->
-        val hcaptcha = HCaptcha.getClient(activity).apply {
+        val hcaptcha = HCaptcha.getClient().apply {
             addOnSuccessListener(object : OnSuccessListener<HCaptchaTokenResponse> {
                 override fun onSuccess(result: HCaptchaTokenResponse) {
                     coroutine.resume(result.tokenResult) { _ -> }
@@ -50,6 +50,6 @@ suspend fun performPassiveHCaptcha(
             retryPredicate = { _, exception -> exception.hCaptchaError == HCaptchaError.SESSION_TIMEOUT }
         )
 
-        hcaptcha.setup(config).verifyWithHCaptcha()
+        hcaptcha.setup(activity, config).verifyWithHCaptcha(activity)
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/hcaptcha/HCaptchaProvider.kt
+++ b/payments-core/src/main/java/com/stripe/android/hcaptcha/HCaptchaProvider.kt
@@ -1,16 +1,15 @@
 package com.stripe.android.hcaptcha
 
 import androidx.annotation.RestrictTo
-import androidx.fragment.app.FragmentActivity
 import com.stripe.hcaptcha.HCaptcha
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun interface HCaptchaProvider {
-    fun get(activity: FragmentActivity): HCaptcha
+    fun get(): HCaptcha
 }
 
 internal class DefaultHCaptchaProvider : HCaptchaProvider {
-    override fun get(activity: FragmentActivity): HCaptcha {
-        return HCaptcha.getClient(activity)
+    override fun get(): HCaptcha {
+        return HCaptcha.getClient()
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/hcaptcha/DefaultHCaptchaServiceTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/hcaptcha/DefaultHCaptchaServiceTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.hcaptcha
 
 import android.os.Handler
 import androidx.fragment.app.FragmentActivity
+import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
 import com.stripe.hcaptcha.HCaptcha
 import com.stripe.hcaptcha.HCaptchaError
@@ -11,11 +12,14 @@ import com.stripe.hcaptcha.config.HCaptchaConfig
 import com.stripe.hcaptcha.config.HCaptchaSize
 import com.stripe.hcaptcha.task.OnFailureListener
 import com.stripe.hcaptcha.task.OnSuccessListener
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import kotlin.test.Test
@@ -23,7 +27,7 @@ import kotlin.test.Test
 internal class DefaultHCaptchaServiceTest {
 
     @Test
-    fun `performPassiveHCaptcha calls hCaptchaProvider with activity`() = runTest {
+    fun `performPassiveHCaptcha calls hCaptchaProvider`() = runTest {
         val testContext = createTestContext()
         testContext.setupSuccessfulHCaptcha("test-token")
 
@@ -33,7 +37,7 @@ internal class DefaultHCaptchaServiceTest {
             rqData = null
         )
 
-        assertThat(testContext.hCaptchaProvider.getInvocations).containsExactly(testContext.activity)
+        testContext.hCaptchaProvider.awaitCall()
     }
 
     @Test
@@ -50,7 +54,7 @@ internal class DefaultHCaptchaServiceTest {
         )
 
         val configCaptor = argumentCaptor<HCaptchaConfig>()
-        verify(testContext.hCaptcha).setup(configCaptor.capture())
+        verify(testContext.hCaptcha).setup(any(), configCaptor.capture())
 
         with(configCaptor.firstValue) {
             assertThat(siteKey).isEqualTo(testSiteKey)
@@ -94,6 +98,63 @@ internal class DefaultHCaptchaServiceTest {
         assertThat((result as HCaptchaService.Result.Failure).error).isEqualTo(exception)
     }
 
+    @Test
+    fun `performPassiveHCaptcha calls reset after successful completion`() = runTest {
+        val testContext = createTestContext()
+        testContext.setupSuccessfulHCaptcha("test-token")
+
+        testContext.service.performPassiveHCaptcha(
+            testContext.activity,
+            siteKey = "test-site-key",
+            rqData = null
+        )
+
+        verify(testContext.hCaptcha).reset()
+    }
+
+    @Test
+    fun `performPassiveHCaptcha calls reset after failed completion`() = runTest {
+        val testContext = createTestContext()
+        val exception = HCaptchaException(HCaptchaError.NETWORK_ERROR)
+        testContext.setupFailedHCaptcha(exception)
+
+        testContext.service.performPassiveHCaptcha(
+            testContext.activity,
+            siteKey = "test-site-key",
+            rqData = null
+        )
+
+        verify(testContext.hCaptcha).reset()
+    }
+
+    @Test
+    fun `performPassiveHCaptcha calls reset on coroutine cancellation`() = runTest {
+        val testContext = createTestContext()
+        testContext.setupHangingHCaptcha()
+
+        var exception: Throwable? = null
+
+        val job = launch {
+            try {
+                testContext.service.performPassiveHCaptcha(
+                    testContext.activity,
+                    siteKey = "test-site-key",
+                    rqData = null
+                )
+            } catch (e: CancellationException) {
+                exception = e
+                throw e
+            }
+        }
+
+        testContext.hCaptchaProvider.awaitCall()
+        job.cancel()
+        job.join()
+
+        assertThat(exception).isInstanceOf(CancellationException::class.java)
+        verify(testContext.hCaptcha, times(2)).reset()
+    }
+
     private fun createTestContext(): TestContext {
         val activity = mock<FragmentActivity>()
         val hCaptcha = mock<HCaptcha>()
@@ -111,13 +172,13 @@ internal class DefaultHCaptchaServiceTest {
     private fun TestContext.setupHCaptchaChaining() {
         whenever(hCaptcha.addOnSuccessListener(any())).doReturn(hCaptcha)
         whenever(hCaptcha.addOnFailureListener(any())).doReturn(hCaptcha)
-        whenever(hCaptcha.setup(any())).doReturn(hCaptcha)
+        whenever(hCaptcha.setup(any(), any())).doReturn(hCaptcha)
     }
 
     private fun TestContext.setupSuccessfulHCaptcha(token: String = "test-token") {
         setupHCaptchaChaining()
 
-        whenever(hCaptcha.verifyWithHCaptcha()).then {
+        whenever(hCaptcha.verifyWithHCaptcha(any())).then {
             val successCaptor = argumentCaptor<OnSuccessListener<HCaptchaTokenResponse>>()
             verify(hCaptcha).addOnSuccessListener(successCaptor.capture())
             successCaptor.firstValue.onSuccess(createHCaptchaTokenResponse(token))
@@ -128,12 +189,17 @@ internal class DefaultHCaptchaServiceTest {
     private fun TestContext.setupFailedHCaptcha(exception: HCaptchaException) {
         setupHCaptchaChaining()
 
-        whenever(hCaptcha.verifyWithHCaptcha()).then {
+        whenever(hCaptcha.verifyWithHCaptcha(any())).then {
             val failureCaptor = argumentCaptor<OnFailureListener>()
             verify(hCaptcha).addOnFailureListener(failureCaptor.capture())
             failureCaptor.firstValue.onFailure(exception)
             hCaptcha
         }
+    }
+
+    private fun TestContext.setupHangingHCaptcha() {
+        setupHCaptchaChaining()
+        whenever(hCaptcha.verifyWithHCaptcha(any())).doReturn(hCaptcha)
     }
 
     private fun createHCaptchaTokenResponse(token: String): HCaptchaTokenResponse {
@@ -150,11 +216,15 @@ internal class DefaultHCaptchaServiceTest {
     private class FakeHCaptchaProvider(
         private val hCaptcha: HCaptcha
     ) : HCaptchaProvider {
-        val getInvocations = mutableListOf<FragmentActivity>()
+        private val calls = Turbine<Unit>()
 
-        override fun get(activity: FragmentActivity): HCaptcha {
-            getInvocations.add(activity)
+        override fun get(): HCaptcha {
+            calls.add(Unit)
             return hCaptcha
+        }
+
+        suspend fun awaitCall() {
+            calls.awaitItem()
         }
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
hCaptcha is retaining an instance of the host activity even after its destroyed. It also sometimes emits an exception emitting a passive captcha token. 

This change removes strong references to activity/context and resets listeners after receiving the first result.

LeakCanary doesn't show any warnings with these changes.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
