### PR TITLE
Forces lighmode Link logo resource on Link button in ECE

### DIFF
--- a/paymentsheet/res/drawable/stripe_link_logo_light.xml
+++ b/paymentsheet/res/drawable/stripe_link_logo_light.xml
@@ -1,0 +1,17 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:autoMirrored="true" android:height="24dp" android:viewportHeight="24" android:viewportWidth="72" android:width="72dp">
+      
+    <path android:fillColor="#011E0F" android:pathData="M36.12,3.677C36.12,2.549 37.07,1.632 38.189,1.632C39.307,1.632 40.258,2.554 40.258,3.677C40.258,4.8 39.341,5.746 38.189,5.746C37.037,5.746 36.12,4.829 36.12,3.677Z"/>
+      
+    <path android:fillColor="#011E0F" android:pathData="M29.981,1.92H33.581V22.08H29.981V1.92Z"/>
+      
+    <path android:fillColor="#011E0F" android:pathData="M40.008,7.68H36.379V22.08H40.008V7.68Z"/>
+      
+    <path android:fillColor="#011E0F" android:pathData="M66.096,14.39C68.827,12.71 70.685,10.21 71.419,7.675H67.79C66.845,10.094 64.675,11.914 62.29,12.686V1.915H58.661V22.075H62.29V16.08C65.059,16.771 67.248,19.166 67.997,22.075H71.65C71.093,19.022 69.005,16.166 66.096,14.39Z"/>
+      
+    <path android:fillColor="#011E0F" android:pathData="M46.44,9.293C47.39,8.03 49.243,7.296 50.746,7.296C53.549,7.296 55.867,9.346 55.872,12.442V22.075H52.243V13.243C52.243,11.971 51.677,10.502 49.838,10.502C47.678,10.502 46.435,12.418 46.435,14.659V22.085H42.806V7.69H46.44V9.293Z"/>
+      
+    <path android:fillColor="#00D66F" android:pathData="M12,24C18.627,24 24,18.627 24,12C24,5.373 18.627,0 12,0C5.373,0 0,5.373 0,12C0,18.627 5.373,24 12,24Z"/>
+      
+    <path android:fillColor="#011E0F" android:pathData="M11.448,4.8H7.747C8.467,7.81 10.569,10.382 13.2,12C10.565,13.618 8.467,16.19 7.747,19.2H11.448C12.365,16.416 14.904,13.997 18.024,13.502V10.493C14.899,10.003 12.36,7.584 11.448,4.8Z"/>
+    
+</vector>

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/LinkButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/LinkButton.kt
@@ -95,7 +95,7 @@ private val LinkButtonTheme.logoRes: Int
     @Composable
     @DrawableRes
     get() = when (this) {
-        LinkButtonTheme.WHITE -> R.drawable.stripe_link_logo
+        LinkButtonTheme.WHITE -> R.drawable.stripe_link_logo_light
         LinkButtonTheme.DEFAULT -> com.stripe.android.uicore.R.drawable.stripe_link_logo_bw
     }
 


### PR DESCRIPTION
# Summary

Issue: Icon being used in ECE has a darkmode variant, but the `ButtonTheme.WHITE` appearance remains white on darkmode:

<img width="464" height="211" alt="image" src="https://github.com/user-attachments/assets/fe6ea898-ef4f-4988-a68f-efe6c78339bd" />

Fix: Add a lightmode only variant of the Link logo.

<img width="464" height="211" alt="image" src="https://github.com/user-attachments/assets/50a568ce-cdfe-4317-aa1c-37a5c566e062" />


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
