### PR TITLE
Use `elements_force_setup_future_use_behavior` for SFU and mandate behavior.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/ElementsSession.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ElementsSession.kt
@@ -194,7 +194,8 @@ data class ElementsSession(
         ELEMENTS_PREFER_FC_LITE("elements_prefer_fc_lite"),
         ELEMENTS_DISABLE_LINK_GLOBAL_HOLDBACK_LOOKUP("elements_disable_link_global_holdback_lookup"),
         ELEMENTS_ENABLE_LINK_SPM("elements_enable_link_spm"),
-        ELEMENTS_ENABLE_PASSIVE_CAPTCHA("elements_enable_passive_captcha")
+        ELEMENTS_ENABLE_PASSIVE_CAPTCHA("elements_enable_passive_captcha"),
+        ELEMENTS_FORCE_SETUP_FUTURE_USE_BEHAVIOR("elements_force_setup_future_use_behavior")
     }
 
     /**

--- a/payments-core/src/main/java/com/stripe/android/model/ElementsSession.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ElementsSession.kt
@@ -195,7 +195,9 @@ data class ElementsSession(
         ELEMENTS_DISABLE_LINK_GLOBAL_HOLDBACK_LOOKUP("elements_disable_link_global_holdback_lookup"),
         ELEMENTS_ENABLE_LINK_SPM("elements_enable_link_spm"),
         ELEMENTS_ENABLE_PASSIVE_CAPTCHA("elements_enable_passive_captcha"),
-        ELEMENTS_FORCE_SETUP_FUTURE_USE_BEHAVIOR("elements_force_setup_future_use_behavior")
+        ELEMENTS_MOBILE_FORCE_SETUP_FUTURE_USE_BEHAVIOR_AND_NEW_MANDATE_TEXT(
+            "elements_mobile_force_setup_future_use_behavior_and_new_mandate_text"
+        )
     }
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkConfiguration.kt
@@ -42,14 +42,8 @@ internal data class LinkConfiguration(
     val linkSignUpOptInInitialValue: Boolean,
     private val customerId: String?,
     val saveConsentBehavior: PaymentMethodSaveConsentBehavior,
+    val forceSetupFutureUseBehavior: Boolean,
 ) : Parcelable {
-
-    val alwaysSaveForFutureUse: Boolean
-        get() {
-            // When this (now poorly named) feature flag is enabled for a merchant, we always show the reuse mandate,
-            // since the merchant will save the payment method for future use.
-            return linkSignUpOptInFeatureEnabled
-        }
 
     val customerIdForEceDefaultValues: String?
         get() = if (enableDisplayableDefaultValuesInEce) customerId else null

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkConfiguration.kt
@@ -42,7 +42,7 @@ internal data class LinkConfiguration(
     val linkSignUpOptInInitialValue: Boolean,
     private val customerId: String?,
     val saveConsentBehavior: PaymentMethodSaveConsentBehavior,
-    val forceSetupFutureUseBehavior: Boolean,
+    val forceSetupFutureUseBehaviorAndNewMandate: Boolean,
 ) : Parcelable {
 
     val customerIdForEceDefaultValues: String?

--- a/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
@@ -173,7 +173,7 @@ internal class DefaultLinkConfirmationHandler @Inject constructor(
             is SetupIntent -> true
         }
 
-        return if (isSettingUp || configuration.forceSetupFutureUseBehavior) {
+        return if (isSettingUp || configuration.forceSetupFutureUseBehaviorAndNewMandate) {
             configuration.saveConsentBehavior.overrideAllowRedisplay ?: PaymentMethod.AllowRedisplay.LIMITED
         } else {
             PaymentMethod.AllowRedisplay.UNSPECIFIED

--- a/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
@@ -173,7 +173,7 @@ internal class DefaultLinkConfirmationHandler @Inject constructor(
             is SetupIntent -> true
         }
 
-        return if (isSettingUp || configuration.alwaysSaveForFutureUse) {
+        return if (isSettingUp || configuration.forceSetupFutureUseBehavior) {
             configuration.saveConsentBehavior.overrideAllowRedisplay ?: PaymentMethod.AllowRedisplay.LIMITED
         } else {
             PaymentMethod.AllowRedisplay.UNSPECIFIED

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -15,7 +15,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.definitions.ExternalPayme
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.LinkCardBrandDefinition
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ElementsSession
-import com.stripe.android.model.ElementsSession.Flag.ELEMENTS_FORCE_SETUP_FUTURE_USE_BEHAVIOR
+import com.stripe.android.model.ElementsSession.Flag.ELEMENTS_MOBILE_FORCE_SETUP_FUTURE_USE_BEHAVIOR_AND_NEW_MANDATE_TEXT
 import com.stripe.android.model.LinkMode
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
@@ -71,7 +71,7 @@ internal data class PaymentMethodMetadata(
     val elementsSessionId: String,
     val shopPayConfiguration: PaymentSheet.ShopPayConfiguration?,
     val termsDisplay: Map<PaymentMethod.Type, PaymentSheet.TermsDisplay>,
-    val forceSetupFutureUseBehavior: Boolean,
+    val forceSetupFutureUseBehaviorAndNewMandate: Boolean,
 ) : Parcelable {
 
     fun hasIntentToSetup(code: PaymentMethodCode): Boolean {
@@ -290,7 +290,7 @@ internal data class PaymentMethodMetadata(
         customerRequestedSave: PaymentSelection.CustomerRequestedSave,
         code: PaymentMethodCode
     ): PaymentMethod.AllowRedisplay {
-        val isSettingUp = hasIntentToSetup(code) || forceSetupFutureUseBehavior
+        val isSettingUp = hasIntentToSetup(code) || forceSetupFutureUseBehaviorAndNewMandate
         return paymentMethodSaveConsentBehavior.allowRedisplay(
             isSetupIntent = isSettingUp,
             customerRequestedSave = customerRequestedSave,
@@ -344,7 +344,8 @@ internal data class PaymentMethodMetadata(
                 elementsSessionId = elementsSession.elementsSessionId,
                 shopPayConfiguration = configuration.shopPayConfiguration,
                 termsDisplay = configuration.termsDisplay,
-                forceSetupFutureUseBehavior = elementsSession.flags[ELEMENTS_FORCE_SETUP_FUTURE_USE_BEHAVIOR] == true,
+                forceSetupFutureUseBehaviorAndNewMandate = elementsSession
+                    .flags[ELEMENTS_MOBILE_FORCE_SETUP_FUTURE_USE_BEHAVIOR_AND_NEW_MANDATE_TEXT] == true,
             )
         }
 
@@ -391,7 +392,8 @@ internal data class PaymentMethodMetadata(
                 financialConnectionsAvailability = GetFinancialConnectionsAvailability(elementsSession),
                 shopPayConfiguration = null,
                 termsDisplay = emptyMap(),
-                forceSetupFutureUseBehavior = elementsSession.flags[ELEMENTS_FORCE_SETUP_FUTURE_USE_BEHAVIOR] == true,
+                forceSetupFutureUseBehaviorAndNewMandate = elementsSession
+                    .flags[ELEMENTS_MOBILE_FORCE_SETUP_FUTURE_USE_BEHAVIOR_AND_NEW_MANDATE_TEXT] == true,
             )
         }
 
@@ -443,7 +445,7 @@ internal data class PaymentMethodMetadata(
                 financialConnectionsAvailability = GetFinancialConnectionsAvailability(elementsSession = null),
                 shopPayConfiguration = null,
                 termsDisplay = emptyMap(),
-                forceSetupFutureUseBehavior = configuration.forceSetupFutureUseBehavior
+                forceSetupFutureUseBehaviorAndNewMandate = configuration.forceSetupFutureUseBehaviorAndNewMandate
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -15,6 +15,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.definitions.ExternalPayme
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.LinkCardBrandDefinition
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ElementsSession
+import com.stripe.android.model.ElementsSession.Flag.ELEMENTS_FORCE_SETUP_FUTURE_USE_BEHAVIOR
 import com.stripe.android.model.LinkMode
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
@@ -70,14 +71,8 @@ internal data class PaymentMethodMetadata(
     val elementsSessionId: String,
     val shopPayConfiguration: PaymentSheet.ShopPayConfiguration?,
     val termsDisplay: Map<PaymentMethod.Type, PaymentSheet.TermsDisplay>,
+    val forceSetupFutureUseBehavior: Boolean,
 ) : Parcelable {
-
-    val alwaysSaveForFutureUse: Boolean
-        get() {
-            // When this (now poorly named) feature flag is enabled for a merchant, we always show the reuse mandate,
-            // since the merchant will save the payment method for future use.
-            return linkState?.configuration?.linkSignUpOptInFeatureEnabled == true
-        }
 
     fun hasIntentToSetup(code: PaymentMethodCode): Boolean {
         return when (stripeIntent) {
@@ -295,7 +290,7 @@ internal data class PaymentMethodMetadata(
         customerRequestedSave: PaymentSelection.CustomerRequestedSave,
         code: PaymentMethodCode
     ): PaymentMethod.AllowRedisplay {
-        val isSettingUp = hasIntentToSetup(code) || alwaysSaveForFutureUse
+        val isSettingUp = hasIntentToSetup(code) || forceSetupFutureUseBehavior
         return paymentMethodSaveConsentBehavior.allowRedisplay(
             isSetupIntent = isSettingUp,
             customerRequestedSave = customerRequestedSave,
@@ -349,6 +344,7 @@ internal data class PaymentMethodMetadata(
                 elementsSessionId = elementsSession.elementsSessionId,
                 shopPayConfiguration = configuration.shopPayConfiguration,
                 termsDisplay = configuration.termsDisplay,
+                forceSetupFutureUseBehavior = elementsSession.flags[ELEMENTS_FORCE_SETUP_FUTURE_USE_BEHAVIOR] == true,
             )
         }
 
@@ -395,6 +391,7 @@ internal data class PaymentMethodMetadata(
                 financialConnectionsAvailability = GetFinancialConnectionsAvailability(elementsSession),
                 shopPayConfiguration = null,
                 termsDisplay = emptyMap(),
+                forceSetupFutureUseBehavior = elementsSession.flags[ELEMENTS_FORCE_SETUP_FUTURE_USE_BEHAVIOR] == true,
             )
         }
 
@@ -446,6 +443,7 @@ internal data class PaymentMethodMetadata(
                 financialConnectionsAvailability = GetFinancialConnectionsAvailability(elementsSession = null),
                 shopPayConfiguration = null,
                 termsDisplay = emptyMap(),
+                forceSetupFutureUseBehavior = configuration.forceSetupFutureUseBehavior
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -109,10 +109,10 @@ private object CardUiDefinitionFactory : UiDefinitionFactory.Simple {
                 metadata = metadata
             )
 
-            val forceSetupFutureUseBehavior = metadata.forceSetupFutureUseBehavior
+            val forceSetupFutureUseBehaviorAndNewMandate = metadata.forceSetupFutureUseBehaviorAndNewMandate
 
             // sign up opt in combines save for future usage and link signup acceptance
-            if (canChangeSaveForFutureUsage && forceSetupFutureUseBehavior.not()) {
+            if (canChangeSaveForFutureUsage && forceSetupFutureUseBehaviorAndNewMandate.not()) {
                 addSavePaymentOptionElements(
                     metadata = metadata,
                     arguments = arguments,
@@ -138,7 +138,7 @@ private object CardUiDefinitionFactory : UiDefinitionFactory.Simple {
             }
 
             val mandateAllowed = metadata.mandateAllowed(CardDefinition.type)
-            if (forceSetupFutureUseBehavior) {
+            if (forceSetupFutureUseBehaviorAndNewMandate) {
                 add(
                     CombinedLinkMandateElement(
                         identifier = IdentifierSpec.Generic("card_mandate"),

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -109,10 +109,7 @@ private object CardUiDefinitionFactory : UiDefinitionFactory.Simple {
                 metadata = metadata
             )
 
-            val forceSetupFutureUseBehaviorAndNewMandate = metadata.forceSetupFutureUseBehaviorAndNewMandate
-
-            // sign up opt in combines save for future usage and link signup acceptance
-            if (canChangeSaveForFutureUsage && forceSetupFutureUseBehaviorAndNewMandate.not()) {
+            if (canChangeSaveForFutureUsage && metadata.forceSetupFutureUseBehaviorAndNewMandate.not()) {
                 addSavePaymentOptionElements(
                     metadata = metadata,
                     arguments = arguments,
@@ -138,7 +135,7 @@ private object CardUiDefinitionFactory : UiDefinitionFactory.Simple {
             }
 
             val mandateAllowed = metadata.mandateAllowed(CardDefinition.type)
-            if (forceSetupFutureUseBehaviorAndNewMandate) {
+            if (metadata.forceSetupFutureUseBehaviorAndNewMandate) {
                 add(
                     CombinedLinkMandateElement(
                         identifier = IdentifierSpec.Generic("card_mandate"),

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -109,11 +109,10 @@ private object CardUiDefinitionFactory : UiDefinitionFactory.Simple {
                 metadata = metadata
             )
 
-            val linkSignupOptInEnabled =
-                metadata.linkState?.configuration?.linkSignUpOptInFeatureEnabled == true
+            val forceSetupFutureUseBehavior = metadata.forceSetupFutureUseBehavior
 
             // sign up opt in combines save for future usage and link signup acceptance
-            if (canChangeSaveForFutureUsage && linkSignupOptInEnabled.not()) {
+            if (canChangeSaveForFutureUsage && forceSetupFutureUseBehavior.not()) {
                 addSavePaymentOptionElements(
                     metadata = metadata,
                     arguments = arguments,
@@ -139,7 +138,7 @@ private object CardUiDefinitionFactory : UiDefinitionFactory.Simple {
             }
 
             val mandateAllowed = metadata.mandateAllowed(CardDefinition.type)
-            if (linkSignupOptInEnabled) {
+            if (forceSetupFutureUseBehavior) {
                 add(
                     CombinedLinkMandateElement(
                         identifier = IdentifierSpec.Generic("card_mandate"),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -31,7 +31,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilter
 import com.stripe.android.lpmfoundations.paymentmethod.toPaymentSheetSaveConsentBehavior
 import com.stripe.android.model.ElementsSession
-import com.stripe.android.model.ElementsSession.Flag.ELEMENTS_FORCE_SETUP_FUTURE_USE_BEHAVIOR
+import com.stripe.android.model.ElementsSession.Flag.ELEMENTS_MOBILE_FORCE_SETUP_FUTURE_USE_BEHAVIOR_AND_NEW_MANDATE_TEXT
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.SetupIntent
@@ -648,7 +648,8 @@ internal class DefaultPaymentElementLoader @Inject constructor(
             customerId = elementsSession.customer?.session?.customerId,
             linkAppearance = linkAppearance,
             saveConsentBehavior = elementsSession.toPaymentSheetSaveConsentBehavior(),
-            forceSetupFutureUseBehavior = elementsSession.flags[ELEMENTS_FORCE_SETUP_FUTURE_USE_BEHAVIOR] == true,
+            forceSetupFutureUseBehaviorAndNewMandate = elementsSession
+                .flags[ELEMENTS_MOBILE_FORCE_SETUP_FUTURE_USE_BEHAVIOR_AND_NEW_MANDATE_TEXT] == true,
         )
 
         // CBF isn't currently supported in the web flow.

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -31,6 +31,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilter
 import com.stripe.android.lpmfoundations.paymentmethod.toPaymentSheetSaveConsentBehavior
 import com.stripe.android.model.ElementsSession
+import com.stripe.android.model.ElementsSession.Flag.ELEMENTS_FORCE_SETUP_FUTURE_USE_BEHAVIOR
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.SetupIntent
@@ -647,6 +648,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
             customerId = elementsSession.customer?.session?.customerId,
             linkAppearance = linkAppearance,
             saveConsentBehavior = elementsSession.toPaymentSheetSaveConsentBehavior(),
+            forceSetupFutureUseBehavior = elementsSession.flags[ELEMENTS_FORCE_SETUP_FUTURE_USE_BEHAVIOR] == true,
         )
 
         // CBF isn't currently supported in the web flow.

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetState.kt
@@ -39,9 +39,9 @@ internal sealed interface PaymentSheetState : Parcelable {
 
         val alwaysSaveForFutureUse: Boolean
             get() {
-                // When this (now poorly named) feature flag is enabled for a merchant, we always show the
+                // When this feature flag is enabled for a merchant, we always show the
                 // reuse mandate, since the merchant will save the payment method for future use.
-                return linkConfiguration?.linkSignUpOptInFeatureEnabled ?: false
+                return paymentMethodMetadata.forceSetupFutureUseBehavior
             }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetState.kt
@@ -41,7 +41,7 @@ internal sealed interface PaymentSheetState : Parcelable {
             get() {
                 // When this feature flag is enabled for a merchant, we always show the
                 // reuse mandate, since the merchant will save the payment method for future use.
-                return paymentMethodMetadata.forceSetupFutureUseBehavior
+                return paymentMethodMetadata.forceSetupFutureUseBehaviorAndNewMandate
             }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
@@ -232,6 +232,7 @@ internal object TestFactory {
         linkSignUpOptInInitialValue = false,
         customerId = null,
         saveConsentBehavior = PaymentMethodSaveConsentBehavior.Disabled(null),
+        forceSetupFutureUseBehavior = false,
     )
 
     val LINK_WALLET_PRIMARY_BUTTON_LABEL = Amount(

--- a/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
@@ -232,7 +232,7 @@ internal object TestFactory {
         linkSignUpOptInInitialValue = false,
         customerId = null,
         saveConsentBehavior = PaymentMethodSaveConsentBehavior.Disabled(null),
-        forceSetupFutureUseBehavior = false,
+        forceSetupFutureUseBehaviorAndNewMandate = false,
     )
 
     val LINK_WALLET_PRIMARY_BUTTON_LABEL = Amount(

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenStateTest.kt
@@ -109,6 +109,7 @@ class SignUpScreenStateTest {
             skipWalletInFlowController = false,
             customerId = null,
             saveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
+            forceSetupFutureUseBehavior = false,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenStateTest.kt
@@ -109,7 +109,7 @@ class SignUpScreenStateTest {
             skipWalletInFlowController = false,
             customerId = null,
             saveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
-            forceSetupFutureUseBehavior = false,
+            forceSetupFutureUseBehaviorAndNewMandate = false,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
@@ -49,6 +49,7 @@ internal object PaymentMethodMetadataFactory {
             PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA_PERMISSIONS,
         shopPayConfiguration: PaymentSheet.ShopPayConfiguration? = SHOP_PAY_CONFIGURATION,
         termsDisplay: Map<PaymentMethod.Type, PaymentSheet.TermsDisplay> = emptyMap(),
+        forceSetupFutureUseBehavior: Boolean = false,
     ): PaymentMethodMetadata {
         return PaymentMethodMetadata(
             stripeIntent = stripeIntent,
@@ -81,6 +82,7 @@ internal object PaymentMethodMetadataFactory {
             financialConnectionsAvailability = financialConnectionsAvailability,
             shopPayConfiguration = shopPayConfiguration,
             termsDisplay = termsDisplay,
+            forceSetupFutureUseBehavior = forceSetupFutureUseBehavior,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
@@ -49,7 +49,7 @@ internal object PaymentMethodMetadataFactory {
             PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA_PERMISSIONS,
         shopPayConfiguration: PaymentSheet.ShopPayConfiguration? = SHOP_PAY_CONFIGURATION,
         termsDisplay: Map<PaymentMethod.Type, PaymentSheet.TermsDisplay> = emptyMap(),
-        forceSetupFutureUseBehavior: Boolean = false,
+        forceSetupFutureUseBehaviorAndNewMandate: Boolean = false,
     ): PaymentMethodMetadata {
         return PaymentMethodMetadata(
             stripeIntent = stripeIntent,
@@ -82,7 +82,7 @@ internal object PaymentMethodMetadataFactory {
             financialConnectionsAvailability = financialConnectionsAvailability,
             shopPayConfiguration = shopPayConfiguration,
             termsDisplay = termsDisplay,
-            forceSetupFutureUseBehavior = forceSetupFutureUseBehavior,
+            forceSetupFutureUseBehaviorAndNewMandate = forceSetupFutureUseBehaviorAndNewMandate,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -1150,6 +1150,7 @@ internal class PaymentMethodMetadataTest {
             financialConnectionsAvailability = FinancialConnectionsAvailability.Full,
             shopPayConfiguration = null,
             termsDisplay = emptyMap(),
+            forceSetupFutureUseBehavior = false,
         )
 
         assertThat(metadata).isEqualTo(expectedMetadata)
@@ -1224,6 +1225,7 @@ internal class PaymentMethodMetadataTest {
             elementsSessionId = "session_1234",
             shopPayConfiguration = null,
             termsDisplay = emptyMap(),
+            forceSetupFutureUseBehavior = false,
         )
         assertThat(metadata).isEqualTo(expectedMetadata)
     }
@@ -2086,6 +2088,7 @@ internal class PaymentMethodMetadataTest {
             linkSignUpOptInInitialValue = false,
             customerId = null,
             saveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
+            forceSetupFutureUseBehavior = false,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -1150,7 +1150,7 @@ internal class PaymentMethodMetadataTest {
             financialConnectionsAvailability = FinancialConnectionsAvailability.Full,
             shopPayConfiguration = null,
             termsDisplay = emptyMap(),
-            forceSetupFutureUseBehavior = false,
+            forceSetupFutureUseBehaviorAndNewMandate = false,
         )
 
         assertThat(metadata).isEqualTo(expectedMetadata)
@@ -1225,7 +1225,7 @@ internal class PaymentMethodMetadataTest {
             elementsSessionId = "session_1234",
             shopPayConfiguration = null,
             termsDisplay = emptyMap(),
-            forceSetupFutureUseBehavior = false,
+            forceSetupFutureUseBehaviorAndNewMandate = false,
         )
         assertThat(metadata).isEqualTo(expectedMetadata)
     }
@@ -2088,7 +2088,7 @@ internal class PaymentMethodMetadataTest {
             linkSignUpOptInInitialValue = false,
             customerId = null,
             saveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
-            forceSetupFutureUseBehavior = false,
+            forceSetupFutureUseBehaviorAndNewMandate = false,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinitionTest.kt
@@ -283,7 +283,7 @@ class CardDefinitionTest {
     fun `createFormElements returns mandate when has intent to setup`() {
         val metadata = PaymentMethodMetadataFactory.create(
             stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
-            forceSetupFutureUseBehavior = true,
+            forceSetupFutureUseBehaviorAndNewMandate = true,
             linkState = LinkState(
                 signupMode = null,
                 configuration = createLinkConfiguration(),
@@ -302,10 +302,10 @@ class CardDefinitionTest {
     }
 
     @Test
-    fun `createFormElements returns mandate when forceSetupFutureUseBehavior even with no email`() {
+    fun `createFormElements returns mandate when forceSetupFutureUseBehaviorAndNewMandate even with no email`() {
         val metadata = PaymentMethodMetadataFactory.create(
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
-            forceSetupFutureUseBehavior = true,
+            forceSetupFutureUseBehaviorAndNewMandate = true,
             linkState = LinkState(
                 signupMode = null,
                 configuration = createLinkConfiguration().copy(
@@ -367,7 +367,7 @@ class CardDefinitionTest {
     fun `createFormElements returns mandate below link_form when has intent to setup`() {
         val metadata = PaymentMethodMetadataFactory.create(
             stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
-            forceSetupFutureUseBehavior = true,
+            forceSetupFutureUseBehaviorAndNewMandate = true,
             linkState = LinkState(
                 signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
                 configuration = createLinkConfiguration(),
@@ -518,7 +518,7 @@ class CardDefinitionTest {
         )
         val metadata = PaymentMethodMetadataFactory.create(
             stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
-            forceSetupFutureUseBehavior = true,
+            forceSetupFutureUseBehaviorAndNewMandate = true,
             termsDisplay = termsDisplay,
             linkState = LinkState(
                 configuration = TestFactory.LINK_CONFIGURATION,

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinitionTest.kt
@@ -283,9 +283,10 @@ class CardDefinitionTest {
     fun `createFormElements returns mandate when has intent to setup`() {
         val metadata = PaymentMethodMetadataFactory.create(
             stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
+            forceSetupFutureUseBehavior = true,
             linkState = LinkState(
                 signupMode = null,
-                configuration = createLinkConfiguration().copy(linkSignUpOptInFeatureEnabled = true),
+                configuration = createLinkConfiguration(),
                 loginState = LinkState.LoginState.LoggedOut,
             ),
         )
@@ -301,13 +302,13 @@ class CardDefinitionTest {
     }
 
     @Test
-    fun `createFormElements returns mandate when linkSignUpOptInFeatureEnabled even with no email`() {
+    fun `createFormElements returns mandate when forceSetupFutureUseBehavior even with no email`() {
         val metadata = PaymentMethodMetadataFactory.create(
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            forceSetupFutureUseBehavior = true,
             linkState = LinkState(
                 signupMode = null,
                 configuration = createLinkConfiguration().copy(
-                    linkSignUpOptInFeatureEnabled = true,
                     customerInfo = LinkConfiguration.CustomerInfo(
                         name = null,
                         email = null,
@@ -366,9 +367,10 @@ class CardDefinitionTest {
     fun `createFormElements returns mandate below link_form when has intent to setup`() {
         val metadata = PaymentMethodMetadataFactory.create(
             stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
+            forceSetupFutureUseBehavior = true,
             linkState = LinkState(
                 signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
-                configuration = createLinkConfiguration().copy(linkSignUpOptInFeatureEnabled = true),
+                configuration = createLinkConfiguration(),
                 loginState = LinkState.LoginState.LoggedOut,
             ),
         )
@@ -516,11 +518,10 @@ class CardDefinitionTest {
         )
         val metadata = PaymentMethodMetadataFactory.create(
             stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
+            forceSetupFutureUseBehavior = true,
             termsDisplay = termsDisplay,
             linkState = LinkState(
-                configuration = TestFactory.LINK_CONFIGURATION.copy(
-                    linkSignUpOptInFeatureEnabled = true,
-                ),
+                configuration = TestFactory.LINK_CONFIGURATION,
                 loginState = LinkState.LoginState.LoggedOut,
                 signupMode = LinkSignupMode.AlongsideSaveForFutureUse,
             )

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElementTest.kt
@@ -163,7 +163,7 @@ class LinkFormElementTest {
             linkSignUpOptInInitialValue = false,
             customerId = null,
             saveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
-            forceSetupFutureUseBehavior = false,
+            forceSetupFutureUseBehaviorAndNewMandate = false,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElementTest.kt
@@ -163,6 +163,7 @@ class LinkFormElementTest {
             linkSignUpOptInInitialValue = false,
             customerId = null,
             saveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
+            forceSetupFutureUseBehavior = false,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
@@ -625,7 +625,7 @@ class ConfirmationHandlerOptionKtxTest {
             linkSignUpOptInInitialValue = false,
             customerId = null,
             saveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
-            forceSetupFutureUseBehavior = false,
+            forceSetupFutureUseBehaviorAndNewMandate = false,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
@@ -625,6 +625,7 @@ class ConfirmationHandlerOptionKtxTest {
             linkSignUpOptInInitialValue = false,
             customerId = null,
             saveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
+            forceSetupFutureUseBehavior = false,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
@@ -706,7 +706,7 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
                 linkSignUpOptInInitialValue = false,
                 customerId = null,
                 saveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
-                forceSetupFutureUseBehavior = false,
+                forceSetupFutureUseBehaviorAndNewMandate = false,
             ),
             userInput = userInput,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
@@ -706,6 +706,7 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
                 linkSignUpOptInInitialValue = false,
                 customerId = null,
                 saveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
+                forceSetupFutureUseBehavior = false,
             ),
             userInput = userInput,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
@@ -99,7 +99,7 @@ internal object LinkTestUtils {
             skipWalletInFlowController = false,
             customerId = null,
             saveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
-            forceSetupFutureUseBehavior = false,
+            forceSetupFutureUseBehaviorAndNewMandate = false,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
@@ -99,6 +99,7 @@ internal object LinkTestUtils {
             skipWalletInFlowController = false,
             customerId = null,
             saveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
+            forceSetupFutureUseBehavior = false,
         )
     }
 }


### PR DESCRIPTION
# Summary
- Introduces `elements_force_setup_future_use_behavior`.
- Decouples logic from the signup opt in flag.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
