### PR TITLE
Add payouts to the Connect SDK

### DIFF
--- a/connect-example/src/main/AndroidManifest.xml
+++ b/connect-example/src/main/AndroidManifest.xml
@@ -17,5 +17,9 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".ui.features.payouts.PayoutsExampleActivity"
+            android:exported="false"
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
     </application>
 </manifest>

--- a/connect-example/src/main/java/com/stripe/android/connect/example/ui/common/BasicExampleComponentActivity.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/ui/common/BasicExampleComponentActivity.kt
@@ -1,0 +1,170 @@
+package com.stripe.android.connect.example.ui.common
+
+import android.content.Context
+import android.os.Bundle
+import android.view.View
+import androidx.activity.compose.BackHandler
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.activity.viewModels
+import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.ModalBottomSheetLayout
+import androidx.compose.material.ModalBottomSheetValue
+import androidx.compose.material.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.stripe.android.connect.EmbeddedComponentManager
+import com.stripe.android.connect.example.BaseActivity
+import com.stripe.android.connect.example.core.Async
+import com.stripe.android.connect.example.core.Success
+import com.stripe.android.connect.example.core.then
+import com.stripe.android.connect.example.ui.appearance.AppearanceView
+import com.stripe.android.connect.example.ui.appearance.AppearanceViewModel
+import com.stripe.android.connect.example.ui.embeddedcomponentmanagerloader.EmbeddedComponentLoaderViewModel
+import com.stripe.android.connect.example.ui.embeddedcomponentmanagerloader.EmbeddedComponentManagerLoader
+import com.stripe.android.connect.example.ui.settings.SettingsViewModel
+import com.stripe.android.connect.example.ui.settings.settingsComposables
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+
+@AndroidEntryPoint
+abstract class BasicExampleComponentActivity : BaseActivity() {
+
+    @get:StringRes
+    abstract val titleRes: Int
+
+    private val settingsViewModel by viewModels<SettingsViewModel>()
+
+    abstract fun createComponentView(context: Context, embeddedComponentManager: EmbeddedComponentManager): View
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val settings = settingsViewModel.state.value
+        val enableEdgeToEdge = settings.presentationSettings.enableEdgeToEdge
+        if (enableEdgeToEdge) {
+            enableEdgeToEdge()
+        }
+
+        setContent {
+            BackHandler(onBack = ::finish)
+            val navController = rememberNavController()
+            ConnectSdkExampleTheme {
+                NavHost(navController = navController, startDestination = BasicComponentExampleDestination.Component) {
+                    composable(BasicComponentExampleDestination.Component) {
+                        ExampleComponentContent(
+                            viewModel = loaderViewModel,
+                            enableEdgeToEdge = enableEdgeToEdge,
+                            openSettings = { navController.navigate(BasicComponentExampleDestination.Settings) },
+                        )
+                    }
+                    settingsComposables(this@BasicExampleComponentActivity, navController)
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun ExampleComponentContent(
+        viewModel: EmbeddedComponentLoaderViewModel,
+        enableEdgeToEdge: Boolean,
+        openSettings: () -> Unit,
+    ) {
+        val state by viewModel.state.collectAsState()
+        val embeddedComponentAsync = state.embeddedComponentManagerAsync
+
+        if (enableEdgeToEdge) {
+            // don't render the scaffold if edge-to-edge is enabled so that we get an entirely
+            // full-screen experience
+            ExampleComponentView(
+                embeddedComponentManagerAsync = embeddedComponentAsync,
+                openSettings = openSettings,
+                reload = viewModel::reload,
+            )
+        } else {
+            ExampleComponentScaffold(
+                embeddedComponentManagerAsync = embeddedComponentAsync,
+            ) {
+                ExampleComponentView(
+                    embeddedComponentManagerAsync = embeddedComponentAsync,
+                    openSettings = openSettings,
+                    reload = viewModel::reload,
+                )
+            }
+        }
+    }
+
+    @OptIn(ExperimentalMaterialApi::class)
+    @Composable
+    private fun ExampleComponentScaffold(
+        embeddedComponentManagerAsync: Async<EmbeddedComponentManager>,
+        content: @Composable () -> Unit,
+    ) {
+        val sheetState = rememberModalBottomSheetState(
+            initialValue = ModalBottomSheetValue.Hidden,
+            skipHalfExpanded = true,
+        )
+        val coroutineScope = rememberCoroutineScope()
+
+        ModalBottomSheetLayout(
+            modifier = Modifier.fillMaxSize(),
+            sheetState = sheetState,
+            sheetContent = {
+                val appearanceViewModel = hiltViewModel<AppearanceViewModel>()
+                AppearanceView(
+                    viewModel = appearanceViewModel,
+                    onDismiss = { coroutineScope.launch { sheetState.hide() } },
+                )
+            },
+        ) {
+            ConnectExampleScaffold(
+                title = stringResource(titleRes),
+                navigationIcon = (embeddedComponentManagerAsync is Success).then {
+                    {
+                        BackIconButton(onClick = ::finish)
+                    }
+                },
+                actions = (embeddedComponentManagerAsync is Success).then {
+                    {
+                        CustomizeAppearanceIconButton(onClick = { coroutineScope.launch { sheetState.show() } })
+                    }
+                } ?: { },
+                content = content
+            )
+        }
+    }
+
+    @Composable
+    private fun ExampleComponentView(
+        embeddedComponentManagerAsync: Async<EmbeddedComponentManager>,
+        openSettings: () -> Unit,
+        reload: () -> Unit,
+    ) {
+        EmbeddedComponentManagerLoader(
+            embeddedComponentAsync = embeddedComponentManagerAsync,
+            openSettings = openSettings,
+            reload = reload,
+        ) { embeddedComponentManager ->
+            AndroidView(modifier = Modifier.fillMaxSize(), factory = {
+                createComponentView(it, embeddedComponentManager)
+            })
+        }
+    }
+}
+
+@Suppress("ConstPropertyName")
+private object BasicComponentExampleDestination {
+    const val Component = "Component"
+    const val Settings = "Settings"
+}

--- a/connect-example/src/main/java/com/stripe/android/connect/example/ui/componentpicker/ComponentPickerScreen.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/ui/componentpicker/ComponentPickerScreen.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.connect.example.ui.componentpicker
 
+import android.content.Intent
 import android.util.Log
 import androidx.annotation.StringRes
 import androidx.compose.foundation.clickable
@@ -41,6 +42,7 @@ import androidx.compose.ui.unit.sp
 import androidx.fragment.app.FragmentActivity
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.stripe.android.connect.AccountOnboardingListener
+import com.stripe.android.connect.PrivateBetaConnectSDK
 import com.stripe.android.connect.StripeComponentController
 import com.stripe.android.connect.example.R
 import com.stripe.android.connect.example.core.Success
@@ -52,10 +54,12 @@ import com.stripe.android.connect.example.ui.common.ConnectExampleScaffold
 import com.stripe.android.connect.example.ui.common.CustomizeAppearanceIconButton
 import com.stripe.android.connect.example.ui.embeddedcomponentmanagerloader.EmbeddedComponentLoaderViewModel
 import com.stripe.android.connect.example.ui.embeddedcomponentmanagerloader.EmbeddedComponentManagerLoader
+import com.stripe.android.connect.example.ui.features.payouts.PayoutsExampleActivity
 import com.stripe.android.connect.example.ui.settings.SettingsViewModel
 import kotlinx.coroutines.launch
 
 @Suppress("LongMethod")
+@OptIn(PrivateBetaConnectSDK::class)
 @Composable
 fun ComponentPickerContent(
     viewModel: EmbeddedComponentLoaderViewModel,
@@ -142,6 +146,9 @@ fun ComponentPickerContent(
                             MenuItem.AccountOnboarding -> {
                                 onboardingController.show()
                             }
+                            MenuItem.Payouts -> {
+                                context.startActivity(Intent(context, PayoutsExampleActivity::class.java))
+                            }
                         }
                     },
                 )
@@ -152,7 +159,7 @@ fun ComponentPickerContent(
 
 @Composable
 private fun ComponentPickerList(onMenuItemClick: (MenuItem) -> Unit) {
-    val items = remember { listOf(MenuItem.AccountOnboarding) }
+    val items = remember { listOf(MenuItem.AccountOnboarding, MenuItem.Payouts) }
     LazyColumn {
         items(items) { menuItem ->
             MenuRowItem(menuItem, onMenuItemClick)
@@ -217,6 +224,11 @@ private enum class MenuItem(
     AccountOnboarding(
         title = R.string.account_onboarding,
         subtitle = R.string.account_onboarding_menu_subtitle,
+        isBeta = false,
+    ),
+    Payouts(
+        title = R.string.payouts,
+        subtitle = R.string.payouts_menu_subtitle,
         isBeta = true,
     ),
 }

--- a/connect-example/src/main/java/com/stripe/android/connect/example/ui/features/payouts/PayoutsExampleActivity.kt
+++ b/connect-example/src/main/java/com/stripe/android/connect/example/ui/features/payouts/PayoutsExampleActivity.kt
@@ -1,0 +1,32 @@
+package com.stripe.android.connect.example.ui.features.payouts
+
+import android.content.Context
+import android.view.View
+import android.widget.Toast
+import com.stripe.android.connect.EmbeddedComponentManager
+import com.stripe.android.connect.PayoutsListener
+import com.stripe.android.connect.PrivateBetaConnectSDK
+import com.stripe.android.connect.example.R
+import com.stripe.android.connect.example.ui.common.BasicExampleComponentActivity
+import dagger.hilt.android.AndroidEntryPoint
+
+@OptIn(PrivateBetaConnectSDK::class)
+@AndroidEntryPoint
+class PayoutsExampleActivity : BasicExampleComponentActivity() {
+    override val titleRes: Int = R.string.payouts
+
+    override fun createComponentView(context: Context, embeddedComponentManager: EmbeddedComponentManager): View {
+        val listener = Listener()
+        return embeddedComponentManager.createPayoutsView(
+            context = context,
+            listener = listener,
+            cacheKey = "PayoutsExampleActivity"
+        )
+    }
+
+    private inner class Listener : PayoutsListener {
+        override fun onLoadError(error: Throwable) {
+            Toast.makeText(this@PayoutsExampleActivity, error.message, Toast.LENGTH_LONG).show()
+        }
+    }
+}

--- a/connect/api/connect.api
+++ b/connect/api/connect.api
@@ -95,6 +95,8 @@ public final class com/stripe/android/connect/EmbeddedComponentManager {
 	public final fun createAccountOnboardingController (Landroidx/fragment/app/FragmentActivity;Ljava/lang/String;)Lcom/stripe/android/connect/AccountOnboardingController;
 	public final fun createAccountOnboardingController (Landroidx/fragment/app/FragmentActivity;Ljava/lang/String;Lcom/stripe/android/connect/AccountOnboardingProps;)Lcom/stripe/android/connect/AccountOnboardingController;
 	public static synthetic fun createAccountOnboardingController$default (Lcom/stripe/android/connect/EmbeddedComponentManager;Landroidx/fragment/app/FragmentActivity;Ljava/lang/String;Lcom/stripe/android/connect/AccountOnboardingProps;ILjava/lang/Object;)Lcom/stripe/android/connect/AccountOnboardingController;
+	public final fun createPayoutsView (Landroid/content/Context;Lcom/stripe/android/connect/PayoutsListener;Ljava/lang/String;)Landroid/view/View;
+	public static synthetic fun createPayoutsView$default (Lcom/stripe/android/connect/EmbeddedComponentManager;Landroid/content/Context;Lcom/stripe/android/connect/PayoutsListener;Ljava/lang/String;ILjava/lang/Object;)Landroid/view/View;
 	public static final fun onActivityCreate (Landroidx/activity/ComponentActivity;)V
 	public final fun update (Lcom/stripe/android/connect/appearance/Appearance;)V
 }
@@ -124,6 +126,9 @@ public abstract class com/stripe/android/connect/FetchClientSecretTask : com/str
 
 public abstract interface class com/stripe/android/connect/FetchClientSecretTask$ResultCallback {
 	public abstract fun onResult (Ljava/lang/String;)V
+}
+
+public abstract interface annotation class com/stripe/android/connect/PrivateBetaConnectSDK : java/lang/annotation/Annotation {
 }
 
 public abstract class com/stripe/android/connect/StripeComponentController {

--- a/connect/src/main/java/com/stripe/android/connect/EmbeddedComponentManager.kt
+++ b/connect/src/main/java/com/stripe/android/connect/EmbeddedComponentManager.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.connect
 
 import android.content.Context
+import android.view.View
 import androidx.activity.ComponentActivity
 import androidx.fragment.app.FragmentActivity
 import com.stripe.android.connect.appearance.Appearance
@@ -77,11 +78,12 @@ class EmbeddedComponentManager @JvmOverloads constructor(
      * @param listener Optional [PayoutsListener] to use for handling events from the view.
      * @param cacheKey Key to use for caching the internal WebView within an Activity across configuration changes.
      */
-    internal fun createPayoutsView(
+    @PrivateBetaConnectSDK
+    fun createPayoutsView(
         context: Context,
         listener: PayoutsListener? = null,
         cacheKey: String? = null,
-    ): PayoutsView {
+    ): View {
         return PayoutsView(
             context = context,
             embeddedComponentManager = this,

--- a/connect/src/main/java/com/stripe/android/connect/PayoutsView.kt
+++ b/connect/src/main/java/com/stripe/android/connect/PayoutsView.kt
@@ -6,6 +6,7 @@ import androidx.annotation.RestrictTo
 import androidx.core.content.withStyledAttributes
 import com.stripe.android.connect.webview.StripeConnectWebViewContainer
 
+@PrivateBetaConnectSDK
 internal class PayoutsView internal constructor(
     context: Context,
     attrs: AttributeSet? = null,
@@ -48,5 +49,6 @@ internal class PayoutsView internal constructor(
     }
 }
 
+@PrivateBetaConnectSDK
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 interface PayoutsListener : StripeEmbeddedComponentListener

--- a/connect/src/main/java/com/stripe/android/connect/PrivateBetaConnectSDK.kt
+++ b/connect/src/main/java/com/stripe/android/connect/PrivateBetaConnectSDK.kt
@@ -1,0 +1,10 @@
+package com.stripe.android.connect
+
+/**
+ * Marks an API for Private Beta usage, meaning it can be changed or removed at any time (use at your own risk).
+ * The Stripe Connect SDK is in private beta and may be changed in the future without notice.
+ */
+@RequiresOptIn(message = "The Stripe Connect SDK is in private beta. It may be changed in the future without notice.")
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+annotation class PrivateBetaConnectSDK


### PR DESCRIPTION
# Summary
Adds the payouts component to the Connect SDK in private preview.

- Re-adds the `PrivateBetaConnectSDK` annotation to mark components as in preview
- Re-adds a basic non-full screen activity
- Reintroduces the Payouts components as approved in this [API review](https://docs.google.com/document/d/1aZ3NYGPTtZbH-OklJ7dNOdUehGHp2n8tkhfd-WbGd_8/edit?tab=t.0#heading=h.8hchwum5vctb)

# Motivation
https://jira.corp.stripe.com/browse/CAX-4478

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots

https://github.com/user-attachments/assets/26e7dc2f-3b60-4132-be91-332683bce480



# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
