### PR TITLE
[onramp] Add `authorize()`

### DIFF
--- a/stripe-crypto-onramp-example/src/main/java/com/stripe/android/crypto/onramp/example/OnrampActivity.kt
+++ b/stripe-crypto-onramp-example/src/main/java/com/stripe/android/crypto/onramp/example/OnrampActivity.kt
@@ -747,12 +747,6 @@ private fun LinkAuthIntentSection(
     var linkAuthIntentId by remember { mutableStateOf("") }
 
     Column {
-        Text(
-            text = "Authorize LinkAuthIntent",
-            fontWeight = FontWeight.SemiBold,
-            modifier = Modifier.padding(bottom = 16.dp)
-        )
-
         OutlinedTextField(
             value = linkAuthIntentId,
             onValueChange = { linkAuthIntentId = it },

--- a/stripe-crypto-onramp-example/src/main/java/com/stripe/android/crypto/onramp/example/OnrampActivity.kt
+++ b/stripe-crypto-onramp-example/src/main/java/com/stripe/android/crypto/onramp/example/OnrampActivity.kt
@@ -77,7 +77,8 @@ internal class OnrampActivity : ComponentActivity() {
         val callbacks = OnrampCallbacks(
             authenticationCallback = viewModel::onAuthenticationResult,
             identityVerificationCallback = viewModel::onIdentityVerificationResult,
-            selectPaymentCallback = viewModel::onSelectPaymentResult
+            selectPaymentCallback = viewModel::onSelectPaymentResult,
+            authorizeCallback = viewModel::onAuthorizeResult
         )
 
         onrampPresenter = viewModel.onrampCoordinator

--- a/stripe-crypto-onramp-example/src/main/java/com/stripe/android/crypto/onramp/example/OnrampActivity.kt
+++ b/stripe-crypto-onramp-example/src/main/java/com/stripe/android/crypto/onramp/example/OnrampActivity.kt
@@ -36,7 +36,6 @@ import androidx.compose.material.darkColors
 import androidx.compose.material.lightColors
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -72,6 +71,7 @@ internal class OnrampActivity : ComponentActivity() {
         OnrampViewModel.Factory()
     }
 
+    @Suppress("LongMethod")
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
@@ -98,10 +98,6 @@ internal class OnrampActivity : ComponentActivity() {
                         )
                     },
                 ) { innerPadding ->
-                    val state by viewModel.uiState.collectAsState()
-                    BackHandler(enabled = state.screen != Screen.EmailInput) {
-                        viewModel.onBackToEmailInput()
-                    }
                     OnrampScreen(
                         modifier = Modifier.padding(innerPadding),
                         viewModel = viewModel,
@@ -160,6 +156,10 @@ internal fun OnrampScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val message by viewModel.message.collectAsStateWithLifecycle()
     val context = LocalContext.current
+
+    BackHandler(enabled = uiState.screen != Screen.EmailInput) {
+        viewModel.onBackToEmailInput()
+    }
 
     // Show toast messages
     LaunchedEffect(message) {
@@ -572,7 +572,6 @@ private fun AuthenticatedOperationsScreen(
         AuthenticateSection(
             onAuthenticate = onAuthenticate
         )
-
 
         Text(
             text = "Register Wallet Address",

--- a/stripe-crypto-onramp-example/src/main/java/com/stripe/android/crypto/onramp/example/OnrampActivity.kt
+++ b/stripe-crypto-onramp-example/src/main/java/com/stripe/android/crypto/onramp/example/OnrampActivity.kt
@@ -100,6 +100,9 @@ internal class OnrampActivity : ComponentActivity() {
                         onAuthenticateUser = {
                             onrampPresenter.presentForVerification()
                         },
+                        onAuthorize = { linkAuthIntentId ->
+                            onrampPresenter.authorize(linkAuthIntentId)
+                        },
                         onRegisterWalletAddress = { address, network ->
                             viewModel.registerWalletAddress(address, network)
                         },
@@ -128,6 +131,7 @@ internal fun OnrampScreen(
     viewModel: OnrampViewModel,
     modifier: Modifier = Modifier,
     onAuthenticateUser: () -> Unit,
+    onAuthorize: (String) -> Unit,
     onRegisterWalletAddress: (String, CryptoNetwork) -> Unit,
     onStartVerification: () -> Unit,
     onCollectPayment: (type: PaymentMethodType) -> Unit,
@@ -156,7 +160,8 @@ internal fun OnrampScreen(
                 EmailInputScreen(
                     onCheckUser = { email ->
                         viewModel.checkIfLinkUser(email)
-                    }
+                    },
+                    onAuthorize = onAuthorize
                 )
             }
             Screen.Loading -> {
@@ -183,6 +188,7 @@ internal fun OnrampScreen(
                 AuthenticationScreen(
                     email = uiState.email,
                     onAuthenticate = onAuthenticateUser,
+                    onAuthorize = onAuthorize,
                     onBack = {
                         viewModel.onBackToEmailInput()
                     }
@@ -211,7 +217,8 @@ internal fun OnrampScreen(
 
 @Composable
 private fun EmailInputScreen(
-    onCheckUser: (String) -> Unit
+    onCheckUser: (String) -> Unit,
+    onAuthorize: (String) -> Unit
 ) {
     var email by remember { mutableStateOf("") }
 
@@ -231,6 +238,10 @@ private fun EmailInputScreen(
         ) {
             Text("Check if Link User Exists")
         }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        LinkAuthIntentSection(onAuthorize = onAuthorize)
     }
 }
 
@@ -365,6 +376,7 @@ private fun RegistrationButtons(
 private fun AuthenticationScreen(
     email: String,
     onAuthenticate: () -> Unit,
+    onAuthorize: (String) -> Unit,
     onBack: () -> Unit
 ) {
     Column {
@@ -392,6 +404,10 @@ private fun AuthenticationScreen(
         ) {
             Text("Authenticate")
         }
+
+        LinkAuthIntentSection(onAuthorize = onAuthorize)
+
+        Spacer(modifier = Modifier.height(24.dp))
 
         TextButton(
             onClick = onBack,
@@ -720,6 +736,39 @@ private fun StartVerificationScreen(
                 .padding(bottom = 24.dp)
         ) {
             Text("Start Identity Verification")
+        }
+    }
+}
+
+@Composable
+private fun LinkAuthIntentSection(
+    onAuthorize: (String) -> Unit
+) {
+    var linkAuthIntentId by remember { mutableStateOf("") }
+
+    Column {
+        Text(
+            text = "Authorize LinkAuthIntent",
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.padding(bottom = 16.dp)
+        )
+
+        OutlinedTextField(
+            value = linkAuthIntentId,
+            onValueChange = { linkAuthIntentId = it },
+            label = { Text("LinkAuthIntent ID") },
+            placeholder = { Text("lai_...") },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 16.dp)
+        )
+
+        Button(
+            onClick = { onAuthorize(linkAuthIntentId) },
+            enabled = linkAuthIntentId.isNotBlank(),
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Authorize")
         }
     }
 }

--- a/stripe-crypto-onramp-example/src/main/java/com/stripe/android/crypto/onramp/example/OnrampViewModel.kt
+++ b/stripe-crypto-onramp-example/src/main/java/com/stripe/android/crypto/onramp/example/OnrampViewModel.kt
@@ -111,7 +111,7 @@ internal class OnrampViewModel(
     }
 
     fun onBackToEmailInput() {
-        _uiState.update { OnrampUiState() }
+        _uiState.update { OnrampUiState(screen = Screen.EmailInput) }
     }
 
     fun clearMessage() {
@@ -211,7 +211,12 @@ internal class OnrampViewModel(
             when (result) {
                 is OnrampRegisterUserResult.Completed -> {
                     _message.value = "Registration successful"
-                    _uiState.update { it.copy(screen = Screen.EmailInput) }
+                    _uiState.update {
+                        it.copy(
+                            screen = Screen.Authentication,
+                            email = userInfo.email
+                        )
+                    }
                 }
                 is OnrampRegisterUserResult.Failed -> {
                     _message.value = "Registration failed: ${result.error.message}"

--- a/stripe-crypto-onramp-example/src/main/java/com/stripe/android/crypto/onramp/example/OnrampViewModel.kt
+++ b/stripe-crypto-onramp-example/src/main/java/com/stripe/android/crypto/onramp/example/OnrampViewModel.kt
@@ -17,6 +17,7 @@ import com.stripe.android.crypto.onramp.example.network.TestBackendRepository
 import com.stripe.android.crypto.onramp.model.CryptoNetwork
 import com.stripe.android.crypto.onramp.model.KycInfo
 import com.stripe.android.crypto.onramp.model.LinkUserInfo
+import com.stripe.android.crypto.onramp.model.OnrampAuthorizeResult
 import com.stripe.android.crypto.onramp.model.OnrampCollectPaymentResult
 import com.stripe.android.crypto.onramp.model.OnrampConfiguration
 import com.stripe.android.crypto.onramp.model.OnrampCreateCryptoPaymentTokenResult
@@ -191,6 +192,23 @@ internal class OnrampViewModel(
             is OnrampCollectPaymentResult.Failed -> {
                 _message.value = "Payment selection failed: ${result.error.message}"
                 _uiState.update { it.copy(screen = Screen.AuthenticatedOperations) }
+            }
+        }
+    }
+
+    fun onAuthorizeResult(result: OnrampAuthorizeResult) {
+        when (result) {
+            is OnrampAuthorizeResult.Consented -> {
+                _message.value = "Authorization successful! User consented to scopes."
+            }
+            is OnrampAuthorizeResult.Denied -> {
+                _message.value = "Authorization denied by user."
+            }
+            is OnrampAuthorizeResult.Canceled -> {
+                _message.value = "Authorization cancelled by user."
+            }
+            is OnrampAuthorizeResult.Failed -> {
+                _message.value = "Authorization failed: ${result.error.message}"
             }
         }
     }

--- a/stripe-crypto-onramp-example/src/main/java/com/stripe/android/crypto/onramp/example/OnrampViewModel.kt
+++ b/stripe-crypto-onramp-example/src/main/java/com/stripe/android/crypto/onramp/example/OnrampViewModel.kt
@@ -55,7 +55,6 @@ internal class OnrampViewModel(
     val message: StateFlow<String?> = _message.asStateFlow()
 
     init {
-
         viewModelScope.launch {
             @Suppress("MagicNumber", "MaxLineLength")
             val configuration = OnrampConfiguration(
@@ -200,6 +199,12 @@ internal class OnrampViewModel(
         when (result) {
             is OnrampAuthorizeResult.Consented -> {
                 _message.value = "Authorization successful! User consented to scopes."
+                _uiState.update {
+                    it.copy(
+                        screen = Screen.AuthenticatedOperations,
+                        customerId = result.customerId
+                    )
+                }
             }
             is OnrampAuthorizeResult.Denied -> {
                 _message.value = "Authorization denied by user."

--- a/stripe-crypto-onramp-example/src/main/java/com/stripe/android/crypto/onramp/example/OnrampViewModel.kt
+++ b/stripe-crypto-onramp-example/src/main/java/com/stripe/android/crypto/onramp/example/OnrampViewModel.kt
@@ -99,10 +99,10 @@ internal class OnrampViewModel(
                 createAuthIntentForUser(currentEmail)
 
                 if (result.isLinkUser) {
-                    _message.value = "User exists in Link. Please authenticate:"
+                    _message.value = "User exists in Link. Please authenticate"
                     _uiState.update { it.copy(screen = Screen.Authentication) }
                 } else {
-                    _message.value = "User does not exist in Link. Please register:"
+                    _message.value = "User does not exist in Link. Please register"
                     _uiState.update { it.copy(screen = Screen.Registration) }
                 }
             }

--- a/stripe-crypto-onramp-example/src/main/java/com/stripe/android/crypto/onramp/example/OnrampViewModel.kt
+++ b/stripe-crypto-onramp-example/src/main/java/com/stripe/android/crypto/onramp/example/OnrampViewModel.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.crypto.onramp.example
 
 import android.app.Application
-import androidx.compose.runtime.currentRecomposeScope
 import androidx.compose.ui.graphics.Color
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.SavedStateHandle

--- a/stripe-crypto-onramp-example/src/main/java/com/stripe/android/crypto/onramp/example/network/CreateAuthIntentRequest.kt
+++ b/stripe-crypto-onramp-example/src/main/java/com/stripe/android/crypto/onramp/example/network/CreateAuthIntentRequest.kt
@@ -1,8 +1,12 @@
 package com.stripe.android.crypto.onramp.example.network
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class CreateAuthIntentRequest(
-    val email: String
+    val email: String,
+
+    @SerialName("oauth_scopes")
+    val oauthScopes: String
 )

--- a/stripe-crypto-onramp-example/src/main/java/com/stripe/android/crypto/onramp/example/network/TestBackendRepository.kt
+++ b/stripe-crypto-onramp-example/src/main/java/com/stripe/android/crypto/onramp/example/network/TestBackendRepository.kt
@@ -23,10 +23,14 @@ class TestBackendRepository {
     }
 
     suspend fun createAuthIntent(
-        email: String
+        email: String,
+        oauthScopes: String,
     ): ApiResult<CreateAuthIntentResponse, FuelError> {
         return withContext(Dispatchers.IO) {
-            val request = CreateAuthIntentRequest(email = email)
+            val request = CreateAuthIntentRequest(
+                email = email,
+                oauthScopes = oauthScopes,
+            )
             val requestBody = json.encodeToString(CreateAuthIntentRequest.serializer(), request)
 
             Fuel.post("$baseUrl/auth_intent/create")

--- a/stripe-crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampCoordinator.kt
+++ b/stripe-crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampCoordinator.kt
@@ -152,6 +152,15 @@ class OnrampCoordinator @Inject internal constructor(
         fun collectPaymentMethod(type: PaymentMethodType) {
             coordinator.collectPaymentMethod(type)
         }
+
+        /**
+         * Authorize a LinkAuthIntent.
+         *
+         * @param linkAuthIntentId The LinkAuthIntent ID to authorize.
+         */
+        fun authorize(linkAuthIntentId: String) {
+            coordinator.authorize(linkAuthIntentId)
+        }
     }
 
     /**

--- a/stripe-crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampInteractor.kt
+++ b/stripe-crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampInteractor.kt
@@ -8,6 +8,7 @@ import com.stripe.android.crypto.onramp.exception.MissingPaymentMethodException
 import com.stripe.android.crypto.onramp.model.CryptoNetwork
 import com.stripe.android.crypto.onramp.model.KycInfo
 import com.stripe.android.crypto.onramp.model.LinkUserInfo
+import com.stripe.android.crypto.onramp.model.OnrampAuthorizeResult
 import com.stripe.android.crypto.onramp.model.OnrampCollectPaymentResult
 import com.stripe.android.crypto.onramp.model.OnrampConfiguration
 import com.stripe.android.crypto.onramp.model.OnrampCreateCryptoPaymentTokenResult
@@ -22,7 +23,6 @@ import com.stripe.android.crypto.onramp.model.PaymentOptionDisplayData
 import com.stripe.android.crypto.onramp.repositories.CryptoApiRepository
 import com.stripe.android.identity.IdentityVerificationSheet
 import com.stripe.android.link.LinkController
-import com.stripe.android.link.LinkController.AuthenticationResult
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -177,9 +177,9 @@ internal class OnrampInteractor @Inject constructor(
     }
 
     suspend fun handleAuthenticationResult(
-        result: AuthenticationResult
+        result: LinkController.AuthenticationResult
     ): OnrampVerificationResult = when (result) {
-        is AuthenticationResult.Success -> {
+        is LinkController.AuthenticationResult.Success -> {
             val secret = consumerSessionClientSecret()
             secret?.let {
                 val permissionsResult = cryptoApiRepository
@@ -196,8 +196,36 @@ internal class OnrampInteractor @Inject constructor(
                 MissingConsumerSecretException()
             )
         }
-        is AuthenticationResult.Failed -> OnrampVerificationResult.Failed(result.error)
-        is AuthenticationResult.Canceled -> OnrampVerificationResult.Cancelled()
+        is LinkController.AuthenticationResult.Failed -> OnrampVerificationResult.Failed(result.error)
+        is LinkController.AuthenticationResult.Canceled -> OnrampVerificationResult.Cancelled()
+    }
+
+    suspend fun handleAuthorizeResult(
+        result: LinkController.AuthorizeResult
+    ): OnrampAuthorizeResult = when (result) {
+        is LinkController.AuthorizeResult.Consented -> {
+            val secret = consumerSessionClientSecret()
+            secret?.let {
+                val permissionsResult = cryptoApiRepository
+                    .grantPartnerMerchantPermissions(it)
+                permissionsResult.fold(
+                    onSuccess = { result ->
+                        OnrampAuthorizeResult.Consented(result.id)
+                    },
+                    onFailure = { error ->
+                        OnrampAuthorizeResult.Failed(error)
+                    }
+                )
+            } ?: OnrampAuthorizeResult.Failed(
+                MissingConsumerSecretException()
+            )
+        }
+        is LinkController.AuthorizeResult.Denied ->
+            OnrampAuthorizeResult.Denied()
+        is LinkController.AuthorizeResult.Canceled ->
+            OnrampAuthorizeResult.Canceled()
+        is LinkController.AuthorizeResult.Failed ->
+            OnrampAuthorizeResult.Failed(result.error)
     }
 
     fun handleIdentityVerificationResult(

--- a/stripe-crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampInteractor.kt
+++ b/stripe-crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampInteractor.kt
@@ -122,30 +122,24 @@ internal class OnrampInteractor @Inject constructor(
 
     suspend fun collectKycInfo(kycInfo: KycInfo): OnrampKYCResult {
         val secret = consumerSessionClientSecret()
+            ?: return OnrampKYCResult.Failed(MissingConsumerSecretException())
 
-        secret?.let {
-            return cryptoApiRepository.collectKycData(kycInfo, secret)
-                .fold(
-                    onSuccess = { OnrampKYCResult.Completed },
-                    onFailure = { OnrampKYCResult.Failed(it) }
-                )
-        } ?: run {
-            return OnrampKYCResult.Failed(MissingConsumerSecretException())
-        }
+        return cryptoApiRepository.collectKycData(kycInfo, secret)
+            .fold(
+                onSuccess = { OnrampKYCResult.Completed },
+                onFailure = { OnrampKYCResult.Failed(it) }
+            )
     }
 
     suspend fun startIdentityVerification(): OnrampStartVerificationResult {
         val secret = consumerSessionClientSecret()
+            ?: return OnrampStartVerificationResult.Failed(MissingConsumerSecretException())
 
-        secret?.let {
-            return cryptoApiRepository.startIdentityVerification(secret)
-                .fold(
-                    onSuccess = { OnrampStartVerificationResult.Completed(it) },
-                    onFailure = { OnrampStartVerificationResult.Failed(it) }
-                )
-        } ?: run {
-            return OnrampStartVerificationResult.Failed(MissingConsumerSecretException())
-        }
+        return cryptoApiRepository.startIdentityVerification(secret)
+            .fold(
+                onSuccess = { OnrampStartVerificationResult.Completed(it) },
+                onFailure = { OnrampStartVerificationResult.Failed(it) }
+            )
     }
 
     suspend fun createCryptoPaymentToken(): OnrampCreateCryptoPaymentTokenResult {

--- a/stripe-crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampPresenterCoordinator.kt
+++ b/stripe-crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampPresenterCoordinator.kt
@@ -118,6 +118,14 @@ internal class OnrampPresenterCoordinator @Inject constructor(
         }
     }
 
+    private fun handleAuthorizeResult(result: LinkController.AuthorizeResult) {
+        coroutineScope.launch {
+            onrampCallbacks.authorizeCallback.onResult(
+                interactor.handleAuthorizeResult(result)
+            )
+        }
+    }
+
     private fun handleIdentityVerificationResult(result: IdentityVerificationSheet.VerificationFlowResult) {
         coroutineScope.launch {
             onrampCallbacks.identityVerificationCallback.onResult(
@@ -132,16 +140,6 @@ internal class OnrampPresenterCoordinator @Inject constructor(
                 interactor.handleSelectPaymentResult(result, activity)
             )
         }
-    }
-
-    private fun handleAuthorizeResult(result: LinkController.AuthorizeResult) {
-        val onrampResult = when (result) {
-            is LinkController.AuthorizeResult.Consented -> OnrampAuthorizeResult.Consented
-            is LinkController.AuthorizeResult.Denied -> OnrampAuthorizeResult.Denied
-            is LinkController.AuthorizeResult.Canceled -> OnrampAuthorizeResult.Canceled
-            is LinkController.AuthorizeResult.Failed -> OnrampAuthorizeResult.Failed(result.error)
-        }
-        onrampCallbacks.authorizeCallback.onResult(onrampResult)
     }
 
     private fun createIdentityVerificationSheet(merchantLogoUrl: String?): IdentityVerificationSheet {

--- a/stripe-crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampPresenterCoordinator.kt
+++ b/stripe-crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampPresenterCoordinator.kt
@@ -8,7 +8,6 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import com.stripe.android.core.exception.APIException
 import com.stripe.android.crypto.onramp.di.OnrampPresenterScope
-import com.stripe.android.crypto.onramp.model.OnrampAuthorizeResult
 import com.stripe.android.crypto.onramp.model.OnrampCallbacks
 import com.stripe.android.crypto.onramp.model.OnrampIdentityVerificationResult
 import com.stripe.android.crypto.onramp.model.OnrampStartVerificationResult

--- a/stripe-crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/model/OnrampAuthorizeCallback.kt
+++ b/stripe-crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/model/OnrampAuthorizeCallback.kt
@@ -14,21 +14,24 @@ fun interface OnrampAuthorizeCallback {
 sealed interface OnrampAuthorizeResult {
     /**
      * The user granted consent to the scopes requested by the LinkAuthIntent.
+     * @param customerId The crypto customer id that matches the authenticated account.
      */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    data object Consented : OnrampAuthorizeResult
+    class Consented(
+        val customerId: String
+    ) : OnrampAuthorizeResult
 
     /**
      * The user denied consent to the scopes requested by the LinkAuthIntent.
      */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    data object Denied : OnrampAuthorizeResult
+    class Denied internal constructor() : OnrampAuthorizeResult
 
     /**
      * The user canceled the authorization.
      */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    data object Canceled : OnrampAuthorizeResult
+    class Canceled internal constructor() : OnrampAuthorizeResult
 
     /**
      * Authorization failed.

--- a/stripe-crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/model/OnrampAuthorizeCallback.kt
+++ b/stripe-crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/model/OnrampAuthorizeCallback.kt
@@ -1,0 +1,41 @@
+package com.stripe.android.crypto.onramp.model
+
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun interface OnrampAuthorizeCallback {
+    fun onResult(result: OnrampAuthorizeResult)
+}
+
+/**
+ * Result of an OnRamp authorize operation.
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+sealed interface OnrampAuthorizeResult {
+    /**
+     * The user granted consent to the scopes requested by the LinkAuthIntent.
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    data object Consented : OnrampAuthorizeResult
+
+    /**
+     * The user denied consent to the scopes requested by the LinkAuthIntent.
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    data object Denied : OnrampAuthorizeResult
+
+    /**
+     * The user canceled the authorization.
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    data object Canceled : OnrampAuthorizeResult
+
+    /**
+     * Authorization failed.
+     * @param error The error that caused the failure
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    class Failed internal constructor(
+        val error: Throwable
+    ) : OnrampAuthorizeResult
+}

--- a/stripe-crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/model/OnrampCallbacks.kt
+++ b/stripe-crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/model/OnrampCallbacks.kt
@@ -11,5 +11,6 @@ import dev.drewhamilton.poko.Poko
 class OnrampCallbacks(
     val authenticationCallback: OnrampVerificationCallback,
     val identityVerificationCallback: OnrampIdentityVerificationCallback,
-    val selectPaymentCallback: OnrampCollectPaymentCallback
+    val selectPaymentCallback: OnrampCollectPaymentCallback,
+    val authorizeCallback: OnrampAuthorizeCallback
 )


### PR DESCRIPTION
# Summary
1. Add `authorize()` that largely delegates to LinkController's.
2. Add demo UI to create and authorize an LAI with variable scopes.

# Motivation
👻 

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
See demo in Slack.