### PR TITLE
Add the card brand filter functionality into the GooglePayLauncher

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncher.kt
@@ -260,7 +260,7 @@ class GooglePayLauncher internal constructor(
          *
          * Default: The credit card class is supported for the card networks specified.
          */
-        var allowCreditCards: Boolean = true
+        var allowCreditCards: Boolean = true,
 
         /**
          * Allows to select the acceptable card brands

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncher.kt
@@ -132,7 +132,8 @@ class GooglePayLauncher internal constructor(
                 errorReporter = ErrorReporter.createFallbackInstance(
                     context = context,
                     productUsage = setOf(PRODUCT_USAGE)
-                )
+                ),
+                cardBrandFilter = config.cardBrandFilter
             )
         },
         paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncher.kt
@@ -12,6 +12,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.lifecycleScope
+import com.stripe.android.CardBrandFilter
+import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.networking.DefaultAnalyticsRequestExecutor
@@ -82,7 +84,8 @@ class GooglePayLauncher internal constructor(
                 errorReporter = ErrorReporter.createFallbackInstance(
                     context = context,
                     productUsage = setOf(PRODUCT_USAGE),
-                )
+                ),
+                cardBrandFilter = config.cardBrandFilter
             )
         },
         PaymentAnalyticsRequestFactory(
@@ -258,6 +261,12 @@ class GooglePayLauncher internal constructor(
          * Default: The credit card class is supported for the card networks specified.
          */
         var allowCreditCards: Boolean = true
+
+        /**
+         * Allows to select the acceptable card brands
+         * Default: Accepts all brands
+         */
+        var cardBrandFilter: CardBrandFilter = DefaultCardBrandFilter
     ) : Parcelable {
 
         internal val isJcbEnabled: Boolean

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModel.kt
@@ -308,7 +308,8 @@ internal class GooglePayLauncherViewModel(
                 existingPaymentMethodRequired = args.config.existingPaymentMethodRequired,
                 allowCreditCards = args.config.allowCreditCards,
                 errorReporter = errorReporter,
-                logger = logger
+                logger = logger,
+                cardBrandFilter = args.config.cardBrandFilter
             )
 
             return GooglePayLauncherViewModel(
@@ -328,7 +329,8 @@ internal class GooglePayLauncherViewModel(
                 ),
                 googlePayJsonFactory = GooglePayJsonFactory(
                     googlePayConfig = GooglePayConfig(publishableKey, stripeAccountId),
-                    isJcbEnabled = args.config.isJcbEnabled
+                    isJcbEnabled = args.config.isJcbEnabled,
+                    cardBrandFilter = args.config.cardBrandFilter
                 ),
                 googlePayRepository = googlePayRepository,
                 savedStateHandle = extras.createSavedStateHandle(),


### PR DESCRIPTION
# Summary
Adds the card brand filter functionality into the GooglePayLauncher.

This functionality is already present in the `DefaultGooglePayRepository` so it shouldn't cause a big issue to add this functionality on this other surface

# Motivation
Customer request

# Testing
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified


# Changelog
    - [Added] Added the `cardBrandFilter` into the `Config` for `GooglePayLauncher`
