### PR TITLE
Show polling screen when attempting to confirm PayNow

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -6270,6 +6270,14 @@ public final class com/stripe/android/model/StripeIntent$NextActionData$DisplayO
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/model/StripeIntent$NextActionData$DisplayPayNowDetails$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/StripeIntent$NextActionData$DisplayPayNowDetails;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/StripeIntent$NextActionData$DisplayPayNowDetails;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/model/StripeIntent$NextActionData$RedirectToUrl : com/stripe/android/model/StripeIntent$NextActionData {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
@@ -6469,6 +6477,7 @@ public final class com/stripe/android/model/StripeIntent$NextActionType : java/l
 	public static final field DisplayKonbiniDetails Lcom/stripe/android/model/StripeIntent$NextActionType;
 	public static final field DisplayMultibancoDetails Lcom/stripe/android/model/StripeIntent$NextActionType;
 	public static final field DisplayOxxoDetails Lcom/stripe/android/model/StripeIntent$NextActionType;
+	public static final field DisplayPayNowDetails Lcom/stripe/android/model/StripeIntent$NextActionType;
 	public static final field RedirectToUrl Lcom/stripe/android/model/StripeIntent$NextActionType;
 	public static final field SwishRedirect Lcom/stripe/android/model/StripeIntent$NextActionType;
 	public static final field UpiAwaitNotification Lcom/stripe/android/model/StripeIntent$NextActionType;

--- a/payments-core/src/main/java/com/stripe/android/StripeIntentResult.kt
+++ b/payments-core/src/main/java/com/stripe/android/StripeIntentResult.kt
@@ -82,6 +82,7 @@ abstract class StripeIntentResult<out T : StripeIntent> internal constructor(
             StripeIntent.NextActionType.WeChatPayRedirect,
             StripeIntent.NextActionType.CashAppRedirect,
             StripeIntent.NextActionType.SwishRedirect,
+            StripeIntent.NextActionType.DisplayPayNowDetails,
             null -> {
                 false
             }

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentIntent.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentIntent.kt
@@ -180,6 +180,9 @@ constructor(
             is StripeIntent.NextActionData.DisplayMultibancoDetails -> {
                 StripeIntent.NextActionType.DisplayMultibancoDetails
             }
+            is StripeIntent.NextActionData.DisplayPayNowDetails -> {
+                StripeIntent.NextActionType.DisplayPayNowDetails
+            }
             is StripeIntent.NextActionData.VerifyWithMicrodeposits -> {
                 StripeIntent.NextActionType.VerifyWithMicrodeposits
             }

--- a/payments-core/src/main/java/com/stripe/android/model/SetupIntent.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/SetupIntent.kt
@@ -147,6 +147,7 @@ constructor(
             is StripeIntent.NextActionData.WeChatPayRedirect,
             is StripeIntent.NextActionData.UpiAwaitNotification,
             is StripeIntent.NextActionData.SwishRedirect,
+            is StripeIntent.NextActionData.DisplayPayNowDetails,
             null -> {
                 null
             }

--- a/payments-core/src/main/java/com/stripe/android/model/StripeIntent.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/StripeIntent.kt
@@ -99,6 +99,7 @@ sealed interface StripeIntent : StripeModel {
         DisplayBoletoDetails("boleto_display_details"),
         DisplayKonbiniDetails("konbini_display_details"),
         DisplayMultibancoDetails("multibanco_display_details"),
+        DisplayPayNowDetails("paynow_display_qr_code"),
         SwishRedirect("swish_handle_redirect_or_display_qr_code");
 
         @Keep
@@ -222,6 +223,15 @@ sealed interface StripeIntent : StripeModel {
              */
             override val hostedVoucherUrl: String? = null,
         ) : NextActionData(), DisplayVoucherDetails
+
+        @Parcelize
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        data class DisplayPayNowDetails(
+            /**
+             * URL of a webpage containing the QR code for this payment.
+             */
+            val qrCodeUrl: String? = null,
+        ) : NextActionData()
 
         /**
          * Contains instructions for authenticating by redirecting your customer to another

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/NextActionDataParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/NextActionDataParser.kt
@@ -21,6 +21,7 @@ internal class NextActionDataParser : ModelJsonParser<StripeIntent.NextActionDat
             StripeIntent.NextActionType.DisplayBoletoDetails -> DisplayBoletoDetailsJsonParser()
             StripeIntent.NextActionType.DisplayKonbiniDetails -> DisplayKonbiniDetailsJsonParser()
             StripeIntent.NextActionType.DisplayMultibancoDetails -> DisplayMultibancoDetailsJsonParser()
+            StripeIntent.NextActionType.DisplayPayNowDetails -> DisplayPayNowDetailsJsonParser()
             StripeIntent.NextActionType.RedirectToUrl -> RedirectToUrlParser()
             StripeIntent.NextActionType.UseStripeSdk -> SdkDataJsonParser()
             StripeIntent.NextActionType.AlipayRedirect -> AlipayRedirectParser()
@@ -96,6 +97,21 @@ internal class NextActionDataParser : ModelJsonParser<StripeIntent.NextActionDat
 
         private companion object {
             private const val FIELD_HOSTED_VOUCHER_URL = "hosted_voucher_url"
+        }
+    }
+
+    private class DisplayPayNowDetailsJsonParser :
+        ModelJsonParser<StripeIntent.NextActionData.DisplayPayNowDetails> {
+        override fun parse(
+            json: JSONObject
+        ): StripeIntent.NextActionData.DisplayPayNowDetails {
+            return StripeIntent.NextActionData.DisplayPayNowDetails(
+                qrCodeUrl = optString(json, FIELD_HOSTED_INSTRUCTIONS_URL)
+            )
+        }
+
+        private companion object {
+            private const val FIELD_HOSTED_INSTRUCTIONS_URL = "hosted_instructions_url"
         }
     }
 

--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -206,6 +206,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_total_amount">Total: %s</string>
   <!-- Error message displayed when updating card brand fails. -->
   <string name="stripe_paymentsheet_update_card_brand_failed_error_message">Card brand was not updated. Please try again.</string>
+  <!-- Text for alert message when user needs to confirm payment in their PayNow app -->
+  <string name="stripe_paynow_confirm_payment">Confirm the payment in your bank or payment app within %s to complete the purchase.</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->
   <string name="stripe_pm_set_as_default">Set as default payment method</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
@@ -268,6 +270,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_view_more">View more</string>
   <!-- Mandate text displayed when paying via Link instant debit. -->
   <string name="stripe_wallet_bank_account_terms"><![CDATA[By continuing, you agree to authorize payments pursuant to these <terms>terms</terms>.]]></string>
+  <!-- Text providing link to terms for bank payments -->
+  <string name="stripe_wallet_bank_account_terms_seller"><![CDATA[By submitting your order to %s you agree to authorize payments pursuant to <terms>these terms</terms>.]]></string>
   <!-- Label for a section displaying payment details. -->
   <string name="stripe_wallet_collapsed_payment">Payment</string>
   <!-- Label of a button that when tapped allows the user to select a different form of payment. -->
@@ -283,6 +287,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_wallet_passthrough_description">Passthrough</string>
   <!-- Label of a button that when tapped allows the user to select a different form of payment. -->
   <string name="stripe_wallet_pay_another_way">Pay another way</string>
+  <!-- Hint shown when selecting a payment method indicating debit cards are preferred. -->
+  <string name="stripe_wallet_prefer_debit_card_hint">Debit cards are most likely to be accepted.</string>
   <!-- A text notice shown when the user selects a card that requires re-entering the security code (CVV/CVC). -->
   <string name="stripe_wallet_recollect_cvc_error">For security, please re-enter your card’s security code.</string>
   <!-- Title of confirmation prompt when removing a linked bank account. -->

--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -270,8 +270,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_view_more">View more</string>
   <!-- Mandate text displayed when paying via Link instant debit. -->
   <string name="stripe_wallet_bank_account_terms"><![CDATA[By continuing, you agree to authorize payments pursuant to these <terms>terms</terms>.]]></string>
-  <!-- Text providing link to terms for bank payments -->
-  <string name="stripe_wallet_bank_account_terms_seller"><![CDATA[By submitting your order to %s you agree to authorize payments pursuant to <terms>these terms</terms>.]]></string>
   <!-- Label for a section displaying payment details. -->
   <string name="stripe_wallet_collapsed_payment">Payment</string>
   <!-- Label of a button that when tapped allows the user to select a different form of payment. -->
@@ -287,8 +285,6 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_wallet_passthrough_description">Passthrough</string>
   <!-- Label of a button that when tapped allows the user to select a different form of payment. -->
   <string name="stripe_wallet_pay_another_way">Pay another way</string>
-  <!-- Hint shown when selecting a payment method indicating debit cards are preferred. -->
-  <string name="stripe_wallet_prefer_debit_card_hint">Debit cards are most likely to be accepted.</string>
   <!-- A text notice shown when the user selects a card that requires re-entering the security code (CVV/CVC). -->
   <string name="stripe_wallet_recollect_cvc_error">For security, please re-enter your card’s security code.</string>
   <!-- Title of confirmation prompt when removing a linked bank account. -->

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetNextActionHandlers.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetNextActionHandlers.kt
@@ -14,6 +14,7 @@ object PaymentSheetNextActionHandlers {
         return mapOf(
             StripeIntent.NextActionData.UpiAwaitNotification::class.java to PollingNextActionHandler(),
             StripeIntent.NextActionData.BlikAuthorize::class.java to PollingNextActionHandler(),
+            StripeIntent.NextActionData.DisplayPayNowDetails::class.java to PollingNextActionHandler(),
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingNextActionHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingNextActionHandler.kt
@@ -20,6 +20,9 @@ private const val UPI_MAX_ATTEMPTS = 12
 private const val BLIK_TIME_LIMIT_IN_SECONDS = 60
 private const val BLIK_INITIAL_DELAY_IN_SECONDS = 5
 private const val BLIK_MAX_ATTEMPTS = 12
+private const val PAYNOW_TIME_LIMIT_IN_SECONDS = 60 * 60
+private const val PAYNOW_INITIAL_DELAY_IN_SECONDS = 5
+private const val PAYNOW_MAX_ATTEMPTS = 12
 
 internal class PollingNextActionHandler : PaymentNextActionHandler<StripeIntent>() {
 
@@ -49,6 +52,16 @@ internal class PollingNextActionHandler : PaymentNextActionHandler<StripeIntent>
                     initialDelayInSeconds = BLIK_INITIAL_DELAY_IN_SECONDS,
                     maxAttempts = BLIK_MAX_ATTEMPTS,
                     ctaText = R.string.stripe_blik_confirm_payment,
+                    stripeAccountId = requestOptions.stripeAccount,
+                )
+            PaymentMethod.Type.PayNow ->
+                PollingContract.Args(
+                    clientSecret = requireNotNull(actionable.clientSecret),
+                    statusBarColor = host.statusBarColor,
+                    timeLimitInSeconds = PAYNOW_TIME_LIMIT_IN_SECONDS,
+                    initialDelayInSeconds = PAYNOW_INITIAL_DELAY_IN_SECONDS,
+                    maxAttempts = PAYNOW_MAX_ATTEMPTS,
+                    ctaText = R.string.stripe_paynow_confirm_payment,
                     stripeAccountId = requestOptions.stripeAccount,
                 )
             else ->


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Show polling screen when attempting to confirm PayNow

Follow up PRs will show the QR code and adjust our polling timing to work well for PayNow.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-1381

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screen recording

https://github.com/user-attachments/assets/71719e32-0f07-406c-90eb-9615f53c63a0

