### PR TITLE
Pass `allow_redisplay` to `hosted_auth_url` for Financial Connections

### DIFF
--- a/financial-connections-core/api/financial-connections-core.api
+++ b/financial-connections-core/api/financial-connections-core.api
@@ -1,3 +1,11 @@
+public final class com/stripe/android/financialconnections/ElementsSessionContext$AllowRedisplay$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/financialconnections/ElementsSessionContext$AllowRedisplay;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/financialconnections/ElementsSessionContext$AllowRedisplay;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/financialconnections/ElementsSessionContext$BillingDetails$Address$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/financialconnections/ElementsSessionContext$BillingDetails$Address;

--- a/financial-connections-core/src/main/java/com/stripe/android/financialconnections/ConfigurationInternal.kt
+++ b/financial-connections-core/src/main/java/com/stripe/android/financialconnections/ConfigurationInternal.kt
@@ -2,6 +2,7 @@ package com.stripe.android.financialconnections
 
 import android.os.Parcelable
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.model.StripeModel
 import com.stripe.android.model.IncentiveEligibilitySession
 import com.stripe.android.model.LinkMode
 import kotlinx.parcelize.Parcelize
@@ -26,6 +27,7 @@ data class ElementsSessionContext(
     val amount: Long?,
     val currency: String?,
     val linkMode: LinkMode?,
+    val allowRedisplay: AllowRedisplay?,
     val billingDetails: BillingDetails?,
     val prefillDetails: PrefillDetails,
     val incentiveEligibilitySession: IncentiveEligibilitySession?
@@ -63,5 +65,13 @@ data class ElementsSessionContext(
         companion object {
             private const val serialVersionUID: Long = 626669472462415908L
         }
+    }
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @Parcelize
+    enum class AllowRedisplay(val value: String) : StripeModel {
+        Unspecified("unspecified"),
+        Limited("limited"),
+        Always("always"),
     }
 }

--- a/financial-connections-core/src/main/java/com/stripe/android/financialconnections/utils/HostedAuthUrlBuilder.kt
+++ b/financial-connections-core/src/main/java/com/stripe/android/financialconnections/utils/HostedAuthUrlBuilder.kt
@@ -24,6 +24,7 @@ object HostedAuthUrlBuilder {
             billingDetails = args.elementsSessionContext?.billingDetails,
             prefillDetails = prefillDetails,
             incentiveEligibilitySession = args.elementsSessionContext?.incentiveEligibilitySession,
+            allowRedisplay = args.elementsSessionContext?.allowRedisplay
         )
     }
 
@@ -34,6 +35,7 @@ object HostedAuthUrlBuilder {
         billingDetails: ElementsSessionContext.BillingDetails?,
         prefillDetails: ElementsSessionContext.PrefillDetails?,
         incentiveEligibilitySession: IncentiveEligibilitySession?,
+        allowRedisplay: ElementsSessionContext.AllowRedisplay?,
     ): String? {
         if (hostedAuthUrl == null) {
             return null
@@ -49,6 +51,7 @@ object HostedAuthUrlBuilder {
             linkMode?.let { queryParams.add("link_mode=${it.value}") }
             billingDetails?.let { queryParams.add(makeBillingDetailsQueryParams(it)) }
             incentiveEligibilitySession?.let { queryParams.add("incentiveEligibilitySession=${it.id}") }
+            allowRedisplay?.let { queryParams.add("allow_redisplay=${it.value}") }
         }
 
         prefillDetails?.run {

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
@@ -169,6 +169,7 @@ internal class FinancialConnectionsPlaygroundViewModel(
                                     phone = null,
                                     phoneCountryCode = null,
                                 ),
+                                allowRedisplay = ElementsSessionContext.AllowRedisplay.Unspecified,
                                 incentiveEligibilitySession = null,
                             ),
                             experience = settings.get<ExperienceSetting>().selectedOption,

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModelTest.kt
@@ -182,6 +182,7 @@ class FinancialConnectionsSheetViewModelTest {
                                 phoneCountryCode = null,
                             ),
                             incentiveEligibilitySession = null,
+                            allowRedisplay = null,
                         ),
                     )
                 )
@@ -218,6 +219,7 @@ class FinancialConnectionsSheetViewModelTest {
                                 phoneCountryCode = null,
                             ),
                             incentiveEligibilitySession = null,
+                            allowRedisplay = null,
                         ),
                     )
                 )
@@ -253,6 +255,7 @@ class FinancialConnectionsSheetViewModelTest {
                             phoneCountryCode = null,
                         ),
                         incentiveEligibilitySession = null,
+                        allowRedisplay = null,
                     ),
                 )
             )
@@ -288,6 +291,7 @@ class FinancialConnectionsSheetViewModelTest {
                             phoneCountryCode = null,
                         ),
                         incentiveEligibilitySession = IncentiveEligibilitySession.PaymentIntent("pi_123"),
+                        allowRedisplay = null,
                     ),
                 )
             )
@@ -324,6 +328,7 @@ class FinancialConnectionsSheetViewModelTest {
                             phoneCountryCode = null,
                         ),
                         incentiveEligibilitySession = null,
+                        allowRedisplay = null,
                     ),
                 )
             )
@@ -360,6 +365,7 @@ class FinancialConnectionsSheetViewModelTest {
                             phoneCountryCode = "US",
                         ),
                         incentiveEligibilitySession = null,
+                        allowRedisplay = null,
                     ),
                 )
             )
@@ -409,6 +415,7 @@ class FinancialConnectionsSheetViewModelTest {
                             phoneCountryCode = null,
                         ),
                         incentiveEligibilitySession = null,
+                        allowRedisplay = null,
                     ),
                 )
             )
@@ -448,6 +455,184 @@ class FinancialConnectionsSheetViewModelTest {
             assertThat(viewEffect.url).isEqualTo("${syncResponse.manifest.hostedAuthUrl}&launched_by=android_sdk")
         }
     }
