### PR TITLE
[lc] LinkAuthIntent and consent wiring

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/LinkControllerPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/LinkControllerPlaygroundActivity.kt
@@ -50,6 +50,7 @@ internal class LinkControllerPlaygroundActivity : AppCompatActivity() {
                         onCreatePaymentMethodClick = viewModel::onCreatePaymentMethodClick,
                         onLookupClick = viewModel::onLookupClick,
                         onAuthenticationClick = viewModel::onAuthenticateClick,
+                        onAuthorizeClick = viewModel::onAuthorizeClick,
                         onRegisterConsumerClick = viewModel::onRegisterConsumerClick,
                         onErrorMessage = { viewModel.status.value = StatusMessage(it) },
                     )

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/LinkControllerPlaygroundState.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/LinkControllerPlaygroundState.kt
@@ -9,5 +9,6 @@ data class LinkControllerPlaygroundState(
     val lookupConsumerResult: LinkController.LookupConsumerResult? = null,
     val createPaymentMethodResult: LinkController.CreatePaymentMethodResult? = null,
     val authenticationResult: LinkController.AuthenticationResult? = null,
+    val authorizeResult: LinkController.AuthorizeResult? = null,
     val registerConsumerResult: LinkController.RegisterConsumerResult? = null,
 )

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/LinkControllerPlaygroundViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/LinkControllerPlaygroundViewModel.kt
@@ -28,6 +28,7 @@ internal class LinkControllerPlaygroundViewModel(
             activity = activity,
             presentPaymentMethodsCallback = this::onLinkControllerPresentPaymentMethod,
             authenticationCallback = this::onLinkControllerAuthentication,
+            authorizeCallback = this::onLinkControllerAuthorization,
         )
         activity.lifecycleScope.launch {
             linkController.state(activity).collect { controllerState ->
@@ -97,7 +98,17 @@ internal class LinkControllerPlaygroundViewModel(
         }
     }
 
+    fun onAuthorizeClick(linkAuthIntentId: String) {
+        linkControllerPresenter?.authorize(
+            linkAuthIntentId = linkAuthIntentId
+        )
+    }
+
     private fun onLinkControllerAuthentication(result: LinkController.AuthenticationResult) {
         state.update { it.copy(authenticationResult = result) }
+    }
+
+    private fun onLinkControllerAuthorization(result: LinkController.AuthorizeResult) {
+        state.update { it.copy(authorizeResult = result) }
     }
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/LinkControllerUi.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/LinkControllerUi.kt
@@ -71,10 +71,12 @@ internal fun LinkControllerUi(
     onCreatePaymentMethodClick: () -> Unit,
     onLookupClick: (email: String) -> Unit,
     onAuthenticationClick: (email: String, existingOnly: Boolean) -> Unit,
+    onAuthorizeClick: (linkAuthIntentId: String) -> Unit,
     onRegisterConsumerClick: (email: String, phone: String, country: String, name: String?) -> Unit,
     onErrorMessage: (message: String) -> Unit,
 ) {
     var email by rememberSaveable { mutableStateOf("") }
+    var linkAuthIntentId by rememberSaveable { mutableStateOf("") }
     var existingOnly by rememberSaveable { mutableStateOf(false) }
     var showRegistrationForm by rememberSaveable { mutableStateOf(false) }
     var registrationPhone by rememberSaveable { mutableStateOf("") }
@@ -212,6 +214,19 @@ internal fun LinkControllerUi(
         )
         Divider(Modifier.padding(top = 10.dp, bottom = 20.dp))
 
+        OutlinedTextField(
+            modifier = Modifier.fillMaxWidth(),
+            value = linkAuthIntentId,
+            label = { Text(text = "LinkAuthIntent ID") },
+            onValueChange = { linkAuthIntentId = it }
+        )
+        AuthorizeButton(
+            modifier = Modifier.fillMaxWidth(),
+            linkAuthIntentId = linkAuthIntentId,
+            onClick = { onAuthorizeClick(linkAuthIntentId) },
+        )
+        Divider(Modifier.padding(top = 10.dp, bottom = 20.dp))
+
         PaymentMethodTypeSelector(
             modifier = Modifier.fillMaxWidth(),
             selectedPaymentMethodType = paymentMethodFilter,
@@ -257,6 +272,7 @@ private fun StatusBox(
         add("Consumer verified" to (controllerState.isConsumerVerified?.toString() ?: ""))
         add("Payment Method created" to (controllerState.createdPaymentMethod?.id ?: ""))
         add("Authentication result" to (playgroundState.authenticationResult?.toString() ?: ""))
+        add("Authorize result" to (playgroundState.authorizeResult?.toString() ?: ""))
         add("Register result" to (playgroundState.registerConsumerResult?.toString() ?: ""))
     }
 
@@ -302,6 +318,7 @@ private fun LinkControllerPlaygroundState.linkControllerError(): Throwable? = li
     (lookupConsumerResult as? LinkController.LookupConsumerResult.Failed)?.error,
     (createPaymentMethodResult as? LinkController.CreatePaymentMethodResult.Failed)?.error,
     (authenticationResult as? LinkController.AuthenticationResult.Failed)?.error,
+    (authorizeResult as? LinkController.AuthorizeResult.Failed)?.error,
 ).firstOrNull { it != null }
 
 @Composable
@@ -316,6 +333,7 @@ private fun LinkControllerUiPreview() {
             onCreatePaymentMethodClick = {},
             onLookupClick = {},
             onAuthenticationClick = { _, _ -> },
+            onAuthorizeClick = {},
             onRegisterConsumerClick = { _, _, _, _ -> },
             onErrorMessage = {},
         )
@@ -522,6 +540,29 @@ private fun AuthenticateButton(
                 append("Authenticate")
                 if (email.isNotBlank()) {
                     append(" ${email.trim()}")
+                }
+            },
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+}
+
+@Composable
+private fun AuthorizeButton(
+    linkAuthIntentId: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Button(
+        onClick = onClick,
+        modifier = modifier,
+    ) {
+        Text(
+            text = buildString {
+                append("Authorize")
+                if (linkAuthIntentId.isNotBlank()) {
+                    append(" ${linkAuthIntentId.trim()}")
                 }
             },
             maxLines = 1,

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -400,6 +400,14 @@ public final class com/stripe/android/link/LinkLaunchMode$Authentication$Creator
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/link/LinkLaunchMode$Authorization$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/link/LinkLaunchMode$Authorization;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/link/LinkLaunchMode$Authorization;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/link/LinkLaunchMode$Confirmation$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/link/LinkLaunchMode$Confirmation;

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivity.kt
@@ -81,8 +81,11 @@ internal class LinkActivity : ComponentActivity() {
         when (this) {
             is LinkLaunchMode.Full,
             is LinkLaunchMode.PaymentMethodSelection,
-            is LinkLaunchMode.Authentication -> setTheme(R.style.StripePaymentSheetDefaultTheme)
-            is LinkLaunchMode.Confirmation -> setTheme(R.style.StripeTransparentTheme)
+            is LinkLaunchMode.Authentication,
+            is LinkLaunchMode.Authorization ->
+                setTheme(R.style.StripePaymentSheetDefaultTheme)
+            is LinkLaunchMode.Confirmation ->
+                setTheme(R.style.StripeTransparentTheme)
         }
         renderEdgeToEdge()
     }

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityResult.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityResult.kt
@@ -18,6 +18,7 @@ internal sealed class LinkActivityResult : Parcelable {
         override val linkAccountUpdate: LinkAccountUpdate,
         val selectedPayment: LinkPaymentMethod? = null,
         val shippingAddress: ConsumerShippingAddress? = null,
+        val authorizationConsentGranted: Boolean? = null,
     ) : LinkActivityResult()
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
@@ -176,9 +176,7 @@ internal class LinkActivityViewModel @Inject constructor(
             )
             is LinkLaunchMode.Authorization -> dismissWithResult(
                 LinkActivityResult.Failed(
-                    error = IllegalStateException(
-                        "authorization only is not supported in web mode"
-                    ),
+                    error = IllegalStateException("Authorization mode is not supported in web"),
                     linkAccountUpdate = LinkAccountUpdate.None
                 )
             )
@@ -338,7 +336,8 @@ internal class LinkActivityViewModel @Inject constructor(
         val authorizingAuthIntent = linkLaunchMode is LinkLaunchMode.Authorization
         val cannotChangeEmails = !linkConfiguration.allowUserEmailEdits
         val accountNotFound = accountStatus == AccountStatus.SignedOut || accountStatus == AccountStatus.Error
-        if (accountNotFound && (authorizingAuthIntent || authenticatingExistingAccount || cannotChangeEmails)) {
+        val accountRequired = authorizingAuthIntent || authenticatingExistingAccount || cannotChangeEmails
+        if (accountNotFound && accountRequired) {
             dismissWithResult(
                 LinkActivityResult.Failed(
                     error = NoLinkAccountFoundException(),
@@ -348,9 +347,9 @@ internal class LinkActivityViewModel @Inject constructor(
             return
         }
 
-        if (linkLaunchMode is LinkLaunchMode.Authorization &&
+        if (authorizingAuthIntent &&
             accountStatus is AccountStatus.Verified &&
-            linkAccount?.consentPresentation is ConsentPresentation.Inline
+            accountStatus.consentPresentation is ConsentPresentation.Inline
         ) {
             // Already completed verification with inline consent.
             dismissWithResult(LinkActivityResult.Completed(linkAccountManager.linkAccountUpdate))

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
@@ -27,6 +27,7 @@ import com.stripe.android.link.injection.LINK_EXPRESS_MODE
 import com.stripe.android.link.injection.NativeLinkComponent
 import com.stripe.android.link.injection.NativeLinkScope
 import com.stripe.android.link.model.AccountStatus
+import com.stripe.android.link.model.ConsentPresentation
 import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.link.ui.LinkAppBarState
 import com.stripe.android.link.ui.signup.SignUpViewModel
@@ -106,7 +107,7 @@ internal class LinkActivityViewModel @Inject constructor(
 
     fun onVerificationSucceeded() {
         viewModelScope.launch {
-            _linkScreenState.value = buildFullScreenState()
+            updateScreenState(withAnimationDelay = false)
         }
     }
 
@@ -170,6 +171,14 @@ internal class LinkActivityViewModel @Inject constructor(
             is LinkLaunchMode.Authentication -> dismissWithResult(
                 LinkActivityResult.Failed(
                     error = error,
+                    linkAccountUpdate = LinkAccountUpdate.None
+                )
+            )
+            is LinkLaunchMode.Authorization -> dismissWithResult(
+                LinkActivityResult.Failed(
+                    error = IllegalStateException(
+                        "authorization only is not supported in web mode"
+                    ),
                     linkAccountUpdate = LinkAccountUpdate.None
                 )
             )
@@ -245,8 +254,11 @@ internal class LinkActivityViewModel @Inject constructor(
             when (linkLaunchMode) {
                 is LinkLaunchMode.Full,
                 is LinkLaunchMode.PaymentMethodSelection,
-                is LinkLaunchMode.Authentication -> loadLink()
-                is LinkLaunchMode.Confirmation -> confirmLinkPayment(linkLaunchMode.selectedPayment)
+                is LinkLaunchMode.Authentication,
+                is LinkLaunchMode.Authorization ->
+                    loadLink()
+                is LinkLaunchMode.Confirmation ->
+                    confirmLinkPayment(linkLaunchMode.selectedPayment)
             }
         }
     }
@@ -258,11 +270,11 @@ internal class LinkActivityViewModel @Inject constructor(
                 when (linkExpressMode) {
                     LinkExpressMode.DISABLED,
                     LinkExpressMode.ENABLED -> moveToWeb(attestationCheckResult.error)
-                    LinkExpressMode.ENABLED_NO_WEB_FALLBACK -> updateScreenState()
+                    LinkExpressMode.ENABLED_NO_WEB_FALLBACK -> updateScreenState(withAnimationDelay = true)
                 }
             }
             LinkAttestationCheck.Result.Successful -> {
-                updateScreenState()
+                updateScreenState(withAnimationDelay = true)
             }
             is LinkAttestationCheck.Result.Error,
             is LinkAttestationCheck.Result.AccountError -> {
@@ -316,13 +328,17 @@ internal class LinkActivityViewModel @Inject constructor(
         )
     }
 
-    private suspend fun updateScreenState() {
+    private suspend fun updateScreenState(withAnimationDelay: Boolean) {
         val accountStatus = linkAccountManager.accountStatus.first()
 
+        // Get linkAccount after getting `accountStatus` because account may be updated.
+        val linkAccount = this.linkAccount
+
         val authenticatingExistingAccount = (linkLaunchMode as? LinkLaunchMode.Authentication)?.existingOnly == true
+        val authorizingAuthIntent = linkLaunchMode is LinkLaunchMode.Authorization
         val cannotChangeEmails = !linkConfiguration.allowUserEmailEdits
         val accountNotFound = accountStatus == AccountStatus.SignedOut || accountStatus == AccountStatus.Error
-        if (accountNotFound && (authenticatingExistingAccount || cannotChangeEmails)) {
+        if (accountNotFound && (authorizingAuthIntent || authenticatingExistingAccount || cannotChangeEmails)) {
             dismissWithResult(
                 LinkActivityResult.Failed(
                     error = NoLinkAccountFoundException(),
@@ -332,37 +348,49 @@ internal class LinkActivityViewModel @Inject constructor(
             return
         }
 
-        val linkAccount = linkAccountManager.linkAccountInfo.value.account
+        if (linkLaunchMode is LinkLaunchMode.Authorization &&
+            accountStatus is AccountStatus.Verified &&
+            linkAccount?.consentPresentation is ConsentPresentation.Inline
+        ) {
+            // Already completed verification with inline consent.
+            dismissWithResult(LinkActivityResult.Completed(linkAccountManager.linkAccountUpdate))
+            return
+        }
+
         when (accountStatus) {
-            AccountStatus.Verified,
+            is AccountStatus.Verified,
             AccountStatus.SignedOut,
             AccountStatus.Error -> {
-                _linkScreenState.value = buildFullScreenState()
+                _linkScreenState.value = buildFullScreenState(withAnimationDelay)
             }
             AccountStatus.NeedsVerification,
             AccountStatus.VerificationStarted -> {
                 if (linkAccount != null && linkExpressMode != LinkExpressMode.DISABLED) {
                     _linkScreenState.value = ScreenState.VerificationDialog(linkAccount)
                 } else {
-                    _linkScreenState.value = buildFullScreenState()
+                    _linkScreenState.value = buildFullScreenState(withAnimationDelay)
                 }
             }
         }
     }
 
-    private suspend fun buildFullScreenState(): ScreenState.FullScreen {
+    private suspend fun buildFullScreenState(withAnimationDelay: Boolean): ScreenState.FullScreen {
         val accountStatus = linkAccountManager.accountStatus.first()
 
         // We add a tiny delay, which gives the loading screen a chance to fully inflate.
         // Otherwise, we get a weird scaling animation when we display the first non-loading screen.
-        delay(LINK_DEFAULT_ANIMATION_DELAY_MILLIS)
+        if (withAnimationDelay) {
+            delay(LINK_DEFAULT_ANIMATION_DELAY_MILLIS)
+        }
 
         val linkAccount = this.linkAccount
 
         return ScreenState.FullScreen(
             initialDestination = when (accountStatus) {
-                AccountStatus.Verified -> {
-                    if (linkAccount?.completedSignup == true && linkLaunchMode.selectedPayment() == null) {
+                is AccountStatus.Verified -> {
+                    if (linkLaunchMode is LinkLaunchMode.Authorization) {
+                        LinkScreen.OAuthConsent
+                    } else if (linkAccount?.completedSignup == true && linkLaunchMode.selectedPayment() == null) {
                         // We just completed signup, but haven't added a payment method yet.
                         when (addPaymentMethodOptionsFactory.create(linkAccount).default) {
                             is AddPaymentMethodOption.Bank -> LinkScreen.Wallet
@@ -375,10 +403,12 @@ internal class LinkActivityViewModel @Inject constructor(
                         LinkScreen.Wallet
                     }
                 }
-                AccountStatus.NeedsVerification, AccountStatus.VerificationStarted -> {
+                AccountStatus.NeedsVerification,
+                AccountStatus.VerificationStarted -> {
                     LinkScreen.Verification
                 }
-                AccountStatus.SignedOut, AccountStatus.Error -> {
+                AccountStatus.SignedOut,
+                AccountStatus.Error -> {
                     LinkScreen.SignUp
                 }
             }
@@ -388,7 +418,7 @@ internal class LinkActivityViewModel @Inject constructor(
     private suspend fun handleAccountError() {
         linkAccountManager.logOut()
         linkAccountHolder.set(LinkAccountUpdate.Value(account = null, lastUpdateReason = LoggedOut))
-        updateScreenState()
+        updateScreenState(withAnimationDelay = true)
     }
 
     private fun dismissWithResult(result: LinkActivityResult) {

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkConfigurationLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkConfigurationLoader.kt
@@ -2,7 +2,6 @@ package com.stripe.android.link
 
 import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.core.Logger
-import com.stripe.android.link.LinkController.Configuration
 import com.stripe.android.link.exceptions.LinkUnavailableException
 import com.stripe.android.link.gate.LinkGate
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -10,7 +9,7 @@ import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import javax.inject.Inject
 
 internal interface LinkConfigurationLoader {
-    suspend fun load(configuration: Configuration): Result<LinkConfiguration>
+    suspend fun load(configuration: LinkController.Configuration): Result<LinkConfiguration>
 }
 
 internal class DefaultLinkConfigurationLoader @Inject constructor(
@@ -20,7 +19,7 @@ internal class DefaultLinkConfigurationLoader @Inject constructor(
 ) : LinkConfigurationLoader {
     private val tag = "LinkConfigurationLoader"
 
-    override suspend fun load(configuration: Configuration): Result<LinkConfiguration> {
+    override suspend fun load(configuration: LinkController.Configuration): Result<LinkConfiguration> {
         return paymentElementLoader.load(
             initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
                 PaymentSheet.IntentConfiguration(

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerCoordinator.kt
@@ -19,6 +19,7 @@ internal class LinkControllerCoordinator @Inject constructor(
     linkActivityContract: NativeLinkActivityContract,
     private val selectedPaymentMethodCallback: LinkController.PresentPaymentMethodsCallback,
     private val authenticationCallback: LinkController.AuthenticationCallback,
+    private val authorizeCallback: LinkController.AuthorizeCallback,
 ) {
     val linkActivityResultLauncher: ActivityResultLauncher<LinkActivityContract.Args>
 
@@ -41,6 +42,10 @@ internal class LinkControllerCoordinator @Inject constructor(
                 launch {
                     interactor.authenticationResultFlow
                         .collect(authenticationCallback::onAuthenticationResult)
+                }
+                launch {
+                    interactor.authorizeResultFlow
+                        .collect(authorizeCallback::onAuthorizeResult)
                 }
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
@@ -45,6 +45,7 @@ import javax.inject.Inject
 import javax.inject.Provider
 import javax.inject.Singleton
 
+@Suppress("TooManyFunctions")
 @Singleton
 internal class LinkControllerInteractor @Inject constructor(
     private val application: Application,

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkLaunchMode.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkLaunchMode.kt
@@ -32,6 +32,11 @@ internal sealed interface LinkLaunchMode : Parcelable {
          * Whether or not a secondary CTA to pay another way should be shown.
          */
         val shouldShowSecondaryCta: Boolean = true,
+
+        /**
+         * Optional hint to be displayed.
+         */
+        val hint: String? = null,
     ) : LinkLaunchMode
 
     /**
@@ -58,8 +63,14 @@ internal sealed interface LinkLaunchMode : Parcelable {
         val existingOnly: Boolean = false,
     ) : LinkLaunchMode
 
+    @Parcelize
+    data class Authorization(
+        val linkAuthIntentId: String,
+    ) : LinkLaunchMode
+
     fun selectedPayment(): ConsumerPaymentDetails.PaymentDetails? = when (this) {
         is Authentication -> null
+        is Authorization -> null
         is Full -> null
         is Confirmation -> selectedPayment.details
         is PaymentMethodSelection -> selectedPayment

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkLaunchMode.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkLaunchMode.kt
@@ -32,11 +32,6 @@ internal sealed interface LinkLaunchMode : Parcelable {
          * Whether or not a secondary CTA to pay another way should be shown.
          */
         val shouldShowSecondaryCta: Boolean = true,
-
-        /**
-         * Optional hint to be displayed.
-         */
-        val hint: String? = null,
     ) : LinkLaunchMode
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkScreen.kt
@@ -6,7 +6,6 @@ import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavType
 import androidx.navigation.navArgument
 import com.stripe.android.link.LinkScreen.UpdateCard.BillingDetailsUpdateFlow
-import kotlin.collections.List
 
 internal sealed class LinkScreen(
     protected val baseRoute: String,
@@ -23,6 +22,7 @@ internal sealed class LinkScreen(
     data object Wallet : LinkScreen("wallet")
     data object PaymentMethod : LinkScreen("paymentMethod")
     data object SignUp : LinkScreen("signUp")
+    data object OAuthConsent : LinkScreen("oauthConsent")
 
     data object UpdateCard : LinkScreen(
         baseRoute = "updateCard",

--- a/paymentsheet/src/main/java/com/stripe/android/link/confirmation/CompleteLinkFlow.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/confirmation/CompleteLinkFlow.kt
@@ -110,7 +110,8 @@ internal class DefaultCompleteLinkFlow @Inject constructor(
                     shippingAddress = linkAccountManager.loadDefaultShippingAddress(),
                 )
             )
-            is LinkLaunchMode.Authentication -> Result.Completed(
+            is LinkLaunchMode.Authentication,
+            is LinkLaunchMode.Authorization -> Result.Completed(
                 linkActivityResult = LinkActivityResult.Completed(
                     linkAccountUpdate = linkAccountManager.linkAccountUpdate,
                     selectedPayment = null,

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerModule.kt
@@ -9,6 +9,7 @@ import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.googlepaylauncher.injection.GooglePayLauncherModule
 import com.stripe.android.link.DefaultLinkConfigurationLoader
 import com.stripe.android.link.LinkConfigurationLoader
+import com.stripe.android.link.LinkLaunchMode
 import com.stripe.android.paymentelement.confirmation.injection.ExtendedPaymentElementConfirmationModule
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.payments.core.injection.StripeRepositoryModule

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerModule.kt
@@ -9,7 +9,6 @@ import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.googlepaylauncher.injection.GooglePayLauncherModule
 import com.stripe.android.link.DefaultLinkConfigurationLoader
 import com.stripe.android.link.LinkConfigurationLoader
-import com.stripe.android.link.LinkLaunchMode
 import com.stripe.android.paymentelement.confirmation.injection.ExtendedPaymentElementConfirmationModule
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.payments.core.injection.StripeRepositoryModule

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerPresenterComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerPresenterComponent.kt
@@ -20,6 +20,7 @@ internal interface LinkControllerPresenterComponent {
             @BindsInstance activityResultRegistryOwner: ActivityResultRegistryOwner,
             @BindsInstance presentPaymentMethodsCallback: LinkController.PresentPaymentMethodsCallback,
             @BindsInstance authenticationCallback: LinkController.AuthenticationCallback,
+            @BindsInstance authorizeCallback: LinkController.AuthorizeCallback,
         ): LinkControllerPresenterComponent
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/model/AccountStatus.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/model/AccountStatus.kt
@@ -2,17 +2,17 @@ package com.stripe.android.link.model
 
 import com.stripe.android.paymentsheet.state.LinkState
 
-internal enum class AccountStatus {
-    Verified, // Customer is signed in
-    NeedsVerification, // Customer needs to authenticate
-    VerificationStarted, // Customer has started OTP verification
-    SignedOut, // Customer is signed out
-    Error // Account status could not be determined
+internal sealed interface AccountStatus {
+    data class Verified(val consentPresentation: ConsentPresentation?) : AccountStatus // Customer is signed in
+    data object NeedsVerification : AccountStatus // Customer needs to authenticate
+    data object VerificationStarted : AccountStatus // Customer has started OTP verification
+    data object SignedOut : AccountStatus // Customer is signed out
+    data object Error : AccountStatus // Account status could not be determined
 }
 
 internal fun AccountStatus.toLoginState(): LinkState.LoginState {
     return when (this) {
-        AccountStatus.Verified ->
+        is AccountStatus.Verified ->
             LinkState.LoginState.LoggedIn
         AccountStatus.NeedsVerification,
         AccountStatus.VerificationStarted ->

--- a/paymentsheet/src/main/java/com/stripe/android/link/model/LinkAccount.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/model/LinkAccount.kt
@@ -11,7 +11,7 @@ import kotlinx.parcelize.Parcelize
  * Immutable object representing a Link account.
  */
 @Parcelize
-internal class LinkAccount(
+internal data class LinkAccount(
     private val consumerSession: ConsumerSession,
     val consumerPublishableKey: String? = null,
     val displayablePaymentDetails: DisplayablePaymentDetails? = null,

--- a/paymentsheet/src/main/java/com/stripe/android/link/model/LinkAccount.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/model/LinkAccount.kt
@@ -52,7 +52,7 @@ internal class LinkAccount(
     @IgnoredOnParcel
     val accountStatus = when {
         isVerified -> {
-            AccountStatus.Verified
+            AccountStatus.Verified(consentPresentation = consentPresentation)
         }
         consumerSession.containsSMSSessionStarted() -> {
             AccountStatus.VerificationStarted

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/LinkAppBarState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/LinkAppBarState.kt
@@ -39,6 +39,7 @@ internal data class LinkAppBarState(
                 LinkScreen.SignUp.route,
                 LinkScreen.Wallet.route,
                 LinkScreen.Verification.route,
+                LinkScreen.OAuthConsent.route,
             )
 
             if (consumerIsSigningUp) {

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/LinkContent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/LinkContent.kt
@@ -102,6 +102,7 @@ internal fun LinkContent(
     }
 }
 
+@SuppressWarnings("LongMethod")
 @Composable
 private fun Screens(
     navController: NavHostController,

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/LinkContent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/LinkContent.kt
@@ -22,6 +22,7 @@ import com.stripe.android.link.linkViewModel
 import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.link.theme.DefaultLinkTheme
 import com.stripe.android.link.theme.LinkTheme
+import com.stripe.android.link.ui.oauth.OAuthConsentScreen
 import com.stripe.android.link.ui.paymentmenthod.PaymentMethodScreen
 import com.stripe.android.link.ui.paymentmenthod.PaymentMethodViewModel
 import com.stripe.android.link.ui.signup.SignUpScreen
@@ -163,6 +164,7 @@ private fun Screens(
 
         composable(LinkScreen.Wallet.route) {
             val linkAccount = getLinkAccount() ?: return@composable dismissWithResult(noLinkAccountResult())
+
             WalletRoute(
                 linkAccount = linkAccount,
                 navigateAndClearStack = navigateAndClearStack,
@@ -176,6 +178,14 @@ private fun Screens(
         composable(LinkScreen.PaymentMethod.route) {
             val linkAccount = getLinkAccount() ?: return@composable dismissWithResult(noLinkAccountResult())
             PaymentMethodRoute(
+                linkAccount = linkAccount,
+                dismissWithResult = dismissWithResult,
+            )
+        }
+
+        composable(LinkScreen.OAuthConsent.route) {
+            val linkAccount = getLinkAccount() ?: return@composable dismissWithResult(noLinkAccountResult())
+            OAuthConsentRoute(
                 linkAccount = linkAccount,
                 dismissWithResult = dismissWithResult,
             )
@@ -285,6 +295,15 @@ private fun WalletRoute(
         hideBottomSheetContent = hideBottomSheetContent,
         onLogoutClicked = onLogoutClicked,
     )
+}
+
+@Composable
+@Suppress("UNUSED_PARAMETER")
+private fun OAuthConsentRoute(
+    linkAccount: LinkAccount,
+    dismissWithResult: (LinkActivityResult) -> Unit,
+) {
+    OAuthConsentScreen()
 }
 
 private fun noLinkAccountResult(): LinkActivityResult {

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/PrimaryButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/PrimaryButton.kt
@@ -201,7 +201,8 @@ internal fun completePaymentButtonLabel(
         }
     }
     is LinkLaunchMode.PaymentMethodSelection,
-    is LinkLaunchMode.Authentication -> uiCoreR.string.stripe_continue_button_label.resolvableString
+    is LinkLaunchMode.Authentication,
+    is LinkLaunchMode.Authorization -> uiCoreR.string.stripe_continue_button_label.resolvableString
 }
 
 private val PrimaryButtonIconWidth = 13.dp

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/oauth/OAuthConsentScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/oauth/OAuthConsentScreen.kt
@@ -1,0 +1,22 @@
+package com.stripe.android.link.ui.oauth
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.stripe.android.link.theme.LinkTheme
+
+@Composable
+internal fun OAuthConsentScreen() {
+    Text(
+        modifier = Modifier
+            .height(100.dp)
+            .fillMaxWidth(),
+        text = "TODO: OAuth Consent",
+        color = LinkTheme.colors.textPrimary,
+        textAlign = TextAlign.Center,
+    )
+}

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/signup/SignUpViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/signup/SignUpViewModel.kt
@@ -15,7 +15,6 @@ import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkDismissalCoordinator
 import com.stripe.android.link.LinkLaunchMode
-import com.stripe.android.link.LinkLaunchMode.Authentication
 import com.stripe.android.link.LinkScreen
 import com.stripe.android.link.NoLinkAccountFoundException
 import com.stripe.android.link.account.LinkAuth
@@ -240,7 +239,7 @@ internal class SignUpViewModel @Inject constructor(
         }
 
         // Return the account in authentication mode if verification not required
-        if (linkLaunchMode is Authentication && targetScreen != LinkScreen.Verification) {
+        if (linkLaunchMode is LinkLaunchMode.Authentication && targetScreen != LinkScreen.Verification) {
             dismissWithResult(
                 LinkActivityResult.Completed(
                     linkAccountUpdate = LinkAccountUpdate.Value(linkAccount),

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
@@ -673,18 +673,18 @@ private fun StripeIntent.secondaryButtonLabel(linkLaunchMode: LinkLaunchMode): R
     return when (linkLaunchMode) {
         is LinkLaunchMode.Full,
         is LinkLaunchMode.Confirmation -> when (this) {
-            is PaymentIntent -> resolvableString(R.string.stripe_wallet_pay_another_way)
-            is SetupIntent -> resolvableString(R.string.stripe_wallet_continue_another_way)
+            is PaymentIntent -> R.string.stripe_wallet_pay_another_way.resolvableString
+            is SetupIntent -> R.string.stripe_wallet_continue_another_way.resolvableString
         }
         is LinkLaunchMode.PaymentMethodSelection -> {
             if (linkLaunchMode.shouldShowSecondaryCta) {
-                resolvableString(R.string.stripe_wallet_continue_another_way)
+                R.string.stripe_wallet_continue_another_way.resolvableString
             } else {
                 null
             }
         }
         is LinkLaunchMode.Authentication,
         is LinkLaunchMode.Authorization ->
-            resolvableString(R.string.stripe_wallet_continue_another_way)
+            R.string.stripe_wallet_continue_another_way.resolvableString
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
@@ -102,6 +102,7 @@ internal class WalletViewModel(
             is LinkLaunchMode.Confirmation -> null
             is LinkLaunchMode.PaymentMethodSelection -> selectedPayment?.id
             is LinkLaunchMode.Authentication -> null
+            is LinkLaunchMode.Authorization -> null
         }
 
     private val paymentMethodFilter
@@ -672,16 +673,18 @@ private fun StripeIntent.secondaryButtonLabel(linkLaunchMode: LinkLaunchMode): R
     return when (linkLaunchMode) {
         is LinkLaunchMode.Full,
         is LinkLaunchMode.Confirmation -> when (this) {
-            is PaymentIntent -> R.string.stripe_wallet_pay_another_way.resolvableString
-            is SetupIntent -> R.string.stripe_wallet_continue_another_way.resolvableString
+            is PaymentIntent -> resolvableString(R.string.stripe_wallet_pay_another_way)
+            is SetupIntent -> resolvableString(R.string.stripe_wallet_continue_another_way)
         }
         is LinkLaunchMode.PaymentMethodSelection -> {
             if (linkLaunchMode.shouldShowSecondaryCta) {
-                R.string.stripe_wallet_continue_another_way.resolvableString
+                resolvableString(R.string.stripe_wallet_continue_another_way)
             } else {
                 null
             }
         }
-        is LinkLaunchMode.Authentication -> null
+        is LinkLaunchMode.Authentication,
+        is LinkLaunchMode.Authorization ->
+            resolvableString(R.string.stripe_wallet_continue_another_way)
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/verification/DefaultLinkInlineInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/verification/DefaultLinkInlineInteractor.kt
@@ -89,10 +89,7 @@ internal class DefaultLinkInlineInteractor @Inject constructor(
                         )
                     }
                     // confirm verification
-                    val result: Result<LinkAccount> = linkAccountManager.confirmVerification(
-                        code = code,
-                        consentGranted = null
-                    )
+                    val result = linkAccountManager.confirmVerification(code = code, consentGranted = null)
                     onConfirmationResult(verificationState, result)
                 }
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinition.kt
@@ -86,7 +86,7 @@ internal class LinkInlineSignupConfirmationDefinition(
         val userInput = linkInlineSignupConfirmationOption.userInput
 
         return when (linkConfigurationCoordinator.getAccountStatusFlow(configuration).first()) {
-            AccountStatus.Verified -> createOptionAfterAttachingToLink(linkInlineSignupConfirmationOption, userInput)
+            is AccountStatus.Verified -> createOptionAfterAttachingToLink(linkInlineSignupConfirmationOption, userInput)
             AccountStatus.VerificationStarted,
             AccountStatus.NeedsVerification -> {
                 linkAnalyticsHelper.onLinkPopupSkipped()

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkConfigurationCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkConfigurationCoordinatorTest.kt
@@ -31,7 +31,7 @@ class LinkConfigurationCoordinatorTest {
             val component = mock<LinkComponent>()
             val linkAccountManager = FakeLinkAccountManager()
             whenever(component.linkAccountManager).thenReturn(linkAccountManager)
-            linkAccountManager.setAccountStatus(AccountStatus.Verified)
+            linkAccountManager.setAccountStatus(AccountStatus.Verified(null))
             linkAccountManager.signInWithUserInputResult = Result.failure(IllegalStateException("Test"))
 
             whenever(component.configuration).thenReturn(configurationCapture.lastValue)

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerCoordinatorTest.kt
@@ -39,6 +39,7 @@ internal class LinkControllerCoordinatorTest {
 
     private val presentPaymentMethodsResults = mutableListOf<LinkController.PresentPaymentMethodsResult>()
     private val authenticationResults = mutableListOf<LinkController.AuthenticationResult>()
+    private val authorizeResults = mutableListOf<LinkController.AuthorizeResult>()
 
     private val lifecycleOwner = TestLifecycleOwner(initialState = Lifecycle.State.INITIALIZED)
 
@@ -57,6 +58,7 @@ internal class LinkControllerCoordinatorTest {
             linkActivityContract = linkActivityContract,
             selectedPaymentMethodCallback = { presentPaymentMethodsResults.add(it) },
             authenticationCallback = { authenticationResults.add(it) },
+            authorizeCallback = { authorizeResults.add(it) },
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerInteractorTest.kt
@@ -1000,6 +1000,7 @@ class LinkControllerInteractorTest {
         }
     }
 
+    @Suppress("LongMethod")
     @Test
     fun `onLinkActivityResult() with Authorization results`() = runTest {
         data class AuthorizationTestCase(

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerInteractorTest.kt
@@ -974,6 +974,104 @@ class LinkControllerInteractorTest {
         interactor.configure(createControllerConfig())
     }
 
+    @Test
+    fun `authorize() launches Link with correct arguments`() = runTest {
+        val interactor = createInteractor()
+        configure(interactor)
+
+        val linkAuthIntentId = "lai_test123"
+        val launcher = FakeActivityResultLauncher<LinkActivityContract.Args>()
+        interactor.authorize(launcher, linkAuthIntentId)
+
+        val args = launcher.calls.awaitItem().input
+        assertThat(args.linkExpressMode).isEqualTo(LinkExpressMode.ENABLED)
+        assertThat(args.linkAccountInfo.account).isNull()
+        assertThat(args.launchMode).isEqualTo(LinkLaunchMode.Authorization(linkAuthIntentId = linkAuthIntentId))
+    }
+
+    @Test
+    fun `authorize() fails when configuration is not set`() = runTest {
+        val interactor = createInteractor()
+
+        interactor.authorizeResultFlow.test {
+            interactor.authorize(mock(), "lai_test123")
+            val result = awaitItem() as LinkController.AuthorizeResult.Failed
+            assertThat(result.error).isInstanceOf(MissingConfigurationException::class.java)
+        }
+    }
+
+    @Test
+    fun `onLinkActivityResult() with Authorization results`() = runTest {
+        data class AuthorizationTestCase(
+            val name: String,
+            val linkActivityResult: LinkActivityResult,
+            val expectedAuthorizeResult: LinkController.AuthorizeResult
+        )
+
+        val error = Exception("Authorization error")
+        val testCases = listOf(
+            AuthorizationTestCase(
+                name = "Canceled",
+                linkActivityResult = LinkActivityResult.Canceled(
+                    reason = LinkActivityResult.Canceled.Reason.BackPressed,
+                    linkAccountUpdate = LinkAccountUpdate.Value(null)
+                ),
+                expectedAuthorizeResult = LinkController.AuthorizeResult.Canceled
+            ),
+            AuthorizationTestCase(
+                name = "Completed - Consented",
+                linkActivityResult = LinkActivityResult.Completed(
+                    linkAccountUpdate = LinkAccountUpdate.Value(null),
+                    selectedPayment = null,
+                    shippingAddress = null,
+                    authorizationConsentGranted = true
+                ),
+                expectedAuthorizeResult = LinkController.AuthorizeResult.Consented
+            ),
+            AuthorizationTestCase(
+                name = "Completed - Denied",
+                linkActivityResult = LinkActivityResult.Completed(
+                    linkAccountUpdate = LinkAccountUpdate.Value(null),
+                    selectedPayment = null,
+                    shippingAddress = null,
+                    authorizationConsentGranted = false
+                ),
+                expectedAuthorizeResult = LinkController.AuthorizeResult.Denied
+            ),
+            AuthorizationTestCase(
+                name = "Completed - null consent (fallback to Canceled)",
+                linkActivityResult = LinkActivityResult.Completed(
+                    linkAccountUpdate = LinkAccountUpdate.Value(null),
+                    selectedPayment = null,
+                    shippingAddress = null,
+                    authorizationConsentGranted = null
+                ),
+                expectedAuthorizeResult = LinkController.AuthorizeResult.Canceled
+            ),
+            AuthorizationTestCase(
+                name = "Failed",
+                linkActivityResult = LinkActivityResult.Failed(
+                    error = error,
+                    linkAccountUpdate = LinkAccountUpdate.Value(null)
+                ),
+                expectedAuthorizeResult = LinkController.AuthorizeResult.Failed(error)
+            )
+        )
+
+        testCases.forEach { testCase ->
+            val interactor = createInteractor()
+            configure(interactor)
+
+            // Set up the launch mode
+            interactor.authorize(FakeActivityResultLauncher(), "lai_test123")
+
+            interactor.authorizeResultFlow.test {
+                interactor.onLinkActivityResult(testCase.linkActivityResult)
+                assertThat(awaitItem()).isEqualTo(testCase.expectedAuthorizeResult)
+            }
+        }
+    }
+
     private data class ConsumerRegistrationParams(
         val email: String = "test@example.com",
         val phone: String = "1234567890",

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAccountManagerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAccountManagerTest.kt
@@ -6,6 +6,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.StripeError
 import com.stripe.android.core.exception.AuthenticationException
 import com.stripe.android.link.LinkAccountUpdate
+import com.stripe.android.link.LinkLaunchMode
 import com.stripe.android.link.LinkPaymentDetails
 import com.stripe.android.link.NoLinkAccountFoundException
 import com.stripe.android.link.TestFactory
@@ -81,7 +82,7 @@ class DefaultLinkAccountManagerTest {
                 TestFactory.EMAIL,
                 linkRepository = linkRepository
             ).accountStatus.first()
-        ).isEqualTo(AccountStatus.Verified)
+        ).isEqualTo(AccountStatus.Verified(null))
 
         assertThat(linkRepository.callCount).isEqualTo(1)
     }
@@ -437,7 +438,7 @@ class DefaultLinkAccountManagerTest {
         assertThat(result.exceptionOrNull()).isEqualTo(
             AlreadyLoggedInLinkException(
                 email = TestFactory.EMAIL,
-                accountStatus = AccountStatus.Verified
+                accountStatus = AccountStatus.Verified(null)
             )
         )
     }
@@ -1089,7 +1090,7 @@ class DefaultLinkAccountManagerTest {
         accountStatusFlowTest(
             customerEmail = TestFactory.CUSTOMER_EMAIL,
             allowUserEmailEdits = true,
-            expectedStatus = AccountStatus.Verified,
+            expectedStatus = AccountStatus.Verified(null),
             expectedLookupEmail = TestFactory.CUSTOMER_EMAIL
         )
 
@@ -1098,7 +1099,7 @@ class DefaultLinkAccountManagerTest {
         accountStatusFlowTest(
             customerEmail = TestFactory.CUSTOMER_EMAIL,
             allowUserEmailEdits = false,
-            expectedStatus = AccountStatus.Verified,
+            expectedStatus = AccountStatus.Verified(null),
             expectedLookupEmail = TestFactory.CUSTOMER_EMAIL
         )
 
@@ -1151,7 +1152,8 @@ class DefaultLinkAccountManagerTest {
             ),
             linkRepository = linkRepository,
             linkEventsReporter = linkEventsReporter,
-            errorReporter = FakeErrorReporter()
+            errorReporter = FakeErrorReporter(),
+            linkLaunchMode = LinkLaunchMode.Full
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/FakeLinkAccountManager.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/FakeLinkAccountManager.kt
@@ -33,7 +33,7 @@ internal open class FakeLinkAccountManager(
 ) : LinkAccountManager {
     override val linkAccountInfo: StateFlow<LinkAccountUpdate.Value> = linkAccountHolder.linkAccountInfo
 
-    private val _accountStatus = MutableStateFlow(AccountStatus.SignedOut)
+    private val _accountStatus = MutableStateFlow<AccountStatus>(AccountStatus.SignedOut)
     override val accountStatus: Flow<AccountStatus> = accountStatusOverride ?: _accountStatus
 
     private val _consumerState =

--- a/paymentsheet/src/test/java/com/stripe/android/link/verification/DefaultLinkInlineInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/verification/DefaultLinkInlineInteractorTest.kt
@@ -97,7 +97,7 @@ class DefaultLinkInlineInteractorTest {
     fun `when account status is LoggedIn, should render button`() = runTest(testDispatcher) {
         // Setup
         linkAccountManager.setLinkAccount(
-            LinkAccountUpdate.Value(createLinkAccount(AccountStatus.Verified))
+            LinkAccountUpdate.Value(createLinkAccount(AccountStatus.Verified(null)))
         )
         val metadata = createPaymentMethodMetadata()
         val interactor = createInteractor()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
@@ -164,7 +164,7 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
 
     @Test
     fun `'action' should skip & return 'Launch' if input is sign in`() = test(
-        initialAccountStatus = AccountStatus.Verified,
+        initialAccountStatus = AccountStatus.Verified(null),
     ) {
         val confirmationOption = createLinkInlineSignupConfirmationOption()
 
@@ -191,7 +191,7 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
     @Test
     fun `'action' should skip & return 'Launch' if failed to attach card`() = test(
         attachNewCardToAccountResult = Result.failure(IllegalStateException("Failed!")),
-        initialAccountStatus = AccountStatus.Verified,
+        initialAccountStatus = AccountStatus.Verified(null),
     ) {
         val confirmationOption = createLinkInlineSignupConfirmationOption()
 
@@ -231,7 +231,7 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
         ),
         signInResult = Result.success(true),
         initialAccountStatus = AccountStatus.SignedOut,
-        accountStatusOnSignIn = AccountStatus.Verified,
+        accountStatusOnSignIn = AccountStatus.Verified(null),
     ) {
         val confirmationOption = createLinkInlineSignupConfirmationOption()
 
@@ -440,7 +440,7 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
                         originalParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                     )
                 ),
-                accountStatus = AccountStatus.Verified,
+                accountStatus = AccountStatus.Verified(null),
                 signInResult = Result.success(true),
                 confirmationOption = confirmationOption,
             ) { launchAction ->
@@ -488,7 +488,7 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
                 )
             ),
             signInResult = Result.success(true),
-            accountStatus = AccountStatus.Verified,
+            accountStatus = AccountStatus.Verified(null),
             confirmationOption = confirmationOption,
         ) { launchAction ->
             val attachNewCardToAccountCall = coordinatorScenario.attachNewCardToAccountCalls.awaitItem()
@@ -537,7 +537,7 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
         attachNewCardToAccountResult = attachNewCardToAccountResult,
         signInResult = signInResult,
         initialAccountStatus = accountStatus,
-        accountStatusOnSignIn = AccountStatus.Verified,
+        accountStatusOnSignIn = AccountStatus.Verified(null),
     ) {
         val action = definition.action(
             confirmationOption = confirmationOption,
@@ -599,8 +599,8 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
             )
         ),
         signInResult: Result<Boolean> = Result.success(true),
-        initialAccountStatus: AccountStatus = AccountStatus.Verified,
-        accountStatusOnSignIn: AccountStatus = AccountStatus.Verified,
+        initialAccountStatus: AccountStatus = AccountStatus.Verified(null),
+        accountStatusOnSignIn: AccountStatus = AccountStatus.Verified(null),
         hasUsedLink: Boolean = false,
         test: suspend Scenario.() -> Unit
     ) = runTest {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -1152,7 +1152,7 @@ internal class PaymentOptionsViewModelTest {
     private fun createLinkViewModel(): PaymentOptionsViewModel {
         val linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(
             attachNewCardToAccountResult = Result.success(LinkTestUtils.LINK_SAVED_PAYMENT_DETAILS),
-            accountStatus = AccountStatus.Verified,
+            accountStatus = AccountStatus.Verified(null),
         )
 
         return createViewModel(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -3693,7 +3693,7 @@ internal class PaymentSheetViewModelTest {
     private fun FakeConfirmationHandler.Scenario.createLinkViewModel(): PaymentSheetViewModel {
         val linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(
             attachNewCardToAccountResult = Result.success(LinkTestUtils.LINK_SAVED_PAYMENT_DETAILS),
-            accountStatus = AccountStatus.Verified,
+            accountStatus = AccountStatus.Verified(null),
         )
 
         return createViewModel(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -746,7 +746,7 @@ internal class DefaultPaymentElementLoaderTest {
 
     @Test
     fun `Considers Link logged in if the account is verified`() = runTest {
-        val loader = createPaymentElementLoader(linkAccountState = AccountStatus.Verified)
+        val loader = createPaymentElementLoader(linkAccountState = AccountStatus.Verified(null))
 
         val result = loader.load(
             initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent("secret"),
@@ -1095,7 +1095,7 @@ internal class DefaultPaymentElementLoaderTest {
     @Test
     fun `Disables Link inline signup if user already has an verified account`() = runTest {
         val loader = createPaymentElementLoader(
-            linkAccountState = AccountStatus.Verified,
+            linkAccountState = AccountStatus.Verified(null),
         )
 
         val result = loader.load(
@@ -3715,7 +3715,7 @@ internal class DefaultPaymentElementLoaderTest {
         isGooglePayReady: Boolean = true,
         stripeIntent: StripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
         customerRepo: CustomerRepository = customerRepository,
-        linkAccountState: AccountStatus = AccountStatus.Verified,
+        linkAccountState: AccountStatus = AccountStatus.Verified(null),
         error: Throwable? = null,
         linkSettings: ElementsSession.LinkSettings? = null,
         linkGate: LinkGate = FakeLinkGate(),

--- a/stripe-crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampPresenterCoordinator.kt
+++ b/stripe-crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampPresenterCoordinator.kt
@@ -105,7 +105,6 @@ internal class OnrampPresenterCoordinator @Inject constructor(
     private fun clientEmail(): String? =
         interactor.state.value.linkControllerState?.internalLinkAccount?.email
 
-
     private fun handleAuthenticationResult(result: LinkController.AuthenticationResult) {
         coroutineScope.launch {
             onrampCallbacks.authenticationCallback.onResult(

--- a/stripe-crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampPresenterCoordinator.kt
+++ b/stripe-crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampPresenterCoordinator.kt
@@ -35,7 +35,8 @@ internal class OnrampPresenterCoordinator @Inject constructor(
     private val linkPresenter = linkController.createPresenter(
         activity = activity,
         presentPaymentMethodsCallback = ::handleSelectPaymentResult,
-        authenticationCallback = ::handleAuthenticationResult
+        authenticationCallback = ::handleAuthenticationResult,
+        authorizeCallback = {}
     )
 
     private var identityVerificationSheet: IdentityVerificationSheet? = null
@@ -103,6 +104,7 @@ internal class OnrampPresenterCoordinator @Inject constructor(
 
     private fun clientEmail(): String? =
         interactor.state.value.linkControllerState?.internalLinkAccount?.email
+
 
     private fun handleAuthenticationResult(result: LinkController.AuthenticationResult) {
         coroutineScope.launch {


### PR DESCRIPTION
# Summary

Follow-up to https://github.com/stripe/stripe-android/pull/11403

Adds `LinkController.authorize()` along with most of the logic and wiring to show a consent screen in LinkActivity. See http://go/lng/oauth-link-mobile-sdk-doc for details.

# Motivation
👻 

# Testing
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots

https://github.com/user-attachments/assets/cb80e823-8b40-4fc8-b040-52767a875af0

