### PR TITLE
Update expected testGrabPayFailure error message

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestGrabPay.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestGrabPay.kt
@@ -8,7 +8,6 @@ import com.stripe.android.paymentsheet.example.playground.settings.Currency
 import com.stripe.android.paymentsheet.example.playground.settings.CurrencySettingsDefinition
 import com.stripe.android.test.core.AuthorizeAction
 import com.stripe.android.test.core.TestParameters
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -27,14 +26,12 @@ internal class TestGrabPay : BasePlaygroundTest() {
         testDriver.confirmNewOrGuestComplete(testParameters)
     }
 
-    @Ignore("shape-together")
     @Test
     fun testGrabPayFailure() {
         testDriver.confirmNewOrGuestComplete(
             testParameters.copy(
                 authorizationAction = AuthorizeAction.Fail(
-                    expectedError = "We are unable to authenticate your payment method. Please " +
-                        "choose a different payment method and try again.",
+                    expectedError = "Your payment method was declined.",
                 ),
             )
         )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Update expected testGrabPayFailure error message
`#bc-shape-together`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
The backend no longer returns an authentication error when we click `Fail Payment` for Grab Pay. I tested this on iOS as well (it doesn't show an authentication error). It returns a `card_error` now. I'm updating the test to reflect that. This fixes R4 (#bc-shape-together)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
