### PR TITLE
Pass passiveCaptchaParams to ConfirmationOption via PaymentMethodMetadata

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -1038,6 +1038,7 @@ internal class CustomerSheetViewModel(
                 confirmationOption = PaymentMethodConfirmationOption.Saved(
                     paymentMethod = paymentMethod,
                     optionsParams = null,
+                    passiveCaptchaParams = customerState.value.metadata?.passiveCaptchaParams
                 ),
                 intent = stripeIntent,
                 initializationMode = PaymentElementLoader.InitializationMode.SetupIntent(

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivity.kt
@@ -125,6 +125,7 @@ internal class LinkActivity : ComponentActivity() {
                     lastUpdateReason = null
                 ),
                 launchMode = LinkLaunchMode.Full,
+                passiveCaptchaParams = null,
             )
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityContract.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import androidx.activity.result.contract.ActivityResultContract
 import com.stripe.android.link.gate.LinkGate
+import com.stripe.android.model.PassiveCaptchaParams
 import javax.inject.Inject
 
 /**
@@ -39,7 +40,8 @@ internal class LinkActivityContract @Inject internal constructor(
         internal val configuration: LinkConfiguration,
         internal val linkExpressMode: LinkExpressMode,
         internal val linkAccountInfo: LinkAccountUpdate.Value,
-        internal val launchMode: LinkLaunchMode
+        internal val launchMode: LinkLaunchMode,
+        internal val passiveCaptchaParams: PassiveCaptchaParams?
     )
 
     data class Result(

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
@@ -435,6 +435,7 @@ internal class LinkActivityViewModel @Inject constructor(
                 DaggerNativeLinkComponent
                     .builder()
                     .configuration(args.configuration)
+                    .passiveCaptchaParams(args.passiveCaptchaParams)
                     .requestSurface(args.requestSurface)
                     .publishableKeyProvider { args.publishableKey }
                     .stripeAccountIdProvider { args.stripeAccountId }

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
@@ -465,6 +465,7 @@ internal class LinkControllerInteractor @Inject constructor(
                         linkExpressMode = LinkExpressMode.ENABLED,
                         linkAccountInfo = linkAccountHolder.linkAccountInfo.value,
                         launchMode = launchMode,
+                        passiveCaptchaParams = null
                     )
                 )
             }

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
@@ -6,6 +6,7 @@ import androidx.activity.result.ActivityResultRegistry
 import com.stripe.android.link.LinkActivityResult.PaymentMethodObtained
 import com.stripe.android.link.account.LinkStore
 import com.stripe.android.link.injection.LinkAnalyticsComponent
+import com.stripe.android.model.PassiveCaptchaParams
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -77,13 +78,15 @@ internal class LinkPaymentLauncher @Inject internal constructor(
         configuration: LinkConfiguration,
         linkAccountInfo: LinkAccountUpdate.Value,
         launchMode: LinkLaunchMode,
-        linkExpressMode: LinkExpressMode
+        linkExpressMode: LinkExpressMode,
+        passiveCaptchaParams: PassiveCaptchaParams?
     ) {
         val args = LinkActivityContract.Args(
             configuration = configuration,
             linkExpressMode = linkExpressMode,
             linkAccountInfo = linkAccountInfo,
-            launchMode = launchMode
+            launchMode = launchMode,
+            passiveCaptchaParams = passiveCaptchaParams
         )
         linkActivityResultLauncher?.launch(args)
         analyticsHelper.onLinkLaunched()

--- a/paymentsheet/src/main/java/com/stripe/android/link/NativeLinkActivityContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/NativeLinkActivityContract.kt
@@ -30,7 +30,8 @@ internal class NativeLinkActivityContract @Inject constructor(
                 linkExpressMode = input.linkExpressMode,
                 launchMode = input.launchMode,
                 paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
-                linkAccountInfo = input.linkAccountInfo
+                linkAccountInfo = input.linkAccountInfo,
+                passiveCaptchaParams = input.passiveCaptchaParams
             )
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/link/NativeLinkArgs.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/NativeLinkArgs.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.link
 
 import android.os.Parcelable
+import com.stripe.android.model.PassiveCaptchaParams
 import com.stripe.android.networking.RequestSurface
 import kotlinx.parcelize.Parcelize
 
@@ -14,4 +15,5 @@ internal data class NativeLinkArgs(
     val linkAccountInfo: LinkAccountUpdate.Value,
     val paymentElementCallbackIdentifier: String,
     val launchMode: LinkLaunchMode,
+    val passiveCaptchaParams: PassiveCaptchaParams?
 ) : Parcelable

--- a/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
@@ -10,6 +10,7 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.LinkMode
+import com.stripe.android.model.PassiveCaptchaParams
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethod.Type.USBankAccount
@@ -28,6 +29,7 @@ internal class DefaultLinkConfirmationHandler @Inject constructor(
     private val configuration: LinkConfiguration,
     private val logger: Logger,
     private val confirmationHandler: ConfirmationHandler,
+    private val passiveCaptchaParams: PassiveCaptchaParams?
 ) : LinkConfirmationHandler {
 
     override suspend fun confirm(
@@ -154,7 +156,8 @@ internal class DefaultLinkConfirmationHandler @Inject constructor(
                 ),
                 extraParams = null,
                 optionsParams = null,
-                shouldSave = false
+                shouldSave = false,
+                passiveCaptchaParams = passiveCaptchaParams
             )
         }
 
@@ -203,7 +206,8 @@ internal class DefaultLinkConfirmationHandler @Inject constructor(
                     cvc = cvc?.takeIf {
                         configuration.passthroughModeEnabled.not()
                     }
-                )
+                ),
+                passiveCaptchaParams = passiveCaptchaParams
             ),
             appearance = PaymentSheet.Appearance(),
             initializationMode = configuration.initializationMode,
@@ -213,6 +217,7 @@ internal class DefaultLinkConfirmationHandler @Inject constructor(
 
     class Factory @Inject constructor(
         private val configuration: LinkConfiguration,
+        private val passiveCaptchaParams: PassiveCaptchaParams?,
         private val logger: Logger,
     ) : LinkConfirmationHandler.Factory {
         override fun create(confirmationHandler: ConfirmationHandler): LinkConfirmationHandler {
@@ -220,6 +225,7 @@ internal class DefaultLinkConfirmationHandler @Inject constructor(
                 confirmationHandler = confirmationHandler,
                 logger = logger,
                 configuration = configuration,
+                passiveCaptchaParams = passiveCaptchaParams
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkComponent.kt
@@ -21,6 +21,7 @@ import com.stripe.android.link.analytics.LinkEventsReporter
 import com.stripe.android.link.confirmation.LinkConfirmationHandler
 import com.stripe.android.link.ui.oauth.OAuthConsentViewModelComponent
 import com.stripe.android.link.ui.wallet.AddPaymentMethodOptions
+import com.stripe.android.model.PassiveCaptchaParams
 import com.stripe.android.networking.RequestSurface
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.paymentelement.confirmation.injection.DefaultConfirmationModule
@@ -53,6 +54,7 @@ internal annotation class NativeLinkScope
 internal interface NativeLinkComponent {
     val linkAccountManager: LinkAccountManager
     val configuration: LinkConfiguration
+    val passiveCaptchaParams: PassiveCaptchaParams?
     val linkEventsReporter: LinkEventsReporter
     val errorReporter: ErrorReporter
     val logger: Logger
@@ -74,6 +76,9 @@ internal interface NativeLinkComponent {
     interface Builder {
         @BindsInstance
         fun configuration(configuration: LinkConfiguration): Builder
+
+        @BindsInstance
+        fun passiveCaptchaParams(passiveCaptchaParams: PassiveCaptchaParams?): Builder
 
         @BindsInstance
         fun publishableKeyProvider(@Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String): Builder

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
@@ -202,6 +202,7 @@ internal class PaymentMethodViewModel @Inject constructor(
                             paymentMethodMetadata = PaymentMethodMetadata.createForNativeLink(
                                 configuration = parentComponent.configuration.withLinkRequiredSettings(),
                                 linkAccount = linkAccount,
+                                passiveCaptchaParams = parentComponent.passiveCaptchaParams,
                             ),
                             eventReporter = parentComponent.eventReporter,
                             savedStateHandle = parentComponent.viewModel.savedStateHandle,

--- a/paymentsheet/src/main/java/com/stripe/android/link/verification/DefaultLinkInlineInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/verification/DefaultLinkInlineInteractor.kt
@@ -41,7 +41,8 @@ internal class DefaultLinkInlineInteractor @Inject constructor(
     override val state: StateFlow<LinkInlineState> = savedStateHandle.getStateFlow(
         key = LINK_EMBEDDED_STATE_KEY,
         initialValue = LinkInlineState(
-            verificationState = VerificationState.Loading
+            verificationState = VerificationState.Loading,
+            passiveCaptchaParams = null
         )
     )
 
@@ -49,6 +50,7 @@ internal class DefaultLinkInlineInteractor @Inject constructor(
      * Sets up Link verification domain logic (should be called once when initializing)
      */
     override fun setup(paymentMethodMetadata: PaymentMethodMetadata) {
+        updateState { it.copy(passiveCaptchaParams = paymentMethodMetadata.passiveCaptchaParams) }
         val linkConfiguration = paymentMethodMetadata.linkState?.configuration
         if (linkConfiguration == null) {
             // If there is no Link account manager, we don't need to handle verification.
@@ -107,7 +109,8 @@ internal class DefaultLinkInlineInteractor @Inject constructor(
                     configuration = verificationState.linkConfiguration,
                     linkAccountInfo = accountManager.linkAccountInfo.value,
                     launchMode = LinkLaunchMode.PaymentMethodSelection(null),
-                    linkExpressMode = LinkExpressMode.ENABLED
+                    linkExpressMode = LinkExpressMode.ENABLED,
+                    passiveCaptchaParams = state.value.passiveCaptchaParams
                 )
                 // No UI changes - keep the 2FA until we get a result from the Link payment selection flow.
             }.onFailure { error ->

--- a/paymentsheet/src/main/java/com/stripe/android/link/verification/LinkInlineState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/verification/LinkInlineState.kt
@@ -3,6 +3,7 @@ package com.stripe.android.link.verification
 import android.os.Parcelable
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.ui.verification.VerificationViewState
+import com.stripe.android.model.PassiveCaptchaParams
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -14,6 +15,7 @@ internal data class LinkInlineState(
      * Current verification state representing the different stages in the verification process.
      */
     val verificationState: VerificationState,
+    val passiveCaptchaParams: PassiveCaptchaParams?
 ) : Parcelable
 
 /**

--- a/paymentsheet/src/main/java/com/stripe/android/link/verification/NoOpLinkInlineInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/verification/NoOpLinkInlineInteractor.kt
@@ -12,7 +12,10 @@ import kotlinx.coroutines.flow.StateFlow
 internal class NoOpLinkInlineInteractor : LinkInlineInteractor {
 
     override val state: StateFlow<LinkInlineState> = MutableStateFlow(
-        LinkInlineState(verificationState = VerificationState.RenderButton)
+        value = LinkInlineState(
+            verificationState = VerificationState.RenderButton,
+            passiveCaptchaParams = null
+        )
     )
     override val otpElement: OTPElement = OTPSpec.transform()
 

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -17,6 +17,7 @@ import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.ElementsSession.Flag.ELEMENTS_MOBILE_FORCE_SETUP_FUTURE_USE_BEHAVIOR_AND_NEW_MANDATE_TEXT
 import com.stripe.android.model.LinkMode
+import com.stripe.android.model.PassiveCaptchaParams
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
@@ -73,6 +74,7 @@ internal data class PaymentMethodMetadata(
     val shopPayConfiguration: PaymentSheet.ShopPayConfiguration?,
     val termsDisplay: Map<PaymentMethod.Type, PaymentSheet.TermsDisplay>,
     val forceSetupFutureUseBehaviorAndNewMandate: Boolean,
+    val passiveCaptchaParams: PassiveCaptchaParams?
 ) : Parcelable {
 
     fun hasIntentToSetup(code: PaymentMethodCode): Boolean {
@@ -349,6 +351,7 @@ internal data class PaymentMethodMetadata(
                 termsDisplay = configuration.termsDisplay,
                 forceSetupFutureUseBehaviorAndNewMandate = elementsSession
                     .flags[ELEMENTS_MOBILE_FORCE_SETUP_FUTURE_USE_BEHAVIOR_AND_NEW_MANDATE_TEXT] == true,
+                passiveCaptchaParams = elementsSession.passiveCaptchaParams
             )
         }
 
@@ -398,12 +401,14 @@ internal data class PaymentMethodMetadata(
                 termsDisplay = emptyMap(),
                 forceSetupFutureUseBehaviorAndNewMandate = elementsSession
                     .flags[ELEMENTS_MOBILE_FORCE_SETUP_FUTURE_USE_BEHAVIOR_AND_NEW_MANDATE_TEXT] == true,
+                passiveCaptchaParams = elementsSession.passiveCaptchaParams
             )
         }
 
         internal fun createForNativeLink(
             configuration: LinkConfiguration,
             linkAccount: LinkAccount,
+            passiveCaptchaParams: PassiveCaptchaParams?
         ): PaymentMethodMetadata {
             return PaymentMethodMetadata(
                 stripeIntent = configuration.stripeIntent,
@@ -450,7 +455,8 @@ internal data class PaymentMethodMetadata(
                 financialConnectionsAvailability = GetFinancialConnectionsAvailability(elementsSession = null),
                 shopPayConfiguration = null,
                 termsDisplay = emptyMap(),
-                forceSetupFutureUseBehaviorAndNewMandate = configuration.forceSetupFutureUseBehaviorAndNewMandate
+                forceSetupFutureUseBehaviorAndNewMandate = configuration.forceSetupFutureUseBehaviorAndNewMandate,
+                passiveCaptchaParams = passiveCaptchaParams
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationOptionKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationOptionKtx.kt
@@ -4,6 +4,7 @@ import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkLaunchMode
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilter
+import com.stripe.android.model.PassiveCaptchaParams
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentelement.confirmation.bacs.BacsConfirmationOption
 import com.stripe.android.paymentelement.confirmation.cpms.CustomPaymentMethodConfirmationOption
@@ -15,27 +16,32 @@ import com.stripe.android.paymentelement.confirmation.shoppay.ShopPayConfirmatio
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
 
+@SuppressWarnings("UnusedParameter")
 internal fun PaymentSelection.toConfirmationOption(
     configuration: CommonConfiguration,
     linkConfiguration: LinkConfiguration?,
+    passiveCaptchaParams: PassiveCaptchaParams?
 ): ConfirmationHandler.Option? {
     return when (this) {
-        is PaymentSelection.Saved -> toConfirmationOption()
+        is PaymentSelection.Saved -> toConfirmationOption(passiveCaptchaParams)
         is PaymentSelection.ExternalPaymentMethod -> toConfirmationOption()
         is PaymentSelection.CustomPaymentMethod -> toConfirmationOption(configuration)
-        is PaymentSelection.New.USBankAccount -> toConfirmationOption()
-        is PaymentSelection.New.LinkInline -> toConfirmationOption(linkConfiguration)
-        is PaymentSelection.New -> toConfirmationOption()
-        is PaymentSelection.GooglePay -> toConfirmationOption(configuration)
-        is PaymentSelection.Link -> toConfirmationOption(linkConfiguration)
+        is PaymentSelection.New.USBankAccount -> toConfirmationOption(passiveCaptchaParams)
+        is PaymentSelection.New.LinkInline -> toConfirmationOption(linkConfiguration, passiveCaptchaParams)
+        is PaymentSelection.New -> toConfirmationOption(passiveCaptchaParams)
+        is PaymentSelection.GooglePay -> toConfirmationOption(configuration, passiveCaptchaParams)
+        is PaymentSelection.Link -> toConfirmationOption(linkConfiguration, passiveCaptchaParams)
         is PaymentSelection.ShopPay -> toConfirmationOption(configuration)
     }
 }
 
-private fun PaymentSelection.Saved.toConfirmationOption(): PaymentMethodConfirmationOption.Saved {
+private fun PaymentSelection.Saved.toConfirmationOption(
+    passiveCaptchaParams: PassiveCaptchaParams?
+): PaymentMethodConfirmationOption.Saved {
     return PaymentMethodConfirmationOption.Saved(
         paymentMethod = paymentMethod,
         optionsParams = paymentMethodOptionsParams,
+        passiveCaptchaParams = passiveCaptchaParams
     )
 }
 
@@ -46,13 +52,16 @@ private fun PaymentSelection.ExternalPaymentMethod.toConfirmationOption(): Exter
     )
 }
 
-private fun PaymentSelection.New.USBankAccount.toConfirmationOption(): PaymentMethodConfirmationOption {
+private fun PaymentSelection.New.USBankAccount.toConfirmationOption(
+    passiveCaptchaParams: PassiveCaptchaParams?
+): PaymentMethodConfirmationOption {
     return if (instantDebits != null) {
         // For Instant Debits, we create the PaymentMethod inside the bank auth flow. Therefore,
         // we can just use the already created object here.
         PaymentMethodConfirmationOption.Saved(
             paymentMethod = instantDebits.paymentMethod,
             optionsParams = paymentMethodOptionsParams,
+            passiveCaptchaParams = passiveCaptchaParams
         )
     } else {
         PaymentMethodConfirmationOption.New(
@@ -60,12 +69,14 @@ private fun PaymentSelection.New.USBankAccount.toConfirmationOption(): PaymentMe
             optionsParams = paymentMethodOptionsParams,
             extraParams = paymentMethodExtraParams,
             shouldSave = customerRequestedSave == PaymentSelection.CustomerRequestedSave.RequestReuse,
+            passiveCaptchaParams = passiveCaptchaParams
         )
     }
 }
 
 private fun PaymentSelection.New.LinkInline.toConfirmationOption(
-    linkConfiguration: LinkConfiguration?
+    linkConfiguration: LinkConfiguration?,
+    passiveCaptchaParams: PassiveCaptchaParams?
 ): LinkInlineSignupConfirmationOption? {
     return linkConfiguration?.let {
         LinkInlineSignupConfirmationOption(
@@ -81,16 +92,20 @@ private fun PaymentSelection.New.LinkInline.toConfirmationOption(
                     LinkInlineSignupConfirmationOption.PaymentMethodSaveOption.NoRequest
             },
             linkConfiguration = linkConfiguration,
-            userInput = input
+            userInput = input,
+            passiveCaptchaParams = passiveCaptchaParams
         )
     }
 }
 
-private fun PaymentSelection.New.toConfirmationOption(): ConfirmationHandler.Option {
+private fun PaymentSelection.New.toConfirmationOption(
+    passiveCaptchaParams: PassiveCaptchaParams?
+): ConfirmationHandler.Option {
     return if (paymentMethodCreateParams.typeCode == PaymentMethod.Type.BacsDebit.code) {
         BacsConfirmationOption(
             createParams = paymentMethodCreateParams,
             optionsParams = paymentMethodOptionsParams,
+            passiveCaptchaParams = passiveCaptchaParams
         )
     } else {
         PaymentMethodConfirmationOption.New(
@@ -98,12 +113,14 @@ private fun PaymentSelection.New.toConfirmationOption(): ConfirmationHandler.Opt
             optionsParams = paymentMethodOptionsParams,
             extraParams = paymentMethodExtraParams,
             shouldSave = customerRequestedSave == PaymentSelection.CustomerRequestedSave.RequestReuse,
+            passiveCaptchaParams = passiveCaptchaParams
         )
     }
 }
 
 private fun PaymentSelection.GooglePay.toConfirmationOption(
     configuration: CommonConfiguration,
+    passiveCaptchaParams: PassiveCaptchaParams?
 ): GooglePayConfirmationOption? {
     return configuration.googlePay?.let { googlePay ->
         GooglePayConfirmationOption(
@@ -116,13 +133,15 @@ private fun PaymentSelection.GooglePay.toConfirmationOption(
                 customLabel = googlePay.label,
                 billingDetailsCollectionConfiguration = configuration.billingDetailsCollectionConfiguration,
                 cardBrandFilter = PaymentSheetCardBrandFilter(configuration.cardBrandAcceptance)
-            )
+            ),
+            passiveCaptchaParams = passiveCaptchaParams
         )
     }
 }
 
 private fun PaymentSelection.Link.toConfirmationOption(
-    linkConfiguration: LinkConfiguration?
+    linkConfiguration: LinkConfiguration?,
+    passiveCaptchaParams: PassiveCaptchaParams?
 ): LinkConfirmationOption? {
     return linkConfiguration?.let {
         LinkConfirmationOption(
@@ -134,6 +153,7 @@ private fun PaymentSelection.Link.toConfirmationOption(
                 // If a payment is not included, launch the link flow regularly
                 else -> LinkLaunchMode.Full
             },
+            passiveCaptchaParams = passiveCaptchaParams
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/PaymentMethodConfirmationOption.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/PaymentMethodConfirmationOption.kt
@@ -14,7 +14,7 @@ internal sealed interface PaymentMethodConfirmationOption : ConfirmationHandler.
         val paymentMethod: com.stripe.android.model.PaymentMethod,
         val optionsParams: PaymentMethodOptionsParams?,
         val originatedFromWallet: Boolean = false,
-        override val passiveCaptchaParams: PassiveCaptchaParams? = null,
+        override val passiveCaptchaParams: PassiveCaptchaParams?,
         val hCaptchaToken: String? = null,
     ) : PaymentMethodConfirmationOption
 
@@ -24,6 +24,6 @@ internal sealed interface PaymentMethodConfirmationOption : ConfirmationHandler.
         val optionsParams: PaymentMethodOptionsParams?,
         val extraParams: PaymentMethodExtraParams?,
         val shouldSave: Boolean,
-        override val passiveCaptchaParams: PassiveCaptchaParams? = null,
+        override val passiveCaptchaParams: PassiveCaptchaParams?,
     ) : PaymentMethodConfirmationOption
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationDefinition.kt
@@ -85,6 +85,7 @@ internal class BacsConfirmationDefinition @Inject constructor(
                     optionsParams = null,
                     extraParams = null,
                     shouldSave = false,
+                    passiveCaptchaParams = confirmationOption.passiveCaptchaParams,
                 )
 
                 ConfirmationDefinition.Result.NextStep(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationOption.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationOption.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentelement.confirmation.bacs
 
+import com.stripe.android.model.PassiveCaptchaParams
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
@@ -9,4 +10,5 @@ import kotlinx.parcelize.Parcelize
 internal data class BacsConfirmationOption(
     val createParams: PaymentMethodCreateParams,
     val optionsParams: PaymentMethodOptionsParams?,
+    val passiveCaptchaParams: PassiveCaptchaParams?
 ) : ConfirmationHandler.Option

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinition.kt
@@ -32,7 +32,7 @@ internal class PassiveChallengeConfirmationDefinition @Inject constructor(
         confirmationOption: PaymentMethodConfirmationOption,
         confirmationParameters: ConfirmationDefinition.Parameters
     ): Boolean {
-        return confirmationOption.passiveCaptchaParams != null
+        return false
     }
 
     override fun toResult(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinition.kt
@@ -115,6 +115,7 @@ internal class GooglePayConfirmationDefinition @Inject constructor(
                     paymentMethod = result.paymentMethod,
                     optionsParams = null,
                     originatedFromWallet = true,
+                    passiveCaptchaParams = confirmationOption.passiveCaptchaParams
                 )
 
                 ConfirmationDefinition.Result.NextStep(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationOption.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationOption.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentelement.confirmation.gpay
 
 import android.os.Parcelable
 import com.stripe.android.CardBrandFilter
+import com.stripe.android.model.PassiveCaptchaParams
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentsheet.PaymentSheet
 import kotlinx.parcelize.Parcelize
@@ -9,6 +10,7 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 internal data class GooglePayConfirmationOption(
     val config: Config,
+    val passiveCaptchaParams: PassiveCaptchaParams?
 ) : ConfirmationHandler.Option {
     @Parcelize
     data class Config(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinition.kt
@@ -59,6 +59,7 @@ internal class LinkConfirmationDefinition @Inject constructor(
             linkAccountInfo = linkAccountHolder.linkAccountInfo.value,
             launchMode = confirmationOption.linkLaunchMode,
             linkExpressMode = confirmationOption.linkExpressMode,
+            passiveCaptchaParams = confirmationOption.passiveCaptchaParams
         )
     }
 
@@ -82,6 +83,7 @@ internal class LinkConfirmationDefinition @Inject constructor(
                         paymentMethod = result.paymentMethod,
                         optionsParams = null,
                         originatedFromWallet = true,
+                        passiveCaptchaParams = confirmationOption.passiveCaptchaParams
                     ),
                     parameters = confirmationParameters,
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationOption.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationOption.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentelement.confirmation.link
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.link.LinkLaunchMode
+import com.stripe.android.model.PassiveCaptchaParams
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import kotlinx.parcelize.Parcelize
 
@@ -10,5 +11,6 @@ import kotlinx.parcelize.Parcelize
 internal data class LinkConfirmationOption(
     val configuration: LinkConfiguration,
     val linkLaunchMode: LinkLaunchMode = LinkLaunchMode.Full,
-    val linkExpressMode: LinkExpressMode
+    val linkExpressMode: LinkExpressMode,
+    val passiveCaptchaParams: PassiveCaptchaParams?
 ) : ConfirmationHandler.Option

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkPassthroughConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkPassthroughConfirmationDefinition.kt
@@ -95,6 +95,7 @@ internal class LinkPassthroughConfirmationDefinition @Inject constructor(
                 paymentMethod = paymentMethod,
                 optionsParams = null,
                 originatedFromWallet = true,
+                passiveCaptchaParams = confirmationOption.passiveCaptchaParams
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkPassthroughConfirmationOption.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkPassthroughConfirmationOption.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentelement.confirmation.link
 
+import com.stripe.android.model.PassiveCaptchaParams
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import kotlinx.parcelize.Parcelize
@@ -11,4 +12,5 @@ internal data class LinkPassthroughConfirmationOption(
     val cvc: String?,
     val billingPhone: String?,
     val allowRedisplay: PaymentMethod.AllowRedisplay? = null,
+    val passiveCaptchaParams: PassiveCaptchaParams? = null,
 ) : ConfirmationHandler.Option

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinition.kt
@@ -10,6 +10,7 @@ import com.stripe.android.link.analytics.LinkAnalyticsHelper
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.model.ConfirmPaymentIntentParams
+import com.stripe.android.model.PassiveCaptchaParams
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodExtraParams
@@ -122,6 +123,7 @@ internal class LinkInlineSignupConfirmationDefinition(
         val saveOption = linkInlineSignupConfirmationOption.saveOption
         val extraParams = linkInlineSignupConfirmationOption.extraParams
         val configuration = linkInlineSignupConfirmationOption.linkConfiguration
+        val passiveCaptchaParams = linkInlineSignupConfirmationOption.passiveCaptchaParams
 
         val linkPaymentDetails = linkConfigurationCoordinator.attachNewCardToAccount(
             configuration,
@@ -132,12 +134,12 @@ internal class LinkInlineSignupConfirmationDefinition(
             is LinkPaymentDetails.New -> {
                 linkStore.markLinkAsUsed()
 
-                linkPaymentDetails.toNewOption(saveOption, configuration, extraParams)
+                linkPaymentDetails.toNewOption(saveOption, configuration, extraParams, passiveCaptchaParams)
             }
             is LinkPaymentDetails.Saved -> {
                 linkStore.markLinkAsUsed()
 
-                linkPaymentDetails.toSavedOption(createParams, saveOption)
+                linkPaymentDetails.toSavedOption(createParams, saveOption, passiveCaptchaParams)
             }
             null -> linkInlineSignupConfirmationOption.toNewOption()
         }
@@ -146,6 +148,7 @@ internal class LinkInlineSignupConfirmationDefinition(
     private fun LinkPaymentDetails.Saved.toSavedOption(
         createParams: PaymentMethodCreateParams,
         saveOption: LinkInlineSignupConfirmationOption.PaymentMethodSaveOption,
+        passiveCaptchaParams: PassiveCaptchaParams?
     ): PaymentMethodConfirmationOption.Saved {
         val last4 = paymentDetails.last4
 
@@ -167,6 +170,7 @@ internal class LinkInlineSignupConfirmationDefinition(
                 } ?: ConfirmPaymentIntentParams.SetupFutureUsage.Blank
             ),
             originatedFromWallet = true,
+            passiveCaptchaParams = passiveCaptchaParams
         )
     }
 
@@ -174,6 +178,7 @@ internal class LinkInlineSignupConfirmationDefinition(
         saveOption: LinkInlineSignupConfirmationOption.PaymentMethodSaveOption,
         configuration: LinkConfiguration,
         extraParams: PaymentMethodExtraParams?,
+        passiveCaptchaParams: PassiveCaptchaParams?
     ): PaymentMethodConfirmationOption.New {
         val passthroughMode = configuration.passthroughModeEnabled
 
@@ -188,6 +193,7 @@ internal class LinkInlineSignupConfirmationDefinition(
             optionsParams = optionsParams,
             extraParams = extraParams,
             shouldSave = saveOption.shouldSave(),
+            passiveCaptchaParams = passiveCaptchaParams
         )
     }
 
@@ -197,6 +203,7 @@ internal class LinkInlineSignupConfirmationDefinition(
             optionsParams = optionsParams,
             extraParams = extraParams,
             shouldSave = saveOption.shouldSave(),
+            passiveCaptchaParams = passiveCaptchaParams
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationOption.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationOption.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentelement.confirmation.linkinline
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.model.ConfirmPaymentIntentParams
+import com.stripe.android.model.PassiveCaptchaParams
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.PaymentMethodOptionsParams
@@ -17,6 +18,7 @@ internal data class LinkInlineSignupConfirmationOption(
     val saveOption: PaymentMethodSaveOption,
     val linkConfiguration: LinkConfiguration,
     private val userInput: UserInput,
+    val passiveCaptchaParams: PassiveCaptchaParams?
 ) : ConfirmationHandler.Option {
     enum class PaymentMethodSaveOption(val setupFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage?) {
         RequestedReuse(ConfirmPaymentIntentParams.SetupFutureUsage.OffSession),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationHelper.kt
@@ -55,6 +55,7 @@ internal class DefaultEmbeddedConfirmationHelper @Inject constructor(
         val confirmationOption = confirmationState.selection?.toConfirmationOption(
             configuration = confirmationState.configuration.asCommonConfiguration(),
             linkConfiguration = confirmationState.paymentMethodMetadata.linkState?.configuration,
+            passiveCaptchaParams = confirmationState.paymentMethodMetadata.passiveCaptchaParams
         ) ?: return null
 
         return ConfirmationHandler.Args(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityConfirmationHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityConfirmationHelper.kt
@@ -73,7 +73,8 @@ internal class DefaultFormActivityConfirmationHelper @Inject constructor(
     private fun confirmationArgs(): ConfirmationHandler.Args? {
         val confirmationOption = selectionHolder.selection.value?.toConfirmationOption(
             configuration = configuration.asCommonConfiguration(),
-            linkConfiguration = paymentMethodMetadata.linkState?.configuration
+            linkConfiguration = paymentMethodMetadata.linkState?.configuration,
+            passiveCaptchaParams = paymentMethodMetadata.passiveCaptchaParams
         ) ?: return null
         return ConfirmationHandler.Args(
             intent = paymentMethodMetadata.stripeIntent,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -286,7 +286,8 @@ internal class PaymentOptionsViewModel @Inject constructor(
                     configuration = linkState!!.configuration,
                     launchMode = LinkLaunchMode.PaymentMethodSelection(selectedPayment = null),
                     linkAccountInfo = linkAccountHolder.linkAccountInfo.value,
-                    linkExpressMode = LinkExpressMode.ENABLED
+                    linkExpressMode = LinkExpressMode.ENABLED,
+                    passiveCaptchaParams = args.state.paymentMethodMetadata.passiveCaptchaParams
                 )
             } else {
                 _paymentOptionsActivityResult.tryEmit(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -509,6 +509,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                     ?.toConfirmationOption(
                         configuration = config.asCommonConfiguration(),
                         linkConfiguration = linkHandler.linkConfiguration.value,
+                        passiveCaptchaParams = paymentMethodMetadata.value?.passiveCaptchaParams,
                     )
             }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -285,7 +285,8 @@ internal class DefaultFlowController @Inject internal constructor(
                     linkExpressMode = LinkExpressMode.ENABLED,
                     launchMode = LinkLaunchMode.PaymentMethodSelection(
                         selectedPayment = (paymentSelection as? Link)?.selectedPayment?.details
-                    )
+                    ),
+                    passiveCaptchaParams = state.paymentSheetState.paymentMethodMetadata.passiveCaptchaParams
                 )
             } else {
                 showPaymentOptionList(state, paymentSelection)
@@ -537,6 +538,7 @@ internal class DefaultFlowController @Inject internal constructor(
             val confirmationOption = paymentSelection?.toConfirmationOption(
                 configuration = state.config,
                 linkConfiguration = state.linkConfiguration,
+                passiveCaptchaParams = state.paymentMethodMetadata.passiveCaptchaParams
             )
 
             confirmationOption?.let { option ->

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
@@ -236,7 +236,8 @@ internal class DefaultWalletButtonsInteractor(
                 configuration = linkConfiguration,
                 linkAccountInfo = linkAccountHolder.linkAccountInfo.value,
                 launchMode = LinkLaunchMode.PaymentMethodSelection(selectedPayment?.details),
-                linkExpressMode = LinkExpressMode.ENABLED
+                linkExpressMode = LinkExpressMode.ENABLED,
+                passiveCaptchaParams = arguments.paymentMethodMetadata.passiveCaptchaParams
             )
         } else {
             handleButtonPressed(
@@ -269,6 +270,7 @@ internal class DefaultWalletButtonsInteractor(
         val confirmationOption = selection.toConfirmationOption(
             configuration = arguments.configuration,
             linkConfiguration = arguments.paymentMethodMetadata.linkState?.configuration,
+            passiveCaptchaParams = arguments.paymentMethodMetadata.passiveCaptchaParams
         ) ?: return null
 
         return ConfirmationHandler.Args(

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -31,6 +31,7 @@ import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures.CARD_PAYMENT_METHOD
 import com.stripe.android.networking.StripeRepository
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.createTestConfirmationHandlerFactory
 import com.stripe.android.paymentelement.confirmation.intent.IntentConfirmationInterceptor
 import com.stripe.android.payments.core.analytics.ErrorReporter
@@ -99,6 +100,7 @@ internal object CustomerSheetTestHelper {
             permissions = customerPermissions,
         ),
         errorReporter: ErrorReporter = FakeErrorReporter(),
+        confirmationHandlerFactory: ConfirmationHandler.Factory? = null,
     ): CustomerSheetViewModel {
         return CustomerSheetViewModel(
             application = application,
@@ -114,7 +116,7 @@ internal object CustomerSheetTestHelper {
             isLiveModeProvider = { isLiveMode },
             logger = Logger.noop(),
             productUsage = emptySet(),
-            confirmationHandlerFactory = createTestConfirmationHandlerFactory(
+            confirmationHandlerFactory = confirmationHandlerFactory ?: createTestConfirmationHandlerFactory(
                 paymentElementCallbackIdentifier = "CustomerSheetTestIdentifier",
                 intentConfirmationInterceptor = intentConfirmationInterceptor,
                 paymentConfiguration = paymentConfiguration,

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/FakeCustomerSheetLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/FakeCustomerSheetLoader.kt
@@ -8,6 +8,7 @@ import com.stripe.android.customersheet.CustomerSheetState
 import com.stripe.android.lpmfoundations.luxe.LpmRepositoryTestHelpers
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.PassiveCaptchaParams
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
@@ -37,6 +38,7 @@ internal class FakeCustomerSheetLoader(
         canUpdateFullPaymentMethodDetails = true,
     ),
     private val isPaymentMethodSyncDefaultEnabled: Boolean = false,
+    private val passiveCaptchaParams: PassiveCaptchaParams? = null,
 ) : CustomerSheetLoader {
 
     override suspend fun load(configuration: CustomerSheet.Configuration): Result<CustomerSheetState.Full> {
@@ -54,6 +56,7 @@ internal class FakeCustomerSheetLoader(
                         paymentMethodOrder = configuration.paymentMethodOrder,
                         isGooglePayReady = isGooglePayAvailable,
                         isPaymentMethodSetAsDefaultEnabled = isPaymentMethodSyncDefaultEnabled,
+                        passiveCaptchaParams = passiveCaptchaParams,
                     ),
                     supportedPaymentMethods = supportedPaymentMethods,
                     customerPaymentMethods = customerPaymentMethods,

--- a/paymentsheet/src/test/java/com/stripe/android/link/FakeNativeLinkComponent.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/FakeNativeLinkComponent.kt
@@ -15,6 +15,8 @@ import com.stripe.android.link.injection.NativeLinkComponent
 import com.stripe.android.link.ui.oauth.OAuthConsentViewModelComponent
 import com.stripe.android.link.ui.wallet.AddPaymentMethodOptions
 import com.stripe.android.link.utils.TestNavigationManager
+import com.stripe.android.model.PassiveCaptchaParams
+import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.addresselement.AutocompleteLauncher
 import com.stripe.android.paymentsheet.addresselement.TestAutocompleteLauncher
@@ -48,4 +50,5 @@ internal class FakeNativeLinkComponent(
     override val autocompleteLauncher: AutocompleteLauncher = TestAutocompleteLauncher.noOp(),
     override val addPaymentMethodOptionsFactory: AddPaymentMethodOptions.Factory = mock(),
     override val oAuthConsentViewModelComponentFactory: OAuthConsentViewModelComponent.Factory = mock(),
+    override val passiveCaptchaParams: PassiveCaptchaParams? = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
 ) : NativeLinkComponent

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityContractTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityContractTest.kt
@@ -7,6 +7,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.link.gate.FakeLinkGate
 import com.stripe.android.link.gate.LinkGate
+import com.stripe.android.model.PassiveCaptchaParamsFactory
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
@@ -27,6 +28,7 @@ class LinkActivityContractTest {
             lastUpdateReason = null
         ),
         launchMode = LinkLaunchMode.Full,
+        passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
     )
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
@@ -35,6 +35,7 @@ import com.stripe.android.link.model.LinkAuthIntentInfo
 import com.stripe.android.link.ui.signup.SignUpViewModel
 import com.stripe.android.link.ui.wallet.AddPaymentMethodOptions
 import com.stripe.android.link.utils.TestNavigationManager
+import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.networking.RequestSurface
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
@@ -151,6 +152,7 @@ internal class LinkActivityViewModelTest {
             ),
             paymentElementCallbackIdentifier = "LinkNativeTestIdentifier",
             launchMode = LinkLaunchMode.Full,
+            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
         )
         val savedStateHandle = SavedStateHandle()
         val factory = LinkActivityViewModel.factory(savedStateHandle)

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerCoordinatorTest.kt
@@ -4,6 +4,7 @@ import androidx.activity.result.ActivityResultRegistryOwner
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.testing.TestLifecycleOwner
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.utils.FakeActivityResultRegistry
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -147,6 +148,7 @@ internal class LinkControllerCoordinatorTest {
                 linkExpressMode = LinkExpressMode.DISABLED,
                 linkAccountInfo = LinkAccountUpdate.Value(null),
                 launchMode = LinkLaunchMode.PaymentMethodSelection(null),
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
         verify(viewModel).onLinkActivityResult(

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkPaymentLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkPaymentLauncherTest.kt
@@ -8,6 +8,7 @@ import com.stripe.android.link.account.LinkStore
 import com.stripe.android.link.analytics.FakeLinkAnalyticsHelper
 import com.stripe.android.link.analytics.LinkAnalyticsHelper
 import com.stripe.android.link.injection.LinkAnalyticsComponent
+import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentelement.confirmation.asCallbackFor
 import com.stripe.android.testing.CoroutineTestRule
@@ -91,7 +92,8 @@ internal class LinkPaymentLauncherTest {
                 configuration = TestFactory.LINK_CONFIGURATION,
                 linkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
                 linkExpressMode = LinkExpressMode.ENABLED,
-                launchMode = LinkLaunchMode.Full
+                launchMode = LinkLaunchMode.Full,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
 
             val launchCall = awaitLaunchCall()
@@ -103,6 +105,7 @@ internal class LinkPaymentLauncherTest {
                         linkExpressMode = LinkExpressMode.ENABLED,
                         linkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
                         launchMode = LinkLaunchMode.Full,
+                        passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
                     )
                 )
 
@@ -124,7 +127,8 @@ internal class LinkPaymentLauncherTest {
                 configuration = TestFactory.LINK_CONFIGURATION,
                 linkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
                 linkExpressMode = LinkExpressMode.DISABLED,
-                launchMode = LinkLaunchMode.Full
+                launchMode = LinkLaunchMode.Full,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
 
             val launchCall = awaitLaunchCall() as? LinkActivityContract.Args
@@ -233,7 +237,8 @@ internal class LinkPaymentLauncherTest {
                 configuration = TestFactory.LINK_CONFIGURATION,
                 linkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
                 linkExpressMode = LinkExpressMode.ENABLED,
-                launchMode = LinkLaunchMode.Full
+                launchMode = LinkLaunchMode.Full,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
 
             verifyActivityResultCallback(
@@ -265,7 +270,8 @@ internal class LinkPaymentLauncherTest {
                     configuration = TestFactory.LINK_CONFIGURATION,
                     linkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
                     linkExpressMode = LinkExpressMode.ENABLED,
-                    launchMode = LinkLaunchMode.Full
+                    launchMode = LinkLaunchMode.Full,
+                    passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
                 )
 
                 val registerCall = awaitRegisterCall()

--- a/paymentsheet/src/test/java/com/stripe/android/link/NativeLinkActivityContractTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/NativeLinkActivityContractTest.kt
@@ -7,6 +7,7 @@ import androidx.core.os.bundleOf
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.networking.RequestSurface
 import org.junit.After
@@ -41,7 +42,8 @@ class NativeLinkActivityContractTest {
             configuration = TestFactory.LINK_CONFIGURATION,
             linkExpressMode = LinkExpressMode.DISABLED,
             linkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
-            launchMode = LinkLaunchMode.Full
+            launchMode = LinkLaunchMode.Full,
+            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
         )
 
         val intent = contract.createIntent(ApplicationProvider.getApplicationContext(), args)
@@ -60,7 +62,8 @@ class NativeLinkActivityContractTest {
                 linkExpressMode = LinkExpressMode.DISABLED,
                 linkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
                 paymentElementCallbackIdentifier = LINK_CALLBACK_TEST_IDENTIFIER,
-                launchMode = LinkLaunchMode.Full
+                launchMode = LinkLaunchMode.Full,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
@@ -22,6 +22,7 @@ import com.stripe.android.model.EmailSource
 import com.stripe.android.model.IncentiveEligibilitySession
 import com.stripe.android.model.LinkAccountSession
 import com.stripe.android.model.LinkMode
+import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
@@ -275,6 +276,7 @@ internal object TestFactory {
         linkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
         paymentElementCallbackIdentifier = "LinkNativeTestIdentifier",
         launchMode = LinkLaunchMode.Full,
+        passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
     )
 
     val FINANCIAL_CONNECTIONS_CHECKING_ACCOUNT = FinancialConnectionsAccount(

--- a/paymentsheet/src/test/java/com/stripe/android/link/WebLinkActivityContractTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/WebLinkActivityContractTest.kt
@@ -7,6 +7,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.customersheet.FakeStripeRepository
+import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.testing.AbsFakeStripeRepository
@@ -43,7 +44,8 @@ class WebLinkActivityContractTest {
             configuration = TestFactory.LINK_CONFIGURATION,
             linkExpressMode = LinkExpressMode.DISABLED,
             linkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
-            launchMode = LinkLaunchMode.Full
+            launchMode = LinkLaunchMode.Full,
+            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
         )
 
         val intent = contract.createIntent(ApplicationProvider.getApplicationContext(), args)

--- a/paymentsheet/src/test/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandlerTest.kt
@@ -11,6 +11,7 @@ import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.model.Address
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.LinkMode
+import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethod.Type.USBankAccount
@@ -559,7 +560,8 @@ internal class DefaultLinkConfirmationHandlerTest {
         val handler = DefaultLinkConfirmationHandler(
             confirmationHandler = confirmationHandler,
             configuration = configuration,
-            logger = logger
+            logger = logger,
+            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
         )
         confirmationHandler.validate()
         return handler

--- a/paymentsheet/src/test/java/com/stripe/android/link/verification/DefaultLinkInlineInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/verification/DefaultLinkInlineInteractorTest.kt
@@ -37,6 +37,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TestRule
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -91,8 +92,6 @@ class DefaultLinkInlineInteractorTest {
 
             interactor.setup(paymentMethodMetadata = metadata)
 
-            awaitItem()
-
             assertThat(awaitItem().verificationState).isEqualTo(VerificationState.RenderButton)
         }
     }
@@ -110,8 +109,6 @@ class DefaultLinkInlineInteractorTest {
             assertThat(awaitItem().verificationState).isEqualTo(Loading)
 
             interactor.setup(paymentMethodMetadata = metadata)
-
-            awaitItem()
 
             assertThat(awaitItem().verificationState).isEqualTo(VerificationState.RenderButton)
         }
@@ -133,8 +130,6 @@ class DefaultLinkInlineInteractorTest {
             assertThat(awaitItem().verificationState).isEqualTo(Loading)
 
             interactor.setup(paymentMethodMetadata = metadata)
-
-            awaitItem()
 
             linkAccountManager.awaitStartVerificationCall()
 
@@ -166,7 +161,7 @@ class DefaultLinkInlineInteractorTest {
                 linkAccountInfo = any(),
                 launchMode = eq(LinkLaunchMode.PaymentMethodSelection(null)),
                 linkExpressMode = any(),
-                passiveCaptchaParams = any()
+                passiveCaptchaParams = anyOrNull()
             )
         }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
@@ -4,6 +4,8 @@ import com.stripe.android.CardBrandFilter
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.common.model.SHOP_PAY_CONFIGURATION
 import com.stripe.android.model.LinkMode
+import com.stripe.android.model.PassiveCaptchaParams
+import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
@@ -50,6 +52,7 @@ internal object PaymentMethodMetadataFactory {
         shopPayConfiguration: PaymentSheet.ShopPayConfiguration? = SHOP_PAY_CONFIGURATION,
         termsDisplay: Map<PaymentMethod.Type, PaymentSheet.TermsDisplay> = emptyMap(),
         forceSetupFutureUseBehaviorAndNewMandate: Boolean = false,
+        passiveCaptchaParams: PassiveCaptchaParams? = PassiveCaptchaParamsFactory.passiveCaptchaParams()
     ): PaymentMethodMetadata {
         return PaymentMethodMetadata(
             stripeIntent = stripeIntent,
@@ -84,6 +87,7 @@ internal object PaymentMethodMetadataFactory {
             shopPayConfiguration = shopPayConfiguration,
             termsDisplay = termsDisplay,
             forceSetupFutureUseBehaviorAndNewMandate = forceSetupFutureUseBehaviorAndNewMandate,
+            passiveCaptchaParams = passiveCaptchaParams
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
@@ -5,7 +5,6 @@ import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.common.model.SHOP_PAY_CONFIGURATION
 import com.stripe.android.model.LinkMode
 import com.stripe.android.model.PassiveCaptchaParams
-import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
@@ -52,7 +51,7 @@ internal object PaymentMethodMetadataFactory {
         shopPayConfiguration: PaymentSheet.ShopPayConfiguration? = SHOP_PAY_CONFIGURATION,
         termsDisplay: Map<PaymentMethod.Type, PaymentSheet.TermsDisplay> = emptyMap(),
         forceSetupFutureUseBehaviorAndNewMandate: Boolean = false,
-        passiveCaptchaParams: PassiveCaptchaParams? = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+        passiveCaptchaParams: PassiveCaptchaParams? = null
     ): PaymentMethodMetadata {
         return PaymentMethodMetadata(
             stripeIntent = stripeIntent,

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -17,6 +17,8 @@ import com.stripe.android.lpmfoundations.paymentmethod.definitions.AffirmDefinit
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.LinkMode
+import com.stripe.android.model.PassiveCaptchaParams
+import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
@@ -1152,6 +1154,7 @@ internal class PaymentMethodMetadataTest {
             shopPayConfiguration = null,
             termsDisplay = emptyMap(),
             forceSetupFutureUseBehaviorAndNewMandate = false,
+            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
         )
 
         assertThat(metadata).isEqualTo(expectedMetadata)
@@ -1228,6 +1231,7 @@ internal class PaymentMethodMetadataTest {
             shopPayConfiguration = null,
             termsDisplay = emptyMap(),
             forceSetupFutureUseBehaviorAndNewMandate = false,
+            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
         )
         assertThat(metadata).isEqualTo(expectedMetadata)
     }
@@ -1309,7 +1313,8 @@ internal class PaymentMethodMetadataTest {
         ),
         orderedPaymentMethodTypesAndWallets: List<String> = intent.paymentMethodTypes,
         customPaymentMethods: List<ElementsSession.CustomPaymentMethod> = emptyList(),
-        mobilePaymentElementComponent: ElementsSession.Customer.Components.MobilePaymentElement? = null
+        mobilePaymentElementComponent: ElementsSession.Customer.Components.MobilePaymentElement? = null,
+        passiveCaptchaParams: PassiveCaptchaParams? = PassiveCaptchaParamsFactory.passiveCaptchaParams()
     ): ElementsSession {
         return ElementsSession(
             stripeIntent = intent,
@@ -1338,11 +1343,13 @@ internal class PaymentMethodMetadataTest {
             externalPaymentMethodData = null,
             paymentMethodSpecs = null,
             elementsSessionId = "session_1234",
-            flags = emptyMap(),
+            flags = mapOf(
+                ElementsSession.Flag.ELEMENTS_ENABLE_PASSIVE_CAPTCHA to true
+            ),
             orderedPaymentMethodTypesAndWallets = orderedPaymentMethodTypesAndWallets,
             experimentsData = null,
-            passiveCaptcha = null,
-            merchantLogoUrl = null
+            merchantLogoUrl = null,
+            passiveCaptcha = passiveCaptchaParams
         )
     }
 
@@ -1706,7 +1713,8 @@ internal class PaymentMethodMetadataTest {
 
         val metadata = PaymentMethodMetadata.createForNativeLink(
             configuration = linkConfiguration,
-            linkAccount = linkAccount()
+            linkAccount = linkAccount(),
+            passiveCaptchaParams = null
         )
 
         assertThat(metadata.cbcEligibility).isEqualTo(
@@ -1727,7 +1735,8 @@ internal class PaymentMethodMetadataTest {
 
         val metadata = PaymentMethodMetadata.createForNativeLink(
             configuration = linkConfiguration,
-            linkAccount = linkAccount()
+            linkAccount = linkAccount(),
+            passiveCaptchaParams = null
         )
 
         assertThat(metadata.cbcEligibility).isEqualTo(CardBrandChoiceEligibility.Ineligible)
@@ -2047,10 +2056,26 @@ internal class PaymentMethodMetadataTest {
 
         val metadata = PaymentMethodMetadata.createForNativeLink(
             configuration = linkConfiguration,
-            linkAccount = linkAccount()
+            linkAccount = linkAccount(),
+            passiveCaptchaParams = null
         )
 
         assertThat(metadata.cardBrandFilter).isEqualTo(linkConfiguration.cardBrandFilter)
+    }
+
+    fun `Passes passiveCaptchaParams along to Link`() {
+        val linkConfiguration = LinkTestUtils.createLinkConfiguration(
+            cardBrandFilter = PaymentSheetCardBrandFilter(PaymentSheet.CardBrandAcceptance.all())
+        )
+
+        val metadata = PaymentMethodMetadata.createForNativeLink(
+            configuration = linkConfiguration,
+            linkAccount = linkAccount(),
+            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+        )
+
+        assertThat(metadata.passiveCaptchaParams)
+            .isEqualTo(PassiveCaptchaParamsFactory.passiveCaptchaParams())
     }
 
     private fun createLinkConfiguration(): LinkConfiguration {

--- a/paymentsheet/src/test/java/com/stripe/android/model/PassiveCaptchaParamsFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/model/PassiveCaptchaParamsFactory.kt
@@ -1,0 +1,13 @@
+package com.stripe.android.model
+
+internal object PassiveCaptchaParamsFactory {
+    fun passiveCaptchaParams(
+        siteKey: String = "2222-0000-ffff",
+        rqData: String? = "test_rq_data",
+    ): PassiveCaptchaParams {
+        return PassiveCaptchaParams(
+            siteKey = siteKey,
+            rqData = rqData
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
@@ -15,6 +15,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilt
 import com.stripe.android.model.Address
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.LinkMode
+import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
@@ -54,6 +55,7 @@ class ConfirmationHandlerOptionKtxTest {
             paymentSelection.toConfirmationOption(
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
                 linkConfiguration = null,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         ).isEqualTo(
             PaymentMethodConfirmationOption.New(
@@ -61,6 +63,7 @@ class ConfirmationHandlerOptionKtxTest {
                 optionsParams = PaymentMethodOptionsParams.Card(network = "cartes_bancaires"),
                 shouldSave = false,
                 extraParams = null,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
     }
@@ -75,6 +78,7 @@ class ConfirmationHandlerOptionKtxTest {
             paymentSelection.toConfirmationOption(
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
                 linkConfiguration = null,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         ).isEqualTo(
             PaymentMethodConfirmationOption.New(
@@ -82,6 +86,7 @@ class ConfirmationHandlerOptionKtxTest {
                 optionsParams = null,
                 shouldSave = false,
                 extraParams = null,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
     }
@@ -96,6 +101,7 @@ class ConfirmationHandlerOptionKtxTest {
             paymentSelection.toConfirmationOption(
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
                 linkConfiguration = null,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         ).isEqualTo(
             PaymentMethodConfirmationOption.New(
@@ -103,6 +109,7 @@ class ConfirmationHandlerOptionKtxTest {
                 optionsParams = null,
                 shouldSave = true,
                 extraParams = null,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
     }
@@ -128,11 +135,13 @@ class ConfirmationHandlerOptionKtxTest {
             paymentSelection.toConfirmationOption(
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
                 linkConfiguration = null,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         ).isEqualTo(
             BacsConfirmationOption(
                 createParams = bacsDebitParams,
                 optionsParams = null,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
     }
@@ -147,6 +156,7 @@ class ConfirmationHandlerOptionKtxTest {
             paymentSelection.toConfirmationOption(
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
                 linkConfiguration = null,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         ).isEqualTo(
             PaymentMethodConfirmationOption.New(
@@ -154,6 +164,7 @@ class ConfirmationHandlerOptionKtxTest {
                 optionsParams = null,
                 shouldSave = false,
                 extraParams = null,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
     }
@@ -171,6 +182,7 @@ class ConfirmationHandlerOptionKtxTest {
             paymentSelection.toConfirmationOption(
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
                 linkConfiguration = null,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         ).isEqualTo(
             PaymentMethodConfirmationOption.Saved(
@@ -178,6 +190,7 @@ class ConfirmationHandlerOptionKtxTest {
                 optionsParams = PaymentMethodOptionsParams.Card(
                     cvc = "505"
                 ),
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
     }
@@ -202,6 +215,7 @@ class ConfirmationHandlerOptionKtxTest {
             paymentSelection.toConfirmationOption(
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
                 linkConfiguration = null,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         ).isEqualTo(
             ExternalPaymentMethodConfirmationOption(
@@ -222,6 +236,7 @@ class ConfirmationHandlerOptionKtxTest {
             PaymentSelection.GooglePay.toConfirmationOption(
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
                 linkConfiguration = null,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         ).isNull()
     }
@@ -243,6 +258,7 @@ class ConfirmationHandlerOptionKtxTest {
                     .build()
                     .asCommonConfiguration(),
                 linkConfiguration = null,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         ).isEqualTo(
             GooglePayConfirmationOption(
@@ -257,7 +273,8 @@ class ConfirmationHandlerOptionKtxTest {
                     cardBrandFilter = PaymentSheetCardBrandFilter(
                         cardBrandAcceptance = PaymentSheet.CardBrandAcceptance.All
                     )
-                )
+                ),
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
     }
@@ -268,6 +285,7 @@ class ConfirmationHandlerOptionKtxTest {
             PaymentSelection.Link().toConfirmationOption(
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
                 linkConfiguration = null,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         ).isNull()
     }
@@ -278,11 +296,13 @@ class ConfirmationHandlerOptionKtxTest {
             PaymentSelection.Link().toConfirmationOption(
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
                 linkConfiguration = LINK_CONFIGURATION,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         ).isEqualTo(
             LinkConfirmationOption(
                 configuration = LINK_CONFIGURATION,
-                linkExpressMode = LinkExpressMode.DISABLED
+                linkExpressMode = LinkExpressMode.DISABLED,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
     }
@@ -295,11 +315,13 @@ class ConfirmationHandlerOptionKtxTest {
             ).toConfirmationOption(
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
                 linkConfiguration = LINK_CONFIGURATION,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         ).isEqualTo(
             LinkConfirmationOption(
                 configuration = LINK_CONFIGURATION,
-                linkExpressMode = LinkExpressMode.ENABLED
+                linkExpressMode = LinkExpressMode.ENABLED,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
     }
@@ -310,6 +332,7 @@ class ConfirmationHandlerOptionKtxTest {
             PaymentMethodFixtures.LINK_INLINE_PAYMENT_SELECTION.toConfirmationOption(
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
                 linkConfiguration = null,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         ).isNull()
     }
@@ -345,11 +368,13 @@ class ConfirmationHandlerOptionKtxTest {
             paymentSelection.toConfirmationOption(
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
                 linkConfiguration = null,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         ).isEqualTo(
             PaymentMethodConfirmationOption.Saved(
                 optionsParams = null,
                 paymentMethod = expectedPaymentMethod,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
     }
@@ -364,11 +389,13 @@ class ConfirmationHandlerOptionKtxTest {
             paymentSelection.toConfirmationOption(
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
                 linkConfiguration = null,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         ).isEqualTo(
             PaymentMethodConfirmationOption.Saved(
                 optionsParams = null,
                 paymentMethod = expectedPaymentMethod,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
     }
@@ -383,6 +410,7 @@ class ConfirmationHandlerOptionKtxTest {
         val confirmationOption = linkInlinePaymentSelection.toConfirmationOption(
             configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
             linkConfiguration = LINK_CONFIGURATION,
+            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
         )
 
         assertThat(confirmationOption).isInstanceOf<LinkInlineSignupConfirmationOption>()
@@ -407,6 +435,7 @@ class ConfirmationHandlerOptionKtxTest {
                 .build()
                 .asCommonConfiguration(),
             linkConfiguration = null,
+            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
         )
 
         assertThat(confirmationOption).isNull()
@@ -436,6 +465,7 @@ class ConfirmationHandlerOptionKtxTest {
                 .build()
                 .asCommonConfiguration(),
             linkConfiguration = null,
+            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
         )
 
         assertThat(confirmationOption).isInstanceOf<CustomPaymentMethodConfirmationOption>()
@@ -451,6 +481,7 @@ class ConfirmationHandlerOptionKtxTest {
             PaymentSelection.ShopPay.toConfirmationOption(
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
                 linkConfiguration = null,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         ).isNull()
     }
@@ -464,6 +495,7 @@ class ConfirmationHandlerOptionKtxTest {
                     customer = null
                 ),
                 linkConfiguration = null,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         ).isNull()
     }
@@ -483,6 +515,7 @@ class ConfirmationHandlerOptionKtxTest {
                         shopPayConfiguration = SHOP_PAY_CONFIGURATION
                     ),
                 linkConfiguration = null,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         ).isEqualTo(
             ShopPayConfirmationOption(
@@ -511,6 +544,7 @@ class ConfirmationHandlerOptionKtxTest {
                 .toConfirmationOption(
                     configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
                     linkConfiguration = LINK_CONFIGURATION,
+                    passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
                 )
         ).isEqualTo(
             LinkInlineSignupConfirmationOption(
@@ -520,6 +554,7 @@ class ConfirmationHandlerOptionKtxTest {
                 saveOption = expectedSaveOption,
                 linkConfiguration = LINK_CONFIGURATION,
                 userInput = userInput,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationTestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationTestUtils.kt
@@ -106,6 +106,11 @@ internal fun <
     }
 }
 
+@Suppress("UNCHECKED_CAST")
+internal fun <T : ConfirmationHandler.Option> ConfirmationHandler.Option.asOption(): T {
+    return this as T
+}
+
 internal fun ConfirmationHandler.Option.asSaved(): PaymentMethodConfirmationOption.Saved {
     return this as PaymentMethodConfirmationOption.Saved
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultIntentConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultIntentConfirmationInterceptorTest.kt
@@ -139,7 +139,8 @@ class DefaultIntentConfirmationInterceptorTest {
                     paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
                     optionsParams = PaymentMethodOptionsParams.Card(
                         setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
-                    )
+                    ),
+                    passiveCaptchaParams = null
                 ),
                 intent = PaymentIntentFactory.create(),
                 initializationMode = InitializationMode.PaymentIntent("pi_1234_secret_4321"),
@@ -1269,6 +1270,7 @@ class DefaultIntentConfirmationInterceptorTest {
                     ),
                     extraParams = null,
                     shouldSave = false,
+                    passiveCaptchaParams = null
                 ),
                 intent = PaymentIntentFactory.create(),
                 initializationMode = InitializationMode.DeferredIntent(
@@ -1339,6 +1341,7 @@ class DefaultIntentConfirmationInterceptorTest {
                     optionsParams = PaymentMethodOptionsParams.Card(),
                     extraParams = null,
                     shouldSave = false,
+                    passiveCaptchaParams = null
                 ),
                 intent = PaymentIntentFactory.create(),
                 initializationMode = InitializationMode.DeferredIntent(
@@ -1420,7 +1423,8 @@ class DefaultIntentConfirmationInterceptorTest {
                 createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                 optionsParams = null,
                 extraParams = null,
-                shouldSave = false
+                shouldSave = false,
+                passiveCaptchaParams = null
             ),
             intent = PaymentIntentFactory.create(),
             initializationMode = InitializationMode.PaymentIntent("pi_1234_secret_4321"),
@@ -1474,7 +1478,8 @@ class DefaultIntentConfirmationInterceptorTest {
             confirmationOption = PaymentMethodConfirmationOption.Saved(
                 paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
                 optionsParams = null,
-                hCaptchaToken = hCaptchaToken
+                hCaptchaToken = hCaptchaToken,
+                passiveCaptchaParams = null
             ),
             intent = SetupIntentFactory.create(),
             initializationMode = InitializationMode.SetupIntent("seti_1234_secret_4321"),
@@ -1720,7 +1725,8 @@ class DefaultIntentConfirmationInterceptorTest {
             confirmationOption = PaymentMethodConfirmationOption.Saved(
                 paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
                 optionsParams = null,
-                hCaptchaToken = hCaptchaToken
+                hCaptchaToken = hCaptchaToken,
+                passiveCaptchaParams = null
             ),
             intent = PaymentIntentFactory.create(),
             initializationMode = InitializationMode.PaymentIntent("pi_1234_secret_4321"),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationDefinitionTest.kt
@@ -71,6 +71,7 @@ class IntentConfirmationDefinitionTest {
                     optionsParams = null,
                     shouldSave = true,
                     extraParams = null,
+                    passiveCaptchaParams = null
                 ),
                 confirmationParameters = CONFIRMATION_PARAMETERS,
             )
@@ -449,6 +450,7 @@ class IntentConfirmationDefinitionTest {
             optionsParams = PaymentMethodOptionsParams.Card(
                 cvc = "505",
             ),
+            passiveCaptchaParams = null
         )
 
         private val CONFIRMATION_PARAMETERS = ConfirmationDefinition.Parameters(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationFlowTest.kt
@@ -42,6 +42,7 @@ internal class IntentConfirmationFlowTest {
                 optionsParams = null,
                 shouldSave = false,
                 extraParams = null,
+                passiveCaptchaParams = null
             ),
             confirmationParameters = defaultConfirmationDefinitionParams(
                 initializationMode = defaultPaymentIntentInitializationMode,
@@ -78,6 +79,7 @@ internal class IntentConfirmationFlowTest {
                 optionsParams = null,
                 shouldSave = false,
                 extraParams = null,
+                passiveCaptchaParams = null
             ),
             confirmationParameters = defaultConfirmationDefinitionParams(
                 initializationMode = defaultSetupIntentInitializationMode,
@@ -231,6 +233,7 @@ internal class IntentConfirmationFlowTest {
                 extraParams = PaymentMethodExtraParams.Card(
                     setAsDefault = true
                 ),
+                passiveCaptchaParams = null
             ),
             confirmationParameters = defaultConfirmationDefinitionParams(
                 initializationMode = defaultSetupIntentInitializationMode,
@@ -257,6 +260,7 @@ internal class IntentConfirmationFlowTest {
                 extraParams = PaymentMethodExtraParams.Card(
                     setAsDefault = true
                 ),
+                passiveCaptchaParams = null
             ),
             confirmationParameters = defaultConfirmationDefinitionParams(
                 initializationMode = defaultPaymentIntentInitializationMode,
@@ -359,6 +363,7 @@ internal class IntentConfirmationFlowTest {
             optionsParams = null,
             shouldSave = false,
             extraParams = null,
+            passiveCaptchaParams = null
         )
 
         val DEFERRED_CONFIRMATION_PARAMETERS = ConfirmationDefinition.Parameters(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationActivityTest.kt
@@ -210,7 +210,7 @@ internal class BacsConfirmationActivityTest {
                 )
             ),
             optionsParams = null,
-            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+            passiveCaptchaParams = null
         )
 
         val CONFIRMATION_ARGUMENTS = ConfirmationHandler.Args(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationActivityTest.kt
@@ -13,7 +13,6 @@ import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.espresso.intent.rule.IntentsRule
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
@@ -82,7 +81,7 @@ internal class BacsConfirmationActivityTest {
                         optionsParams = CONFIRMATION_OPTION.optionsParams,
                         shouldSave = false,
                         extraParams = null,
-                        passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                        passiveCaptchaParams = null
                     )
                 )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationActivityTest.kt
@@ -13,6 +13,7 @@ import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.espresso.intent.rule.IntentsRule
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
@@ -81,6 +82,7 @@ internal class BacsConfirmationActivityTest {
                         optionsParams = CONFIRMATION_OPTION.optionsParams,
                         shouldSave = false,
                         extraParams = null,
+                        passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
                     )
                 )
 
@@ -208,6 +210,7 @@ internal class BacsConfirmationActivityTest {
                 )
             ),
             optionsParams = null,
+            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
         )
 
         val CONFIRMATION_ARGUMENTS = ConfirmationHandler.Args(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationDefinitionTest.kt
@@ -4,6 +4,7 @@ import androidx.activity.result.ActivityResultCallback
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.isInstanceOf
+import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
@@ -285,6 +286,7 @@ class BacsConfirmationDefinitionTest {
                 )
             ),
             optionsParams = null,
+            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationDefinitionTest.kt
@@ -115,6 +115,7 @@ class BacsConfirmationDefinitionTest {
 
         assertThat(newPaymentMethodOption.createParams).isEqualTo(bacsConfirmationOption.createParams)
         assertThat(newPaymentMethodOption.optionsParams).isEqualTo(bacsConfirmationOption.optionsParams)
+        assertThat(newPaymentMethodOption.passiveCaptchaParams).isEqualTo(bacsConfirmationOption.passiveCaptchaParams)
         assertThat(newPaymentMethodOption.shouldSave).isFalse()
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationFlowTest.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentelement.confirmation.bacs
 
-import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
@@ -38,7 +37,7 @@ class BacsConfirmationFlowTest {
                 optionsParams = BACS_CONFIRMATION_OPTION.optionsParams,
                 shouldSave = false,
                 extraParams = null,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                passiveCaptchaParams = null
             ),
             parameters = CONFIRMATION_PARAMETERS,
         ),
@@ -57,7 +56,7 @@ class BacsConfirmationFlowTest {
                 )
             ),
             optionsParams = null,
-            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+            passiveCaptchaParams = null
         )
 
         private val PAYMENT_INTENT = PaymentIntentFactory.create()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationFlowTest.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentelement.confirmation.bacs
 
+import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
@@ -37,6 +38,7 @@ class BacsConfirmationFlowTest {
                 optionsParams = BACS_CONFIRMATION_OPTION.optionsParams,
                 shouldSave = false,
                 extraParams = null,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             ),
             parameters = CONFIRMATION_PARAMETERS,
         ),
@@ -55,6 +57,7 @@ class BacsConfirmationFlowTest {
                 )
             ),
             optionsParams = null,
+            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
         )
 
         private val PAYMENT_INTENT = PaymentIntentFactory.create()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinitionTest.kt
@@ -68,7 +68,7 @@ internal class PassiveChallengeConfirmationDefinitionTest {
             confirmationParameters = CONFIRMATION_PARAMETERS
         )
 
-        assertThat(result).isTrue()
+        assertThat(result).isFalse()
     }
 
     @Test
@@ -80,7 +80,7 @@ internal class PassiveChallengeConfirmationDefinitionTest {
             confirmationParameters = CONFIRMATION_PARAMETERS
         )
 
-        assertThat(result).isTrue()
+        assertThat(result).isFalse()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationActivityTest.kt
@@ -13,6 +13,7 @@ import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.espresso.intent.rule.IntentsRule
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.ExtendedPaymentElementConfirmationTestActivity
@@ -77,6 +78,7 @@ internal class CvcRecollectionConfirmationActivityTest {
                     PaymentMethodConfirmationOption.Saved(
                         paymentMethod = PAYMENT_METHOD,
                         optionsParams = PaymentMethodOptionsParams.Card(cvc = "444"),
+                        passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
                     )
                 )
 
@@ -109,6 +111,7 @@ internal class CvcRecollectionConfirmationActivityTest {
                     PaymentMethodConfirmationOption.Saved(
                         paymentMethod = PAYMENT_METHOD,
                         optionsParams = null,
+                        passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
                     )
                 )
 
@@ -187,6 +190,7 @@ internal class CvcRecollectionConfirmationActivityTest {
         val CONFIRMATION_OPTION = PaymentMethodConfirmationOption.Saved(
             paymentMethod = PAYMENT_METHOD,
             optionsParams = null,
+            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
         )
 
         val CONFIRMATION_ARGUMENTS = ConfirmationHandler.Args(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationActivityTest.kt
@@ -13,7 +13,6 @@ import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.espresso.intent.rule.IntentsRule
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.ExtendedPaymentElementConfirmationTestActivity
@@ -78,7 +77,7 @@ internal class CvcRecollectionConfirmationActivityTest {
                     PaymentMethodConfirmationOption.Saved(
                         paymentMethod = PAYMENT_METHOD,
                         optionsParams = PaymentMethodOptionsParams.Card(cvc = "444"),
-                        passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                        passiveCaptchaParams = null
                     )
                 )
 
@@ -111,7 +110,7 @@ internal class CvcRecollectionConfirmationActivityTest {
                     PaymentMethodConfirmationOption.Saved(
                         paymentMethod = PAYMENT_METHOD,
                         optionsParams = null,
-                        passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                        passiveCaptchaParams = null
                     )
                 )
 
@@ -190,7 +189,7 @@ internal class CvcRecollectionConfirmationActivityTest {
         val CONFIRMATION_OPTION = PaymentMethodConfirmationOption.Saved(
             paymentMethod = PAYMENT_METHOD,
             optionsParams = null,
-            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+            passiveCaptchaParams = null
         )
 
         val CONFIRMATION_ARGUMENTS = ConfirmationHandler.Args(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationDefinitionTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentelement.confirmation.cvc
 import androidx.activity.result.ActivityResultCallback
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.isInstanceOf
+import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
@@ -296,6 +297,7 @@ class CvcRecollectionConfirmationDefinitionTest {
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             optionsParams = optionsParams,
             originatedFromWallet = originatedFromWallet,
+            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationActivityTest.kt
@@ -17,6 +17,7 @@ import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.isInstanceOf
+import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.PaymentElementConfirmationTestActivity
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
@@ -83,6 +84,7 @@ internal class GooglePayConfirmationActivityTest {
                         paymentMethod = paymentMethod,
                         optionsParams = null,
                         originatedFromWallet = true,
+                        passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
                     )
                 )
 
@@ -155,6 +157,7 @@ internal class GooglePayConfirmationActivityTest {
                     PaymentMethodConfirmationOption.Saved(
                         paymentMethod = paymentMethod,
                         optionsParams = null,
+                        passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
                     )
                 )
 
@@ -214,6 +217,7 @@ internal class GooglePayConfirmationActivityTest {
                     PaymentMethodConfirmationOption.Saved(
                         paymentMethod = paymentMethod,
                         optionsParams = null,
+                        passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
                     )
                 )
 
@@ -292,7 +296,8 @@ internal class GooglePayConfirmationActivityTest {
                 billingDetailsCollectionConfiguration = PaymentSheet
                     .BillingDetailsCollectionConfiguration(),
                 cardBrandFilter = DefaultCardBrandFilter,
-            )
+            ),
+            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
         )
 
         val CONFIRMATION_ARGUMENTS = ConfirmationHandler.Args(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationActivityTest.kt
@@ -17,7 +17,6 @@ import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.isInstanceOf
-import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.PaymentElementConfirmationTestActivity
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
@@ -84,7 +83,7 @@ internal class GooglePayConfirmationActivityTest {
                         paymentMethod = paymentMethod,
                         optionsParams = null,
                         originatedFromWallet = true,
-                        passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                        passiveCaptchaParams = null
                     )
                 )
 
@@ -157,7 +156,7 @@ internal class GooglePayConfirmationActivityTest {
                     PaymentMethodConfirmationOption.Saved(
                         paymentMethod = paymentMethod,
                         optionsParams = null,
-                        passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                        passiveCaptchaParams = null
                     )
                 )
 
@@ -217,7 +216,7 @@ internal class GooglePayConfirmationActivityTest {
                     PaymentMethodConfirmationOption.Saved(
                         paymentMethod = paymentMethod,
                         optionsParams = null,
-                        passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                        passiveCaptchaParams = null
                     )
                 )
 
@@ -297,7 +296,7 @@ internal class GooglePayConfirmationActivityTest {
                     .BillingDetailsCollectionConfiguration(),
                 cardBrandFilter = DefaultCardBrandFilter,
             ),
-            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+            passiveCaptchaParams = null
         )
 
         val CONFIRMATION_ARGUMENTS = ConfirmationHandler.Args(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinitionTest.kt
@@ -13,6 +13,7 @@ import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContra
 import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLauncherFactory
 import com.stripe.android.isInstanceOf
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.model.wallets.Wallet
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
@@ -657,7 +658,8 @@ class GooglePayConfirmationDefinitionTest {
                     address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
                 ),
                 cardBrandFilter = DefaultCardBrandFilter,
-            )
+            ),
+            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
         )
 
         private val PAYMENT_INTENT = PaymentIntentFactory.create()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationFlowTest.kt
@@ -5,7 +5,6 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.isInstanceOf
-import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationMediator
 import com.stripe.android.paymentelement.confirmation.ConfirmationMediator.Parameters
@@ -92,7 +91,7 @@ class GooglePayConfirmationFlowTest {
                 paymentMethod = PAYMENT_METHOD,
                 optionsParams = null,
                 originatedFromWallet = true,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                passiveCaptchaParams = null
             ),
             parameters = CONFIRMATION_PARAMETERS,
         )
@@ -112,7 +111,7 @@ class GooglePayConfirmationFlowTest {
                 ),
                 cardBrandFilter = DefaultCardBrandFilter,
             ),
-            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+            passiveCaptchaParams = null
         )
 
         private val PAYMENT_METHOD = PaymentMethodFactory.card()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationFlowTest.kt
@@ -5,6 +5,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.isInstanceOf
+import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationMediator
 import com.stripe.android.paymentelement.confirmation.ConfirmationMediator.Parameters
@@ -91,6 +92,7 @@ class GooglePayConfirmationFlowTest {
                 paymentMethod = PAYMENT_METHOD,
                 optionsParams = null,
                 originatedFromWallet = true,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             ),
             parameters = CONFIRMATION_PARAMETERS,
         )
@@ -109,7 +111,8 @@ class GooglePayConfirmationFlowTest {
                     address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
                 ),
                 cardBrandFilter = DefaultCardBrandFilter,
-            )
+            ),
+            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
         )
 
         private val PAYMENT_METHOD = PaymentMethodFactory.card()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationActivityTest.kt
@@ -22,6 +22,7 @@ import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.link.LinkLaunchMode
 import com.stripe.android.link.NativeLinkArgs
 import com.stripe.android.link.TestFactory
+import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.networking.RequestSurface
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
@@ -126,6 +127,7 @@ internal class LinkConfirmationActivityTest(private val nativeLinkEnabled: Boole
                         paymentMethod = paymentMethod,
                         optionsParams = null,
                         originatedFromWallet = true,
+                        passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
                     )
                 )
 
@@ -211,6 +213,7 @@ internal class LinkConfirmationActivityTest(private val nativeLinkEnabled: Boole
                             linkAccountInfo = LinkAccountUpdate.Value(null),
                             paymentElementCallbackIdentifier = "ConfirmationTestIdentifier",
                             launchMode = LinkLaunchMode.Full,
+                            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
                         )
                     )
                 )
@@ -245,6 +248,7 @@ internal class LinkConfirmationActivityTest(private val nativeLinkEnabled: Boole
         val LINK_CONFIRMATION_OPTION = LinkConfirmationOption(
             configuration = TestFactory.LINK_CONFIGURATION,
             linkExpressMode = LinkExpressMode.ENABLED,
+            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
         )
 
         val CONFIRMATION_PARAMETERS = ConfirmationDefinition.Parameters(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationActivityTest.kt
@@ -22,7 +22,6 @@ import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.link.LinkLaunchMode
 import com.stripe.android.link.NativeLinkArgs
 import com.stripe.android.link.TestFactory
-import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.networking.RequestSurface
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
@@ -127,7 +126,7 @@ internal class LinkConfirmationActivityTest(private val nativeLinkEnabled: Boole
                         paymentMethod = paymentMethod,
                         optionsParams = null,
                         originatedFromWallet = true,
-                        passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                        passiveCaptchaParams = null
                     )
                 )
 
@@ -213,7 +212,7 @@ internal class LinkConfirmationActivityTest(private val nativeLinkEnabled: Boole
                             linkAccountInfo = LinkAccountUpdate.Value(null),
                             paymentElementCallbackIdentifier = "ConfirmationTestIdentifier",
                             launchMode = LinkLaunchMode.Full,
-                            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                            passiveCaptchaParams = null
                         )
                     )
                 )
@@ -248,7 +247,7 @@ internal class LinkConfirmationActivityTest(private val nativeLinkEnabled: Boole
         val LINK_CONFIRMATION_OPTION = LinkConfirmationOption(
             configuration = TestFactory.LINK_CONFIGURATION,
             linkExpressMode = LinkExpressMode.ENABLED,
-            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+            passiveCaptchaParams = null
         )
 
         val CONFIRMATION_PARAMETERS = ConfirmationDefinition.Parameters(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinitionTest.kt
@@ -11,6 +11,7 @@ import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.TestFactory
 import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.link.account.LinkStore
+import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationOption
@@ -357,6 +358,7 @@ internal class LinkConfirmationDefinitionTest {
         private val LINK_CONFIRMATION_OPTION = LinkConfirmationOption(
             configuration = TestFactory.LINK_CONFIGURATION,
             linkExpressMode = LinkExpressMode.ENABLED,
+            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationFlowTest.kt
@@ -7,7 +7,6 @@ import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.link.TestFactory
 import com.stripe.android.link.account.LinkAccountHolder
-import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationMediator
 import com.stripe.android.paymentelement.confirmation.ConfirmationMediator.Parameters
@@ -123,7 +122,7 @@ class LinkConfirmationFlowTest {
                     paymentMethod = PAYMENT_METHOD,
                     optionsParams = null,
                     originatedFromWallet = true,
-                    passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                    passiveCaptchaParams = null
                 ),
                 parameters = CONFIRMATION_PARAMETERS,
             )
@@ -155,7 +154,7 @@ class LinkConfirmationFlowTest {
         private val LINK_CONFIRMATION_OPTION = LinkConfirmationOption(
             configuration = TestFactory.LINK_CONFIGURATION,
             linkExpressMode = LinkExpressMode.ENABLED,
-            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+            passiveCaptchaParams = null
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationFlowTest.kt
@@ -7,6 +7,7 @@ import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.link.TestFactory
 import com.stripe.android.link.account.LinkAccountHolder
+import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationMediator
 import com.stripe.android.paymentelement.confirmation.ConfirmationMediator.Parameters
@@ -122,6 +123,7 @@ class LinkConfirmationFlowTest {
                     paymentMethod = PAYMENT_METHOD,
                     optionsParams = null,
                     originatedFromWallet = true,
+                    passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
                 ),
                 parameters = CONFIRMATION_PARAMETERS,
             )
@@ -153,6 +155,7 @@ class LinkConfirmationFlowTest {
         private val LINK_CONFIRMATION_OPTION = LinkConfirmationOption(
             configuration = TestFactory.LINK_CONFIGURATION,
             linkExpressMode = LinkExpressMode.ENABLED,
+            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
@@ -26,6 +26,7 @@ import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.ConsumerSession
 import com.stripe.android.model.CvcCheck
 import com.stripe.android.model.LinkMode
+import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
@@ -298,6 +299,7 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
             optionsParams = PaymentMethodOptionsParams.Card(
                 setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OnSession,
             ),
+            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
         )
 
         definition.launch(
@@ -323,6 +325,7 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
             optionsParams = PaymentMethodOptionsParams.Card(
                 setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OnSession,
             ),
+            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
         )
 
         val result = definition.toResult(
@@ -711,6 +714,7 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
                 forceSetupFutureUseBehaviorAndNewMandate = false,
             ),
             userInput = userInput,
+            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/foundations/LpmTestAssertions.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/foundations/LpmTestAssertions.kt
@@ -36,6 +36,7 @@ internal suspend fun assertIntentConfirmed(
         optionsParams = params.optionsParams,
         extraParams = params.extraParams,
         shouldSave = params.customerRequestedSave,
+        passiveCaptchaParams = null
     )
 
     activity.confirmationHandler.state.test {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/ConfirmationStateHelpers.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/ConfirmationStateHelpers.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentelement.embedded.form
 
 import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.toConfirmationOption
@@ -11,7 +12,8 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 internal fun confirmationStateConfirming(selection: PaymentSelection): ConfirmationHandler.State.Confirming {
     val confirmationOption = selection.toConfirmationOption(
         configuration = EmbeddedConfirmationStateFixtures.defaultState().configuration.asCommonConfiguration(),
-        linkConfiguration = null
+        linkConfiguration = null,
+        passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
     )
     return ConfirmationHandler.State.Confirming(requireNotNull(confirmationOption))
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -30,7 +30,6 @@ import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.WalletType
 import com.stripe.android.model.CardBrand
-import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
@@ -72,6 +71,7 @@ import org.junit.After
 import org.junit.Rule
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -241,7 +241,7 @@ internal class PaymentOptionsViewModelTest {
             linkAccountInfo = eq(LinkAccountUpdate.Value(unverifiedAccount)),
             launchMode = eq(LinkLaunchMode.PaymentMethodSelection(selectedPayment = null)),
             linkExpressMode = eq(LinkExpressMode.ENABLED),
-            passiveCaptchaParams = eq(PassiveCaptchaParamsFactory.passiveCaptchaParams())
+            passiveCaptchaParams = anyOrNull()
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -30,6 +30,7 @@ import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.WalletType
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
@@ -239,7 +240,8 @@ internal class PaymentOptionsViewModelTest {
             configuration = any(),
             linkAccountInfo = eq(LinkAccountUpdate.Value(unverifiedAccount)),
             launchMode = eq(LinkLaunchMode.PaymentMethodSelection(selectedPayment = null)),
-            linkExpressMode = eq(LinkExpressMode.ENABLED)
+            linkExpressMode = eq(LinkExpressMode.ENABLED),
+            passiveCaptchaParams = eq(PassiveCaptchaParamsFactory.passiveCaptchaParams())
         )
     }
 
@@ -277,7 +279,8 @@ internal class PaymentOptionsViewModelTest {
             configuration = any(),
             linkAccountInfo = any(),
             launchMode = any(),
-            linkExpressMode = any()
+            linkExpressMode = any(),
+            passiveCaptchaParams = any()
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -34,6 +34,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilt
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.CardDefinition
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConfirmPaymentIntentParams
+import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
@@ -439,6 +440,7 @@ internal class PaymentSheetViewModelTest {
                 paymentMethod = CARD_PAYMENT_METHOD,
                 optionsParams = optionsParams,
                 originatedFromWallet = false,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
         assertThat(arguments.intent).isEqualTo(stripeIntent)
@@ -513,6 +515,7 @@ internal class PaymentSheetViewModelTest {
                 paymentMethod = PaymentMethodFixtures.US_BANK_ACCOUNT,
                 optionsParams = optionsParams,
                 originatedFromWallet = false,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
         assertThat(arguments.intent).isEqualTo(stripeIntent)
@@ -540,6 +543,7 @@ internal class PaymentSheetViewModelTest {
                     paymentMethod = SEPA_DEBIT_PAYMENT_METHOD,
                     optionsParams = null,
                     originatedFromWallet = false,
+                    passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
                 )
             )
             assertThat(arguments.intent).isEqualTo(stripeIntent)
@@ -574,6 +578,7 @@ internal class PaymentSheetViewModelTest {
                 ),
                 extraParams = null,
                 shouldSave = true,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
         assertThat(arguments.intent).isEqualTo(stripeIntent)
@@ -619,6 +624,7 @@ internal class PaymentSheetViewModelTest {
                 optionsParams = optionsParams,
                 extraParams = null,
                 shouldSave = true,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
         assertThat(arguments.intent).isEqualTo(stripeIntent)
@@ -971,6 +977,7 @@ internal class PaymentSheetViewModelTest {
                 LinkConfirmationOption(
                     linkExpressMode = LinkExpressMode.DISABLED,
                     configuration = TestFactory.LINK_CONFIGURATION,
+                    passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
                 )
             )
 
@@ -1007,6 +1014,7 @@ internal class PaymentSheetViewModelTest {
             PaymentMethodConfirmationOption.Saved(
                 paymentMethod = CARD_PAYMENT_METHOD,
                 optionsParams = null,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
 
@@ -1076,6 +1084,7 @@ internal class PaymentSheetViewModelTest {
                 optionsParams = null,
                 extraParams = null,
                 shouldSave = true,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
 
@@ -1135,6 +1144,7 @@ internal class PaymentSheetViewModelTest {
             PaymentMethodConfirmationOption.Saved(
                 paymentMethod = CARD_PAYMENT_METHOD,
                 optionsParams = null,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
 
@@ -1615,6 +1625,7 @@ internal class PaymentSheetViewModelTest {
                 LinkConfirmationOption(
                     configuration = TestFactory.LINK_CONFIGURATION,
                     linkExpressMode = LinkExpressMode.ENABLED_NO_WEB_FALLBACK,
+                    passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
                 )
             )
 
@@ -2117,6 +2128,7 @@ internal class PaymentSheetViewModelTest {
                     paymentMethod = CARD_PAYMENT_METHOD,
                     optionsParams = null,
                     originatedFromWallet = false,
+                    passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
                 )
             )
 
@@ -2155,6 +2167,7 @@ internal class PaymentSheetViewModelTest {
                     paymentMethod = CARD_PAYMENT_METHOD,
                     optionsParams = null,
                     originatedFromWallet = false,
+                    passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
                 )
             )
 
@@ -2253,6 +2266,7 @@ internal class PaymentSheetViewModelTest {
             PaymentMethodConfirmationOption.Saved(
                 paymentMethod = paymentMethod,
                 optionsParams = null,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
 
@@ -2287,6 +2301,7 @@ internal class PaymentSheetViewModelTest {
                     paymentMethod = CARD_PAYMENT_METHOD,
                     optionsParams = null,
                     originatedFromWallet = false,
+                    passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
                 )
             )
 
@@ -2321,6 +2336,7 @@ internal class PaymentSheetViewModelTest {
                     paymentMethod = CARD_PAYMENT_METHOD,
                     optionsParams = null,
                     originatedFromWallet = false,
+                    passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
                 )
             )
 
@@ -2355,6 +2371,7 @@ internal class PaymentSheetViewModelTest {
                     paymentMethod = CARD_PAYMENT_METHOD,
                     optionsParams = null,
                     originatedFromWallet = false,
+                    passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
                 )
             )
 
@@ -2508,6 +2525,7 @@ internal class PaymentSheetViewModelTest {
             BacsConfirmationOption(
                 createParams = bacsPaymentSelection.paymentMethodCreateParams,
                 optionsParams = bacsPaymentSelection.paymentMethodOptionsParams,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
     }
@@ -2677,7 +2695,8 @@ internal class PaymentSheetViewModelTest {
                     merchantCurrencyCode = googlePayConfig.currencyCode,
                     billingDetailsCollectionConfiguration = config.billingDetailsCollectionConfiguration,
                     cardBrandFilter = PaymentSheetCardBrandFilter(config.cardBrandAcceptance),
-                )
+                ),
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
 
@@ -2720,7 +2739,8 @@ internal class PaymentSheetViewModelTest {
                     merchantCurrencyCode = googlePayConfig.currencyCode,
                     billingDetailsCollectionConfiguration = config.billingDetailsCollectionConfiguration,
                     cardBrandFilter = PaymentSheetCardBrandFilter(config.cardBrandAcceptance),
-                )
+                ),
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
 
@@ -2758,6 +2778,7 @@ internal class PaymentSheetViewModelTest {
             LinkConfirmationOption(
                 linkExpressMode = LinkExpressMode.DISABLED,
                 configuration = LINK_CONFIG,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
 
@@ -2795,6 +2816,7 @@ internal class PaymentSheetViewModelTest {
             LinkConfirmationOption(
                 linkExpressMode = LinkExpressMode.DISABLED,
                 configuration = LINK_CONFIG,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
 
@@ -2833,6 +2855,7 @@ internal class PaymentSheetViewModelTest {
             LinkConfirmationOption(
                 linkExpressMode = LinkExpressMode.ENABLED_NO_WEB_FALLBACK,
                 configuration = LINK_CONFIG,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
 
@@ -2870,6 +2893,7 @@ internal class PaymentSheetViewModelTest {
             LinkConfirmationOption(
                 linkExpressMode = LinkExpressMode.ENABLED_NO_WEB_FALLBACK,
                 configuration = LINK_CONFIG,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
 
@@ -3205,6 +3229,7 @@ internal class PaymentSheetViewModelTest {
                 paymentMethod = CARD_PAYMENT_METHOD,
                 optionsParams = null,
                 originatedFromWallet = false,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
     }
@@ -3533,6 +3558,7 @@ internal class PaymentSheetViewModelTest {
                 createParams = createParams,
                 optionsParams = null,
                 extraParams = null,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -20,6 +20,7 @@ import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.isInstanceOf
 import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.link.LinkExpressMode
+import com.stripe.android.link.LinkLaunchMode
 import com.stripe.android.link.TestFactory
 import com.stripe.android.link.attestation.FakeLinkAttestationCheck
 import com.stripe.android.link.attestation.LinkAttestationCheck
@@ -34,6 +35,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilt
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.CardDefinition
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConfirmPaymentIntentParams
+import com.stripe.android.model.PassiveCaptchaParams
 import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
@@ -440,7 +442,7 @@ internal class PaymentSheetViewModelTest {
                 paymentMethod = CARD_PAYMENT_METHOD,
                 optionsParams = optionsParams,
                 originatedFromWallet = false,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                passiveCaptchaParams = null
             )
         )
         assertThat(arguments.intent).isEqualTo(stripeIntent)
@@ -515,7 +517,7 @@ internal class PaymentSheetViewModelTest {
                 paymentMethod = PaymentMethodFixtures.US_BANK_ACCOUNT,
                 optionsParams = optionsParams,
                 originatedFromWallet = false,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                passiveCaptchaParams = null
             )
         )
         assertThat(arguments.intent).isEqualTo(stripeIntent)
@@ -543,7 +545,7 @@ internal class PaymentSheetViewModelTest {
                     paymentMethod = SEPA_DEBIT_PAYMENT_METHOD,
                     optionsParams = null,
                     originatedFromWallet = false,
-                    passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                    passiveCaptchaParams = null
                 )
             )
             assertThat(arguments.intent).isEqualTo(stripeIntent)
@@ -578,7 +580,7 @@ internal class PaymentSheetViewModelTest {
                 ),
                 extraParams = null,
                 shouldSave = true,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                passiveCaptchaParams = null
             )
         )
         assertThat(arguments.intent).isEqualTo(stripeIntent)
@@ -624,7 +626,7 @@ internal class PaymentSheetViewModelTest {
                 optionsParams = optionsParams,
                 extraParams = null,
                 shouldSave = true,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                passiveCaptchaParams = null
             )
         )
         assertThat(arguments.intent).isEqualTo(stripeIntent)
@@ -977,7 +979,7 @@ internal class PaymentSheetViewModelTest {
                 LinkConfirmationOption(
                     linkExpressMode = LinkExpressMode.DISABLED,
                     configuration = TestFactory.LINK_CONFIGURATION,
-                    passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                    passiveCaptchaParams = null
                 )
             )
 
@@ -1014,7 +1016,7 @@ internal class PaymentSheetViewModelTest {
             PaymentMethodConfirmationOption.Saved(
                 paymentMethod = CARD_PAYMENT_METHOD,
                 optionsParams = null,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                passiveCaptchaParams = null
             )
         )
 
@@ -1084,7 +1086,7 @@ internal class PaymentSheetViewModelTest {
                 optionsParams = null,
                 extraParams = null,
                 shouldSave = true,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                passiveCaptchaParams = null
             )
         )
 
@@ -1144,7 +1146,7 @@ internal class PaymentSheetViewModelTest {
             PaymentMethodConfirmationOption.Saved(
                 paymentMethod = CARD_PAYMENT_METHOD,
                 optionsParams = null,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                passiveCaptchaParams = null
             )
         )
 
@@ -1625,7 +1627,7 @@ internal class PaymentSheetViewModelTest {
                 LinkConfirmationOption(
                     configuration = TestFactory.LINK_CONFIGURATION,
                     linkExpressMode = LinkExpressMode.ENABLED_NO_WEB_FALLBACK,
-                    passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                    passiveCaptchaParams = null
                 )
             )
 
@@ -2128,7 +2130,7 @@ internal class PaymentSheetViewModelTest {
                     paymentMethod = CARD_PAYMENT_METHOD,
                     optionsParams = null,
                     originatedFromWallet = false,
-                    passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                    passiveCaptchaParams = null
                 )
             )
 
@@ -2167,7 +2169,7 @@ internal class PaymentSheetViewModelTest {
                     paymentMethod = CARD_PAYMENT_METHOD,
                     optionsParams = null,
                     originatedFromWallet = false,
-                    passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                    passiveCaptchaParams = null
                 )
             )
 
@@ -2266,7 +2268,7 @@ internal class PaymentSheetViewModelTest {
             PaymentMethodConfirmationOption.Saved(
                 paymentMethod = paymentMethod,
                 optionsParams = null,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                passiveCaptchaParams = null
             )
         )
 
@@ -2301,7 +2303,7 @@ internal class PaymentSheetViewModelTest {
                     paymentMethod = CARD_PAYMENT_METHOD,
                     optionsParams = null,
                     originatedFromWallet = false,
-                    passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                    passiveCaptchaParams = null
                 )
             )
 
@@ -2336,7 +2338,7 @@ internal class PaymentSheetViewModelTest {
                     paymentMethod = CARD_PAYMENT_METHOD,
                     optionsParams = null,
                     originatedFromWallet = false,
-                    passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                    passiveCaptchaParams = null
                 )
             )
 
@@ -2371,7 +2373,7 @@ internal class PaymentSheetViewModelTest {
                     paymentMethod = CARD_PAYMENT_METHOD,
                     optionsParams = null,
                     originatedFromWallet = false,
-                    passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                    passiveCaptchaParams = null
                 )
             )
 
@@ -2525,7 +2527,7 @@ internal class PaymentSheetViewModelTest {
             BacsConfirmationOption(
                 createParams = bacsPaymentSelection.paymentMethodCreateParams,
                 optionsParams = bacsPaymentSelection.paymentMethodOptionsParams,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                passiveCaptchaParams = null
             )
         )
     }
@@ -2696,7 +2698,7 @@ internal class PaymentSheetViewModelTest {
                     billingDetailsCollectionConfiguration = config.billingDetailsCollectionConfiguration,
                     cardBrandFilter = PaymentSheetCardBrandFilter(config.cardBrandAcceptance),
                 ),
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                passiveCaptchaParams = null
             )
         )
 
@@ -2740,7 +2742,7 @@ internal class PaymentSheetViewModelTest {
                     billingDetailsCollectionConfiguration = config.billingDetailsCollectionConfiguration,
                     cardBrandFilter = PaymentSheetCardBrandFilter(config.cardBrandAcceptance),
                 ),
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                passiveCaptchaParams = null
             )
         )
 
@@ -2778,7 +2780,7 @@ internal class PaymentSheetViewModelTest {
             LinkConfirmationOption(
                 linkExpressMode = LinkExpressMode.DISABLED,
                 configuration = LINK_CONFIG,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                passiveCaptchaParams = null
             )
         )
 
@@ -2816,7 +2818,7 @@ internal class PaymentSheetViewModelTest {
             LinkConfirmationOption(
                 linkExpressMode = LinkExpressMode.DISABLED,
                 configuration = LINK_CONFIG,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                passiveCaptchaParams = null
             )
         )
 
@@ -2855,7 +2857,7 @@ internal class PaymentSheetViewModelTest {
             LinkConfirmationOption(
                 linkExpressMode = LinkExpressMode.ENABLED_NO_WEB_FALLBACK,
                 configuration = LINK_CONFIG,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                passiveCaptchaParams = null
             )
         )
 
@@ -2893,7 +2895,7 @@ internal class PaymentSheetViewModelTest {
             LinkConfirmationOption(
                 linkExpressMode = LinkExpressMode.ENABLED_NO_WEB_FALLBACK,
                 configuration = LINK_CONFIG,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                passiveCaptchaParams = null
             )
         )
 
@@ -3229,7 +3231,125 @@ internal class PaymentSheetViewModelTest {
                 paymentMethod = CARD_PAYMENT_METHOD,
                 optionsParams = null,
                 originatedFromWallet = false,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                passiveCaptchaParams = null
+            )
+        )
+    }
+
+    @Test
+    fun `confirmation with saved card pm should include passive captcha params when available`() = confirmationTest {
+        val passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+        val optionsParams = PaymentMethodOptionsParams.Card(
+            setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession,
+        )
+
+        testPassiveCaptchaParams(
+            paymentSelection = PaymentSelection.Saved(
+                paymentMethod = CARD_PAYMENT_METHOD,
+            ),
+            optionsParams = optionsParams,
+            expectedConfirmationOption = PaymentMethodConfirmationOption.Saved(
+                paymentMethod = CARD_PAYMENT_METHOD,
+                optionsParams = optionsParams,
+                originatedFromWallet = false,
+                passiveCaptchaParams = passiveCaptchaParams
+            )
+        )
+    }
+
+    @Test
+    fun `confirmation with USBankAccount pm should include passive captcha params when available`() = confirmationTest {
+        val passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+        val optionsParams = PaymentMethodOptionsParams.USBankAccount(
+            setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession,
+        )
+
+        testPassiveCaptchaParams(
+            paymentSelection = PaymentMethodFixtures.US_BANK_PAYMENT_SELECTION,
+            optionsParams = optionsParams,
+            expectedConfirmationOption = PaymentMethodConfirmationOption.New(
+                createParams = PaymentMethodCreateParamsFixtures.US_BANK_ACCOUNT,
+                optionsParams = optionsParams,
+                extraParams = null,
+                shouldSave = false,
+                passiveCaptchaParams = passiveCaptchaParams
+            )
+        )
+    }
+
+    @Test
+    fun `confirmation with LinkInline pm should include passive captcha params when available`() = confirmationTest {
+        val passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+
+        testPassiveCaptchaParams(
+            paymentSelection = PaymentMethodFixtures.LINK_INLINE_PAYMENT_SELECTION,
+            expectedConfirmationOption = LinkInlineSignupConfirmationOption(
+                createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                optionsParams = null,
+                extraParams = null,
+                saveOption = LinkInlineSignupConfirmationOption.PaymentMethodSaveOption.NoRequest,
+                linkConfiguration = LINK_CONFIG,
+                userInput = PaymentMethodFixtures.LINK_INLINE_PAYMENT_SELECTION.input,
+                passiveCaptchaParams = passiveCaptchaParams
+            ),
+            linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
+            paymentElementLoader = FakePaymentElementLoader(
+                stripeIntent = PAYMENT_INTENT,
+                linkState = LinkState(
+                    configuration = LINK_CONFIG,
+                    loginState = LinkState.LoginState.LoggedOut,
+                    signupMode = null,
+                ),
+                passiveCaptchaParams = passiveCaptchaParams
+            )
+        )
+    }
+
+    @Test
+    fun `confirmation with New pm should include passive captcha params when available`() = confirmationTest {
+        val passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+        val optionsParams = PaymentMethodOptionsParams.Card(
+            setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession,
+        )
+
+        testPassiveCaptchaParams(
+            paymentSelection = PaymentSelection.New.Card(
+                paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                brand = CardBrand.Visa,
+                customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest,
+            ),
+            optionsParams = optionsParams,
+            expectedConfirmationOption = PaymentMethodConfirmationOption.New(
+                createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                optionsParams = optionsParams,
+                extraParams = null,
+                shouldSave = false,
+                passiveCaptchaParams = passiveCaptchaParams
+            )
+        )
+    }
+
+    @Test
+    fun `confirmation with Link pm should include passive captcha params when available`() = confirmationTest {
+        val passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+
+        testPassiveCaptchaParams(
+            paymentSelection = PaymentSelection.Link(),
+            expectedConfirmationOption = LinkConfirmationOption(
+                configuration = LINK_CONFIG,
+                linkExpressMode = LinkExpressMode.DISABLED,
+                linkLaunchMode = LinkLaunchMode.Full,
+                passiveCaptchaParams = passiveCaptchaParams
+            ),
+            linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
+            paymentElementLoader = FakePaymentElementLoader(
+                stripeIntent = PAYMENT_INTENT,
+                linkState = LinkState(
+                    configuration = LINK_CONFIG,
+                    loginState = LinkState.LoginState.LoggedOut,
+                    signupMode = null,
+                ),
+                passiveCaptchaParams = passiveCaptchaParams
             )
         )
     }
@@ -3558,7 +3678,7 @@ internal class PaymentSheetViewModelTest {
                 createParams = createParams,
                 optionsParams = null,
                 extraParams = null,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                passiveCaptchaParams = null
             )
         )
 
@@ -3612,6 +3732,7 @@ internal class PaymentSheetViewModelTest {
             customer?.paymentMethods?.firstOrNull()?.let { PaymentSelection.Saved(it) },
         validationError: PaymentSheetLoadingException? = null,
         savedStateHandle: SavedStateHandle = SavedStateHandle(),
+        passiveCaptchaParams: PassiveCaptchaParams? = null,
         paymentElementLoader: PaymentElementLoader = FakePaymentElementLoader(
             stripeIntent = stripeIntent,
             shouldFail = shouldFailLoad,
@@ -3621,6 +3742,7 @@ internal class PaymentSheetViewModelTest {
             isGooglePayAvailable = isGooglePayReady,
             paymentSelection = initialPaymentSelection,
             validationError = validationError,
+            passiveCaptchaParams = passiveCaptchaParams
         ),
         errorReporter: ErrorReporter = FakeErrorReporter(),
         eventReporter: EventReporter = this@PaymentSheetViewModelTest.eventReporter,
@@ -3840,6 +3962,44 @@ internal class PaymentSheetViewModelTest {
 
             block(this@runTest)
         }
+    }
+
+    private suspend fun FakeConfirmationHandler.Scenario.testPassiveCaptchaParams(
+        paymentSelection: PaymentSelection,
+        optionsParams: PaymentMethodOptionsParams? = null,
+        expectedConfirmationOption: ConfirmationHandler.Option,
+        linkConfigurationCoordinator: LinkConfigurationCoordinator =
+            this@PaymentSheetViewModelTest.linkConfigurationCoordinator,
+        paymentElementLoader: PaymentElementLoader? = null
+    ) {
+        val passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+        val stripeIntent = PAYMENT_INTENT
+        val viewModel = createViewModel(
+            stripeIntent = stripeIntent,
+            linkConfigurationCoordinator = linkConfigurationCoordinator,
+            paymentElementLoader = paymentElementLoader ?: FakePaymentElementLoader(
+                stripeIntent = stripeIntent,
+                passiveCaptchaParams = passiveCaptchaParams
+            )
+        )
+
+        val finalPaymentSelection = if (optionsParams != null) {
+            when (paymentSelection) {
+                is PaymentSelection.Saved -> paymentSelection.copy(paymentMethodOptionsParams = optionsParams)
+                is PaymentSelection.New.USBankAccount ->
+                    paymentSelection.copy(paymentMethodOptionsParams = optionsParams)
+                is PaymentSelection.New.Card -> paymentSelection.copy(paymentMethodOptionsParams = optionsParams)
+                else -> paymentSelection
+            }
+        } else {
+            paymentSelection
+        }
+
+        viewModel.updateSelection(finalPaymentSelection)
+        viewModel.checkout()
+
+        val arguments = startTurbine.awaitItem()
+        assertThat(arguments.confirmationOption).isEqualTo(expectedConfirmationOption)
     }
 
     private fun getPaymentMethodOptionJsonStringWithCvcRecollectionValue(enabled: Boolean): String {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -36,6 +36,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilt
 import com.stripe.android.lpmfoundations.paymentmethod.WalletType
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.CardParams
+import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
@@ -304,6 +305,7 @@ internal class DefaultFlowControllerTest {
                     extraParams = selection.paymentMethodExtraParams,
                     shouldSave = selection.customerRequestedSave == PaymentSelection
                         .CustomerRequestedSave.RequestReuse,
+                    passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
                 )
             )
 
@@ -350,7 +352,8 @@ internal class DefaultFlowControllerTest {
                     merchantName = config.merchantDisplayName,
                     billingDetailsCollectionConfiguration = config.billingDetailsCollectionConfiguration,
                     cardBrandFilter = PaymentSheetCardBrandFilter(config.cardBrandAcceptance),
-                )
+                ),
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
 
@@ -520,7 +523,8 @@ internal class DefaultFlowControllerTest {
             configuration = any(),
             linkAccountInfo = anyOrNull(),
             launchMode = any(),
-            linkExpressMode = any()
+            linkExpressMode = any(),
+            passiveCaptchaParams = any()
         )
 
         verify(paymentOptionActivityLauncher, never()).launch(any(), anyOrNull())
@@ -560,7 +564,8 @@ internal class DefaultFlowControllerTest {
             configuration = any(),
             linkAccountInfo = anyOrNull(),
             launchMode = any(),
-            linkExpressMode = any()
+            linkExpressMode = any(),
+            passiveCaptchaParams = any()
         )
 
         // Simulate user dismissing 2FA with back press
@@ -582,7 +587,8 @@ internal class DefaultFlowControllerTest {
             configuration = any(),
             linkAccountInfo = anyOrNull(),
             linkExpressMode = any(),
-            launchMode = any()
+            launchMode = any(),
+            passiveCaptchaParams = any()
         )
 
         // Verify payment option launcher was called instead
@@ -1020,6 +1026,7 @@ internal class DefaultFlowControllerTest {
             LinkConfirmationOption(
                 linkExpressMode = LinkExpressMode.DISABLED,
                 configuration = TestFactory.LINK_CONFIGURATION,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
     }
@@ -1069,6 +1076,7 @@ internal class DefaultFlowControllerTest {
                     saveOption = LinkInlineSignupConfirmationOption.PaymentMethodSaveOption.NoRequest,
                     linkConfiguration = TestFactory.LINK_CONFIGURATION,
                     userInput = paymentSelection.input,
+                    passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
                 )
             )
 
@@ -1127,6 +1135,7 @@ internal class DefaultFlowControllerTest {
                     userInput = paymentSelection.input,
                     linkConfiguration = linkConfiguration,
                     saveOption = LinkInlineSignupConfirmationOption.PaymentMethodSaveOption.NoRequest,
+                    passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
                 )
             )
             assertThat(arguments.intent).isEqualTo(intent)
@@ -1181,6 +1190,7 @@ internal class DefaultFlowControllerTest {
                     saveOption = LinkInlineSignupConfirmationOption.PaymentMethodSaveOption.NoRequest,
                     linkConfiguration = linkConfig,
                     userInput = paymentSelection.input,
+                    passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
                 )
             )
             assertThat(arguments.intent).isEqualTo(intent)
@@ -1215,6 +1225,7 @@ internal class DefaultFlowControllerTest {
             PaymentMethodConfirmationOption.Saved(
                 paymentMethod = PaymentMethodFixtures.SEPA_DEBIT_PAYMENT_METHOD,
                 optionsParams = null,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
     }
@@ -1276,6 +1287,7 @@ internal class DefaultFlowControllerTest {
             PaymentMethodConfirmationOption.Saved(
                 paymentMethod = PaymentMethodFixtures.SEPA_DEBIT_PAYMENT_METHOD,
                 optionsParams = null,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
     }
@@ -1293,6 +1305,7 @@ internal class DefaultFlowControllerTest {
                 optionsParams = expectedPaymentMethodOptions,
                 extraParams = null,
                 shouldSave = false,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
         assertThat(arguments.intent).isEqualTo(intent)
@@ -1329,7 +1342,8 @@ internal class DefaultFlowControllerTest {
                     merchantName = config.merchantDisplayName,
                     billingDetailsCollectionConfiguration = config.billingDetailsCollectionConfiguration,
                     cardBrandFilter = PaymentSheetCardBrandFilter(config.cardBrandAcceptance),
-                )
+                ),
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
     }
@@ -1390,6 +1404,7 @@ internal class DefaultFlowControllerTest {
                 extraParams = GENERIC_PAYMENT_SELECTION.paymentMethodExtraParams,
                 shouldSave = GENERIC_PAYMENT_SELECTION.customerRequestedSave ==
                     PaymentSelection.CustomerRequestedSave.RequestReuse,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
 
@@ -1431,6 +1446,7 @@ internal class DefaultFlowControllerTest {
             LinkConfirmationOption(
                 linkExpressMode = LinkExpressMode.DISABLED,
                 configuration = TestFactory.LINK_CONFIGURATION,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
     }
@@ -1735,6 +1751,7 @@ internal class DefaultFlowControllerTest {
             PaymentMethodConfirmationOption.Saved(
                 paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
                 optionsParams = null,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
         assertThat(arguments.initializationMode)
@@ -2067,7 +2084,8 @@ internal class DefaultFlowControllerTest {
                     merchantName = "My merchant",
                     billingDetailsCollectionConfiguration = config.billingDetailsCollectionConfiguration,
                     cardBrandFilter = PaymentSheetCardBrandFilter(config.cardBrandAcceptance),
-                )
+                ),
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
     }
@@ -2106,6 +2124,7 @@ internal class DefaultFlowControllerTest {
             BacsConfirmationOption(
                 createParams = selection.paymentMethodCreateParams,
                 optionsParams = selection.paymentMethodOptionsParams,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
         assertThat(arguments.appearance).isEqualTo(appearance)
@@ -2391,6 +2410,7 @@ internal class DefaultFlowControllerTest {
                     cvc = "505"
                 ),
                 originatedFromWallet = false,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
         assertThat(arguments.shippingDetails).isEqualTo(shippingDetails)
@@ -2439,6 +2459,7 @@ internal class DefaultFlowControllerTest {
                 optionsParams = null,
                 extraParams = null,
                 shouldSave = true,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
         assertThat(arguments.shippingDetails).isNull()
@@ -2480,6 +2501,7 @@ internal class DefaultFlowControllerTest {
                 createParams = createParams,
                 optionsParams = null,
                 extraParams = null,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -36,6 +36,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilt
 import com.stripe.android.lpmfoundations.paymentmethod.WalletType
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.CardParams
+import com.stripe.android.model.PassiveCaptchaParams
 import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
@@ -52,6 +53,7 @@ import com.stripe.android.paymentelement.callbacks.PaymentElementCallbacks
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
+import com.stripe.android.paymentelement.confirmation.asOption
 import com.stripe.android.paymentelement.confirmation.bacs.BacsConfirmationOption
 import com.stripe.android.paymentelement.confirmation.epms.ExternalPaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayConfirmationOption
@@ -305,7 +307,7 @@ internal class DefaultFlowControllerTest {
                     extraParams = selection.paymentMethodExtraParams,
                     shouldSave = selection.customerRequestedSave == PaymentSelection
                         .CustomerRequestedSave.RequestReuse,
-                    passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                    passiveCaptchaParams = null
                 )
             )
 
@@ -353,7 +355,7 @@ internal class DefaultFlowControllerTest {
                     billingDetailsCollectionConfiguration = config.billingDetailsCollectionConfiguration,
                     cardBrandFilter = PaymentSheetCardBrandFilter(config.cardBrandAcceptance),
                 ),
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                passiveCaptchaParams = null
             )
         )
 
@@ -524,7 +526,7 @@ internal class DefaultFlowControllerTest {
             linkAccountInfo = anyOrNull(),
             launchMode = any(),
             linkExpressMode = any(),
-            passiveCaptchaParams = any()
+            passiveCaptchaParams = anyOrNull()
         )
 
         verify(paymentOptionActivityLauncher, never()).launch(any(), anyOrNull())
@@ -565,7 +567,7 @@ internal class DefaultFlowControllerTest {
             linkAccountInfo = anyOrNull(),
             launchMode = any(),
             linkExpressMode = any(),
-            passiveCaptchaParams = any()
+            passiveCaptchaParams = anyOrNull()
         )
 
         // Simulate user dismissing 2FA with back press
@@ -1026,7 +1028,7 @@ internal class DefaultFlowControllerTest {
             LinkConfirmationOption(
                 linkExpressMode = LinkExpressMode.DISABLED,
                 configuration = TestFactory.LINK_CONFIGURATION,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                passiveCaptchaParams = null
             )
         )
     }
@@ -1076,7 +1078,7 @@ internal class DefaultFlowControllerTest {
                     saveOption = LinkInlineSignupConfirmationOption.PaymentMethodSaveOption.NoRequest,
                     linkConfiguration = TestFactory.LINK_CONFIGURATION,
                     userInput = paymentSelection.input,
-                    passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                    passiveCaptchaParams = null
                 )
             )
 
@@ -1135,7 +1137,7 @@ internal class DefaultFlowControllerTest {
                     userInput = paymentSelection.input,
                     linkConfiguration = linkConfiguration,
                     saveOption = LinkInlineSignupConfirmationOption.PaymentMethodSaveOption.NoRequest,
-                    passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                    passiveCaptchaParams = null
                 )
             )
             assertThat(arguments.intent).isEqualTo(intent)
@@ -1190,7 +1192,7 @@ internal class DefaultFlowControllerTest {
                     saveOption = LinkInlineSignupConfirmationOption.PaymentMethodSaveOption.NoRequest,
                     linkConfiguration = linkConfig,
                     userInput = paymentSelection.input,
-                    passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                    passiveCaptchaParams = null
                 )
             )
             assertThat(arguments.intent).isEqualTo(intent)
@@ -1225,7 +1227,7 @@ internal class DefaultFlowControllerTest {
             PaymentMethodConfirmationOption.Saved(
                 paymentMethod = PaymentMethodFixtures.SEPA_DEBIT_PAYMENT_METHOD,
                 optionsParams = null,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                passiveCaptchaParams = null
             )
         )
     }
@@ -1287,7 +1289,7 @@ internal class DefaultFlowControllerTest {
             PaymentMethodConfirmationOption.Saved(
                 paymentMethod = PaymentMethodFixtures.SEPA_DEBIT_PAYMENT_METHOD,
                 optionsParams = null,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                passiveCaptchaParams = null
             )
         )
     }
@@ -1305,7 +1307,7 @@ internal class DefaultFlowControllerTest {
                 optionsParams = expectedPaymentMethodOptions,
                 extraParams = null,
                 shouldSave = false,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                passiveCaptchaParams = null
             )
         )
         assertThat(arguments.intent).isEqualTo(intent)
@@ -1343,7 +1345,7 @@ internal class DefaultFlowControllerTest {
                     billingDetailsCollectionConfiguration = config.billingDetailsCollectionConfiguration,
                     cardBrandFilter = PaymentSheetCardBrandFilter(config.cardBrandAcceptance),
                 ),
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                passiveCaptchaParams = null
             )
         )
     }
@@ -1404,7 +1406,7 @@ internal class DefaultFlowControllerTest {
                 extraParams = GENERIC_PAYMENT_SELECTION.paymentMethodExtraParams,
                 shouldSave = GENERIC_PAYMENT_SELECTION.customerRequestedSave ==
                     PaymentSelection.CustomerRequestedSave.RequestReuse,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                passiveCaptchaParams = null
             )
         )
 
@@ -1446,7 +1448,7 @@ internal class DefaultFlowControllerTest {
             LinkConfirmationOption(
                 linkExpressMode = LinkExpressMode.DISABLED,
                 configuration = TestFactory.LINK_CONFIGURATION,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                passiveCaptchaParams = null
             )
         )
     }
@@ -1751,7 +1753,7 @@ internal class DefaultFlowControllerTest {
             PaymentMethodConfirmationOption.Saved(
                 paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
                 optionsParams = null,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                passiveCaptchaParams = null
             )
         )
         assertThat(arguments.initializationMode)
@@ -2085,7 +2087,7 @@ internal class DefaultFlowControllerTest {
                     billingDetailsCollectionConfiguration = config.billingDetailsCollectionConfiguration,
                     cardBrandFilter = PaymentSheetCardBrandFilter(config.cardBrandAcceptance),
                 ),
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                passiveCaptchaParams = null
             )
         )
     }
@@ -2124,7 +2126,7 @@ internal class DefaultFlowControllerTest {
             BacsConfirmationOption(
                 createParams = selection.paymentMethodCreateParams,
                 optionsParams = selection.paymentMethodOptionsParams,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                passiveCaptchaParams = null
             )
         )
         assertThat(arguments.appearance).isEqualTo(appearance)
@@ -2410,7 +2412,7 @@ internal class DefaultFlowControllerTest {
                     cvc = "505"
                 ),
                 originatedFromWallet = false,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                passiveCaptchaParams = null
             )
         )
         assertThat(arguments.shippingDetails).isEqualTo(shippingDetails)
@@ -2459,7 +2461,7 @@ internal class DefaultFlowControllerTest {
                 optionsParams = null,
                 extraParams = null,
                 shouldSave = true,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                passiveCaptchaParams = null
             )
         )
         assertThat(arguments.shippingDetails).isNull()
@@ -2501,7 +2503,7 @@ internal class DefaultFlowControllerTest {
                 createParams = createParams,
                 optionsParams = null,
                 extraParams = null,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                passiveCaptchaParams = null
             )
         )
 
@@ -2534,6 +2536,62 @@ internal class DefaultFlowControllerTest {
                     isLinkAvailable = true
                 )
             ).isEqualTo(SavedSelection.None)
+        }
+    }
+
+    private suspend fun FakeConfirmationHandler.Scenario.testPassiveCaptchaParams(
+        paymentSelection: PaymentSelection,
+        linkState: LinkState? = null,
+        paymentMethodTypes: List<String> = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.paymentMethodTypes,
+        assertionBlock: (ConfirmationHandler.Args, PassiveCaptchaParams) -> Unit
+    ) {
+        val passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+        val flowController = createFlowController(
+            paymentSelection = paymentSelection,
+            linkState = linkState,
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = paymentMethodTypes
+            ),
+            passiveCaptchaParams = passiveCaptchaParams,
+        )
+
+        flowController.configureExpectingSuccess(
+            configuration = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY
+        )
+
+        flowController.confirm()
+
+        val arguments = startTurbine.awaitItem()
+
+        assertionBlock(arguments, passiveCaptchaParams)
+    }
+
+    @Test
+    fun `confirm Link should pass passive captcha params when available in PaymentMethodMetadata`() = confirmationTest {
+        testPassiveCaptchaParams(
+            paymentSelection = PaymentSelection.Link(),
+            linkState = LinkState(
+                configuration = TestFactory.LINK_CONFIGURATION,
+                loginState = LinkState.LoginState.LoggedOut,
+                signupMode = null,
+            ),
+            paymentMethodTypes = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.paymentMethodTypes.plus("link")
+        ) { arguments, passiveCaptchaParams ->
+            assertThat(arguments.confirmationOption.asOption<LinkConfirmationOption>().passiveCaptchaParams)
+                .isEqualTo(passiveCaptchaParams)
+        }
+    }
+
+    @Test
+    fun `confirm should pass passive captcha params when available in PaymentMethodMetadata`() = confirmationTest {
+        testPassiveCaptchaParams(
+            paymentSelection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION
+        ) { arguments, passiveCaptchaParams ->
+            assertThat(
+                arguments.confirmationOption
+                    .asOption<PaymentMethodConfirmationOption.New>()
+                    .passiveCaptchaParams
+            ).isEqualTo(passiveCaptchaParams)
         }
     }
 
@@ -2583,6 +2641,7 @@ internal class DefaultFlowControllerTest {
         viewModel: FlowControllerViewModel = createViewModel(),
         errorReporter: ErrorReporter = FakeErrorReporter(),
         eventReporter: EventReporter = this@DefaultFlowControllerTest.eventReporter,
+        passiveCaptchaParams: PassiveCaptchaParams? = null,
     ): DefaultFlowController {
         return createFlowController(
             FakePaymentElementLoader(
@@ -2590,6 +2649,7 @@ internal class DefaultFlowControllerTest {
                 stripeIntent = stripeIntent,
                 paymentSelection = paymentSelection,
                 linkState = linkState,
+                passiveCaptchaParams = passiveCaptchaParams,
             ),
             viewModel,
             errorReporter,
@@ -2617,6 +2677,7 @@ internal class DefaultFlowControllerTest {
         eventReporter: EventReporter = this.eventReporter,
         confirmationHandler: ConfirmationHandler? = null,
         linkHandler: LinkHandler? = null,
+        passiveCaptchaParams: PassiveCaptchaParams? = null
     ): DefaultFlowController {
         return createFlowController(
             FakePaymentElementLoader(
@@ -2624,6 +2685,7 @@ internal class DefaultFlowControllerTest {
                 stripeIntent = stripeIntent,
                 paymentSelection = paymentSelection,
                 linkState = linkState,
+                passiveCaptchaParams = passiveCaptchaParams
             ),
             viewModel,
             errorReporter,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateDataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateDataTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.paymentdatacollection.bacs
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentelement.confirmation.bacs.BacsConfirmationOption
@@ -65,6 +66,7 @@ class BacsMandateDataTest {
         return BacsConfirmationOption(
             createParams = createParams,
             optionsParams = null,
+            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultWalletButtonsInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultWalletButtonsInteractorTest.kt
@@ -20,6 +20,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFact
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilter
 import com.stripe.android.lpmfoundations.paymentmethod.WalletType
 import com.stripe.android.model.DisplayablePaymentDetails
+import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayConfirmationOption
@@ -267,7 +268,8 @@ class DefaultWalletButtonsInteractorTest {
                 state.value = ConfirmationHandler.State.Confirming(
                     LinkConfirmationOption(
                         linkExpressMode = LinkExpressMode.DISABLED,
-                        configuration = mock()
+                        configuration = mock(),
+                        passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
                     )
                 )
             }
@@ -463,7 +465,8 @@ class DefaultWalletButtonsInteractorTest {
                         customLabel = "This is a purchase!",
                         billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration,
                         cardBrandFilter = PaymentSheetCardBrandFilter(cardBrandAcceptance)
-                    )
+                    ),
+                    passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
                 )
             )
         }
@@ -759,7 +762,8 @@ class DefaultWalletButtonsInteractorTest {
                 state.value = ConfirmationHandler.State.Confirming(
                     LinkConfirmationOption(
                         linkExpressMode = LinkExpressMode.DISABLED,
-                        configuration = mock()
+                        configuration = mock(),
+                        passiveCaptchaParams = null
                     )
                 )
             }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultWalletButtonsInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultWalletButtonsInteractorTest.kt
@@ -466,7 +466,7 @@ class DefaultWalletButtonsInteractorTest {
                         billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration,
                         cardBrandFilter = PaymentSheetCardBrandFilter(cardBrandAcceptance)
                     ),
-                    passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                    passiveCaptchaParams = null
                 )
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeElementsSessionRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeElementsSessionRepository.kt
@@ -2,7 +2,6 @@ package com.stripe.android.utils
 
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PassiveCaptchaParams
-import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
@@ -18,7 +17,7 @@ internal class FakeElementsSessionRepository(
     private val customPaymentMethods: List<ElementsSession.CustomPaymentMethod> = emptyList(),
     private val cardBrandChoice: ElementsSession.CardBrandChoice? = null,
     private val externalPaymentMethodData: String? = null,
-    private val passiveCaptchaParams: PassiveCaptchaParams? = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+    private val passiveCaptchaParams: PassiveCaptchaParams? = null
 ) : ElementsSessionRepository {
     data class Params(
         val initializationMode: PaymentElementLoader.InitializationMode,

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeElementsSessionRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeElementsSessionRepository.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.utils
 
 import com.stripe.android.model.ElementsSession
+import com.stripe.android.model.PassiveCaptchaParams
+import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
@@ -16,6 +18,7 @@ internal class FakeElementsSessionRepository(
     private val customPaymentMethods: List<ElementsSession.CustomPaymentMethod> = emptyList(),
     private val cardBrandChoice: ElementsSession.CardBrandChoice? = null,
     private val externalPaymentMethodData: String? = null,
+    private val passiveCaptchaParams: PassiveCaptchaParams? = PassiveCaptchaParamsFactory.passiveCaptchaParams()
 ) : ElementsSessionRepository {
     data class Params(
         val initializationMode: PaymentElementLoader.InitializationMode,
@@ -57,10 +60,12 @@ internal class FakeElementsSessionRepository(
                     cardBrandChoice = cardBrandChoice,
                     customPaymentMethods = this.customPaymentMethods,
                     elementsSessionId = "session_1234",
-                    flags = emptyMap(),
+                    flags = mapOf(
+                        ElementsSession.Flag.ELEMENTS_ENABLE_PASSIVE_CAPTCHA to true
+                    ),
                     orderedPaymentMethodTypesAndWallets = stripeIntent.paymentMethodTypes,
                     experimentsData = null,
-                    passiveCaptcha = null,
+                    passiveCaptcha = passiveCaptchaParams,
                     merchantLogoUrl = null
                 )
             )

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentElementLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentElementLoader.kt
@@ -2,6 +2,7 @@ package com.stripe.android.utils
 
 import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.PassiveCaptchaParams
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
@@ -24,6 +25,7 @@ internal class FakePaymentElementLoader(
     private val linkState: LinkState? = null,
     private val validationError: PaymentSheetLoadingException? = null,
     private val cbcEligibility: CardBrandChoiceEligibility = CardBrandChoiceEligibility.Ineligible,
+    private val passiveCaptchaParams: PassiveCaptchaParams? = null,
 ) : PaymentElementLoader {
 
     fun updatePaymentMethods(paymentMethods: List<PaymentMethod>) {
@@ -60,6 +62,7 @@ internal class FakePaymentElementLoader(
                         isGooglePayReady = isGooglePayAvailable,
                         cbcEligibility = cbcEligibility,
                         linkState = linkState,
+                        passiveCaptchaParams = passiveCaptchaParams,
                     ),
                 )
             )

--- a/paymentsheet/src/test/java/com/stripe/android/utils/RecordingLinkPaymentLauncher.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/RecordingLinkPaymentLauncher.kt
@@ -9,6 +9,7 @@ import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.link.LinkLaunchMode
 import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.model.LinkAccount
+import com.stripe.android.model.PassiveCaptchaParams
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doAnswer
@@ -41,7 +42,7 @@ internal object RecordingLinkPaymentLauncher {
                 unregisterCalls.add(Unit)
             }
 
-            on { present(any(), anyOrNull(), any(), any()) } doAnswer { invocation ->
+            on { present(any(), anyOrNull(), any(), any(), anyOrNull()) } doAnswer { invocation ->
                 val arguments = invocation.arguments
 
                 presentCalls.add(
@@ -49,7 +50,8 @@ internal object RecordingLinkPaymentLauncher {
                         configuration = arguments[0] as LinkConfiguration,
                         linkAccount = arguments[1] as? LinkAccount,
                         launchMode = arguments[2] as LinkLaunchMode,
-                        linkExpressMode = arguments[3] as LinkExpressMode
+                        linkExpressMode = arguments[3] as LinkExpressMode,
+                        passiveCaptchaParams = arguments[4] as? PassiveCaptchaParams,
                     )
                 )
             }
@@ -86,5 +88,6 @@ internal object RecordingLinkPaymentLauncher {
         val linkAccount: LinkAccount?,
         val launchMode: LinkLaunchMode,
         val linkExpressMode: LinkExpressMode,
+        val passiveCaptchaParams: PassiveCaptchaParams?
     )
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Pass passiveCaptchaParams to *ConfirmationOption via `PaymentMethodMetadata`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
This will allow to run passive captcha for both saved and new payment methods when `PassiveCaptchaParams` is available

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
