### PR TITLE
Support `allowedCountries` in `BillingDetailsCollectionConfiguration` for Payment Element

### DIFF
--- a/payments-core-testing/src/main/java/com/stripe/android/testing/PaymentMethodFactory.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/PaymentMethodFactory.kt
@@ -8,7 +8,12 @@ import kotlin.random.Random
 
 object PaymentMethodFactory {
 
-    fun card(last4: String, id: String? = null, addCbcNetworks: Boolean = false): PaymentMethod {
+    fun card(
+        last4: String,
+        id: String? = null,
+        addCbcNetworks: Boolean = false,
+        billingDetails: PaymentMethod.BillingDetails? = null,
+    ): PaymentMethod {
         val card = if (id == null) {
             card(random = true)
         } else {
@@ -16,7 +21,11 @@ object PaymentMethodFactory {
         }
 
         return card.run {
-            update(last4, addCbcNetworks)
+            update(
+                last4 = last4,
+                addCbcNetworks = addCbcNetworks,
+                billingDetails = billingDetails,
+            )
         }
     }
 
@@ -25,6 +34,7 @@ object PaymentMethodFactory {
         addCbcNetworks: Boolean,
         brand: CardBrand = CardBrand.Visa,
         fingerprint: String? = card?.fingerprint,
+        billingDetails: PaymentMethod.BillingDetails? = null,
     ): PaymentMethod {
         return copy(
             card = card?.copy(
@@ -38,7 +48,8 @@ object PaymentMethodFactory {
                 displayBrand = "cartes_bancaries".takeIf { addCbcNetworks },
                 brand = brand,
                 fingerprint = fingerprint,
-            )
+            ),
+            billingDetails = billingDetails,
         )
     }
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/BillingDetailsCollectionConfiguration.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/BillingDetailsCollectionConfiguration.kt
@@ -11,6 +11,7 @@ data class BillingDetailsCollectionConfiguration(
     val collectEmail: Boolean = false,
     val collectPhone: Boolean = false,
     val address: AddressCollectionMode = AddressCollectionMode.Automatic,
+    val allowedCountries: Set<String> = emptySet(),
 ) : Parcelable {
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     enum class AddressCollectionMode {

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/AllowedBillingCountriesSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/AllowedBillingCountriesSettingsDefinition.kt
@@ -1,0 +1,81 @@
+package com.stripe.android.paymentsheet.example.playground.settings
+
+import com.stripe.android.customersheet.CustomerSheet
+import com.stripe.android.link.LinkController
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.example.playground.PlaygroundState
+
+internal object AllowedBillingCountriesSettingsDefinition :
+    PlaygroundSettingDefinition.Saveable<AllowedBillingCountries> by EnumSaveable(
+        key = "allowedBillingCountries",
+        defaultValue = AllowedBillingCountries.All,
+        values = AllowedBillingCountries.entries.toTypedArray(),
+    ),
+    PlaygroundSettingDefinition.Displayable<AllowedBillingCountries> {
+    override val displayName: String = "Allowed billing countries"
+
+    override fun createOptions(
+        configurationData: PlaygroundConfigurationData
+    ) = listOf(
+        option("All", AllowedBillingCountries.All),
+        option("US Only", AllowedBillingCountries.UsOnly),
+        option("North America (US, CA, MX)", AllowedBillingCountries.NorthAmerica),
+        option("5 countries (US, CA, GB, AU, DE)", AllowedBillingCountries.FiveCountries),
+    )
+
+    override fun configure(
+        value: AllowedBillingCountries,
+        configurationBuilder: PaymentSheet.Configuration.Builder,
+        playgroundState: PlaygroundState.Payment,
+        configurationData: PlaygroundSettingDefinition.PaymentSheetConfigurationData,
+    ) {
+        configurationData.updateBillingDetails { allowedCountries = value.countries }
+    }
+
+    override fun configure(
+        value: AllowedBillingCountries,
+        configurationBuilder: EmbeddedPaymentElement.Configuration.Builder,
+        playgroundState: PlaygroundState.Payment,
+        configurationData: PlaygroundSettingDefinition.EmbeddedConfigurationData
+    ) {
+        configurationData.updateBillingDetails { allowedCountries = value.countries }
+    }
+
+    override fun configure(
+        value: AllowedBillingCountries,
+        configurationBuilder: CustomerSheet.Configuration.Builder,
+        playgroundState: PlaygroundState.Customer,
+        configurationData: PlaygroundSettingDefinition.CustomerSheetConfigurationData,
+    ) {
+        configurationData.updateBillingDetails { allowedCountries = value.countries }
+    }
+
+    override fun configure(
+        value: AllowedBillingCountries,
+        configurationBuilder: PaymentSheet.Configuration.Builder,
+        playgroundState: PlaygroundState.SharedPaymentToken,
+        configurationData: PlaygroundSettingDefinition.PaymentSheetConfigurationData,
+    ) {
+        configurationData.updateBillingDetails { allowedCountries = value.countries }
+    }
+
+    override fun configure(
+        value: AllowedBillingCountries,
+        configurationBuilder: LinkController.Configuration.Builder,
+        playgroundState: PlaygroundState.Payment,
+        configurationData: PlaygroundSettingDefinition.LinkControllerConfigurationData,
+    ) {
+        configurationData.updateBillingDetails { allowedCountries = value.countries }
+    }
+}
+
+enum class AllowedBillingCountries(
+    override val value: String,
+    val countries: Set<String>,
+) : ValueEnum {
+    All(value = "all", countries = emptySet()),
+    UsOnly(value = "us_only", countries = setOf("US")),
+    NorthAmerica(value = "north_america", countries = setOf("US", "CA", "MX")),
+    FiveCountries(value = "five_countries", countries = setOf("US", "CA", "GB", "AU", "DE"))
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/BillingDetailsCollectionConfigurationBuilder.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/BillingDetailsCollectionConfigurationBuilder.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentsheet.example.playground.settings
 
-import com.stripe.android.paymentelement.AllowedBillingCountriesInPaymentElementPreview
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode
@@ -13,7 +12,6 @@ internal class BillingDetailsCollectionConfigurationBuilder(
     var attachDefaultsToPaymentMethod: Boolean = false,
     var allowedCountries: Set<String> = emptySet()
 ) {
-    @OptIn(AllowedBillingCountriesInPaymentElementPreview::class)
     fun build(): PaymentSheet.BillingDetailsCollectionConfiguration {
         return PaymentSheet.BillingDetailsCollectionConfiguration(
             name = name,

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/BillingDetailsCollectionConfigurationBuilder.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/BillingDetailsCollectionConfigurationBuilder.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.example.playground.settings
 
+import com.stripe.android.paymentelement.AllowedBillingCountriesInPaymentElementPreview
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode
@@ -10,7 +11,9 @@ internal class BillingDetailsCollectionConfigurationBuilder(
     var email: CollectionMode = CollectionMode.Automatic,
     var address: AddressCollectionMode = AddressCollectionMode.Automatic,
     var attachDefaultsToPaymentMethod: Boolean = false,
+    var allowedCountries: Set<String> = emptySet()
 ) {
+    @OptIn(AllowedBillingCountriesInPaymentElementPreview::class)
     fun build(): PaymentSheet.BillingDetailsCollectionConfiguration {
         return PaymentSheet.BillingDetailsCollectionConfiguration(
             name = name,
@@ -18,6 +21,7 @@ internal class BillingDetailsCollectionConfigurationBuilder(
             email = email,
             address = address,
             attachDefaultsToPaymentMethod = attachDefaultsToPaymentMethod,
+            allowedCountries = allowedCountries,
         )
     }
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -496,6 +496,7 @@ internal class PlaygroundSettings private constructor(
             CollectEmailSettingsDefinition,
             CollectPhoneSettingsDefinition,
             CollectAddressSettingsDefinition,
+            AllowedBillingCountriesSettingsDefinition,
             AutocompleteAddressSettingsDefinition,
             DefaultShippingAddressSettingsDefinition,
             DelayedPaymentMethodsSettingsDefinition,

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -1900,13 +1900,11 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCo
 	public final fun component3 ()Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;
 	public final fun component4 ()Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$AddressCollectionMode;
 	public final fun component5 ()Z
-	public final fun component6 ()Ljava/util/Set;
 	public final fun copy (Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$AddressCollectionMode;ZLjava/util/Set;)Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;
 	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$AddressCollectionMode;ZLjava/util/Set;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAddress ()Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$AddressCollectionMode;
-	public final fun getAllowedCountries ()Ljava/util/Set;
 	public final fun getAttachDefaultsToPaymentMethod ()Z
 	public final fun getEmail ()Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;
 	public final fun getName ()Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -823,6 +823,9 @@ public abstract interface annotation class com/stripe/android/paymentelement/Add
 public abstract interface annotation class com/stripe/android/paymentelement/AddressElementSameAsBillingPreview : java/lang/annotation/Annotation {
 }
 
+public abstract interface annotation class com/stripe/android/paymentelement/AllowedBillingCountriesInPaymentElementPreview : java/lang/annotation/Annotation {
+}
+
 public abstract class com/stripe/android/paymentelement/AnalyticEvent {
 	public static final field $stable I
 }
@@ -1893,16 +1896,20 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCo
 	public fun <init> ()V
 	public fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$AddressCollectionMode;Z)V
 	public synthetic fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$AddressCollectionMode;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$AddressCollectionMode;ZLjava/util/Set;)V
+	public synthetic fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$AddressCollectionMode;ZLjava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;
 	public final fun component2 ()Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;
 	public final fun component3 ()Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;
 	public final fun component4 ()Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$AddressCollectionMode;
 	public final fun component5 ()Z
-	public final fun copy (Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$AddressCollectionMode;Z)Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;
-	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$AddressCollectionMode;ZILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;
+	public final fun component6 ()Ljava/util/Set;
+	public final fun copy (Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$AddressCollectionMode;ZLjava/util/Set;)Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$AddressCollectionMode;ZLjava/util/Set;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAddress ()Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$AddressCollectionMode;
+	public final fun getAllowedCountries ()Ljava/util/Set;
 	public final fun getAttachDefaultsToPaymentMethod ()Z
 	public final fun getEmail ()Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;
 	public final fun getName ()Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -823,9 +823,6 @@ public abstract interface annotation class com/stripe/android/paymentelement/Add
 public abstract interface annotation class com/stripe/android/paymentelement/AddressElementSameAsBillingPreview : java/lang/annotation/Annotation {
 }
 
-public abstract interface annotation class com/stripe/android/paymentelement/AllowedBillingCountriesInPaymentElementPreview : java/lang/annotation/Annotation {
-}
-
 public abstract class com/stripe/android/paymentelement/AnalyticEvent {
 	public static final field $stable I
 }

--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -29,6 +29,7 @@
     <ID>LargeClass:PaymentOptionsViewModelTest.kt$PaymentOptionsViewModelTest</ID>
     <ID>LargeClass:PaymentSheetActivityTest.kt$PaymentSheetActivityTest</ID>
     <ID>LargeClass:PaymentSheetViewModelTest.kt$PaymentSheetViewModelTest</ID>
+    <ID>LargeClass:PlaceholderHelperTest.kt$PlaceholderHelperTest</ID>
     <ID>LargeClass:USBankAccountFormViewModel.kt$USBankAccountFormViewModel : ViewModel</ID>
     <ID>LargeClass:USBankAccountFormViewModelTest.kt$USBankAccountFormViewModelTest</ID>
     <ID>LargeClass:WalletScreenTest.kt$WalletScreenTest</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/common/validation/PaymentMethodUtils.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/validation/PaymentMethodUtils.kt
@@ -14,7 +14,7 @@ internal fun PaymentMethod.isSupportedWithBillingConfig(
         return true
     }
 
-    return billingDetails?.address?.country?.let { allowedCountries.contains(it) } ?: true
+    return billingDetails?.address?.country?.let { allowedCountries.contains(it) } ?: false
 }
 
 internal fun ConsumerPaymentDetails.PaymentDetails.isSupportedWithBillingConfig(

--- a/paymentsheet/src/main/java/com/stripe/android/common/validation/PaymentMethodUtils.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/validation/PaymentMethodUtils.kt
@@ -1,0 +1,32 @@
+package com.stripe.android.common.validation
+
+import com.stripe.android.model.ConsumerPaymentDetails
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentsheet.PaymentSheet
+
+internal fun PaymentMethod.isSupportedWithBillingConfig(
+    billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration
+): Boolean = isSupportedWithConfig(
+    billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration,
+    countryCode = billingDetails?.address?.country,
+)
+
+internal fun ConsumerPaymentDetails.PaymentDetails.isSupportedWithBillingConfig(
+    billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration
+): Boolean = isSupportedWithConfig(
+    billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration,
+    countryCode = billingAddress?.countryCode?.value,
+)
+
+private fun isSupportedWithConfig(
+    billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration,
+    countryCode: String?,
+): Boolean {
+    val allowedCountries = billingDetailsCollectionConfiguration.allowedCountries
+
+    if (allowedCountries.isEmpty()) {
+        return true
+    }
+
+    return countryCode?.let { allowedCountries.contains(it) } ?: true
+}

--- a/paymentsheet/src/main/java/com/stripe/android/common/validation/PaymentMethodUtils.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/validation/PaymentMethodUtils.kt
@@ -8,19 +8,23 @@ import com.stripe.android.paymentsheet.PaymentSheet
 internal fun PaymentMethod.isSupportedWithBillingConfig(
     billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration
 ): Boolean {
-    val allowedCountries = billingDetailsCollectionConfiguration.allowedCountries
+    val allowedCountries = billingDetailsCollectionConfiguration.allowedBillingCountries
 
     if (allowedCountries.isEmpty()) {
         return true
     }
 
-    return billingDetails?.address?.country?.let { allowedCountries.contains(it) } ?: false
+    val billingCountry = billingDetails?.address?.country?.uppercase()
+
+    return billingCountry?.let {
+        allowedCountries.contains(it)
+    } ?: false
 }
 
 internal fun ConsumerPaymentDetails.PaymentDetails.isSupportedWithBillingConfig(
     billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration
 ): Boolean {
-    val allowedCountries = billingDetailsCollectionConfiguration.allowedCountries
+    val allowedCountries = billingDetailsCollectionConfiguration.allowedBillingCountries
 
     if (allowedCountries.isEmpty()) {
         return true
@@ -28,7 +32,7 @@ internal fun ConsumerPaymentDetails.PaymentDetails.isSupportedWithBillingConfig(
 
     return when (this) {
         is ConsumerPaymentDetails.Card -> billingAddress?.countryCode?.let {
-            allowedCountries.contains(it.value)
+            allowedCountries.contains(it.value.uppercase())
         } ?: false
         is ConsumerPaymentDetails.BankAccount -> allowedCountries.contains(CountryCode.US.value)
         is ConsumerPaymentDetails.Passthrough -> false

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -2,6 +2,7 @@ package com.stripe.android.customersheet
 
 import com.stripe.android.common.coroutines.Single
 import com.stripe.android.common.coroutines.awaitWithTimeout
+import com.stripe.android.common.validation.isSupportedWithBillingConfig
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.injection.IS_LIVE_MODE
@@ -81,7 +82,8 @@ internal class DefaultCustomerSheetLoader(
             )
 
             val filteredPaymentMethods = customerSheetSession.paymentMethods.filter { paymentMethod ->
-                PaymentSheetCardBrandFilter(configuration.cardBrandAcceptance).isAccepted(paymentMethod)
+                PaymentSheetCardBrandFilter(configuration.cardBrandAcceptance).isAccepted(paymentMethod) &&
+                    paymentMethod.isSupportedWithBillingConfig(configuration.billingDetailsCollectionConfiguration)
             }.filterToSupportedPaymentMethods(isPaymentMethodSyncDefaultEnabled)
 
             customerSheetSession = customerSheetSession.copy(

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -565,6 +565,7 @@ internal class CustomerSheetViewModel(
                     canUpdateFullPaymentMethodDetails = customerState.canUpdateFullPaymentMethodDetails,
                     displayableSavedPaymentMethod = paymentMethod,
                     addressCollectionMode = configuration.billingDetailsCollectionConfiguration.address,
+                    allowedBillingCountries = configuration.billingDetailsCollectionConfiguration.allowedCountries,
                     cardBrandFilter = PaymentSheetCardBrandFilter(customerState.configuration.cardBrandAcceptance),
                     removeExecutor = ::removeExecutor,
                     onBrandChoiceSelected = { brand ->

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -565,7 +565,8 @@ internal class CustomerSheetViewModel(
                     canUpdateFullPaymentMethodDetails = customerState.canUpdateFullPaymentMethodDetails,
                     displayableSavedPaymentMethod = paymentMethod,
                     addressCollectionMode = configuration.billingDetailsCollectionConfiguration.address,
-                    allowedBillingCountries = configuration.billingDetailsCollectionConfiguration.allowedCountries,
+                    allowedBillingCountries =
+                        configuration.billingDetailsCollectionConfiguration.allowedBillingCountries,
                     cardBrandFilter = PaymentSheetCardBrandFilter(customerState.configuration.cardBrandAcceptance),
                     removeExecutor = ::removeExecutor,
                     onBrandChoiceSelected = { brand ->

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -566,7 +566,7 @@ internal class CustomerSheetViewModel(
                     displayableSavedPaymentMethod = paymentMethod,
                     addressCollectionMode = configuration.billingDetailsCollectionConfiguration.address,
                     allowedBillingCountries =
-                        configuration.billingDetailsCollectionConfiguration.allowedBillingCountries,
+                    configuration.billingDetailsCollectionConfiguration.allowedBillingCountries,
                     cardBrandFilter = PaymentSheetCardBrandFilter(customerState.configuration.cardBrandAcceptance),
                     removeExecutor = ::removeExecutor,
                     onBrandChoiceSelected = { brand ->

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
@@ -230,7 +230,7 @@ internal class PaymentMethodViewModel @Inject constructor(
                     billingDetailsCollectionConfiguration.address
                 },
                 attachDefaultsToPaymentMethod = billingDetailsCollectionConfiguration.attachDefaultsToPaymentMethod,
-                allowedCountries = billingDetailsCollectionConfiguration.allowedCountries,
+                allowedCountries = billingDetailsCollectionConfiguration.allowedBillingCountries,
             )
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
@@ -24,6 +24,7 @@ import com.stripe.android.link.ui.completePaymentButtonLabel
 import com.stripe.android.link.withDismissalDisabled
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentelement.AllowedBillingCountriesInPaymentElementPreview
 import com.stripe.android.paymentsheet.DefaultFormHelper
 import com.stripe.android.paymentsheet.FormHelper
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -213,6 +214,7 @@ internal class PaymentMethodViewModel @Inject constructor(
             }
         }
 
+        @OptIn(AllowedBillingCountriesInPaymentElementPreview::class)
         private fun LinkConfiguration.withLinkRequiredSettings() = copy(
             billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
                 name = billingDetailsCollectionConfiguration.name,
@@ -230,6 +232,7 @@ internal class PaymentMethodViewModel @Inject constructor(
                     billingDetailsCollectionConfiguration.address
                 },
                 attachDefaultsToPaymentMethod = billingDetailsCollectionConfiguration.attachDefaultsToPaymentMethod,
+                allowedCountries = billingDetailsCollectionConfiguration.allowedCountries,
             )
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
@@ -24,7 +24,6 @@ import com.stripe.android.link.ui.completePaymentButtonLabel
 import com.stripe.android.link.withDismissalDisabled
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethod
-import com.stripe.android.paymentelement.AllowedBillingCountriesInPaymentElementPreview
 import com.stripe.android.paymentsheet.DefaultFormHelper
 import com.stripe.android.paymentsheet.FormHelper
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -214,7 +213,6 @@ internal class PaymentMethodViewModel @Inject constructor(
             }
         }
 
-        @OptIn(AllowedBillingCountriesInPaymentElementPreview::class)
         private fun LinkConfiguration.withLinkRequiredSettings() = copy(
             billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
                 name = billingDetailsCollectionConfiguration.name,

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/updatecard/UpdateCardScreenViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/updatecard/UpdateCardScreenViewModel.kt
@@ -203,7 +203,7 @@ internal class UpdateCardScreenViewModel @Inject constructor(
                     defaultConfiguration.address
                 },
                 attachDefaultsToPaymentMethod = defaultConfiguration.attachDefaultsToPaymentMethod,
-                allowedCountries = defaultConfiguration.allowedCountries,
+                allowedCountries = defaultConfiguration.allowedBillingCountries,
             ),
             onCardUpdateParamsChanged = ::onCardUpdateParamsChanged,
             onBrandChoiceChanged = ::onBrandChoiceChanged,

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/updatecard/UpdateCardScreenViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/updatecard/UpdateCardScreenViewModel.kt
@@ -31,6 +31,7 @@ import com.stripe.android.model.ConsumerPaymentDetailsUpdateParams
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodCreateParams.Card.Networks
+import com.stripe.android.paymentelement.AllowedBillingCountriesInPaymentElementPreview
 import com.stripe.android.paymentsheet.CardUpdateParams
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
@@ -178,6 +179,7 @@ internal class UpdateCardScreenViewModel @Inject constructor(
 
         val defaultConfiguration = configuration.billingDetailsCollectionConfiguration
 
+        @OptIn(AllowedBillingCountriesInPaymentElementPreview::class)
         return DefaultEditCardDetailsInteractor.Factory().create(
             coroutineScope = viewModelScope,
             cardEditConfiguration = cardEditConfiguration,
@@ -203,6 +205,7 @@ internal class UpdateCardScreenViewModel @Inject constructor(
                     defaultConfiguration.address
                 },
                 attachDefaultsToPaymentMethod = defaultConfiguration.attachDefaultsToPaymentMethod,
+                allowedCountries = defaultConfiguration.allowedCountries,
             ),
             onCardUpdateParamsChanged = ::onCardUpdateParamsChanged,
             onBrandChoiceChanged = ::onBrandChoiceChanged,

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/updatecard/UpdateCardScreenViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/updatecard/UpdateCardScreenViewModel.kt
@@ -31,7 +31,6 @@ import com.stripe.android.model.ConsumerPaymentDetailsUpdateParams
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodCreateParams.Card.Networks
-import com.stripe.android.paymentelement.AllowedBillingCountriesInPaymentElementPreview
 import com.stripe.android.paymentsheet.CardUpdateParams
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
@@ -179,7 +178,6 @@ internal class UpdateCardScreenViewModel @Inject constructor(
 
         val defaultConfiguration = configuration.billingDetailsCollectionConfiguration
 
-        @OptIn(AllowedBillingCountriesInPaymentElementPreview::class)
         return DefaultEditCardDetailsInteractor.Factory().create(
             coroutineScope = viewModelScope,
             cardEditConfiguration = cardEditConfiguration,

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletUiState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletUiState.kt
@@ -2,12 +2,14 @@ package com.stripe.android.link.ui.wallet
 
 import androidx.compose.runtime.Immutable
 import com.stripe.android.CardBrandFilter
+import com.stripe.android.common.validation.isSupportedWithBillingConfig
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.link.LinkPaymentMethod
 import com.stripe.android.link.ui.PrimaryButtonState
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.ConsumerPaymentDetails.Card
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.uicore.forms.FormFieldEntry
 
@@ -36,6 +38,7 @@ internal data class WalletUiState(
     val isAutoSelecting: Boolean = false,
     val hasAttemptedAutoSelection: Boolean = false,
     val signupToggleEnabled: Boolean,
+    val billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration,
 ) {
 
     val selectedItem: ConsumerPaymentDetails.PaymentDetails?
@@ -98,7 +101,9 @@ internal data class WalletUiState(
         get() = addPaymentMethodOptions.isNotEmpty()
 
     fun isItemAvailable(item: ConsumerPaymentDetails.PaymentDetails): Boolean {
-        return item !is Card || cardBrandFilter.isAccepted(item.brand)
+        return (
+            item !is Card || cardBrandFilter.isAccepted(item.brand)
+            ) && item.isSupportedWithBillingConfig(billingDetailsCollectionConfiguration)
     }
 
     fun updateWithResponse(

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
@@ -91,7 +91,8 @@ internal class WalletViewModel @Inject constructor(
             addPaymentMethodOptions = getAddPaymentMethodOptions(),
             paymentSelectionHint = linkLaunchMode.paymentSelectionHint,
             isAutoSelecting = shouldAutoSelectDefaultPaymentMethod(),
-            signupToggleEnabled = configuration.linkSignUpOptInFeatureEnabled
+            signupToggleEnabled = configuration.linkSignUpOptInFeatureEnabled,
+            billingDetailsCollectionConfiguration = configuration.billingDetailsCollectionConfiguration,
         )
     )
 

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/FormElementsBuilder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/FormElementsBuilder.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.lpmfoundations.luxe
 
-import com.stripe.android.core.model.CountryUtils
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.ui.core.elements.AddressSpec
@@ -16,7 +15,7 @@ internal class FormElementsBuilder(
     private val requiredContactInformationCollectionModes: MutableSet<ContactInformationCollectionMode> = mutableSetOf()
 
     private var requireBillingAddressCollection: Boolean = false
-    private var availableCountries: Set<String> = CountryUtils.supportedBillingCountries
+    private var availableCountries: Set<String> = arguments.billingDetailsCollectionConfiguration.allowedCountries
 
     init {
         // Setup the required contact information fields based on the merchant billingDetailsCollectionConfiguration.

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/FormElementsBuilder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/FormElementsBuilder.kt
@@ -15,7 +15,8 @@ internal class FormElementsBuilder(
     private val requiredContactInformationCollectionModes: MutableSet<ContactInformationCollectionMode> = mutableSetOf()
 
     private var requireBillingAddressCollection: Boolean = false
-    private var availableCountries: Set<String> = arguments.billingDetailsCollectionConfiguration.allowedCountries
+    private var availableCountries: Set<String> =
+        arguments.billingDetailsCollectionConfiguration.allowedBillingCountries
 
     init {
         // Setup the required contact information fields based on the merchant billingDetailsCollectionConfiguration.

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -194,7 +194,7 @@ private object CardUiDefinitionFactory : UiDefinitionFactory.Simple {
         ) {
             addAll(
                 cardBillingElements(
-                    billingDetailsCollectionConfiguration.allowedCountries,
+                    billingDetailsCollectionConfiguration.allowedBillingCountries,
                     billingDetailsCollectionConfiguration.toInternal(),
                     arguments.autocompleteAddressInteractorFactory,
                     arguments.initialValues,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -6,7 +6,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import com.stripe.android.core.model.CountryUtils
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.link.ui.inline.InlineSignupViewState
 import com.stripe.android.link.ui.inline.LinkSignupMode
@@ -195,6 +194,7 @@ private object CardUiDefinitionFactory : UiDefinitionFactory.Simple {
         ) {
             addAll(
                 cardBillingElements(
+                    billingDetailsCollectionConfiguration.allowedCountries,
                     billingDetailsCollectionConfiguration.toInternal(),
                     arguments.autocompleteAddressInteractorFactory,
                     arguments.initialValues,
@@ -226,6 +226,7 @@ internal fun PaymentSheet.BillingDetailsCollectionConfiguration.toInternal(): Bi
 }
 
 private fun cardBillingElements(
+    allowedCountries: Set<String>,
     collectionConfiguration: BillingDetailsCollectionConfiguration,
     autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
     initialValues: Map<IdentifierSpec, String?>,
@@ -242,7 +243,7 @@ private fun cardBillingElements(
             }
     val addressElement = CardBillingAddressElement(
         IdentifierSpec.Generic("credit_billing"),
-        countryCodes = CountryUtils.supportedBillingCountries,
+        countryCodes = allowedCountries,
         rawValuesMap = initialValues,
         sameAsShippingElement = sameAsShippingElement,
         shippingValuesMap = shippingValues,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/AllowedBillingCountriesInPaymentElementPreview.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/AllowedBillingCountriesInPaymentElementPreview.kt
@@ -1,8 +1,0 @@
-package com.stripe.android.paymentelement
-
-@RequiresOptIn(
-    level = RequiresOptIn.Level.ERROR,
-    message = "This API is under construction. It can be changed or removed at any time (use at your own risk)."
-)
-@Retention(AnnotationRetention.BINARY)
-annotation class AllowedBillingCountriesInPaymentElementPreview

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/AllowedBillingCountriesInPaymentElementPreview.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/AllowedBillingCountriesInPaymentElementPreview.kt
@@ -1,0 +1,8 @@
+package com.stripe.android.paymentelement
+
+@RequiresOptIn(
+    level = RequiresOptIn.Level.ERROR,
+    message = "This API is under construction. It can be changed or removed at any time (use at your own risk)."
+)
+@Retention(AnnotationRetention.BINARY)
+annotation class AllowedBillingCountriesInPaymentElementPreview

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
@@ -36,6 +36,7 @@ internal class DefaultEmbeddedUpdateScreenInteractorFactory @Inject constructor(
             displayableSavedPaymentMethod = displayableSavedPaymentMethod,
             cardBrandFilter = paymentMethodMetadata.cardBrandFilter,
             addressCollectionMode = paymentMethodMetadata.billingDetailsCollectionConfiguration.address,
+            allowedBillingCountries = paymentMethodMetadata.billingDetailsCollectionConfiguration.allowedCountries,
             removeExecutor = { method ->
                 val result = savedPaymentMethodMutatorProvider.get().removePaymentMethodInEditScreen(method)
                 if (result == null) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
@@ -36,7 +36,8 @@ internal class DefaultEmbeddedUpdateScreenInteractorFactory @Inject constructor(
             displayableSavedPaymentMethod = displayableSavedPaymentMethod,
             cardBrandFilter = paymentMethodMetadata.cardBrandFilter,
             addressCollectionMode = paymentMethodMetadata.billingDetailsCollectionConfiguration.address,
-            allowedBillingCountries = paymentMethodMetadata.billingDetailsCollectionConfiguration.allowedCountries,
+            allowedBillingCountries =
+                paymentMethodMetadata.billingDetailsCollectionConfiguration.allowedBillingCountries,
             removeExecutor = { method ->
                 val result = savedPaymentMethodMutatorProvider.get().removePaymentMethodInEditScreen(method)
                 if (result == null) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
@@ -37,7 +37,7 @@ internal class DefaultEmbeddedUpdateScreenInteractorFactory @Inject constructor(
             cardBrandFilter = paymentMethodMetadata.cardBrandFilter,
             addressCollectionMode = paymentMethodMetadata.billingDetailsCollectionConfiguration.address,
             allowedBillingCountries =
-                paymentMethodMetadata.billingDetailsCollectionConfiguration.allowedBillingCountries,
+            paymentMethodMetadata.billingDetailsCollectionConfiguration.allowedBillingCountries,
             removeExecutor = { method ->
                 val result = savedPaymentMethodMutatorProvider.get().removePaymentMethodInEditScreen(method)
                 if (result == null) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -28,7 +28,6 @@ import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.paymentelement.AddressAutocompletePreview
-import com.stripe.android.paymentelement.AllowedBillingCountriesInPaymentElementPreview
 import com.stripe.android.paymentelement.AnalyticEventCallback
 import com.stripe.android.paymentelement.AppearanceAPIAdditionsPreview
 import com.stripe.android.paymentelement.ConfirmCustomPaymentMethodCallback
@@ -2741,7 +2740,7 @@ class PaymentSheet internal constructor(
      * Configuration for how billing details are collected during checkout.
      */
     @Parcelize
-    data class BillingDetailsCollectionConfiguration @AllowedBillingCountriesInPaymentElementPreview constructor(
+    data class BillingDetailsCollectionConfiguration(
         /**
          * How to collect the name field.
          */
@@ -2777,7 +2776,6 @@ class PaymentSheet internal constructor(
          */
         val allowedCountries: Set<String> = emptySet(),
     ) : Parcelable {
-        @OptIn(AllowedBillingCountriesInPaymentElementPreview::class)
         constructor(
             /**
              * How to collect the name field.

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -28,6 +28,7 @@ import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.paymentelement.AddressAutocompletePreview
+import com.stripe.android.paymentelement.AllowedBillingCountriesInPaymentElementPreview
 import com.stripe.android.paymentelement.AnalyticEventCallback
 import com.stripe.android.paymentelement.AppearanceAPIAdditionsPreview
 import com.stripe.android.paymentelement.ConfirmCustomPaymentMethodCallback
@@ -2740,7 +2741,7 @@ class PaymentSheet internal constructor(
      * Configuration for how billing details are collected during checkout.
      */
     @Parcelize
-    data class BillingDetailsCollectionConfiguration(
+    data class BillingDetailsCollectionConfiguration @AllowedBillingCountriesInPaymentElementPreview constructor(
         /**
          * How to collect the name field.
          */
@@ -2768,7 +2769,52 @@ class PaymentSheet internal constructor(
          * If `false` (the default), those values will only be used to prefill the corresponding fields in the form.
          */
         val attachDefaultsToPaymentMethod: Boolean = false,
+
+        /**
+         * A list of two-letter country codes representing countries the customers can select.
+         *
+         * If the set is empty (the default), we display all countries.
+         */
+        val allowedCountries: Set<String> = emptySet(),
     ) : Parcelable {
+        @OptIn(AllowedBillingCountriesInPaymentElementPreview::class)
+        constructor(
+            /**
+             * How to collect the name field.
+             */
+            name: CollectionMode = CollectionMode.Automatic,
+
+            /**
+             * How to collect the phone field.
+             */
+            phone: CollectionMode = CollectionMode.Automatic,
+
+            /**
+             * How to collect the email field.
+             */
+            email: CollectionMode = CollectionMode.Automatic,
+
+            /**
+             * How to collect the billing address.
+             */
+            address: AddressCollectionMode = AddressCollectionMode.Automatic,
+
+            /**
+             * Whether the values included in [PaymentSheet.Configuration.defaultBillingDetails]
+             * should be attached to the payment method, this includes fields that aren't displayed in the form.
+             *
+             * If `false` (the default), those values will only be used to prefill the corresponding fields in the
+             * form.
+             */
+            attachDefaultsToPaymentMethod: Boolean = false,
+        ) : this(
+            name = name,
+            phone = phone,
+            email = email,
+            address = address,
+            attachDefaultsToPaymentMethod = attachDefaultsToPaymentMethod,
+            allowedCountries = emptySet(),
+        )
 
         internal val collectsName: Boolean
             get() = name == CollectionMode.Always

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -2774,7 +2774,7 @@ class PaymentSheet internal constructor(
          *
          * If the set is empty (the default), we display all countries.
          */
-        val allowedCountries: Set<String> = emptySet(),
+        private val allowedCountries: Set<String> = emptySet(),
     ) : Parcelable {
         constructor(
             /**
@@ -2831,6 +2831,11 @@ class PaymentSheet internal constructor(
 
         private val collectsFullAddress: Boolean
             get() = address == AddressCollectionMode.Full
+
+        @IgnoredOnParcel
+        internal val allowedBillingCountries by lazy {
+            allowedCountries.map { it.uppercase() }.toSet()
+        }
 
         internal fun toBillingAddressParameters(): GooglePayJsonFactory.BillingAddressParameters {
             val format = when (address) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentsheet
 
 import androidx.lifecycle.viewModelScope
-import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.orEmpty
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
@@ -386,8 +385,9 @@ internal class SavedPaymentMethodMutator(
                                 .canUpdateFullPaymentMethodDetails.value,
                             displayableSavedPaymentMethod = displayableSavedPaymentMethod,
                             cardBrandFilter = PaymentSheetCardBrandFilter(viewModel.config.cardBrandAcceptance),
-                            addressCollectionMode = viewModel.config.asCommonConfiguration()
-                                .billingDetailsCollectionConfiguration.address,
+                            addressCollectionMode = viewModel.config.billingDetailsCollectionConfiguration.address,
+                            allowedBillingCountries =
+                            viewModel.config.billingDetailsCollectionConfiguration.allowedCountries,
                             removeExecutor = { method ->
                                 performRemove()
                             },

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -387,7 +387,7 @@ internal class SavedPaymentMethodMutator(
                             cardBrandFilter = PaymentSheetCardBrandFilter(viewModel.config.cardBrandAcceptance),
                             addressCollectionMode = viewModel.config.billingDetailsCollectionConfiguration.address,
                             allowedBillingCountries =
-                            viewModel.config.billingDetailsCollectionConfiguration.allowedCountries,
+                            viewModel.config.billingDetailsCollectionConfiguration.allowedBillingCountries,
                             removeExecutor = { method ->
                                 performRemove()
                             },

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/PlaceholderHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/PlaceholderHelper.kt
@@ -158,7 +158,9 @@ internal object PlaceholderHelper {
                     )
         }
 
-        PlaceholderField.BillingAddress -> AddressSpec().takeIf {
+        PlaceholderField.BillingAddress -> AddressSpec(
+            allowedCountryCodes = configuration.allowedCountries,
+        ).takeIf {
             configuration.address == AddressCollectionMode.Full ||
                 (
                     placeholderOverrideList.contains(it.apiPath) &&
@@ -167,7 +169,7 @@ internal object PlaceholderHelper {
         }
 
         PlaceholderField.BillingAddressWithoutCountry ->
-            AddressSpec(hideCountry = true).takeIf {
+            AddressSpec(allowedCountryCodes = configuration.allowedCountries, hideCountry = true).takeIf {
                 configuration.address == AddressCollectionMode.Full ||
                     (
                         placeholderOverrideList.contains(it.apiPath) &&

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/PlaceholderHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/PlaceholderHelper.kt
@@ -159,7 +159,7 @@ internal object PlaceholderHelper {
         }
 
         PlaceholderField.BillingAddress -> AddressSpec(
-            allowedCountryCodes = configuration.allowedCountries,
+            allowedCountryCodes = configuration.allowedBillingCountries,
         ).takeIf {
             configuration.address == AddressCollectionMode.Full ||
                 (
@@ -169,7 +169,7 @@ internal object PlaceholderHelper {
         }
 
         PlaceholderField.BillingAddressWithoutCountry ->
-            AddressSpec(allowedCountryCodes = configuration.allowedCountries, hideCountry = true).takeIf {
+            AddressSpec(allowedCountryCodes = configuration.allowedBillingCountries, hideCountry = true).takeIf {
                 configuration.address == AddressCollectionMode.Full ||
                     (
                         placeholderOverrideList.contains(it.apiPath) &&

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -175,7 +175,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
         AutocompleteAddressElement(
             identifier = IdentifierSpec.Generic("billing_details[address]"),
             initialValues = defaultAddress?.asFormFieldValues() ?: emptyMap(),
-            countryCodes = collectionConfiguration.allowedCountries,
+            countryCodes = collectionConfiguration.allowedBillingCountries,
             sameAsShippingElement = sameAsShippingElement,
             interactorFactory = it,
             shippingValuesMap = args.formArgs.shippingDetails?.toIdentifierMap(args.formArgs.billingDetails),
@@ -185,7 +185,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
     val addressElement = autocompleteAddressElement ?: AddressElement(
         _identifier = IdentifierSpec.Generic("billing_details[address]"),
         rawValuesMap = defaultAddress?.asFormFieldValues() ?: emptyMap(),
-        countryCodes = collectionConfiguration.allowedCountries,
+        countryCodes = collectionConfiguration.allowedBillingCountries,
         sameAsShippingElement = sameAsShippingElement,
         shippingValuesMap = args.formArgs.shippingDetails?.toIdentifierMap(args.formArgs.billingDetails),
     )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -175,6 +175,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
         AutocompleteAddressElement(
             identifier = IdentifierSpec.Generic("billing_details[address]"),
             initialValues = defaultAddress?.asFormFieldValues() ?: emptyMap(),
+            countryCodes = collectionConfiguration.allowedCountries,
             sameAsShippingElement = sameAsShippingElement,
             interactorFactory = it,
             shippingValuesMap = args.formArgs.shippingDetails?.toIdentifierMap(args.formArgs.billingDetails),
@@ -184,6 +185,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
     val addressElement = autocompleteAddressElement ?: AddressElement(
         _identifier = IdentifierSpec.Generic("billing_details[address]"),
         rawValuesMap = defaultAddress?.asFormFieldValues() ?: emptyMap(),
+        countryCodes = collectionConfiguration.allowedCountries,
         sameAsShippingElement = sameAsShippingElement,
         shippingValuesMap = args.formArgs.shippingDetails?.toIdentifierMap(args.formArgs.billingDetails),
     )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BillingDetailsForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BillingDetailsForm.kt
@@ -25,6 +25,7 @@ internal class BillingDetailsForm(
     private val nameCollection: NameCollection,
     private val collectEmail: Boolean,
     private val collectPhone: Boolean,
+    allowedBillingCountries: Set<String>
 ) {
     val nameElement: SimpleTextElement? = if (nameCollection == NameCollection.OutsideBillingDetailsForm) {
         SimpleTextElement(
@@ -39,6 +40,7 @@ internal class BillingDetailsForm(
         identifier = IdentifierSpec.BillingAddress,
         sameAsShippingElement = null,
         shippingValuesMap = null,
+        countryCodes = allowedBillingCountries,
         collectionConfiguration = BillingDetailsCollectionConfiguration(
             address = when (addressCollectionMode) {
                 AddressCollectionMode.Automatic ->

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/EditCardDetailsInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/EditCardDetailsInteractor.kt
@@ -338,7 +338,7 @@ internal class DefaultEditCardDetailsInteractor(
             },
             collectEmail = billingDetailsCollectionConfiguration.collectsEmail,
             collectPhone = billingDetailsCollectionConfiguration.collectsPhone,
-            allowedBillingCountries = billingDetailsCollectionConfiguration.allowedCountries,
+            allowedBillingCountries = billingDetailsCollectionConfiguration.allowedBillingCountries,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/EditCardDetailsInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/EditCardDetailsInteractor.kt
@@ -338,6 +338,7 @@ internal class DefaultEditCardDetailsInteractor(
             },
             collectEmail = billingDetailsCollectionConfiguration.collectsEmail,
             collectPhone = billingDetailsCollectionConfiguration.collectsPhone,
+            allowedBillingCountries = billingDetailsCollectionConfiguration.allowedCountries,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
@@ -8,6 +8,7 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.LinkPaymentDetails
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentelement.AllowedBillingCountriesInPaymentElementPreview
 import com.stripe.android.paymentsheet.CardUpdateParams
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration
@@ -39,6 +40,7 @@ internal interface UpdatePaymentMethodInteractor {
     val shouldShowSaveButton: Boolean
     val canUpdateFullPaymentMethodDetails: Boolean
     val addressCollectionMode: AddressCollectionMode
+    val allowedBillingCountries: Set<String>
     val editCardDetailsInteractor: EditCardDetailsInteractor
 
     val state: StateFlow<State>
@@ -106,6 +108,7 @@ internal class DefaultUpdatePaymentMethodInteractor(
     override val displayableSavedPaymentMethod: DisplayableSavedPaymentMethod,
     override val cardBrandFilter: CardBrandFilter,
     override val addressCollectionMode: AddressCollectionMode,
+    override val allowedBillingCountries: Set<String>,
     override val canUpdateFullPaymentMethodDetails: Boolean,
     val isDefaultPaymentMethod: Boolean,
     override val shouldShowSetAsDefaultCheckbox: Boolean,
@@ -162,6 +165,7 @@ internal class DefaultUpdatePaymentMethodInteractor(
         }
     }
 
+    @OptIn(AllowedBillingCountriesInPaymentElementPreview::class)
     private fun createEditCardDetailsInteractorForCard(
         savedPaymentMethodCard: SavedPaymentMethod.Card,
     ): EditCardDetailsInteractor {
@@ -185,12 +189,14 @@ internal class DefaultUpdatePaymentMethodInteractor(
                 address = addressCollectionMode,
                 email = CollectionMode.Never,
                 phone = CollectionMode.Never,
-                name = CollectionMode.Never
+                name = CollectionMode.Never,
+                allowedCountries = allowedBillingCountries,
             ),
             requiresModification = true
         )
     }
 
+    @OptIn(AllowedBillingCountriesInPaymentElementPreview::class)
     private fun createEditCardDetailsInteractorForLink(
         savedPaymentMethodCard: LinkPaymentDetails.Card,
     ): EditCardDetailsInteractor {
@@ -212,7 +218,8 @@ internal class DefaultUpdatePaymentMethodInteractor(
                 address = AddressCollectionMode.Never,
                 email = CollectionMode.Never,
                 phone = CollectionMode.Never,
-                name = CollectionMode.Never
+                name = CollectionMode.Never,
+                allowedCountries = allowedBillingCountries,
             ),
             requiresModification = true
         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
@@ -8,7 +8,6 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.LinkPaymentDetails
 import com.stripe.android.model.PaymentMethod
-import com.stripe.android.paymentelement.AllowedBillingCountriesInPaymentElementPreview
 import com.stripe.android.paymentsheet.CardUpdateParams
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration
@@ -165,7 +164,6 @@ internal class DefaultUpdatePaymentMethodInteractor(
         }
     }
 
-    @OptIn(AllowedBillingCountriesInPaymentElementPreview::class)
     private fun createEditCardDetailsInteractorForCard(
         savedPaymentMethodCard: SavedPaymentMethod.Card,
     ): EditCardDetailsInteractor {
@@ -196,7 +194,6 @@ internal class DefaultUpdatePaymentMethodInteractor(
         )
     }
 
-    @OptIn(AllowedBillingCountriesInPaymentElementPreview::class)
     private fun createEditCardDetailsInteractorForLink(
         savedPaymentMethodCard: LinkPaymentDetails.Card,
     ): EditCardDetailsInteractor {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
@@ -334,6 +334,7 @@ private fun PreviewUpdatePaymentMethodUI() {
             canUpdateFullPaymentMethodDetails = true,
             displayableSavedPaymentMethod = exampleCard,
             addressCollectionMode = AddressCollectionMode.Automatic,
+            allowedBillingCountries = emptySet(),
             removeExecutor = { null },
             updatePaymentMethodExecutor = { paymentMethod, _ -> Result.success(paymentMethod) },
             setDefaultPaymentMethodExecutor = { _ -> Result.success(Unit) },

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -372,6 +372,7 @@ internal class CustomerSheetScreenshotTest {
                 // This checkbox is never displayed in CustomerSheet.
                 shouldShowSetAsDefaultCheckbox = false,
                 isDefaultPaymentMethod = false,
+                allowedBillingCountries = emptySet(),
                 onUpdateSuccess = {},
             ),
             isLiveMode = true,

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -28,7 +28,6 @@ import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.StripeIntent
-import com.stripe.android.paymentelement.AllowedBillingCountriesInPaymentElementPreview
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.financialconnections.IsFinancialConnectionsSdkAvailable
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -573,7 +572,6 @@ internal class DefaultCustomerSheetLoaderTest {
         assertThat(eventReporter.onLoadFailedCalls.awaitItem().message).isEqualTo("oops")
     }
 
-    @OptIn(AllowedBillingCountriesInPaymentElementPreview::class)
     @Test
     fun `Retains all payment method when 'allowedCountries' is empty`() = runTest {
         val paymentMethods = createCardsWithDifferentBillingDetails()
@@ -600,7 +598,6 @@ internal class DefaultCustomerSheetLoaderTest {
         assertThat(customerPaymentMethods).containsExactlyElementsIn(paymentMethods)
     }
 
-    @OptIn(AllowedBillingCountriesInPaymentElementPreview::class)
     @Test
     fun `Filters out countries not in 'allowedCountries' array`() = runTest {
         val paymentMethods = createCardsWithDifferentBillingDetails()

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -625,7 +625,6 @@ internal class DefaultCustomerSheetLoaderTest {
 
         assertThat(customerPaymentMethods).isNotNull()
         assertThat(customerPaymentMethods).containsExactly(
-            paymentMethods[0],
             paymentMethods[1],
             paymentMethods[4],
         )

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -612,7 +612,7 @@ internal class DefaultCustomerSheetLoaderTest {
             )
                 .billingDetailsCollectionConfiguration(
                     PaymentSheet.BillingDetailsCollectionConfiguration(
-                        allowedCountries = setOf("CA", "MX"),
+                        allowedCountries = setOf("CA", "mx"),
                     ),
                 )
                 .build(),

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/updatecard/UpdateCardScreenViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/updatecard/UpdateCardScreenViewModelTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.link.ui.updatecard
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.Logger
+import com.stripe.android.core.model.CountryUtils
 import com.stripe.android.isInstanceOf
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkDismissalCoordinator
@@ -15,6 +16,7 @@ import com.stripe.android.link.confirmation.DefaultCompleteLinkFlow
 import com.stripe.android.link.confirmation.FakeLinkConfirmationHandler
 import com.stripe.android.link.utils.TestNavigationManager
 import com.stripe.android.model.ConsumerPaymentDetails
+import com.stripe.android.paymentelement.AllowedBillingCountriesInPaymentElementPreview
 import com.stripe.android.paymentsheet.CardUpdateParams
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.testing.CoroutineTestRule
@@ -275,6 +277,92 @@ class UpdateCardScreenViewModelTest {
 
                     assertThat(hasPostalCodeElement).isTrue()
                     assertThat(hasCountryElement).isTrue()
+                }
+            }
+        }
+
+    @OptIn(AllowedBillingCountriesInPaymentElementPreview::class)
+    @Test
+    fun `when providing an empty set of allowed billing countries, should use all countries`() =
+        runTest(dispatcher) {
+            val card = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD
+
+            val viewModel = createViewModel(
+                linkAccountManager = FakeLinkAccountManager().apply {
+                    setConsumerPaymentDetails(ConsumerPaymentDetails(listOf(card)))
+                },
+                configuration = TestFactory.LINK_CONFIGURATION.copy(
+                    billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                        allowedCountries = emptySet()
+                    ),
+                ),
+                paymentDetailsId = card.id,
+                billingDetailsUpdateFlow = BillingDetailsUpdateFlow(),
+            )
+
+            viewModel.interactor.test {
+                val interactor = awaitItem()
+
+                assertThat(interactor).isNotNull()
+
+                requireNotNull(interactor).state.test {
+                    val billingElements = awaitItem().billingDetailsForm?.addressSectionElement?.fields
+
+                    assertThat(billingElements).isNotNull()
+
+                    val nonNullBillingElements = requireNotNull(billingElements)
+
+                    assertThat(nonNullBillingElements).hasSize(1)
+                    assertThat(nonNullBillingElements[0]).isInstanceOf<CardBillingAddressElement>()
+
+                    val cardBillingAddressElement = nonNullBillingElements[0] as CardBillingAddressElement
+
+                    assertThat(cardBillingAddressElement.countryElement.controller.displayItems)
+                        .hasSize(CountryUtils.supportedBillingCountries.size)
+                }
+            }
+        }
+
+    @OptIn(AllowedBillingCountriesInPaymentElementPreview::class)
+    @Test
+    fun `when providing an limited set of allowed billing countries, should use limited countries`() =
+        runTest(dispatcher) {
+            val card = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD
+
+            val viewModel = createViewModel(
+                linkAccountManager = FakeLinkAccountManager().apply {
+                    setConsumerPaymentDetails(ConsumerPaymentDetails(listOf(card)))
+                },
+                configuration = TestFactory.LINK_CONFIGURATION.copy(
+                    billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                        allowedCountries = setOf("US", "CA")
+                    ),
+                ),
+                paymentDetailsId = card.id,
+                billingDetailsUpdateFlow = BillingDetailsUpdateFlow(),
+            )
+
+            viewModel.interactor.test {
+                val interactor = awaitItem()
+
+                assertThat(interactor).isNotNull()
+
+                requireNotNull(interactor).state.test {
+                    val billingElements = awaitItem().billingDetailsForm?.addressSectionElement?.fields
+
+                    assertThat(billingElements).isNotNull()
+
+                    val nonNullBillingElements = requireNotNull(billingElements)
+
+                    assertThat(nonNullBillingElements).hasSize(1)
+                    assertThat(nonNullBillingElements[0]).isInstanceOf<CardBillingAddressElement>()
+
+                    val cardBillingAddressElement = nonNullBillingElements[0] as CardBillingAddressElement
+
+                    assertThat(cardBillingAddressElement.countryElement.controller.displayItems).containsExactly(
+                        "\uD83C\uDDFA\uD83C\uDDF8 United States",
+                        "\uD83C\uDDE8\uD83C\uDDE6 Canada"
+                    )
                 }
             }
         }

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/updatecard/UpdateCardScreenViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/updatecard/UpdateCardScreenViewModelTest.kt
@@ -16,7 +16,6 @@ import com.stripe.android.link.confirmation.DefaultCompleteLinkFlow
 import com.stripe.android.link.confirmation.FakeLinkConfirmationHandler
 import com.stripe.android.link.utils.TestNavigationManager
 import com.stripe.android.model.ConsumerPaymentDetails
-import com.stripe.android.paymentelement.AllowedBillingCountriesInPaymentElementPreview
 import com.stripe.android.paymentsheet.CardUpdateParams
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.testing.CoroutineTestRule
@@ -281,7 +280,6 @@ class UpdateCardScreenViewModelTest {
             }
         }
 
-    @OptIn(AllowedBillingCountriesInPaymentElementPreview::class)
     @Test
     fun `when providing an empty set of allowed billing countries, should use all countries`() =
         runTest(dispatcher) {
@@ -323,7 +321,6 @@ class UpdateCardScreenViewModelTest {
             }
         }
 
-    @OptIn(AllowedBillingCountriesInPaymentElementPreview::class)
     @Test
     fun `when providing an limited set of allowed billing countries, should use limited countries`() =
         runTest(dispatcher) {

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletScreenScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletScreenScreenshotTest.kt
@@ -12,6 +12,7 @@ import com.stripe.android.link.ui.LinkScreenshotSurface
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.CvcCheck
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.screenshottesting.Orientation
 import com.stripe.android.screenshottesting.PaparazziRule
 import com.stripe.android.screenshottesting.SystemAppearance
@@ -214,7 +215,8 @@ internal class WalletScreenScreenshotTest {
             cvcInput = cvcInput,
             alertMessage = alertMessage,
             collectMissingBillingDetailsForExistingPaymentMethods = true,
-            signupToggleEnabled = signupToggleEnabled
+            signupToggleEnabled = signupToggleEnabled,
+            billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(),
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletScreenTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletScreenTest.kt
@@ -46,6 +46,7 @@ import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.ConsumerPaymentDetailsUpdateParams
 import com.stripe.android.model.CvcCheck
 import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FakeLogger
 import com.stripe.android.ui.core.elements.CvcController
@@ -764,7 +765,8 @@ internal class WalletScreenTest {
                 addPaymentMethodOptions = addPaymentMethodOptions,
                 userSetIsExpanded = true,
                 collectMissingBillingDetailsForExistingPaymentMethods = true,
-                signupToggleEnabled = false
+                signupToggleEnabled = false,
+                billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(),
             ),
             onItemSelected = {},
             onExpandedChanged = {},

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletUiStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletUiStateTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.link.ui.wallet
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.CardBrandFilter
+import com.stripe.android.core.model.CountryCode
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.link.TestFactory
@@ -11,6 +12,8 @@ import com.stripe.android.link.ui.PrimaryButtonState
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.CvcCheck
+import com.stripe.android.paymentelement.AllowedBillingCountriesInPaymentElementPreview
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.uicore.forms.FormFieldEntry
 import org.junit.Test
@@ -221,6 +224,46 @@ class WalletUiStateTest {
         assertThat(state.isItemAvailable(paymentDetailsList[2])).isTrue()
     }
 
+    @OptIn(AllowedBillingCountriesInPaymentElementPreview::class)
+    @Test
+    fun testPaymentMethodAvailabilityForAllAllowedBillingCountries() {
+        val paymentDetailsList = createPaymentMethodsWithDifferentBillingDetails()
+
+        val state = walletUiState(
+            paymentDetailsList = paymentDetailsList,
+            selectedItem = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD,
+            billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                allowedCountries = emptySet(),
+            )
+        )
+
+        assertThat(state.isItemAvailable(paymentDetailsList[0])).isTrue()
+        assertThat(state.isItemAvailable(paymentDetailsList[1])).isTrue()
+        assertThat(state.isItemAvailable(paymentDetailsList[2])).isTrue()
+        assertThat(state.isItemAvailable(paymentDetailsList[3])).isTrue()
+        assertThat(state.isItemAvailable(paymentDetailsList[4])).isTrue()
+    }
+
+    @OptIn(AllowedBillingCountriesInPaymentElementPreview::class)
+    @Test
+    fun testPaymentMethodAvailabilityForLimitedAllowedBillingCountries() {
+        val paymentDetailsList = createPaymentMethodsWithDifferentBillingDetails()
+
+        val state = walletUiState(
+            paymentDetailsList = paymentDetailsList,
+            selectedItem = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD,
+            billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                allowedCountries = setOf("CA", "GB"),
+            )
+        )
+
+        assertThat(state.isItemAvailable(paymentDetailsList[0])).isTrue()
+        assertThat(state.isItemAvailable(paymentDetailsList[1])).isFalse()
+        assertThat(state.isItemAvailable(paymentDetailsList[2])).isFalse()
+        assertThat(state.isItemAvailable(paymentDetailsList[3])).isTrue()
+        assertThat(state.isItemAvailable(paymentDetailsList[4])).isTrue()
+    }
+
     @Test
     fun testIsExpanded() {
         val state = walletUiState(
@@ -256,7 +299,9 @@ class WalletUiStateTest {
         isSettingUp: Boolean = false,
         merchantName: String = "Example Inc.",
         collectMissingBillingDetailsForExistingPaymentMethods: Boolean = true,
-        signupToggleEnabled: Boolean = false
+        signupToggleEnabled: Boolean = false,
+        billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration =
+            PaymentSheet.BillingDetailsCollectionConfiguration(),
     ): WalletUiState {
         return WalletUiState(
             paymentDetailsList = paymentDetailsList,
@@ -276,7 +321,56 @@ class WalletUiStateTest {
             merchantName = merchantName,
             collectMissingBillingDetailsForExistingPaymentMethods =
             collectMissingBillingDetailsForExistingPaymentMethods,
-            signupToggleEnabled = signupToggleEnabled
+            signupToggleEnabled = signupToggleEnabled,
+            billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration,
         )
     }
+
+    private fun createPaymentMethodsWithDifferentBillingDetails() = listOf(
+        TestFactory.CONSUMER_PAYMENT_DETAILS_CARD.copy(
+            id = "pm_1",
+            last4 = "1235",
+            billingAddress = null,
+        ),
+        TestFactory.CONSUMER_PAYMENT_DETAILS_CARD.copy(
+            id = "pm_2",
+            last4 = "4235",
+            billingAddress = createBillingAddress(
+                countryCode = CountryCode.US,
+            ),
+        ),
+        TestFactory.CONSUMER_PAYMENT_DETAILS_BANK_ACCOUNT.copy(
+            id = "pm_3",
+            last4 = "9382",
+            billingAddress = createBillingAddress(
+                countryCode = CountryCode.US,
+            ),
+        ),
+        TestFactory.CONSUMER_PAYMENT_DETAILS_CARD.copy(
+            brand = CardBrand.MasterCard,
+            last4 = "1234",
+            billingAddress = createBillingAddress(
+                countryCode = CountryCode.GB,
+            ),
+        ),
+        TestFactory.CONSUMER_PAYMENT_DETAILS_CARD.copy(
+            brand = CardBrand.MasterCard,
+            last4 = "8902",
+            billingAddress = createBillingAddress(
+                countryCode = CountryCode.CA,
+            ),
+        )
+    )
+
+    private fun createBillingAddress(
+        countryCode: CountryCode,
+    ) = ConsumerPaymentDetails.BillingAddress(
+        name = null,
+        line1 = null,
+        line2 = null,
+        locality = null,
+        administrativeArea = null,
+        countryCode = countryCode,
+        postalCode = null,
+    )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletUiStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletUiStateTest.kt
@@ -242,6 +242,7 @@ class WalletUiStateTest {
         assertThat(state.isItemAvailable(paymentDetailsList[2])).isTrue()
         assertThat(state.isItemAvailable(paymentDetailsList[3])).isTrue()
         assertThat(state.isItemAvailable(paymentDetailsList[4])).isTrue()
+        assertThat(state.isItemAvailable(paymentDetailsList[5])).isTrue()
     }
 
     @OptIn(AllowedBillingCountriesInPaymentElementPreview::class)
@@ -257,11 +258,12 @@ class WalletUiStateTest {
             )
         )
 
-        assertThat(state.isItemAvailable(paymentDetailsList[0])).isTrue()
+        assertThat(state.isItemAvailable(paymentDetailsList[0])).isFalse()
         assertThat(state.isItemAvailable(paymentDetailsList[1])).isFalse()
         assertThat(state.isItemAvailable(paymentDetailsList[2])).isFalse()
-        assertThat(state.isItemAvailable(paymentDetailsList[3])).isTrue()
+        assertThat(state.isItemAvailable(paymentDetailsList[3])).isFalse()
         assertThat(state.isItemAvailable(paymentDetailsList[4])).isTrue()
+        assertThat(state.isItemAvailable(paymentDetailsList[5])).isTrue()
     }
 
     @Test
@@ -346,11 +348,10 @@ class WalletUiStateTest {
                 countryCode = CountryCode.US,
             ),
         ),
-        TestFactory.CONSUMER_PAYMENT_DETAILS_CARD.copy(
-            brand = CardBrand.MasterCard,
+        TestFactory.CONSUMER_PAYMENT_DETAILS_PASSTHROUGH.copy(
             last4 = "1234",
             billingAddress = createBillingAddress(
-                countryCode = CountryCode.GB,
+                countryCode = CountryCode.US,
             ),
         ),
         TestFactory.CONSUMER_PAYMENT_DETAILS_CARD.copy(
@@ -358,6 +359,13 @@ class WalletUiStateTest {
             last4 = "8902",
             billingAddress = createBillingAddress(
                 countryCode = CountryCode.CA,
+            ),
+        ),
+        TestFactory.CONSUMER_PAYMENT_DETAILS_CARD.copy(
+            brand = CardBrand.MasterCard,
+            last4 = "8902",
+            billingAddress = createBillingAddress(
+                countryCode = CountryCode.GB,
             ),
         )
     )

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletUiStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletUiStateTest.kt
@@ -12,7 +12,6 @@ import com.stripe.android.link.ui.PrimaryButtonState
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.CvcCheck
-import com.stripe.android.paymentelement.AllowedBillingCountriesInPaymentElementPreview
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.uicore.forms.FormFieldEntry
@@ -224,7 +223,6 @@ class WalletUiStateTest {
         assertThat(state.isItemAvailable(paymentDetailsList[2])).isTrue()
     }
 
-    @OptIn(AllowedBillingCountriesInPaymentElementPreview::class)
     @Test
     fun testPaymentMethodAvailabilityForAllAllowedBillingCountries() {
         val paymentDetailsList = createPaymentMethodsWithDifferentBillingDetails()
@@ -245,7 +243,6 @@ class WalletUiStateTest {
         assertThat(state.isItemAvailable(paymentDetailsList[5])).isTrue()
     }
 
-    @OptIn(AllowedBillingCountriesInPaymentElementPreview::class)
     @Test
     fun testPaymentMethodAvailabilityForLimitedAllowedBillingCountries() {
         val paymentDetailsList = createPaymentMethodsWithDifferentBillingDetails()

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
@@ -34,6 +34,7 @@ import com.stripe.android.model.ConsumerPaymentDetailsUpdateParams
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FakeLogger
 import com.stripe.android.uicore.forms.FormFieldEntry
@@ -91,7 +92,8 @@ class WalletViewModelTest {
                 isSettingUp = false,
                 merchantName = "merchantName",
                 collectMissingBillingDetailsForExistingPaymentMethods = true,
-                signupToggleEnabled = false
+                signupToggleEnabled = false,
+                billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(),
             )
         )
         assertThat(state.selectedItem).isEqualTo(TestFactory.CONSUMER_PAYMENT_DETAILS.paymentDetails.firstOrNull())

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/FormElementsBuilderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/FormElementsBuilderTest.kt
@@ -5,12 +5,15 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.cards.DefaultCardAccountRangeRepositoryFactory
+import com.stripe.android.core.model.CountryUtils
 import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
+import com.stripe.android.paymentelement.AllowedBillingCountriesInPaymentElementPreview
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.TestAutocompleteAddressInteractor
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.ui.core.elements.EmptyFormElement
+import com.stripe.android.uicore.elements.AddressElement
 import com.stripe.android.uicore.elements.AutocompleteAddressElement
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.IdentifierSpec
@@ -152,6 +155,66 @@ class FormElementsBuilderTest {
 
         assertThat(sectionElement.fields.size).isEqualTo(1)
         assertThat(sectionElement.fields.firstOrNull()).isInstanceOf<AutocompleteAddressElement>()
+    }
+
+    @OptIn(AllowedBillingCountriesInPaymentElementPreview::class)
+    @Test
+    fun `build contains all supported billing countries when allowed countries is empty`() {
+        val arguments = arguments(
+            billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never,
+                phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never,
+                email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never,
+                address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
+                allowedCountries = emptySet()
+            )
+        )
+        val formElements = FormElementsBuilder(arguments).build()
+
+        assertThat(formElements).hasSize(1)
+        assertThat(formElements.firstOrNull()).isInstanceOf<SectionElement>()
+
+        val sectionElement = formElements.first() as SectionElement
+        val sectionFields = sectionElement.fields
+
+        assertThat(sectionFields.size).isEqualTo(1)
+        assertThat(sectionFields.firstOrNull()).isInstanceOf<AddressElement>()
+
+        val addressElement = sectionFields.first() as AddressElement
+
+        assertThat(addressElement.countryElement.controller.displayItems)
+            .hasSize(CountryUtils.supportedBillingCountries.size)
+    }
+
+    @OptIn(AllowedBillingCountriesInPaymentElementPreview::class)
+    @Test
+    fun `build contains only countries provided through billing configuration`() {
+        val arguments = arguments(
+            billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never,
+                phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never,
+                email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never,
+                address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
+                allowedCountries = setOf("US", "CA")
+            )
+        )
+        val formElements = FormElementsBuilder(arguments).build()
+
+        assertThat(formElements).hasSize(1)
+        assertThat(formElements.firstOrNull()).isInstanceOf<SectionElement>()
+
+        val sectionElement = formElements.first() as SectionElement
+        val sectionFields = sectionElement.fields
+
+        assertThat(sectionFields.size).isEqualTo(1)
+        assertThat(sectionFields.firstOrNull()).isInstanceOf<AddressElement>()
+
+        val addressElement = sectionFields.first() as AddressElement
+
+        assertThat(addressElement.countryElement.controller.displayItems).containsExactly(
+            "\uD83C\uDDFA\uD83C\uDDF8 United States",
+            "\uD83C\uDDE8\uD83C\uDDE6 Canada"
+        )
     }
 
     private fun arguments(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/FormElementsBuilderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/FormElementsBuilderTest.kt
@@ -8,7 +8,6 @@ import com.stripe.android.cards.DefaultCardAccountRangeRepositoryFactory
 import com.stripe.android.core.model.CountryUtils
 import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
-import com.stripe.android.paymentelement.AllowedBillingCountriesInPaymentElementPreview
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.TestAutocompleteAddressInteractor
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
@@ -157,7 +156,6 @@ class FormElementsBuilderTest {
         assertThat(sectionElement.fields.firstOrNull()).isInstanceOf<AutocompleteAddressElement>()
     }
 
-    @OptIn(AllowedBillingCountriesInPaymentElementPreview::class)
     @Test
     fun `build contains all supported billing countries when allowed countries is empty`() {
         val arguments = arguments(
@@ -186,7 +184,6 @@ class FormElementsBuilderTest {
             .hasSize(CountryUtils.supportedBillingCountries.size)
     }
 
-    @OptIn(AllowedBillingCountriesInPaymentElementPreview::class)
     @Test
     fun `build contains only countries provided through billing configuration`() {
         val arguments = arguments(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinitionTest.kt
@@ -16,7 +16,6 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.model.SetupIntentFixtures
-import com.stripe.android.paymentelement.AllowedBillingCountriesInPaymentElementPreview
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
@@ -407,7 +406,6 @@ class CardDefinitionTest {
             .isInstanceOf<AutocompleteAddressController>()
     }
 
-    @OptIn(AllowedBillingCountriesInPaymentElementPreview::class)
     @Test
     fun `createFormElements contains all supported billing countries when allowed countries is empty`() {
         val formElements = CardDefinition.formElements(
@@ -437,7 +435,6 @@ class CardDefinitionTest {
             .hasSize(CountryUtils.supportedBillingCountries.size)
     }
 
-    @OptIn(AllowedBillingCountriesInPaymentElementPreview::class)
     @Test
     fun `createFormElements contains only countries provided through billing configuration`() {
         val formElements = CardDefinition.formElements(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/PlaceholderHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/PlaceholderHelperTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.forms
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.isInstanceOf
+import com.stripe.android.paymentelement.AllowedBillingCountriesInPaymentElementPreview
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.forms.PlaceholderHelper.removeCorrespondingPlaceholder
 import com.stripe.android.paymentsheet.forms.PlaceholderHelper.specForPlaceholderField
@@ -111,7 +112,7 @@ class PlaceholderHelperTest {
                 label = StripeR.string.stripe_affirm_buy_now_pay_later,
             ),
             PhoneSpec(),
-            AddressSpec(),
+            AddressSpec(allowedCountryCodes = emptySet()),
         )
     }
 
@@ -283,7 +284,7 @@ class PlaceholderHelperTest {
                 configuration = billingDetailsCollectionConfiguration,
                 termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
             )
-        ).isEqualTo(AddressSpec())
+        ).isEqualTo(AddressSpec(allowedCountryCodes = emptySet()),)
         assertThat(
             specForPlaceholderField(
                 field = PlaceholderField.BillingAddressWithoutCountry,
@@ -292,7 +293,7 @@ class PlaceholderHelperTest {
                 configuration = billingDetailsCollectionConfiguration,
                 termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
             )
-        ).isEqualTo(AddressSpec(hideCountry = true))
+        ).isEqualTo(AddressSpec(allowedCountryCodes = emptySet(), hideCountry = true))
         assertThat(
             specForPlaceholderField(
                 field = PlaceholderField.SepaMandate,
@@ -561,6 +562,90 @@ class PlaceholderHelperTest {
             >()
     }
 
+    @OptIn(AllowedBillingCountriesInPaymentElementPreview::class)
+    @Test
+    fun `Test with empty set of allowed billing countries`() {
+        val billingDetailsCollectionConfigurationWithAllCountries =
+            PaymentSheet.BillingDetailsCollectionConfiguration(
+                name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic,
+                email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic,
+                phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic,
+                address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
+                attachDefaultsToPaymentMethod = false,
+                allowedCountries = emptySet()
+            )
+
+        val placeholderSpecForBillingAddress = specForPlaceholderField(
+            field = PlaceholderField.BillingAddress,
+            placeholderOverrideList = listOf(IdentifierSpec.BillingAddress),
+            requiresMandate = false,
+            configuration = billingDetailsCollectionConfigurationWithAllCountries,
+            termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
+        )
+
+        assertThat(placeholderSpecForBillingAddress).isInstanceOf<AddressSpec>()
+
+        val addressSpec = placeholderSpecForBillingAddress as AddressSpec
+
+        assertThat(addressSpec.allowedCountryCodes).isEmpty()
+
+        val placeholderSpecForBillingAddressWithoutCountry = specForPlaceholderField(
+            field = PlaceholderField.BillingAddressWithoutCountry,
+            placeholderOverrideList = listOf(IdentifierSpec.BillingAddress),
+            requiresMandate = false,
+            configuration = billingDetailsCollectionConfigurationWithAllCountries,
+            termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
+        )
+
+        assertThat(placeholderSpecForBillingAddressWithoutCountry).isInstanceOf<AddressSpec>()
+
+        val addressSpecWithoutCountry = placeholderSpecForBillingAddressWithoutCountry as AddressSpec
+
+        assertThat(addressSpecWithoutCountry.allowedCountryCodes).isEmpty()
+    }
+
+    @OptIn(AllowedBillingCountriesInPaymentElementPreview::class)
+    @Test
+    fun `Test with limited set of allowed billing countries`() {
+        val billingDetailsCollectionConfigurationWithAllCountries =
+            PaymentSheet.BillingDetailsCollectionConfiguration(
+                name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic,
+                email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic,
+                phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic,
+                address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
+                attachDefaultsToPaymentMethod = false,
+                allowedCountries = setOf("US", "CA"),
+            )
+
+        val placeholderSpecForBillingAddress = specForPlaceholderField(
+            field = PlaceholderField.BillingAddress,
+            placeholderOverrideList = listOf(IdentifierSpec.BillingAddress),
+            requiresMandate = false,
+            configuration = billingDetailsCollectionConfigurationWithAllCountries,
+            termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
+        )
+
+        assertThat(placeholderSpecForBillingAddress).isInstanceOf<AddressSpec>()
+
+        val addressSpec = placeholderSpecForBillingAddress as AddressSpec
+
+        assertThat(addressSpec.allowedCountryCodes).containsExactly("US", "CA")
+
+        val placeholderSpecForBillingAddressWithoutCountry = specForPlaceholderField(
+            field = PlaceholderField.BillingAddressWithoutCountry,
+            placeholderOverrideList = listOf(IdentifierSpec.BillingAddress),
+            requiresMandate = false,
+            configuration = billingDetailsCollectionConfigurationWithAllCountries,
+            termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
+        )
+
+        assertThat(placeholderSpecForBillingAddressWithoutCountry).isInstanceOf<AddressSpec>()
+
+        val addressSpecWithoutCountry = placeholderSpecForBillingAddressWithoutCountry as AddressSpec
+
+        assertThat(addressSpecWithoutCountry.allowedCountryCodes).containsExactly("US", "CA")
+    }
+
     @Test
     fun `Test mandate is moved to the end of the list`() {
         val billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
@@ -592,7 +677,7 @@ class PlaceholderHelperTest {
             NameSpec(),
             EmailSpec(),
             PhoneSpec(),
-            AddressSpec(),
+            AddressSpec(allowedCountryCodes = emptySet()),
             mandateTextSpec
         )
     }
@@ -628,7 +713,7 @@ class PlaceholderHelperTest {
             NameSpec(),
             EmailSpec(),
             PhoneSpec(),
-            AddressSpec(),
+            AddressSpec(allowedCountryCodes = emptySet()),
             mandateTextSpec
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/PlaceholderHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/PlaceholderHelperTest.kt
@@ -2,7 +2,6 @@ package com.stripe.android.paymentsheet.forms
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.isInstanceOf
-import com.stripe.android.paymentelement.AllowedBillingCountriesInPaymentElementPreview
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.forms.PlaceholderHelper.removeCorrespondingPlaceholder
 import com.stripe.android.paymentsheet.forms.PlaceholderHelper.specForPlaceholderField
@@ -562,7 +561,6 @@ class PlaceholderHelperTest {
             >()
     }
 
-    @OptIn(AllowedBillingCountriesInPaymentElementPreview::class)
     @Test
     fun `Test with empty set of allowed billing countries`() {
         val billingDetailsCollectionConfigurationWithAllCountries =
@@ -604,7 +602,6 @@ class PlaceholderHelperTest {
         assertThat(addressSpecWithoutCountry.allowedCountryCodes).isEmpty()
     }
 
-    @OptIn(AllowedBillingCountriesInPaymentElementPreview::class)
     @Test
     fun `Test with limited set of allowed billing countries`() {
         val billingDetailsCollectionConfigurationWithAllCountries =

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
@@ -22,7 +22,6 @@ import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.PaymentMethodOptionsParams
-import com.stripe.android.paymentelement.AllowedBillingCountriesInPaymentElementPreview
 import com.stripe.android.payments.bankaccount.CollectBankAccountConfiguration
 import com.stripe.android.payments.bankaccount.CollectBankAccountLauncher
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResponseInternal
@@ -1556,7 +1555,6 @@ class USBankAccountFormViewModelTest {
         }
     }
 
-    @OptIn(AllowedBillingCountriesInPaymentElementPreview::class)
     @Test
     fun `Contains all supported billing countries when allowed countries is empty`() {
         val viewModel = createViewModel(
@@ -1579,7 +1577,6 @@ class USBankAccountFormViewModelTest {
             .hasSize(CountryUtils.supportedBillingCountries.size)
     }
 
-    @OptIn(AllowedBillingCountriesInPaymentElementPreview::class)
     @Test
     fun `Contains only countries provided through billing configuration`() {
         val viewModel = createViewModel(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
@@ -7,6 +7,7 @@ import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.model.CountryUtils
 import com.stripe.android.financialconnections.ElementsSessionContext
 import com.stripe.android.financialconnections.model.BankAccount
 import com.stripe.android.financialconnections.model.FinancialConnectionsAccount
@@ -21,6 +22,7 @@ import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.PaymentMethodOptionsParams
+import com.stripe.android.paymentelement.AllowedBillingCountriesInPaymentElementPreview
 import com.stripe.android.payments.bankaccount.CollectBankAccountConfiguration
 import com.stripe.android.payments.bankaccount.CollectBankAccountLauncher
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResponseInternal
@@ -1552,6 +1554,54 @@ class USBankAccountFormViewModelTest {
             viewModel.emailController.onValueChange("email@email.com")
             assertThat(awaitItem()?.paymentMethodCreateParams?.billingDetails?.email).isEqualTo("email@email.com")
         }
+    }
+
+    @OptIn(AllowedBillingCountriesInPaymentElementPreview::class)
+    @Test
+    fun `Contains all supported billing countries when allowed countries is empty`() {
+        val viewModel = createViewModel(
+            args = defaultArgs.run {
+                copy(
+                    formArgs = formArgs.copy(
+                        billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                            name = CollectionMode.Automatic,
+                            phone = CollectionMode.Automatic,
+                            email = CollectionMode.Automatic,
+                            address = AddressCollectionMode.Full,
+                            allowedCountries = emptySet()
+                        )
+                    )
+                )
+            }
+        )
+
+        assertThat(viewModel.addressElement.countryElement.controller.displayItems)
+            .hasSize(CountryUtils.supportedBillingCountries.size)
+    }
+
+    @OptIn(AllowedBillingCountriesInPaymentElementPreview::class)
+    @Test
+    fun `Contains only countries provided through billing configuration`() {
+        val viewModel = createViewModel(
+            args = defaultArgs.run {
+                copy(
+                    formArgs = formArgs.copy(
+                        billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                            name = CollectionMode.Automatic,
+                            phone = CollectionMode.Automatic,
+                            email = CollectionMode.Automatic,
+                            address = AddressCollectionMode.Full,
+                            allowedCountries = setOf("US", "CA")
+                        )
+                    )
+                )
+            }
+        )
+
+        assertThat(viewModel.addressElement.countryElement.controller.displayItems).containsExactly(
+            "\uD83C\uDDFA\uD83C\uDDF8 United States",
+            "\uD83C\uDDE8\uD83C\uDDE6 Canada"
+        )
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -1864,7 +1864,6 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(customerPaymentMethods).isNotNull()
         assertThat(customerPaymentMethods).containsExactly(
-            paymentMethods[0],
             paymentMethods[1],
             paymentMethods[4],
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -1847,7 +1847,7 @@ internal class DefaultPaymentElementLoaderTest {
             ),
             configuration = CommonConfigurationFactory.create(
                 billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
-                    allowedCountries = setOf("CA", "MX"),
+                    allowedCountries = setOf("CA", "mx"),
                 ),
                 customer = PaymentSheet.CustomerConfiguration.createWithCustomerSession(
                     id = "cus_1",

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.state
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.common.analytics.experiment.LogLinkHoldbackExperiment
+import com.stripe.android.common.model.CommonConfigurationFactory
 import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.exception.APIConnectionException
@@ -22,6 +23,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.DisplayableCustomPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilter
+import com.stripe.android.model.Address
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.LinkMode
@@ -33,6 +35,7 @@ import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.StripeIntent.Status.Canceled
 import com.stripe.android.model.StripeIntent.Status.Succeeded
 import com.stripe.android.model.wallets.Wallet
+import com.stripe.android.paymentelement.AllowedBillingCountriesInPaymentElementPreview
 import com.stripe.android.paymentelement.ExperimentalCustomPaymentMethodsApi
 import com.stripe.android.paymentelement.WalletButtonsPreview
 import com.stripe.android.payments.core.analytics.ErrorReporter
@@ -1790,6 +1793,80 @@ internal class DefaultPaymentElementLoaderTest {
             passthroughModeEnabled = true,
             useNativeLink = false,
             expectedEnabled = false
+        )
+    }
+
+    @OptIn(AllowedBillingCountriesInPaymentElementPreview::class, ExperimentalCustomerSessionApi::class)
+    @Test
+    fun `Retains all payment method when 'allowedCountries' is empty`() = runTest {
+        val paymentMethods = createCardsWithDifferentBillingDetails()
+
+        val loader = createPaymentElementLoader(
+            customer = createElementsSessionCustomer(
+                paymentMethods = paymentMethods,
+            ),
+        )
+
+        val result = loader.load(
+            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
+                clientSecret = "pi_123_secret_123"
+            ),
+            configuration = CommonConfigurationFactory.create(
+                billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                    allowedCountries = emptySet(),
+                ),
+                customer = PaymentSheet.CustomerConfiguration.createWithCustomerSession(
+                    id = "cus_1",
+                    clientSecret = "cus_123",
+                ),
+            ),
+            metadata = PaymentElementLoader.Metadata(
+                initializedViaCompose = false,
+            ),
+        )
+
+        val customerPaymentMethods = result.getOrNull()?.customer?.paymentMethods
+
+        assertThat(customerPaymentMethods).isNotNull()
+        assertThat(customerPaymentMethods).containsExactlyElementsIn(paymentMethods)
+    }
+
+    @OptIn(AllowedBillingCountriesInPaymentElementPreview::class, ExperimentalCustomerSessionApi::class)
+    @Test
+    fun `Filters out countries not in 'allowedCountries' array`() = runTest {
+        val paymentMethods = createCardsWithDifferentBillingDetails()
+
+        val loader = createPaymentElementLoader(
+            customer = createElementsSessionCustomer(
+                paymentMethods = paymentMethods,
+            ),
+        )
+
+        val result = loader.load(
+            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
+                clientSecret = "pi_123_secret_123"
+            ),
+            configuration = CommonConfigurationFactory.create(
+                billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                    allowedCountries = setOf("CA", "MX"),
+                ),
+                customer = PaymentSheet.CustomerConfiguration.createWithCustomerSession(
+                    id = "cus_1",
+                    clientSecret = "cus_123",
+                ),
+            ),
+            metadata = PaymentElementLoader.Metadata(
+                initializedViaCompose = false,
+            ),
+        )
+
+        val customerPaymentMethods = result.getOrNull()?.customer?.paymentMethods
+
+        assertThat(customerPaymentMethods).isNotNull()
+        assertThat(customerPaymentMethods).containsExactly(
+            paymentMethods[0],
+            paymentMethods[1],
+            paymentMethods[4],
         )
     }
 
@@ -3591,6 +3668,45 @@ internal class DefaultPaymentElementLoaderTest {
             defaultPaymentMethod = null,
         )
     }
+
+    private fun createCardsWithDifferentBillingDetails(): List<PaymentMethod> = listOf(
+        PaymentMethodFactory.card(
+            last4 = "4242",
+            billingDetails = null,
+        ),
+        PaymentMethodFactory.card(
+            last4 = "4444",
+            billingDetails = PaymentMethod.BillingDetails(
+                address = Address(
+                    country = "CA",
+                )
+            )
+        ),
+        PaymentMethodFactory.card(
+            last4 = "4444",
+            billingDetails = PaymentMethod.BillingDetails(
+                address = Address(
+                    country = "US",
+                )
+            )
+        ),
+        PaymentMethodFactory.card(
+            last4 = "4444",
+            billingDetails = PaymentMethod.BillingDetails(
+                address = Address(
+                    country = "US",
+                )
+            )
+        ),
+        PaymentMethodFactory.card(
+            last4 = "4444",
+            billingDetails = PaymentMethod.BillingDetails(
+                address = Address(
+                    country = "MX",
+                )
+            )
+        ),
+    )
 
     private fun createPaymentElementLoader(
         isGooglePayReady: Boolean = true,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -35,7 +35,6 @@ import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.StripeIntent.Status.Canceled
 import com.stripe.android.model.StripeIntent.Status.Succeeded
 import com.stripe.android.model.wallets.Wallet
-import com.stripe.android.paymentelement.AllowedBillingCountriesInPaymentElementPreview
 import com.stripe.android.paymentelement.ExperimentalCustomPaymentMethodsApi
 import com.stripe.android.paymentelement.WalletButtonsPreview
 import com.stripe.android.payments.core.analytics.ErrorReporter
@@ -1796,7 +1795,7 @@ internal class DefaultPaymentElementLoaderTest {
         )
     }
 
-    @OptIn(AllowedBillingCountriesInPaymentElementPreview::class, ExperimentalCustomerSessionApi::class)
+    @OptIn(ExperimentalCustomerSessionApi::class)
     @Test
     fun `Retains all payment method when 'allowedCountries' is empty`() = runTest {
         val paymentMethods = createCardsWithDifferentBillingDetails()
@@ -1831,7 +1830,7 @@ internal class DefaultPaymentElementLoaderTest {
         assertThat(customerPaymentMethods).containsExactlyElementsIn(paymentMethods)
     }
 
-    @OptIn(AllowedBillingCountriesInPaymentElementPreview::class, ExperimentalCustomerSessionApi::class)
+    @OptIn(ExperimentalCustomerSessionApi::class)
     @Test
     fun `Filters out countries not in 'allowedCountries' array`() = runTest {
         val paymentMethods = createCardsWithDifferentBillingDetails()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/BillingDetailsFormTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/BillingDetailsFormTest.kt
@@ -2,10 +2,13 @@ package com.stripe.android.paymentsheet.ui
 
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.model.CountryUtils
+import com.stripe.android.isInstanceOf
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode
 import com.stripe.android.testing.CoroutineTestRule
+import com.stripe.android.ui.core.elements.CardBillingAddressElement
 import com.stripe.android.uicore.forms.FormFieldEntry
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -64,6 +67,34 @@ internal class BillingDetailsFormTest {
         }
     }
 
+    @Test
+    fun testAllBillingCountriesUsed() = runScenario(
+        allowedCountries = emptySet()
+    ) {
+        assertThat(addressSectionElement.fields.size).isEqualTo(1)
+        assertThat(addressSectionElement.fields.firstOrNull()).isInstanceOf<CardBillingAddressElement>()
+
+        val cardBillingAddressElement = addressSectionElement.fields[0] as CardBillingAddressElement
+
+        assertThat(cardBillingAddressElement.countryElement.controller.displayItems)
+            .hasSize(CountryUtils.supportedBillingCountries.size)
+    }
+
+    @Test
+    fun testLimitedBillingCountriesUsed() = runScenario(
+        allowedCountries = setOf("US", "CA")
+    ) {
+        assertThat(addressSectionElement.fields.size).isEqualTo(1)
+        assertThat(addressSectionElement.fields.firstOrNull()).isInstanceOf<CardBillingAddressElement>()
+
+        val cardBillingAddressElement = addressSectionElement.fields[0] as CardBillingAddressElement
+
+        assertThat(cardBillingAddressElement.countryElement.controller.displayItems).containsExactly(
+            "\uD83C\uDDFA\uD83C\uDDF8 United States",
+            "\uD83C\uDDE8\uD83C\uDDE6 Canada"
+        )
+    }
+
     private fun FormFieldEntry?.isEqualTo(other: Any?) {
         assertThat(this?.value?.takeIf { it.isNotBlank() }).isEqualTo(other)
     }
@@ -75,6 +106,7 @@ internal class BillingDetailsFormTest {
     private fun runScenario(
         billingDetails: PaymentMethod.BillingDetails? = PaymentMethodFixtures.BILLING_DETAILS,
         addressCollectionMode: AddressCollectionMode = AddressCollectionMode.Full,
+        allowedCountries: Set<String> = emptySet(),
         block: suspend BillingDetailsForm.() -> Unit
     ) = runTest(testDispatcher) {
         val form = BillingDetailsForm(
@@ -83,6 +115,7 @@ internal class BillingDetailsFormTest {
             nameCollection = NameCollection.Disabled,
             collectEmail = false,
             collectPhone = false,
+            allowedBillingCountries = allowedCountries,
         )
         block(form)
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/BillingDetailsFormUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/BillingDetailsFormUITest.kt
@@ -84,6 +84,7 @@ internal class BillingDetailsFormUITest {
             nameCollection = NameCollection.Disabled,
             collectEmail = false,
             collectPhone = false,
+            allowedBillingCountries = emptySet(),
         )
         composeRule.setContent {
             BillingDetailsFormUI(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultEditCardDetailsInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultEditCardDetailsInteractorTest.kt
@@ -9,7 +9,6 @@ import com.stripe.android.isInstanceOf
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
-import com.stripe.android.paymentelement.AllowedBillingCountriesInPaymentElementPreview
 import com.stripe.android.paymentsheet.CardUpdateParams
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode
@@ -591,7 +590,6 @@ internal class DefaultEditCardDetailsInteractorTest {
     private val EditCardDetailsInteractor.selectedBrand
         get() = uiState.cardDetailsState?.selectedCardBrand?.brand ?: CardBrand.Unknown
 
-    @OptIn(AllowedBillingCountriesInPaymentElementPreview::class)
     private fun handler(
         card: PaymentMethod.Card = PaymentMethodFixtures.CARD_WITH_NETWORKS,
         cardBrandFilter: CardBrandFilter = DefaultCardBrandFilter,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultUpdatePaymentMethodInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultUpdatePaymentMethodInteractorTest.kt
@@ -616,7 +616,7 @@ class DefaultUpdatePaymentMethodInteractorTest {
         runScenario(
             displayableSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
             addressCollectionMode = AddressCollectionMode.Full,
-            allowedBillingCountries = setOf("US", "CA"),
+            allowedBillingCountries = setOf("us", "CA"),
             editCardDetailsInteractorFactory = editCardDetailsInteractorFactory
         ) {
             assertThat(interactor.editCardDetailsInteractor.state.value).isNotNull()
@@ -631,7 +631,7 @@ class DefaultUpdatePaymentMethodInteractorTest {
                 .isEqualTo(PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never)
 
             assertThat(configuration?.address).isEqualTo(AddressCollectionMode.Full)
-            assertThat(configuration?.allowedCountries).isEqualTo(setOf("US", "CA"))
+            assertThat(configuration?.allowedBillingCountries).isEqualTo(setOf("US", "CA"))
             assertThat(configuration?.attachDefaultsToPaymentMethod).isFalse()
         }
     }
@@ -642,7 +642,7 @@ class DefaultUpdatePaymentMethodInteractorTest {
         runScenario(
             displayableSavedPaymentMethod = PaymentMethodFixtures.displayableLinkPaymentMethod(),
             addressCollectionMode = AddressCollectionMode.Full,
-            allowedBillingCountries = setOf("US", "CA"),
+            allowedBillingCountries = setOf("us", "CA"),
             editCardDetailsInteractorFactory = editCardDetailsInteractorFactory
         ) {
             assertThat(interactor.editCardDetailsInteractor.state.value).isNotNull()
@@ -657,7 +657,7 @@ class DefaultUpdatePaymentMethodInteractorTest {
                 .isEqualTo(PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never)
 
             assertThat(configuration?.address).isEqualTo(AddressCollectionMode.Never)
-            assertThat(configuration?.allowedCountries).isEqualTo(setOf("US", "CA"))
+            assertThat(configuration?.allowedBillingCountries).isEqualTo(setOf("US", "CA"))
             assertThat(configuration?.attachDefaultsToPaymentMethod).isFalse()
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultUpdatePaymentMethodInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultUpdatePaymentMethodInteractorTest.kt
@@ -12,6 +12,7 @@ import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodFixtures.toDisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.CardUpdateParams
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode
 import com.stripe.android.paymentsheet.ui.DefaultUpdatePaymentMethodInteractor.Companion.setDefaultPaymentMethodErrorMessage
 import com.stripe.android.paymentsheet.ui.DefaultUpdatePaymentMethodInteractor.Companion.updateCardBrandErrorMessage
@@ -609,6 +610,58 @@ class DefaultUpdatePaymentMethodInteractorTest {
         }
     }
 
+    @Test
+    fun editCardDetailsInteractorCallback_passesBillingConfigurationProperly_forCard() {
+        val editCardDetailsInteractorFactory = FakeEditCardDetailsInteractorFactory()
+        runScenario(
+            displayableSavedPaymentMethod = PaymentMethodFixtures.displayableCard(),
+            addressCollectionMode = AddressCollectionMode.Full,
+            allowedBillingCountries = setOf("US", "CA"),
+            editCardDetailsInteractorFactory = editCardDetailsInteractorFactory
+        ) {
+            assertThat(interactor.editCardDetailsInteractor.state.value).isNotNull()
+
+            val configuration = editCardDetailsInteractorFactory.billingDetailsCollectionConfiguration
+
+            assertThat(configuration?.name)
+                .isEqualTo(PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never)
+            assertThat(configuration?.email)
+                .isEqualTo(PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never)
+            assertThat(configuration?.phone)
+                .isEqualTo(PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never)
+
+            assertThat(configuration?.address).isEqualTo(AddressCollectionMode.Full)
+            assertThat(configuration?.allowedCountries).isEqualTo(setOf("US", "CA"))
+            assertThat(configuration?.attachDefaultsToPaymentMethod).isFalse()
+        }
+    }
+
+    @Test
+    fun editCardDetailsInteractorCallback_passesBillingConfigurationProperly_forLink() {
+        val editCardDetailsInteractorFactory = FakeEditCardDetailsInteractorFactory()
+        runScenario(
+            displayableSavedPaymentMethod = PaymentMethodFixtures.displayableLinkPaymentMethod(),
+            addressCollectionMode = AddressCollectionMode.Full,
+            allowedBillingCountries = setOf("US", "CA"),
+            editCardDetailsInteractorFactory = editCardDetailsInteractorFactory
+        ) {
+            assertThat(interactor.editCardDetailsInteractor.state.value).isNotNull()
+
+            val configuration = editCardDetailsInteractorFactory.billingDetailsCollectionConfiguration
+
+            assertThat(configuration?.name)
+                .isEqualTo(PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never)
+            assertThat(configuration?.email)
+                .isEqualTo(PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never)
+            assertThat(configuration?.phone)
+                .isEqualTo(PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never)
+
+            assertThat(configuration?.address).isEqualTo(AddressCollectionMode.Never)
+            assertThat(configuration?.allowedCountries).isEqualTo(setOf("US", "CA"))
+            assertThat(configuration?.attachDefaultsToPaymentMethod).isFalse()
+        }
+    }
+
     private fun updateCardAndDefaultPaymentMethod(
         interactor: UpdatePaymentMethodInteractor,
     ) {
@@ -638,6 +691,8 @@ class DefaultUpdatePaymentMethodInteractorTest {
         shouldShowSetAsDefaultCheckbox: Boolean = false,
         isDefaultPaymentMethod: Boolean = false,
         canUpdateFullPaymentMethodDetails: Boolean = false,
+        addressCollectionMode: AddressCollectionMode = AddressCollectionMode.Automatic,
+        allowedBillingCountries: Set<String> = setOf("US", "CA"),
         editCardDetailsInteractorFactory: EditCardDetailsInteractor.Factory = DefaultEditCardDetailsInteractor
             .Factory(),
         onBrandChoiceSelected: (CardBrand) -> Unit = {},
@@ -649,7 +704,7 @@ class DefaultUpdatePaymentMethodInteractorTest {
             canRemove = canRemove,
             canUpdateFullPaymentMethodDetails = canUpdateFullPaymentMethodDetails,
             displayableSavedPaymentMethod = displayableSavedPaymentMethod,
-            addressCollectionMode = AddressCollectionMode.Automatic,
+            addressCollectionMode = addressCollectionMode,
             removeExecutor = onRemovePaymentMethod,
             updatePaymentMethodExecutor = updatePaymentMethodExecutor,
             setDefaultPaymentMethodExecutor = onSetDefaultPaymentMethod,
@@ -660,7 +715,8 @@ class DefaultUpdatePaymentMethodInteractorTest {
             onUpdateSuccess = {
                 onUpdateSuccessTurbine.add(Unit)
             },
-            editCardDetailsInteractorFactory = editCardDetailsInteractorFactory
+            editCardDetailsInteractorFactory = editCardDetailsInteractorFactory,
+            allowedBillingCountries = allowedBillingCountries,
         )
 
         TestParams(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeEditCardDetailsInteractorFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeEditCardDetailsInteractorFactory.kt
@@ -4,6 +4,9 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import kotlinx.coroutines.CoroutineScope
 
 internal class FakeEditCardDetailsInteractorFactory : EditCardDetailsInteractor.Factory {
+    var billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration? = null
+        private set
+
     var onCardUpdateParamsChanged: CardUpdateParamsCallback? = null
         private set
 
@@ -17,6 +20,7 @@ internal class FakeEditCardDetailsInteractorFactory : EditCardDetailsInteractor.
         onCardUpdateParamsChanged: CardUpdateParamsCallback
     ): EditCardDetailsInteractor {
         this.onCardUpdateParamsChanged = onCardUpdateParamsChanged
+        this.billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration
         return FakeEditCardDetailsInteractor(
             payload = payload,
             shouldShowCardBrandDropdown = cardEditConfiguration?.isCbcModifiable ?: false,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeUpdatePaymentMethodInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeUpdatePaymentMethodInteractor.kt
@@ -25,6 +25,7 @@ internal class FakeUpdatePaymentMethodInteractor(
     override val shouldShowSetAsDefaultCheckbox: Boolean = false,
     override val shouldShowSaveButton: Boolean = false,
     override val addressCollectionMode: AddressCollectionMode = AddressCollectionMode.Automatic,
+    override val allowedBillingCountries: Set<String> = setOf("US", "CA"),
     val viewActionRecorder: ViewActionRecorder<UpdatePaymentMethodInteractor.ViewAction>? = ViewActionRecorder(),
     initialState: UpdatePaymentMethodInteractor.State = UpdatePaymentMethodInteractor.State(
         error = null,


### PR DESCRIPTION
# Summary
Support `allowedCountries` in `BillingDetailsCollectionConfiguration` for Payment Element

# Motivation
Merchant ask to allow filtering possible billing countries a customer can use in Payment Element similar to Address Element.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified