### PR TITLE
Update polling for PayNow to be every second instead of exponential backoff

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -7238,6 +7238,22 @@ public final class com/stripe/android/payments/paymentlauncher/PaymentResult$Fai
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/polling/IntentStatusPoller$PollingStrategy$ExponentialBackoff$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/polling/IntentStatusPoller$PollingStrategy$ExponentialBackoff;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/polling/IntentStatusPoller$PollingStrategy$ExponentialBackoff;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/polling/IntentStatusPoller$PollingStrategy$FixedIntervals$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/polling/IntentStatusPoller$PollingStrategy$FixedIntervals;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/polling/IntentStatusPoller$PollingStrategy$FixedIntervals;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/view/BecsDebitBanks$Bank : android/os/Parcelable {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;

--- a/payments-core/src/main/java/com/stripe/android/polling/DefaultIntentStatusPoller.kt
+++ b/payments-core/src/main/java/com/stripe/android/polling/DefaultIntentStatusPoller.kt
@@ -5,6 +5,7 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.StripeRepository
+import com.stripe.android.polling.IntentStatusPoller.PollingStrategy
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -39,17 +40,47 @@ class DefaultIntentStatusPoller @Inject constructor(
     }
 
     private suspend fun performPoll() {
-        if (attempts < config.maxAttempts) {
+        when (state.value) {
+            StripeIntent.Status.Canceled,
+            StripeIntent.Status.Succeeded ->
+                // Do not poll when stripe intent is in terminal state.
+                return
+            StripeIntent.Status.Processing,
+            StripeIntent.Status.RequiresAction,
+            StripeIntent.Status.RequiresConfirmation,
+            StripeIntent.Status.RequiresPaymentMethod,
+            StripeIntent.Status.RequiresCapture,
+            null -> {}
+        }
+        when (val pollingStrategy = config.pollingStrategy) {
+            is PollingStrategy.ExponentialBackoff -> performPollWithExponentialBackoff(pollingStrategy)
+            is PollingStrategy.FixedIntervals -> performPollWithFixedIntervals(pollingStrategy)
+        }
+    }
+
+    private suspend fun performPollWithExponentialBackoff(
+        exponentialBackoff: PollingStrategy.ExponentialBackoff,
+    ) {
+        if (attempts < exponentialBackoff.maxAttempts) {
             attempts += 1
 
             _state.value = fetchIntentStatus()
 
-            val canTryAgain = attempts < config.maxAttempts
+            val canTryAgain = attempts < exponentialBackoff.maxAttempts
             if (canTryAgain) {
-                delay(calculateDelay(attempts))
+                delay(calculateDelayForExponentialBackoff(attempts))
                 performPoll()
             }
         }
+    }
+
+    private suspend fun performPollWithFixedIntervals(
+        fixedIntervals: PollingStrategy.FixedIntervals,
+    ) {
+        _state.value = fetchIntentStatus()
+
+        delay(fixedIntervals.retryIntervalInSeconds.seconds)
+        performPoll()
     }
 
     private suspend fun fetchIntentStatus(): StripeIntent.Status? {
@@ -74,7 +105,7 @@ class DefaultIntentStatusPoller @Inject constructor(
     }
 }
 
-internal fun calculateDelay(attempts: Int): Duration {
+internal fun calculateDelayForExponentialBackoff(attempts: Int): Duration {
     val delay = (1.0 + attempts).pow(2)
     return delay.seconds
 }

--- a/payments-core/src/main/java/com/stripe/android/polling/IntentStatusPoller.kt
+++ b/payments-core/src/main/java/com/stripe/android/polling/IntentStatusPoller.kt
@@ -1,9 +1,11 @@
 package com.stripe.android.polling
 
+import android.os.Parcelable
 import androidx.annotation.RestrictTo
 import com.stripe.android.model.StripeIntent
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.parcelize.Parcelize
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 interface IntentStatusPoller {
@@ -16,6 +18,21 @@ interface IntentStatusPoller {
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     data class Config(
         val clientSecret: String,
-        val maxAttempts: Int,
+        val pollingStrategy: PollingStrategy,
     )
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @Parcelize
+    sealed class PollingStrategy : Parcelable {
+
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        data class ExponentialBackoff(
+            val maxAttempts: Int,
+        ) : PollingStrategy()
+
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        data class FixedIntervals(
+            val retryIntervalInSeconds: Int,
+        ) : PollingStrategy()
+    }
 }

--- a/payments-core/src/test/java/com/stripe/android/polling/PollingTestUtils.kt
+++ b/payments-core/src/test/java/com/stripe/android/polling/PollingTestUtils.kt
@@ -14,14 +14,16 @@ internal fun exponentialDelayProvider(): () -> Long {
         // Add a minor offset so that we run after the delay has finished,
         // not when it's just about to finish.
         val offset = if (attempt == 1) 1 else 0
-        calculateDelay(attempts = attempt++).inWholeMilliseconds + offset
+        calculateDelayForExponentialBackoff(attempts = attempt++).inWholeMilliseconds + offset
     }
 }
 
 internal fun createIntentStatusPoller(
     enqueuedStatuses: List<StripeIntent.Status>,
     dispatcher: CoroutineDispatcher,
-    maxAttempts: Int = 10,
+    pollingStrategy: IntentStatusPoller.PollingStrategy = IntentStatusPoller.PollingStrategy.ExponentialBackoff(
+        maxAttempts = 10
+    ),
 ): DefaultIntentStatusPoller {
     return DefaultIntentStatusPoller(
         stripeRepository = FakeStripeRepository(enqueuedStatuses),
@@ -33,7 +35,7 @@ internal fun createIntentStatusPoller(
         },
         config = IntentStatusPoller.Config(
             clientSecret = "secret",
-            maxAttempts = maxAttempts,
+            pollingStrategy = pollingStrategy,
         ),
         dispatcher = dispatcher,
     )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingActivity.kt
@@ -32,7 +32,7 @@ internal class PollingActivity : AppCompatActivity() {
             clientSecret = args.clientSecret,
             timeLimit = args.timeLimitInSeconds.seconds,
             initialDelay = args.initialDelayInSeconds.seconds,
-            maxAttempts = args.maxAttempts,
+            pollingStrategy = args.pollingStrategy,
             ctaText = args.ctaText,
             stripeAccountId = args.stripeAccountId,
         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingContract.kt
@@ -8,6 +8,7 @@ import androidx.annotation.ColorInt
 import androidx.annotation.StringRes
 import androidx.core.os.bundleOf
 import com.stripe.android.payments.PaymentFlowResult
+import com.stripe.android.polling.IntentStatusPoller.PollingStrategy
 import kotlinx.parcelize.Parcelize
 
 private const val EXTRA_ARGS = "extra_args"
@@ -30,7 +31,7 @@ internal class PollingContract :
         @ColorInt val statusBarColor: Int?,
         val timeLimitInSeconds: Int,
         val initialDelayInSeconds: Int,
-        val maxAttempts: Int,
+        val pollingStrategy: PollingStrategy,
         @StringRes val ctaText: Int,
         val stripeAccountId: String?,
     ) : Parcelable {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingNextActionHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingNextActionHandler.kt
@@ -11,6 +11,7 @@ import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.authentication.PaymentNextActionHandler
 import com.stripe.android.paymentsheet.R
+import com.stripe.android.polling.IntentStatusPoller.PollingStrategy
 import com.stripe.android.uicore.utils.AnimationConstants
 import com.stripe.android.view.AuthActivityStarterHost
 
@@ -22,7 +23,6 @@ private const val BLIK_INITIAL_DELAY_IN_SECONDS = 5
 private const val BLIK_MAX_ATTEMPTS = 12
 private const val PAYNOW_TIME_LIMIT_IN_SECONDS = 60 * 60
 private const val PAYNOW_INITIAL_DELAY_IN_SECONDS = 5
-private const val PAYNOW_MAX_ATTEMPTS = 12
 
 internal class PollingNextActionHandler : PaymentNextActionHandler<StripeIntent>() {
 
@@ -40,7 +40,7 @@ internal class PollingNextActionHandler : PaymentNextActionHandler<StripeIntent>
                     statusBarColor = host.statusBarColor,
                     timeLimitInSeconds = UPI_TIME_LIMIT_IN_SECONDS,
                     initialDelayInSeconds = UPI_INITIAL_DELAY_IN_SECONDS,
-                    maxAttempts = UPI_MAX_ATTEMPTS,
+                    pollingStrategy = PollingStrategy.ExponentialBackoff(maxAttempts = UPI_MAX_ATTEMPTS),
                     ctaText = R.string.stripe_upi_polling_message,
                     stripeAccountId = requestOptions.stripeAccount,
                 )
@@ -50,7 +50,7 @@ internal class PollingNextActionHandler : PaymentNextActionHandler<StripeIntent>
                     statusBarColor = host.statusBarColor,
                     timeLimitInSeconds = BLIK_TIME_LIMIT_IN_SECONDS,
                     initialDelayInSeconds = BLIK_INITIAL_DELAY_IN_SECONDS,
-                    maxAttempts = BLIK_MAX_ATTEMPTS,
+                    pollingStrategy = PollingStrategy.ExponentialBackoff(maxAttempts = BLIK_MAX_ATTEMPTS),
                     ctaText = R.string.stripe_blik_confirm_payment,
                     stripeAccountId = requestOptions.stripeAccount,
                 )
@@ -60,7 +60,7 @@ internal class PollingNextActionHandler : PaymentNextActionHandler<StripeIntent>
                     statusBarColor = host.statusBarColor,
                     timeLimitInSeconds = PAYNOW_TIME_LIMIT_IN_SECONDS,
                     initialDelayInSeconds = PAYNOW_INITIAL_DELAY_IN_SECONDS,
-                    maxAttempts = PAYNOW_MAX_ATTEMPTS,
+                    pollingStrategy = PollingStrategy.FixedIntervals(retryIntervalInSeconds = 1),
                     ctaText = R.string.stripe_paynow_confirm_payment,
                     stripeAccountId = requestOptions.stripeAccount,
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingViewModel.kt
@@ -14,6 +14,7 @@ import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.paymentsheet.paymentdatacollection.polling.di.DaggerPollingComponent
 import com.stripe.android.polling.IntentStatusPoller
+import com.stripe.android.polling.IntentStatusPoller.PollingStrategy
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -206,7 +207,7 @@ internal class PollingViewModel @Inject constructor(
 
             val config = IntentStatusPoller.Config(
                 clientSecret = args.clientSecret,
-                maxAttempts = args.maxAttempts,
+                pollingStrategy = args.pollingStrategy,
             )
 
             return DaggerPollingComponent
@@ -227,7 +228,7 @@ internal class PollingViewModel @Inject constructor(
         val clientSecret: String,
         val timeLimit: Duration,
         val initialDelay: Duration,
-        val maxAttempts: Int,
+        val pollingStrategy: PollingStrategy,
         @StringRes val ctaText: Int,
         val stripeAccountId: String?,
     )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingActivityTest.kt
@@ -187,7 +187,7 @@ internal class PollingActivityTest {
                 args.clientSecret,
                 args.timeLimitInSeconds.seconds,
                 args.initialDelayInSeconds.seconds,
-                args.maxAttempts,
+                args.pollingStrategy,
                 args.ctaText,
                 args.stripeAccountId
             ),
@@ -225,12 +225,12 @@ internal class PollingActivityTest {
 
         val defaultArgs = PollingContract.Args(
             clientSecret = "client_secret",
-            initialDelayInSeconds = 0,
-            timeLimitInSeconds = 60,
-            maxAttempts = 3,
             statusBarColor = null,
+            timeLimitInSeconds = 60,
+            initialDelayInSeconds = 0,
+            pollingStrategy = IntentStatusPoller.PollingStrategy.ExponentialBackoff(maxAttempts = 3),
             ctaText = R.string.stripe_upi_polling_message,
-            stripeAccountId = null
+            stripeAccountId = null,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingViewModelTest.kt
@@ -210,7 +210,7 @@ private fun createPollingViewModel(
             clientSecret = "secret",
             timeLimit = timeLimit,
             initialDelay = initialDelay,
-            maxAttempts = 10,
+            pollingStrategy = IntentStatusPoller.PollingStrategy.ExponentialBackoff(maxAttempts = 10),
             ctaText = R.string.stripe_upi_polling_message,
             stripeAccountId = null
         ),


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Update polling for PayNow to be every second instead of exponential backoff

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Match polling behavior on iOS

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified