### PR TITLE
Don't use address if not allowed by country in `AddressElement`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
@@ -26,8 +26,8 @@ internal class InputAddressViewModel @Inject constructor(
 ) : ViewModel(), AutocompleteAddressInteractor {
     private var eventListener: ((AutocompleteAddressInteractor.Event) -> Unit)? = null
 
-    private val initialBillingAddress = args.config?.billingAddress?.toAddressDetails()
-    private val initialShippingAddress = args.config?.address
+    private val initialBillingAddress = args.config?.billingAddress?.toAddressDetails()?.takeIfUsable()
+    private val initialShippingAddress = args.config?.address?.takeIfUsable()
 
     private val initialInputsAreTheSame = addressesAreTheSame(initialBillingAddress, initialShippingAddress)
 
@@ -277,6 +277,16 @@ internal class InputAddressViewModel @Inject constructor(
             phoneNumber = phone,
             address = address,
         )
+    }
+
+    private fun AddressDetails.takeIfUsable(): AddressDetails? {
+        val allowedCountries = args.config?.allowedCountries?.takeIf {
+            it.isNotEmpty()
+        } ?: CountryUtils.supportedBillingCountries
+
+        return takeIf {
+            address?.country == null || allowedCountries.contains(address.country)
+        }
     }
 
     override fun onAutocomplete(country: String) {


### PR DESCRIPTION
# Summary
Don't use address if not allowed by country in `AddressElement`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
