### PR TITLE
Use different remove messaging for partial customer session remove permissions

### DIFF
--- a/paymentsheet/res/values-b+es+419/strings.xml
+++ b/paymentsheet/res/values-b+es+419/strings.xml
@@ -176,6 +176,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_remove_card">Quitar tarjeta</string>
   <!-- Title for confirmation alert to remove a card -->
   <string name="stripe_paymentsheet_remove_card_title">¿Deseas eliminar la tarjeta?</string>
+  <!-- Description for a confirmation alert indicating to the customer that their payment method will be removed but still available to the merchant for subscriptions -->
+  <string name="stripe_paymentsheet_remove_partial_description">Este método de pago se eliminará, pero seguirá disponible para las suscripciones de %s.</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">Elimina %s</string>
   <!-- Title shown above a view containing a customer's payment method that they can delete -->

--- a/paymentsheet/res/values-ca-rES/strings.xml
+++ b/paymentsheet/res/values-ca-rES/strings.xml
@@ -176,6 +176,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_remove_card">Elimina la targeta</string>
   <!-- Title for confirmation alert to remove a card -->
   <string name="stripe_paymentsheet_remove_card_title">Voleu eliminar la targeta?</string>
+  <!-- Description for a confirmation alert indicating to the customer that their payment method will be removed but still available to the merchant for subscriptions -->
+  <string name="stripe_paymentsheet_remove_partial_description">Aquesta forma de pagament se suprimirà, però continuarà disponible per a les subscripcions del %s.</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">Eliminar %s</string>
   <!-- Title shown above a view containing a customer's payment method that they can delete -->

--- a/paymentsheet/res/values-cs-rCZ/strings.xml
+++ b/paymentsheet/res/values-cs-rCZ/strings.xml
@@ -176,6 +176,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_remove_card">Odebrat kartu</string>
   <!-- Title for confirmation alert to remove a card -->
   <string name="stripe_paymentsheet_remove_card_title">Odebrat kartu?</string>
+  <!-- Description for a confirmation alert indicating to the customer that their payment method will be removed but still available to the merchant for subscriptions -->
+  <string name="stripe_paymentsheet_remove_partial_description">Tato platební metoda bude odebrána, ale zůstane dostupná pro předplatné %s.</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">Odebrat %s</string>
   <!-- Title shown above a view containing a customer's payment method that they can delete -->

--- a/paymentsheet/res/values-da/strings.xml
+++ b/paymentsheet/res/values-da/strings.xml
@@ -176,6 +176,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_remove_card">Fjern kort</string>
   <!-- Title for confirmation alert to remove a card -->
   <string name="stripe_paymentsheet_remove_card_title">Vil du fjerne kortet?</string>
+  <!-- Description for a confirmation alert indicating to the customer that their payment method will be removed but still available to the merchant for subscriptions -->
+  <string name="stripe_paymentsheet_remove_partial_description">Denne betalingsmetode vil blive fjernet, men vil fortsat være tilgængelig for %s-abonnementer.</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">Fjern %s</string>
   <!-- Title shown above a view containing a customer's payment method that they can delete -->

--- a/paymentsheet/res/values-de/strings.xml
+++ b/paymentsheet/res/values-de/strings.xml
@@ -176,6 +176,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_remove_card">Karte entfernen</string>
   <!-- Title for confirmation alert to remove a card -->
   <string name="stripe_paymentsheet_remove_card_title">Karte entfernen?</string>
+  <!-- Description for a confirmation alert indicating to the customer that their payment method will be removed but still available to the merchant for subscriptions -->
+  <string name="stripe_paymentsheet_remove_partial_description">Diese Zahlungsmethode wird entfernt, bleibt jedoch für %s Abos verfügbar.</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">%s entfernen</string>
   <!-- Title shown above a view containing a customer's payment method that they can delete -->

--- a/paymentsheet/res/values-el-rGR/strings.xml
+++ b/paymentsheet/res/values-el-rGR/strings.xml
@@ -176,6 +176,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_remove_card">Αφαίρεση κάρτας</string>
   <!-- Title for confirmation alert to remove a card -->
   <string name="stripe_paymentsheet_remove_card_title">Αφαίρεση κάρτας;</string>
+  <!-- Description for a confirmation alert indicating to the customer that their payment method will be removed but still available to the merchant for subscriptions -->
+  <string name="stripe_paymentsheet_remove_partial_description">Αυτή η μέθοδος πληρωμής θα καταργηθεί, αλλά θα παραμείνει διαθέσιμη για %s συνδρομές.</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">Αφαίρεση %s</string>
   <!-- Title shown above a view containing a customer's payment method that they can delete -->

--- a/paymentsheet/res/values-en-rGB/strings.xml
+++ b/paymentsheet/res/values-en-rGB/strings.xml
@@ -176,6 +176,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_remove_card">Remove card</string>
   <!-- Title for confirmation alert to remove a card -->
   <string name="stripe_paymentsheet_remove_card_title">Remove card?</string>
+  <!-- Description for a confirmation alert indicating to the customer that their payment method will be removed but still available to the merchant for subscriptions -->
+  <string name="stripe_paymentsheet_remove_partial_description">This payment method will be removed but will remain available for %s subscriptions.</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">Remove %s</string>
   <!-- Title shown above a view containing a customer's payment method that they can delete -->

