### PR TITLE
Fix confirmation tests

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationUtils.kt
@@ -7,6 +7,8 @@ import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.link.analytics.FakeLinkAnalyticsHelper
+import com.stripe.android.link.analytics.FakeLinkEventsReporter
+import com.stripe.android.link.analytics.LinkEventsReporter
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import com.stripe.android.paymentelement.confirmation.bacs.BacsConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.cvc.CvcRecollectionConfirmationDefinition
@@ -90,4 +92,20 @@ internal fun createTestConfirmationHandlerFactory(
         errorReporter = FakeErrorReporter(),
         ioContext = Dispatchers.Unconfined,
     )
+}
+
+internal class ConfirmationTestScenario(
+    val confirmationHandler: ConfirmationHandler,
+)
+
+internal class FakeLinkEventsReporterForConfirmation(
+    reporter: FakeLinkEventsReporter
+) : LinkEventsReporter by reporter {
+    override fun onPopupShow() {
+        // No-op
+    }
+
+    override fun onPopupSuccess() {
+        // No-op
+    }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ExtendedPaymentElementConfirmationTestActivity.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ExtendedPaymentElementConfirmationTestActivity.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentelement.confirmation
 
 import android.app.Application
 import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -11,12 +12,14 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
+import androidx.test.core.app.ActivityScenario
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.Logger
-import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.core.injection.ENABLE_LOGGING
+import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
+import com.stripe.android.core.injection.UIContext
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.utils.DurationProvider
 import com.stripe.android.core.utils.UserFacingLogger
@@ -48,10 +51,33 @@ import dagger.BindsInstance
 import dagger.Component
 import dagger.Module
 import dagger.Provides
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
+import kotlin.coroutines.CoroutineContext
+
+internal fun extendedPaymentElementConfirmationTest(
+    application: Application,
+    test: suspend ConfirmationTestScenario.() -> Unit
+) {
+    ActivityScenario.launch<ExtendedPaymentElementConfirmationTestActivity>(
+        Intent(application, ExtendedPaymentElementConfirmationTestActivity::class.java)
+    ).use { scenario ->
+        scenario.onActivity { activity ->
+            runTest {
+                test(
+                    ConfirmationTestScenario(
+                        confirmationHandler = activity.confirmationHandler,
+                    )
+                )
+            }
+        }
+    }
+}
 
 internal class ExtendedPaymentElementConfirmationTestActivity : AppCompatActivity() {
     val viewModel: TestViewModel by viewModels {
@@ -92,7 +118,6 @@ internal class ExtendedPaymentElementConfirmationTestActivity : AppCompatActivit
 @Component(
     modules = [
         ExtendedPaymentElementConfirmationModule::class,
-        CoroutineContextModule::class,
         ExtendedPaymentElementConfirmationTestModule::class,
     ]
 )
@@ -127,6 +152,16 @@ internal interface ExtendedPaymentElementConfirmationTestModule {
     fun bindLinkGateFactory(linkGateFactory: DefaultLinkGate.Factory): LinkGate.Factory
 
     companion object {
+        @Provides
+        @Singleton
+        @IOContext
+        fun provideWorkContext(): CoroutineContext = UnconfinedTestDispatcher()
+
+        @Provides
+        @Singleton
+        @UIContext
+        fun provideUIContext(): CoroutineContext = Dispatchers.Main
+
         @Provides
         @PaymentElementCallbackIdentifier
         fun providesPaymentElementCallbackIdentifier(): String = "ExtendedConfirmationTestIdentifier"
@@ -189,6 +224,8 @@ internal interface ExtendedPaymentElementConfirmationTestModule {
 
         @Provides
         @Singleton
-        fun providesLinkEventsReporter(): LinkEventsReporter = FakeLinkEventsReporter()
+        fun providesLinkEventsReporter(): LinkEventsReporter = FakeLinkEventsReporterForConfirmation(
+            FakeLinkEventsReporter()
+        )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cpms/CustomPaymentMethodConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cpms/CustomPaymentMethodConfirmationActivityTest.kt
@@ -4,7 +4,6 @@ import android.app.Activity
 import android.app.Application
 import android.app.Instrumentation
 import android.content.Intent
-import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.intent.Intents.intended
 import androidx.test.espresso.intent.Intents.intending
@@ -19,6 +18,7 @@ import com.stripe.android.paymentelement.ExperimentalCustomPaymentMethodsApi
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbacks
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.ConfirmationTestScenario
 import com.stripe.android.paymentelement.confirmation.PaymentElementConfirmationTestActivity
 import com.stripe.android.paymentelement.confirmation.assertCanceled
 import com.stripe.android.paymentelement.confirmation.assertComplete
@@ -26,22 +26,18 @@ import com.stripe.android.paymentelement.confirmation.assertConfirming
 import com.stripe.android.paymentelement.confirmation.assertFailed
 import com.stripe.android.paymentelement.confirmation.assertIdle
 import com.stripe.android.paymentelement.confirmation.assertSucceeded
+import com.stripe.android.paymentelement.confirmation.paymentElementConfirmationTest
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.createTestActivityRule
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.utils.PaymentElementCallbackTestRule
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 
 @OptIn(ExperimentalCustomPaymentMethodsApi::class)
 @RunWith(RobolectricTestRunner::class)
@@ -139,23 +135,8 @@ internal class CustomPaymentMethodConfirmationActivityTest {
     }
 
     private fun test(
-        test: suspend PaymentElementConfirmationTestActivity.() -> Unit
-    ) = runTest(StandardTestDispatcher()) {
-        val countDownLatch = CountDownLatch(1)
-
-        ActivityScenario.launch<PaymentElementConfirmationTestActivity>(
-            Intent(application, PaymentElementConfirmationTestActivity::class.java)
-        ).use { scenario ->
-            scenario.onActivity { activity ->
-                launch {
-                    test(activity)
-                    countDownLatch.countDown()
-                }
-            }
-
-            countDownLatch.await(10, TimeUnit.SECONDS)
-        }
-    }
+        test: suspend ConfirmationTestScenario.() -> Unit
+    ) = paymentElementConfirmationTest(application, test)
 
     private fun intendingCpmToBeLaunched(result: InternalCustomPaymentMethodResult) {
         intending(hasComponent(CPM_ACTIVITY_NAME)).respondWith(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationActivityTest.kt
@@ -5,7 +5,6 @@ import android.app.Application
 import android.app.Instrumentation
 import android.content.Intent
 import androidx.core.os.bundleOf
-import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.intent.Intents.intended
 import androidx.test.espresso.intent.Intents.intending
@@ -15,12 +14,14 @@ import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.ConfirmationTestScenario
 import com.stripe.android.paymentelement.confirmation.ExtendedPaymentElementConfirmationTestActivity
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.assertComplete
 import com.stripe.android.paymentelement.confirmation.assertConfirming
 import com.stripe.android.paymentelement.confirmation.assertIdle
 import com.stripe.android.paymentelement.confirmation.assertSucceeded
+import com.stripe.android.paymentelement.confirmation.extendedPaymentElementConfirmationTest
 import com.stripe.android.payments.paymentlauncher.InternalPaymentResult
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
@@ -30,15 +31,10 @@ import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.view.ActivityStarter
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 
 @RunWith(RobolectricTestRunner::class)
 internal class CvcRecollectionConfirmationActivityTest {
@@ -124,23 +120,8 @@ internal class CvcRecollectionConfirmationActivityTest {
     }
 
     private fun test(
-        test: suspend ExtendedPaymentElementConfirmationTestActivity.() -> Unit
-    ) = runTest(StandardTestDispatcher()) {
-        val countDownLatch = CountDownLatch(1)
-
-        ActivityScenario.launch<ExtendedPaymentElementConfirmationTestActivity>(
-            Intent(application, ExtendedPaymentElementConfirmationTestActivity::class.java)
-        ).use { scenario ->
-            scenario.onActivity { activity ->
-                launch {
-                    test(activity)
-                    countDownLatch.countDown()
-                }
-            }
-
-            countDownLatch.await(10, TimeUnit.SECONDS)
-        }
-    }
+        test: suspend ConfirmationTestScenario.() -> Unit
+    ) = extendedPaymentElementConfirmationTest(application, test)
 
     private fun intendingCvcRecollectionToBeLaunched(result: CvcRecollectionResult) {
         intending(hasComponent(CVC_RECOLLECTION_ACTIVITY_NAME)).respondWith(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationActivityTest.kt
@@ -4,7 +4,6 @@ import android.app.Activity
 import android.app.Application
 import android.app.Instrumentation
 import android.content.Intent
-import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.intent.Intents.intended
 import androidx.test.espresso.intent.Intents.intending
@@ -19,6 +18,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbacks
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.ConfirmationTestScenario
 import com.stripe.android.paymentelement.confirmation.PaymentElementConfirmationTestActivity
 import com.stripe.android.paymentelement.confirmation.assertCanceled
 import com.stripe.android.paymentelement.confirmation.assertComplete
@@ -26,6 +26,7 @@ import com.stripe.android.paymentelement.confirmation.assertConfirming
 import com.stripe.android.paymentelement.confirmation.assertFailed
 import com.stripe.android.paymentelement.confirmation.assertIdle
 import com.stripe.android.paymentelement.confirmation.assertSucceeded
+import com.stripe.android.paymentelement.confirmation.paymentElementConfirmationTest
 import com.stripe.android.paymentsheet.ExternalPaymentMethodResult
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
@@ -33,16 +34,11 @@ import com.stripe.android.paymentsheet.createTestActivityRule
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.utils.PaymentElementCallbackTestRule
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 
 @RunWith(RobolectricTestRunner::class)
 internal class ExternalPaymentMethodConfirmationActivityTest {
@@ -162,23 +158,8 @@ internal class ExternalPaymentMethodConfirmationActivityTest {
     }
 
     private fun test(
-        test: suspend PaymentElementConfirmationTestActivity.() -> Unit
-    ) = runTest(StandardTestDispatcher()) {
-        val countDownLatch = CountDownLatch(1)
-
-        ActivityScenario.launch<PaymentElementConfirmationTestActivity>(
-            Intent(application, PaymentElementConfirmationTestActivity::class.java)
-        ).use { scenario ->
-            scenario.onActivity { activity ->
-                launch {
-                    test(activity)
-                    countDownLatch.countDown()
-                }
-            }
-
-            countDownLatch.await(10, TimeUnit.SECONDS)
-        }
-    }
+        test: suspend ConfirmationTestScenario.() -> Unit
+    ) = paymentElementConfirmationTest(application, test)
 
     private fun intendingEpmToBeLaunched(result: Instrumentation.ActivityResult) {
         intending(hasComponent(EPM_ACTIVITY_NAME)).respondWith(result)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationActivityTest.kt
@@ -5,7 +5,6 @@ import android.app.Application
 import android.app.Instrumentation
 import android.content.Intent
 import androidx.core.os.bundleOf
-import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.intent.Intents.intended
 import androidx.test.espresso.intent.Intents.intending
@@ -18,6 +17,7 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.isInstanceOf
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.ConfirmationTestScenario
 import com.stripe.android.paymentelement.confirmation.PaymentElementConfirmationTestActivity
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.assertCanceled
@@ -26,6 +26,7 @@ import com.stripe.android.paymentelement.confirmation.assertConfirming
 import com.stripe.android.paymentelement.confirmation.assertFailed
 import com.stripe.android.paymentelement.confirmation.assertIdle
 import com.stripe.android.paymentelement.confirmation.assertSucceeded
+import com.stripe.android.paymentelement.confirmation.paymentElementConfirmationTest
 import com.stripe.android.payments.paymentlauncher.InternalPaymentResult
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
@@ -34,15 +35,10 @@ import com.stripe.android.paymentsheet.createTestActivityRule
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.PaymentMethodFactory
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 import com.stripe.android.R as PaymentsCoreR
 
 @RunWith(RobolectricTestRunner::class)
@@ -156,7 +152,8 @@ internal class GooglePayConfirmationActivityTest {
                     PaymentMethodConfirmationOption.Saved(
                         paymentMethod = paymentMethod,
                         optionsParams = null,
-                        passiveCaptchaParams = null
+                        originatedFromWallet = true,
+                        passiveCaptchaParams = null,
                     )
                 )
 
@@ -216,7 +213,8 @@ internal class GooglePayConfirmationActivityTest {
                     PaymentMethodConfirmationOption.Saved(
                         paymentMethod = paymentMethod,
                         optionsParams = null,
-                        passiveCaptchaParams = null
+                        originatedFromWallet = true,
+                        passiveCaptchaParams = null,
                     )
                 )
 
@@ -229,23 +227,8 @@ internal class GooglePayConfirmationActivityTest {
     }
 
     private fun test(
-        test: suspend PaymentElementConfirmationTestActivity.() -> Unit
-    ) = runTest(StandardTestDispatcher()) {
-        val countDownLatch = CountDownLatch(1)
-
-        ActivityScenario.launch<PaymentElementConfirmationTestActivity>(
-            Intent(application, PaymentElementConfirmationTestActivity::class.java)
-        ).use { scenario ->
-            scenario.onActivity { activity ->
-                launch {
-                    test(activity)
-                    countDownLatch.countDown()
-                }
-            }
-
-            countDownLatch.await(10, TimeUnit.SECONDS)
-        }
-    }
+        test: suspend ConfirmationTestScenario.() -> Unit
+    ) = paymentElementConfirmationTest(application, test)
 
     private fun intendingGooglePayToBeLaunched(result: GooglePayPaymentMethodLauncher.Result) {
         intending(hasComponent(GOOGLE_PAY_ACTIVITY_NAME)).respondWith(


### PR DESCRIPTION
# Summary
Fix confirmation tests by removing the `CountDownLatch`, relying on `runTest` blocking behavior to ensure the test runs, and making the IO context a test dispatcher.

# Motivation
Reduce overall `test` pipeline time & actually run these tests.

I found an issue where most of the confirmation tests hang on the `CountDownLatch` timer that was added to ensure the tests executed properly given coroutine issues. Seems like after the changes to ensure we executed our UI updates on the main thread, our confirmation tests broke and stopped executing. Instead, the full 10 second wait was executed then the tests would complete successfully even though they weren't executed because we weren't checking the result of the `CountDownLatch`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified