### PR TITLE
Revert "Use applicationContext to start passive captcha (#11505)"

### DIFF
--- a/hcaptcha/src/main/java/com/stripe/hcaptcha/HCaptcha.kt
+++ b/hcaptcha/src/main/java/com/stripe/hcaptcha/HCaptcha.kt
@@ -1,8 +1,8 @@
 package com.stripe.hcaptcha
 
-import android.content.Context
 import android.util.AndroidRuntimeException
 import androidx.annotation.RestrictTo
+import androidx.fragment.app.FragmentActivity
 import com.stripe.hcaptcha.config.HCaptchaConfig
 import com.stripe.hcaptcha.config.HCaptchaInternalConfig
 import com.stripe.hcaptcha.config.HCaptchaSize
@@ -48,12 +48,12 @@ interface IHCaptcha {
     /**
      * Constructs a new client which allows to display a challenge dialog
      *
-     * @param context The Context required for starting the challenge
+     * @param activity The FragmentActivity context required for starting the challenge
      * @param config Config to customize: size, theme, locale, endpoint, rqdata, etc.
      * @return new [HCaptcha] object
      */
     fun setup(
-        context: Context,
+        activity: FragmentActivity,
         config: HCaptchaConfig
     ): HCaptcha?
 
@@ -61,10 +61,10 @@ interface IHCaptcha {
      * Presents a captcha challenge. Depending on the configuration passed in setup, this will be either a passive
      * challenge or a dialog to be completed by the user.
      *
-     * @param context The Context required for starting the challenge
+     * @param activity The FragmentActivity context required for starting the challenge
      * @return [HCaptcha]
      */
-    fun verifyWithHCaptcha(context: Context): HCaptcha
+    fun verifyWithHCaptcha(activity: FragmentActivity): HCaptcha?
 
     /**
      * Force stop verification and release resources.
@@ -78,7 +78,7 @@ class HCaptcha private constructor(
 ) : Task<HCaptchaTokenResponse>(), IHCaptcha {
     private var captchaVerifier: IHCaptchaVerifier? = null
 
-    override fun setup(context: Context, config: HCaptchaConfig): HCaptcha {
+    override fun setup(activity: FragmentActivity, config: HCaptchaConfig): HCaptcha {
         val listener = HCaptchaStateListener(
             onOpen = { captchaOpened() },
             onSuccess = { token ->
@@ -92,7 +92,7 @@ class HCaptcha private constructor(
             captchaVerifier = if (config.hideDialog) {
                 // Overwrite certain config values in case the dialog is hidden to avoid behavior collision
                 HCaptchaHeadlessWebView(
-                    context = context,
+                    activity = activity,
                     config = config.copy(size = HCaptchaSize.INVISIBLE, loading = false),
                     internalConfig = internalConfig,
                     listener = listener
@@ -106,12 +106,12 @@ class HCaptcha private constructor(
         return this
     }
 
-    override fun verifyWithHCaptcha(context: Context): HCaptcha {
+    override fun verifyWithHCaptcha(activity: FragmentActivity): HCaptcha? {
         val captchaVerifier = captchaVerifier
             ?: // Cold start at verification time.
             throw IllegalStateException("verifyWithHCaptcha must not be called before setup.")
         handler.removeCallbacksAndMessages(null)
-        captchaVerifier.startVerification(context)
+        captchaVerifier.startVerification(activity)
         return this
     }
 

--- a/hcaptcha/src/main/java/com/stripe/hcaptcha/HCaptchaDialogFragment.kt
+++ b/hcaptcha/src/main/java/com/stripe/hcaptcha/HCaptchaDialogFragment.kt
@@ -2,7 +2,6 @@ package com.stripe.hcaptcha
 
 import android.animation.Animator
 import android.animation.AnimatorListenerAdapter
-import android.content.Context
 import android.content.DialogInterface
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
@@ -204,8 +203,8 @@ class HCaptchaDialogFragment : DialogFragment(), IHCaptchaVerifier {
         webViewHelper?.listener?.onSuccess?.let { it(result) }
     }
 
-    override fun startVerification(context: Context) {
-        val fragmentManager = (context as? FragmentActivity)?.supportFragmentManager ?: return
+    override fun startVerification(activity: FragmentActivity) {
+        val fragmentManager = activity.supportFragmentManager
         val oldFragment = fragmentManager.findFragmentByTag(TAG)
 
         if (oldFragment?.isAdded == true) {

--- a/hcaptcha/src/main/java/com/stripe/hcaptcha/IHCaptchaVerifier.kt
+++ b/hcaptcha/src/main/java/com/stripe/hcaptcha/IHCaptchaVerifier.kt
@@ -1,7 +1,7 @@
 package com.stripe.hcaptcha
 
-import android.content.Context
 import androidx.annotation.RestrictTo
+import androidx.fragment.app.FragmentActivity
 import com.stripe.hcaptcha.task.OnFailureListener
 import com.stripe.hcaptcha.task.OnLoadedListener
 import com.stripe.hcaptcha.task.OnOpenListener
@@ -12,7 +12,7 @@ internal interface IHCaptchaVerifier : OnLoadedListener, OnOpenListener, OnSucce
     /**
      * Starts the human verification process.
      */
-    fun startVerification(context: Context)
+    fun startVerification(activity: FragmentActivity)
 
     /**
      * Force stop verification and release resources.

--- a/hcaptcha/src/main/java/com/stripe/hcaptcha/webview/HCaptchaHeadlessWebView.kt
+++ b/hcaptcha/src/main/java/com/stripe/hcaptcha/webview/HCaptchaHeadlessWebView.kt
@@ -1,12 +1,13 @@
 package com.stripe.hcaptcha.webview
 
-import android.content.Context
+import android.app.Activity
 import android.os.Handler
 import android.os.Looper
 import android.view.View
 import android.view.ViewGroup
 import android.webkit.WebView
 import androidx.annotation.RestrictTo
+import androidx.fragment.app.FragmentActivity
 import com.stripe.hcaptcha.HCaptchaException
 import com.stripe.hcaptcha.HCaptchaStateListener
 import com.stripe.hcaptcha.IHCaptchaVerifier
@@ -16,7 +17,7 @@ import com.stripe.hcaptcha.config.HCaptchaInternalConfig
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 internal class HCaptchaHeadlessWebView(
-    context: Context,
+    activity: Activity,
     config: HCaptchaConfig,
     internalConfig: HCaptchaInternalConfig,
     private val listener: HCaptchaStateListener
@@ -27,13 +28,18 @@ internal class HCaptchaHeadlessWebView(
     private var shouldResetOnLoad = false
 
     init {
-        val webView: WebView = HCaptchaWebView(context)
+        val webView: WebView = HCaptchaWebView(activity)
         webView.id = R.id.webView
         webView.visibility = View.GONE
 
+        if (webView.parent == null) {
+            val rootView = activity.window.decorView.rootView as ViewGroup
+            rootView.addView(webView)
+        }
+
         webViewHelper = HCaptchaWebViewHelper(
             Handler(Looper.getMainLooper()),
-            context,
+            activity,
             config,
             internalConfig,
             this,
@@ -42,7 +48,7 @@ internal class HCaptchaHeadlessWebView(
         )
     }
 
-    override fun startVerification(context: Context) {
+    override fun startVerification(activity: FragmentActivity) {
         if (webViewLoaded) {
             // Safe to execute
             webViewHelper.resetAndExecute()

--- a/payments-core/src/main/java/com/stripe/android/challenge/PassiveChallengeActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/challenge/PassiveChallengeActivity.kt
@@ -30,7 +30,7 @@ internal class PassiveChallengeActivity : AppCompatActivity() {
         }
 
         lifecycleScope.launch {
-            viewModel.startPassiveChallenge()
+            viewModel.startPassiveChallenge(this@PassiveChallengeActivity)
         }
     }
 

--- a/payments-core/src/main/java/com/stripe/android/challenge/PassiveChallengeViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/challenge/PassiveChallengeViewModel.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.challenge
 
 import android.app.Application
-import android.content.Context
+import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.APPLICATION_KEY
 import androidx.lifecycle.createSavedStateHandle
@@ -15,16 +15,15 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import javax.inject.Inject
 
 internal class PassiveChallengeViewModel @Inject constructor(
-    private val context: Context,
     private val passiveCaptchaParams: PassiveCaptchaParams,
     private val hCaptchaService: HCaptchaService
 ) : ViewModel() {
     private val _result = MutableSharedFlow<PassiveChallengeActivityResult>(replay = 1)
     val result: Flow<PassiveChallengeActivityResult> = _result
 
-    suspend fun startPassiveChallenge() {
+    suspend fun startPassiveChallenge(activity: FragmentActivity) {
         val result = hCaptchaService.performPassiveHCaptcha(
-            context = context,
+            activity = activity,
             siteKey = passiveCaptchaParams.siteKey,
             rqData = passiveCaptchaParams.rqData
         )

--- a/payments-core/src/main/java/com/stripe/android/hcaptcha/DefaultHCaptchaService.kt
+++ b/payments-core/src/main/java/com/stripe/android/hcaptcha/DefaultHCaptchaService.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.hcaptcha
 
-import android.content.Context
+import androidx.fragment.app.FragmentActivity
 import com.stripe.android.hcaptcha.analytics.CaptchaEventsReporter
 import com.stripe.hcaptcha.HCaptcha
 import com.stripe.hcaptcha.HCaptchaError
@@ -18,7 +18,7 @@ internal class DefaultHCaptchaService(
     private val captchaEventsReporter: CaptchaEventsReporter
 ) : HCaptchaService {
     override suspend fun performPassiveHCaptcha(
-        context: Context,
+        activity: FragmentActivity,
         siteKey: String,
         rqData: String?
     ): HCaptchaService.Result {
@@ -26,7 +26,7 @@ internal class DefaultHCaptchaService(
         captchaEventsReporter.init(siteKey)
         val result = runCatching {
             startVerification(
-                context = context,
+                activity = activity,
                 siteKey = siteKey,
                 rqData = rqData,
                 hCaptcha = hCaptcha
@@ -47,7 +47,7 @@ internal class DefaultHCaptchaService(
     }
 
     private suspend fun startVerification(
-        context: Context,
+        activity: FragmentActivity,
         siteKey: String,
         rqData: String?,
         hCaptcha: HCaptcha
@@ -77,7 +77,7 @@ internal class DefaultHCaptchaService(
                 retryPredicate = { _, exception -> exception.hCaptchaError == HCaptchaError.SESSION_TIMEOUT }
             )
 
-            hCaptcha.setup(context, config).verifyWithHCaptcha(context)
+            hCaptcha.setup(activity, config).verifyWithHCaptcha(activity)
             captchaEventsReporter.execute(siteKey)
         }
     }

--- a/payments-core/src/main/java/com/stripe/android/hcaptcha/HCaptchaService.kt
+++ b/payments-core/src/main/java/com/stripe/android/hcaptcha/HCaptchaService.kt
@@ -1,12 +1,12 @@
 package com.stripe.android.hcaptcha
 
-import android.content.Context
 import androidx.annotation.RestrictTo
+import androidx.fragment.app.FragmentActivity
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 interface HCaptchaService {
     suspend fun performPassiveHCaptcha(
-        context: Context,
+        activity: FragmentActivity,
         siteKey: String,
         rqData: String?
     ): Result

--- a/payments-core/src/test/java/com/stripe/android/challenge/FakeHCaptchaService.kt
+++ b/payments-core/src/test/java/com/stripe/android/challenge/FakeHCaptchaService.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.challenge
 
-import android.content.Context
+import androidx.fragment.app.FragmentActivity
 import app.cash.turbine.Turbine
 import com.stripe.android.hcaptcha.HCaptchaService
 
@@ -9,11 +9,11 @@ internal class FakeHCaptchaService : HCaptchaService {
     private val calls = Turbine<Call>()
 
     override suspend fun performPassiveHCaptcha(
-        context: Context,
+        activity: FragmentActivity,
         siteKey: String,
         rqData: String?
     ): HCaptchaService.Result {
-        calls.add(Call(context, siteKey, rqData))
+        calls.add(Call(activity, siteKey, rqData))
         return result ?: HCaptchaService.Result.Success("default_token")
     }
 
@@ -22,7 +22,7 @@ internal class FakeHCaptchaService : HCaptchaService {
     }
 
     data class Call(
-        val context: Context,
+        val activity: FragmentActivity,
         val siteKey: String,
         val rqData: String?
     )

--- a/payments-core/src/test/java/com/stripe/android/challenge/PassiveChallengeActivityTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/challenge/PassiveChallengeActivityTest.kt
@@ -130,16 +130,14 @@ internal class PassiveChallengeActivityTest {
     }
 
     private fun createTestViewModelFactory(
-        hCaptchaService: HCaptchaService = FakeHCaptchaService(),
-        context: Context = ApplicationProvider.getApplicationContext()
+        hCaptchaService: HCaptchaService = FakeHCaptchaService()
     ): ViewModelProvider.Factory {
         return object : ViewModelProvider.Factory {
             @Suppress("UNCHECKED_CAST")
             override fun <T : ViewModel> create(modelClass: Class<T>): T {
                 return PassiveChallengeViewModel(
                     passiveCaptchaParams = passiveCaptchaParams,
-                    hCaptchaService = hCaptchaService,
-                    context = context
+                    hCaptchaService = hCaptchaService
                 ) as T
             }
         }

--- a/payments-core/src/test/java/com/stripe/android/challenge/PassiveChallengeViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/challenge/PassiveChallengeViewModelTest.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.challenge
 
-import android.content.Context
-import androidx.test.core.app.ApplicationProvider
+import androidx.fragment.app.FragmentActivity
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.hcaptcha.HCaptchaService
@@ -21,6 +20,7 @@ internal class PassiveChallengeViewModelTest {
     val coroutineTestRule = CoroutineTestRule()
 
     private val fakeHCaptchaService = FakeHCaptchaService()
+    private val fakeActivity = object : FragmentActivity() {}
 
     private val testPassiveCaptchaParams = PassiveCaptchaParams(
         siteKey = "test_site_key",
@@ -34,7 +34,7 @@ internal class PassiveChallengeViewModelTest {
 
         val viewModel = createViewModel()
 
-        viewModel.startPassiveChallenge()
+        viewModel.startPassiveChallenge(fakeActivity)
 
         viewModel.result.test {
             val result = awaitItem()
@@ -53,7 +53,7 @@ internal class PassiveChallengeViewModelTest {
 
         val viewModel = createViewModel()
 
-        viewModel.startPassiveChallenge()
+        viewModel.startPassiveChallenge(fakeActivity)
 
         viewModel.result.test {
             val result = awaitItem()
@@ -69,28 +69,25 @@ internal class PassiveChallengeViewModelTest {
     fun `startPassiveChallenge should pass correct parameters to HCaptchaService`() = runTest {
         val hCaptchaService = FakeHCaptchaService()
         hCaptchaService.result = HCaptchaService.Result.Success("token")
-        val context: Context = ApplicationProvider.getApplicationContext()
 
         val viewModel = createViewModel(
             passiveCaptchaParams = testPassiveCaptchaParams,
             hCaptchaService = hCaptchaService
         )
 
-        viewModel.startPassiveChallenge()
+        viewModel.startPassiveChallenge(fakeActivity)
 
         val passiveCaptcha = hCaptchaService.awaitCall()
         assertThat(passiveCaptcha.siteKey).isEqualTo(passiveCaptcha.siteKey)
         assertThat(passiveCaptcha.rqData).isEqualTo(passiveCaptcha.rqData)
-        assertThat(passiveCaptcha.context).isEqualTo(context)
+        assertThat(passiveCaptcha.activity).isEqualTo(fakeActivity)
     }
 
     private fun createViewModel(
         passiveCaptchaParams: PassiveCaptchaParams = testPassiveCaptchaParams,
-        hCaptchaService: HCaptchaService = fakeHCaptchaService,
-        context: Context = ApplicationProvider.getApplicationContext()
+        hCaptchaService: HCaptchaService = fakeHCaptchaService
     ) = PassiveChallengeViewModel(
         passiveCaptchaParams = passiveCaptchaParams,
-        hCaptchaService = hCaptchaService,
-        context = context
+        hCaptchaService = hCaptchaService
     )
 }


### PR DESCRIPTION
This reverts commit a82382dd2021b5df9d1a1cf5831b2830cacb212d.

# Summary
<!-- Simple summary of what was changed. -->

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
This makes RadarSessionTest flaky. HCaptcha.onLoaded is not called consistently.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
