### PR TITLE
Support `partial` value for `payment_method_remove` for `customer_session`.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/parsers/ElementsSessionJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/ElementsSessionJsonParser.kt
@@ -338,7 +338,8 @@ internal class ElementsSessionJsonParser(
 
             ElementsSession.Customer.Components.MobilePaymentElement.Enabled(
                 isPaymentMethodSaveEnabled = paymentMethodSaveFeature == VALUE_ENABLED,
-                isPaymentMethodRemoveEnabled = paymentMethodRemoveFeature == VALUE_ENABLED,
+                isPaymentMethodRemoveEnabled = paymentMethodRemoveFeature == VALUE_ENABLED ||
+                    paymentMethodRemoveFeature == VALUE_PARTIAL,
                 canRemoveLastPaymentMethod = paymentMethodRemoveLastFeature == VALUE_ENABLED,
                 isPaymentMethodSetAsDefaultEnabled = paymentMethodSetAsDefaultFeature == VALUE_ENABLED,
                 allowRedisplayOverride = allowRedisplayOverride,
@@ -364,7 +365,8 @@ internal class ElementsSessionJsonParser(
             val paymentMethodSyncDefaultFeature = customerSheetFeatures.optString(FIELD_PAYMENT_METHOD_SYNC_DEFAULT)
 
             ElementsSession.Customer.Components.CustomerSheet.Enabled(
-                isPaymentMethodRemoveEnabled = paymentMethodRemoveFeature == VALUE_ENABLED,
+                isPaymentMethodRemoveEnabled = paymentMethodRemoveFeature == VALUE_ENABLED ||
+                    paymentMethodRemoveFeature == VALUE_PARTIAL,
                 canRemoveLastPaymentMethod = paymentMethodRemoveLastFeature == VALUE_ENABLED,
                 isPaymentMethodSyncDefaultEnabled = paymentMethodSyncDefaultFeature == VALUE_ENABLED,
             )
@@ -501,6 +503,7 @@ internal class ElementsSessionJsonParser(
         private const val FIELD_PAYMENT_METHOD_SET_AS_DEFAULT = "payment_method_set_as_default"
         private const val FIELD_PAYMENT_METHOD_SYNC_DEFAULT = "payment_method_sync_default"
         private const val VALUE_ENABLED = FIELD_ENABLED
+        private const val VALUE_PARTIAL = "partial"
         const val FIELD_GOOGLE_PAY_PREFERENCE = "google_pay_preference"
         private const val FIELD_EXPERIMENTS_DATA = "experiments_data"
         private const val FIELD_EXPERIMENTS_ASSIGNMENTS = "experiment_assignments"

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
@@ -936,6 +936,14 @@ class ElementsSessionJsonParserTest {
     }
 
     @Test
+    fun `when 'payment_method_remove' is 'partial', 'canRemovePaymentMethods' should be true`() {
+        permissionsTest(
+            paymentMethodRemoveFeatureValue = "partial",
+            canRemovePaymentMethods = true,
+        )
+    }
+
+    @Test
     fun `when 'payment_method_remove' is 'disabled', 'canRemovePaymentMethods' should be false`() {
         permissionsTest(
             paymentMethodRemoveFeatureValue = "disabled",


### PR DESCRIPTION
# Summary
Support `partial` value for `payment_method_remove` for `customer_session`.

# Motivation
New value that supports a new integration type for deleting PMs.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified