### PR TITLE
Update Bank mandate on Link and MPE.

### DIFF
--- a/paymentsheet/res/values-b+es+419/strings.xml
+++ b/paymentsheet/res/values-b+es+419/strings.xml
@@ -266,6 +266,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_view_more">Ver más</string>
   <!-- Mandate text displayed when paying via Link instant debit. -->
   <string name="stripe_wallet_bank_account_terms"><![CDATA[Al continuar, aceptas autorizar pagos conforme a estas <terms>condiciones</terms>.]]></string>
+  <!-- Text providing link to terms for bank payments -->
+  <string name="stripe_wallet_bank_account_terms_seller"><![CDATA[Al enviarle tu pedido a %s, aceptas autorizar pagos conforme a <terms>estas Condiciones</terms>.]]></string>
   <!-- Label for a section displaying payment details. -->
   <string name="stripe_wallet_collapsed_payment">Pago</string>
   <!-- Label of a button that when tapped allows the user to select a different form of payment. -->

--- a/paymentsheet/res/values-cs-rCZ/strings.xml
+++ b/paymentsheet/res/values-cs-rCZ/strings.xml
@@ -266,6 +266,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_view_more">Zobrazit více</string>
   <!-- Mandate text displayed when paying via Link instant debit. -->
   <string name="stripe_wallet_bank_account_terms"><![CDATA[Pokračováním souhlasíte s autorizací plateb v souladu s těmito <terms>podmínkami</terms>.]]></string>
+  <!-- Text providing link to terms for bank payments -->
+  <string name="stripe_wallet_bank_account_terms_seller"><![CDATA[Odesláním objednávky společnosti %s souhlasíte s autorizací plateb podle <terms>těchto podmínek</terms>.]]></string>
   <!-- Label for a section displaying payment details. -->
   <string name="stripe_wallet_collapsed_payment">Platba</string>
   <!-- Label of a button that when tapped allows the user to select a different form of payment. -->

--- a/paymentsheet/res/values-da/strings.xml
+++ b/paymentsheet/res/values-da/strings.xml
@@ -268,6 +268,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_view_more">Vis mere</string>
   <!-- Mandate text displayed when paying via Link instant debit. -->
   <string name="stripe_wallet_bank_account_terms"><![CDATA[Ved at fortsætte accepterer du at godkende betalinger i henhold til disse <terms>vilkår</terms>.]]></string>
+  <!-- Text providing link to terms for bank payments -->
+  <string name="stripe_wallet_bank_account_terms_seller"><![CDATA[Ved at indsende din ordre til %s accepterer du at autorisere betalinger i henhold til <terms>disse vilkår</terms>.]]></string>
   <!-- Label for a section displaying payment details. -->
   <string name="stripe_wallet_collapsed_payment">Betaling</string>
   <!-- Label of a button that when tapped allows the user to select a different form of payment. -->

--- a/paymentsheet/res/values-de/strings.xml
+++ b/paymentsheet/res/values-de/strings.xml
@@ -266,6 +266,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_view_more">Mehr anzeigen</string>
   <!-- Mandate text displayed when paying via Link instant debit. -->
   <string name="stripe_wallet_bank_account_terms"><![CDATA[Indem Sie fortfahren, akzeptieren Sie die Autorisierung von Zahlungen gemäß <terms>diesen Bedingungen</terms>.]]></string>
+  <!-- Text providing link to terms for bank payments -->
+  <string name="stripe_wallet_bank_account_terms_seller"><![CDATA[Mit der Übermittlung Ihrer Bestellung an %s stimmen Sie der Autorisierung von Zahlungen gemäß <terms>diesen Konditionen</terms> zu.]]></string>
   <!-- Label for a section displaying payment details. -->
   <string name="stripe_wallet_collapsed_payment">Zahlung</string>
   <!-- Label of a button that when tapped allows the user to select a different form of payment. -->

--- a/paymentsheet/res/values-el-rGR/strings.xml
+++ b/paymentsheet/res/values-el-rGR/strings.xml
@@ -268,6 +268,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_view_more">Προβολή περισσότερων</string>
   <!-- Mandate text displayed when paying via Link instant debit. -->
   <string name="stripe_wallet_bank_account_terms"><![CDATA[Εάν συνεχίσετε, συμφωνείτε να εξουσιοδοτείτε πληρωμές με βάση αυτούς τους <terms>όρους</terms>.]]></string>
+  <!-- Text providing link to terms for bank payments -->
+  <string name="stripe_wallet_bank_account_terms_seller"><![CDATA[Υποβάλλοντας την παραγγελία σας σε %s, συμφωνείτε στην εξουσιοδότηση πληρωμών σύμφωνα με <terms>αυτούς τους όρους</terms>.]]></string>
   <!-- Label for a section displaying payment details. -->
   <string name="stripe_wallet_collapsed_payment">Πληρωμή</string>
   <!-- Label of a button that when tapped allows the user to select a different form of payment. -->

--- a/paymentsheet/res/values-en-rGB/strings.xml
+++ b/paymentsheet/res/values-en-rGB/strings.xml
@@ -268,6 +268,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_view_more">View more</string>
   <!-- Mandate text displayed when paying via Link instant debit. -->
   <string name="stripe_wallet_bank_account_terms"><![CDATA[By continuing, you agree to authorise payments pursuant to these <terms>terms</terms>.]]></string>
+  <!-- Text providing link to terms for bank payments -->
+  <string name="stripe_wallet_bank_account_terms_seller"><![CDATA[By submitting your order to %s you agree to authorise payments pursuant to <terms>these terms</terms>.]]></string>
   <!-- Label for a section displaying payment details. -->
   <string name="stripe_wallet_collapsed_payment">Payment</string>
   <!-- Label of a button that when tapped allows the user to select a different form of payment. -->

--- a/paymentsheet/res/values-es/strings.xml
+++ b/paymentsheet/res/values-es/strings.xml
@@ -268,6 +268,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_view_more">Ver más</string>
   <!-- Mandate text displayed when paying via Link instant debit. -->
   <string name="stripe_wallet_bank_account_terms"><![CDATA[Al continuar, aceptas autorizar pagos de conformidad con estas <terms>condiciones</terms>.]]></string>
+  <!-- Text providing link to terms for bank payments -->
+  <string name="stripe_wallet_bank_account_terms_seller"><![CDATA[Al enviar tu pedido a %s, aceptas autorizar pagos de acuerdo con <terms>estas condiciones</terms>.]]></string>
   <!-- Label for a section displaying payment details. -->
   <string name="stripe_wallet_collapsed_payment">Pago</string>
   <!-- Label of a button that when tapped allows the user to select a different form of payment. -->

--- a/paymentsheet/res/values-et-rEE/strings.xml
+++ b/paymentsheet/res/values-et-rEE/strings.xml
@@ -268,6 +268,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_view_more">Kuva rohkem</string>
   <!-- Mandate text displayed when paying via Link instant debit. -->
   <string name="stripe_wallet_bank_account_terms"><![CDATA[Jätkates nõustute maksete autoriseerimisega vastavalt nendele <terms>tingimustele</terms>.]]></string>
+  <!-- Text providing link to terms for bank payments -->
+  <string name="stripe_wallet_bank_account_terms_seller"><![CDATA[Esitades oma tellimuse aadressile %s, nõustute autoriseerima makseid vastavalt <terms>nendele tingimustele</terms>.]]></string>
   <!-- Label for a section displaying payment details. -->
   <string name="stripe_wallet_collapsed_payment">Makse</string>
   <!-- Label of a button that when tapped allows the user to select a different form of payment. -->

--- a/paymentsheet/res/values-fi/strings.xml
+++ b/paymentsheet/res/values-fi/strings.xml
@@ -268,6 +268,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_view_more">Näytä lisää</string>
   <!-- Mandate text displayed when paying via Link instant debit. -->
   <string name="stripe_wallet_bank_account_terms"><![CDATA[Jatkamalla hyväksyt maksut näiden <terms>ehtojen</terms> mukaisesti.]]></string>
+  <!-- Text providing link to terms for bank payments -->
+  <string name="stripe_wallet_bank_account_terms_seller"><![CDATA[Lähettämällä tilauksesi yritykselle %s, valtuutat maksut <terms>näiden ehtojen</terms> mukaisesti.]]></string>
   <!-- Label for a section displaying payment details. -->
   <string name="stripe_wallet_collapsed_payment">Maksu</string>
   <!-- Label of a button that when tapped allows the user to select a different form of payment. -->

--- a/paymentsheet/res/values-fil/strings.xml
+++ b/paymentsheet/res/values-fil/strings.xml
@@ -268,6 +268,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_view_more">Tingnan ang higit pa</string>
   <!-- Mandate text displayed when paying via Link instant debit. -->
   <string name="stripe_wallet_bank_account_terms"><![CDATA[Sa pagpapatuloy, sumasang-ayon ka na pahintulutan ang mga pagbabayad alinsunod sa <terms>mga tuntunin</terms> na ito.]]></string>
+  <!-- Text providing link to terms for bank payments -->
+  <string name="stripe_wallet_bank_account_terms_seller"><![CDATA[Sa pagsusumite ng iyong order sa %s, sumasang-ayon kang pahintulutan ang mga pagbabayad alinsunod sa <terms> mga tuntuning ito</terms>.]]></string>
   <!-- Label for a section displaying payment details. -->
   <string name="stripe_wallet_collapsed_payment">Pagbabayad</string>
   <!-- Label of a button that when tapped allows the user to select a different form of payment. -->

--- a/paymentsheet/res/values-fr-rCA/strings.xml
+++ b/paymentsheet/res/values-fr-rCA/strings.xml
@@ -266,6 +266,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_view_more">Voir plus</string>
   <!-- Mandate text displayed when paying via Link instant debit. -->
   <string name="stripe_wallet_bank_account_terms"><![CDATA[En continuant, vous autorisez les paiements conformément à ces <terms>conditions</terms>.]]></string>
+  <!-- Text providing link to terms for bank payments -->
+  <string name="stripe_wallet_bank_account_terms_seller"><![CDATA[En envoyant votre commande à %s, vous autorisez les paiements en vertu des <terms>présentes conditions</terms>.]]></string>
   <!-- Label for a section displaying payment details. -->
   <string name="stripe_wallet_collapsed_payment">Paiement</string>
   <!-- Label of a button that when tapped allows the user to select a different form of payment. -->

--- a/paymentsheet/res/values-fr/strings.xml
+++ b/paymentsheet/res/values-fr/strings.xml
@@ -266,6 +266,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_view_more">Afficher plus</string>
   <!-- Mandate text displayed when paying via Link instant debit. -->
   <string name="stripe_wallet_bank_account_terms"><![CDATA[En continuant, vous autorisez les paiements, conformément à ces <terms>conditions</terms>.]]></string>
+  <!-- Text providing link to terms for bank payments -->
+  <string name="stripe_wallet_bank_account_terms_seller"><![CDATA[En soumettant votre commande à %s, vous autoriser les paiements conformément à <terms>ces conditions</terms>.]]></string>
   <!-- Label for a section displaying payment details. -->
   <string name="stripe_wallet_collapsed_payment">Paiement</string>
   <!-- Label of a button that when tapped allows the user to select a different form of payment. -->

--- a/paymentsheet/res/values-hr/strings.xml
+++ b/paymentsheet/res/values-hr/strings.xml
@@ -268,6 +268,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_view_more">Vidi više</string>
   <!-- Mandate text displayed when paying via Link instant debit. -->
   <string name="stripe_wallet_bank_account_terms"><![CDATA[Ako nastavite, pristajete na autorizaciju plaćanja u skladu s ovim <terms>uvjetima</terms>.]]></string>
+  <!-- Text providing link to terms for bank payments -->
+  <string name="stripe_wallet_bank_account_terms_seller"><![CDATA[Podnošenjem narudžbe za %s pristajete na odobravanje plaćanja kojim ćete se pridržavati <terms>ovih uvjeta</terms>.]]></string>
   <!-- Label for a section displaying payment details. -->
   <string name="stripe_wallet_collapsed_payment">Plaćanje</string>
   <!-- Label of a button that when tapped allows the user to select a different form of payment. -->

--- a/paymentsheet/res/values-hu/strings.xml
+++ b/paymentsheet/res/values-hu/strings.xml
@@ -268,6 +268,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_view_more">Továbbiak megjelenítése</string>
   <!-- Mandate text displayed when paying via Link instant debit. -->
   <string name="stripe_wallet_bank_account_terms"><![CDATA[A folytatással elfogadja, hogy engedélyezi a kifizetéseket ezen <terms>feltételek</terms> szerint.]]></string>
+  <!-- Text providing link to terms for bank payments -->
+  <string name="stripe_wallet_bank_account_terms_seller"><![CDATA[A megrendelésének a(z) %s részére történő elküldésével Ön beleegyezik abba, hogy engedélyezi a fizetéseket a <terms>jelen feltételek</terms> szerint.]]></string>
   <!-- Label for a section displaying payment details. -->
   <string name="stripe_wallet_collapsed_payment">Fizetés</string>
   <!-- Label of a button that when tapped allows the user to select a different form of payment. -->

--- a/paymentsheet/res/values-in/strings.xml
+++ b/paymentsheet/res/values-in/strings.xml
@@ -266,6 +266,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_view_more">Lihat selengkapnya</string>
   <!-- Mandate text displayed when paying via Link instant debit. -->
   <string name="stripe_wallet_bank_account_terms"><![CDATA[Dengan melanjutkan, berarti Anda setuju untuk mengotorisasi pembayaran sesuai dengan <terms>ketentuan</terms> ini.]]></string>
+  <!-- Text providing link to terms for bank payments -->
+  <string name="stripe_wallet_bank_account_terms_seller"><![CDATA[Dengan mengirimkan pesanan Anda ke %s, Anda setuju untuk mengotorisasi pembayaran sesuai dengan <terms>ketentuan ini</terms>.]]></string>
   <!-- Label for a section displaying payment details. -->
   <string name="stripe_wallet_collapsed_payment">Pembayaran</string>
   <!-- Label of a button that when tapped allows the user to select a different form of payment. -->

--- a/paymentsheet/res/values-ja/strings.xml
+++ b/paymentsheet/res/values-ja/strings.xml
@@ -266,6 +266,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_view_more">さらに表示</string>
   <!-- Mandate text displayed when paying via Link instant debit. -->
   <string name="stripe_wallet_bank_account_terms"><![CDATA[続行すると、これらの<terms>規約</terms>に従って支払いをオーソリすることに同意したものとみなされます。]]></string>
+  <!-- Text providing link to terms for bank payments -->
+  <string name="stripe_wallet_bank_account_terms_seller"><![CDATA[%s に注文を送信することにより、<terms>これらの規約</terms> に従って決済を承認することに同意したものとみなされます。]]></string>
   <!-- Label for a section displaying payment details. -->
   <string name="stripe_wallet_collapsed_payment">決済</string>
   <!-- Label of a button that when tapped allows the user to select a different form of payment. -->

--- a/paymentsheet/res/values-ko/strings.xml
+++ b/paymentsheet/res/values-ko/strings.xml
@@ -268,6 +268,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_view_more">자세히 보기</string>
   <!-- Mandate text displayed when paying via Link instant debit. -->
   <string name="stripe_wallet_bank_account_terms"><![CDATA[계속하면 해당 <terms>약관</terms>에 따라 결제를 승인하는 데 동의하는 것입니다.]]></string>
+  <!-- Text providing link to terms for bank payments -->
+  <string name="stripe_wallet_bank_account_terms_seller"><![CDATA[%s에 주문을 제출하면 귀하는 <terms>이 약관</terms>에 따라 결제 승인을 동의하는 것입니다.]]></string>
   <!-- Label for a section displaying payment details. -->
   <string name="stripe_wallet_collapsed_payment">결제</string>
   <!-- Label of a button that when tapped allows the user to select a different form of payment. -->

--- a/paymentsheet/res/values-lt-rLT/strings.xml
+++ b/paymentsheet/res/values-lt-rLT/strings.xml
@@ -266,6 +266,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_view_more">Peržiūrėti daugiau</string>
   <!-- Mandate text displayed when paying via Link instant debit. -->
   <string name="stripe_wallet_bank_account_terms"><![CDATA[Tęsdami sutinkate autorizuoti mokėjimus pagal šias <terms>sąlygas</terms>.]]></string>
+  <!-- Text providing link to terms for bank payments -->
+  <string name="stripe_wallet_bank_account_terms_seller"><![CDATA[Pateikdami užsakymą %s, sutinkate mokėjimus autorizuoti pagal <terms>šias sąlygas</terms>.]]></string>
   <!-- Label for a section displaying payment details. -->
   <string name="stripe_wallet_collapsed_payment">Mokėjimas</string>
   <!-- Label of a button that when tapped allows the user to select a different form of payment. -->

--- a/paymentsheet/res/values-lv-rLV/strings.xml
+++ b/paymentsheet/res/values-lv-rLV/strings.xml
@@ -266,6 +266,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_view_more">Skatīt vairāk</string>
   <!-- Mandate text displayed when paying via Link instant debit. -->
   <string name="stripe_wallet_bank_account_terms"><![CDATA[Turpinot, jūs piekrītat autorizēt maksājumus saskaņā ar šiem<terms>noteikumiem</terms>.]]></string>
+  <!-- Text providing link to terms for bank payments -->
+  <string name="stripe_wallet_bank_account_terms_seller"><![CDATA[Iesniedzot savu pasūtījumu %s, jūs piekrītat autorizēt maksājumus saskaņā ar <terms>šiem noteikumiem</terms>.]]></string>
   <!-- Label for a section displaying payment details. -->
   <string name="stripe_wallet_collapsed_payment">Maksājums</string>
   <!-- Label of a button that when tapped allows the user to select a different form of payment. -->

--- a/paymentsheet/res/values-ms-rMY/strings.xml
+++ b/paymentsheet/res/values-ms-rMY/strings.xml
@@ -268,6 +268,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_view_more">Lihat lebih banyak</string>
   <!-- Mandate text displayed when paying via Link instant debit. -->
   <string name="stripe_wallet_bank_account_terms"><![CDATA[Dengan meneruskan langkah, anda bersetuju untuk mengizinkan pembayaran menurut <terms>terma</terms> ini.]]></string>
+  <!-- Text providing link to terms for bank payments -->
+  <string name="stripe_wallet_bank_account_terms_seller"><![CDATA[Dengan menghantar pesanan anda kepada %s anda bersetuju untuk mengizinkan pembayaran mengikut <terms>terma-terma ini</terms>.]]></string>
   <!-- Label for a section displaying payment details. -->
   <string name="stripe_wallet_collapsed_payment">Pembayaran</string>
   <!-- Label of a button that when tapped allows the user to select a different form of payment. -->

--- a/paymentsheet/res/values-mt/strings.xml
+++ b/paymentsheet/res/values-mt/strings.xml
@@ -268,6 +268,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_view_more">Uri iktar</string>
   <!-- Mandate text displayed when paying via Link instant debit. -->
   <string name="stripe_wallet_bank_account_terms"><![CDATA[Meta tkompli tkun qed taqbel li tawtorizza l-pagamenti skont dar-<terms>regoli</terms>.]]></string>
+  <!-- Text providing link to terms for bank payments -->
+  <string name="stripe_wallet_bank_account_terms_seller"><![CDATA[Billi tissottometti l-ordni tiegħek lil %s inti taqbel li tawtorizza pagamenti skont <terms>dawn it-termini</terms>.]]></string>
   <!-- Label for a section displaying payment details. -->
   <string name="stripe_wallet_collapsed_payment">Pagament</string>
   <!-- Label of a button that when tapped allows the user to select a different form of payment. -->

--- a/paymentsheet/res/values-nb/strings.xml
+++ b/paymentsheet/res/values-nb/strings.xml
@@ -268,6 +268,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_view_more">Se mer</string>
   <!-- Mandate text displayed when paying via Link instant debit. -->
   <string name="stripe_wallet_bank_account_terms"><![CDATA[Ved å fortsette godtar du å autorisere betalinger i samsvar med <terms>vilkårene</terms>.]]></string>
+  <!-- Text providing link to terms for bank payments -->
+  <string name="stripe_wallet_bank_account_terms_seller"><![CDATA[Ved å sende inn bestillingen til %s godtar du å autorisere betalinger i samsvar med <terms>disse vilkårene</terms>.]]></string>
   <!-- Label for a section displaying payment details. -->
   <string name="stripe_wallet_collapsed_payment">Betaling</string>
   <!-- Label of a button that when tapped allows the user to select a different form of payment. -->

--- a/paymentsheet/res/values-nl/strings.xml
+++ b/paymentsheet/res/values-nl/strings.xml
@@ -266,6 +266,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_view_more">Meer weergeven</string>
   <!-- Mandate text displayed when paying via Link instant debit. -->
   <string name="stripe_wallet_bank_account_terms"><![CDATA[Als je doorgaat, stem je in dat betalingen worden geautoriseerd in overeenstemming met deze <terms>voorwaarden</terms>.]]></string>
+  <!-- Text providing link to terms for bank payments -->
+  <string name="stripe_wallet_bank_account_terms_seller"><![CDATA[Door je bestelling te plaatsen bij %s, autoriseer je betalingen in overeenstemming met <terms>deze voorwaarden</terms>.]]></string>
   <!-- Label for a section displaying payment details. -->
   <string name="stripe_wallet_collapsed_payment">Betaling</string>
   <!-- Label of a button that when tapped allows the user to select a different form of payment. -->

--- a/paymentsheet/res/values-pl-rPL/strings.xml
+++ b/paymentsheet/res/values-pl-rPL/strings.xml
@@ -268,6 +268,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_view_more">Wyświetl więcej</string>
   <!-- Mandate text displayed when paying via Link instant debit. -->
   <string name="stripe_wallet_bank_account_terms"><![CDATA[Kontynuując, wyrażasz zgodę na autoryzowanie płatności zgodnie z tymi <terms>warunkami</terms>.]]></string>
+  <!-- Text providing link to terms for bank payments -->
+  <string name="stripe_wallet_bank_account_terms_seller"><![CDATA[Przesyłając zamówienie do %s, wyrażasz zgodę na autoryzację płatności zgodnie z <terms>niniejszymi warunkami</terms>.]]></string>
   <!-- Label for a section displaying payment details. -->
   <string name="stripe_wallet_collapsed_payment">Płatność</string>
   <!-- Label of a button that when tapped allows the user to select a different form of payment. -->

--- a/paymentsheet/res/values-pt-rPT/strings.xml
+++ b/paymentsheet/res/values-pt-rPT/strings.xml
@@ -268,6 +268,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_view_more">Ver mais</string>
   <!-- Mandate text displayed when paying via Link instant debit. -->
   <string name="stripe_wallet_bank_account_terms"><![CDATA[Ao continuar, concorda em autorizar pagamentos de acordo com estes <terms>termos</terms>.]]></string>
+  <!-- Text providing link to terms for bank payments -->
+  <string name="stripe_wallet_bank_account_terms_seller"><![CDATA[Ao submeter o seu pedido a %s, concorda em autorizar pagamentos de acordo com <terms>estas condições</terms>.]]></string>
   <!-- Label for a section displaying payment details. -->
   <string name="stripe_wallet_collapsed_payment">Pagamento</string>
   <!-- Label of a button that when tapped allows the user to select a different form of payment. -->

--- a/paymentsheet/res/values-ro-rRO/strings.xml
+++ b/paymentsheet/res/values-ro-rRO/strings.xml
@@ -268,6 +268,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_view_more">Vizualizați mai multe</string>
   <!-- Mandate text displayed when paying via Link instant debit. -->
   <string name="stripe_wallet_bank_account_terms"><![CDATA[Continuând, sunteți de acord să autorizați plățile în conformitate cu acești <terms>termeni</terms>.]]></string>
+  <!-- Text providing link to terms for bank payments -->
+  <string name="stripe_wallet_bank_account_terms_seller"><![CDATA[Prin trimiterea comenzii dvs. către %s, sunteți de acord să autorizați plățile în conformitate cu <terms>acești termeni</terms>.]]></string>
   <!-- Label for a section displaying payment details. -->
   <string name="stripe_wallet_collapsed_payment">Plată</string>
   <!-- Label of a button that when tapped allows the user to select a different form of payment. -->

--- a/paymentsheet/res/values-ro/strings.xml
+++ b/paymentsheet/res/values-ro/strings.xml
@@ -268,6 +268,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_view_more">Vizualizați mai multe</string>
   <!-- Mandate text displayed when paying via Link instant debit. -->
   <string name="stripe_wallet_bank_account_terms"><![CDATA[Continuând, sunteți de acord să autorizați plățile în conformitate cu acești <terms>termeni</terms>.]]></string>
+  <!-- Text providing link to terms for bank payments -->
+  <string name="stripe_wallet_bank_account_terms_seller"><![CDATA[Prin trimiterea comenzii dvs. către %s, sunteți de acord să autorizați plățile în conformitate cu <terms>acești termeni</terms>.]]></string>
   <!-- Label for a section displaying payment details. -->
   <string name="stripe_wallet_collapsed_payment">Plată</string>
   <!-- Label of a button that when tapped allows the user to select a different form of payment. -->

--- a/paymentsheet/res/values-ru/strings.xml
+++ b/paymentsheet/res/values-ru/strings.xml
@@ -268,6 +268,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_view_more">Показать ещё</string>
   <!-- Mandate text displayed when paying via Link instant debit. -->
   <string name="stripe_wallet_bank_account_terms"><![CDATA[Продолжая использование, вы тем самым соглашаетесь авторизовать платежи согласно данным <terms>условиям</terms>.]]></string>
+  <!-- Text providing link to terms for bank payments -->
+  <string name="stripe_wallet_bank_account_terms_seller"><![CDATA[Отправляя заказ в %s, вы соглашаетесь разрешить платежи в соответствии с <terms>этими условиями</terms>.]]></string>
   <!-- Label for a section displaying payment details. -->
   <string name="stripe_wallet_collapsed_payment">Платеж</string>
   <!-- Label of a button that when tapped allows the user to select a different form of payment. -->

--- a/paymentsheet/res/values-sk-rSK/strings.xml
+++ b/paymentsheet/res/values-sk-rSK/strings.xml
@@ -266,6 +266,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_view_more">Zobraziť viac</string>
   <!-- Mandate text displayed when paying via Link instant debit. -->
   <string name="stripe_wallet_bank_account_terms"><![CDATA[Pokračovaním súhlasíte s autorizáciou platieb podľa týchto <terms>podmienok</terms>.]]></string>
+  <!-- Text providing link to terms for bank payments -->
+  <string name="stripe_wallet_bank_account_terms_seller"><![CDATA[Odoslaním objednávky na %s súhlasíte s autorizáciou platieb podľa <terms>týchto podmienok</terms>.]]></string>
   <!-- Label for a section displaying payment details. -->
   <string name="stripe_wallet_collapsed_payment">Platba</string>
   <!-- Label of a button that when tapped allows the user to select a different form of payment. -->

--- a/paymentsheet/res/values-sl-rSI/strings.xml
+++ b/paymentsheet/res/values-sl-rSI/strings.xml
@@ -268,6 +268,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_view_more">Prikaži več</string>
   <!-- Mandate text displayed when paying via Link instant debit. -->
   <string name="stripe_wallet_bank_account_terms"><![CDATA[Če nadaljujete postopek, se strinjate z odobritvijo plačil v skladu s temi <terms>pogoji</terms>.]]></string>
+  <!-- Text providing link to terms for bank payments -->
+  <string name="stripe_wallet_bank_account_terms_seller"><![CDATA[Z oddajo naročila podjetju %s se strinjate, da boste odobrili plačila v skladu s <terms>temi pogoji</terms>.]]></string>
   <!-- Label for a section displaying payment details. -->
   <string name="stripe_wallet_collapsed_payment">Plačilo</string>
   <!-- Label of a button that when tapped allows the user to select a different form of payment. -->

--- a/paymentsheet/res/values-sv/strings.xml
+++ b/paymentsheet/res/values-sv/strings.xml
@@ -268,6 +268,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_view_more">Visa mer</string>
   <!-- Mandate text displayed when paying via Link instant debit. -->
   <string name="stripe_wallet_bank_account_terms"><![CDATA[Genom att fortsätta samtycker du till att godkänna betalningar i enlighet med dessa <terms>villkor</terms>.]]></string>
+  <!-- Text providing link to terms for bank payments -->
+  <string name="stripe_wallet_bank_account_terms_seller"><![CDATA[Genom att skicka din beställning till %s samtycker du till att godkänna betalningar i enlighet med <terms>dessa villkor</terms>.]]></string>
   <!-- Label for a section displaying payment details. -->
   <string name="stripe_wallet_collapsed_payment">Betalning</string>
   <!-- Label of a button that when tapped allows the user to select a different form of payment. -->

--- a/paymentsheet/res/values-th/strings.xml
+++ b/paymentsheet/res/values-th/strings.xml
@@ -268,6 +268,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_view_more">ดูเพิ่มเติม</string>
   <!-- Mandate text displayed when paying via Link instant debit. -->
   <string name="stripe_wallet_bank_account_terms"><![CDATA[การดำเนินการต่อหมายความว่าคุณตกลงที่จะอนุมัติการชำระเงินซึ่งดำเนินการตาม<terms>ข้อกำหนด</terms>เหล่านี้]]></string>
+  <!-- Text providing link to terms for bank payments -->
+  <string name="stripe_wallet_bank_account_terms_seller"><![CDATA[การส่งคำสั่งซื้อให้ %s หมายความว่าคุณตกลงที่จะอนุมัติการชำระเงินตาม<terms>ข้อกำหนดเหล่านี้</terms>]]></string>
   <!-- Label for a section displaying payment details. -->
   <string name="stripe_wallet_collapsed_payment">การชำระเงิน</string>
   <!-- Label of a button that when tapped allows the user to select a different form of payment. -->

--- a/paymentsheet/res/values-tr/strings.xml
+++ b/paymentsheet/res/values-tr/strings.xml
@@ -268,6 +268,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_view_more">Daha fazla göster</string>
   <!-- Mandate text displayed when paying via Link instant debit. -->
   <string name="stripe_wallet_bank_account_terms"><![CDATA[Devam ettiğinizde, bu <terms>koşullar</terms>a uygun olarak ödemelere izin vermeyi kabul etmiş olursunuz.]]></string>
+  <!-- Text providing link to terms for bank payments -->
+  <string name="stripe_wallet_bank_account_terms_seller"><![CDATA[Siparişinizi %s’ye göndererek ödemeleri <terms>bu koşullara</terms> uygun olarak yetkilendirmeyi kabul etmiş olursunuz.]]></string>
   <!-- Label for a section displaying payment details. -->
   <string name="stripe_wallet_collapsed_payment">Ödeme</string>
   <!-- Label of a button that when tapped allows the user to select a different form of payment. -->

--- a/paymentsheet/res/values-vi/strings.xml
+++ b/paymentsheet/res/values-vi/strings.xml
@@ -268,6 +268,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_view_more">Xem thêm</string>
   <!-- Mandate text displayed when paying via Link instant debit. -->
   <string name="stripe_wallet_bank_account_terms"><![CDATA[Bằng việc tiếp tục, quý vị đồng ý xác thực thanh toán tuân theo các <terms>điều khoản</terms> sau.]]></string>
+  <!-- Text providing link to terms for bank payments -->
+  <string name="stripe_wallet_bank_account_terms_seller"><![CDATA[Bằng cách gửi đơn hàng của bạn đến %s, bạn đồng ý ủy quyền thanh toán theo <terms>các điều khoản này</terms>.]]></string>
   <!-- Label for a section displaying payment details. -->
   <string name="stripe_wallet_collapsed_payment">Thanh toán</string>
   <!-- Label of a button that when tapped allows the user to select a different form of payment. -->

--- a/paymentsheet/res/values-zh-rHK/strings.xml
+++ b/paymentsheet/res/values-zh-rHK/strings.xml
@@ -268,6 +268,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_view_more">查看更多</string>
   <!-- Mandate text displayed when paying via Link instant debit. -->
   <string name="stripe_wallet_bank_account_terms"><![CDATA[點擊「繼續」，即表示您同意按照這些<terms>條款</terms>授權付款。]]></string>
+  <!-- Text providing link to terms for bank payments -->
+  <string name="stripe_wallet_bank_account_terms_seller"><![CDATA[將訂單提交至 %s 即表示您同意根據<terms>這些條款</terms>授權付款。]]></string>
   <!-- Label for a section displaying payment details. -->
   <string name="stripe_wallet_collapsed_payment">支付方式</string>
   <!-- Label of a button that when tapped allows the user to select a different form of payment. -->

--- a/paymentsheet/res/values-zh/strings.xml
+++ b/paymentsheet/res/values-zh/strings.xml
@@ -268,6 +268,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_view_more">查看更多</string>
   <!-- Mandate text displayed when paying via Link instant debit. -->
   <string name="stripe_wallet_bank_account_terms"><![CDATA[点击“继续”，即表示您同意按照这些<terms>条款</terms>授权付款。]]></string>
+  <!-- Text providing link to terms for bank payments -->
+  <string name="stripe_wallet_bank_account_terms_seller"><![CDATA[向 %s 提交您的订单即表示您同意按照<terms>这些条款</terms>授权付款。]]></string>
   <!-- Label for a section displaying payment details. -->
   <string name="stripe_wallet_collapsed_payment">支付方式</string>
   <!-- Label of a button that when tapped allows the user to select a different form of payment. -->

--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -270,6 +270,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_view_more">View more</string>
   <!-- Mandate text displayed when paying via Link instant debit. -->
   <string name="stripe_wallet_bank_account_terms"><![CDATA[By continuing, you agree to authorize payments pursuant to these <terms>terms</terms>.]]></string>
+    <!-- Mandate text displayed when paying via Link instant debit with seller information. -->
+  <string name="stripe_wallet_bank_account_terms_seller"><![CDATA[By submitting your order to %s you agree to authorize payments pursuant to these <terms>terms</terms>.]]></string>
   <!-- Label for a section displaying payment details. -->
   <string name="stripe_wallet_collapsed_payment">Payment</string>
   <!-- Label of a button that when tapped allows the user to select a different form of payment. -->

--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -270,8 +270,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_view_more">View more</string>
   <!-- Mandate text displayed when paying via Link instant debit. -->
   <string name="stripe_wallet_bank_account_terms"><![CDATA[By continuing, you agree to authorize payments pursuant to these <terms>terms</terms>.]]></string>
-    <!-- Mandate text displayed when paying via Link instant debit with seller information. -->
-  <string name="stripe_wallet_bank_account_terms_seller"><![CDATA[By submitting your order to %s you agree to authorize payments pursuant to these <terms>terms</terms>.]]></string>
+  <!-- Text providing link to terms for bank payments -->
+  <string name="stripe_wallet_bank_account_terms_seller"><![CDATA[By submitting your order to %s you agree to authorize payments pursuant to <terms>these terms</terms>.]]></string>
   <!-- Label for a section displaying payment details. -->
   <string name="stripe_wallet_collapsed_payment">Payment</string>
   <!-- Label of a button that when tapped allows the user to select a different form of payment. -->

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -878,6 +878,8 @@ internal class CustomerSheetViewModel(
             setAsDefaultMatchesSaveForFutureUse = FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE,
             autocompleteAddressInteractorFactory = null,
             termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
+            sellerBusinessName = null,
+            linkSignUpOptInFeatureEnabled = false,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkConfiguration.kt
@@ -15,6 +15,7 @@ import kotlinx.parcelize.Parcelize
 internal data class LinkConfiguration(
     val stripeIntent: StripeIntent,
     val merchantName: String,
+    val sellerBusinessName: String?,
     val merchantCountryCode: String?,
     val merchantLogoUrl: String?,
     val customerInfo: CustomerInfo,

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletUiState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletUiState.kt
@@ -22,6 +22,7 @@ internal data class WalletUiState(
     val isProcessing: Boolean,
     val isSettingUp: Boolean,
     val merchantName: String,
+    val sellerBusinessName: String?,
     val primaryButtonLabel: ResolvableString,
     val secondaryButtonLabel: ResolvableString?,
     val hasCompleted: Boolean,
@@ -55,6 +56,7 @@ internal data class WalletUiState(
         get() = selectedItem?.makeMandateText(
             isSettingUp = isSettingUp,
             merchantName = merchantName,
+            sellerBusinessName = sellerBusinessName,
             signupToggleEnabled = signupToggleEnabled
         )
 
@@ -120,11 +122,16 @@ internal data class WalletUiState(
 private fun ConsumerPaymentDetails.PaymentDetails.makeMandateText(
     isSettingUp: Boolean,
     merchantName: String,
+    sellerBusinessName: String?,
     signupToggleEnabled: Boolean
 ): ResolvableString? {
     return when (this) {
-        is ConsumerPaymentDetails.BankAccount -> {
-            resolvableString(R.string.stripe_wallet_bank_account_terms)
+        is ConsumerPaymentDetails.BankAccount -> when {
+            signupToggleEnabled && sellerBusinessName != null -> resolvableString(
+                R.string.stripe_wallet_bank_account_terms_seller,
+                sellerBusinessName
+            )
+            else -> resolvableString(R.string.stripe_wallet_bank_account_terms)
         }
         is Card,
         is ConsumerPaymentDetails.Passthrough -> when {

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
@@ -78,6 +78,7 @@ internal class WalletViewModel @Inject constructor(
             email = linkAccount.email,
             isSettingUp = stripeIntent.isSetupForFutureUsage(configuration.passthroughModeEnabled),
             merchantName = configuration.merchantName,
+            sellerBusinessName = configuration.sellerBusinessName,
             selectedItemId = null,
             cardBrandFilter = configuration.cardBrandFilter,
             collectMissingBillingDetailsForExistingPaymentMethods = configuration

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -53,6 +53,7 @@ internal data class PaymentMethodMetadata(
     val paymentMethodOrder: List<String>,
     val cbcEligibility: CardBrandChoiceEligibility,
     val merchantName: String,
+    val sellerBusinessName: String?,
     val defaultBillingDetails: PaymentSheet.BillingDetails?,
     val shippingDetails: AddressDetails?,
     val sharedDataSpecs: List<SharedDataSpec>,
@@ -311,6 +312,7 @@ internal data class PaymentMethodMetadata(
             isGooglePayReady: Boolean,
             linkState: LinkState?,
             customerMetadata: CustomerMetadata,
+            sellerBusinessName: String? = null,
         ): PaymentMethodMetadata {
             val linkSettings = elementsSession.linkSettings
             return PaymentMethodMetadata(
@@ -332,6 +334,7 @@ internal data class PaymentMethodMetadata(
                     preferredNetworks = configuration.preferredNetworks,
                 ),
                 merchantName = configuration.merchantDisplayName,
+                sellerBusinessName = sellerBusinessName,
                 defaultBillingDetails = configuration.defaultBillingDetails,
                 shippingDetails = configuration.shippingDetails,
                 customerMetadata = customerMetadata,
@@ -378,6 +381,7 @@ internal data class PaymentMethodMetadata(
                     preferredNetworks = configuration.preferredNetworks,
                 ),
                 merchantName = configuration.merchantDisplayName,
+                sellerBusinessName = null,
                 defaultBillingDetails = configuration.defaultBillingDetails,
                 shippingDetails = null,
                 customerMetadata = customerMetadata,
@@ -417,6 +421,7 @@ internal data class PaymentMethodMetadata(
                     }.orEmpty(),
                 ),
                 merchantName = configuration.merchantName,
+                sellerBusinessName = configuration.sellerBusinessName,
                 // Use effective billing details to prefill billing details in new card flows
                 defaultBillingDetails = effectiveBillingDetails(
                     configuration = configuration,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -185,6 +185,8 @@ internal sealed class PaymentSelection : Parcelable {
                         isSaveForFutureUseSelected = false,
                         isInstantDebits = false,
                         isSetupFlow = isSetupFlow,
+                        linkSignUpOptInFeatureEnabled = false,
+                        sellerBusinessName = null,
                     )
                 }
                 PaymentMethod.Type.SepaDebit -> {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountForm.kt
@@ -99,6 +99,8 @@ internal fun USBankAccountForm(
                 financialConnectionsAvailability = usBankAccountFormArgs.financialConnectionsAvailability,
                 setAsDefaultMatchesSaveForFutureUse = usBankAccountFormArgs.setAsDefaultMatchesSaveForFutureUse,
                 termsDisplay = usBankAccountFormArgs.termsDisplay,
+                sellerBusinessName = usBankAccountFormArgs.sellerBusinessName,
+                linkSignUpOptInFeatureEnabled = usBankAccountFormArgs.linkSignUpOptInFeatureEnabled,
             )
         },
     )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArguments.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArguments.kt
@@ -68,6 +68,8 @@ internal class USBankAccountFormArguments(
     val financialConnectionsAvailability: FinancialConnectionsAvailability?,
     val setAsDefaultMatchesSaveForFutureUse: Boolean,
     val termsDisplay: PaymentSheet.TermsDisplay,
+    val sellerBusinessName: String?,
+    val linkSignUpOptInFeatureEnabled: Boolean,
 ) {
     companion object {
         fun create(
@@ -122,6 +124,9 @@ internal class USBankAccountFormArguments(
                 financialConnectionsAvailability = paymentMethodMetadata.financialConnectionsAvailability,
                 setAsDefaultMatchesSaveForFutureUse = viewModel.customerStateHolder.paymentMethods.value.isEmpty(),
                 termsDisplay = paymentMethodMetadata.termsDisplayForCode(selectedPaymentMethodCode),
+                sellerBusinessName = paymentMethodMetadata.sellerBusinessName,
+                linkSignUpOptInFeatureEnabled = paymentMethodMetadata?.linkState?.configuration
+                    ?.linkSignUpOptInFeatureEnabled == true,
             )
         }
 
@@ -179,6 +184,9 @@ internal class USBankAccountFormArguments(
                 // If no saved payment methods, then first saved payment method is automatically set as default
                 setAsDefaultMatchesSaveForFutureUse = !hasSavedPaymentMethods,
                 termsDisplay = paymentMethodMetadata.termsDisplayForType(PaymentMethod.Type.USBankAccount),
+                sellerBusinessName = paymentMethodMetadata.sellerBusinessName,
+                linkSignUpOptInFeatureEnabled = paymentMethodMetadata?.linkState?.configuration
+                    ?.linkSignUpOptInFeatureEnabled == true,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -755,6 +755,8 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
         }
         return USBankAccountTextBuilder.buildMandateAndMicrodepositsText(
             merchantName = formattedMerchantName(),
+            sellerBusinessName = args.sellerBusinessName,
+            linkSignUpOptInFeatureEnabled = args.linkSignUpOptInFeatureEnabled,
             isVerifyingMicrodeposits = isVerifyWithMicrodeposits,
             isSaveForFutureUseSelected = isSaveForFutureUseSelected,
             isInstantDebits = args.instantDebits,
@@ -821,6 +823,8 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
         val setAsDefaultPaymentMethodEnabled: Boolean,
         val setAsDefaultMatchesSaveForFutureUse: Boolean,
         val termsDisplay: PaymentSheet.TermsDisplay,
+        val sellerBusinessName: String?,
+        val linkSignUpOptInFeatureEnabled: Boolean,
     )
 
     private companion object {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountTextBuilder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountTextBuilder.kt
@@ -14,6 +14,8 @@ internal object USBankAccountTextBuilder {
 
     fun buildMandateAndMicrodepositsText(
         merchantName: String,
+        sellerBusinessName: String?,
+        linkSignUpOptInFeatureEnabled: Boolean,
         isVerifyingMicrodeposits: Boolean,
         isSaveForFutureUseSelected: Boolean,
         isInstantDebits: Boolean,
@@ -21,6 +23,8 @@ internal object USBankAccountTextBuilder {
     ): ResolvableString {
         val mandateText = buildMandateText(
             merchantName = merchantName,
+            sellerBusinessName = sellerBusinessName,
+            linkSignUpOptInFeatureEnabled = linkSignUpOptInFeatureEnabled,
             isSaveForFutureUseSelected = isSaveForFutureUseSelected,
             isInstantDebits = isInstantDebits,
             isSetupFlow = isSetupFlow,
@@ -42,6 +46,8 @@ internal object USBankAccountTextBuilder {
     @VisibleForTesting
     fun buildMandateText(
         merchantName: String,
+        sellerBusinessName: String?,
+        linkSignUpOptInFeatureEnabled: Boolean,
         isSaveForFutureUseSelected: Boolean,
         isInstantDebits: Boolean,
         isSetupFlow: Boolean,
@@ -56,7 +62,15 @@ internal object USBankAccountTextBuilder {
                 replacement = "</a>",
             ),
         )
-        val text = if (isSaveForFutureUseSelected || isSetupFlow) {
+
+        val text = if (linkSignUpOptInFeatureEnabled && sellerBusinessName != null) {
+            // Use alternative terms for signup-opt-in merchant, including seller details.
+            resolvableString(
+                R.string.stripe_wallet_bank_account_terms_seller,
+                sellerBusinessName,
+                transformations = transforms
+            )
+        } else if (isSaveForFutureUseSelected || isSetupFlow) {
             resolvableString(R.string.stripe_paymentsheet_ach_save_mandate, merchantName, transformations = transforms)
         } else {
             resolvableString(R.string.stripe_paymentsheet_ach_continue_mandate, transformations = transforms)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -35,6 +35,7 @@ import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.paymentelement.confirmation.utils.sellerBusinessName
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.financialconnections.GetFinancialConnectionsAvailability
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -217,6 +218,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                 customerInfo = customerInfo,
                 isGooglePayReady = isGooglePayReady,
                 linkState = linkState.await(),
+                initializationMode = initializationMode,
             )
         }
 
@@ -325,6 +327,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         customerInfo: CustomerInfo?,
         linkState: LinkState?,
         isGooglePayReady: Boolean,
+        initializationMode: PaymentElementLoader.InitializationMode,
     ): PaymentMethodMetadata {
         val sharedDataSpecsResult = lpmRepository.getSharedDataSpecs(
             stripeIntent = elementsSession.stripeIntent,
@@ -358,6 +361,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                 elementsSession = elementsSession,
                 customerInfo = customerInfo,
             ),
+            sellerBusinessName = initializationMode.sellerBusinessName
         )
     }
 
@@ -619,6 +623,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         val linkConfiguration = LinkConfiguration(
             stripeIntent = elementsSession.stripeIntent,
             merchantName = configuration.merchantDisplayName,
+            sellerBusinessName = initializationMode.sellerBusinessName,
             merchantCountryCode = elementsSession.merchantCountry,
             merchantLogoUrl = elementsSession.merchantLogoUrl,
             customerInfo = customerInfo,

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -85,6 +85,8 @@ internal class CustomerSheetScreenshotTest {
         setAsDefaultMatchesSaveForFutureUse = false,
         autocompleteAddressInteractorFactory = null,
         termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
+        sellerBusinessName = null,
+        linkSignUpOptInFeatureEnabled = false,
     )
 
     private val selectPaymentMethodViewState = CustomerSheetViewState.SelectPaymentMethod(

--- a/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
@@ -206,6 +206,7 @@ internal object TestFactory {
     val LINK_CONFIGURATION = LinkConfiguration(
         stripeIntent = PaymentIntentFixtures.PI_SUCCEEDED,
         merchantName = MERCHANT_NAME,
+        sellerBusinessName = null,
         merchantCountryCode = "",
         merchantLogoUrl = null,
         customerInfo = LINK_CUSTOMER_INFO,

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenStateTest.kt
@@ -83,6 +83,7 @@ class SignUpScreenStateTest {
         return LinkConfiguration(
             stripeIntent = PaymentIntentFactory.create(),
             merchantName = "Merchant, Inc.",
+            sellerBusinessName = null,
             merchantCountryCode = "US",
             merchantLogoUrl = null,
             customerInfo = customerInfo,

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletScreenScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletScreenScreenshotTest.kt
@@ -206,6 +206,7 @@ internal class WalletScreenScreenshotTest {
             isProcessing = isProcessing,
             isSettingUp = false,
             merchantName = "Example Inc.",
+            sellerBusinessName = null,
             primaryButtonLabel = primaryButtonLabel,
             secondaryButtonLabel = secondaryButtonLabel,
             hasCompleted = hasCompleted,

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletScreenTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletScreenTest.kt
@@ -759,6 +759,7 @@ internal class WalletScreenTest {
                 isProcessing = false,
                 isSettingUp = false,
                 merchantName = "Example Inc.",
+                sellerBusinessName = null,
                 primaryButtonLabel = "Buy".resolvableString,
                 secondaryButtonLabel = "Pay another way".resolvableString,
                 hasCompleted = false,

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletUiStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletUiStateTest.kt
@@ -318,6 +318,7 @@ class WalletUiStateTest {
             cardBeingUpdated = cardBeingUpdated,
             isSettingUp = isSettingUp,
             merchantName = merchantName,
+            sellerBusinessName = null,
             collectMissingBillingDetailsForExistingPaymentMethods =
             collectMissingBillingDetailsForExistingPaymentMethods,
             signupToggleEnabled = signupToggleEnabled,

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
@@ -92,6 +92,7 @@ class WalletViewModelTest {
                 addPaymentMethodOptions = listOf(AddPaymentMethodOption.Card),
                 isSettingUp = false,
                 merchantName = "merchantName",
+                sellerBusinessName = null,
                 collectMissingBillingDetailsForExistingPaymentMethods = true,
                 signupToggleEnabled = false,
                 billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(),

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
@@ -60,6 +60,7 @@ internal object PaymentMethodMetadataFactory {
             paymentMethodOrder = paymentMethodOrder,
             cbcEligibility = cbcEligibility,
             merchantName = PaymentSheetFixtures.MERCHANT_DISPLAY_NAME,
+            sellerBusinessName = null,
             defaultBillingDetails = defaultBillingDetails,
             shippingDetails = shippingDetails,
             customerMetadata = CustomerMetadata(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -1112,6 +1112,7 @@ internal class PaymentMethodMetadataTest {
                 )
             ),
             merchantName = "Merchant Inc.",
+            sellerBusinessName = null,
             defaultBillingDetails = defaultBillingDetails,
             shippingDetails = shippingDetails,
             sharedDataSpecs = sharedDataSpecs,
@@ -1205,6 +1206,7 @@ internal class PaymentMethodMetadataTest {
                 preferredNetworks = listOf(CardBrand.CartesBancaires, CardBrand.Visa)
             ),
             merchantName = "Merchant Inc.",
+            sellerBusinessName = null,
             defaultBillingDetails = defaultBillingDetails,
             shippingDetails = null,
             sharedDataSpecs = listOf(SharedDataSpec("card")),
@@ -2059,6 +2061,7 @@ internal class PaymentMethodMetadataTest {
                 phone = "1234567890"
             ),
             merchantName = "Merchant Inc.",
+            sellerBusinessName = null,
             merchantCountryCode = "CA",
             merchantLogoUrl = null,
             shippingDetails = null,

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElementTest.kt
@@ -130,6 +130,7 @@ class LinkFormElementTest {
         return LinkConfiguration(
             stripeIntent = PaymentIntentFactory.create(),
             merchantName = "Merchant, Inc.",
+            sellerBusinessName = null,
             merchantCountryCode = "CA",
             merchantLogoUrl = null,
             customerInfo = LinkConfiguration.CustomerInfo(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
@@ -592,6 +592,7 @@ class ConfirmationHandlerOptionKtxTest {
         val LINK_CONFIGURATION = LinkConfiguration(
             stripeIntent = PaymentIntentFactory.create(),
             merchantName = "Merchant, Inc.",
+            sellerBusinessName = null,
             merchantCountryCode = "CA",
             merchantLogoUrl = null,
             customerInfo = LinkConfiguration.CustomerInfo(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
@@ -673,6 +673,7 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
             linkConfiguration = LinkConfiguration(
                 stripeIntent = PaymentIntentFactory.create(),
                 merchantName = "Merchant Inc.",
+                sellerBusinessName = null,
                 merchantCountryCode = "CA",
                 merchantLogoUrl = null,
                 customerInfo = LinkConfiguration.CustomerInfo(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentSelectionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentSelectionTest.kt
@@ -235,6 +235,8 @@ class PaymentSelectionTest {
         ).isEqualTo(
             USBankAccountTextBuilder.buildMandateText(
                 merchantName = metadata.merchantName,
+                sellerBusinessName = null,
+                linkSignUpOptInFeatureEnabled = false,
                 isSaveForFutureUseSelected = false,
                 isInstantDebits = false,
                 isSetupFlow = true

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
@@ -89,6 +89,8 @@ class USBankAccountFormViewModelTest {
         setAsDefaultMatchesSaveForFutureUse = false,
         financialConnectionsAvailability = FinancialConnectionsAvailability.Full,
         termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
+        sellerBusinessName = null,
+        linkSignUpOptInFeatureEnabled = false,
     )
 
     private val mockCollectBankAccountLauncher = mock<CollectBankAccountLauncher>()
@@ -392,10 +394,14 @@ class USBankAccountFormViewModelTest {
             isSaveForFutureUseSelected = true,
             isInstantDebits = false,
             isSetupFlow = false,
+            sellerBusinessName = null,
+            linkSignUpOptInFeatureEnabled = false,
         )
 
         val continueWithMicrodepositsMandate = USBankAccountTextBuilder.buildMandateAndMicrodepositsText(
             merchantName = MERCHANT_NAME,
+            sellerBusinessName = null,
+            linkSignUpOptInFeatureEnabled = false,
             isVerifyingMicrodeposits = true,
             isSaveForFutureUseSelected = true,
             isInstantDebits = false,
@@ -1048,6 +1054,8 @@ class USBankAccountFormViewModelTest {
             isSaveForFutureUseSelected = false,
             isSetupFlow = false,
             isInstantDebits = false,
+            sellerBusinessName = null,
+            linkSignUpOptInFeatureEnabled = false,
         )
 
         viewModel.currentScreenState.test {
@@ -1067,6 +1075,8 @@ class USBankAccountFormViewModelTest {
 
         val expectedResult = USBankAccountTextBuilder.buildMandateAndMicrodepositsText(
             merchantName = MERCHANT_NAME,
+            sellerBusinessName = null,
+            linkSignUpOptInFeatureEnabled = false,
             isVerifyingMicrodeposits = true,
             isSaveForFutureUseSelected = false,
             isSetupFlow = false,
@@ -1090,6 +1100,8 @@ class USBankAccountFormViewModelTest {
 
         val expectedResult = USBankAccountTextBuilder.buildMandateAndMicrodepositsText(
             merchantName = MERCHANT_NAME,
+            sellerBusinessName = null,
+            linkSignUpOptInFeatureEnabled = false,
             isVerifyingMicrodeposits = false,
             isSaveForFutureUseSelected = false,
             isSetupFlow = false,
@@ -1327,24 +1339,25 @@ class USBankAccountFormViewModelTest {
     }
 
     @Test
-    fun `Creates correct ElementsSessionContext if not attaching defaults to PaymentMethod with specific collection`() = runTest {
-        val args = createArgsForBillingDetailsCollectionInInstantDebits(
-            collectName = false,
-            collectEmail = true,
-            collectPhone = true,
-            collectAddress = false,
-            attachDefaultsToPaymentMethod = false,
-        )
-
-        val elementsSessionContext = testElementsSessionContextGeneration(viewModelArgs = args)
-
-        assertThat(elementsSessionContext?.billingDetails).isEqualTo(
-            ElementsSessionContext.BillingDetails(
-                email = "email@email.com",
-                phone = "+13105551234",
+    fun `Creates correct ElementsSessionContext if not attaching defaults to PaymentMethod with specific collection`() =
+        runTest {
+            val args = createArgsForBillingDetailsCollectionInInstantDebits(
+                collectName = false,
+                collectEmail = true,
+                collectPhone = true,
+                collectAddress = false,
+                attachDefaultsToPaymentMethod = false,
             )
-        )
-    }
+
+            val elementsSessionContext = testElementsSessionContextGeneration(viewModelArgs = args)
+
+            assertThat(elementsSessionContext?.billingDetails).isEqualTo(
+                ElementsSessionContext.BillingDetails(
+                    email = "email@email.com",
+                    phone = "+13105551234",
+                )
+            )
+        }
 
     @Test
     fun `Updates result when 'save for future use' changes after linking account`() = runTest {
@@ -1440,64 +1453,68 @@ class USBankAccountFormViewModelTest {
     }
 
     @Test
-    fun `'setAsDefaultPaymentMethod' hidden when saveForFutureUse checked & setAsDefaultMatchesSaveForFutureUse`() = runTest {
-        testSetAsDefaultPaymentMethod(
-            setAsDefaultMatchesSaveForFutureUse = true,
-        ) { saveForFutureUseElement, setAsDefaultPaymentMethodElement, testContext ->
-            var nextItem = testContext.awaitItem()
-            assertThat(nextItem?.input?.saveForFutureUse).isFalse()
+    fun `'setAsDefaultPaymentMethod' hidden when saveForFutureUse checked & setAsDefaultMatchesSaveForFutureUse`() =
+        runTest {
+            testSetAsDefaultPaymentMethod(
+                setAsDefaultMatchesSaveForFutureUse = true,
+            ) { saveForFutureUseElement, setAsDefaultPaymentMethodElement, testContext ->
+                var nextItem = testContext.awaitItem()
+                assertThat(nextItem?.input?.saveForFutureUse).isFalse()
 
-            saveForFutureUseElement.controller.onValueChange(true)
+                saveForFutureUseElement.controller.onValueChange(true)
 
-            nextItem = testContext.awaitItem()
-            assertThat(nextItem?.input?.saveForFutureUse).isTrue()
-            assertThat(setAsDefaultPaymentMethodElement.shouldShowElementFlow.value).isFalse()
+                nextItem = testContext.awaitItem()
+                assertThat(nextItem?.input?.saveForFutureUse).isTrue()
+                assertThat(setAsDefaultPaymentMethodElement.shouldShowElementFlow.value).isFalse()
+            }
         }
-    }
 
     @Test
-    fun `'setAsDefaultPaymentMethod' fieldVal true, saveForFutureUse checked & setAsDefaultMatchesSaveForFutureUse`() = runTest {
-        testSetAsDefaultPaymentMethod(
-            setAsDefaultMatchesSaveForFutureUse = true,
-        ) { saveForFutureUseElement, setAsDefaultPaymentMethodElement, testContext ->
-            var nextItem = testContext.awaitItem()
-            assertThat(nextItem?.input?.saveForFutureUse).isFalse()
+    fun `'setAsDefaultPaymentMethod' fieldVal true, saveForFutureUse checked & setAsDefaultMatchesSaveForFutureUse`() =
+        runTest {
+            testSetAsDefaultPaymentMethod(
+                setAsDefaultMatchesSaveForFutureUse = true,
+            ) { saveForFutureUseElement, setAsDefaultPaymentMethodElement, testContext ->
+                var nextItem = testContext.awaitItem()
+                assertThat(nextItem?.input?.saveForFutureUse).isFalse()
 
-            saveForFutureUseElement.controller.onValueChange(true)
+                saveForFutureUseElement.controller.onValueChange(true)
 
-            nextItem = testContext.awaitItem()
-            assertThat(nextItem?.input?.saveForFutureUse).isTrue()
-            assertThat(setAsDefaultPaymentMethodElement.controller.fieldValue.value.toBoolean()).isTrue()
+                nextItem = testContext.awaitItem()
+                assertThat(nextItem?.input?.saveForFutureUse).isTrue()
+                assertThat(setAsDefaultPaymentMethodElement.controller.fieldValue.value.toBoolean()).isTrue()
+            }
         }
-    }
 
     @Test
-    fun `'setAsDefaultPaymentMethod' hidden when saveForFutureUse !checked & setAsDefaultMatchesSaveForFutureUse`() = runTest {
-        testSetAsDefaultPaymentMethod(
-            setAsDefaultMatchesSaveForFutureUse = true,
-        ) { saveForFutureUseElement, setAsDefaultPaymentMethodElement, testContext ->
-            val nextItem = testContext.awaitItem()
-            assertThat(nextItem?.input?.saveForFutureUse).isFalse()
+    fun `'setAsDefaultPaymentMethod' hidden when saveForFutureUse !checked & setAsDefaultMatchesSaveForFutureUse`() =
+        runTest {
+            testSetAsDefaultPaymentMethod(
+                setAsDefaultMatchesSaveForFutureUse = true,
+            ) { saveForFutureUseElement, setAsDefaultPaymentMethodElement, testContext ->
+                val nextItem = testContext.awaitItem()
+                assertThat(nextItem?.input?.saveForFutureUse).isFalse()
 
-            saveForFutureUseElement.controller.onValueChange(false)
+                saveForFutureUseElement.controller.onValueChange(false)
 
-            assertThat(setAsDefaultPaymentMethodElement.shouldShowElementFlow.value).isFalse()
+                assertThat(setAsDefaultPaymentMethodElement.shouldShowElementFlow.value).isFalse()
+            }
         }
-    }
 
     @Test
-    fun `setAsDefaultPaymentMethod fieldVal false, saveForFutureUse !checked & setAsDefaultMatchesSaveForFutureUse`() = runTest {
-        testSetAsDefaultPaymentMethod(
-            setAsDefaultMatchesSaveForFutureUse = true,
-        ) { saveForFutureUseElement, setAsDefaultPaymentMethodElement, testContext ->
-            val nextItem = testContext.awaitItem()
-            assertThat(nextItem?.input?.saveForFutureUse).isFalse()
+    fun `setAsDefaultPaymentMethod fieldVal false, saveForFutureUse !checked & setAsDefaultMatchesSaveForFutureUse`() =
+        runTest {
+            testSetAsDefaultPaymentMethod(
+                setAsDefaultMatchesSaveForFutureUse = true,
+            ) { saveForFutureUseElement, setAsDefaultPaymentMethodElement, testContext ->
+                val nextItem = testContext.awaitItem()
+                assertThat(nextItem?.input?.saveForFutureUse).isFalse()
 
-            saveForFutureUseElement.controller.onValueChange(false)
+                saveForFutureUseElement.controller.onValueChange(false)
 
-            assertThat(setAsDefaultPaymentMethodElement.controller.fieldValue.value.toBoolean()).isFalse()
+                assertThat(setAsDefaultPaymentMethodElement.controller.fieldValue.value.toBoolean()).isFalse()
+            }
         }
-    }
 
     @Test
     fun `Updates result when 'setAsDefaultPaymentMethod' changes after linking account`() = runTest {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
@@ -75,6 +75,7 @@ internal object LinkTestUtils {
             customerInfo = LinkConfiguration.CustomerInfo(null, null, null, null),
             flags = mapOf(),
             merchantName = "Test merchant inc.",
+            sellerBusinessName = null,
             merchantCountryCode = "US",
             merchantLogoUrl = null,
             passthroughModeEnabled = false,


### PR DESCRIPTION
# Summary

- Use new terms on Link wallet when bank is selected.
- Use new terms on MPE (bank tab) before payment confirmation. 

Both above will use `sellerDetails` instead of the merchant name for `signupOptIn` merchants. 

**Link wallet**
<img width="484" height="601" alt="image" src="https://github.com/user-attachments/assets/e7c7017b-373f-4a3e-9600-d48b88fd70ce" />

**IBP confirmation**
<img width="500" height="1083" alt="image" src="https://github.com/user-attachments/assets/0faedaeb-dba8-49d2-a8a5-41d97399589b" />

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
