### PR TITLE
[Link in FlowController] Fallback to preferred SPM after logout from Link

### DIFF
--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -21,6 +21,7 @@
     <ID>LargeClass:CustomerSheetViewModelTest.kt$CustomerSheetViewModelTest</ID>
     <ID>LargeClass:DefaultConfirmationHandlerTest.kt$DefaultConfirmationHandlerTest</ID>
     <ID>LargeClass:DefaultEventReporterTest.kt$DefaultEventReporterTest</ID>
+    <ID>LargeClass:DefaultFlowController.kt$DefaultFlowController : FlowController</ID>
     <ID>LargeClass:DefaultFlowControllerTest.kt$DefaultFlowControllerTest</ID>
     <ID>LargeClass:DefaultIntentConfirmationInterceptorTest.kt$DefaultIntentConfirmationInterceptorTest</ID>
     <ID>LargeClass:DefaultPaymentElementLoaderTest.kt$DefaultPaymentElementLoaderTest</ID>
@@ -76,7 +77,6 @@
     <ID>MatchingDeclarationName:ErrorText.kt$ErrorTextStyle</ID>
     <ID>MatchingDeclarationName:LinkTerms.kt$LinkTermsType</ID>
     <ID>MatchingDeclarationName:Type.kt$LinkTypography</ID>
-    <ID>MaxLineLength:CardDefinition.kt$internal</ID>
     <ID>MaxLineLength:CustomerRepositoryTest.kt$CustomerRepositoryTest$fun</ID>
     <ID>MaxLineLength:CustomerSheetViewModelTest.kt$CustomerSheetViewModelTest$fun</ID>
     <ID>MaxLineLength:CustomerSheetViewModelTest.kt$CustomerSheetViewModelTest$publishableKey = "pk_test_51HvTI7Lu5o3livep6t5AgBSkMvWoTtA0nyA7pVYDqpfLkRtWun7qZTYCOHCReprfLM464yaBeF72UFfB7cY9WG4a00ZnDtiC2C"</ID>
@@ -97,7 +97,6 @@
     <ID>MaxLineLength:PrimaryButtonTest.kt$PrimaryButtonTest$primaryButton.setAppearanceConfiguration(StripeThemeDefaults.primaryButtonStyle, ColorStateList.valueOf(Color.BLACK))</ID>
     <ID>MaxLineLength:SupportedPaymentMethod.kt$SupportedPaymentMethod$/** This describes the image in the LPM selector. These can be found internally [here](https://www.figma.com/file/2b9r3CJbyeVAmKi1VHV2h9/Mobile-Payment-Element?node-id=1128%3A0) */</ID>
     <ID>MaxLineLength:USBankAccountFormViewModelTest.kt$USBankAccountFormViewModelTest$fun</ID>
-    <ID>MaximumLineLength:CardDefinition.kt$internal</ID>
     <ID>TooGenericExceptionCaught:IntentConfirmationInterceptor.kt$DefaultIntentConfirmationInterceptor$exception: Exception</ID>
     <ID>TooManyFunctions:CustomerSheetEventReporter.kt$CustomerSheetEventReporter</ID>
     <ID>TooManyFunctions:DefaultCustomerSheetEventReporter.kt$DefaultCustomerSheetEventReporter : CustomerSheetEventReporter</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/link/utils/LinkPaymentSelectionUtils.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/utils/LinkPaymentSelectionUtils.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.link.utils
 
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
-import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.state.CustomerState
 
@@ -26,16 +25,9 @@ internal fun determineFallbackPaymentSelection(
         // Use default payment method if available
         customer.paymentMethods.firstOrNull { paymentMethod ->
             customer.defaultPaymentMethodId != null && paymentMethod.id == customer.defaultPaymentMethodId
-        }?.toPaymentSelection()
+        }
     } else {
         // Fall back to first customer payment method (most recently used appears first)
-        customer.paymentMethods.firstOrNull()?.toPaymentSelection()
-    }
-}
-
-/**
- * Converts a PaymentMethod to a PaymentSelection.Saved
- */
-private fun PaymentMethod.toPaymentSelection(): PaymentSelection.Saved {
-    return PaymentSelection.Saved(this)
+        customer.paymentMethods.firstOrNull()
+    }?.let { PaymentSelection.Saved(it) }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/utils/LinkPaymentSelectionUtils.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/utils/LinkPaymentSelectionUtils.kt
@@ -3,23 +3,20 @@ package com.stripe.android.link.utils
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.state.CustomerState
+import com.stripe.android.paymentsheet.state.PaymentSheetState
 
 /**
- * Determines the best fallback payment selection when Link is cleared (e.g., on logout).
+ * Determines the best fallback payment selection.
  * Follows the same logic as initial payment selection: default PM > first customer PM.
  *
- * @param customer The customer state containing payment methods and default PM info
- * @param metadata Payment method metadata containing feature flags and configuration
  * @return The best fallback payment selection, or null if no suitable fallback exists
  */
-internal fun determineFallbackPaymentSelection(
-    customer: CustomerState?,
-    metadata: PaymentMethodMetadata
-): PaymentSelection? {
+internal fun PaymentSheetState.Full.determineFallbackPaymentSelection(): PaymentSelection? {
     if (customer == null) return null
 
     // Check if default payment method feature is enabled
-    val isDefaultPaymentMethodEnabled = metadata.customerMetadata?.isPaymentMethodSetAsDefaultEnabled ?: false
+    val isDefaultPaymentMethodEnabled = paymentMethodMetadata
+        .customerMetadata?.isPaymentMethodSetAsDefaultEnabled ?: false
 
     return if (isDefaultPaymentMethodEnabled) {
         // Use default payment method if available

--- a/paymentsheet/src/main/java/com/stripe/android/link/utils/LinkPaymentSelectionUtils.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/utils/LinkPaymentSelectionUtils.kt
@@ -1,8 +1,6 @@
 package com.stripe.android.link.utils
 
-import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.paymentsheet.state.PaymentSheetState
 
 /**
@@ -11,7 +9,7 @@ import com.stripe.android.paymentsheet.state.PaymentSheetState
  *
  * @return The best fallback payment selection, or null if no suitable fallback exists
  */
-internal fun PaymentSheetState.Full.determineFallbackPaymentSelection(): PaymentSelection? {
+internal fun PaymentSheetState.Full.determineFallbackPaymentSelectionAfterLinkLogout(): PaymentSelection? {
     if (customer == null) return null
 
     // Check if default payment method feature is enabled

--- a/paymentsheet/src/main/java/com/stripe/android/link/utils/LinkPaymentSelectionUtils.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/utils/LinkPaymentSelectionUtils.kt
@@ -1,0 +1,41 @@
+package com.stripe.android.link.utils
+
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.state.CustomerState
+
+/**
+ * Determines the best fallback payment selection when Link is cleared (e.g., on logout).
+ * Follows the same logic as initial payment selection: default PM > first customer PM.
+ *
+ * @param customer The customer state containing payment methods and default PM info
+ * @param metadata Payment method metadata containing feature flags and configuration
+ * @return The best fallback payment selection, or null if no suitable fallback exists
+ */
+internal fun determineFallbackPaymentSelection(
+    customer: CustomerState?,
+    metadata: PaymentMethodMetadata
+): PaymentSelection? {
+    if (customer == null) return null
+
+    // Check if default payment method feature is enabled
+    val isDefaultPaymentMethodEnabled = metadata.customerMetadata?.isPaymentMethodSetAsDefaultEnabled ?: false
+
+    return if (isDefaultPaymentMethodEnabled) {
+        // Use default payment method if available
+        customer.paymentMethods.firstOrNull { paymentMethod ->
+            customer.defaultPaymentMethodId != null && paymentMethod.id == customer.defaultPaymentMethodId
+        }?.toPaymentSelection()
+    } else {
+        // Fall back to first customer payment method (most recently used appears first)
+        customer.paymentMethods.firstOrNull()?.toPaymentSelection()
+    }
+}
+
+/**
+ * Converts a PaymentMethod to a PaymentSelection.Saved
+ */
+private fun PaymentMethod.toPaymentSelection(): PaymentSelection.Saved {
+    return PaymentSelection.Saved(this)
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -30,6 +30,7 @@ import com.stripe.android.link.account.updateLinkAccount
 import com.stripe.android.link.gate.LinkGate
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.model.toLoginState
+import com.stripe.android.link.utils.determineFallbackPaymentSelection
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.WalletType
 import com.stripe.android.model.PaymentMethod
@@ -441,18 +442,25 @@ internal class DefaultFlowController @Inject internal constructor(
     ) {
         val paymentSelection = viewModel.paymentSelection
         if (paymentSelection is Link) {
-            val updated = paymentSelection.copy(
-                selectedPayment = linkPaymentMethod
-            )
-            viewModel.paymentSelection = updated
-
-            val paymentOption = paymentOptionFactory.create(updated)
-
+            val newSelection = if (linkPaymentMethod != null) {
+                // User updated their Link PM - update the Link selection
+                paymentSelection.copy(
+                    selectedPayment = linkPaymentMethod
+                )
+            } else {
+                // User logged out - determine best fallback payment method
+                val state = viewModel.state
+                determineFallbackPaymentSelection(
+                    customer = state?.paymentSheetState?.customer,
+                    metadata = state?.paymentSheetState?.paymentMethodMetadata ?: return
+                )
+            }
+            viewModel.paymentSelection = newSelection
+            val paymentOption = newSelection?.let { paymentOptionFactory.create(it) }
             val result = PaymentOptionResult(
                 paymentOption = paymentOption,
                 didCancel = canceled,
             )
-
             paymentOptionResultCallback.onPaymentOptionResult(result)
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -448,12 +448,12 @@ internal class DefaultFlowController @Inject internal constructor(
                     selectedPayment = linkPaymentMethod
                 )
             } else {
-                // User logged out - determine best fallback payment method
+                // User logged out - determine best fallback payment method,
+                // or clear selection if there is no fallback
                 val state = viewModel.state
-                determineFallbackPaymentSelection(
-                    customer = state?.paymentSheetState?.customer,
-                    metadata = state?.paymentSheetState?.paymentMethodMetadata ?: return
-                )
+                val fallbackSelection: PaymentSelection? = state?.paymentSheetState
+                    ?.determineFallbackPaymentSelection()
+                fallbackSelection
             }
             viewModel.paymentSelection = newSelection
             val paymentOption = newSelection?.let { paymentOptionFactory.create(it) }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -30,7 +30,7 @@ import com.stripe.android.link.account.updateLinkAccount
 import com.stripe.android.link.gate.LinkGate
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.model.toLoginState
-import com.stripe.android.link.utils.determineFallbackPaymentSelection
+import com.stripe.android.link.utils.determineFallbackPaymentSelectionAfterLinkLogout
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.WalletType
 import com.stripe.android.model.PaymentMethod
@@ -450,10 +450,7 @@ internal class DefaultFlowController @Inject internal constructor(
             } else {
                 // User logged out - determine best fallback payment method,
                 // or clear selection if there is no fallback
-                val state = viewModel.state
-                val fallbackSelection: PaymentSelection? = state?.paymentSheetState
-                    ?.determineFallbackPaymentSelection()
-                fallbackSelection
+                viewModel.state?.paymentSheetState?.determineFallbackPaymentSelectionAfterLinkLogout()
             }
             viewModel.paymentSelection = newSelection
             val paymentOption = newSelection?.let { paymentOptionFactory.create(it) }


### PR DESCRIPTION
# Summary
- After logout from Link in FlowController, we present the payment method options sheet. If the user dismisses it, we keep Link selected with no underlying payment method.
- Instead, we'll try to fall back to the user's default SPM, or the first one if any. If none, we'll clear the selection.
 
[use_saved_pm.webm](https://github.com/user-attachments/assets/d4417600-c76f-4414-9b01-ae507303e93a)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
