### PR TITLE
Parcelize runtime plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -129,12 +129,13 @@ subprojects {
                             "See https://github.com/cashapp/paparazzi/issues/906.")
                 }
             }
-
-            // Auto-add kotlin-parcelize-runtime when parcelize plugin is applied
-            if(project.plugins.hasPlugin('org.jetbrains.kotlin.plugin.parcelize')) {
-                project.dependencies {
-                    implementation libs.kotlin.parcelizeRuntimePlugin
-                }
+        }
+    }
+    // Auto-add kotlin-parcelize-runtime when parcelize plugin is applied
+    plugins.withId("org.jetbrains.kotlin.plugin.parcelize") {
+        afterEvaluate {
+            dependencies {
+                implementation libs.kotlin.parcelizeRuntimePlugin
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -129,6 +129,13 @@ subprojects {
                             "See https://github.com/cashapp/paparazzi/issues/906.")
                 }
             }
+
+            // Auto-add kotlin-parcelize-runtime when parcelize plugin is applied
+            if(project.plugins.hasPlugin('org.jetbrains.kotlin.plugin.parcelize')) {
+                project.dependencies {
+                    implementation libs.kotlin.parcelizeRuntimePlugin
+                }
+            }
         }
     }
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -175,6 +175,7 @@ ext.libs = [
                 coroutinesAndroid     : "org.jetbrains.kotlinx:kotlinx-coroutines-android:${versions.kotlinCoroutines}",
                 coroutinesPlayServices: "org.jetbrains.kotlinx:kotlinx-coroutines-play-services:${versions.playServicesCoroutines}",
                 serialization         : "org.jetbrains.kotlinx:kotlinx-serialization-json:${versions.kotlinSerialization}",
+                parcelizeRuntimePlugin: "org.jetbrains.kotlin:kotlin-parcelize-runtime:${versions.kotlin}",
         ],
         lint                                : "com.android.tools.lint:lint-api:${versions.lint}",
         lintChecks                          : "com.android.tools.lint:lint-checks:${versions.lint}",


### PR DESCRIPTION
# Summary
Fixed R8 minification failures due to missing kotlin-parcelize-runtime dependency in published POM files

When any module applies the kotlin-parcelize plugin, the required runtime dependency is automatically added.
New modules will automatically get the dependency

# Motivation
https://github.com/stripe/stripe-react-native/issues/2065

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

# Screenshots
N.A.

# Changelog
N.A.