### PR TITLE
Extend timeout.

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -254,7 +254,7 @@ workflows:
     steps:
       - script@1:
           title: Assemble Instrumentation tests
-          timeout: 600
+          timeout: 1200
           inputs:
             - content: ./gradlew assembleAndroidTest -x :paymentsheet-example:assembleAndroidTest -x :paymentsheet:assembleAndroidTest -x :example:assembleAndroidTest -x :financial-connections:assembleAndroidTest -x :financial-connections-example:assembleAndroidTest -x :camera-core:assembleAndroidTest -x :stripecardscan:assembleAndroidTest -x :stripecardscan-example:assembleAndroidTest
       - wait-for-android-emulator@1:


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Our build cache is failing (seemingly hit our limit) so extending the build timeout.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
#ir-thin-eerie

