### PR TITLE
Consume new flag to disable bank tab

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/ElementsSession.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ElementsSession.kt
@@ -90,7 +90,8 @@ data class ElementsSession(
         val linkEnableDisplayableDefaultValuesInEce: Boolean,
         val linkMobileSkipWalletInFlowController: Boolean,
         val linkSignUpOptInFeatureEnabled: Boolean,
-        val linkSignUpOptInInitialValue: Boolean
+        val linkSignUpOptInInitialValue: Boolean,
+        val linkSupportedPaymentMethodsOnboardingEnabled: List<String>,
     ) : StripeModel
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/ElementsSessionJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/ElementsSessionJsonParser.kt
@@ -202,6 +202,10 @@ internal class ElementsSessionJsonParser(
             null
         }
 
+        val linkSupportedPaymentMethodsOnboardingEnabled = jsonArrayToList(
+            jsonArray = json?.optJSONArray(FIELD_LINK_SUPPORTED_PAYMENT_METHODS_ONBOARDING_ENABLED),
+        )
+
         return ElementsSession.LinkSettings(
             linkFundingSources = jsonArrayToList(linkFundingSources),
             linkPassthroughModeEnabled = linkPassthroughModeEnabled,
@@ -215,7 +219,8 @@ internal class ElementsSessionJsonParser(
             linkEnableDisplayableDefaultValuesInEce = linkEnableDisplayableDefaultValuesInEce,
             linkMobileSkipWalletInFlowController = linkMobileSkipWalletInFlowController,
             linkSignUpOptInFeatureEnabled = linkSignUpOptInFeatureEnabled,
-            linkSignUpOptInInitialValue = linkSignUpOptInInitialValue
+            linkSignUpOptInInitialValue = linkSignUpOptInInitialValue,
+            linkSupportedPaymentMethodsOnboardingEnabled = linkSupportedPaymentMethodsOnboardingEnabled,
         )
     }
 
@@ -479,6 +484,8 @@ internal class ElementsSessionJsonParser(
             "link_mobile_skip_wallet_in_flow_controller"
         private const val FIELD_LINK_SIGN_UP_OPT_IN_FEATURE_ENABLED = "link_sign_up_opt_in_feature_enabled"
         private const val FIELD_LINK_SIGN_UP_OPT_IN_INITIAL_VALUE = "link_sign_up_opt_in_initial_value"
+        private const val FIELD_LINK_SUPPORTED_PAYMENT_METHODS_ONBOARDING_ENABLED =
+            "link_supported_payment_methods_onboarding_enabled"
         private const val FIELD_MERCHANT_COUNTRY = "merchant_country"
         private const val FIELD_MERCHANT_LOGO_URL = "merchant_logo_url"
         private const val FIELD_PAYMENT_METHOD_PREFERENCE = "payment_method_preference"

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkConfiguration.kt
@@ -46,6 +46,7 @@ internal data class LinkConfiguration(
     private val customerId: String?,
     val saveConsentBehavior: PaymentMethodSaveConsentBehavior,
     val forceSetupFutureUseBehaviorAndNewMandate: Boolean,
+    val linkSupportedPaymentMethodsOnboardingEnabled: List<String>,
 ) : Parcelable {
 
     val customerIdForEceDefaultValues: String?
@@ -53,6 +54,9 @@ internal data class LinkConfiguration(
 
     val enableLinkPaymentSelectionHint: Boolean
         get() = flags["link_show_prefer_debit_card_hint"] == true
+
+    val supportsInstantDebitsOnboarding: Boolean
+        get() = linkSupportedPaymentMethodsOnboardingEnabled.contains("INSTANT_DEBITS")
 
     @Parcelize
     data class CustomerInfo(

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/AddPaymentMethodRequirement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/AddPaymentMethodRequirement.kt
@@ -88,10 +88,8 @@ internal enum class AddPaymentMethodRequirement {
 
 private val PaymentMethodMetadata.supportsMobileInstantDebitsFlow: Boolean
     get() {
-        val paymentMethodTypes = stripeIntent.paymentMethodTypes
-        val noUsBankAccount = USBankAccount.code !in paymentMethodTypes
-        val supportsBankAccounts = "bank_account" in stripeIntent.linkFundingSources
-        return noUsBankAccount && supportsBankAccounts && canShowBankForm
+        val supportsInstantDebitsOnboarding = linkState?.configuration?.supportsInstantDebitsOnboarding == true
+        return supportsInstantDebitsOnboarding && canShowBankForm
     }
 
 private val PaymentMethodMetadata.canShowBankForm: Boolean

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -657,6 +657,8 @@ internal class DefaultPaymentElementLoader @Inject constructor(
             saveConsentBehavior = elementsSession.toPaymentSheetSaveConsentBehavior(),
             forceSetupFutureUseBehaviorAndNewMandate = elementsSession
                 .flags[ELEMENTS_MOBILE_FORCE_SETUP_FUTURE_USE_BEHAVIOR_AND_NEW_MANDATE_TEXT] == true,
+            linkSupportedPaymentMethodsOnboardingEnabled =
+                elementsSession.linkSettings?.linkSupportedPaymentMethodsOnboardingEnabled.orEmpty(),
         )
 
         // CBF isn't currently supported in the web flow.

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -658,7 +658,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
             forceSetupFutureUseBehaviorAndNewMandate = elementsSession
                 .flags[ELEMENTS_MOBILE_FORCE_SETUP_FUTURE_USE_BEHAVIOR_AND_NEW_MANDATE_TEXT] == true,
             linkSupportedPaymentMethodsOnboardingEnabled =
-                elementsSession.linkSettings?.linkSupportedPaymentMethodsOnboardingEnabled.orEmpty(),
+            elementsSession.linkSettings?.linkSupportedPaymentMethodsOnboardingEnabled.orEmpty(),
         )
 
         // CBF isn't currently supported in the web flow.

--- a/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
@@ -241,6 +241,10 @@ internal object TestFactory {
         linkSupportedPaymentMethodsOnboardingEnabled = listOf("CARD"),
     )
 
+    val LINK_CONFIGURATION_WITH_INSTANT_DEBITS_ONBOARDING = LINK_CONFIGURATION.copy(
+        linkSupportedPaymentMethodsOnboardingEnabled = listOf("CARD", "INSTANT_DEBITS"),
+    )
+
     val LINK_WALLET_PRIMARY_BUTTON_LABEL = Amount(
         requireNotNull(PaymentIntentFixtures.PI_SUCCEEDED.amount),
         requireNotNull(PaymentIntentFixtures.PI_SUCCEEDED.currency)

--- a/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
@@ -238,6 +238,7 @@ internal object TestFactory {
         customerId = null,
         saveConsentBehavior = PaymentMethodSaveConsentBehavior.Disabled(null),
         forceSetupFutureUseBehaviorAndNewMandate = false,
+        linkSupportedPaymentMethodsOnboardingEnabled = listOf("CARD"),
     )
 
     val LINK_WALLET_PRIMARY_BUTTON_LABEL = Amount(

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenStateTest.kt
@@ -113,6 +113,7 @@ class SignUpScreenStateTest {
             customerId = null,
             saveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
             forceSetupFutureUseBehaviorAndNewMandate = false,
+            linkSupportedPaymentMethodsOnboardingEnabled = listOf("CARD"),
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/AddPaymentMethodRequirementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/AddPaymentMethodRequirementTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.lpmfoundations.paymentmethod
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.link.TestFactory
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement.InstantDebits
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement.LinkCardBrand
 import com.stripe.android.model.Address
@@ -15,6 +16,7 @@ import com.stripe.android.payments.financialconnections.FinancialConnectionsAvai
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode
+import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.testing.PaymentIntentFactory
 import org.junit.Test
 
@@ -214,28 +216,27 @@ internal class AddPaymentMethodRequirementTest {
     fun testInstantDebitsReturnsTrue() {
         val metadata = PaymentMethodMetadataFactory.create(
             stripeIntent = createValidInstantDebitsPaymentIntent(),
+            linkState = LinkState(
+                configuration = TestFactory.LINK_CONFIGURATION_WITH_INSTANT_DEBITS_ONBOARDING,
+                loginState = LinkState.LoginState.LoggedOut,
+                signupMode = null,
+            )
         )
 
         assertThat(InstantDebits.isMetBy(metadata, "")).isTrue()
     }
 
     @Test
-    fun testInstantDebitsReturnsFalseIfShowingUsBankAccount() {
+    fun testInstantDebitsReturnsFalseIfOnboardingDisabledForInstantDebits() {
         val metadata = PaymentMethodMetadataFactory.create(
-            stripeIntent = createValidInstantDebitsPaymentIntent().copy(
-                paymentMethodTypes = listOf("card", "link", "us_bank_account"),
-            ),
-        )
-
-        assertThat(InstantDebits.isMetBy(metadata, "")).isFalse()
-    }
-
-    @Test
-    fun testInstantDebitsReturnsFalseIfOnlyCardFundingSource() {
-        val metadata = PaymentMethodMetadataFactory.create(
-            stripeIntent = createValidInstantDebitsPaymentIntent().copy(
-                linkFundingSources = listOf("card"),
-            ),
+            stripeIntent = createValidInstantDebitsPaymentIntent(),
+            linkState = LinkState(
+                configuration = TestFactory.LINK_CONFIGURATION.copy(
+                    linkSupportedPaymentMethodsOnboardingEnabled = listOf("CARD"),
+                ),
+                loginState = LinkState.LoginState.LoggedOut,
+                signupMode = null,
+            )
         )
 
         assertThat(InstantDebits.isMetBy(metadata, "")).isFalse()
@@ -246,6 +247,11 @@ internal class AddPaymentMethodRequirementTest {
         val metadata = PaymentMethodMetadataFactory.create(
             stripeIntent = createValidInstantDebitsPaymentIntent(),
             linkMode = LinkMode.LinkCardBrand,
+            linkState = LinkState(
+                configuration = TestFactory.LINK_CONFIGURATION_WITH_INSTANT_DEBITS_ONBOARDING,
+                loginState = LinkState.LoginState.LoggedOut,
+                signupMode = null,
+            ),
         )
 
         assertThat(InstantDebits.isMetBy(metadata, "")).isFalse()
@@ -257,6 +263,11 @@ internal class AddPaymentMethodRequirementTest {
             stripeIntent = createValidInstantDebitsPaymentIntent(),
             linkConfiguration = PaymentSheet.LinkConfiguration(
                 display = PaymentSheet.LinkConfiguration.Display.Automatic,
+            ),
+            linkState = LinkState(
+                configuration = TestFactory.LINK_CONFIGURATION_WITH_INSTANT_DEBITS_ONBOARDING,
+                loginState = LinkState.LoginState.LoggedOut,
+                signupMode = null,
             ),
         )
 
@@ -270,6 +281,11 @@ internal class AddPaymentMethodRequirementTest {
             linkConfiguration = PaymentSheet.LinkConfiguration(
                 display = PaymentSheet.LinkConfiguration.Display.Never,
             ),
+            linkState = LinkState(
+                configuration = TestFactory.LINK_CONFIGURATION_WITH_INSTANT_DEBITS_ONBOARDING,
+                loginState = LinkState.LoginState.LoggedOut,
+                signupMode = null,
+            ),
         )
 
         assertThat(InstantDebits.isMetBy(metadata, "")).isFalse()
@@ -280,6 +296,11 @@ internal class AddPaymentMethodRequirementTest {
         val metadata = PaymentMethodMetadataFactory.create(
             stripeIntent = createValidInstantDebitsPaymentIntent(),
             linkMode = LinkMode.LinkCardBrand,
+            linkState = LinkState(
+                configuration = TestFactory.LINK_CONFIGURATION_WITH_INSTANT_DEBITS_ONBOARDING,
+                loginState = LinkState.LoginState.LoggedOut,
+                signupMode = null,
+            ),
         )
 
         assertThat(LinkCardBrand.isMetBy(metadata, "")).isTrue()
@@ -290,6 +311,11 @@ internal class AddPaymentMethodRequirementTest {
         val metadata = PaymentMethodMetadataFactory.create(
             stripeIntent = createValidInstantDebitsPaymentIntent(),
             linkMode = LinkMode.LinkCardBrand,
+            linkState = LinkState(
+                configuration = TestFactory.LINK_CONFIGURATION_WITH_INSTANT_DEBITS_ONBOARDING,
+                loginState = LinkState.LoginState.LoggedOut,
+                signupMode = null,
+            ),
             billingDetailsCollectionConfiguration = BillingDetailsCollectionConfiguration(
                 email = CollectionMode.Never,
                 attachDefaultsToPaymentMethod = true,
@@ -305,6 +331,11 @@ internal class AddPaymentMethodRequirementTest {
         val metadata = PaymentMethodMetadataFactory.create(
             stripeIntent = createValidInstantDebitsPaymentIntent(),
             linkMode = LinkMode.LinkCardBrand,
+            linkState = LinkState(
+                configuration = TestFactory.LINK_CONFIGURATION_WITH_INSTANT_DEBITS_ONBOARDING,
+                loginState = LinkState.LoginState.LoggedOut,
+                signupMode = null,
+            ),
             billingDetailsCollectionConfiguration = BillingDetailsCollectionConfiguration(
                 email = CollectionMode.Never,
                 attachDefaultsToPaymentMethod = false,
@@ -322,6 +353,11 @@ internal class AddPaymentMethodRequirementTest {
         val metadata = PaymentMethodMetadataFactory.create(
             stripeIntent = createValidInstantDebitsPaymentIntent(),
             linkMode = LinkMode.LinkCardBrand,
+            linkState = LinkState(
+                configuration = TestFactory.LINK_CONFIGURATION_WITH_INSTANT_DEBITS_ONBOARDING,
+                loginState = LinkState.LoginState.LoggedOut,
+                signupMode = null,
+            ),
             billingDetailsCollectionConfiguration = BillingDetailsCollectionConfiguration(
                 email = CollectionMode.Never,
                 attachDefaultsToPaymentMethod = true,
@@ -342,6 +378,11 @@ internal class AddPaymentMethodRequirementTest {
             linkConfiguration = PaymentSheet.LinkConfiguration(
                 display = PaymentSheet.LinkConfiguration.Display.Automatic,
             ),
+            linkState = LinkState(
+                configuration = TestFactory.LINK_CONFIGURATION_WITH_INSTANT_DEBITS_ONBOARDING,
+                loginState = LinkState.LoginState.LoggedOut,
+                signupMode = null,
+            )
         )
 
         assertThat(LinkCardBrand.isMetBy(metadata, "")).isTrue()
@@ -352,6 +393,11 @@ internal class AddPaymentMethodRequirementTest {
         val metadata = PaymentMethodMetadataFactory.create(
             stripeIntent = createValidInstantDebitsPaymentIntent(),
             linkMode = LinkMode.LinkCardBrand,
+            linkState = LinkState(
+                configuration = TestFactory.LINK_CONFIGURATION_WITH_INSTANT_DEBITS_ONBOARDING,
+                loginState = LinkState.LoginState.LoggedOut,
+                signupMode = null,
+            ),
             linkConfiguration = PaymentSheet.LinkConfiguration(
                 display = PaymentSheet.LinkConfiguration.Display.Never,
             ),

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -1684,6 +1684,13 @@ internal class PaymentMethodMetadataTest {
                 paymentMethodTypes = listOf("card"),
             ),
             linkMode = LinkMode.LinkCardBrand,
+            linkState = LinkState(
+                configuration = TestFactory.LINK_CONFIGURATION.copy(
+                    linkSupportedPaymentMethodsOnboardingEnabled = listOf("CARD", "INSTANT_DEBITS"),
+                ),
+                loginState = LinkState.LoginState.LoggedOut,
+                signupMode = null,
+            ),
         )
 
         val displayedPaymentMethodTypes = metadata.supportedPaymentMethodTypes()
@@ -1698,6 +1705,13 @@ internal class PaymentMethodMetadataTest {
                 paymentMethodTypes = listOf("card"),
             ),
             linkMode = LinkMode.Passthrough,
+            linkState = LinkState(
+                configuration = TestFactory.LINK_CONFIGURATION.copy(
+                    linkSupportedPaymentMethodsOnboardingEnabled = listOf("CARD"),
+                ),
+                loginState = LinkState.LoginState.LoggedOut,
+                signupMode = null,
+            ),
         )
 
         val displayedPaymentMethodTypes = metadata.supportedPaymentMethodTypes()

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -2122,6 +2122,7 @@ internal class PaymentMethodMetadataTest {
             customerId = null,
             saveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
             forceSetupFutureUseBehaviorAndNewMandate = false,
+            linkSupportedPaymentMethodsOnboardingEnabled = listOf("CARD"),
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElementTest.kt
@@ -168,6 +168,7 @@ class LinkFormElementTest {
             customerId = null,
             saveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
             forceSetupFutureUseBehaviorAndNewMandate = false,
+            linkSupportedPaymentMethodsOnboardingEnabled = listOf("CARD"),
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
@@ -664,6 +664,7 @@ class ConfirmationHandlerOptionKtxTest {
             customerId = null,
             saveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
             forceSetupFutureUseBehaviorAndNewMandate = false,
+            linkSupportedPaymentMethodsOnboardingEnabled = listOf("CARD"),
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
@@ -713,6 +713,7 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
                 customerId = null,
                 saveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
                 forceSetupFutureUseBehaviorAndNewMandate = false,
+                linkSupportedPaymentMethodsOnboardingEnabled = listOf("CARD"),
             ),
             userInput = userInput,
             passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentScreenshotTest.kt
@@ -1,8 +1,11 @@
 package com.stripe.android.paymentelement.embedded.content
 
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.link.TestFactory
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded
+import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.verticalmode.FakePaymentMethodVerticalLayoutInteractor
 import com.stripe.android.screenshottesting.PaparazziRule
 import com.stripe.android.screenshottesting.SystemAppearance
@@ -18,7 +21,7 @@ internal class EmbeddedContentScreenshotTest {
 
     @Test
     fun displaysVerticalModeList() {
-        val metadata = PaymentMethodMetadataFactory.create()
+        val metadata = createMetadata()
         val interactor = FakePaymentMethodVerticalLayoutInteractor.create(metadata)
         val content = EmbeddedContent(
             interactor = interactor,
@@ -33,7 +36,7 @@ internal class EmbeddedContentScreenshotTest {
 
     @Test
     fun displaysVerticalModeListWithMandate() {
-        val metadata = PaymentMethodMetadataFactory.create()
+        val metadata = createMetadata()
         val interactor = FakePaymentMethodVerticalLayoutInteractor.create(
             paymentMethodMetadata = metadata,
             mandate = "Some mandate".resolvableString,
@@ -51,7 +54,7 @@ internal class EmbeddedContentScreenshotTest {
 
     @Test
     fun displaysVerticalModeListWithoutMandate() {
-        val metadata = PaymentMethodMetadataFactory.create()
+        val metadata = createMetadata()
         val interactor = FakePaymentMethodVerticalLayoutInteractor.create(
             paymentMethodMetadata = metadata,
             mandate = "Some mandate".resolvableString,
@@ -65,5 +68,15 @@ internal class EmbeddedContentScreenshotTest {
         paparazziRule.snapshot {
             content.Content()
         }
+    }
+
+    private fun createMetadata(): PaymentMethodMetadata {
+        return PaymentMethodMetadataFactory.create(
+            linkState = LinkState(
+                configuration = TestFactory.LINK_CONFIGURATION_WITH_INSTANT_DEBITS_ONBOARDING,
+                loginState = LinkState.LoginState.LoggedOut,
+                signupMode = null,
+            ),
+        )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -44,6 +44,7 @@ import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLaun
 import com.stripe.android.isInstanceOf
 import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkPaymentLauncher
+import com.stripe.android.link.TestFactory
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.ui.LinkButtonTestTag
 import com.stripe.android.model.CardBrand
@@ -467,7 +468,7 @@ internal class PaymentSheetActivityTest {
     @Test
     fun `removing last selected saved PM clears out saved payment selection`() {
         val paymentMethods = PAYMENT_METHODS.take(1)
-        val viewModel = createViewModel(paymentMethods = paymentMethods)
+        val viewModel = createViewModel(paymentMethods = paymentMethods, isLinkAvailable = true)
         val scenario = activityScenario(viewModel)
 
         scenario.launch(intent).onActivity { activity ->
@@ -1237,7 +1238,7 @@ internal class PaymentSheetActivityTest {
                     customer = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE.copy(paymentMethods = paymentMethods),
                     isGooglePayAvailable = isGooglePayAvailable,
                     linkState = LinkState(
-                        configuration = mock(),
+                        configuration = TestFactory.LINK_CONFIGURATION_WITH_INSTANT_DEBITS_ONBOARDING,
                         loginState = LinkState.LoginState.LoggedOut,
                         signupMode = null,
                     ).takeIf { isLinkAvailable },

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenAddFirstPaymentMethodScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenAddFirstPaymentMethodScreenshotTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.link.TestFactory
 import com.stripe.android.link.ui.LinkButtonState
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.WalletType
@@ -11,6 +12,7 @@ import com.stripe.android.payments.financialconnections.FinancialConnectionsAvai
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.AddFirstPaymentMethod
 import com.stripe.android.paymentsheet.parseAppearance
+import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.WalletsState
 import com.stripe.android.paymentsheet.ui.FakeAddPaymentMethodInteractor
 import com.stripe.android.paymentsheet.ui.FakeAddPaymentMethodInteractor.Companion.createState
@@ -96,7 +98,13 @@ internal class PaymentSheetScreenAddFirstPaymentMethodScreenshotTest {
 
     @Test
     fun displaysWithExpandedPrimaryButtonHeight() {
-        val metadata = PaymentMethodMetadataFactory.create()
+        val metadata = PaymentMethodMetadataFactory.create(
+            linkState = LinkState(
+                configuration = TestFactory.LINK_CONFIGURATION_WITH_INSTANT_DEBITS_ONBOARDING,
+                loginState = LinkState.LoginState.LoggedOut,
+                signupMode = null,
+            ),
+        )
         val interactor = FakeAddPaymentMethodInteractor(initialState = createState(metadata))
         val initialScreen = AddFirstPaymentMethod(interactor)
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenVerticalModeScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenVerticalModeScreenshotTest.kt
@@ -4,7 +4,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.link.TestFactory
 import com.stripe.android.link.ui.LinkButtonState
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.WalletType
 import com.stripe.android.model.SetupIntentFixtures
@@ -14,6 +16,7 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.VerticalMode
 import com.stripe.android.paymentsheet.parseAppearance
+import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.WalletsState
 import com.stripe.android.paymentsheet.ui.PaymentSheetFlowType
 import com.stripe.android.paymentsheet.ui.PaymentSheetScreen
@@ -64,7 +67,7 @@ internal class PaymentSheetScreenVerticalModeScreenshotTest {
 
     @Test
     fun displaysVerticalModeList() {
-        val metadata = PaymentMethodMetadataFactory.create()
+        val metadata = createMetadata()
         val initialScreen = VerticalMode(FakePaymentMethodVerticalLayoutInteractor.create(metadata))
         val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen, canGoBack = false)
 
@@ -75,7 +78,7 @@ internal class PaymentSheetScreenVerticalModeScreenshotTest {
 
     @Test
     fun displaysVerticalModeListWithError() {
-        val metadata = PaymentMethodMetadataFactory.create()
+        val metadata = createMetadata()
         val initialScreen = VerticalMode(FakePaymentMethodVerticalLayoutInteractor.create(metadata))
         val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen, canGoBack = false)
         viewModel.onError("Example error".resolvableString)
@@ -136,7 +139,7 @@ internal class PaymentSheetScreenVerticalModeScreenshotTest {
 
     @Test
     fun displaysVerticalModeListWithLink() {
-        val metadata = PaymentMethodMetadataFactory.create()
+        val metadata = createMetadata()
         val interactor = FakePaymentMethodVerticalLayoutInteractor.create(
             paymentMethodMetadata = metadata,
             initialShowsWalletsHeader = true
@@ -184,7 +187,7 @@ internal class PaymentSheetScreenVerticalModeScreenshotTest {
 
     @Test
     fun displaysVerticalModeListWithSmallRowPadding() {
-        val metadata = PaymentMethodMetadataFactory.create()
+        val metadata = createMetadata()
         val initialScreen = VerticalMode(FakePaymentMethodVerticalLayoutInteractor.create(metadata))
         val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen, canGoBack = false)
 
@@ -195,7 +198,7 @@ internal class PaymentSheetScreenVerticalModeScreenshotTest {
 
     @Test
     fun displaysVerticalModeListWithLargeRowPadding() {
-        val metadata = PaymentMethodMetadataFactory.create()
+        val metadata = createMetadata()
         val initialScreen = VerticalMode(FakePaymentMethodVerticalLayoutInteractor.create(metadata))
         val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen, canGoBack = false)
 
@@ -219,5 +222,15 @@ internal class PaymentSheetScreenVerticalModeScreenshotTest {
         override fun reset() {
             PaymentSheetAppearance.DefaultAppearance.reset()
         }
+    }
+
+    private fun createMetadata(): PaymentMethodMetadata {
+        return PaymentMethodMetadataFactory.create(
+            linkState = LinkState(
+                configuration = TestFactory.LINK_CONFIGURATION_WITH_INSTANT_DEBITS_ONBOARDING,
+                loginState = LinkState.LoginState.LoggedOut,
+                signupMode = null,
+            ),
+        )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -876,7 +876,8 @@ internal class DefaultPaymentElementLoaderTest {
                 linkEnableDisplayableDefaultValuesInEce = false,
                 linkMobileSkipWalletInFlowController = false,
                 linkSignUpOptInFeatureEnabled = false,
-                linkSignUpOptInInitialValue = false
+                linkSignUpOptInInitialValue = false,
+                linkSupportedPaymentMethodsOnboardingEnabled = listOf("CARD"),
             )
         )
 
@@ -917,7 +918,8 @@ internal class DefaultPaymentElementLoaderTest {
                 linkEnableDisplayableDefaultValuesInEce = false,
                 linkMobileSkipWalletInFlowController = false,
                 linkSignUpOptInFeatureEnabled = false,
-                linkSignUpOptInInitialValue = false
+                linkSignUpOptInInitialValue = false,
+                linkSupportedPaymentMethodsOnboardingEnabled = listOf("CARD"),
             )
         )
 
@@ -1006,7 +1008,8 @@ internal class DefaultPaymentElementLoaderTest {
                 linkEnableDisplayableDefaultValuesInEce = false,
                 linkMobileSkipWalletInFlowController = false,
                 linkSignUpOptInFeatureEnabled = false,
-                linkSignUpOptInInitialValue = false
+                linkSignUpOptInInitialValue = false,
+                linkSupportedPaymentMethodsOnboardingEnabled = listOf("CARD"),
             ),
             linkStore = mock {
                 on { hasUsedLink() } doReturn true
@@ -1041,7 +1044,8 @@ internal class DefaultPaymentElementLoaderTest {
                 linkEnableDisplayableDefaultValuesInEce = false,
                 linkMobileSkipWalletInFlowController = false,
                 linkSignUpOptInFeatureEnabled = false,
-                linkSignUpOptInInitialValue = false
+                linkSignUpOptInInitialValue = false,
+                linkSupportedPaymentMethodsOnboardingEnabled = listOf("CARD"),
             )
         )
 
@@ -1566,7 +1570,8 @@ internal class DefaultPaymentElementLoaderTest {
                 linkEnableDisplayableDefaultValuesInEce = false,
                 linkMobileSkipWalletInFlowController = false,
                 linkSignUpOptInFeatureEnabled = false,
-                linkSignUpOptInInitialValue = false
+                linkSignUpOptInInitialValue = false,
+                linkSupportedPaymentMethodsOnboardingEnabled = listOf("CARD"),
             ),
             linkStore = linkStore,
         )
@@ -3720,6 +3725,7 @@ internal class DefaultPaymentElementLoaderTest {
             linkMobileSkipWalletInFlowController = false,
             linkSignUpOptInFeatureEnabled = linkSignUpOptInFeatureEnabled,
             linkSignUpOptInInitialValue = false,
+            linkSupportedPaymentMethodsOnboardingEnabled = listOf("CARD"),
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -3178,6 +3178,7 @@ internal class DefaultPaymentElementLoaderTest {
     fun `Allows Link if Link display is set to 'automatic'`() = runTest {
         val loader = createPaymentElementLoader(
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            linkSettings = createLinkSettings(passthroughModeEnabled = false),
         )
 
         val config = PaymentSheet.Configuration(
@@ -3725,7 +3726,7 @@ internal class DefaultPaymentElementLoaderTest {
             linkMobileSkipWalletInFlowController = false,
             linkSignUpOptInFeatureEnabled = linkSignUpOptInFeatureEnabled,
             linkSignUpOptInInitialValue = false,
-            linkSupportedPaymentMethodsOnboardingEnabled = listOf("CARD"),
+            linkSupportedPaymentMethodsOnboardingEnabled = listOf("CARD", "INSTANT_DEBITS"),
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeAddPaymentMethodInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeAddPaymentMethodInteractor.kt
@@ -1,11 +1,13 @@
 package com.stripe.android.paymentsheet.ui
 
+import com.stripe.android.link.TestFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentsheet.ViewActionRecorder
 import com.stripe.android.paymentsheet.forms.FormArgumentsFactory
+import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.uicore.utils.stateFlowOf
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
 import kotlinx.coroutines.flow.StateFlow
@@ -28,7 +30,13 @@ internal class FakeAddPaymentMethodInteractor(
 
     companion object {
         fun createState(
-            metadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+            metadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                linkState = LinkState(
+                    configuration = TestFactory.LINK_CONFIGURATION_WITH_INSTANT_DEBITS_ONBOARDING,
+                    loginState = LinkState.LoginState.LoggedOut,
+                    signupMode = null,
+                ),
+            ),
             paymentMethodCode: PaymentMethodCode = metadata.supportedPaymentMethodTypes().first(),
             isValidating: Boolean = false,
         ): AddPaymentMethodInteractor.State {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
@@ -103,6 +103,7 @@ internal object LinkTestUtils {
             customerId = null,
             saveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
             forceSetupFutureUseBehaviorAndNewMandate = false,
+            linkSupportedPaymentMethodsOnboardingEnabled = listOf("CARD"),
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -6,6 +6,7 @@ import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.R
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.link.TestFactory
 import com.stripe.android.link.ui.LinkButtonState
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
@@ -24,6 +25,7 @@ import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.GooglePayButtonType
 import com.stripe.android.paymentsheet.model.PaymentMethodIncentive
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.WalletsState
 import com.stripe.android.paymentsheet.verticalmode.PaymentMethodVerticalLayoutInteractor.ViewAction
 import com.stripe.android.testing.PaymentMethodFactory
@@ -1488,7 +1490,12 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
             cbcEligibility = CardBrandChoiceEligibility.create(
                 isEligible = true,
                 preferredNetworks = emptyList()
-            )
+            ),
+            linkState = LinkState(
+                configuration = TestFactory.LINK_CONFIGURATION_WITH_INSTANT_DEBITS_ONBOARDING,
+                loginState = LinkState.LoginState.LoggedOut,
+                signupMode = null,
+            ),
         ),
         initialProcessing: Boolean = false,
         initialSelection: PaymentSelection? = null,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactoryTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.verticalmode
 import androidx.lifecycle.SavedStateHandle
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.isInstanceOf
+import com.stripe.android.link.TestFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.PaymentIntentFixtures
@@ -11,6 +12,7 @@ import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.state.CustomerState
+import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.viewmodels.FakeBaseSheetViewModel
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.uicore.utils.stateFlowOf
@@ -56,7 +58,13 @@ class VerticalModeInitialScreenFactoryTest {
     }
 
     private fun runScenario(
-        paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+        paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            linkState = LinkState(
+                configuration = TestFactory.LINK_CONFIGURATION_WITH_INSTANT_DEBITS_ONBOARDING,
+                loginState = LinkState.LoginState.LoggedOut,
+                signupMode = null,
+            ),
+        ),
         hasSavedPaymentMethods: Boolean = false,
         selection: PaymentSelection? = null,
         block: Scenario.() -> Unit,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request updates the SDK to disable the `Bank` tab if `link_supported_payment_methods_onboarding_enabled` does not include `"INSTANT_DEBITS"`.

This flag didn't exist when we rolled out Instant Debits initially, but should now be used instead of the client logic.

cc @ericazhou-stripe

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
