### PR TITLE
Handle edge2edge on FCLite

### DIFF
--- a/financial-connections-lite/src/main/java/com/stripe/android/financialconnections/lite/FinancialConnectionsSheetLiteActivity.kt
+++ b/financial-connections-lite/src/main/java/com/stripe/android/financialconnections/lite/FinancialConnectionsSheetLiteActivity.kt
@@ -5,6 +5,7 @@ import android.app.AlertDialog
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.view.View
 import android.webkit.WebChromeClient
@@ -19,7 +20,11 @@ import androidx.annotation.RestrictTo
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isVisible
+import androidx.core.view.updatePadding
 import androidx.lifecycle.lifecycleScope
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetActivityArgs
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetActivityArgs.Companion.EXTRA_ARGS
@@ -47,6 +52,8 @@ internal class FinancialConnectionsSheetLiteActivity : ComponentActivity(R.layou
 
         webView = findViewById(R.id.webView)
         progressBar = findViewById(R.id.progressBar)
+
+        handleEdgeToEdge()
         setupProgressBar()
         setupWebView()
         setupBackButtonHandling()
@@ -58,6 +65,28 @@ internal class FinancialConnectionsSheetLiteActivity : ComponentActivity(R.layou
                     is FinishWithResult -> finishWithResult(viewEffect.result)
                     is OpenCustomTab -> openCustomTab(viewEffect.url)
                 }
+            }
+        }
+    }
+
+    private fun handleEdgeToEdge() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            // Enable edge-to-edge rendering for Android R and above (auto enabled starting Android 35)
+            WindowCompat.setDecorFitsSystemWindows(window, false)
+            // Handle window insets to adjust padding for system bars
+            val rootView = findViewById<View>(android.R.id.content)
+            ViewCompat.setOnApplyWindowInsetsListener(rootView) { view, insets ->
+                val systemBarsInsets = insets.getInsets(
+                    WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
+                )
+                view.updatePadding(
+                    left = systemBarsInsets.left,
+                    top = systemBarsInsets.top,
+                    right = systemBarsInsets.right,
+                    bottom = systemBarsInsets.bottom
+                )
+
+                insets
             }
         }
     }


### PR DESCRIPTION
# Summary

- **Issue**: on apps targeting API 35, FCLite web-view renders under bars as edgeToedge is enforced.
- **Solution**: handle insets properly on `FCLiteActivity`.
# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Before:

<img width="351" height="783" alt="image" src="https://github.com/user-attachments/assets/614cb214-feb3-450c-ad92-b785ff5b405f" />

After:

<img width="354" height="784" alt="image" src="https://github.com/user-attachments/assets/ccba766c-b570-4628-aaf6-e66ab36f7eb1" />

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
