### PR TITLE
Don't follow redirect.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/RedirectResolver.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/RedirectResolver.kt
@@ -32,18 +32,19 @@ internal class RealRedirectResolver(
                 val connection = (URL(url).openConnection() as HttpURLConnection).apply {
                     connectTimeout = RedirectTimeoutInMillis
                     readTimeout = RedirectTimeoutInMillis
+                    instanceFollowRedirects = false
 
                     if (this is HttpsURLConnection) {
                         configureSSL()
                     }
                 }
 
-                // Seems like we need to call getResponseCode() so that HttpURLConnection internally
-                // follows the redirect. If we didn't call this method, connection.url would be the
-                // same as the provided url, making this method redundant.
-                connection.responseCode
-
-                connection.url.toString()
+                val locationHeader = connection.getHeaderField("Location")
+                if (!locationHeader.isNullOrEmpty()) {
+                    locationHeader
+                } else {
+                    url
+                }
             }.getOrElse {
                 url
             }

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/RealRedirectResolverTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/RealRedirectResolverTest.kt
@@ -17,6 +17,23 @@ internal class RealRedirectResolverTest {
     val networkRule = NetworkRule()
 
     @Test
+    fun `Does not attempt to resolve after the first redirect`() = runTest {
+        val resolver = buildResolver()
+        val url = buildPmRedirectsUrl()
+
+        networkRule.enqueue(
+            path("/authorize/acct_1234567890"),
+            method("GET"),
+        ) { response ->
+            response.setResponseCode(302)
+            response.addHeader("Location", url)
+        }
+
+        val result = resolver(url)
+        assertThat(result).isEqualTo(url)
+    }
+
+    @Test
     fun `Resolves redirect if original URL returns corresponding status code`() = runTest {
         val resolver = buildResolver()
         val url = buildPmRedirectsUrl()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
We no longer follow multiple redirects.

Before we were treating it more like a browser would ([pm-redirects.stripe.com](http://pm-redirects.stripe.com/) -> [payments.klarna.com](http://payments.klarna.com/) -> [login.klarna.com](http://login.klarna.com/)). But now we'll only attempt a single redirect -- more similar to `curl -I`.

This will now only follow the very first redirect -- so in this case, [pm-redirects.stripe.com](http://pm-redirects.stripe.com/) -> [payments.klarna.com](http://payments.klarna.com/).

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
klarna app to app redirects.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

