### PR TITLE
[onramp] Fix crypto request errors

### DIFF
--- a/crypto-onramp-example/src/main/java/com/stripe/android/crypto/onramp/example/OnrampActivity.kt
+++ b/crypto-onramp-example/src/main/java/com/stripe/android/crypto/onramp/example/OnrampActivity.kt
@@ -454,7 +454,7 @@ private fun AuthenticationScreen(
 fun AuthenticateSection(
     onAuthenticate: (oauthScopes: String?) -> Unit,
 ) {
-    var oauthScopes by remember { mutableStateOf("") }
+    var oauthScopes by remember { mutableStateOf("kyc.status:read,crypto:ramp") }
     OutlinedTextField(
         value = oauthScopes,
         onValueChange = { oauthScopes = it },

--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/repositories/CryptoApiRepository.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/repositories/CryptoApiRepository.kt
@@ -253,6 +253,7 @@ internal class CryptoApiRepository @Inject constructor(
                 val error = StripeErrorJsonParser().parse(response.responseJson())
                 throw APIException(error)
             }
+            @Suppress("TooGenericExceptionCaught")
             try {
                 val body = requireNotNull(response.body) { "No response body found" }
                 val json = Json { ignoreUnknownKeys = true }

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkAppearance.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkAppearance.kt
@@ -25,7 +25,7 @@ import kotlinx.parcelize.TypeParceler
 class LinkAppearance(
     val lightColors: Colors = Colors.default(isDark = false),
     val darkColors: Colors = Colors.default(isDark = true),
-    val style: Style,
+    val style: Style = Style.AUTOMATIC,
     val primaryButton: PrimaryButton = PrimaryButton()
 ) : Parcelable {
 


### PR DESCRIPTION
# Summary
Fix `APIException`s being swallowed by `APIConnectionException`s, losing useful error information. This was particularly noticeable when testing errors in the RN SDK.

# Motivation
👻 

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
