### PR TITLE
Remove `Blank` in `TextFieldStateConstants` from API

### DIFF
--- a/stripe-ui-core/api/stripe-ui-core.api
+++ b/stripe-ui-core/api/stripe-ui-core.api
@@ -173,13 +173,6 @@ public final class com/stripe/android/uicore/elements/SameAsShippingElementUIKt 
 	public static final field SAME_AS_SHIPPING_CHECKBOX_TEST_TAG Ljava/lang/String;
 }
 
-public final class com/stripe/android/uicore/elements/TextFieldStateConstants$Error$Blank : com/stripe/android/uicore/elements/TextFieldStateConstants$Error {
-	public static final field $stable I
-	public static final field INSTANCE Lcom/stripe/android/uicore/elements/TextFieldStateConstants$Error$Blank;
-	public fun isBlank ()Z
-	public fun shouldShowError (Z)Z
-}
-
 public final class com/stripe/android/uicore/elements/TextFieldUIKt {
 	public static final fun AnimatedIcons (Ljava/util/List;ZLandroidx/compose/runtime/Composer;I)V
 	public static final fun TextField-ZkbtPhE (Lcom/stripe/android/uicore/elements/TextFieldController;ZILandroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;IILandroidx/compose/ui/focus/FocusRequester;ZZLandroidx/compose/runtime/Composer;II)V

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldStateConstants.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldStateConstants.kt
@@ -52,6 +52,7 @@ class TextFieldStateConstants {
             override fun isFull(): Boolean = preventMoreInput
         }
 
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         object Blank : Error(R.string.stripe_blank_and_required) {
             override fun shouldShowError(hasFocus: Boolean): Boolean = false
             override fun isBlank(): Boolean = true


### PR DESCRIPTION
# Summary
Remove `Blank` in `TextFieldStateConstants` from API

# Motivation
Missed one when removing the other classes from the API

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified