### PR TITLE
Fix flaky `AutocompleteScreenTest`

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenTest.kt
@@ -19,19 +19,19 @@ import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePr
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 
 @ExperimentalAnimationApi
 @RunWith(AndroidJUnit4::class)
 class AutocompleteScreenTest {
-    @get:Rule
     val composeTestRule = createComposeRule()
 
     @get:Rule
-    val composeCleanupRule = createComposeCleanupRule()
-
-    @get:Rule
-    val coroutineTestRule = CoroutineTestRule()
+    val rules: RuleChain = RuleChain.emptyRuleChain()
+        .around(createComposeCleanupRule())
+        .around(composeTestRule)
+        .around(CoroutineTestRule())
 
     @Test
     fun `On enter manually, should set result to null and force expand key to true then go back`() = runTest {


### PR DESCRIPTION
# Summary
Fix flaky `AutocompleteScreenTest` that has been failing once per PR fairly constantly.

# Motivation
Ensures our CI is stabilized and reduces `test` pipeline from ~12 minutes to ~6 minutes.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified