### PR TITLE
[Link] Do not filter countries on update card form.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/updatecard/UpdateCardScreenViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/updatecard/UpdateCardScreenViewModel.kt
@@ -203,7 +203,18 @@ internal class UpdateCardScreenViewModel @Inject constructor(
                     defaultConfiguration.address
                 },
                 attachDefaultsToPaymentMethod = defaultConfiguration.attachDefaultsToPaymentMethod,
-                allowedCountries = defaultConfiguration.allowedBillingCountries,
+                // Country filtering behavior depends on the update flow type:
+                // - Regular edit flow: Allow all countries. When updating your card, you can select any
+                //   country. You'll get back to the wallet and that card won't be selectable if the
+                //   country is not allowed, but users can still update existing cards.
+                // - Billing details update flow: Apply country filtering. This flow triggers when there's
+                //   missing billing details and directly confirms the payment there, so we don't want to
+                //   allow changing the country to an unallowed one.
+                allowedCountries = if (state.value.isBillingDetailsUpdateFlow) {
+                    defaultConfiguration.allowedBillingCountries
+                } else {
+                    emptySet()
+                },
             ),
             onCardUpdateParamsChanged = ::onCardUpdateParamsChanged,
             onBrandChoiceChanged = ::onBrandChoiceChanged,

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/updatecard/UpdateCardScreenViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/updatecard/UpdateCardScreenViewModelTest.kt
@@ -322,7 +322,7 @@ class UpdateCardScreenViewModelTest {
         }
 
     @Test
-    fun `when providing an limited set of allowed billing countries, should use limited countries`() =
+    fun `when in billing details update flow with limited countries, should use limited countries`() =
         runTest(dispatcher) {
             val card = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD
 
@@ -356,10 +356,53 @@ class UpdateCardScreenViewModelTest {
 
                     val cardBillingAddressElement = nonNullBillingElements[0] as CardBillingAddressElement
 
+                    // Billing details update flow should respect country filtering
                     assertThat(cardBillingAddressElement.countryElement.controller.displayItems).containsExactly(
                         "\uD83C\uDDFA\uD83C\uDDF8 United States",
                         "\uD83C\uDDE8\uD83C\uDDE6 Canada"
                     )
+                }
+            }
+        }
+
+    @Test
+    fun `when in regular edit flow with limited countries, should show all countries`() =
+        runTest(dispatcher) {
+            val card = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD
+
+            val viewModel = createViewModel(
+                linkAccountManager = FakeLinkAccountManager().apply {
+                    setConsumerPaymentDetails(ConsumerPaymentDetails(listOf(card)))
+                },
+                configuration = TestFactory.LINK_CONFIGURATION.copy(
+                    billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                        allowedCountries = setOf("US", "CA")
+                    ),
+                ),
+                paymentDetailsId = card.id,
+                billingDetailsUpdateFlow = null, // Regular edit flow, not billing details update
+            )
+
+            viewModel.interactor.test {
+                val interactor = awaitItem()
+
+                assertThat(interactor).isNotNull()
+
+                requireNotNull(interactor).state.test {
+                    val billingElements = awaitItem().billingDetailsForm?.addressSectionElement?.fields
+
+                    assertThat(billingElements).isNotNull()
+
+                    val nonNullBillingElements = requireNotNull(billingElements)
+
+                    assertThat(nonNullBillingElements).hasSize(1)
+                    assertThat(nonNullBillingElements[0]).isInstanceOf<CardBillingAddressElement>()
+
+                    val cardBillingAddressElement = nonNullBillingElements[0] as CardBillingAddressElement
+
+                    // Regular edit flow should show all countries, ignoring filter
+                    assertThat(cardBillingAddressElement.countryElement.controller.displayItems)
+                        .hasSize(CountryUtils.supportedBillingCountries.size)
                 }
             }
         }


### PR DESCRIPTION
# Summary
**Problem**: When editing a card with a country that's filtered out, the dropdown showed the wrong country (because we're filtering out the actual one).
**Solution**: Implement conditional country filtering based on update flow type:
- Regular edit flow: Allow all countries (users can update existing cards, validation happens at payment time)
- Billing details update flow: Apply country filtering (prevents unallowed countries during payment confirmation)

See below how switching between allowed an non-allowed countries make the payment selectable.
 
[fix-card-edit-country.webm](https://github.com/user-attachments/assets/f80db500-e3d5-425b-8ba9-378eda0037df)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
