### PR TITLE
[lc] Add LinkAuthIntent and Consent data layer

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepository.kt
@@ -233,6 +233,7 @@ private class FinancialConnectionsConsumerSessionRepositoryImpl(
             verificationCode = verificationCode,
             type = type,
             requestSurface = requestSurface,
+            consentGranted = null,
             requestOptions = provideApiRequestOptions(useConsumerPublishableKey = false),
         ).also { session ->
             updateCachedConsumerSession("confirmConsumerVerification", session)
@@ -322,6 +323,7 @@ private class FinancialConnectionsConsumerSessionRepositoryImpl(
     ): ConsumerSessionLookup = consumersApiService.mobileLookupConsumerSession(
         email = email,
         emailSource = emailSource,
+        linkAuthIntentId = null,
         requestSurface = requestSurface,
         verificationToken = verificationToken,
         appId = appId,

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepositoryImplTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepositoryImplTest.kt
@@ -277,6 +277,7 @@ class FinancialConnectionsConsumerSessionRepositoryImplTest {
                 verificationCode = eq(verificationCode),
                 requestSurface = eq("android_connections"),
                 type = eq(type),
+                consentGranted = eq(null),
                 requestOptions = eq(apiOptions)
             )
         ).thenReturn(consumerSession)
@@ -295,9 +296,10 @@ class FinancialConnectionsConsumerSessionRepositoryImplTest {
         verify(consumersApiService).confirmConsumerVerification(
             consumerSessionClientSecret = consumerSessionClientSecret,
             verificationCode = verificationCode,
-            "android_connections",
-            type,
-            apiOptions
+            requestSurface = "android_connections",
+            type = type,
+            consentGranted = null,
+            requestOptions = apiOptions
         )
 
         // ensures there's a cached consumer session after the confirm-verification call.

--- a/payments-core/src/test/java/com/stripe/android/model/ConsentUiFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/ConsentUiFixtures.kt
@@ -1,0 +1,36 @@
+package com.stripe.android.model
+
+object ConsentUiFixtures {
+    const val HAS_CONSENT_PANE =
+        """
+        {
+          "consent_pane": {
+            "title": "Connect Example with Link",
+            "scopes_section": {
+              "header": "Example will have access to:",
+              "scopes": [
+                {
+                  "icon": {
+                    "default": "https://asset.stripe.com/account_scope.png"
+                  },
+                  "header": "Account info",
+                  "description": "Name, email, and profile picture"
+                }
+              ]
+            },
+            "disclaimer": "By allowing, you agree...",
+            "deny_button_label": "Cancel",
+            "allow_button_label": "Allow"
+          }
+        }
+        """
+
+    const val HAS_CONSENT_SECTION =
+        """
+        {
+          "consent_section": {
+            "disclaimer": "By continuing you'll share your name, email, and phone with Example"
+          }
+        }
+        """
+}

--- a/payments-core/src/test/java/com/stripe/android/model/ConsentUiTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/ConsentUiTest.kt
@@ -1,0 +1,26 @@
+package com.stripe.android.model
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.serialization.json.Json
+import org.junit.Test
+
+class ConsentUiTest {
+
+    private val format = Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+    }
+
+    @Test
+    fun `decodes without error`() {
+        assertThat(
+            format.decodeFromString<ConsentUi>(ConsentUiFixtures.HAS_CONSENT_PANE)
+                .consentPane
+        ).isNotNull()
+
+        assertThat(
+            format.decodeFromString<ConsentUi>(ConsentUiFixtures.HAS_CONSENT_SECTION)
+                .consentSection
+        ).isNotNull()
+    }
+}

--- a/payments-core/src/test/java/com/stripe/android/model/ElementsSessionTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/ElementsSessionTest.kt
@@ -80,13 +80,13 @@ class ElementsSessionTest {
             experimentsData = null,
             customer = null,
             merchantCountry = null,
+            merchantLogoUrl = null,
             cardBrandChoice = null,
             isGooglePayEnabled = false,
             sessionsError = null,
             customPaymentMethods = emptyList(),
             elementsSessionId = "elements_session_test",
             passiveCaptcha = passiveCaptcha,
-            merchantLogoUrl = null
         )
     }
 }

--- a/payments-model/api/payments-model.api
+++ b/payments-model/api/payments-model.api
@@ -198,6 +198,138 @@ public final class com/stripe/android/model/CardFunding : java/lang/Enum {
 	public static fun values ()[Lcom/stripe/android/model/CardFunding;
 }
 
+public synthetic class com/stripe/android/model/ConsentUi$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/stripe/android/model/ConsentUi$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/model/ConsentUi;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/model/ConsentUi;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+}
+
+public final class com/stripe/android/model/ConsentUi$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public synthetic class com/stripe/android/model/ConsentUi$ConsentPane$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/stripe/android/model/ConsentUi$ConsentPane$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/model/ConsentUi$ConsentPane;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/model/ConsentUi$ConsentPane;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+}
+
+public final class com/stripe/android/model/ConsentUi$ConsentPane$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/model/ConsentUi$ConsentPane$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/ConsentUi$ConsentPane;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/ConsentUi$ConsentPane;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public synthetic class com/stripe/android/model/ConsentUi$ConsentPane$ScopesSection$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/stripe/android/model/ConsentUi$ConsentPane$ScopesSection$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/model/ConsentUi$ConsentPane$ScopesSection;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/model/ConsentUi$ConsentPane$ScopesSection;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+}
+
+public final class com/stripe/android/model/ConsentUi$ConsentPane$ScopesSection$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/model/ConsentUi$ConsentPane$ScopesSection$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/ConsentUi$ConsentPane$ScopesSection;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/ConsentUi$ConsentPane$ScopesSection;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public synthetic class com/stripe/android/model/ConsentUi$ConsentPane$ScopesSection$Scope$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/stripe/android/model/ConsentUi$ConsentPane$ScopesSection$Scope$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/model/ConsentUi$ConsentPane$ScopesSection$Scope;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/model/ConsentUi$ConsentPane$ScopesSection$Scope;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+}
+
+public final class com/stripe/android/model/ConsentUi$ConsentPane$ScopesSection$Scope$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/model/ConsentUi$ConsentPane$ScopesSection$Scope$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/ConsentUi$ConsentPane$ScopesSection$Scope;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/ConsentUi$ConsentPane$ScopesSection$Scope;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public synthetic class com/stripe/android/model/ConsentUi$ConsentSection$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/stripe/android/model/ConsentUi$ConsentSection$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/model/ConsentUi$ConsentSection;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/model/ConsentUi$ConsentSection;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+}
+
+public final class com/stripe/android/model/ConsentUi$ConsentSection$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/model/ConsentUi$ConsentSection$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/ConsentUi$ConsentSection;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/ConsentUi$ConsentSection;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/ConsentUi$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/ConsentUi;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/ConsentUi;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public synthetic class com/stripe/android/model/ConsentUi$Icon$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/stripe/android/model/ConsentUi$Icon$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/model/ConsentUi$Icon;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/model/ConsentUi$Icon;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+}
+
+public final class com/stripe/android/model/ConsentUi$Icon$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/model/ConsentUi$Icon$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/ConsentUi$Icon;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/ConsentUi$Icon;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/model/ConsumerPaymentDetails$BankAccount$Companion {
 }
 

--- a/payments-model/src/main/java/com/stripe/android/model/ConsentUi.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/ConsentUi.kt
@@ -1,0 +1,75 @@
+package com.stripe.android.model
+
+import androidx.annotation.RestrictTo
+import com.stripe.android.core.model.StripeModel
+import kotlinx.parcelize.Parcelize
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Parcelize
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Serializable
+data class ConsentUi(
+    @SerialName("consent_pane")
+    val consentPane: ConsentPane?,
+    @SerialName("consent_section")
+    val consentSection: ConsentSection?,
+) : StripeModel {
+
+    @Parcelize
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @Serializable
+    data class ConsentPane(
+        @SerialName("title")
+        val title: String,
+        @SerialName("scopes_section")
+        val scopesSection: ScopesSection,
+        @SerialName("disclaimer")
+        val disclaimer: String?,
+        @SerialName("deny_button_label")
+        val denyButtonLabel: String?,
+        @SerialName("allow_button_label")
+        val allowButtonLabel: String,
+    ) : StripeModel {
+
+        @Parcelize
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        @Serializable
+        data class ScopesSection(
+            @SerialName("header")
+            val header: String,
+            @SerialName("scopes")
+            val scopes: List<Scope>,
+        ) : StripeModel {
+
+            @Parcelize
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            @Serializable
+            data class Scope(
+                @SerialName("icon")
+                val icon: Icon,
+                @SerialName("header")
+                val header: String?,
+                @SerialName("description")
+                val description: String,
+            ) : StripeModel
+        }
+    }
+
+    @Parcelize
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @Serializable
+    data class ConsentSection(
+        @SerialName("disclaimer")
+        val disclaimer: String,
+    ) : StripeModel
+
+    @Parcelize
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @Serializable
+    data class Icon(
+        @SerialName("default")
+        val default: String,
+    ) : StripeModel
+
+}

--- a/payments-model/src/main/java/com/stripe/android/model/ConsentUi.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/ConsentUi.kt
@@ -71,5 +71,4 @@ data class ConsentUi(
         @SerialName("default")
         val default: String,
     ) : StripeModel
-
 }

--- a/payments-model/src/main/java/com/stripe/android/model/ConsumerSessionLookup.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/ConsumerSessionLookup.kt
@@ -40,4 +40,6 @@ data class ConsumerSessionLookup(
     val publishableKey: String? = null,
     @SerialName("displayable_payment_details")
     val displayablePaymentDetails: DisplayablePaymentDetails? = null,
+    @SerialName("consent_ui")
+    val consentUi: ConsentUi? = null,
 ) : StripeModel

--- a/payments-model/src/main/java/com/stripe/android/model/parsers/ConsumerSessionLookupJsonParser.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/parsers/ConsumerSessionLookupJsonParser.kt
@@ -4,11 +4,19 @@ import androidx.annotation.RestrictTo
 import com.stripe.android.core.model.StripeJsonUtils.optBoolean
 import com.stripe.android.core.model.StripeJsonUtils.optString
 import com.stripe.android.core.model.parsers.ModelJsonParser
+import com.stripe.android.model.ConsentUi
 import com.stripe.android.model.ConsumerSessionLookup
+import kotlinx.serialization.json.Json
 import org.json.JSONObject
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class ConsumerSessionLookupJsonParser : ModelJsonParser<ConsumerSessionLookup> {
+
+    private val format = Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+    }
+
     override fun parse(json: JSONObject): ConsumerSessionLookup {
         val exists = optBoolean(json, FIELD_EXISTS)
         val consumerSession = ConsumerSessionJsonParser().parse(json)
@@ -17,7 +25,16 @@ class ConsumerSessionLookupJsonParser : ModelJsonParser<ConsumerSessionLookup> {
         val displayablePaymentDetails = json.optJSONObject(FIELD_DISPLAYABLE_PAYMENT_DETAILS)?.let {
             DisplayablePaymentDetailsJsonParser.parse(it)
         }
-        return ConsumerSessionLookup(exists, consumerSession, errorMessage, publishableKey, displayablePaymentDetails)
+        val consentUi = optString(json, FIELD_CONSENT_UI)
+            ?.let { format.decodeFromString<ConsentUi>(it) }
+        return ConsumerSessionLookup(
+            exists = exists,
+            consumerSession = consumerSession,
+            errorMessage = errorMessage,
+            publishableKey = publishableKey,
+            displayablePaymentDetails = displayablePaymentDetails,
+            consentUi = consentUi,
+        )
     }
 
     private companion object {
@@ -25,5 +42,6 @@ class ConsumerSessionLookupJsonParser : ModelJsonParser<ConsumerSessionLookup> {
         private const val FIELD_ERROR_MESSAGE = "error_message"
         private const val FIELD_PUBLISHABLE_KEY = "publishable_key"
         private const val FIELD_DISPLAYABLE_PAYMENT_DETAILS = "displayable_payment_details"
+        private const val FIELD_CONSENT_UI = "consent_ui"
     }
 }

--- a/payments-model/src/test/java/com/stripe/android/repository/ConsumersApiServiceImplTest.kt
+++ b/payments-model/src/test/java/com/stripe/android/repository/ConsumersApiServiceImplTest.kt
@@ -103,6 +103,7 @@ class ConsumersApiServiceImplTest {
 
         val lookup = consumersApiService.lookupConsumerSession(
             email = email,
+            linkAuthIntentId = null,
             requestSurface = requestSurface,
             sessionId = DEFAULT_SESSION_ID,
             requestOptions = DEFAULT_OPTIONS,
@@ -135,6 +136,7 @@ class ConsumersApiServiceImplTest {
         assertFailsWith<APIException> {
             consumersApiService.lookupConsumerSession(
                 email = email,
+                linkAuthIntentId = null,
                 requestSurface = requestSurface,
                 sessionId = DEFAULT_SESSION_ID,
                 doNotLogConsumerFunnelEvent = false,
@@ -204,6 +206,7 @@ class ConsumersApiServiceImplTest {
             verificationCode = verificationCode,
             requestSurface = "android_payment_element",
             type = VerificationType.SMS,
+            consentGranted = null,
             requestOptions = DEFAULT_OPTIONS
         )
 

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -464,11 +464,35 @@ public final class com/stripe/android/link/NativeLinkArgs$Creator : android/os/P
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/link/model/ConsentPresentation$FullScreen$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/link/model/ConsentPresentation$FullScreen;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/link/model/ConsentPresentation$FullScreen;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/link/model/ConsentPresentation$Inline$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/link/model/ConsentPresentation$Inline;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/link/model/ConsentPresentation$Inline;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/link/model/LinkAccount$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/link/model/LinkAccount;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/link/model/LinkAccount;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/link/model/LinkAuthIntentInfo$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/link/model/LinkAuthIntentInfo;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/link/model/LinkAuthIntentInfo;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAuth.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAuth.kt
@@ -63,6 +63,7 @@ internal class DefaultLinkAuth @Inject constructor(
         } else {
             linkAccountManager.lookupConsumer(
                 email = email,
+                linkAuthIntentId = null,
                 startSession = startSession,
                 customerId = customerId
             )
@@ -104,6 +105,7 @@ internal class DefaultLinkAuth @Inject constructor(
             linkAccountManager.mobileLookupConsumer(
                 email = email,
                 emailSource = emailSource,
+                linkAuthIntentId = null,
                 verificationToken = verificationToken,
                 appId = applicationId,
                 startSession = startSession,

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
@@ -11,7 +11,6 @@ import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.ConsumerPaymentDetailsUpdateParams
 import com.stripe.android.model.ConsumerSession
-import com.stripe.android.model.ConsumerSessionLookup
 import com.stripe.android.model.ConsumerShippingAddresses
 import com.stripe.android.model.EmailSource
 import com.stripe.android.model.LinkAccountSession
@@ -48,7 +47,8 @@ internal interface LinkAccountManager {
      *                   retrieval of displayable payment details.
      */
     suspend fun lookupConsumer(
-        email: String,
+        email: String?,
+        linkAuthIntentId: String?,
         startSession: Boolean = true,
         customerId: String?
     ): Result<LinkAccount?>
@@ -63,8 +63,9 @@ internal interface LinkAccountManager {
      *                   retrieval of displayable payment details.
      */
     suspend fun mobileLookupConsumer(
-        email: String,
-        emailSource: EmailSource,
+        email: String?,
+        emailSource: EmailSource?,
+        linkAuthIntentId: String?,
         verificationToken: String,
         appId: String,
         startSession: Boolean,
@@ -129,11 +130,6 @@ internal interface LinkAccountManager {
         allowRedisplay: String? = null,
     ): Result<SharePaymentDetails>
 
-    suspend fun setLinkAccountFromLookupResult(
-        lookup: ConsumerSessionLookup,
-        startSession: Boolean,
-    ): LinkAccount?
-
     suspend fun createLinkAccountSession(): Result<LinkAccountSession>
 
     /**
@@ -144,7 +140,12 @@ internal interface LinkAccountManager {
     /**
      * Confirms a verification code sent to the user.
      */
-    suspend fun confirmVerification(code: String): Result<LinkAccount>
+    suspend fun confirmVerification(code: String, consentGranted: Boolean?): Result<LinkAccount>
+
+    /**
+     * Update consent status for the current Link account.
+     */
+    suspend fun consentUpdate(consentGranted: Boolean): Result<Unit>
 
     /**
      * Fetch all saved payment methods for the signed in consumer.

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkModule.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.link.injection
 
+import com.stripe.android.link.LinkLaunchMode
 import com.stripe.android.link.account.DefaultLinkAccountManager
 import com.stripe.android.link.account.DefaultLinkAuth
 import com.stripe.android.link.account.LinkAccountManager
@@ -10,6 +11,7 @@ import com.stripe.android.link.gate.DefaultLinkGate
 import com.stripe.android.link.gate.LinkGate
 import dagger.Binds
 import dagger.Module
+import dagger.Provides
 
 @Module
 internal interface LinkModule {
@@ -28,4 +30,9 @@ internal interface LinkModule {
     @Binds
     @LinkScope
     fun bindsLinkAttestationCheck(linkAttestationCheck: DefaultLinkAttestationCheck): LinkAttestationCheck
+
+    companion object {
+        @Provides
+        fun provideLinkLaunchMode(): LinkLaunchMode? = null
+    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/model/ConsentPresentation.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/model/ConsentPresentation.kt
@@ -1,0 +1,21 @@
+package com.stripe.android.link.model
+
+import android.os.Parcelable
+import com.stripe.android.model.ConsentUi
+import kotlinx.parcelize.Parcelize
+
+internal sealed interface ConsentPresentation : Parcelable {
+    @Parcelize
+    data class Inline(
+        val consentSection: ConsentUi.ConsentSection
+    ) : ConsentPresentation
+
+    @Parcelize
+    data class FullScreen(
+        val consentPane: ConsentUi.ConsentPane
+    ) : ConsentPresentation
+}
+
+internal fun ConsentUi.toPresentation(): ConsentPresentation? =
+    consentPane?.let { ConsentPresentation.FullScreen(it) }
+        ?: consentSection?.let { ConsentPresentation.Inline(it) }

--- a/paymentsheet/src/main/java/com/stripe/android/link/model/LinkAccount.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/model/LinkAccount.kt
@@ -4,7 +4,6 @@ import android.os.Parcelable
 import com.stripe.android.model.ConsumerSession
 import com.stripe.android.model.DisplayablePaymentDetails
 import com.stripe.android.uicore.elements.convertPhoneNumberToE164
-import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 
@@ -12,11 +11,11 @@ import kotlinx.parcelize.Parcelize
  * Immutable object representing a Link account.
  */
 @Parcelize
-@Poko
 internal class LinkAccount(
     private val consumerSession: ConsumerSession,
     val consumerPublishableKey: String? = null,
     val displayablePaymentDetails: DisplayablePaymentDetails? = null,
+    val linkAuthIntentInfo: LinkAuthIntentInfo? = null,
 ) : Parcelable {
 
     @IgnoredOnParcel
@@ -46,6 +45,9 @@ internal class LinkAccount(
 
     @IgnoredOnParcel
     val completedSignup: Boolean = consumerSession.isVerifiedForSignup()
+
+    val consentPresentation: ConsentPresentation?
+        get() = linkAuthIntentInfo?.consentPresentation
 
     @IgnoredOnParcel
     val accountStatus = when {

--- a/paymentsheet/src/main/java/com/stripe/android/link/model/LinkAuthIntentInfo.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/model/LinkAuthIntentInfo.kt
@@ -1,0 +1,10 @@
+package com.stripe.android.link.model
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+internal data class LinkAuthIntentInfo(
+    val linkAuthIntentId: String,
+    val consentPresentation: ConsentPresentation?,
+) : Parcelable

--- a/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
@@ -31,7 +31,8 @@ internal interface LinkRepository {
      *                   retrieval of displayable payment details.
      */
     suspend fun lookupConsumer(
-        email: String,
+        email: String?,
+        linkAuthIntentId: String?,
         sessionId: String,
         customerId: String?
     ): Result<ConsumerSessionLookup>
@@ -53,8 +54,9 @@ internal interface LinkRepository {
      *                   retrieval of displayable payment details.
      */
     suspend fun mobileLookupConsumer(
-        email: String,
-        emailSource: EmailSource,
+        email: String?,
+        emailSource: EmailSource?,
+        linkAuthIntentId: String?,
         verificationToken: String,
         appId: String,
         sessionId: String,
@@ -142,7 +144,17 @@ internal interface LinkRepository {
         verificationCode: String,
         consumerSessionClientSecret: String,
         consumerPublishableKey: String?,
+        consentGranted: Boolean?,
     ): Result<ConsumerSession>
+
+    /**
+     * Update consent status for the signed in consumer.
+     */
+    suspend fun consentUpdate(
+        consumerSessionClientSecret: String,
+        consentGranted: Boolean,
+        consumerPublishableKey: String?
+    ): Result<Unit>
 
     /**
      * Fetch all saved payment methods for the signed in consumer.

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/inline/InlineSignupViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/inline/InlineSignupViewModel.kt
@@ -269,6 +269,7 @@ internal class InlineSignupViewModel(
         clearError()
         linkAccountManager.lookupConsumer(
             email = email,
+            linkAuthIntentId = null,
             startSession = false,
             customerId = null
         ).fold(

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/verification/VerificationViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/verification/VerificationViewModel.kt
@@ -85,7 +85,10 @@ internal class VerificationViewModel @Inject constructor(
             )
         }
 
-        linkAccountManager.confirmVerification(code).fold(
+        linkAccountManager.confirmVerification(
+            code = code,
+            consentGranted = null
+        ).fold(
             onSuccess = { account ->
                 updateViewState { it.copy(isProcessing = false) }
                 // Handle Authentication mode logic in ViewModel

--- a/paymentsheet/src/main/java/com/stripe/android/link/verification/DefaultLinkInlineInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/verification/DefaultLinkInlineInteractor.kt
@@ -89,7 +89,10 @@ internal class DefaultLinkInlineInteractor @Inject constructor(
                         )
                     }
                     // confirm verification
-                    val result: Result<LinkAccount> = linkAccountManager.confirmVerification(code)
+                    val result: Result<LinkAccount> = linkAccountManager.confirmVerification(
+                        code = code,
+                        consentGranted = null
+                    )
                     onConfirmationResult(verificationState, result)
                 }
             }

--- a/paymentsheet/src/test/java/com/stripe/android/link/FakeConsumersApiService.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/FakeConsumersApiService.kt
@@ -56,7 +56,8 @@ internal open class FakeConsumersApiService : ConsumersApiService {
     }
 
     override suspend fun lookupConsumerSession(
-        email: String,
+        email: String?,
+        linkAuthIntentId: String?,
         requestSurface: String,
         sessionId: String,
         doNotLogConsumerFunnelEvent: Boolean,
@@ -66,6 +67,7 @@ internal open class FakeConsumersApiService : ConsumersApiService {
         lookupCalls.add(
             LookupCall(
                 email = email,
+                linkAuthIntentId = linkAuthIntentId,
                 requestOptions = requestOptions,
                 requestSurface = requestSurface,
                 sessionId = sessionId,
@@ -75,8 +77,9 @@ internal open class FakeConsumersApiService : ConsumersApiService {
     }
 
     override suspend fun mobileLookupConsumerSession(
-        email: String,
-        emailSource: EmailSource,
+        email: String?,
+        emailSource: EmailSource?,
+        linkAuthIntentId: String?,
         requestSurface: String,
         verificationToken: String,
         appId: String,
@@ -88,6 +91,7 @@ internal open class FakeConsumersApiService : ConsumersApiService {
             MobileLookupCall(
                 email = email,
                 emailSource = emailSource,
+                linkAuthIntentId = linkAuthIntentId,
                 requestOptions = requestOptions,
                 verificationToken = verificationToken,
                 appId = appId,
@@ -115,8 +119,18 @@ internal open class FakeConsumersApiService : ConsumersApiService {
         verificationCode: String,
         requestSurface: String,
         type: VerificationType,
+        consentGranted: Boolean?,
         requestOptions: ApiRequest.Options
     ): ConsumerSession {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun consentUpdate(
+        consumerSessionClientSecret: String,
+        consentGranted: Boolean,
+        requestSurface: String,
+        requestOptions: ApiRequest.Options
+    ): Result<Unit> {
         TODO("Not yet implemented")
     }
 
@@ -171,15 +185,17 @@ internal open class FakeConsumersApiService : ConsumersApiService {
     }
 
     data class LookupCall(
-        val email: String,
+        val email: String?,
+        val linkAuthIntentId: String?,
         val requestSurface: String,
         val sessionId: String,
         val requestOptions: ApiRequest.Options
     )
 
     data class MobileLookupCall(
-        val email: String,
-        val emailSource: EmailSource,
+        val email: String?,
+        val emailSource: EmailSource?,
+        val linkAuthIntentId: String?,
         val requestSurface: String,
         val verificationToken: String,
         val appId: String,

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAccountManagerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAccountManagerTest.kt
@@ -12,11 +12,14 @@ import com.stripe.android.link.TestFactory
 import com.stripe.android.link.analytics.FakeLinkEventsReporter
 import com.stripe.android.link.analytics.LinkEventsReporter
 import com.stripe.android.link.model.AccountStatus
+import com.stripe.android.link.model.ConsentPresentation
 import com.stripe.android.link.model.LinkAccount
+import com.stripe.android.link.model.LinkAuthIntentInfo
 import com.stripe.android.link.repositories.FakeLinkRepository
 import com.stripe.android.link.repositories.LinkRepository
 import com.stripe.android.link.ui.inline.SignUpConsentAction
 import com.stripe.android.link.ui.inline.UserInput
+import com.stripe.android.model.ConsentUi
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.ConsumerPaymentDetailsUpdateParams
 import com.stripe.android.model.ConsumerSession
@@ -1055,6 +1058,30 @@ class DefaultLinkAccountManagerTest {
         val result = accountManager.createLinkAccountSession()
 
         assertThat(result.exceptionOrNull()).isEqualTo(error)
+    }
+
+    @Test
+    fun `setLinkAccountFromLookupResult creates LinkAccount with LinkAuthIntentInfo`() = runSuspendTest {
+        val accountManager = accountManager()
+        val consentSection = ConsentUi.ConsentSection("disclaimer")
+        val lookup = TestFactory.CONSUMER_SESSION_LOOKUP.copy(
+            consentUi = ConsentUi(
+                consentPane = null,
+                consentSection = consentSection,
+            )
+        )
+        val linkAuthIntentId = "lai_123"
+        val account = accountManager.setLinkAccountFromLookupResult(
+            lookup = lookup,
+            startSession = true,
+            linkAuthIntentId = linkAuthIntentId,
+        )
+        assertThat(account?.linkAuthIntentInfo).isEqualTo(
+            LinkAuthIntentInfo(
+                linkAuthIntentId = linkAuthIntentId,
+                consentPresentation = ConsentPresentation.Inline(consentSection)
+            )
+        )
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/FakeLinkAccountManager.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/FakeLinkAccountManager.kt
@@ -15,7 +15,6 @@ import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.ConsumerPaymentDetailsUpdateParams
 import com.stripe.android.model.ConsumerSession
-import com.stripe.android.model.ConsumerSessionLookup
 import com.stripe.android.model.ConsumerShippingAddresses
 import com.stripe.android.model.EmailSource
 import com.stripe.android.model.LinkAccountSession
@@ -51,6 +50,7 @@ internal open class FakeLinkAccountManager(
     var mobileLookupConsumerResult: Result<LinkAccount?> = Result.success(TestFactory.LINK_ACCOUNT)
     var startVerificationResult: Result<LinkAccount> = Result.success(TestFactory.LINK_ACCOUNT)
     var confirmVerificationResult: Result<LinkAccount> = Result.success(TestFactory.LINK_ACCOUNT)
+    var consentUpdateResult: Result<Unit> = Result.success(Unit)
     var signUpResult: Result<LinkAccount> = Result.success(TestFactory.LINK_ACCOUNT)
     var mobileSignUpResult: Result<LinkAccount> = Result.success(TestFactory.LINK_ACCOUNT)
     var signInWithUserInputResult: Result<LinkAccount> = Result.success(TestFactory.LINK_ACCOUNT)
@@ -73,7 +73,6 @@ internal open class FakeLinkAccountManager(
     var sharePaymentDetails: Result<SharePaymentDetails> = Result.success(TestFactory.LINK_SHARE_PAYMENT_DETAILS)
     var updatePaymentDetailsResult = Result.success(TestFactory.CONSUMER_PAYMENT_DETAILS)
     var deletePaymentDetailsResult: Result<Unit> = Result.success(Unit)
-    var linkAccountFromLookupResult: LinkAccount? = null
     var listPaymentDetailsResult: Result<ConsumerPaymentDetails> = Result.success(TestFactory.CONSUMER_PAYMENT_DETAILS)
         set(value) {
             field = value
@@ -114,13 +113,15 @@ internal open class FakeLinkAccountManager(
     }
 
     override suspend fun lookupConsumer(
-        email: String,
+        email: String?,
+        linkAuthIntentId: String?,
         startSession: Boolean,
         customerId: String?
     ): Result<LinkAccount?> {
         lookupTurbine.add(
             item = LookupCall(
                 email = email,
+                linkAuthIntentId = linkAuthIntentId,
                 startSession = startSession
             )
         )
@@ -128,8 +129,9 @@ internal open class FakeLinkAccountManager(
     }
 
     override suspend fun mobileLookupConsumer(
-        email: String,
-        emailSource: EmailSource,
+        email: String?,
+        emailSource: EmailSource?,
+        linkAuthIntentId: String?,
         verificationToken: String,
         appId: String,
         startSession: Boolean,
@@ -139,6 +141,7 @@ internal open class FakeLinkAccountManager(
             item = MobileLookupCall(
                 email = email,
                 emailSource = emailSource,
+                linkAuthIntentId = linkAuthIntentId,
                 verificationToken = verificationToken,
                 appId = appId,
                 startSession = startSession
@@ -227,13 +230,6 @@ internal open class FakeLinkAccountManager(
         return sharePaymentDetails
     }
 
-    override suspend fun setLinkAccountFromLookupResult(
-        lookup: ConsumerSessionLookup,
-        startSession: Boolean,
-    ): LinkAccount? {
-        return linkAccountFromLookupResult
-    }
-
     override suspend fun createLinkAccountSession(): Result<LinkAccountSession> {
         yield()
         return createLinkAccountSessionResult
@@ -250,9 +246,13 @@ internal open class FakeLinkAccountManager(
         return startVerificationResult
     }
 
-    override suspend fun confirmVerification(code: String): Result<LinkAccount> {
+    override suspend fun confirmVerification(code: String, consentGranted: Boolean?): Result<LinkAccount> {
         confirmVerificationTurbine.add(code)
         return confirmVerificationResult
+    }
+
+    override suspend fun consentUpdate(consentGranted: Boolean): Result<Unit> {
+        return consentUpdateResult
     }
 
     override suspend fun listPaymentDetails(paymentMethodTypes: Set<String>): Result<ConsumerPaymentDetails> {
@@ -324,13 +324,15 @@ internal open class FakeLinkAccountManager(
         }
 
     data class LookupCall(
-        val email: String,
+        val email: String?,
+        val linkAuthIntentId: String?,
         val startSession: Boolean
     )
 
     data class MobileLookupCall(
-        val email: String,
-        val emailSource: EmailSource,
+        val email: String?,
+        val emailSource: EmailSource?,
+        val linkAuthIntentId: String?,
         val verificationToken: String,
         val appId: String,
         val startSession: Boolean

--- a/paymentsheet/src/test/java/com/stripe/android/link/repositories/FakeLinkRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/repositories/FakeLinkRepository.kt
@@ -6,6 +6,7 @@ import com.stripe.android.link.LinkPaymentMethod
 import com.stripe.android.link.TestFactory
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.ConsumerPaymentDetailsUpdateParams
+import com.stripe.android.model.ConsumerSession
 import com.stripe.android.model.ConsumerSessionLookup
 import com.stripe.android.model.ConsumerSessionSignup
 import com.stripe.android.model.ConsumerShippingAddresses
@@ -33,6 +34,7 @@ internal open class FakeLinkRepository : LinkRepository {
     var logOutResult = Result.success(TestFactory.CONSUMER_SESSION)
     var startVerificationResult = Result.success(TestFactory.CONSUMER_SESSION)
     var confirmVerificationResult = Result.success(TestFactory.CONSUMER_SESSION)
+    var consentUpdateResult = Result.success(Unit)
     var listPaymentDetailsResult = Result.success(TestFactory.CONSUMER_PAYMENT_DETAILS)
     var listShippingAddressesResult = Result.success(TestFactory.CONSUMER_SHIPPING_ADDRESSES)
     var updatePaymentDetailsResult = Result.success(TestFactory.CONSUMER_PAYMENT_DETAILS)
@@ -44,13 +46,15 @@ internal open class FakeLinkRepository : LinkRepository {
     private val mobileSignUpCalls = Turbine<MobileSignUpCall>()
 
     override suspend fun lookupConsumer(
-        email: String,
+        email: String?,
+        linkAuthIntentId: String?,
         sessionId: String,
         customerId: String?
     ): Result<ConsumerSessionLookup> {
         lookupConsumerCalls.add(
             item = LookupCall(
-                email = email
+                email = email,
+                linkAuthIntentId = linkAuthIntentId,
             )
         )
         return lookupConsumerResult
@@ -62,15 +66,17 @@ internal open class FakeLinkRepository : LinkRepository {
     ): Result<ConsumerSessionLookup> {
         lookupConsumerWithoutBackendLoggingCalls.add(
             item = LookupCall(
-                email = email
+                email = email,
+                linkAuthIntentId = null
             )
         )
         return lookupConsumerWithoutBackendLoggingResult
     }
 
     override suspend fun mobileLookupConsumer(
-        email: String,
-        emailSource: EmailSource,
+        email: String?,
+        emailSource: EmailSource?,
+        linkAuthIntentId: String?,
         verificationToken: String,
         appId: String,
         sessionId: String,
@@ -80,6 +86,7 @@ internal open class FakeLinkRepository : LinkRepository {
             item = MobileLookupCall(
                 email = email,
                 emailSource = emailSource,
+                linkAuthIntentId = linkAuthIntentId,
                 verificationToken = verificationToken,
                 appId = appId,
                 sessionId = sessionId
@@ -172,8 +179,15 @@ internal open class FakeLinkRepository : LinkRepository {
     override suspend fun confirmVerification(
         verificationCode: String,
         consumerSessionClientSecret: String,
+        consumerPublishableKey: String?,
+        consentGranted: Boolean?
+    ): Result<ConsumerSession> = confirmVerificationResult
+
+    override suspend fun consentUpdate(
+        consumerSessionClientSecret: String,
+        consentGranted: Boolean,
         consumerPublishableKey: String?
-    ) = confirmVerificationResult
+    ): Result<Unit> = consentUpdateResult
 
     override suspend fun listPaymentDetails(
         paymentMethodTypes: Set<String>,
@@ -227,12 +241,14 @@ internal open class FakeLinkRepository : LinkRepository {
     }
 
     data class LookupCall(
-        val email: String
+        val email: String?,
+        val linkAuthIntentId: String?,
     )
 
     data class MobileLookupCall(
-        val email: String,
-        val emailSource: EmailSource,
+        val email: String?,
+        val emailSource: EmailSource?,
+        val linkAuthIntentId: String?,
         val verificationToken: String,
         val appId: String,
         val sessionId: String

--- a/paymentsheet/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
@@ -69,6 +69,7 @@ class LinkApiRepositoryTest {
 
         val result = linkRepository.lookupConsumer(
             email = TestFactory.EMAIL,
+            linkAuthIntentId = null,
             sessionId = SESSION_ID,
             customerId = null,
         )
@@ -88,7 +89,8 @@ class LinkApiRepositoryTest {
         val error = RuntimeException("error")
         val consumersApiService = object : FakeConsumersApiService() {
             override suspend fun lookupConsumerSession(
-                email: String,
+                email: String?,
+                linkAuthIntentId: String?,
                 requestSurface: String,
                 sessionId: String,
                 doNotLogConsumerFunnelEvent: Boolean,
@@ -100,7 +102,12 @@ class LinkApiRepositoryTest {
         }
         val linkRepository = linkRepository(consumersApiService)
 
-        val result = linkRepository.lookupConsumer("email", sessionId = SESSION_ID, customerId = null)
+        val result = linkRepository.lookupConsumer(
+            email = "email",
+            linkAuthIntentId = null,
+            sessionId = SESSION_ID,
+            customerId = null
+        )
 
         assertThat(result).isEqualTo(Result.failure<ConsumerSessionLookup>(error))
     }
@@ -112,6 +119,7 @@ class LinkApiRepositoryTest {
 
         val result = linkRepository.mobileLookupConsumer(
             email = TestFactory.EMAIL,
+            linkAuthIntentId = null,
             verificationToken = TestFactory.VERIFICATION_TOKEN,
             appId = TestFactory.APP_ID,
             sessionId = TestFactory.SESSION_ID,
@@ -137,8 +145,9 @@ class LinkApiRepositoryTest {
         val error = RuntimeException("error")
         val consumersApiService = object : FakeConsumersApiService() {
             override suspend fun mobileLookupConsumerSession(
-                email: String,
-                emailSource: EmailSource,
+                email: String?,
+                emailSource: EmailSource?,
+                linkAuthIntentId: String?,
                 requestSurface: String,
                 verificationToken: String,
                 appId: String,
@@ -153,6 +162,7 @@ class LinkApiRepositoryTest {
 
         val result = linkRepository.mobileLookupConsumer(
             email = TestFactory.EMAIL,
+            linkAuthIntentId = null,
             verificationToken = TestFactory.VERIFICATION_TOKEN,
             appId = TestFactory.APP_ID,
             sessionId = TestFactory.SESSION_ID,

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/inline/InlineSignupViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/inline/InlineSignupViewModelTest.kt
@@ -42,12 +42,18 @@ class InlineSignupViewModelTest {
                 var counter = 0
 
                 override suspend fun lookupConsumer(
-                    email: String,
+                    email: String?,
+                    linkAuthIntentId: String?,
                     startSession: Boolean,
                     customerId: String?
                 ): Result<LinkAccount?> {
                     counter += 1
-                    return super.lookupConsumer(email, startSession, customerId)
+                    return super.lookupConsumer(
+                        email = email,
+                        linkAuthIntentId = linkAuthIntentId,
+                        startSession = startSession,
+                        customerId = customerId
+                    )
                 }
             }
             val viewModel = InlineSignupViewModel(

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/verification/VerificationScreenTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/verification/VerificationScreenTest.kt
@@ -154,9 +154,9 @@ internal class VerificationScreenTest {
     @Test
     fun `title, email, otp should be displayed when verification is in process`() = runTest(dispatcher) {
         val linkAccountManager = object : FakeLinkAccountManager() {
-            override suspend fun confirmVerification(code: String): Result<LinkAccount> {
+            override suspend fun confirmVerification(code: String, consentGranted: Boolean?): Result<LinkAccount> {
                 delay(5500)
-                return super.confirmVerification(code)
+                return super.confirmVerification(code, consentGranted)
             }
         }
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/verification/VerificationViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/verification/VerificationViewModelTest.kt
@@ -97,7 +97,7 @@ internal class VerificationViewModelTest {
         }
         val linkAccountManager = object : FakeLinkAccountManager() {
             var codeUsed: String? = null
-            override suspend fun confirmVerification(code: String): Result<LinkAccount> {
+            override suspend fun confirmVerification(code: String, consentGranted: Boolean?): Result<LinkAccount> {
                 codeUsed = code
                 return Result.failure(RuntimeException("Error"))
             }


### PR DESCRIPTION
# Summary
Add data layer for LAI APIs. No existing requests are changed, and no new requests are being made yet. UX and wiring to follow.

Changes:
* Add optional `link_auth_intent_id` param to `/lookup` as an alternative to `email` + `email_source`
* Add optional `consent_granted` param to `/confirm_verification`
* Add optional `consent_ui` field parsing from `/lookup` response
* Add method to make `POST /consent_update consent_granted=true|false` request

# Motivation
👻 

# Testing
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified
