### PR TITLE
Add warmup to HCaptchService

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/hcaptcha/DefaultHCaptchaService.kt
+++ b/payments-core/src/main/java/com/stripe/android/hcaptcha/DefaultHCaptchaService.kt
@@ -10,39 +10,46 @@ import com.stripe.hcaptcha.config.HCaptchaConfig
 import com.stripe.hcaptcha.config.HCaptchaSize
 import com.stripe.hcaptcha.task.OnFailureListener
 import com.stripe.hcaptcha.task.OnSuccessListener
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeout
 import kotlin.coroutines.resume
+import kotlin.time.Duration.Companion.seconds
 
 internal class DefaultHCaptchaService(
     private val hCaptchaProvider: HCaptchaProvider,
     private val captchaEventsReporter: CaptchaEventsReporter
 ) : HCaptchaService {
+    private val cachedResult = MutableStateFlow<CachedResult>(CachedResult.Idle)
+
+    override suspend fun warmUp(activity: FragmentActivity, siteKey: String, rqData: String?) {
+        if (cachedResult.value.canWarmUp.not()) return
+        cachedResult.emit(CachedResult.Loading)
+        val update = when (val result = performPassiveHCaptchaHelper(activity, siteKey, rqData)) {
+            is HCaptchaService.Result.Failure -> {
+                CachedResult.Failure(result.error)
+            }
+            is HCaptchaService.Result.Success -> {
+                CachedResult.Success(result.token)
+            }
+        }
+        cachedResult.emit(update)
+    }
+
     override suspend fun performPassiveHCaptcha(
         activity: FragmentActivity,
         siteKey: String,
         rqData: String?
     ): HCaptchaService.Result {
-        val hCaptcha = hCaptchaProvider.get()
-        captchaEventsReporter.init(siteKey)
         val result = runCatching {
-            startVerification(
-                activity = activity,
-                siteKey = siteKey,
-                rqData = rqData,
-                hCaptcha = hCaptcha
-            )
+            withTimeout(TIMEOUT) {
+                transformCachedResult(activity, siteKey, rqData)
+            }
         }.getOrElse { e ->
             HCaptchaService.Result.Failure(e)
         }
-        when (result) {
-            is HCaptchaService.Result.Failure -> {
-                captchaEventsReporter.error(result.error, siteKey)
-            }
-            is HCaptchaService.Result.Success -> {
-                captchaEventsReporter.success(siteKey)
-            }
-        }
-        hCaptcha.reset()
         return result
     }
 
@@ -80,5 +87,72 @@ internal class DefaultHCaptchaService(
             hCaptcha.setup(activity, config).verifyWithHCaptcha(activity)
             captchaEventsReporter.execute(siteKey)
         }
+    }
+
+    private suspend fun performPassiveHCaptchaHelper(
+        activity: FragmentActivity,
+        siteKey: String,
+        rqData: String?
+    ): HCaptchaService.Result {
+        val hCaptcha = hCaptchaProvider.get()
+        captchaEventsReporter.init(siteKey)
+        val result = runCatching {
+            startVerification(
+                activity = activity,
+                siteKey = siteKey,
+                rqData = rqData,
+                hCaptcha = hCaptcha
+            )
+        }.getOrElse { e ->
+            HCaptchaService.Result.Failure(e)
+        }
+        when (result) {
+            is HCaptchaService.Result.Failure -> {
+                captchaEventsReporter.error(result.error, siteKey)
+            }
+            is HCaptchaService.Result.Success -> {
+                captchaEventsReporter.success(siteKey)
+            }
+        }
+        hCaptcha.reset()
+        return result
+    }
+
+    private suspend fun transformCachedResult(
+        activity: FragmentActivity,
+        siteKey: String,
+        rqData: String?
+    ): HCaptchaService.Result {
+        return cachedResult.mapNotNull { cachedResult ->
+            when (cachedResult) {
+                CachedResult.Idle -> {
+                    performPassiveHCaptchaHelper(activity, siteKey, rqData)
+                }
+                CachedResult.Loading -> {
+                    null
+                }
+                is CachedResult.Success -> HCaptchaService.Result.Success(cachedResult.token)
+                is CachedResult.Failure -> HCaptchaService.Result.Failure(cachedResult.error)
+            }
+        }.first()
+    }
+
+    sealed interface CachedResult {
+        data object Idle : CachedResult
+        data object Loading : CachedResult
+        data class Success(val token: String) : CachedResult
+        data class Failure(val error: Throwable) : CachedResult
+
+        val canWarmUp: Boolean
+            get() {
+                return when (this) {
+                    is Failure, Idle -> true
+                    Loading, is Success -> false
+                }
+            }
+    }
+
+    companion object {
+        internal val TIMEOUT = 6.seconds
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/hcaptcha/HCaptchaModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/hcaptcha/HCaptchaModule.kt
@@ -13,6 +13,9 @@ import dagger.Provides
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Module
 object HCaptchaModule {
+    @Volatile
+    private var hCaptchaService: HCaptchaService? = null
+
     @Provides
     internal fun provideHCaptchaProvider(): HCaptchaProvider {
         return DefaultHCaptchaProvider()
@@ -23,7 +26,10 @@ object HCaptchaModule {
         hCaptchaProvider: HCaptchaProvider,
         captchaEventsReporter: CaptchaEventsReporter
     ): HCaptchaService {
-        return DefaultHCaptchaService(hCaptchaProvider, captchaEventsReporter)
+        return hCaptchaService ?: synchronized(this) {
+            hCaptchaService ?: DefaultHCaptchaService(hCaptchaProvider, captchaEventsReporter)
+                .also { hCaptchaService = it }
+        }
     }
 
     @Provides

--- a/payments-core/src/main/java/com/stripe/android/hcaptcha/HCaptchaService.kt
+++ b/payments-core/src/main/java/com/stripe/android/hcaptcha/HCaptchaService.kt
@@ -5,6 +5,12 @@ import androidx.fragment.app.FragmentActivity
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 interface HCaptchaService {
+    suspend fun warmUp(
+        activity: FragmentActivity,
+        siteKey: String,
+        rqData: String?
+    )
+
     suspend fun performPassiveHCaptcha(
         activity: FragmentActivity,
         siteKey: String,

--- a/payments-core/src/test/java/com/stripe/android/challenge/FakeHCaptchaService.kt
+++ b/payments-core/src/test/java/com/stripe/android/challenge/FakeHCaptchaService.kt
@@ -6,19 +6,26 @@ import com.stripe.android.hcaptcha.HCaptchaService
 
 internal class FakeHCaptchaService : HCaptchaService {
     var result: HCaptchaService.Result? = null
-    private val calls = Turbine<Call>()
+    var warmUpResult: () -> Unit = {}
+    private val performPassiveHCaptchaCalls = Turbine<Call>()
+    private val warmUpCalls = Turbine<Call>()
+
+    override suspend fun warmUp(activity: FragmentActivity, siteKey: String, rqData: String?) {
+        warmUpCalls.add(Call(activity, siteKey, rqData))
+        warmUpResult()
+    }
 
     override suspend fun performPassiveHCaptcha(
         activity: FragmentActivity,
         siteKey: String,
         rqData: String?
     ): HCaptchaService.Result {
-        calls.add(Call(activity, siteKey, rqData))
+        performPassiveHCaptchaCalls.add(Call(activity, siteKey, rqData))
         return result ?: HCaptchaService.Result.Success("default_token")
     }
 
-    suspend fun awaitCall(): Call {
-        return calls.awaitItem()
+    suspend fun awaitPerformPassiveHCaptchaCall(): Call {
+        return performPassiveHCaptchaCalls.awaitItem()
     }
 
     data class Call(

--- a/payments-core/src/test/java/com/stripe/android/challenge/PassiveChallengeViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/challenge/PassiveChallengeViewModelTest.kt
@@ -77,7 +77,7 @@ internal class PassiveChallengeViewModelTest {
 
         viewModel.startPassiveChallenge(fakeActivity)
 
-        val passiveCaptcha = hCaptchaService.awaitCall()
+        val passiveCaptcha = hCaptchaService.awaitPerformPassiveHCaptchaCall()
         assertThat(passiveCaptcha.siteKey).isEqualTo(passiveCaptcha.siteKey)
         assertThat(passiveCaptcha.rqData).isEqualTo(passiveCaptcha.rqData)
         assertThat(passiveCaptcha.activity).isEqualTo(fakeActivity)

--- a/payments-core/src/test/java/com/stripe/android/hcaptcha/DefaultHCaptchaServiceTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/hcaptcha/DefaultHCaptchaServiceTest.kt
@@ -4,6 +4,7 @@ import android.os.Handler
 import androidx.fragment.app.FragmentActivity
 import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.hcaptcha.DefaultHCaptchaServiceTest.FakeHCaptchaProvider.HCaptchaHandler
 import com.stripe.android.hcaptcha.analytics.CaptchaEventsReporter
 import com.stripe.hcaptcha.HCaptcha
 import com.stripe.hcaptcha.HCaptchaError
@@ -15,249 +16,418 @@ import com.stripe.hcaptcha.task.OnFailureListener
 import com.stripe.hcaptcha.task.OnSuccessListener
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
+import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
 
+@RunWith(RobolectricTestRunner::class)
 internal class DefaultHCaptchaServiceTest {
 
     @Test
     fun `performPassiveHCaptcha calls hCaptchaProvider`() = runTest {
-        val testContext = createTestContext()
-        testContext.setupSuccessfulHCaptcha("test-token")
+        TestContext.test {
+            hCaptchaProvider.hCaptchaHandler = SetupSuccessfulHCaptcha()
 
-        testContext.service.performPassiveHCaptcha(
-            testContext.activity,
-            siteKey = "test-site-key",
-            rqData = null
-        )
+            service.performPassiveHCaptcha(
+                activity,
+                siteKey = TEST_SITE_KEY,
+                rqData = null
+            )
 
-        testContext.hCaptchaProvider.awaitCall()
+            hCaptchaProvider.awaitCall()
+        }
     }
 
     @Test
     fun `performPassiveHCaptcha configures HCaptcha with correct settings`() = runTest {
-        val testContext = createTestContext()
-        testContext.setupSuccessfulHCaptcha()
-        val testSiteKey = "test-site-key"
-        val testRqData = "test-rq-data"
+        TestContext.test {
+            hCaptchaProvider.hCaptchaHandler = SetupSuccessfulHCaptcha()
 
-        testContext.service.performPassiveHCaptcha(
-            testContext.activity,
-            siteKey = testSiteKey,
-            rqData = testRqData
-        )
+            service.performPassiveHCaptcha(
+                activity,
+                siteKey = TEST_SITE_KEY,
+                rqData = TEST_RQ_DATA
+            )
 
-        val configCaptor = argumentCaptor<HCaptchaConfig>()
-        verify(testContext.hCaptcha).setup(any(), configCaptor.capture())
-
-        with(configCaptor.firstValue) {
-            assertThat(siteKey).isEqualTo(testSiteKey)
-            assertThat(size).isEqualTo(HCaptchaSize.INVISIBLE)
-            assertThat(rqdata).isEqualTo(testRqData)
-            assertThat(loading).isFalse()
-            assertThat(hideDialog).isTrue()
-            assertThat(disableHardwareAcceleration).isTrue()
+            val configCaptor = argumentCaptor<HCaptchaConfig>()
+            verify(hCaptchaProvider.awaitCall()).setup(any(), configCaptor.capture())
+            with(configCaptor.firstValue) {
+                assertThat(siteKey).isEqualTo(TEST_SITE_KEY)
+                assertThat(size).isEqualTo(HCaptchaSize.INVISIBLE)
+                assertThat(rqdata).isEqualTo(TEST_RQ_DATA)
+                assertThat(loading).isFalse()
+                assertThat(hideDialog).isTrue()
+                assertThat(disableHardwareAcceleration).isTrue()
+            }
         }
     }
 
     @Test
     fun `performPassiveHCaptcha returns success when HCaptcha succeeds`() = runTest {
-        val testContext = createTestContext()
-        val expectedToken = "success-token"
-        val siteKey = "test-site-key"
-        testContext.setupSuccessfulHCaptcha(expectedToken)
+        TestContext.test {
+            hCaptchaProvider.hCaptchaHandler = SetupSuccessfulHCaptcha()
 
-        val result = testContext.service.performPassiveHCaptcha(
-            testContext.activity,
-            siteKey = siteKey,
-            rqData = null
-        )
+            val result = service.performPassiveHCaptcha(
+                activity,
+                siteKey = TEST_SITE_KEY,
+                rqData = null
+            )
 
-        assertThat(result).isInstanceOf(HCaptchaService.Result.Success::class.java)
-        assertThat((result as HCaptchaService.Result.Success).token).isEqualTo(expectedToken)
+            assertThat(result).isInstanceOf(HCaptchaService.Result.Success::class.java)
+            assertThat((result as HCaptchaService.Result.Success).token).isEqualTo("token")
 
-        // Verify analytics calls in order
-        assertThat(testContext.captchaEventsReporter.awaitCall())
-            .isEqualTo(FakeCaptchaEventsReporter.Call.Init(siteKey))
-        assertThat(testContext.captchaEventsReporter.awaitCall())
-            .isEqualTo(FakeCaptchaEventsReporter.Call.Execute(siteKey))
-        assertThat(testContext.captchaEventsReporter.awaitCall())
-            .isEqualTo(FakeCaptchaEventsReporter.Call.Success(siteKey))
-        testContext.captchaEventsReporter.ensureAllEventsConsumed()
+            // Verify analytics calls in order
+            assertThat(captchaEventsReporter.awaitCall())
+                .isEqualTo(FakeCaptchaEventsReporter.Call.Init(TEST_SITE_KEY))
+            assertThat(captchaEventsReporter.awaitCall())
+                .isEqualTo(FakeCaptchaEventsReporter.Call.Execute(TEST_SITE_KEY))
+            assertThat(captchaEventsReporter.awaitCall())
+                .isEqualTo(FakeCaptchaEventsReporter.Call.Success(TEST_SITE_KEY))
+            captchaEventsReporter.ensureAllEventsConsumed()
+        }
     }
 
     @Test
     fun `performPassiveHCaptcha returns failure when HCaptcha fails`() = runTest {
-        val testContext = createTestContext()
-        val exception = HCaptchaException(HCaptchaError.NETWORK_ERROR)
-        val siteKey = "test-site-key"
-        testContext.setupFailedHCaptcha(exception)
+        TestContext.test {
+            val exception = HCaptchaException(HCaptchaError.NETWORK_ERROR)
+            hCaptchaProvider.hCaptchaHandler = SetupFailedHCaptcha(exception)
 
-        val result = testContext.service.performPassiveHCaptcha(
-            testContext.activity,
-            siteKey = siteKey,
-            rqData = null
-        )
+            val result = service.performPassiveHCaptcha(
+                activity,
+                siteKey = TEST_SITE_KEY,
+                rqData = null
+            )
 
-        assertThat(result).isInstanceOf(HCaptchaService.Result.Failure::class.java)
-        assertThat((result as HCaptchaService.Result.Failure).error).isEqualTo(exception)
+            assertThat(result).isInstanceOf(HCaptchaService.Result.Failure::class.java)
+            assertThat((result as HCaptchaService.Result.Failure).error).isEqualTo(exception)
 
-        // Verify analytics calls in order
-        assertThat(testContext.captchaEventsReporter.awaitCall())
-            .isEqualTo(FakeCaptchaEventsReporter.Call.Init(siteKey))
-        assertThat(testContext.captchaEventsReporter.awaitCall())
-            .isEqualTo(FakeCaptchaEventsReporter.Call.Execute(siteKey))
-        assertThat(testContext.captchaEventsReporter.awaitCall())
-            .isEqualTo(FakeCaptchaEventsReporter.Call.Error(exception, siteKey))
-        testContext.captchaEventsReporter.ensureAllEventsConsumed()
+            // Verify analytics calls in order
+            assertThat(captchaEventsReporter.awaitCall())
+                .isEqualTo(FakeCaptchaEventsReporter.Call.Init(TEST_SITE_KEY))
+            assertThat(captchaEventsReporter.awaitCall())
+                .isEqualTo(FakeCaptchaEventsReporter.Call.Execute(TEST_SITE_KEY))
+            assertThat(captchaEventsReporter.awaitCall())
+                .isEqualTo(FakeCaptchaEventsReporter.Call.Error(exception, TEST_SITE_KEY))
+            captchaEventsReporter.ensureAllEventsConsumed()
+        }
     }
 
     @Test
     fun `performPassiveHCaptcha calls reset after successful completion`() = runTest {
-        val testContext = createTestContext()
-        testContext.setupSuccessfulHCaptcha("test-token")
+        TestContext.test {
+            hCaptchaProvider.hCaptchaHandler = SetupSuccessfulHCaptcha()
 
-        testContext.service.performPassiveHCaptcha(
-            testContext.activity,
-            siteKey = "test-site-key",
-            rqData = null
-        )
-
-        verify(testContext.hCaptcha).reset()
+            service.performPassiveHCaptcha(
+                activity,
+                siteKey = TEST_SITE_KEY,
+                rqData = null
+            )
+            verify(hCaptchaProvider.awaitCall()).reset()
+        }
     }
 
     @Test
     fun `performPassiveHCaptcha calls reset after failed completion`() = runTest {
-        val testContext = createTestContext()
-        val exception = HCaptchaException(HCaptchaError.NETWORK_ERROR)
-        testContext.setupFailedHCaptcha(exception)
+        TestContext.test {
+            val exception = HCaptchaException(HCaptchaError.NETWORK_ERROR)
+            hCaptchaProvider.hCaptchaHandler = SetupFailedHCaptcha(exception)
 
-        testContext.service.performPassiveHCaptcha(
-            testContext.activity,
-            siteKey = "test-site-key",
-            rqData = null
-        )
+            service.performPassiveHCaptcha(
+                activity,
+                siteKey = TEST_SITE_KEY,
+                rqData = null
+            )
 
-        verify(testContext.hCaptcha).reset()
+            verify(hCaptchaProvider.awaitCall()).reset()
+        }
     }
 
     @Test
     fun `performPassiveHCaptcha calls reset on coroutine cancellation`() = runTest {
-        val testContext = createTestContext()
-        testContext.setupHangingHCaptcha()
+        TestContext.test {
+            hCaptchaProvider.hCaptchaHandler = SetupHangingHCaptcha
 
-        val job = launch {
-            testContext.service.performPassiveHCaptcha(
-                testContext.activity,
-                siteKey = "test-site-key",
-                rqData = null
-            )
+            val job = launch {
+                service.performPassiveHCaptcha(
+                    activity,
+                    siteKey = TEST_SITE_KEY,
+                    rqData = null
+                )
+            }
+
+            val hCaptcha = hCaptchaProvider.awaitCall()
+            job.cancel()
+            job.join()
+
+            verify(hCaptcha, times(2)).reset()
         }
-
-        testContext.hCaptchaProvider.awaitCall()
-        job.cancel()
-        job.join()
-
-        verify(testContext.hCaptcha, times(2)).reset()
     }
 
     @Test
     fun `performPassiveHCaptcha returns failure when startVerification throws exception`() = runTest {
-        val testContext = createTestContext()
-        val expectedException = RuntimeException("Test exception")
-        val siteKey = "test-site-key"
-        testContext.setupExceptionDuringSetup(expectedException)
+        TestContext.test {
+            val expectedException = RuntimeException("Test exception")
+            hCaptchaProvider.hCaptchaHandler = SetupExceptionDuringSetup(expectedException)
 
-        val result = testContext.service.performPassiveHCaptcha(
-            testContext.activity,
-            siteKey = siteKey,
-            rqData = null
-        )
+            val result = service.performPassiveHCaptcha(
+                activity,
+                siteKey = TEST_SITE_KEY,
+                rqData = null
+            )
 
-        assertThat(result).isInstanceOf(HCaptchaService.Result.Failure::class.java)
-        assertThat((result as HCaptchaService.Result.Failure).error).isEqualTo(expectedException)
-        verify(testContext.hCaptcha).reset()
+            assertThat(result).isInstanceOf(HCaptchaService.Result.Failure::class.java)
+            assertThat((result as HCaptchaService.Result.Failure).error).isEqualTo(expectedException)
+            verify(hCaptchaProvider.awaitCall(), atLeastOnce()).reset()
 
-        // Verify analytics calls - setup failure happens before execute
-        assertThat(testContext.captchaEventsReporter.awaitCall())
-            .isEqualTo(FakeCaptchaEventsReporter.Call.Init(siteKey))
-        assertThat(testContext.captchaEventsReporter.awaitCall())
-            .isEqualTo(FakeCaptchaEventsReporter.Call.Error(expectedException, siteKey))
-        testContext.captchaEventsReporter.ensureAllEventsConsumed()
-    }
-
-    private fun createTestContext(): TestContext {
-        val activity = mock<FragmentActivity>()
-        val hCaptcha = mock<HCaptcha>()
-        val hCaptchaProvider = FakeHCaptchaProvider(hCaptcha)
-        val captchaEventsReporter = FakeCaptchaEventsReporter()
-        val service = DefaultHCaptchaService(hCaptchaProvider, captchaEventsReporter)
-
-        return TestContext(
-            activity = activity,
-            hCaptcha = hCaptcha,
-            captchaEventsReporter = captchaEventsReporter,
-            hCaptchaProvider = hCaptchaProvider,
-            service = service
-        )
-    }
-
-    private fun TestContext.setupHCaptchaChaining() {
-        whenever(hCaptcha.addOnSuccessListener(any())).doReturn(hCaptcha)
-        whenever(hCaptcha.addOnFailureListener(any())).doReturn(hCaptcha)
-        whenever(hCaptcha.setup(any(), any())).doReturn(hCaptcha)
-    }
-
-    private fun TestContext.setupSuccessfulHCaptcha(token: String = "test-token") {
-        setupHCaptchaChaining()
-
-        whenever(hCaptcha.verifyWithHCaptcha(any())).then {
-            val successCaptor = argumentCaptor<OnSuccessListener<HCaptchaTokenResponse>>()
-            verify(hCaptcha).addOnSuccessListener(successCaptor.capture())
-            successCaptor.firstValue.onSuccess(createHCaptchaTokenResponse(token))
-            hCaptcha
+            // Verify analytics calls - setup failure happens before execute
+            assertThat(captchaEventsReporter.awaitCall())
+                .isEqualTo(FakeCaptchaEventsReporter.Call.Init(TEST_SITE_KEY))
+            assertThat(captchaEventsReporter.awaitCall())
+                .isEqualTo(FakeCaptchaEventsReporter.Call.Error(expectedException, TEST_SITE_KEY))
+            captchaEventsReporter.ensureAllEventsConsumed()
         }
     }
 
-    private fun TestContext.setupFailedHCaptcha(exception: HCaptchaException) {
-        setupHCaptchaChaining()
+    @Test
+    fun `warmUp calls hCaptchaProvider and updates cache on success`() = runTest {
+        TestContext.test {
+            val expectedToken = "warm-up-token"
+            hCaptchaProvider.hCaptchaHandler = SetupSuccessfulHCaptcha(expectedToken)
 
-        whenever(hCaptcha.verifyWithHCaptcha(any())).then {
-            val failureCaptor = argumentCaptor<OnFailureListener>()
-            verify(hCaptcha).addOnFailureListener(failureCaptor.capture())
-            failureCaptor.firstValue.onFailure(exception)
-            hCaptcha
+            service.warmUp(
+                activity,
+                siteKey = TEST_SITE_KEY,
+                rqData = TEST_RQ_DATA
+            )
+
+            hCaptchaProvider.awaitCall()
+
+            val result = service.performPassiveHCaptcha(
+                activity,
+                siteKey = TEST_SITE_KEY,
+                rqData = TEST_RQ_DATA
+            )
+            assertThat(result).isInstanceOf(HCaptchaService.Result.Success::class.java)
+            assertThat((result as HCaptchaService.Result.Success).token).isEqualTo(expectedToken)
         }
     }
 
-    private fun TestContext.setupHangingHCaptcha() {
-        setupHCaptchaChaining()
-        whenever(hCaptcha.verifyWithHCaptcha(any())).doReturn(hCaptcha)
+    @Test
+    fun `warmUp updates cache on failure`() = runTest {
+        TestContext.test {
+            val expectedException = HCaptchaException(HCaptchaError.NETWORK_ERROR)
+            hCaptchaProvider.hCaptchaHandler = SetupFailedHCaptcha(expectedException)
+
+            service.warmUp(
+                activity,
+                siteKey = TEST_SITE_KEY,
+                rqData = null
+            )
+
+            hCaptchaProvider.awaitCall()
+
+            val result = service.performPassiveHCaptcha(
+                activity,
+                siteKey = TEST_SITE_KEY,
+                rqData = null
+            )
+
+            assertThat(result).isInstanceOf(HCaptchaService.Result.Failure::class.java)
+            assertThat((result as HCaptchaService.Result.Failure).error).isEqualTo(expectedException)
+        }
     }
 
-    private fun TestContext.setupExceptionDuringSetup(exception: Throwable) {
-        whenever(hCaptcha.addOnSuccessListener(any())).doReturn(hCaptcha)
-        whenever(hCaptcha.addOnFailureListener(any())).doReturn(hCaptcha)
-        whenever(hCaptcha.setup(any(), any())).thenThrow(exception)
+    @Test
+    fun `warmUp skips execution when cache is in Loading state`() = runTest {
+        TestContext.test {
+            hCaptchaProvider.hCaptchaHandler = SetupHangingHCaptcha
+
+            // Start first warmUp that will hang (Loading state)
+            val firstWarmUpJob = launch {
+                service.warmUp(
+                    activity,
+                    siteKey = TEST_SITE_KEY,
+                    rqData = null
+                )
+            }
+
+            val firstHCaptcha = hCaptchaProvider.awaitCall()
+
+            service.warmUp(
+                activity,
+                siteKey = TEST_SITE_KEY,
+                rqData = null
+            )
+
+            hCaptchaProvider.ensureAllEventsConsumed()
+
+            verify(firstHCaptcha).verifyWithHCaptcha(any())
+
+            firstWarmUpJob.cancel()
+            firstWarmUpJob.join()
+        }
     }
 
-    private fun createHCaptchaTokenResponse(token: String): HCaptchaTokenResponse {
-        return HCaptchaTokenResponse(token, mock<Handler>())
+    @Test
+    fun `warmUp skips execution when cache has Success state`() = runTest {
+        TestContext.test {
+            hCaptchaProvider.hCaptchaHandler = SetupSuccessfulHCaptcha()
+
+            service.warmUp(
+                activity,
+                siteKey = TEST_SITE_KEY,
+                rqData = null
+            )
+
+            hCaptchaProvider.awaitCall()
+
+            service.warmUp(
+                activity,
+                siteKey = TEST_SITE_KEY,
+                rqData = null
+            )
+
+            hCaptchaProvider.ensureAllEventsConsumed()
+        }
     }
 
-    private data class TestContext(
+    @Test
+    fun `warmUp allows execution when cache is in Failure state`() = runTest {
+        TestContext.test {
+            val exception = HCaptchaException(HCaptchaError.NETWORK_ERROR)
+            hCaptchaProvider.hCaptchaHandler = SetupFailedHCaptcha(exception)
+
+            service.warmUp(
+                activity,
+                siteKey = TEST_SITE_KEY,
+                rqData = null
+            )
+
+            hCaptchaProvider.awaitCall()
+
+            hCaptchaProvider.hCaptchaHandler = SetupSuccessfulHCaptcha()
+
+            service.warmUp(
+                activity,
+                siteKey = TEST_SITE_KEY,
+                rqData = null
+            )
+
+            val secondHCaptcha = hCaptchaProvider.awaitCall()
+            verify(secondHCaptcha).verifyWithHCaptcha(any())
+        }
+    }
+
+    private object SetupHCaptchaChaining : HCaptchaHandler {
+        override fun handle(hCaptcha: HCaptcha) {
+            whenever(hCaptcha.addOnSuccessListener(any())).doReturn(hCaptcha)
+            whenever(hCaptcha.addOnFailureListener(any())).doReturn(hCaptcha)
+            whenever(hCaptcha.setup(any(), any())).doReturn(hCaptcha)
+        }
+    }
+
+    private class SetupSuccessfulHCaptcha(private val token: String = "token") : HCaptchaHandler {
+        override fun handle(hCaptcha: HCaptcha) {
+            SetupHCaptchaChaining.handle(hCaptcha)
+
+            whenever(hCaptcha.verifyWithHCaptcha(any())).then {
+                val successCaptor = argumentCaptor<OnSuccessListener<HCaptchaTokenResponse>>()
+                verify(hCaptcha).addOnSuccessListener(successCaptor.capture())
+                successCaptor.firstValue.onSuccess(createHCaptchaTokenResponse(token))
+                hCaptcha
+            }
+        }
+
+        private fun createHCaptchaTokenResponse(token: String): HCaptchaTokenResponse {
+            return HCaptchaTokenResponse(token, mock<Handler>())
+        }
+    }
+
+    private object SetupHangingHCaptcha : HCaptchaHandler {
+        override fun handle(hCaptcha: HCaptcha) {
+            SetupHCaptchaChaining.handle(hCaptcha)
+
+            whenever(hCaptcha.verifyWithHCaptcha(any())).doReturn(hCaptcha)
+        }
+    }
+
+    private class SetupExceptionDuringSetup(private val exception: Throwable) : HCaptchaHandler {
+        override fun handle(hCaptcha: HCaptcha) {
+            whenever(hCaptcha.addOnSuccessListener(any())).doReturn(hCaptcha)
+            whenever(hCaptcha.addOnFailureListener(any())).doReturn(hCaptcha)
+            whenever(hCaptcha.setup(any(), any())).thenThrow(exception)
+        }
+    }
+
+    private class SetupFailedHCaptcha(private val exception: HCaptchaException) : HCaptchaHandler {
+        override fun handle(hCaptcha: HCaptcha) {
+            SetupHCaptchaChaining.handle(hCaptcha)
+
+            whenever(hCaptcha.verifyWithHCaptcha(any())).then {
+                val failureCaptor = argumentCaptor<OnFailureListener>()
+                verify(hCaptcha).addOnFailureListener(failureCaptor.capture())
+                failureCaptor.firstValue.onFailure(exception)
+                hCaptcha
+            }
+        }
+    }
+
+    private data class TestContext private constructor(
         val activity: FragmentActivity,
-        val hCaptcha: HCaptcha,
-        val captchaEventsReporter: FakeCaptchaEventsReporter,
         val hCaptchaProvider: FakeHCaptchaProvider,
-        val service: DefaultHCaptchaService
-    )
+        val service: DefaultHCaptchaService,
+        val captchaEventsReporter: FakeCaptchaEventsReporter
+    ) {
+
+        companion object {
+            suspend fun test(
+                activity: FragmentActivity = mock(),
+                hCaptchaProvider: FakeHCaptchaProvider = FakeHCaptchaProvider(),
+                captchaEventsReporter: FakeCaptchaEventsReporter = FakeCaptchaEventsReporter(),
+                service: DefaultHCaptchaService = DefaultHCaptchaService(hCaptchaProvider, captchaEventsReporter),
+                block: suspend TestContext.() -> Unit
+            ) {
+                TestContext(
+                    activity = activity,
+                    hCaptchaProvider = hCaptchaProvider,
+                    service = service,
+                    captchaEventsReporter = captchaEventsReporter
+
+                ).apply { block(this) }
+            }
+        }
+    }
+
+    private class FakeHCaptchaProvider : HCaptchaProvider {
+        var hCaptchaHandler: HCaptchaHandler = HCaptchaHandler {}
+        private val calls = Turbine<HCaptcha>()
+
+        override fun get(): HCaptcha {
+            val hCaptcha = mock<HCaptcha>()
+            hCaptchaHandler.handle(hCaptcha)
+            calls.add(hCaptcha)
+            return hCaptcha
+        }
+
+        suspend fun awaitCall(): HCaptcha {
+            return calls.awaitItem()
+        }
+
+        fun ensureAllEventsConsumed() = calls.ensureAllEventsConsumed()
+
+        fun interface HCaptchaHandler {
+            fun handle(hCaptcha: HCaptcha)
+        }
+    }
 
     private class FakeCaptchaEventsReporter : CaptchaEventsReporter {
         private val calls = Turbine<Call>()
@@ -294,18 +464,8 @@ internal class DefaultHCaptchaServiceTest {
         }
     }
 
-    private class FakeHCaptchaProvider(
-        private val hCaptcha: HCaptcha
-    ) : HCaptchaProvider {
-        private val calls = Turbine<Unit>()
-
-        override fun get(): HCaptcha {
-            calls.add(Unit)
-            return hCaptcha
-        }
-
-        suspend fun awaitCall() {
-            calls.awaitItem()
-        }
+    companion object {
+        private const val TEST_SITE_KEY = "test-site-key"
+        private const val TEST_RQ_DATA = "test-rq-data"
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add warmup function to HCaptchService. This will allow us to start the passive challenge from the product's (PaymentSheet / FlowController / Embedded / Link) entrypoint. This will drastically reduce latency on payment confirmation.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
