### PR TITLE
Remove `TextFieldStateConstants` classes from API

### DIFF
--- a/stripe-ui-core/api/stripe-ui-core.api
+++ b/stripe-ui-core/api/stripe-ui-core.api
@@ -173,58 +173,11 @@ public final class com/stripe/android/uicore/elements/SameAsShippingElementUIKt 
 	public static final field SAME_AS_SHIPPING_CHECKBOX_TEST_TAG Ljava/lang/String;
 }
 
-public abstract class com/stripe/android/uicore/elements/TextFieldStateConstants$Error : com/stripe/android/uicore/elements/TextFieldState {
-	public static final field $stable I
-	public synthetic fun <init> (I[Ljava/lang/Object;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (I[Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getError ()Lcom/stripe/android/uicore/elements/FieldError;
-	protected fun getErrorMessageResId ()I
-	protected fun getFormatArgs ()[Ljava/lang/Object;
-	public fun isFull ()Z
-	public fun isValid ()Z
-}
-
 public final class com/stripe/android/uicore/elements/TextFieldStateConstants$Error$Blank : com/stripe/android/uicore/elements/TextFieldStateConstants$Error {
 	public static final field $stable I
 	public static final field INSTANCE Lcom/stripe/android/uicore/elements/TextFieldStateConstants$Error$Blank;
 	public fun isBlank ()Z
 	public fun shouldShowError (Z)Z
-}
-
-public final class com/stripe/android/uicore/elements/TextFieldStateConstants$Error$Incomplete : com/stripe/android/uicore/elements/TextFieldStateConstants$Error {
-	public static final field $stable I
-	public fun <init> (I)V
-	public fun isBlank ()Z
-	public fun shouldShowError (Z)Z
-}
-
-public final class com/stripe/android/uicore/elements/TextFieldStateConstants$Error$Invalid : com/stripe/android/uicore/elements/TextFieldStateConstants$Error {
-	public static final field $stable I
-	public fun <init> (I[Ljava/lang/Object;Z)V
-	public synthetic fun <init> (I[Ljava/lang/Object;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun isBlank ()Z
-	public fun isFull ()Z
-	public fun shouldShowError (Z)Z
-}
-
-public abstract class com/stripe/android/uicore/elements/TextFieldStateConstants$Valid : com/stripe/android/uicore/elements/TextFieldState {
-	public static final field $stable I
-	public fun getError ()Lcom/stripe/android/uicore/elements/FieldError;
-	public fun isBlank ()Z
-	public fun isValid ()Z
-	public fun shouldShowError (Z)Z
-}
-
-public final class com/stripe/android/uicore/elements/TextFieldStateConstants$Valid$Full : com/stripe/android/uicore/elements/TextFieldStateConstants$Valid {
-	public static final field $stable I
-	public static final field INSTANCE Lcom/stripe/android/uicore/elements/TextFieldStateConstants$Valid$Full;
-	public fun isFull ()Z
-}
-
-public final class com/stripe/android/uicore/elements/TextFieldStateConstants$Valid$Limitless : com/stripe/android/uicore/elements/TextFieldStateConstants$Valid {
-	public static final field $stable I
-	public static final field INSTANCE Lcom/stripe/android/uicore/elements/TextFieldStateConstants$Valid$Limitless;
-	public fun isFull ()Z
 }
 
 public final class com/stripe/android/uicore/elements/TextFieldUIKt {

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldStateConstants.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldStateConstants.kt
@@ -6,21 +6,25 @@ import com.stripe.android.uicore.R
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class TextFieldStateConstants {
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     sealed class Valid : TextFieldState {
         override fun shouldShowError(hasFocus: Boolean): Boolean = false
         override fun isValid(): Boolean = true
         override fun getError(): FieldError? = null
         override fun isBlank(): Boolean = false
 
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         object Full : Valid() {
             override fun isFull(): Boolean = true
         }
 
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         object Limitless : Valid() { // no auto-advance
             override fun isFull(): Boolean = false
         }
     }
 
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     sealed class Error(
         @StringRes protected open val errorMessageResId: Int,
         protected open val formatArgs: Array<out Any>? = null
@@ -29,6 +33,7 @@ class TextFieldStateConstants {
         override fun isFull(): Boolean = false
         override fun getError() = FieldError(errorMessageResId, formatArgs)
 
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         class Incomplete(
             @StringRes override val errorMessageResId: Int
         ) : Error(errorMessageResId) {
@@ -36,6 +41,7 @@ class TextFieldStateConstants {
             override fun isBlank(): Boolean = false
         }
 
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         class Invalid(
             @StringRes override val errorMessageResId: Int,
             override val formatArgs: Array<out Any>? = null,


### PR DESCRIPTION
# Summary
Remove `TextFieldStateConstants` classes from API.

# Motivation
Remove APIs that shouldn't be public.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified