### PR TITLE
Fix flake in default PMs integration tests

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/DefaultPaymentMethodsConfirmationTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/DefaultPaymentMethodsConfirmationTest.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet
 
+import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.rule.IntentsRule
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
@@ -18,6 +19,8 @@ import com.stripe.android.paymentsheet.utils.runProductIntegrationTest
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.paymentelementtestpages.FormPage
 import com.stripe.paymentelementtestpages.VerticalModePage
+import org.junit.After
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -44,6 +47,16 @@ internal class DefaultPaymentMethodsConfirmationTest {
 
     // Confirmation behavior between horizontal and vertical doesn't differ, so we're testing with vertical mode only.
     private val layoutType: PaymentSheetLayoutType = PaymentSheetLayoutType.Vertical()
+
+    @Before
+    fun initIntents() {
+        Intents.init()
+    }
+
+    @After
+    fun releaseIntents() {
+        Intents.release()
+    }
 
     @Test
     fun setNewPMAsDefault_withSavedPaymentMethods_sendsSetAsDefaultParamInConfirmCall() = runProductIntegrationTest(

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/DefaultPaymentMethodsFlowControllerConfirmationTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/DefaultPaymentMethodsFlowControllerConfirmationTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet
 
 import androidx.compose.ui.test.hasTestTag
+import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.rule.IntentsRule
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
@@ -18,6 +19,8 @@ import com.stripe.android.paymentsheet.utils.TestRules
 import com.stripe.android.paymentsheet.utils.assertCompleted
 import com.stripe.android.paymentsheet.utils.runFlowControllerTest
 import com.stripe.android.testing.PaymentMethodFactory
+import org.junit.After
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -40,6 +43,16 @@ internal class DefaultPaymentMethodsFlowControllerConfirmationTest {
 
     // Confirmation behavior between horizontal and vertical doesn't differ, so we're testing with vertical mode only.
     private val layoutType: PaymentSheetLayoutType = PaymentSheetLayoutType.Vertical()
+
+    @Before
+    fun initIntents() {
+        Intents.init()
+    }
+
+    @After
+    fun releaseIntents() {
+        Intents.release()
+    }
 
     @Test
     fun relaunchesIntoFormPageWithSaveForFutureUseChecked() = relaunchIntoFormPage(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Fix flake in default PMs integration tests

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
These tests were flaking on [this line](https://github.com/stripe/stripe-android/blob/da3caaf0d4f236d4602b1a5e51f6de6587fa9b3a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/PaymentMethodType.kt#L65) because `Intents.init()` hadn't been called. Not sure why they passed sometimes but they very consistently failed with ShampooRule enabled.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

Ran these tests with ShampooRule before and after the change. They always failed before and they succeeded after.

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->