+
+    @Test
+    fun `init - hosted auth url contains allow_redisplay=unspecified for instant debits`() = runTest {
+        // Given
+        whenever(browserManager.canOpenHttpsUrl()).thenReturn(true)
+        whenever(getOrFetchSync(any(), any())).thenReturn(syncResponse)
+        whenever(nativeRouter.nativeAuthFlowEnabled(any())).thenReturn(false)
+
+        // When
+        val viewModel = createViewModel(
+            defaultInitialState.copy(
+                initialArgs = ForInstantDebits(
+                    configuration = configuration,
+                    elementsSessionContext = ElementsSessionContext(
+                        amount = 123,
+                        currency = "usd",
+                        linkMode = null,
+                        billingDetails = null,
+                        prefillDetails = ElementsSessionContext.PrefillDetails(
+                            email = null,
+                            phone = null,
+                            phoneCountryCode = null,
+                        ),
+                        incentiveEligibilitySession = null,
+                        allowRedisplay = ElementsSessionContext.AllowRedisplay.Unspecified,
+                    ),
+                )
+            )
+        )
+
+        // Then
+        withState(viewModel) {
+            val viewEffect = it.viewEffect as OpenAuthFlowWithUrl
+            assertThat(viewEffect.url).contains("allow_redisplay=unspecified")
+        }
+    }
+
+    @Test
+    fun `init - hosted auth url contains allow_redisplay=limited for instant debits`() = runTest {
+        // Given
+        whenever(browserManager.canOpenHttpsUrl()).thenReturn(true)
+        whenever(getOrFetchSync(any(), any())).thenReturn(syncResponse)
+        whenever(nativeRouter.nativeAuthFlowEnabled(any())).thenReturn(false)
+
+        // When
+        val viewModel = createViewModel(
+            defaultInitialState.copy(
+                initialArgs = ForInstantDebits(
+                    configuration = configuration,
+                    elementsSessionContext = ElementsSessionContext(
+                        amount = 123,
+                        currency = "usd",
+                        linkMode = null,
+                        billingDetails = null,
+                        prefillDetails = ElementsSessionContext.PrefillDetails(
+                            email = null,
+                            phone = null,
+                            phoneCountryCode = null,
+                        ),
+                        incentiveEligibilitySession = null,
+                        allowRedisplay = ElementsSessionContext.AllowRedisplay.Limited,
+                    ),
+                )
+            )
+        )
+
+        // Then
+        withState(viewModel) {
+            val viewEffect = it.viewEffect as OpenAuthFlowWithUrl
+            assertThat(viewEffect.url).contains("allow_redisplay=limited")
+        }
+    }
+
+    @Test
+    fun `init - hosted auth url contains allow_redisplay=always for instant debits`() = runTest {
+        // Given
+        whenever(browserManager.canOpenHttpsUrl()).thenReturn(true)
+        whenever(getOrFetchSync(any(), any())).thenReturn(syncResponse)
+        whenever(nativeRouter.nativeAuthFlowEnabled(any())).thenReturn(false)
+
+        // When
+        val viewModel = createViewModel(
+            defaultInitialState.copy(
+                initialArgs = ForInstantDebits(
+                    configuration = configuration,
+                    elementsSessionContext = ElementsSessionContext(
+                        amount = 123,
+                        currency = "usd",
+                        linkMode = null,
+                        billingDetails = null,
+                        prefillDetails = ElementsSessionContext.PrefillDetails(
+                            email = null,
+                            phone = null,
+                            phoneCountryCode = null,
+                        ),
+                        incentiveEligibilitySession = null,
+                        allowRedisplay = ElementsSessionContext.AllowRedisplay.Always,
+                    ),
+                )
+            )
+        )
+
+        // Then
+        withState(viewModel) {
+            val viewEffect = it.viewEffect as OpenAuthFlowWithUrl
+            assertThat(viewEffect.url).contains("allow_redisplay=always")
+        }
+    }
+
+    @Test
+    fun `init - hosted auth url does not contain allow_redisplay for instant debits`() = runTest {
+        // Given
+        whenever(browserManager.canOpenHttpsUrl()).thenReturn(true)
+        whenever(getOrFetchSync(any(), any())).thenReturn(syncResponse)
+        whenever(nativeRouter.nativeAuthFlowEnabled(any())).thenReturn(false)
+
+        // When
+        val viewModel = createViewModel(
+            defaultInitialState.copy(
+                initialArgs = ForInstantDebits(
+                    configuration = configuration,
+                    elementsSessionContext = ElementsSessionContext(
+                        amount = 123,
+                        currency = "usd",
+                        linkMode = null,
+                        billingDetails = null,
+                        prefillDetails = ElementsSessionContext.PrefillDetails(
+                            email = null,
+                            phone = null,
+                            phoneCountryCode = null,
+                        ),
+                        incentiveEligibilitySession = null,
+                        allowRedisplay = null,
+                    ),
+                )
+            )
+        )
+
+        // Then
+        withState(viewModel) {
+            val viewEffect = it.viewEffect as OpenAuthFlowWithUrl
+            assertThat(viewEffect.url).doesNotContain("allow_redisplay")
+        }
+    }
+
+    @Test
+    fun `init - hosted auth url does not have allow_redisplay for data flow even when allowRedisplay is provided`() =
+        runTest {
+            whenever(browserManager.canOpenHttpsUrl()).thenReturn(true)
+            whenever(getOrFetchSync(any(), any())).thenReturn(syncResponse)
+            whenever(nativeRouter.nativeAuthFlowEnabled(any())).thenReturn(false)
+
+            val viewModel = createViewModel(
+                defaultInitialState.copy(
+                    initialArgs = ForData(
+                        configuration = configuration,
+                        elementsSessionContext = ElementsSessionContext(
+                            amount = 123,
+                            currency = "usd",
+                            linkMode = null,
+                            billingDetails = null,
+                            prefillDetails = ElementsSessionContext.PrefillDetails(
+                                email = null,
+                                phone = null,
+                                phoneCountryCode = null,
+                            ),
+                            incentiveEligibilitySession = null,
+                            allowRedisplay = ElementsSessionContext.AllowRedisplay.Always,
+                        ),
+                    )
+                )
+            )
+
+            withState(viewModel) {
+                val viewEffect = it.viewEffect as OpenAuthFlowWithUrl
+                assertThat(viewEffect.url).doesNotContain("allow_redisplay")
+            }
+        }
 
     @Test
     fun `handleOnNewIntent - wrong intent should fire analytics event and set fail result`() = runTest {

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/RealCreateInstantDebitsResultTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/RealCreateInstantDebitsResultTest.kt
@@ -302,6 +302,7 @@ class RealCreateInstantDebitsResultTest {
                 phoneCountryCode = null,
             ),
             incentiveEligibilitySession = incentiveEligibilitySession,
+            allowRedisplay = null,
         )
     }
 }

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkinglinksignup/NetworkingLinkSignupViewModelTest.kt
@@ -152,6 +152,7 @@ class NetworkingLinkSignupViewModelTest {
                     phoneCountryCode = "US",
                 ),
                 incentiveEligibilitySession = null,
+                allowRedisplay = null,
             )
         )
 

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepositoryImplTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepositoryImplTest.kt
@@ -153,6 +153,7 @@ class FinancialConnectionsConsumerSessionRepositoryImplTest {
                     phoneCountryCode = null,
                 ),
                 incentiveEligibilitySession = IncentiveEligibilitySession.PaymentIntent("pi_123"),
+                allowRedisplay = null,
             )
         )
 


### PR DESCRIPTION
# Summary
Pass `allow_redisplay` to `hosted_auth_url` for Financial Connections

# Motivation
Ensures PMs created from the web view have the proper `allow_redisplay` value.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified