### PR TITLE
Retrieve PaymentConfiguration values via `getInstance` in DI

### DIFF
--- a/stripe-crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/di/OnrampModule.kt
+++ b/stripe-crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/di/OnrampModule.kt
@@ -20,7 +20,6 @@ import com.stripe.android.networking.RequestSurface
 import dagger.Module
 import dagger.Provides
 import javax.inject.Named
-import javax.inject.Provider
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
@@ -45,29 +44,25 @@ internal class OnrampModule {
     )
 
     @Provides
-    fun providePaymentConfiguration(appContext: Context): PaymentConfiguration {
-        return PaymentConfiguration.getInstance(appContext)
-    }
-
-    @Provides
     @Named(PUBLISHABLE_KEY)
-    fun providePublishableKey(paymentConfiguration: Provider<PaymentConfiguration>): () -> String =
-        { paymentConfiguration.get().publishableKey }
+    fun providePublishableKey(context: Context): () -> String =
+        { PaymentConfiguration.getInstance(context).publishableKey }
 
     @Provides
     @Named(STRIPE_ACCOUNT_ID)
-    fun provideStripeAccountId(paymentConfiguration: Provider<PaymentConfiguration>): () -> String? =
-        { paymentConfiguration.get().stripeAccountId }
+    fun provideStripeAccountId(context: Context): () -> String? =
+        { PaymentConfiguration.getInstance(context).stripeAccountId }
 
     @Provides
     fun provideCryptoApiRepository(
         stripeNetworkClient: StripeNetworkClient,
-        paymentConfiguration: PaymentConfiguration
+        @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
+        @Named(STRIPE_ACCOUNT_ID) stripeAccountIdProvider: () -> String?,
     ): CryptoApiRepository {
         return CryptoApiRepository(
             stripeNetworkClient = stripeNetworkClient,
-            publishableKeyProvider = { paymentConfiguration.publishableKey },
-            stripeAccountIdProvider = { paymentConfiguration.stripeAccountId },
+            publishableKeyProvider = publishableKeyProvider,
+            stripeAccountIdProvider = stripeAccountIdProvider,
             apiVersion = ApiVersion.get().code,
             appInfo = Stripe.appInfo
         )


### PR DESCRIPTION
# Summary

- Issue: We were trying to inject the `PaymentConfiguration` object instead of retrieving its stored values when needed. That resulted in a crash if `PaymentsConfiguration` wasn't initialized on a previous session.  

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