--- a/paymentsheet/res/values-es/strings.xml
+++ b/paymentsheet/res/values-es/strings.xml
@@ -176,6 +176,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_remove_card">Eliminar tarjeta</string>
   <!-- Title for confirmation alert to remove a card -->
   <string name="stripe_paymentsheet_remove_card_title">¿Deseas eliminar la tarjeta?</string>
+  <!-- Description for a confirmation alert indicating to the customer that their payment method will be removed but still available to the merchant for subscriptions -->
+  <string name="stripe_paymentsheet_remove_partial_description">Este método de pago se eliminará, pero seguirá disponible para %s suscripciones.</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">Elimina %s</string>
   <!-- Title shown above a view containing a customer's payment method that they can delete -->

--- a/paymentsheet/res/values-et-rEE/strings.xml
+++ b/paymentsheet/res/values-et-rEE/strings.xml
@@ -176,6 +176,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_remove_card">Eemalda kaart</string>
   <!-- Title for confirmation alert to remove a card -->
   <string name="stripe_paymentsheet_remove_card_title">Kas soovite kaardi eemaldada?</string>
+  <!-- Description for a confirmation alert indicating to the customer that their payment method will be removed but still available to the merchant for subscriptions -->
+  <string name="stripe_paymentsheet_remove_partial_description">See makseviis eemaldatakse, kuid jääb %s kordustellimuste jaoks saadavale.</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">Eemalda %s</string>
   <!-- Title shown above a view containing a customer's payment method that they can delete -->

--- a/paymentsheet/res/values-fi/strings.xml
+++ b/paymentsheet/res/values-fi/strings.xml
@@ -176,6 +176,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_remove_card">Poista kortti</string>
   <!-- Title for confirmation alert to remove a card -->
   <string name="stripe_paymentsheet_remove_card_title">Poista kortti?</string>
+  <!-- Description for a confirmation alert indicating to the customer that their payment method will be removed but still available to the merchant for subscriptions -->
+  <string name="stripe_paymentsheet_remove_partial_description">Tämä maksutapa poistetaan, mutta se on edelleen käytettävissä %s tilauksissa.</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">Poista %s</string>
   <!-- Title shown above a view containing a customer's payment method that they can delete -->

--- a/paymentsheet/res/values-fil/strings.xml
+++ b/paymentsheet/res/values-fil/strings.xml
@@ -176,6 +176,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_remove_card">Alisin ang kard</string>
   <!-- Title for confirmation alert to remove a card -->
   <string name="stripe_paymentsheet_remove_card_title">Alisin ang kard?</string>
+  <!-- Description for a confirmation alert indicating to the customer that their payment method will be removed but still available to the merchant for subscriptions -->
+  <string name="stripe_paymentsheet_remove_partial_description">Tatanggalin ang paraan ng pagbabayad na ito pero mananatiling available para sa %s (na) subskripsiyon.</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">Alisin ang %s</string>
   <!-- Title shown above a view containing a customer's payment method that they can delete -->

--- a/paymentsheet/res/values-fr-rCA/strings.xml
+++ b/paymentsheet/res/values-fr-rCA/strings.xml
@@ -176,6 +176,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_remove_card">Retirer la carte</string>
   <!-- Title for confirmation alert to remove a card -->
   <string name="stripe_paymentsheet_remove_card_title">Voulez-vous retirer la carte?</string>
+  <!-- Description for a confirmation alert indicating to the customer that their payment method will be removed but still available to the merchant for subscriptions -->
+  <string name="stripe_paymentsheet_remove_partial_description">Ce mode de paiement sera supprimé mais restera disponible pour les abonnements %s.</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">Supprimer %s</string>
   <!-- Title shown above a view containing a customer's payment method that they can delete -->

--- a/paymentsheet/res/values-fr/strings.xml
+++ b/paymentsheet/res/values-fr/strings.xml
@@ -176,6 +176,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_remove_card">Supprimer la carte bancaire</string>
   <!-- Title for confirmation alert to remove a card -->
   <string name="stripe_paymentsheet_remove_card_title">Voulez-vous supprimer la carte ?</string>
+  <!-- Description for a confirmation alert indicating to the customer that their payment method will be removed but still available to the merchant for subscriptions -->
+  <string name="stripe_paymentsheet_remove_partial_description">Ce moyen de paiement sera supprimé mais restera disponible pour les Abonnements %s.</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">Supprimer %s</string>
   <!-- Title shown above a view containing a customer's payment method that they can delete -->

--- a/paymentsheet/res/values-hr/strings.xml
+++ b/paymentsheet/res/values-hr/strings.xml
@@ -176,6 +176,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_remove_card">Ukloni karticu</string>
   <!-- Title for confirmation alert to remove a card -->
   <string name="stripe_paymentsheet_remove_card_title">Ukloniti karticu?</string>
+  <!-- Description for a confirmation alert indicating to the customer that their payment method will be removed but still available to the merchant for subscriptions -->
+  <string name="stripe_paymentsheet_remove_partial_description">Ovaj način plaćanja bit će uklonjen, ali će ostati dostupan za pretplate %s.</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">Uklonite %s</string>
   <!-- Title shown above a view containing a customer's payment method that they can delete -->

--- a/paymentsheet/res/values-hu/strings.xml
+++ b/paymentsheet/res/values-hu/strings.xml
@@ -176,6 +176,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_remove_card">Kártya törlése</string>
   <!-- Title for confirmation alert to remove a card -->
   <string name="stripe_paymentsheet_remove_card_title">Kártya eltávolítása?</string>
+  <!-- Description for a confirmation alert indicating to the customer that their payment method will be removed but still available to the merchant for subscriptions -->
+  <string name="stripe_paymentsheet_remove_partial_description">Ez a fizetési mód eltávolításra kerül, de továbbra is elérhető marad %s előfizetések esetén.</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">%s eltávolítása</string>
   <!-- Title shown above a view containing a customer's payment method that they can delete -->

--- a/paymentsheet/res/values-in/strings.xml
+++ b/paymentsheet/res/values-in/strings.xml
@@ -176,6 +176,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_remove_card">Hapus kartu</string>
   <!-- Title for confirmation alert to remove a card -->
   <string name="stripe_paymentsheet_remove_card_title">Hapus kartu?</string>
+  <!-- Description for a confirmation alert indicating to the customer that their payment method will be removed but still available to the merchant for subscriptions -->
+  <string name="stripe_paymentsheet_remove_partial_description">Metode pembayaran ini akan dihapus tetapi akan tetap tersedia untuk langganan %s.</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">Hapus %s</string>
   <!-- Title shown above a view containing a customer's payment method that they can delete -->

--- a/paymentsheet/res/values-it/strings.xml
+++ b/paymentsheet/res/values-it/strings.xml
@@ -172,6 +172,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_remove_card">Rimuovi la carta</string>
   <!-- Title for confirmation alert to remove a card -->
   <string name="stripe_paymentsheet_remove_card_title">Rimuovere la carta?</string>
+  <!-- Description for a confirmation alert indicating to the customer that their payment method will be removed but still available to the merchant for subscriptions -->
+  <string name="stripe_paymentsheet_remove_partial_description">Questo metodo di pagamento sarà rimosso, ma rimarrà disponibile per gli abbonamenti %s.</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">Rimuovi %s</string>
   <!-- Title shown above a view containing a customer's payment method that they can delete -->

--- a/paymentsheet/res/values-ja/strings.xml
+++ b/paymentsheet/res/values-ja/strings.xml
@@ -176,6 +176,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_remove_card">カードを削除</string>
   <!-- Title for confirmation alert to remove a card -->
   <string name="stripe_paymentsheet_remove_card_title">カードを削除しますか？</string>
+  <!-- Description for a confirmation alert indicating to the customer that their payment method will be removed but still available to the merchant for subscriptions -->
+  <string name="stripe_paymentsheet_remove_partial_description">この決済手段は削除されますが、%s のサブスクリプションでは引き続き使用できます。</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">%s を削除</string>
   <!-- Title shown above a view containing a customer's payment method that they can delete -->

--- a/paymentsheet/res/values-ko/strings.xml
+++ b/paymentsheet/res/values-ko/strings.xml
@@ -176,6 +176,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_remove_card">카드 제거</string>
   <!-- Title for confirmation alert to remove a card -->
   <string name="stripe_paymentsheet_remove_card_title">카드를 삭제하시겠습니까?</string>
+  <!-- Description for a confirmation alert indicating to the customer that their payment method will be removed but still available to the merchant for subscriptions -->
+  <string name="stripe_paymentsheet_remove_partial_description">이 결제 방식은 제거되지만 %s 구독에는 계속 사용할 수 있습니다.</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">%s 제거</string>
   <!-- Title shown above a view containing a customer's payment method that they can delete -->

--- a/paymentsheet/res/values-lt-rLT/strings.xml
+++ b/paymentsheet/res/values-lt-rLT/strings.xml
@@ -176,6 +176,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_remove_card">Pašalinti kortelę</string>
   <!-- Title for confirmation alert to remove a card -->
   <string name="stripe_paymentsheet_remove_card_title">Ištraukti kortelę?</string>
+  <!-- Description for a confirmation alert indicating to the customer that their payment method will be removed but still available to the merchant for subscriptions -->
+  <string name="stripe_paymentsheet_remove_partial_description">Šis mokėjimo būdas bus pašalintas, tačiau ir toliau bus galima naudotis %s prenumeratomis.</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">Pašalinti %s</string>
   <!-- Title shown above a view containing a customer's payment method that they can delete -->

--- a/paymentsheet/res/values-lv-rLV/strings.xml
+++ b/paymentsheet/res/values-lv-rLV/strings.xml
@@ -176,6 +176,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_remove_card">Noņemt karti</string>
   <!-- Title for confirmation alert to remove a card -->
   <string name="stripe_paymentsheet_remove_card_title">Noņemt karti?</string>
+  <!-- Description for a confirmation alert indicating to the customer that their payment method will be removed but still available to the merchant for subscriptions -->
+  <string name="stripe_paymentsheet_remove_partial_description">Šis maksājuma veids tiks noņemts, bet joprojām būs pieejams %s abonementiem.</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">Noņemt%s</string>
   <!-- Title shown above a view containing a customer's payment method that they can delete -->

--- a/paymentsheet/res/values-ms-rMY/strings.xml
+++ b/paymentsheet/res/values-ms-rMY/strings.xml
@@ -176,6 +176,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_remove_card">Alih keluar kad</string>
   <!-- Title for confirmation alert to remove a card -->
   <string name="stripe_paymentsheet_remove_card_title">Alih keluar kad?</string>
+  <!-- Description for a confirmation alert indicating to the customer that their payment method will be removed but still available to the merchant for subscriptions -->
+  <string name="stripe_paymentsheet_remove_partial_description">Kaedah pembayaran ini akan dialih keluar tetapi akan kekal tersedia untuk langganan %s.</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">Alih keluar %s</string>
   <!-- Title shown above a view containing a customer's payment method that they can delete -->

--- a/paymentsheet/res/values-mt/strings.xml
+++ b/paymentsheet/res/values-mt/strings.xml
@@ -176,6 +176,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_remove_card">Neħħi l-karta</string>
   <!-- Title for confirmation alert to remove a card -->
   <string name="stripe_paymentsheet_remove_card_title">Tixtieq tneħħi l-karta?</string>
+  <!-- Description for a confirmation alert indicating to the customer that their payment method will be removed but still available to the merchant for subscriptions -->
+  <string name="stripe_paymentsheet_remove_partial_description">Dan il-metodu ta\' pagament se jitneħħa iżda se jibqa\' disponibbli għal abbonamenti ta\' %s.</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">Neħħi %s</string>
   <!-- Title shown above a view containing a customer's payment method that they can delete -->

--- a/paymentsheet/res/values-nb/strings.xml
+++ b/paymentsheet/res/values-nb/strings.xml
@@ -176,6 +176,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_remove_card">Fjern kort</string>
   <!-- Title for confirmation alert to remove a card -->
   <string name="stripe_paymentsheet_remove_card_title">Vil du fjerne kortet?</string>
+  <!-- Description for a confirmation alert indicating to the customer that their payment method will be removed but still available to the merchant for subscriptions -->
+  <string name="stripe_paymentsheet_remove_partial_description">Denne betalingsmåten vil bli fjernet, men vil fortsatt være tilgjengelig for %s abonnementer.</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">Fjern %s</string>
   <!-- Title shown above a view containing a customer's payment method that they can delete -->

--- a/paymentsheet/res/values-nl/strings.xml
+++ b/paymentsheet/res/values-nl/strings.xml
@@ -176,6 +176,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_remove_card">Betaalkaart verwijderen</string>
   <!-- Title for confirmation alert to remove a card -->
   <string name="stripe_paymentsheet_remove_card_title">Betaalkaart verwijderen?</string>
+  <!-- Description for a confirmation alert indicating to the customer that their payment method will be removed but still available to the merchant for subscriptions -->
+  <string name="stripe_paymentsheet_remove_partial_description">Deze betaalmethode wordt verwijderd, maar blijft beschikbaar voor %s abonnementen.</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">%s verwijderen</string>
   <!-- Title shown above a view containing a customer's payment method that they can delete -->

--- a/paymentsheet/res/values-nn-rNO/strings.xml
+++ b/paymentsheet/res/values-nn-rNO/strings.xml
@@ -164,6 +164,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_remove_card">Fjern kort</string>
   <!-- Title for confirmation alert to remove a card -->
   <string name="stripe_paymentsheet_remove_card_title">Fjerne kort?</string>
+  <!-- Description for a confirmation alert indicating to the customer that their payment method will be removed but still available to the merchant for subscriptions -->
+  <string name="stripe_paymentsheet_remove_partial_description">Denne betalingsmåten vil bli fjernet, men vil fortsatt være tilgjengelig for %s abonnementer.</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">Fjern %s</string>
   <!-- Title shown above a view containing a customer's payment method that they can delete -->

--- a/paymentsheet/res/values-pl-rPL/strings.xml
+++ b/paymentsheet/res/values-pl-rPL/strings.xml
@@ -176,6 +176,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_remove_card">Usuń kartę</string>
   <!-- Title for confirmation alert to remove a card -->
   <string name="stripe_paymentsheet_remove_card_title">Usunąć kartę?</string>
+  <!-- Description for a confirmation alert indicating to the customer that their payment method will be removed but still available to the merchant for subscriptions -->
+  <string name="stripe_paymentsheet_remove_partial_description">Ta metoda płatności zostanie usunięta, ale pozostanie dostępna dla %s subskrypcji.</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">Usuń: %s</string>
   <!-- Title shown above a view containing a customer's payment method that they can delete -->

--- a/paymentsheet/res/values-pt-rBR/strings.xml
+++ b/paymentsheet/res/values-pt-rBR/strings.xml
@@ -172,6 +172,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_remove_card">Remover cartão</string>
   <!-- Title for confirmation alert to remove a card -->
   <string name="stripe_paymentsheet_remove_card_title">Remover cartão?</string>
+  <!-- Description for a confirmation alert indicating to the customer that their payment method will be removed but still available to the merchant for subscriptions -->
+  <string name="stripe_paymentsheet_remove_partial_description">Esta forma de pagamento será removida, mas permanecerá disponível para %s assinaturas.</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">Remover %s</string>
   <!-- Title shown above a view containing a customer's payment method that they can delete -->

--- a/paymentsheet/res/values-pt-rPT/strings.xml
+++ b/paymentsheet/res/values-pt-rPT/strings.xml
@@ -176,6 +176,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_remove_card">Eliminar cartão</string>
   <!-- Title for confirmation alert to remove a card -->
   <string name="stripe_paymentsheet_remove_card_title">Remover cartão?</string>
+  <!-- Description for a confirmation alert indicating to the customer that their payment method will be removed but still available to the merchant for subscriptions -->
+  <string name="stripe_paymentsheet_remove_partial_description">Este método de pagamento será removido, mas continuará disponível para subscrições %s.</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">Remover %s</string>
   <!-- Title shown above a view containing a customer's payment method that they can delete -->

--- a/paymentsheet/res/values-ro-rRO/strings.xml
+++ b/paymentsheet/res/values-ro-rRO/strings.xml
@@ -176,6 +176,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_remove_card">Eliminare card</string>
   <!-- Title for confirmation alert to remove a card -->
   <string name="stripe_paymentsheet_remove_card_title">Doresti sa elimini cardul?</string>
+  <!-- Description for a confirmation alert indicating to the customer that their payment method will be removed but still available to the merchant for subscriptions -->
+  <string name="stripe_paymentsheet_remove_partial_description">Această metodă de plată va fi eliminată, dar va rămâne disponibilă pentru abonamentele %s.</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">Elimina %s</string>
   <!-- Title shown above a view containing a customer's payment method that they can delete -->

--- a/paymentsheet/res/values-ro/strings.xml
+++ b/paymentsheet/res/values-ro/strings.xml
@@ -176,6 +176,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_remove_card">Eliminare card</string>
   <!-- Title for confirmation alert to remove a card -->
   <string name="stripe_paymentsheet_remove_card_title">Doresti sa elimini cardul?</string>
+  <!-- Description for a confirmation alert indicating to the customer that their payment method will be removed but still available to the merchant for subscriptions -->
+  <string name="stripe_paymentsheet_remove_partial_description">Această metodă de plată va fi eliminată, dar va rămâne disponibilă pentru abonamentele %s.</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">Elimina %s</string>
   <!-- Title shown above a view containing a customer's payment method that they can delete -->

--- a/paymentsheet/res/values-ru/strings.xml
+++ b/paymentsheet/res/values-ru/strings.xml
@@ -176,6 +176,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_remove_card">Удалить карту</string>
   <!-- Title for confirmation alert to remove a card -->
   <string name="stripe_paymentsheet_remove_card_title">Удалить карту?</string>
+  <!-- Description for a confirmation alert indicating to the customer that their payment method will be removed but still available to the merchant for subscriptions -->
+  <string name="stripe_paymentsheet_remove_partial_description">Этот способ оплаты будет удален, но останется доступным для подписок (%s).</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">Удалить %s</string>
   <!-- Title shown above a view containing a customer's payment method that they can delete -->

--- a/paymentsheet/res/values-sk-rSK/strings.xml
+++ b/paymentsheet/res/values-sk-rSK/strings.xml
@@ -176,6 +176,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_remove_card">Odstrániť kartu</string>
   <!-- Title for confirmation alert to remove a card -->
   <string name="stripe_paymentsheet_remove_card_title">Odstrániť kartu?</string>
+  <!-- Description for a confirmation alert indicating to the customer that their payment method will be removed but still available to the merchant for subscriptions -->
+  <string name="stripe_paymentsheet_remove_partial_description">Tento spôsob platby sa odstráni, ale ostane k dispozícii pre predplatné %s.</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">Odstrániť %s</string>
   <!-- Title shown above a view containing a customer's payment method that they can delete -->

--- a/paymentsheet/res/values-sl-rSI/strings.xml
+++ b/paymentsheet/res/values-sl-rSI/strings.xml
@@ -176,6 +176,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_remove_card">Odstrani kartico</string>
   <!-- Title for confirmation alert to remove a card -->
   <string name="stripe_paymentsheet_remove_card_title">Ali želite odstranit kartico?</string>
+  <!-- Description for a confirmation alert indicating to the customer that their payment method will be removed but still available to the merchant for subscriptions -->
+  <string name="stripe_paymentsheet_remove_partial_description">Ta način plačila bo odstranjen, vendar bo še naprej na voljo za naročnine %s.</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">Odstrani %s</string>
   <!-- Title shown above a view containing a customer's payment method that they can delete -->

--- a/paymentsheet/res/values-sv/strings.xml
+++ b/paymentsheet/res/values-sv/strings.xml
@@ -176,6 +176,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_remove_card">Ta bort kort</string>
   <!-- Title for confirmation alert to remove a card -->
   <string name="stripe_paymentsheet_remove_card_title">Ta bort kort?</string>
+  <!-- Description for a confirmation alert indicating to the customer that their payment method will be removed but still available to the merchant for subscriptions -->
+  <string name="stripe_paymentsheet_remove_partial_description">Den här betalningsmetoden kommer att tas bort, men förblir tillgänglig för %s abonnemang.</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">Ta bort %s</string>
   <!-- Title shown above a view containing a customer's payment method that they can delete -->

--- a/paymentsheet/res/values-th/strings.xml
+++ b/paymentsheet/res/values-th/strings.xml
@@ -176,6 +176,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_remove_card">นำบัตรออก</string>
   <!-- Title for confirmation alert to remove a card -->
   <string name="stripe_paymentsheet_remove_card_title">นำบัตรออกไหม</string>
+  <!-- Description for a confirmation alert indicating to the customer that their payment method will be removed but still available to the merchant for subscriptions -->
+  <string name="stripe_paymentsheet_remove_partial_description">วิธีการชำระเงินนี้จะถูกนำออกไปแต่จะยังคงใช้ได้สำหรับการชำระเงินตามรอบบิล %s</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">นำ %s ออก</string>
   <!-- Title shown above a view containing a customer's payment method that they can delete -->

--- a/paymentsheet/res/values-tr/strings.xml
+++ b/paymentsheet/res/values-tr/strings.xml
@@ -176,6 +176,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_remove_card">Kartı kaldır</string>
   <!-- Title for confirmation alert to remove a card -->
   <string name="stripe_paymentsheet_remove_card_title">Kart kaldırılsın mı?</string>
+  <!-- Description for a confirmation alert indicating to the customer that their payment method will be removed but still available to the merchant for subscriptions -->
+  <string name="stripe_paymentsheet_remove_partial_description">Bu ödeme yöntemi kaldırılacak ancak %s abonelikleri için kullanılabilir kalacaktır.</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">%s yöntemini kaldırın</string>
   <!-- Title shown above a view containing a customer's payment method that they can delete -->

--- a/paymentsheet/res/values-vi/strings.xml
+++ b/paymentsheet/res/values-vi/strings.xml
@@ -176,6 +176,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_remove_card">Xóa thẻ</string>
   <!-- Title for confirmation alert to remove a card -->
   <string name="stripe_paymentsheet_remove_card_title">Xóa thẻ?</string>
+  <!-- Description for a confirmation alert indicating to the customer that their payment method will be removed but still available to the merchant for subscriptions -->
+  <string name="stripe_paymentsheet_remove_partial_description">Phương thức thanh toán này sẽ bị xóa nhưng sẽ vẫn khả dụng cho các gói đăng ký %s.</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">Xóa %s</string>
   <!-- Title shown above a view containing a customer's payment method that they can delete -->

--- a/paymentsheet/res/values-zh-rHK/strings.xml
+++ b/paymentsheet/res/values-zh-rHK/strings.xml
@@ -174,6 +174,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_remove_card">解除綁定</string>
   <!-- Title for confirmation alert to remove a card -->
   <string name="stripe_paymentsheet_remove_card_title">移除卡？</string>
+  <!-- Description for a confirmation alert indicating to the customer that their payment method will be removed but still available to the merchant for subscriptions -->
+  <string name="stripe_paymentsheet_remove_partial_description">此支付方式將被移除，但仍適用於 %s 項訂閱。</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">移除 %s</string>
   <!-- Title shown above a view containing a customer's payment method that they can delete -->

--- a/paymentsheet/res/values-zh-rTW/strings.xml
+++ b/paymentsheet/res/values-zh-rTW/strings.xml
@@ -162,6 +162,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_remove_card">解除綁定</string>
   <!-- Title for confirmation alert to remove a card -->
   <string name="stripe_paymentsheet_remove_card_title">移除卡？</string>
+  <!-- Description for a confirmation alert indicating to the customer that their payment method will be removed but still available to the merchant for subscriptions -->
+  <string name="stripe_paymentsheet_remove_partial_description">此支付方式將被移除，但仍適用於 %s 項訂閱。</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">移除 %s</string>
   <!-- Title shown above a view containing a customer's payment method that they can delete -->

--- a/paymentsheet/res/values-zh/strings.xml
+++ b/paymentsheet/res/values-zh/strings.xml
@@ -176,6 +176,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_remove_card">移除卡</string>
   <!-- Title for confirmation alert to remove a card -->
   <string name="stripe_paymentsheet_remove_card_title">移除卡？</string>
+  <!-- Description for a confirmation alert indicating to the customer that their payment method will be removed but still available to the merchant for subscriptions -->
+  <string name="stripe_paymentsheet_remove_partial_description">此支付方式将被移除，但仍可用于 %s 订阅。</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">移除 %s</string>
   <!-- Title shown above a view containing a customer's payment method that they can delete -->

--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -176,6 +176,8 @@ to be saved and used in future checkout sessions. -->
   <string name="stripe_paymentsheet_remove_card">Remove card</string>
   <!-- Title for confirmation alert to remove a card -->
   <string name="stripe_paymentsheet_remove_card_title">Remove card?</string>
+  <!-- Description for a confirmation alert indicating to the customer that their payment method will be removed but still available to the merchant for subscriptions -->
+  <string name="stripe_paymentsheet_remove_partial_description">This payment method will be removed but will remain available for %s subscriptions.</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->
   <string name="stripe_paymentsheet_remove_pm">Remove %s</string>
   <!-- Title shown above a view containing a customer's payment method that they can delete -->

--- a/paymentsheet/src/main/java/com/stripe/android/common/model/PaymentMethodRemovePermission.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/model/PaymentMethodRemovePermission.kt
@@ -1,7 +1,14 @@
 package com.stripe.android.common.model
 
-internal enum class PaymentMethodRemovePermission {
-    Full,
-    Partial,
-    None
+import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.paymentsheet.R
+
+internal enum class PaymentMethodRemovePermission(private val removeMessageId: Int?) {
+    Full(removeMessageId = null),
+    Partial(removeMessageId = R.string.stripe_paymentsheet_remove_partial_description),
+    None(removeMessageId = null);
+
+    fun removeMessage(merchantDisplayName: String) = removeMessageId?.let {
+        resolvableString(it, merchantDisplayName)
+    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -587,6 +587,8 @@ internal class CustomerSheetViewModel(
                     // This checkbox is never displayed in CustomerSheet.
                     shouldShowSetAsDefaultCheckbox = false,
                     isDefaultPaymentMethod = false,
+                    removeMessage = customerState.permissions.removePaymentMethod
+                        .removeMessage(configuration.merchantDisplayName),
                     // Should never be called from CustomerSheet, because we don't enable the set as default checkbox.
                     setDefaultPaymentMethodExecutor = {
                         Result.failure(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
@@ -77,6 +77,8 @@ internal class DefaultEmbeddedUpdateScreenInteractorFactory @Inject constructor(
                     defaultPaymentMethodId = customerStateHolder.customer.value?.defaultPaymentMethodId
                 )
                 ),
+            removeMessage = paymentMethodMetadata.customerMetadata?.permissions?.removePaymentMethod
+                ?.removeMessage(paymentMethodMetadata.merchantName),
             onUpdateSuccess = {
                 manageNavigatorProvider.get().performAction(ManageNavigator.Action.Back)
             },

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -376,6 +376,7 @@ internal class SavedPaymentMethodMutator(
         ) {
             if (displayableSavedPaymentMethod.savedPaymentMethod != SavedPaymentMethod.Unexpected) {
                 val isLiveMode = requireNotNull(viewModel.paymentMethodMetadata.value).stripeIntent.isLiveMode
+                val paymentMethodMetadata = viewModel.paymentMethodMetadata.value
                 viewModel.navigationHandler.transitionTo(
                     PaymentSheetScreen.UpdatePaymentMethod(
                         DefaultUpdatePaymentMethodInteractor(
@@ -402,9 +403,7 @@ internal class SavedPaymentMethodMutator(
                                 )
                             },
                             shouldShowSetAsDefaultCheckbox = (
-                                viewModel
-                                    .paymentMethodMetadata
-                                    .value?.customerMetadata?.isPaymentMethodSetAsDefaultEnabled == true
+                                paymentMethodMetadata?.customerMetadata?.isPaymentMethodSetAsDefaultEnabled == true
                                 ),
                             isDefaultPaymentMethod = (
                                 displayableSavedPaymentMethod.isDefaultPaymentMethod(
@@ -412,6 +411,8 @@ internal class SavedPaymentMethodMutator(
                                     viewModel.customerStateHolder.customer.value?.defaultPaymentMethodId
                                 )
                                 ),
+                            removeMessage = paymentMethodMetadata?.customerMetadata?.permissions?.removePaymentMethod
+                                ?.removeMessage(paymentMethodMetadata.merchantName),
                             onUpdateSuccess = viewModel.navigationHandler::pop,
                         )
                     )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/RemoveButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/RemoveButton.kt
@@ -52,13 +52,13 @@ internal fun RemoveButton(
     ) {
         Box(
             modifier = Modifier
-                .testTag(testTag)
                 .fillMaxWidth()
         ) {
             CompositionLocalProvider(LocalMinimumInteractiveComponentEnforcement provides false) {
                 TextButton(
                     modifier = Modifier
                         .align(Alignment.Center)
+                        .testTag(testTag)
                         .fillMaxWidth()
                         .defaultMinSize(minHeight = shape.height),
                     border = BorderStroke(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/RemovePaymentMethodDialogUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/RemovePaymentMethodDialogUI.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.ui
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
+import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.LinkPaymentDetails
 import com.stripe.android.model.PaymentMethod
@@ -14,11 +15,13 @@ import com.stripe.android.R as StripeR
 @Composable
 internal fun RemovePaymentMethodDialogUI(
     paymentMethod: DisplayableSavedPaymentMethod,
+    removeMessage: ResolvableString?,
     onConfirmListener: () -> Unit,
     onDismissListener: () -> Unit,
 ) {
     val removeTitle = paymentMethod.getRemoveDialogTitle().resolve()
-    val messageText = paymentMethod.getRemoveDialogDescription().resolve()
+    val messageText = removeMessage?.resolve()
+        ?: paymentMethod.getRemoveDialogDescription().resolve()
 
     SimpleDialogElementUI(
         titleText = removeTitle,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodInteractor.kt
@@ -29,6 +29,7 @@ internal interface UpdatePaymentMethodInteractor {
     val topBarState: PaymentSheetTopBarState
     val canRemove: Boolean
     val displayableSavedPaymentMethod: DisplayableSavedPaymentMethod
+    val removeMessage: ResolvableString?
     val screenTitle: ResolvableString?
     val cardBrandFilter: CardBrandFilter
     val isExpiredCard: Boolean
@@ -110,6 +111,7 @@ internal class DefaultUpdatePaymentMethodInteractor(
     override val addressCollectionMode: AddressCollectionMode,
     override val allowedBillingCountries: Set<String>,
     override val canUpdateFullPaymentMethodDetails: Boolean,
+    override val removeMessage: ResolvableString?,
     val isDefaultPaymentMethod: Boolean,
     override val shouldShowSetAsDefaultCheckbox: Boolean,
     private val removeExecutor: PaymentMethodRemoveOperation,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUI.kt
@@ -308,12 +308,17 @@ private fun DeletePaymentMethodUi(interactor: UpdatePaymentMethodInteractor) {
     )
 
     if (openDialogValue.value) {
-        RemovePaymentMethodDialogUI(paymentMethod = interactor.displayableSavedPaymentMethod, onConfirmListener = {
-            openDialogValue.value = false
-            interactor.handleViewAction(UpdatePaymentMethodInteractor.ViewAction.RemovePaymentMethod)
-        }, onDismissListener = {
-            openDialogValue.value = false
-        })
+        RemovePaymentMethodDialogUI(
+            paymentMethod = interactor.displayableSavedPaymentMethod,
+            removeMessage = interactor.removeMessage,
+            onConfirmListener = {
+                openDialogValue.value = false
+                interactor.handleViewAction(UpdatePaymentMethodInteractor.ViewAction.RemovePaymentMethod)
+            },
+            onDismissListener = {
+                openDialogValue.value = false
+            }
+        )
     }
 }
 
@@ -343,6 +348,7 @@ private fun PreviewUpdatePaymentMethodUI() {
             updatePaymentMethodExecutor = { paymentMethod, _ -> Result.success(paymentMethod) },
             setDefaultPaymentMethodExecutor = { _ -> Result.success(Unit) },
             cardBrandFilter = DefaultCardBrandFilter,
+            removeMessage = null,
             onBrandChoiceSelected = {},
             shouldShowSetAsDefaultCheckbox = true,
             isDefaultPaymentMethod = false,

--- a/paymentsheet/src/test/java/com/stripe/android/common/model/PaymentMethodRemovePermissionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/model/PaymentMethodRemovePermissionTest.kt
@@ -1,0 +1,28 @@
+package com.stripe.android.common.model
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.paymentsheet.R
+import kotlin.test.Test
+
+class PaymentMethodRemovePermissionTest {
+    @Test
+    fun `on 'Full' permissions, remove message should be null`() {
+        assertThat(PaymentMethodRemovePermission.Full.removeMessage("Merchant, Inc."))
+            .isNull()
+    }
+
+    @Test
+    fun `on 'None' permissions, remove message should be null`() {
+        assertThat(PaymentMethodRemovePermission.None.removeMessage("Merchant, Inc."))
+            .isNull()
+    }
+
+    @Test
+    fun `on 'Partial' permissions, remove message should be expected message`() {
+        assertThat(PaymentMethodRemovePermission.Partial.removeMessage("Merchant, Inc."))
+            .isEqualTo(
+                resolvableString(R.string.stripe_paymentsheet_remove_partial_description, "Merchant, Inc.")
+            )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -375,6 +375,7 @@ internal class CustomerSheetScreenshotTest {
                 shouldShowSetAsDefaultCheckbox = false,
                 isDefaultPaymentMethod = false,
                 allowedBillingCountries = emptySet(),
+                removeMessage = null,
                 onUpdateSuccess = {},
             ),
             isLiveMode = true,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultUpdatePaymentMethodInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultUpdatePaymentMethodInteractorTest.kt
@@ -737,6 +737,7 @@ class DefaultUpdatePaymentMethodInteractorTest {
                 onUpdateSuccessTurbine.add(Unit)
             },
             editCardDetailsInteractorFactory = editCardDetailsInteractorFactory,
+            removeMessage = null,
             allowedBillingCountries = allowedBillingCountries,
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeUpdatePaymentMethodInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeUpdatePaymentMethodInteractor.kt
@@ -26,6 +26,7 @@ internal class FakeUpdatePaymentMethodInteractor(
     override val shouldShowSaveButton: Boolean = false,
     override val addressCollectionMode: AddressCollectionMode = AddressCollectionMode.Automatic,
     override val allowedBillingCountries: Set<String> = setOf("US", "CA"),
+    override val removeMessage: ResolvableString? = null,
     private val useDefaultBillingDetails: Boolean = true,
     val viewActionRecorder: ViewActionRecorder<UpdatePaymentMethodInteractor.ViewAction>? = ViewActionRecorder(),
     initialState: UpdatePaymentMethodInteractor.State = UpdatePaymentMethodInteractor.State(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/RemovePaymentMethodDialogUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/RemovePaymentMethodDialogUITest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onChildren
 import androidx.compose.ui.test.onNodeWithTag
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodFixtures.toDisplayableSavedPaymentMethod
 import com.stripe.android.testing.createComposeCleanupRule
@@ -35,6 +36,7 @@ class RemovePaymentMethodDialogUITest {
         composeRule.setContent {
             RemovePaymentMethodDialogUI(
                 paymentMethod = paymentMethod,
+                removeMessage = null,
                 onConfirmListener = {},
                 onDismissListener = {}
             )
@@ -42,6 +44,27 @@ class RemovePaymentMethodDialogUITest {
 
         composeRule.onNodeWithTag(TEST_TAG_SIMPLE_DIALOG).onChildren().assertAny(
             hasText("Cartes Bancaires ····4242")
+        )
+    }
+
+    @Test
+    fun removeDescription_usesMessageIfAvailable() {
+        val removeMessage = "This payment method will be removed but will remain " +
+            "available for Merchant, Inc. subscriptions."
+
+        composeRule.setContent {
+            RemovePaymentMethodDialogUI(
+                paymentMethod = PaymentMethodFixtures
+                    .CARD_WITH_NETWORKS_PAYMENT_METHOD
+                    .toDisplayableSavedPaymentMethod(),
+                removeMessage = resolvableString(removeMessage),
+                onConfirmListener = {},
+                onDismissListener = {}
+            )
+        }
+
+        composeRule.onNodeWithTag(TEST_TAG_SIMPLE_DIALOG).onChildren().assertAny(
+            hasText(removeMessage)
         )
     }
 }


### PR DESCRIPTION
# Summary
Use different remove messaging for partial customer session remove permissions

# Motivation
Merchant ask to better indicate how payment methods are being removed.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified