### PR TITLE
Fix PassiveChallengeConfirmationFlowTest

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationFlowTest.kt
@@ -21,26 +21,20 @@ internal class PassiveChallengeConfirmationFlowTest {
     fun `on launch with New option, should persist parameters & launch using launcher as expected`() = runLaunchTest(
         confirmationOption = NEW_CONFIRMATION_OPTION,
         parameters = CONFIRMATION_PARAMETERS,
-        definition = PassiveChallengeConfirmationDefinition(
-            errorReporter = FakeErrorReporter(),
-        ),
+        definition = confirmationDefinition(),
     )
 
     @Test
     fun `on launch with Saved option, should persist parameters & launch using launcher as expected`() = runLaunchTest(
         confirmationOption = SAVED_CONFIRMATION_OPTION,
         parameters = CONFIRMATION_PARAMETERS,
-        definition = PassiveChallengeConfirmationDefinition(
-            errorReporter = FakeErrorReporter(),
-        ),
+        definition = confirmationDefinition(),
     )
 
     @Test
     fun `on result with Success, should return NextStep result with token attached for New option`() = runResultTest(
         confirmationOption = NEW_CONFIRMATION_OPTION,
-        definition = PassiveChallengeConfirmationDefinition(
-            errorReporter = FakeErrorReporter(),
-        ),
+        definition = confirmationDefinition(),
         launcherResult = PassiveChallengeActivityResult.Success("test_token"),
         parameters = CONFIRMATION_PARAMETERS,
         definitionResult = ConfirmationDefinition.Result.NextStep(
@@ -60,9 +54,7 @@ internal class PassiveChallengeConfirmationFlowTest {
     @Test
     fun `on result with Success, should return NextStep result with token attached for Saved option`() = runResultTest(
         confirmationOption = SAVED_CONFIRMATION_OPTION,
-        definition = PassiveChallengeConfirmationDefinition(
-            errorReporter = FakeErrorReporter(),
-        ),
+        definition = confirmationDefinition(),
         launcherResult = PassiveChallengeActivityResult.Success("test_token"),
         parameters = CONFIRMATION_PARAMETERS,
         definitionResult = ConfirmationDefinition.Result.NextStep(
@@ -80,9 +72,7 @@ internal class PassiveChallengeConfirmationFlowTest {
     @Test
     fun `on result with Failed, should return NextStep result with no token for New option`() = runResultTest(
         confirmationOption = NEW_CONFIRMATION_OPTION,
-        definition = PassiveChallengeConfirmationDefinition(
-            errorReporter = FakeErrorReporter(),
-        ),
+        definition = confirmationDefinition(),
         launcherResult = PassiveChallengeActivityResult.Failed(RuntimeException("Challenge failed")),
         parameters = CONFIRMATION_PARAMETERS,
         definitionResult = ConfirmationDefinition.Result.NextStep(
@@ -100,9 +90,7 @@ internal class PassiveChallengeConfirmationFlowTest {
     @Test
     fun `on result with Failed, should return NextStep result with no token for Saved option`() = runResultTest(
         confirmationOption = SAVED_CONFIRMATION_OPTION,
-        definition = PassiveChallengeConfirmationDefinition(
-            errorReporter = FakeErrorReporter(),
-        ),
+        definition = confirmationDefinition(),
         launcherResult = PassiveChallengeActivityResult.Failed(RuntimeException("Challenge failed")),
         parameters = CONFIRMATION_PARAMETERS,
         definitionResult = ConfirmationDefinition.Result.NextStep(
@@ -149,4 +137,12 @@ internal class PassiveChallengeConfirmationFlowTest {
             appearance = PaymentSheet.Appearance(),
         )
     }
+
+    private fun confirmationDefinition(
+        errorReporter: FakeErrorReporter = FakeErrorReporter(),
+    ) = PassiveChallengeConfirmationDefinition(
+        errorReporter = errorReporter,
+        publishableKeyProvider = { "pk_123" },
+        productUsage = setOf("PaymentSheet"),
+    )
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Fix PassiveChallengeConfirmationFlowTest. This [PR](https://github.com/stripe/stripe-android/pull/11494) changed the constructor parameters of `PassiveChallengeConfirmationDefinition` causing `PassiveChallengeConfirmationFlowTest`, which was merged afterwards to fail

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
