### PR TITLE
Show PayNow QR code

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/view/PaymentAuthWebView.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/PaymentAuthWebView.kt
@@ -4,13 +4,15 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.util.AttributeSet
 import android.webkit.WebView
+import androidx.annotation.RestrictTo
 import com.stripe.android.core.networking.RequestHeadersFactory
 import com.stripe.android.view.PaymentAuthWebViewClient.Companion.BLANK_PAGE
 
 /**
  * A `WebView` used for authenticating payment details
  */
-internal class PaymentAuthWebView @JvmOverloads constructor(
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class PaymentAuthWebView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0

--- a/payments-core/src/main/java/com/stripe/android/view/PaymentAuthWebViewClient.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/PaymentAuthWebViewClient.kt
@@ -6,12 +6,14 @@ import android.webkit.URLUtil
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
 import com.stripe.android.core.Logger
 import com.stripe.android.payments.DefaultReturnUrl
 import kotlinx.coroutines.flow.MutableStateFlow
 
-internal class PaymentAuthWebViewClient(
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class PaymentAuthWebViewClient(
     private val logger: Logger,
     private val isPageLoaded: MutableStateFlow<Boolean>,
     private val clientSecret: String,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingActivity.kt
@@ -35,6 +35,7 @@ internal class PollingActivity : AppCompatActivity() {
             pollingStrategy = args.pollingStrategy,
             ctaText = args.ctaText,
             stripeAccountId = args.stripeAccountId,
+            qrCodeUrl = args.qrCodeUrl,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingActivity.kt
@@ -81,7 +81,16 @@ internal class PollingActivity : AppCompatActivity() {
                     state = state,
                     onDismissed = { /* Not applicable here */ },
                 ) {
-                    PollingScreen(viewModel)
+                    val qrCodeUrl = args.qrCodeUrl
+                    if (uiState.shouldShowQrCode && qrCodeUrl != null) {
+                        QrCodeWebView(
+                            url = qrCodeUrl,
+                            clientSecret = args.clientSecret,
+                            onClose = viewModel::hideQrCode,
+                        )
+                    } else {
+                        PollingScreen(viewModel)
+                    }
                 }
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingContract.kt
@@ -34,6 +34,7 @@ internal class PollingContract :
         val pollingStrategy: PollingStrategy,
         @StringRes val ctaText: Int,
         val stripeAccountId: String?,
+        val qrCodeUrl: String?,
     ) : Parcelable {
 
         internal companion object {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingNextActionHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingNextActionHandler.kt
@@ -43,6 +43,7 @@ internal class PollingNextActionHandler : PaymentNextActionHandler<StripeIntent>
                     pollingStrategy = PollingStrategy.ExponentialBackoff(maxAttempts = UPI_MAX_ATTEMPTS),
                     ctaText = R.string.stripe_upi_polling_message,
                     stripeAccountId = requestOptions.stripeAccount,
+                    qrCodeUrl = null,
                 )
             PaymentMethod.Type.Blik ->
                 PollingContract.Args(
@@ -53,6 +54,7 @@ internal class PollingNextActionHandler : PaymentNextActionHandler<StripeIntent>
                     pollingStrategy = PollingStrategy.ExponentialBackoff(maxAttempts = BLIK_MAX_ATTEMPTS),
                     ctaText = R.string.stripe_blik_confirm_payment,
                     stripeAccountId = requestOptions.stripeAccount,
+                    qrCodeUrl = null,
                 )
             PaymentMethod.Type.PayNow ->
                 PollingContract.Args(
@@ -63,6 +65,7 @@ internal class PollingNextActionHandler : PaymentNextActionHandler<StripeIntent>
                     pollingStrategy = PollingStrategy.FixedIntervals(retryIntervalInSeconds = 1),
                     ctaText = R.string.stripe_paynow_confirm_payment,
                     stripeAccountId = requestOptions.stripeAccount,
+                    qrCodeUrl = getQrCodeForPayNow(actionable),
                 )
             else ->
                 error(
@@ -85,6 +88,11 @@ internal class PollingNextActionHandler : PaymentNextActionHandler<StripeIntent>
         } else {
             localPollingAuthenticator.launch(args, options)
         }
+    }
+
+    private fun getQrCodeForPayNow(actionable: StripeIntent): String {
+        // TODO: test what happens when null.
+        return requireNotNull((actionable.nextActionData as StripeIntent.NextActionData.DisplayPayNowDetails).qrCodeUrl)
     }
 
     override fun onNewActivityResultCaller(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingNextActionHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingNextActionHandler.kt
@@ -91,7 +91,6 @@ internal class PollingNextActionHandler : PaymentNextActionHandler<StripeIntent>
     }
 
     private fun getQrCodeForPayNow(actionable: StripeIntent): String {
-        // TODO: test what happens when null.
         return requireNotNull((actionable.nextActionData as StripeIntent.NextActionData.DisplayPayNowDetails).qrCodeUrl)
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingScreen.kt
@@ -240,6 +240,7 @@ private fun ActivePollingScreenPreview() {
                     durationRemaining = 83.seconds,
                     ctaText = R.string.stripe_upi_polling_message,
                     pollingState = PollingState.Active,
+                    shouldShowQrCode = false,
                 ),
                 onCancel = {},
             )
@@ -257,6 +258,7 @@ private fun FailedPollingScreenPreview() {
                     durationRemaining = 83.seconds,
                     ctaText = R.string.stripe_upi_polling_message,
                     pollingState = PollingState.Failed,
+                    shouldShowQrCode = false,
                 ),
                 onCancel = {},
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingViewModel.kt
@@ -231,6 +231,7 @@ internal class PollingViewModel @Inject constructor(
         val pollingStrategy: PollingStrategy,
         @StringRes val ctaText: Int,
         val stripeAccountId: String?,
+        val qrCodeUrl: String?,
     )
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingViewModel.kt
@@ -91,11 +91,13 @@ internal class PollingViewModel @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
-    private val _uiState = MutableStateFlow(PollingUiState(
-        durationRemaining = args.timeLimit,
-        ctaText = args.ctaText,
-        shouldShowQrCode = args.qrCodeUrl != null,
-    ))
+    private val _uiState = MutableStateFlow(
+        PollingUiState(
+            durationRemaining = args.timeLimit,
+            ctaText = args.ctaText,
+            shouldShowQrCode = args.qrCodeUrl != null,
+        )
+    )
     val uiState: StateFlow<PollingUiState> = _uiState
 
     init {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingViewModel.kt
@@ -81,6 +81,7 @@ internal data class PollingUiState(
     val durationRemaining: Duration,
     @StringRes val ctaText: Int,
     val pollingState: PollingState = PollingState.Active,
+    val shouldShowQrCode: Boolean,
 )
 
 internal class PollingViewModel @Inject constructor(
@@ -90,7 +91,11 @@ internal class PollingViewModel @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
-    private val _uiState = MutableStateFlow(PollingUiState(durationRemaining = args.timeLimit, ctaText = args.ctaText))
+    private val _uiState = MutableStateFlow(PollingUiState(
+        durationRemaining = args.timeLimit,
+        ctaText = args.ctaText,
+        shouldShowQrCode = args.qrCodeUrl != null,
+    ))
     val uiState: StateFlow<PollingUiState> = _uiState
 
     init {
@@ -166,7 +171,10 @@ internal class PollingViewModel @Inject constructor(
 
     fun handleCancel() {
         _uiState.update {
-            it.copy(pollingState = PollingState.Canceled)
+            it.copy(
+                pollingState = PollingState.Canceled,
+                shouldShowQrCode = false,
+            )
         }
         poller.stopPolling()
     }
@@ -194,7 +202,10 @@ internal class PollingViewModel @Inject constructor(
 
     private fun updatePollingState(pollingState: PollingState) {
         _uiState.update {
-            it.copy(pollingState = pollingState)
+            it.copy(
+                pollingState = pollingState,
+                shouldShowQrCode = it.shouldShowQrCode && pollingState == PollingState.Active,
+            )
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingViewModel.kt
@@ -179,6 +179,12 @@ internal class PollingViewModel @Inject constructor(
         poller.stopPolling()
     }
 
+    fun hideQrCode() {
+        _uiState.update {
+            it.copy(shouldShowQrCode = false)
+        }
+    }
+
     private suspend fun observeCountdown(timeLimit: Duration) {
         countdownFlow(timeLimit).collect { duration ->
             _uiState.update {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/QrCodeWebView.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/QrCodeWebView.kt
@@ -34,6 +34,9 @@ internal fun QrCodeWebView(
                 com.stripe.android.paymentsheet.R.drawable.stripe_ic_paymentsheet_close
             )
             localBinding.toolbar.setNavigationOnClickListener { onClose() }
+            localBinding.toolbar.setNavigationContentDescription(
+                com.stripe.android.paymentsheet.R.string.stripe_paymentsheet_close
+            )
 
             val webViewClient = PaymentAuthWebViewClient(
                 logger = Logger.getInstance(BuildConfig.DEBUG),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/QrCodeWebView.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/QrCodeWebView.kt
@@ -17,15 +17,15 @@ import kotlinx.coroutines.flow.MutableStateFlow
 internal const val QR_CODE_WEB_VIEW_TEST_TAG = "qr_code_web_view"
 
 @Composable
-fun QrCodeWebView(
+internal fun QrCodeWebView(
     url: String,
     clientSecret: String,
     onClose: () -> Unit,
 ) {
     val isPageLoaded = MutableStateFlow(false)
     val isPageLoadedState by isPageLoaded.collectAsState()
-    var binding : StripePaymentAuthWebViewActivityBinding? = null
-    
+    var binding: StripePaymentAuthWebViewActivityBinding? = null
+
     AndroidViewBinding(
         factory = { layoutInflater, _, _ ->
             val localBinding = StripePaymentAuthWebViewActivityBinding.inflate(layoutInflater)
@@ -55,5 +55,6 @@ fun QrCodeWebView(
             if (isPageLoadedState) {
                 binding?.progressBar?.isGone = true
             }
-        })
+        }
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/QrCodeWebView.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/QrCodeWebView.kt
@@ -1,0 +1,56 @@
+package com.stripe.android.paymentsheet.paymentdatacollection.polling
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidViewBinding
+import androidx.core.view.isGone
+import com.stripe.android.BuildConfig
+import com.stripe.android.core.Logger
+import com.stripe.android.databinding.StripePaymentAuthWebViewActivityBinding
+import com.stripe.android.uicore.utils.collectAsState
+import com.stripe.android.view.PaymentAuthWebViewClient
+import kotlinx.coroutines.flow.MutableStateFlow
+
+@Composable
+fun QrCodeWebView(
+    url: String,
+    clientSecret: String,
+    onClose: () -> Unit,
+) {
+    val isPageLoaded = MutableStateFlow(false)
+    val isPageLoadedState by isPageLoaded.collectAsState()
+    var binding : StripePaymentAuthWebViewActivityBinding? = null
+    
+    AndroidViewBinding(
+        factory = { layoutInflater, _, _ ->
+            val localBinding = StripePaymentAuthWebViewActivityBinding.inflate(layoutInflater)
+
+            localBinding.toolbar.setNavigationIcon(
+                com.stripe.android.paymentsheet.R.drawable.stripe_ic_paymentsheet_close
+            )
+            localBinding.toolbar.setNavigationOnClickListener { onClose() }
+
+            val webViewClient = PaymentAuthWebViewClient(
+                logger = Logger.getInstance(BuildConfig.DEBUG),
+                isPageLoaded = isPageLoaded,
+                clientSecret = clientSecret,
+                returnUrl = null,
+                activityStarter = {},
+                activityFinisher = { _ -> onClose() }
+            )
+
+            localBinding.webView.webViewClient = webViewClient
+            localBinding.webView.loadUrl(url)
+
+            binding = localBinding
+            localBinding
+        },
+        modifier = Modifier.fillMaxSize(),
+        update = {
+            if (isPageLoadedState) {
+                binding?.progressBar?.isGone = true
+            }
+        })
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/QrCodeWebView.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/QrCodeWebView.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.viewinterop.AndroidViewBinding
 import androidx.core.view.isGone
 import com.stripe.android.BuildConfig
@@ -12,6 +13,8 @@ import com.stripe.android.databinding.StripePaymentAuthWebViewActivityBinding
 import com.stripe.android.uicore.utils.collectAsState
 import com.stripe.android.view.PaymentAuthWebViewClient
 import kotlinx.coroutines.flow.MutableStateFlow
+
+internal const val QR_CODE_WEB_VIEW_TEST_TAG = "qr_code_web_view"
 
 @Composable
 fun QrCodeWebView(
@@ -47,7 +50,7 @@ fun QrCodeWebView(
             binding = localBinding
             localBinding
         },
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier.fillMaxSize().testTag(QR_CODE_WEB_VIEW_TEST_TAG),
         update = {
             if (isPageLoadedState) {
                 binding?.progressBar?.isGone = true

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingActivityTest.kt
@@ -192,13 +192,10 @@ internal class PollingActivityTest {
         )
 
         scenario.onActivity {
-            // Verify QR code is displayed initially
             assertQrCodeWebViewIsDisplayed()
 
-            // Simulate configuration change
             scenario.recreate()
 
-            // Verify QR code is still displayed after configuration change
             assertQrCodeWebViewIsDisplayed()
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingActivityTest.kt
@@ -189,7 +189,8 @@ internal class PollingActivityTest {
                 args.initialDelayInSeconds.seconds,
                 args.pollingStrategy,
                 args.ctaText,
-                args.stripeAccountId
+                args.stripeAccountId,
+                args.qrCodeUrl,
             ),
             poller = poller,
             timeProvider = timeProvider,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingActivityTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.paymentdatacollection.polling
 import android.os.Build
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -42,6 +43,22 @@ internal class PollingActivityTest {
             composeTestRule
                 .onNodeWithText("Approve payment")
                 .assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun `Displays qr code screen when activity is opened and qr code url available`() {
+        val scenario = pollingScenario(
+            args = defaultArgs.copy(qrCodeUrl = "valid_url")
+        )
+
+        scenario.onActivity {
+            composeTestRule.waitUntil(timeoutMillis = 5_000) {
+                composeTestRule
+                    .onAllNodesWithTag(QR_CODE_WEB_VIEW_TEST_TAG)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingActivityTest.kt
@@ -231,6 +231,7 @@ internal class PollingActivityTest {
             pollingStrategy = IntentStatusPoller.PollingStrategy.ExponentialBackoff(maxAttempts = 3),
             ctaText = R.string.stripe_upi_polling_message,
             stripeAccountId = null,
+            qrCodeUrl = null,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingViewModelTest.kt
@@ -212,7 +212,8 @@ private fun createPollingViewModel(
             initialDelay = initialDelay,
             pollingStrategy = IntentStatusPoller.PollingStrategy.ExponentialBackoff(maxAttempts = 10),
             ctaText = R.string.stripe_upi_polling_message,
-            stripeAccountId = null
+            stripeAccountId = null,
+            qrCodeUrl = null,
         ),
         poller = poller,
         timeProvider = timeProvider,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Show PayNow QR code

This finishes out implementation for PayNow. I'll send out a follow up PR to add TestPayNow

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-1381

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified

Manually verified that if I confirm (or fail) the payment outside of our playground app, then the QR code web view closes and success (or failure) is shown properly.

# Screen recordings
Success:

https://github.com/user-attachments/assets/1278f182-9312-446a-a09a-a7e4fa5c0da8



Failure:

https://github.com/user-attachments/assets/95213fd6-d605-41b3-9a22-24933e5b452b



Cancel:

https://github.com/user-attachments/assets/85e61595-96a5-4004-bdc5-6016f2a4f575

