### PR TITLE
[Onramp] Adds configuration section and attestation override

### DIFF
--- a/stripe-crypto-onramp-example/src/main/java/com/stripe/android/crypto/onramp/example/ConfigurationManager.kt
+++ b/stripe-crypto-onramp-example/src/main/java/com/stripe/android/crypto/onramp/example/ConfigurationManager.kt
@@ -1,0 +1,37 @@
+package com.stripe.android.crypto.onramp.example
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import com.stripe.android.core.utils.FeatureFlags
+
+internal class ConfigurationManager(context: Context) {
+    private val prefs: SharedPreferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    var attestationMode: AttestationMode
+        get() {
+            val modeString = prefs.getString(KEY_ATTESTATION_MODE, AttestationMode.NONE.name)
+            return AttestationMode.valueOf(modeString ?: AttestationMode.NONE.name)
+        }
+        set(value) {
+            prefs.edit { putString(KEY_ATTESTATION_MODE, value.name) }
+            updateFeatureFlag(value)
+        }
+
+    private fun updateFeatureFlag(mode: AttestationMode) {
+        when (mode) {
+            AttestationMode.ENABLED -> FeatureFlags.nativeLinkAttestationEnabled.setEnabled(true)
+            AttestationMode.DISABLED -> FeatureFlags.nativeLinkAttestationEnabled.setEnabled(false)
+            AttestationMode.NONE -> FeatureFlags.nativeLinkAttestationEnabled.reset()
+        }
+    }
+
+    fun restore() {
+        updateFeatureFlag(attestationMode)
+    }
+
+    companion object {
+        private const val PREFS_NAME = "onramp_config"
+        private const val KEY_ATTESTATION_MODE = "attestation_mode"
+    }
+}


### PR DESCRIPTION
# Summary

- Adds config section (collapsed)
- Adds configuration with persistence (so that previous config is reloaded before configuring onramp)

See attestation failing on a non-play-services emulator, and then being bypassed.

[attestation_flow.webm](https://github.com/user-attachments/assets/bffb19cf-7cf5-4853-8f5c-db3f62b3d9e8)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
