### PR TITLE
Parse out `partial` field for `payment_method_remove` in `ElementsSession`

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/ElementsSession.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ElementsSession.kt
@@ -162,11 +162,15 @@ data class ElementsSession(
                 @Parcelize
                 data class Enabled(
                     val isPaymentMethodSaveEnabled: Boolean,
-                    val isPaymentMethodRemoveEnabled: Boolean,
+                    val paymentMethodRemove: PaymentMethodRemoveFeature,
                     val canRemoveLastPaymentMethod: Boolean,
                     val allowRedisplayOverride: PaymentMethod.AllowRedisplay?,
                     val isPaymentMethodSetAsDefaultEnabled: Boolean,
-                ) : MobilePaymentElement
+                ) : MobilePaymentElement {
+                    val isPaymentMethodRemoveEnabled: Boolean
+                        get() = paymentMethodRemove == PaymentMethodRemoveFeature.Enabled ||
+                            paymentMethodRemove == PaymentMethodRemoveFeature.Partial
+                }
             }
 
             @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -178,10 +182,21 @@ data class ElementsSession(
                 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
                 @Parcelize
                 data class Enabled(
-                    val isPaymentMethodRemoveEnabled: Boolean,
+                    val paymentMethodRemove: PaymentMethodRemoveFeature,
                     val canRemoveLastPaymentMethod: Boolean,
                     val isPaymentMethodSyncDefaultEnabled: Boolean,
-                ) : CustomerSheet
+                ) : CustomerSheet {
+                    val isPaymentMethodRemoveEnabled: Boolean
+                        get() = paymentMethodRemove == PaymentMethodRemoveFeature.Enabled ||
+                            paymentMethodRemove == PaymentMethodRemoveFeature.Partial
+                }
+            }
+
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            enum class PaymentMethodRemoveFeature {
+                Enabled,
+                Partial,
+                Disabled,
             }
         }
     }

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/ElementsSessionJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/ElementsSessionJsonParser.kt
@@ -340,8 +340,11 @@ internal class ElementsSessionJsonParser(
 
             ElementsSession.Customer.Components.MobilePaymentElement.Enabled(
                 isPaymentMethodSaveEnabled = paymentMethodSaveFeature == VALUE_ENABLED,
-                isPaymentMethodRemoveEnabled = paymentMethodRemoveFeature == VALUE_ENABLED ||
-                    paymentMethodRemoveFeature == VALUE_PARTIAL,
+                paymentMethodRemove = when (paymentMethodRemoveFeature) {
+                    VALUE_ENABLED -> ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled
+                    VALUE_PARTIAL -> ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Partial
+                    else -> ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Disabled
+                },
                 canRemoveLastPaymentMethod = paymentMethodRemoveLastFeature == VALUE_ENABLED,
                 isPaymentMethodSetAsDefaultEnabled = paymentMethodSetAsDefaultFeature == VALUE_ENABLED,
                 allowRedisplayOverride = allowRedisplayOverride,
@@ -367,8 +370,11 @@ internal class ElementsSessionJsonParser(
             val paymentMethodSyncDefaultFeature = customerSheetFeatures.optString(FIELD_PAYMENT_METHOD_SYNC_DEFAULT)
 
             ElementsSession.Customer.Components.CustomerSheet.Enabled(
-                isPaymentMethodRemoveEnabled = paymentMethodRemoveFeature == VALUE_ENABLED ||
-                    paymentMethodRemoveFeature == VALUE_PARTIAL,
+                paymentMethodRemove = when (paymentMethodRemoveFeature) {
+                    VALUE_ENABLED -> ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled
+                    VALUE_PARTIAL -> ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Partial
+                    else -> ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Disabled
+                },
                 canRemoveLastPaymentMethod = paymentMethodRemoveLastFeature == VALUE_ENABLED,
                 isPaymentMethodSyncDefaultEnabled = paymentMethodSyncDefaultFeature == VALUE_ENABLED,
             )

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
@@ -712,13 +712,15 @@ class ElementsSessionJsonParserTest {
                     components = ElementsSession.Customer.Components(
                         mobilePaymentElement = ElementsSession.Customer.Components.MobilePaymentElement.Enabled(
                             isPaymentMethodSaveEnabled = false,
-                            isPaymentMethodRemoveEnabled = true,
+                            paymentMethodRemove =
+                            ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled,
                             canRemoveLastPaymentMethod = true,
                             allowRedisplayOverride = PaymentMethod.AllowRedisplay.LIMITED,
                             isPaymentMethodSetAsDefaultEnabled = false,
                         ),
                         customerSheet = ElementsSession.Customer.Components.CustomerSheet.Enabled(
-                            isPaymentMethodRemoveEnabled = true,
+                            paymentMethodRemove =
+                            ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled,
                             canRemoveLastPaymentMethod = true,
                             isPaymentMethodSyncDefaultEnabled = false,
                         ),
@@ -786,7 +788,8 @@ class ElementsSessionJsonParserTest {
                     components = ElementsSession.Customer.Components(
                         mobilePaymentElement = ElementsSession.Customer.Components.MobilePaymentElement.Disabled,
                         customerSheet = ElementsSession.Customer.Components.CustomerSheet.Enabled(
-                            isPaymentMethodRemoveEnabled = true,
+                            paymentMethodRemove =
+                            ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled,
                             canRemoveLastPaymentMethod = true,
                             isPaymentMethodSyncDefaultEnabled = false,
                         ),
@@ -854,7 +857,8 @@ class ElementsSessionJsonParserTest {
                     components = ElementsSession.Customer.Components(
                         mobilePaymentElement = ElementsSession.Customer.Components.MobilePaymentElement.Enabled(
                             isPaymentMethodSaveEnabled = false,
-                            isPaymentMethodRemoveEnabled = true,
+                            paymentMethodRemove =
+                            ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled,
                             canRemoveLastPaymentMethod = true,
                             allowRedisplayOverride = PaymentMethod.AllowRedisplay.LIMITED,
                             isPaymentMethodSetAsDefaultEnabled = false,
@@ -928,25 +932,28 @@ class ElementsSessionJsonParserTest {
     }
 
     @Test
-    fun `when 'payment_method_remove' is 'enabled', 'canRemovePaymentMethods' should be true`() {
+    fun `when 'payment_method_remove' is 'enabled', 'paymentMethodRemove' should be 'Disabled' & helper true`() {
         permissionsTest(
             paymentMethodRemoveFeatureValue = "enabled",
+            paymentMethodRemoveFeature = ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled,
             canRemovePaymentMethods = true,
         )
     }
 
     @Test
-    fun `when 'payment_method_remove' is 'partial', 'canRemovePaymentMethods' should be true`() {
+    fun `when 'payment_method_remove' is 'partial', 'paymentMethodRemove' should be 'Partial' & helper true`() {
         permissionsTest(
             paymentMethodRemoveFeatureValue = "partial",
+            paymentMethodRemoveFeature = ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Partial,
             canRemovePaymentMethods = true,
         )
     }
 
     @Test
-    fun `when 'payment_method_remove' is 'disabled', 'canRemovePaymentMethods' should be false`() {
+    fun `when 'payment_method_remove' is 'disabled', 'paymentMethodRemove' should be 'Disabled' & helper false`() {
         permissionsTest(
             paymentMethodRemoveFeatureValue = "disabled",
+            paymentMethodRemoveFeature = ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Disabled,
             canRemovePaymentMethods = false,
         )
     }
@@ -955,6 +962,7 @@ class ElementsSessionJsonParserTest {
     fun `when 'payment_method_remove' is unknown value, 'canRemovePaymentMethods' should be false`() {
         permissionsTest(
             paymentMethodRemoveFeatureValue = "something",
+            paymentMethodRemoveFeature = ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Disabled,
             canRemovePaymentMethods = false,
         )
     }
@@ -1127,7 +1135,8 @@ class ElementsSessionJsonParserTest {
                     components = ElementsSession.Customer.Components(
                         mobilePaymentElement = ElementsSession.Customer.Components.MobilePaymentElement.Disabled,
                         customerSheet = ElementsSession.Customer.Components.CustomerSheet.Enabled(
-                            isPaymentMethodRemoveEnabled = true,
+                            paymentMethodRemove =
+                            ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled,
                             canRemoveLastPaymentMethod = true,
                             isPaymentMethodSyncDefaultEnabled = false,
                         ),
@@ -1381,6 +1390,8 @@ class ElementsSessionJsonParserTest {
     private fun permissionsTest(
         paymentMethodRemoveFeatureValue: String? = "enabled",
         paymentMethodRemoveLastFeatureValue: String? = "enabled",
+        paymentMethodRemoveFeature: ElementsSession.Customer.Components.PaymentMethodRemoveFeature =
+            ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled,
         canRemovePaymentMethods: Boolean = true,
         canRemoveLastPaymentMethod: Boolean = true,
     ) {
@@ -1410,6 +1421,7 @@ class ElementsSessionJsonParserTest {
         val enabledPaymentElementComponent = mobilePaymentElementComponent as?
             ElementsSession.Customer.Components.MobilePaymentElement.Enabled
 
+        assertThat(enabledPaymentElementComponent?.paymentMethodRemove).isEqualTo(paymentMethodRemoveFeature)
         assertThat(enabledPaymentElementComponent?.isPaymentMethodRemoveEnabled).isEqualTo(canRemovePaymentMethods)
         assertThat(enabledPaymentElementComponent?.canRemoveLastPaymentMethod).isEqualTo(canRemoveLastPaymentMethod)
 
@@ -1421,6 +1433,7 @@ class ElementsSessionJsonParserTest {
         val enabledCustomerSheetComponent = customerSheetComponent as?
             ElementsSession.Customer.Components.CustomerSheet.Enabled
 
+        assertThat(enabledCustomerSheetComponent?.paymentMethodRemove).isEqualTo(paymentMethodRemoveFeature)
         assertThat(enabledCustomerSheetComponent?.isPaymentMethodRemoveEnabled).isEqualTo(canRemovePaymentMethods)
         assertThat(enabledCustomerSheetComponent?.canRemoveLastPaymentMethod).isEqualTo(canRemoveLastPaymentMethod)
     }

--- a/paymentsheet/src/test/java/com/stripe/android/common/analytics/experiment/LogLinkGlobalHoldbackExposureTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/analytics/experiment/LogLinkGlobalHoldbackExposureTest.kt
@@ -363,7 +363,7 @@ class LogLinkGlobalHoldbackExposureTest {
             customer = createCustomer(
                 MobilePaymentElement.Enabled(
                     isPaymentMethodSaveEnabled = true,
-                    isPaymentMethodRemoveEnabled = true,
+                    paymentMethodRemove = Components.PaymentMethodRemoveFeature.Enabled,
                     canRemoveLastPaymentMethod = true,
                     isPaymentMethodSetAsDefaultEnabled = true,
                     allowRedisplayOverride = null

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetFixtures.kt
@@ -82,7 +82,8 @@ internal object CustomerSheetFixtures {
                     components = ElementsSession.Customer.Components(
                         mobilePaymentElement = ElementsSession.Customer.Components.MobilePaymentElement.Disabled,
                         customerSheet = ElementsSession.Customer.Components.CustomerSheet.Enabled(
-                            isPaymentMethodRemoveEnabled = false,
+                            paymentMethodRemove =
+                            ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Disabled,
                             canRemoveLastPaymentMethod = true,
                             isPaymentMethodSyncDefaultEnabled = isPaymentMethodSyncDefaultEnabled,
                         ),

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionInitializationDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionInitializationDataSourceTest.kt
@@ -27,7 +27,8 @@ class CustomerSessionInitializationDataSourceTest {
                 intent = intent,
                 paymentMethods = paymentMethods,
                 customerSheetComponent = createEnabledCustomerSheetComponent(
-                    isPaymentMethodRemoveEnabled = true,
+                    paymentMethodRemoveFeature =
+                    ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled,
                     canRemoveLastPaymentMethod = true,
                     isPaymentMethodSyncDefaultEnabled = false,
                 ),
@@ -63,7 +64,8 @@ class CustomerSessionInitializationDataSourceTest {
         val dataSource = createInitializationDataSource(
             elementsSessionManager = FakeCustomerSessionElementsSessionManager(
                 customerSheetComponent = createEnabledCustomerSheetComponent(
-                    isPaymentMethodRemoveEnabled = false,
+                    paymentMethodRemoveFeature =
+                    ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Disabled,
                     canRemoveLastPaymentMethod = false,
                 ),
             ),
@@ -236,7 +238,8 @@ class CustomerSessionInitializationDataSourceTest {
                     ElementsSession.Customer.Components.CustomerSheet.Disabled
                 } else {
                     createEnabledCustomerSheetComponent(
-                        isPaymentMethodRemoveEnabled = true,
+                        paymentMethodRemoveFeature =
+                        ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled,
                         canRemoveLastPaymentMethod = canRemoveLastPaymentMethod,
                     )
                 },
@@ -277,12 +280,13 @@ class CustomerSessionInitializationDataSourceTest {
     }
 
     private fun createEnabledCustomerSheetComponent(
-        isPaymentMethodRemoveEnabled: Boolean = true,
+        paymentMethodRemoveFeature: ElementsSession.Customer.Components.PaymentMethodRemoveFeature =
+            ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled,
         canRemoveLastPaymentMethod: Boolean = true,
         isPaymentMethodSyncDefaultEnabled: Boolean = false,
     ): ElementsSession.Customer.Components.CustomerSheet.Enabled {
         return ElementsSession.Customer.Components.CustomerSheet.Enabled(
-            isPaymentMethodRemoveEnabled = isPaymentMethodRemoveEnabled,
+            paymentMethodRemove = paymentMethodRemoveFeature,
             canRemoveLastPaymentMethod = canRemoveLastPaymentMethod,
             isPaymentMethodSyncDefaultEnabled = isPaymentMethodSyncDefaultEnabled,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/FakeCustomerSessionElementsSessionManager.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/FakeCustomerSessionElementsSessionManager.kt
@@ -20,7 +20,8 @@ internal class FakeCustomerSessionElementsSessionManager(
     private val isPaymentMethodSyncDefaultEnabled: Boolean = false,
     private val customerSheetComponent: ElementsSession.Customer.Components.CustomerSheet =
         ElementsSession.Customer.Components.CustomerSheet.Enabled(
-            isPaymentMethodRemoveEnabled = true,
+            paymentMethodRemove =
+            ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled,
             canRemoveLastPaymentMethod = true,
             isPaymentMethodSyncDefaultEnabled = isPaymentMethodSyncDefaultEnabled,
         ),

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -696,7 +696,8 @@ internal class DefaultCustomerSheetLoaderTest {
                     components = ElementsSession.Customer.Components(
                         mobilePaymentElement = ElementsSession.Customer.Components.MobilePaymentElement.Disabled,
                         customerSheet = ElementsSession.Customer.Components.CustomerSheet.Enabled(
-                            isPaymentMethodRemoveEnabled = false,
+                            paymentMethodRemove =
+                            ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Disabled,
                             canRemoveLastPaymentMethod = true,
                             isPaymentMethodSyncDefaultEnabled = isPaymentMethodSyncDefaultEnabled,
                         ),

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/CustomerMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/CustomerMetadataTest.kt
@@ -109,13 +109,14 @@ internal class CustomerMetadataTest {
         }
 
     private fun createEnabledMobilePaymentElement(
-        isPaymentMethodRemoveEnabled: Boolean = true,
+        paymentMethodRemove: ElementsSession.Customer.Components.PaymentMethodRemoveFeature =
+            ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled,
         canRemoveLastPaymentMethod: Boolean = true,
         isPaymentMethodSetAsDefaultEnabled: Boolean = true,
     ): ElementsSession.Customer.Components.MobilePaymentElement.Enabled {
         return ElementsSession.Customer.Components.MobilePaymentElement.Enabled(
             isPaymentMethodSaveEnabled = true,
-            isPaymentMethodRemoveEnabled = isPaymentMethodRemoveEnabled,
+            paymentMethodRemove = paymentMethodRemove,
             canRemoveLastPaymentMethod = canRemoveLastPaymentMethod,
             allowRedisplayOverride = null,
             isPaymentMethodSetAsDefaultEnabled = isPaymentMethodSetAsDefaultEnabled
@@ -139,14 +140,15 @@ internal class CustomerMetadataTest {
         paymentElementDisabled: Boolean = false,
         canRemoveLastPaymentMethodConfigValue: Boolean = true,
         canRemoveLastPaymentMethod: Boolean = true,
-        canRemovePaymentMethods: Boolean = true,
+        paymentMethodRemove: ElementsSession.Customer.Components.PaymentMethodRemoveFeature =
+            ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled,
         block: (CustomerMetadata.Permissions) -> Unit
     ) {
         val mobilePaymentElementComponent = if (paymentElementDisabled) {
             ElementsSession.Customer.Components.MobilePaymentElement.Disabled
         } else {
             createEnabledMobilePaymentElement(
-                isPaymentMethodRemoveEnabled = canRemovePaymentMethods,
+                paymentMethodRemove = paymentMethodRemove,
                 canRemoveLastPaymentMethod = canRemoveLastPaymentMethod,
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -1237,7 +1237,7 @@ internal class PaymentMethodMetadataTest {
         val metadata = createPaymentMethodMetadataForPaymentSheet(
             mobilePaymentElementComponent = ElementsSession.Customer.Components.MobilePaymentElement.Enabled(
                 isPaymentMethodSaveEnabled = true,
-                isPaymentMethodRemoveEnabled = true,
+                paymentMethodRemove = ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled,
                 canRemoveLastPaymentMethod = true,
                 allowRedisplayOverride = null,
                 isPaymentMethodSetAsDefaultEnabled = false,
@@ -1252,7 +1252,7 @@ internal class PaymentMethodMetadataTest {
         val metadata = createPaymentMethodMetadataForPaymentSheet(
             mobilePaymentElementComponent = ElementsSession.Customer.Components.MobilePaymentElement.Enabled(
                 isPaymentMethodSaveEnabled = false,
-                isPaymentMethodRemoveEnabled = true,
+                paymentMethodRemove = ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled,
                 canRemoveLastPaymentMethod = true,
                 allowRedisplayOverride = null,
                 isPaymentMethodSetAsDefaultEnabled = false,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CustomerStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CustomerStateTest.kt
@@ -82,7 +82,7 @@ class CustomerStateTest {
                 ),
                 mobilePaymentElementComponent = createEnabledMobilePaymentElement(
                     isPaymentMethodSaveEnabled = false,
-                    isPaymentMethodRemoveEnabled = false,
+                    paymentMethodRemove = ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Disabled,
                     canRemoveLastPaymentMethod = false,
                     allowRedisplayOverride = null,
                 ),
@@ -99,14 +99,15 @@ class CustomerStateTest {
 
     private fun createEnabledMobilePaymentElement(
         isPaymentMethodSaveEnabled: Boolean = true,
-        isPaymentMethodRemoveEnabled: Boolean = false,
+        paymentMethodRemove: ElementsSession.Customer.Components.PaymentMethodRemoveFeature =
+            ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Disabled,
         canRemoveLastPaymentMethod: Boolean = false,
         allowRedisplayOverride: PaymentMethod.AllowRedisplay? = null,
         isPaymentMethodSetAsDefaultEnabled: Boolean = false,
     ): ElementsSession.Customer.Components.MobilePaymentElement {
         return ElementsSession.Customer.Components.MobilePaymentElement.Enabled(
             isPaymentMethodSaveEnabled = isPaymentMethodSaveEnabled,
-            isPaymentMethodRemoveEnabled = isPaymentMethodRemoveEnabled,
+            paymentMethodRemove = paymentMethodRemove,
             canRemoveLastPaymentMethod = canRemoveLastPaymentMethod,
             allowRedisplayOverride = allowRedisplayOverride,
             isPaymentMethodSetAsDefaultEnabled = isPaymentMethodSetAsDefaultEnabled,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -2085,7 +2085,8 @@ internal class DefaultPaymentElementLoaderTest {
                     paymentMethods = PaymentMethodFactory.cards(4),
                     session = createElementsSessionCustomerSession(
                         createEnabledMobilePaymentElement(
-                            isPaymentMethodRemoveEnabled = true,
+                            paymentMethodRemove =
+                            ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled,
                             canRemoveLastPaymentMethod = true,
                             isPaymentMethodSaveEnabled = false,
                             allowRedisplayOverride = null,
@@ -2130,7 +2131,8 @@ internal class DefaultPaymentElementLoaderTest {
                     paymentMethods = PaymentMethodFactory.cards(4),
                     session = createElementsSessionCustomerSession(
                         createEnabledMobilePaymentElement(
-                            isPaymentMethodRemoveEnabled = false,
+                            paymentMethodRemove =
+                            ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Disabled,
                             isPaymentMethodSaveEnabled = false,
                             canRemoveLastPaymentMethod = true,
                             allowRedisplayOverride = null,
@@ -2175,7 +2177,8 @@ internal class DefaultPaymentElementLoaderTest {
                     paymentMethods = PaymentMethodFactory.cards(4),
                     session = createElementsSessionCustomerSession(
                         createEnabledMobilePaymentElement(
-                            isPaymentMethodRemoveEnabled = false,
+                            paymentMethodRemove =
+                            ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Disabled,
                             isPaymentMethodSaveEnabled = false,
                             canRemoveLastPaymentMethod = true,
                             allowRedisplayOverride = null,
@@ -2220,7 +2223,8 @@ internal class DefaultPaymentElementLoaderTest {
                     paymentMethods = PaymentMethodFactory.cards(4),
                     session = createElementsSessionCustomerSession(
                         createEnabledMobilePaymentElement(
-                            isPaymentMethodRemoveEnabled = false,
+                            paymentMethodRemove =
+                            ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Disabled,
                             isPaymentMethodSaveEnabled = false,
                             canRemoveLastPaymentMethod = true,
                             allowRedisplayOverride = null,
@@ -3420,7 +3424,8 @@ internal class DefaultPaymentElementLoaderTest {
                         ElementsSession.Customer.Components.MobilePaymentElement.Disabled
                     } else {
                         createEnabledMobilePaymentElement(
-                            isPaymentMethodRemoveEnabled = false,
+                            paymentMethodRemove =
+                            ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Disabled,
                             isPaymentMethodSaveEnabled = false,
                             canRemoveLastPaymentMethod = canRemoveLastPaymentMethodFromServer,
                             allowRedisplayOverride = null,
@@ -3643,7 +3648,7 @@ internal class DefaultPaymentElementLoaderTest {
             isPaymentMethodSaveEnabled?.let {
                 createEnabledMobilePaymentElement(
                     isPaymentMethodSaveEnabled = it,
-                    isPaymentMethodRemoveEnabled = true,
+                    paymentMethodRemove = ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled,
                     canRemoveLastPaymentMethod = true,
                     allowRedisplayOverride = null,
                     isPaymentMethodSetAsDefaultEnabled = false,
@@ -3838,7 +3843,7 @@ internal class DefaultPaymentElementLoaderTest {
                     mobilePaymentElementComponent = ElementsSession.Customer.Components.MobilePaymentElement.Enabled(
                         isPaymentMethodSetAsDefaultEnabled = true,
                         isPaymentMethodSaveEnabled = true,
-                        isPaymentMethodRemoveEnabled = true,
+                        paymentMethodRemove = ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled,
                         canRemoveLastPaymentMethod = true,
                         allowRedisplayOverride = null,
                     ),
@@ -3865,14 +3870,15 @@ internal class DefaultPaymentElementLoaderTest {
 
     private fun createEnabledMobilePaymentElement(
         isPaymentMethodSaveEnabled: Boolean = true,
-        isPaymentMethodRemoveEnabled: Boolean = false,
+        paymentMethodRemove: ElementsSession.Customer.Components.PaymentMethodRemoveFeature =
+            ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Disabled,
         canRemoveLastPaymentMethod: Boolean = false,
         allowRedisplayOverride: PaymentMethod.AllowRedisplay? = null,
         isPaymentMethodSetAsDefaultEnabled: Boolean = false,
     ): ElementsSession.Customer.Components.MobilePaymentElement {
         return ElementsSession.Customer.Components.MobilePaymentElement.Enabled(
             isPaymentMethodSaveEnabled = isPaymentMethodSaveEnabled,
-            isPaymentMethodRemoveEnabled = isPaymentMethodRemoveEnabled,
+            paymentMethodRemove = paymentMethodRemove,
             canRemoveLastPaymentMethod = canRemoveLastPaymentMethod,
             allowRedisplayOverride = allowRedisplayOverride,
             isPaymentMethodSetAsDefaultEnabled = isPaymentMethodSetAsDefaultEnabled,


### PR DESCRIPTION
# Summary
Parse out `partial` field for `payment_method_remove` in `ElementsSession`.

`partial` is a new Customer Session feature that soft-deletes PMs. It's actual behavior when calling the detach endpoint will be converting a PM with an `always` redisplay value to `limited`.

# Motivation
`partial` will be used to determine some remove messaging. Parsing it out will also to determine the remove messaging.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified