### PR TITLE
Fix no address bug in US Bank account flow when no default address

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -190,13 +190,13 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
         shippingValuesMap = args.formArgs.shippingDetails?.toIdentifierMap(args.formArgs.billingDetails),
     )
 
-    // AddressElement generates a default address if the initial value is null, so we can't rely
-    // on the value produced by the controller in that case.
-    val address: StateFlow<Address?> = if (defaultAddress == null) {
-        MutableStateFlow(null)
-    } else {
-        addressElement.getFormFieldValueFlow().mapAsStateFlow { formFieldValues ->
-            val rawMap = formFieldValues.associate { it.first to it.second.value }
+    val address: StateFlow<Address?> = addressElement.getFormFieldValueFlow().mapAsStateFlow { formFieldValues ->
+        formFieldValues.takeIf {
+            it.all { value ->
+                value.second.isComplete
+            }
+        }?.let { values ->
+            val rawMap = values.associate { it.first to it.second.value }
             Address.fromFormFieldValues(rawMap)
         }
     }


### PR DESCRIPTION
# Summary
This PR fixes an old bug where the address is not properly added when there is no default address used in the US Bank Account flow.

# Motivation
Fixes an issue where user address input is not properly taken into account when building the US bank selection.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified