### PR TITLE
Fix flakes in `DefaultPaymentMethodsConfirmationTest`

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/DefaultPaymentMethodsConfirmationTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/DefaultPaymentMethodsConfirmationTest.kt
@@ -20,15 +20,17 @@ import com.stripe.paymentelementtestpages.FormPage
 import com.stripe.paymentelementtestpages.VerticalModePage
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 
 @RunWith(TestParameterInjector::class)
 internal class DefaultPaymentMethodsConfirmationTest {
+    private val testRules: TestRules = TestRules.create()
 
     @get:Rule
-    val testRules: TestRules = TestRules.create {
-        around(IntentsRule())
-    }
+    val rules: RuleChain = RuleChain.emptyRuleChain()
+        .around(IntentsRule())
+        .around(testRules)
 
     private val composeTestRule = testRules.compose
     private val networkRule = testRules.networkRule


### PR DESCRIPTION
# Summary
Fix flakes in `DefaultPaymentMethodsConfirmationTest` by having `IntentsRule` always be the first rule in the rule chain.

# Motivation
Stabilizes `run-paymentsheet-instrumentation-tests` pipeline.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified