### PR TITLE
Move optional settings to `TextFieldConfig` where possible.

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModel.kt
@@ -117,7 +117,6 @@ internal class NetworkingLinkSignupViewModel @AssistedInject constructor(
                         label = resolvableString(R.string.stripe_networking_signup_email_label)
                     ),
                     initialValue = initialEmail,
-                    showOptionalLabel = false
                 ),
                 phoneController = PhoneNumberController.createPhoneNumberController(
                     initialValue = sync.manifest.accountholderPhoneNumber ?: prefillDetails?.phone ?: "",

--- a/identity/src/main/java/com/stripe/android/identity/ui/IDNumberSection.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/IDNumberSection.kt
@@ -219,6 +219,7 @@ private object BRIDConfig : SimpleTextFieldConfig(
     override val placeHolder = BRAZIL_ID_PLACEHOLDER
     override val keyboard = KeyboardType.Number
     override val visualTransformation = BRVisualTransformation
+    override val optional: Boolean = false
     override fun determineState(input: String): TextFieldState = object : TextFieldState {
         override fun shouldShowError(hasFocus: Boolean) = !hasFocus && input.length < 11
 
@@ -236,6 +237,7 @@ private object SGIDConfig : SimpleTextFieldConfig(
     label = resolvableString(R.string.stripe_nric_or_fin)
 ) {
     override val placeHolder = SINGAPORE_ID_PLACEHOLDER
+    override val optional: Boolean = false
     override fun determineState(input: String): TextFieldState = object : TextFieldState {
         override fun shouldShowError(hasFocus: Boolean) = false
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AuBankAccountNumberConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AuBankAccountNumberConfig.kt
@@ -28,6 +28,8 @@ class AuBankAccountNumberConfig : TextFieldConfig {
     override val label = resolvableString(StripeR.string.stripe_becs_widget_account_number)
     override val keyboard = KeyboardType.Number
 
+    override val optional: Boolean = false
+
     override fun filter(userTyped: String) =
         userTyped.filter { VALID_INPUT_RANGES.contains(it) }.take(MAXIMUM_LENGTH)
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BacsDebitAccountNumberConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BacsDebitAccountNumberConfig.kt
@@ -33,6 +33,8 @@ class BacsDebitAccountNumberConfig : TextFieldConfig {
 
     override val loading: StateFlow<Boolean> = MutableStateFlow(false)
 
+    override val optional: Boolean = false
+
     override fun determineState(input: String): TextFieldState {
         return when {
             input.isBlank() -> TextFieldStateConstants.Error.Blank

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BacsDebitSortCodeConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BacsDebitSortCodeConfig.kt
@@ -27,6 +27,8 @@ class BacsDebitSortCodeConfig : TextFieldConfig {
 
     override val keyboard: KeyboardType = KeyboardType.NumberPassword
 
+    override val optional: Boolean = false
+
     override val visualTransformation: VisualTransformation = BacsDebitSortCodeVisualTransformation
 
     override val trailingIcon: StateFlow<TextFieldIcon?> = MutableStateFlow(null)

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BlikConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BlikConfig.kt
@@ -31,6 +31,7 @@ class BlikConfig : TextFieldConfig {
     override val visualTransformation: VisualTransformation? = null
     override val trailingIcon: StateFlow<TextFieldIcon?> = MutableStateFlow(value = null)
     override val loading: StateFlow<Boolean> = MutableStateFlow(value = false)
+    override val optional: Boolean = false
 
     override fun determineState(input: String): TextFieldState {
         val isValid = blikPattern.matches(input)

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BsbConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BsbConfig.kt
@@ -30,6 +30,7 @@ class BsbConfig(private val banks: List<BecsDebitBanks.Bank>) : TextFieldConfig 
     override val loading: StateFlow<Boolean> = MutableStateFlow(false)
 
     override val label = resolvableString(StripeR.string.stripe_becs_widget_bsb)
+    override val optional: Boolean = false
     override val keyboard = KeyboardType.Number
 
     // Displays the BSB number in 2 groups of 3 characters with a dash added between them

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
@@ -80,13 +80,13 @@ internal class DefaultCardNumberController(
     workContext: CoroutineContext,
     staticCardAccountRanges: StaticCardAccountRanges = DefaultStaticCardAccountRanges(),
     override val initialValue: String?,
-    override val showOptionalLabel: Boolean = false,
     private val cardBrandChoiceConfig: CardBrandChoiceConfig = CardBrandChoiceConfig.Ineligible,
     private val cardBrandFilter: CardBrandFilter = DefaultCardBrandFilter,
 ) : CardNumberController() {
     override val capitalization: KeyboardCapitalization = cardTextFieldConfig.capitalization
     override val keyboardType: KeyboardType = cardTextFieldConfig.keyboard
     override val debugLabel = cardTextFieldConfig.debugLabel
+    override val showOptionalLabel: Boolean = false
 
     override val label: StateFlow<ResolvableString> = stateFlowOf(cardTextFieldConfig.label)
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcController.kt
@@ -28,7 +28,6 @@ class CvcController constructor(
     private val cvcTextFieldConfig: CvcConfig = CvcConfig(),
     cardBrandFlow: StateFlow<CardBrand>,
     override val initialValue: String? = null,
-    override val showOptionalLabel: Boolean = false
 ) : TextFieldController {
     override val capitalization: KeyboardCapitalization = cvcTextFieldConfig.capitalization
     override val keyboardType: KeyboardType = cvcTextFieldConfig.keyboard
@@ -47,6 +46,8 @@ class CvcController constructor(
     override val debugLabel = cvcTextFieldConfig.debugLabel
 
     override val layoutDirection: LayoutDirection = LayoutDirection.Ltr
+
+    override val showOptionalLabel: Boolean = false
 
     @OptIn(ExperimentalComposeUiApi::class)
     override val autofillType: AutofillType = AutofillType.CreditCardSecurityCode

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/IbanConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/IbanConfig.kt
@@ -31,6 +31,7 @@ class IbanConfig : TextFieldConfig {
     override val debugLabel = "iban"
 
     override val label = resolvableString(R.string.stripe_iban)
+    override val optional: Boolean = false
     override val keyboard = KeyboardType.Ascii
 
     override val trailingIcon: MutableStateFlow<TextFieldIcon?> = MutableStateFlow(

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SimpleTextSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SimpleTextSpec.kt
@@ -97,10 +97,10 @@ data class SimpleTextSpec(
                         KeyboardType.Email -> androidx.compose.ui.text.input.KeyboardType.Email
                         KeyboardType.Password -> androidx.compose.ui.text.input.KeyboardType.Password
                         KeyboardType.NumberPassword -> androidx.compose.ui.text.input.KeyboardType.NumberPassword
-                    }
+                    },
+                    optional = this.showOptionalLabel
                 ),
                 initialValue = initialValues[this.apiPath],
-                showOptionalLabel = this.showOptionalLabel
             )
         )
     )

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/UpiConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/UpiConfig.kt
@@ -32,6 +32,7 @@ class UpiConfig : TextFieldConfig {
     override val visualTransformation: VisualTransformation? = null
     override val trailingIcon: StateFlow<TextFieldIcon?> = MutableStateFlow(value = null)
     override val loading: StateFlow<Boolean> = MutableStateFlow(value = false)
+    override val optional: Boolean = false
 
     override fun determineState(input: String): TextFieldState {
         val isValid = upiPattern.matches(input) && input.length <= UPI_MAX_LENGTH

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KonbiniDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KonbiniDefinition.kt
@@ -55,9 +55,9 @@ private object KonbiniUiDefinitionFactory : UiDefinitionFactory.Simple {
                     label = resolvableString(R.string.stripe_konbini_confirmation_number_label),
                     capitalization = KeyboardCapitalization.None,
                     keyboard = KeyboardType.Phone,
+                    optional = true,
                 ),
                 initialValue = arguments.initialValues[IdentifierSpec.KonbiniConfirmationNumber],
-                showOptionalLabel = true,
             ),
         )
         return FormElementsBuilder(arguments)

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/TransformAddressToElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/TransformAddressToElement.kt
@@ -270,10 +270,10 @@ private fun FieldType.toElement(
                 label = label,
                 capitalization = capitalization,
                 keyboardType = keyboardType,
-                countryCode = countryCode
+                countryCode = countryCode,
+                optional = showOptionalLabel,
             ),
             overrideContentDescriptionProvider = getOverrideContentDescription(),
-            showOptionalLabel = showOptionalLabel
         )
     )
     return when (this) {
@@ -306,17 +306,20 @@ private fun FieldType.toConfig(
     label: Int,
     capitalization: KeyboardCapitalization,
     keyboardType: KeyboardType,
-    countryCode: String
+    countryCode: String,
+    optional: Boolean,
 ): TextFieldConfig {
     return when (this) {
         FieldType.PostalCode -> PostalCodeConfig(
             label = resolvableString(label),
-            country = countryCode
+            country = countryCode,
+            optional = optional,
         )
         else -> SimpleTextFieldConfig(
             label = resolvableString(label),
             capitalization = capitalization,
-            keyboard = keyboardType
+            keyboard = keyboardType,
+            optional = optional,
         )
     }
 }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressElement.kt
@@ -40,9 +40,9 @@ class AddressElement(
         IdentifierSpec.Name,
         SimpleTextFieldController(
             textFieldConfig = SimpleTextFieldConfig(
-                label = resolvableString(CoreR.string.stripe_address_label_full_name)
+                label = resolvableString(CoreR.string.stripe_address_label_full_name),
+                optional = addressInputMode.nameConfig == AddressFieldConfiguration.OPTIONAL,
             ),
-            showOptionalLabel = addressInputMode.nameConfig == AddressFieldConfiguration.OPTIONAL,
             initialValue = rawValuesMap[IdentifierSpec.Name]
         )
     )

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DateConfig.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DateConfig.kt
@@ -26,6 +26,7 @@ class DateConfig : TextFieldConfig {
     override val layoutDirection: LayoutDirection = LayoutDirection.Ltr
     override val shouldAnnounceFieldValue = false
     override val shouldAnnounceLabel = false
+    override val optional: Boolean = false
 
     override fun filter(userTyped: String) = userTyped.filter { it.isDigit() }
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/EmailConfig.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/EmailConfig.kt
@@ -15,7 +15,8 @@ import java.util.regex.Pattern
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class EmailConfig(
-    override val label: ResolvableString = resolvableString(R.string.stripe_email)
+    override val label: ResolvableString = resolvableString(R.string.stripe_email),
+    override val optional: Boolean = false,
 ) : TextFieldConfig {
 
     override val capitalization: KeyboardCapitalization = KeyboardCapitalization.None
@@ -57,9 +58,8 @@ class EmailConfig(
             initialValue: String?,
             showOptionalLabel: Boolean = false,
         ) = SimpleTextFieldController(
-            textFieldConfig = EmailConfig(),
+            textFieldConfig = EmailConfig(optional = showOptionalLabel),
             initialValue = initialValue,
-            showOptionalLabel = showOptionalLabel,
         )
 
         // This is copied from Patterns.EMAIL_ADDRESS because it is not defined for unit tests

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/NameConfig.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/NameConfig.kt
@@ -20,6 +20,7 @@ class NameConfig : TextFieldConfig {
     override val visualTransformation: VisualTransformation? = null
     override val trailingIcon: MutableStateFlow<TextFieldIcon?> = MutableStateFlow(null)
     override val loading: StateFlow<Boolean> = MutableStateFlow(false)
+    override val optional: Boolean = false
 
     override fun determineState(input: String): TextFieldState {
         return when {

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PostalCodeConfig.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PostalCodeConfig.kt
@@ -12,7 +12,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 class PostalCodeConfig(
     override val label: ResolvableString,
     override val trailingIcon: MutableStateFlow<TextFieldIcon?> = MutableStateFlow(null),
-    private val country: String
+    private val country: String,
+    override val optional: Boolean = false,
 ) : TextFieldConfig {
     private val format = CountryPostalFormat.forCountry(country)
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SimpleTextFieldConfig.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SimpleTextFieldConfig.kt
@@ -12,7 +12,8 @@ open class SimpleTextFieldConfig(
     override val label: ResolvableString,
     override val capitalization: KeyboardCapitalization = KeyboardCapitalization.Words,
     override val keyboard: KeyboardType = KeyboardType.Text,
-    override val trailingIcon: MutableStateFlow<TextFieldIcon?> = MutableStateFlow(null)
+    override val trailingIcon: MutableStateFlow<TextFieldIcon?> = MutableStateFlow(null),
+    override val optional: Boolean = false,
 ) : TextFieldConfig {
     override val debugLabel: String = "generic_text"
     override val visualTransformation: VisualTransformation? = null

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldConfig.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldConfig.kt
@@ -45,6 +45,8 @@ interface TextFieldConfig {
     val overrideContentDescriptionProvider: ((fieldValue: String) -> ResolvableString)?
         get() = null
 
+    val optional: Boolean
+
     /** This will determine the state of the field based on the text */
     fun determineState(input: String): TextFieldState
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldController.kt
@@ -121,7 +121,6 @@ sealed class TextFieldIcon {
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
 class SimpleTextFieldController(
     val textFieldConfig: TextFieldConfig,
-    override val showOptionalLabel: Boolean = false,
     override val initialValue: String? = null,
     private val overrideContentDescriptionProvider: ((fieldValue: String) -> ResolvableString)? = null,
 ) : TextFieldController {
@@ -131,6 +130,7 @@ class SimpleTextFieldController(
     override val visualTransformation = stateFlowOf(
         value = textFieldConfig.visualTransformation ?: VisualTransformation.None
     )
+    override val showOptionalLabel: Boolean = textFieldConfig.optional
 
     override val label = MutableStateFlow(textFieldConfig.label)
     override val debugLabel = textFieldConfig.debugLabel
@@ -177,7 +177,7 @@ class SimpleTextFieldController(
     }
 
     override val isComplete: StateFlow<Boolean> = _fieldState.mapAsStateFlow {
-        it.isValid() || (!it.isValid() && showOptionalLabel && it.isBlank())
+        it.isValid() || (!it.isValid() && textFieldConfig.optional && it.isBlank())
     }
 
     override val formFieldValue: StateFlow<FormFieldEntry> =

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/SimpleTextFieldControllerTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/SimpleTextFieldControllerTest.kt
@@ -105,7 +105,7 @@ internal class SimpleTextFieldControllerTest {
 
     @Test
     fun `Verify is blank optional fields are considered complete`() = runTest {
-        val controller = createControllerWithState(showOptionalLabel = true)
+        val controller = createControllerWithState(isOptional = true)
         controller.onValueChange("invalid")
 
         controller.isComplete.test {
@@ -207,13 +207,27 @@ internal class SimpleTextFieldControllerTest {
         assertThat(controller.placeHolder.value).isNotNull()
     }
 
+    @Test
+    fun `Verify 'showOptionalLabel' is true when 'optional' is true in config`() {
+        val controller = createControllerWithState(isOptional = true)
+        assertThat(controller.showOptionalLabel).isTrue()
+    }
+
+    @Test
+    fun `Verify 'showOptionalLabel' is false when 'optional' is false in config`() {
+        val controller = createControllerWithState(isOptional = false)
+        assertThat(controller.showOptionalLabel).isFalse()
+    }
+
     private fun createControllerWithState(
-        showOptionalLabel: Boolean = false,
-        nullPlaceHolder: Boolean = true
+        isOptional: Boolean = false,
+        nullPlaceHolder: Boolean = true,
     ): SimpleTextFieldController {
         val config: TextFieldConfig = mock {
             on { determineState("full") } doReturn Full
             on { filter("full") } doReturn "full"
+
+            on { optional } doReturn isOptional
 
             on { determineState("limitless") } doReturn Limitless
             on { filter("limitless") } doReturn "limitless"
@@ -238,7 +252,7 @@ internal class SimpleTextFieldControllerTest {
             }
         }
 
-        return SimpleTextFieldController(config, showOptionalLabel)
+        return SimpleTextFieldController(config)
     }
 
     companion object {

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/TextFieldTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/TextFieldTest.kt
@@ -166,6 +166,7 @@ class TextFieldTest {
         override val visualTransformation: VisualTransformation? = null
         override val trailingIcon: StateFlow<TextFieldIcon?> = MutableStateFlow(null)
         override val loading: StateFlow<Boolean> = MutableStateFlow(false)
+        override val optional: Boolean = false
 
         override fun determineState(input: String): TextFieldState {
             return if (input.length == maxInputLength) {


### PR DESCRIPTION
# Summary
Move optional settings to `TextFieldConfig` where possible.

# Motivation
`TextFieldConfig` handles error management & other text field state values. It should be aware if the `TextField` is intended to be optional and properly calculate the error using this value. Fixes for error states will be added in a follow-up PR.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified