### PR TITLE
Remove termsDisplay validation.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
@@ -5,7 +5,6 @@ import com.stripe.android.common.configuration.ConfigurationDefaults
 import com.stripe.android.common.validation.CustomerSessionClientSecretValidator
 import com.stripe.android.link.LinkController
 import com.stripe.android.link.model.LinkAppearance
-import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodRegistry
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
@@ -45,8 +44,6 @@ internal data class CommonConfiguration(
         customer?.accessType?.let { customerAccessType ->
             customerAccessTypeValidate(customerAccessType)
         }
-
-        validateTermsDisplay()
     }
 
     // These exception messages are not localized as they are not intended to be displayed to a user.
@@ -145,17 +142,6 @@ internal data class CommonConfiguration(
             throw IllegalArgumentException(
                 "`ephemeralKeySecret` format does not match expected client secret formatting"
             )
-        }
-    }
-
-    private fun validateTermsDisplay() {
-        termsDisplay.forEach { (key, _) ->
-            val paymentMethodDefinition = requireNotNull(PaymentMethodRegistry.definitionsByCode[key.code]) {
-                "Unsupported payment method $key"
-            }
-            if (!paymentMethodDefinition.supportsTermDisplayConfiguration) {
-                throw IllegalArgumentException("$key does not support terms display configuration.")
-            }
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodDefinition.kt
@@ -10,9 +10,6 @@ internal interface PaymentMethodDefinition {
 
     val supportedAsSavedPaymentMethod: Boolean
 
-    val supportsTermDisplayConfiguration: Boolean
-        get() = false
-
     fun requiresMandate(metadata: PaymentMethodMetadata): Boolean
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AmazonPayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AmazonPayDefinition.kt
@@ -18,8 +18,6 @@ internal object AmazonPayDefinition : PaymentMethodDefinition {
 
     override val supportedAsSavedPaymentMethod: Boolean = false
 
-    override val supportsTermDisplayConfiguration: Boolean = true
-
     override fun requirementsToBeUsedAsNewPaymentMethod(
         hasIntentToSetup: Boolean
     ): Set<AddPaymentMethodRequirement> = setOf()

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AuBecsDebitDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AuBecsDebitDefinition.kt
@@ -14,8 +14,6 @@ internal object AuBecsDebitDefinition : PaymentMethodDefinition {
 
     override val supportedAsSavedPaymentMethod: Boolean = false
 
-    override val supportsTermDisplayConfiguration: Boolean = true
-
     override fun requirementsToBeUsedAsNewPaymentMethod(
         hasIntentToSetup: Boolean
     ): Set<AddPaymentMethodRequirement> = setOf(

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BacsDebitDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BacsDebitDefinition.kt
@@ -20,8 +20,6 @@ internal object BacsDebitDefinition : PaymentMethodDefinition {
 
     override val supportedAsSavedPaymentMethod: Boolean = false
 
-    override val supportsTermDisplayConfiguration: Boolean = true
-
     override fun requirementsToBeUsedAsNewPaymentMethod(
         hasIntentToSetup: Boolean
     ): Set<AddPaymentMethodRequirement> = setOf(

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BancontactDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BancontactDefinition.kt
@@ -17,8 +17,6 @@ internal object BancontactDefinition : PaymentMethodDefinition {
 
     override val supportedAsSavedPaymentMethod: Boolean = false
 
-    override val supportsTermDisplayConfiguration: Boolean = true
-
     override fun requirementsToBeUsedAsNewPaymentMethod(
         hasIntentToSetup: Boolean
     ): Set<AddPaymentMethodRequirement> = setOfNotNull(

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -50,8 +50,6 @@ internal object CardDefinition : PaymentMethodDefinition {
 
     override val supportedAsSavedPaymentMethod: Boolean = true
 
-    override val supportsTermDisplayConfiguration: Boolean = true
-
     override fun requirementsToBeUsedAsNewPaymentMethod(
         hasIntentToSetup: Boolean
     ): Set<AddPaymentMethodRequirement> = setOf()

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CashAppPayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CashAppPayDefinition.kt
@@ -17,8 +17,6 @@ internal object CashAppPayDefinition : PaymentMethodDefinition {
 
     override val supportedAsSavedPaymentMethod: Boolean = false
 
-    override val supportsTermDisplayConfiguration: Boolean = true
-
     override fun requirementsToBeUsedAsNewPaymentMethod(
         hasIntentToSetup: Boolean
     ): Set<AddPaymentMethodRequirement> = setOf()

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/IdealDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/IdealDefinition.kt
@@ -17,8 +17,6 @@ internal object IdealDefinition : PaymentMethodDefinition {
 
     override val supportedAsSavedPaymentMethod: Boolean = false
 
-    override val supportsTermDisplayConfiguration: Boolean = true
-
     override fun requirementsToBeUsedAsNewPaymentMethod(
         hasIntentToSetup: Boolean
     ): Set<AddPaymentMethodRequirement> = setOfNotNull(

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/InstantDebitsDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/InstantDebitsDefinition.kt
@@ -16,8 +16,6 @@ internal object InstantDebitsDefinition : PaymentMethodDefinition {
 
     override val supportedAsSavedPaymentMethod: Boolean = false
 
-    override val supportsTermDisplayConfiguration: Boolean = true
-
     override fun requirementsToBeUsedAsNewPaymentMethod(
         hasIntentToSetup: Boolean
     ): Set<AddPaymentMethodRequirement> = setOf(

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KlarnaDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KlarnaDefinition.kt
@@ -18,8 +18,6 @@ internal object KlarnaDefinition : PaymentMethodDefinition {
 
     override val supportedAsSavedPaymentMethod: Boolean = false
 
-    override val supportsTermDisplayConfiguration: Boolean = true
-
     override fun requirementsToBeUsedAsNewPaymentMethod(
         hasIntentToSetup: Boolean
     ): Set<AddPaymentMethodRequirement> = setOf()

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/LinkCardBrandDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/LinkCardBrandDefinition.kt
@@ -16,8 +16,6 @@ internal object LinkCardBrandDefinition : PaymentMethodDefinition {
 
     override val supportedAsSavedPaymentMethod: Boolean = false
 
-    override val supportsTermDisplayConfiguration: Boolean = true
-
     override fun requirementsToBeUsedAsNewPaymentMethod(
         hasIntentToSetup: Boolean
     ): Set<AddPaymentMethodRequirement> = setOf(

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/PayPalDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/PayPalDefinition.kt
@@ -18,8 +18,6 @@ internal object PayPalDefinition : PaymentMethodDefinition {
 
     override val supportedAsSavedPaymentMethod: Boolean = false
 
-    override val supportsTermDisplayConfiguration: Boolean = true
-
     override fun requirementsToBeUsedAsNewPaymentMethod(
         hasIntentToSetup: Boolean
     ): Set<AddPaymentMethodRequirement> = setOf()

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/RevolutPayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/RevolutPayDefinition.kt
@@ -18,8 +18,6 @@ internal object RevolutPayDefinition : PaymentMethodDefinition {
 
     override val supportedAsSavedPaymentMethod: Boolean = false
 
-    override val supportsTermDisplayConfiguration: Boolean = true
-
     override fun requirementsToBeUsedAsNewPaymentMethod(
         hasIntentToSetup: Boolean
     ): Set<AddPaymentMethodRequirement> = setOf()

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SatispayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SatispayDefinition.kt
@@ -17,8 +17,6 @@ internal object SatispayDefinition : PaymentMethodDefinition {
 
     override val supportedAsSavedPaymentMethod: Boolean = false
 
-    override val supportsTermDisplayConfiguration: Boolean = true
-
     override fun requirementsToBeUsedAsNewPaymentMethod(
         hasIntentToSetup: Boolean
     ): Set<AddPaymentMethodRequirement> = setOf()

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SepaDebitDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SepaDebitDefinition.kt
@@ -19,8 +19,6 @@ internal object SepaDebitDefinition : PaymentMethodDefinition {
 
     override val supportedAsSavedPaymentMethod: Boolean = true
 
-    override val supportsTermDisplayConfiguration: Boolean = true
-
     override fun requirementsToBeUsedAsNewPaymentMethod(
         hasIntentToSetup: Boolean
     ): Set<AddPaymentMethodRequirement> = setOf(

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SofortDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SofortDefinition.kt
@@ -17,8 +17,6 @@ internal object SofortDefinition : PaymentMethodDefinition {
 
     override val supportedAsSavedPaymentMethod: Boolean = false
 
-    override val supportsTermDisplayConfiguration: Boolean = true
-
     override fun requirementsToBeUsedAsNewPaymentMethod(
         hasIntentToSetup: Boolean
     ): Set<AddPaymentMethodRequirement> = setOf(

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/UsBankAccountDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/UsBankAccountDefinition.kt
@@ -17,8 +17,6 @@ internal object UsBankAccountDefinition : PaymentMethodDefinition {
 
     override val supportedAsSavedPaymentMethod: Boolean = true
 
-    override val supportsTermDisplayConfiguration: Boolean = true
-
     override fun requirementsToBeUsedAsNewPaymentMethod(
         hasIntentToSetup: Boolean
     ): Set<AddPaymentMethodRequirement> = setOf(

--- a/paymentsheet/src/test/java/com/stripe/android/common/model/CommonConfigurationTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/model/CommonConfigurationTest.kt
@@ -1,9 +1,7 @@
 package com.stripe.android.common.model
 
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet
-import org.junit.Assert.fail
 import org.junit.Test
 
 internal class CommonConfigurationTest {
@@ -43,45 +41,5 @@ internal class CommonConfigurationTest {
         )
 
         assertThat(configuration.containsVolatileDifferences(configWithBillingConfigChanges)).isTrue()
-    }
-
-    @Test
-    fun `validateTermsDisplay throws exception for unsupported payment method type`() {
-        val termsDisplay = mapOf(
-            PaymentMethod.Type.Affirm to PaymentSheet.TermsDisplay.NEVER
-        )
-
-        val configuration = CommonConfigurationFactory.create(termsDisplay = termsDisplay)
-
-        try {
-            configuration.validate(isLiveMode = true)
-            fail("Expected IllegalArgumentException to be thrown")
-        } catch (e: IllegalArgumentException) {
-            assertThat(e.message).isEqualTo("affirm does not support terms display configuration.")
-        }
-    }
-
-    @Test
-    fun `validateTermsDisplay works with empty termsDisplay map`() {
-        val configuration = CommonConfigurationFactory.create(termsDisplay = emptyMap())
-
-        configuration.validate(isLiveMode = true)
-    }
-
-    @Test
-    fun `validateTermsDisplay does not throw an exception for both TermsDisplay values`() {
-        val termsDisplayAutomatic = mapOf(
-            PaymentMethod.Type.Card to PaymentSheet.TermsDisplay.AUTOMATIC
-        )
-
-        val termsDisplayNever = mapOf(
-            PaymentMethod.Type.CashAppPay to PaymentSheet.TermsDisplay.NEVER
-        )
-
-        val configAutomatic = CommonConfigurationFactory.create(termsDisplay = termsDisplayAutomatic)
-        val configNever = CommonConfigurationFactory.create(termsDisplay = termsDisplayNever)
-
-        configAutomatic.validate(isLiveMode = true)
-        configNever.validate(isLiveMode = true)
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Now that we support termsDisplay for all payment methods, we no longer need the validation.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-3929

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified
