### PR TITLE
Format and compare addresses properly in `AddressElement` when using `Same as billing` checkbox

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementUtils.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementUtils.kt
@@ -1,0 +1,17 @@
+package com.stripe.android.paymentsheet.addresselement
+
+import com.stripe.android.uicore.elements.AddressFieldConfiguration
+
+internal fun parsePhoneNumberConfig(
+    configuration: AddressLauncher.AdditionalFieldsConfiguration.FieldConfiguration?
+): AddressFieldConfiguration {
+    return when (configuration) {
+        AddressLauncher.AdditionalFieldsConfiguration.FieldConfiguration.HIDDEN ->
+            AddressFieldConfiguration.HIDDEN
+        AddressLauncher.AdditionalFieldsConfiguration.FieldConfiguration.OPTIONAL ->
+            AddressFieldConfiguration.OPTIONAL
+        AddressLauncher.AdditionalFieldsConfiguration.FieldConfiguration.REQUIRED ->
+            AddressFieldConfiguration.REQUIRED
+        null -> AddressFieldConfiguration.OPTIONAL
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressFormController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressFormController.kt
@@ -46,18 +46,4 @@ internal class AddressFormController(
             it.second.isComplete
         }
         .toMap()
-
-    private fun parsePhoneNumberConfig(
-        configuration: AddressLauncher.AdditionalFieldsConfiguration.FieldConfiguration?
-    ): AddressFieldConfiguration {
-        return when (configuration) {
-            AddressLauncher.AdditionalFieldsConfiguration.FieldConfiguration.HIDDEN ->
-                AddressFieldConfiguration.HIDDEN
-            AddressLauncher.AdditionalFieldsConfiguration.FieldConfiguration.OPTIONAL ->
-                AddressFieldConfiguration.OPTIONAL
-            AddressLauncher.AdditionalFieldsConfiguration.FieldConfiguration.REQUIRED ->
-                AddressFieldConfiguration.REQUIRED
-            null -> AddressFieldConfiguration.OPTIONAL
-        }
-    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressFormatParser.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressFormatParser.kt
@@ -1,0 +1,37 @@
+package com.stripe.android.paymentsheet.addresselement
+
+import com.stripe.android.core.model.CountryUtils
+import com.stripe.android.uicore.elements.AddressElement
+import com.stripe.android.uicore.elements.AddressFieldConfiguration
+import com.stripe.android.uicore.elements.AddressInputMode
+import com.stripe.android.uicore.elements.IdentifierSpec
+
+internal class AddressFormatParser(
+    private val config: AddressLauncher.Configuration?
+) {
+    fun parse(
+        values: AddressDetails,
+    ): Map<IdentifierSpec, String?> {
+        val addressElement = createAddressElement(values)
+
+        return addressElement.getFormFieldValueFlow().value.toMap().mapValues {
+            it.value.value
+        }
+    }
+
+    private fun createAddressElement(
+        values: AddressDetails,
+    ): AddressElement {
+        return AddressElement(
+            _identifier = IdentifierSpec.Generic("address"),
+            rawValuesMap = values.toIdentifierMap(),
+            countryCodes = config?.allowedCountries ?: CountryUtils.supportedBillingCountries,
+            addressInputMode = AddressInputMode.NoAutocomplete(
+                nameConfig = AddressFieldConfiguration.REQUIRED,
+                phoneNumberConfig = parsePhoneNumberConfig(config?.additionalFields?.phone),
+            ),
+            sameAsShippingElement = null,
+            shippingValuesMap = emptyMap()
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
@@ -780,6 +780,55 @@ class InputAddressViewModelTest {
             .build()
     )
 
+    @OptIn(AddressElementSameAsBillingPreview::class)
+    @Test
+    fun `Billing same as shipping box is checked even if initial inputs have slightly different formatting`() =
+        runTest {
+            val viewModel = createViewModel(
+                config = AddressLauncher.Configuration.Builder()
+                    .allowedCountries(setOf("US"))
+                    .address(
+                        AddressDetails(
+                            name = "John Doe",
+                            address = PaymentSheet.Address(
+                                line1 = "123 Apple Street",
+                                line2 = "",
+                                city = "San Francisco",
+                                country = "US",
+                                state = "CA",
+                                postalCode = "99999 "
+                            ),
+                            phoneNumber = "+12347682350"
+                        )
+                    )
+                    .billingAddress(
+                        PaymentSheet.BillingDetails(
+                            name = "John Doe",
+                            address = PaymentSheet.Address(
+                                line1 = "123 Apple Street",
+                                line2 = null,
+                                city = "San Francisco",
+                                country = "US",
+                                state = "CA",
+                                postalCode = "99999"
+                            ),
+                            phone = "(234) 768-2350"
+                        )
+                    )
+                    .additionalFields(
+                        AddressLauncher.AdditionalFieldsConfiguration(
+                            phone = AddressLauncher.AdditionalFieldsConfiguration.FieldConfiguration.REQUIRED,
+                        )
+                    )
+                    .build()
+            )
+
+            viewModel.shippingSameAsBillingState.test {
+                // Should be checked
+                assertThat(awaitItem()).isEqualTo(createShowState(isChecked = true))
+            }
+        }
+
     private fun doesNotUseAddressTest(
         config: AddressLauncher.Configuration,
     ) = runTest {


### PR DESCRIPTION
# Summary
Format and compare addresses properly in `AddressElement` when using `Same as billing` checkbox

# Motivation
Fixes an issue for a merchant where addresses provided are effectively the same despite being formatted slightly differently.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified