### PR TITLE
Include information about integration path choices to better serve developers using Google Pay

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
@@ -5,6 +5,7 @@ import android.os.Parcelable
 import androidx.annotation.RestrictTo
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
+import com.stripe.android.core.version.StripeSdkVersion
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.model.CardBrand
 import kotlinx.parcelize.Parcelize
@@ -169,7 +170,7 @@ class GooglePayJsonFactory internal constructor(
          * Merchant name encoded as UTF-8. Merchant name is rendered in the payment sheet.
          * In TEST environment, or if a merchant isn't recognized, a “Pay Unverified Merchant” message is displayed in the payment sheet.
          */
-        merchantInfo: MerchantInfo? = null,
+        merchantInfo: MerchantInfo,
 
         /**
          * Set to false if you don't support credit cards
@@ -200,13 +201,18 @@ class GooglePayJsonFactory internal constructor(
                     )
                 }
 
-                if (merchantInfo != null && !merchantInfo.merchantName.isNullOrEmpty()) {
-                    put(
-                        "merchantInfo",
-                        JSONObject()
-                            .put("merchantName", merchantInfo.merchantName)
-                    )
-                }
+                put(
+                    "merchantInfo",
+                    JSONObject().apply {
+                        put("softwareInfo", JSONObject()
+                            .put("id", merchantInfo.softwareInfo.id.code)
+                            .put("version", StripeSdkVersion.VERSION_NAME)
+                        )
+                        if (!merchantInfo.merchantName.isNullOrEmpty()) {
+                            put("merchantName", merchantInfo.merchantName)
+                        }
+                    }
+                )
             }
     }
 
@@ -500,6 +506,26 @@ class GooglePayJsonFactory internal constructor(
         }
     }
 
+    @Parcelize
+    data class SoftwareInfo(
+        internal val id: SoftwareId
+    ) : Parcelable {
+        /**
+         * An identifier for the library
+         */
+        enum class SoftwareId(internal val code: String) {
+            /**
+             * An identifier for the flow using the payment sheet UI
+             */
+            Launcher("android/stripe-launcher"),
+
+            /**
+             * An identifier for the flow using the custom element UI
+             */
+            Elements("android/stripe-elements"),
+        }
+    }
+
     /**
      * [MerchantInfo](https://developers.google.com/pay/api/android/reference/request-objects#MerchantInfo)
      */
@@ -510,7 +536,12 @@ class GooglePayJsonFactory internal constructor(
          * In TEST environment, or if a merchant isn't recognized, a “Pay Unverified Merchant”
          * message is displayed in the payment sheet.
          */
-        internal val merchantName: String? = null
+        internal val merchantName: String? = null,
+
+        /**
+         * Basic information about the library used to make calls to Google Pay from this SDK.
+         */
+        internal val softwareInfo: SoftwareInfo
     ) : Parcelable
 
     private companion object {

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModel.kt
@@ -132,6 +132,9 @@ internal class GooglePayLauncherViewModel(
                 transactionInfo = info,
                 merchantInfo = GooglePayJsonFactory.MerchantInfo(
                     merchantName = args.config.merchantName,
+                    softwareInfo = GooglePayJsonFactory.SoftwareInfo(
+                        id = GooglePayJsonFactory.SoftwareInfo.SoftwareId.Launcher
+                    )
                 ),
                 billingAddressParameters = GooglePayJsonFactory.BillingAddressParameters(
                     isRequired = args.config.billingAddressConfig.isRequired,

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModel.kt
@@ -62,7 +62,10 @@ internal class GooglePayPaymentMethodLauncherViewModel @Inject constructor(
         return googlePayJsonFactory.createPaymentDataRequest(
             transactionInfo = createTransactionInfo(args),
             merchantInfo = GooglePayJsonFactory.MerchantInfo(
-                merchantName = args.config.merchantName
+                merchantName = args.config.merchantName,
+                softwareInfo = GooglePayJsonFactory.SoftwareInfo(
+                    id = GooglePayJsonFactory.SoftwareInfo.SoftwareId.Elements
+                )
             ),
             billingAddressParameters = args.config.billingAddressConfig.convert(),
             isEmailRequired = args.config.isEmailRequired,

--- a/payments-core/src/test/java/com/stripe/android/GooglePayJsonFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/GooglePayJsonFactoryTest.kt
@@ -136,6 +136,10 @@ class GooglePayJsonFactoryTest {
                     "phoneNumberRequired": true
                 },
                 "merchantInfo": {
+                    "softwareInfo": {
+                        "id": "android/stripe-launcher",
+                        "version": "${StripeSdkVersion.VERSION_NAME}"
+                    },
                     "merchantName": "Widget Store"
                 }
             }
@@ -158,7 +162,10 @@ class GooglePayJsonFactoryTest {
                 isPhoneNumberRequired = true
             ),
             merchantInfo = GooglePayJsonFactory.MerchantInfo(
-                merchantName = "Widget Store"
+                merchantName = "Widget Store",
+                softwareInfo = GooglePayJsonFactory.SoftwareInfo(
+                    id = GooglePayJsonFactory.SoftwareInfo.SoftwareId.Launcher
+                )
             ),
             shippingAddressParameters = GooglePayJsonFactory.ShippingAddressParameters(
                 isRequired = true,
@@ -177,7 +184,12 @@ class GooglePayJsonFactoryTest {
                 currencyCode = "USD",
                 totalPriceStatus = GooglePayJsonFactory.TransactionInfo.TotalPriceStatus.Estimated,
                 countryCode = "us"
-            )
+            ),
+            merchantInfo = GooglePayJsonFactory.MerchantInfo(
+                softwareInfo = GooglePayJsonFactory.SoftwareInfo(
+                    id = GooglePayJsonFactory.SoftwareInfo.SoftwareId.Launcher
+                )
+            ),
         )
         val countryCode = createPaymentDataRequestJson
             .getJSONObject("transactionInfo")
@@ -192,7 +204,12 @@ class GooglePayJsonFactoryTest {
             transactionInfo = GooglePayJsonFactory.TransactionInfo(
                 currencyCode = "usd",
                 totalPriceStatus = GooglePayJsonFactory.TransactionInfo.TotalPriceStatus.Final
-            )
+            ),
+            merchantInfo = GooglePayJsonFactory.MerchantInfo(
+                softwareInfo = GooglePayJsonFactory.SoftwareInfo(
+                    id = GooglePayJsonFactory.SoftwareInfo.SoftwareId.Launcher
+                )
+            ),
         )
         val currencyCode = createPaymentDataRequestJson
             .getJSONObject("transactionInfo")
@@ -214,7 +231,12 @@ class GooglePayJsonFactoryTest {
             shippingAddressParameters = GooglePayJsonFactory.ShippingAddressParameters(
                 isRequired = true,
                 allowedCountryCodes = setOf("us", "de")
-            )
+            ),
+            merchantInfo = GooglePayJsonFactory.MerchantInfo(
+                softwareInfo = GooglePayJsonFactory.SoftwareInfo(
+                    id = GooglePayJsonFactory.SoftwareInfo.SoftwareId.Launcher
+                )
+            ),
         )
 
         val allowedCountryCodes = createPaymentDataRequestJson
@@ -559,7 +581,12 @@ class GooglePayJsonFactoryTest {
                 currencyCode = "USD",
                 totalPriceStatus = GooglePayJsonFactory.TransactionInfo.TotalPriceStatus.Final,
                 totalPrice = 100
-            )
+            ),
+            merchantInfo = GooglePayJsonFactory.MerchantInfo(
+                softwareInfo = GooglePayJsonFactory.SoftwareInfo(
+                    id = GooglePayJsonFactory.SoftwareInfo.SoftwareId.Launcher
+                )
+            ),
         )
 
         val paymentDataAllowedCardNetworks = paymentDataRequestJson


### PR DESCRIPTION
# Summary
Populate fields in the Google Pay `PaymentDataRequest` to understand developer preferences using Google Pay via Stripe.

# Motivation
Today, developers using Stripe can use Google Pay to their applications following various paths (Google Pay SDK, Payment sheet UI, custom elements). Understanding trends and developer preferences is key to improve integration offerings to satisfy ever-changing programming styles and tooling. This PR adds basic versioning telemetry to help identify these patterns and focus efforts on the preferred integration paths.

# Testing
- [x] Added tests
- [x] Modified tests

# Outstanding tasks
- [ ] Review variable and value nomenclatures to ensure consistency (payment sheet, custom elements, etc)
- [ ] Review `MerchantInfo` nullability
