### PR TITLE
Update captcha analytics

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/hcaptcha/DefaultHCaptchaService.kt
+++ b/payments-core/src/main/java/com/stripe/android/hcaptcha/DefaultHCaptchaService.kt
@@ -63,7 +63,6 @@ internal class DefaultHCaptchaService(
                 captchaEventsReporter.success(siteKey, resultImmediatelyAvailable, duration)
             }
         }
-        cachedResult.emit(CachedResult.Idle)
         return result
     }
 

--- a/payments-core/src/main/java/com/stripe/android/hcaptcha/HCaptchaModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/hcaptcha/HCaptchaModule.kt
@@ -24,10 +24,11 @@ object HCaptchaModule {
     @Provides
     fun provideHCaptchaService(
         hCaptchaProvider: HCaptchaProvider,
-        captchaEventsReporter: CaptchaEventsReporter
+        captchaEventsReporter: CaptchaEventsReporter,
+        durationProvider: DurationProvider
     ): HCaptchaService {
         return hCaptchaService ?: synchronized(this) {
-            hCaptchaService ?: DefaultHCaptchaService(hCaptchaProvider, captchaEventsReporter)
+            hCaptchaService ?: DefaultHCaptchaService(hCaptchaProvider, captchaEventsReporter, durationProvider)
                 .also { hCaptchaService = it }
         }
     }
@@ -36,13 +37,11 @@ object HCaptchaModule {
     internal fun provideChallengeEventsReporter(
         analyticsRequestExecutor: AnalyticsRequestExecutor,
         analyticsRequestFactory: AnalyticsRequestFactory,
-        durationProvider: DurationProvider,
         errorReporter: ErrorReporter
     ): CaptchaEventsReporter {
         return DefaultCaptchaEventsReporter(
             analyticsRequestExecutor,
             analyticsRequestFactory,
-            durationProvider,
             errorReporter
         )
     }

--- a/payments-core/src/main/java/com/stripe/android/hcaptcha/analytics/CaptchaAnalyticsEvent.kt
+++ b/payments-core/src/main/java/com/stripe/android/hcaptcha/analytics/CaptchaAnalyticsEvent.kt
@@ -15,18 +15,27 @@ internal sealed interface CaptchaAnalyticsEvent : AnalyticsEvent {
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     class Error(
         error: Throwable?,
+        resultImmediatelyAvailable: Boolean,
         override val siteKey: String
     ) : CaptchaAnalyticsEvent {
         override val eventName = "elements.captcha.passive.error"
 
         override val additionalParams = mapOf(
-            FIELD_ERROR_MESSAGE to error?.message
+            FIELD_ERROR_MESSAGE to error?.message,
+            FIELD_RESULT_IMMEDIATELY_AVAILABLE to resultImmediatelyAvailable
         )
     }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    class Success(override val siteKey: String) : CaptchaAnalyticsEvent {
+    class Success(
+        resultImmediatelyAvailable: Boolean,
+        override val siteKey: String,
+    ) : CaptchaAnalyticsEvent {
         override val eventName = "elements.captcha.passive.success"
+
+        override val additionalParams = mapOf(
+            FIELD_RESULT_IMMEDIATELY_AVAILABLE to resultImmediatelyAvailable
+        )
     }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -42,5 +51,6 @@ internal sealed interface CaptchaAnalyticsEvent : AnalyticsEvent {
     companion object {
         internal const val FIELD_ERROR_MESSAGE = "error_message"
         internal const val FIELD_SITE_KEY = "site_key"
+        internal const val FIELD_RESULT_IMMEDIATELY_AVAILABLE = "result_immediately_available"
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/hcaptcha/analytics/CaptchaEventsReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/hcaptcha/analytics/CaptchaEventsReporter.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.hcaptcha.analytics
 
 import androidx.annotation.RestrictTo
+import kotlin.time.Duration
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 interface CaptchaEventsReporter {
@@ -8,7 +9,16 @@ interface CaptchaEventsReporter {
 
     fun execute(siteKey: String)
 
-    fun success(siteKey: String)
+    fun success(
+        siteKey: String,
+        resultImmediatelyAvailable: Boolean,
+        duration: Duration?
+    )
 
-    fun error(error: Throwable?, siteKey: String)
+    fun error(
+        error: Throwable?,
+        siteKey: String,
+        resultImmediatelyAvailable: Boolean,
+        duration: Duration?
+    )
 }

--- a/payments-core/src/test/java/com/stripe/android/hcaptcha/DefaultHCaptchaServiceTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/hcaptcha/DefaultHCaptchaServiceTest.kt
@@ -164,45 +164,6 @@ internal class DefaultHCaptchaServiceTest {
     }
 
     @Test
-    fun `performPassiveHCaptcha resets cache after completion`() = runTest {
-        TestContext.test {
-            // First, warm up the cache with a successful result
-            val warmUpToken = "warm-up-token"
-            hCaptchaProvider.hCaptchaHandler = SetupSuccessfulHCaptcha(warmUpToken)
-            
-            service.warmUp(
-                activity,
-                siteKey = TEST_SITE_KEY,
-                rqData = null
-            )
-            
-            val firstCall = hCaptchaProvider.awaitCall()
-            
-            // Verify warmUp populated the cache by checking performPassiveHCaptcha returns cached result
-            val cachedResult = service.performPassiveHCaptcha(
-                activity,
-                siteKey = TEST_SITE_KEY,
-                rqData = null
-            )
-            assertThat(cachedResult).isInstanceOf(HCaptchaService.Result.Success::class.java)
-            assertThat((cachedResult as HCaptchaService.Result.Success).token).isEqualTo(warmUpToken)
-            
-            // Verify the cache was reset after performPassiveHCaptcha by checking warmUp can execute again
-            val newToken = "new-warm-up-token"
-            hCaptchaProvider.hCaptchaHandler = SetupSuccessfulHCaptcha(newToken)
-            
-            service.warmUp(
-                activity,
-                siteKey = TEST_SITE_KEY,
-                rqData = null
-            )
-            
-            val secondCall = hCaptchaProvider.awaitCall()
-            verify(secondCall).verifyWithHCaptcha(any())
-        }
-    }
-
-    @Test
     fun `performPassiveHCaptcha calls reset on coroutine cancellation`() = runTest {
         TestContext.test {
             hCaptchaProvider.hCaptchaHandler = SetupHangingHCaptcha

--- a/payments-core/src/test/java/com/stripe/android/hcaptcha/analytics/DefaultCaptchaEventsReporterTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/hcaptcha/analytics/DefaultCaptchaEventsReporterTest.kt
@@ -2,7 +2,6 @@ package com.stripe.android.hcaptcha.analytics
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.networking.AnalyticsRequestFactory
-import com.stripe.android.core.utils.DefaultDurationProvider
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.testing.FakeAnalyticsRequestExecutor
 import com.stripe.android.testing.FakeErrorReporter
@@ -13,6 +12,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.shadows.ShadowSystemClock
 import java.util.concurrent.TimeUnit
+import kotlin.time.Duration
 
 @RunWith(RobolectricTestRunner::class)
 internal class DefaultCaptchaEventsReporterTest {
@@ -46,20 +46,29 @@ internal class DefaultCaptchaEventsReporterTest {
         defaultChallengeEventsReporter.init(SITE_KEY)
         ShadowSystemClock.advanceBy(15, TimeUnit.SECONDS)
 
-        defaultChallengeEventsReporter.success(SITE_KEY)
+        defaultChallengeEventsReporter.success(
+            SITE_KEY,
+            resultImmediatelyAvailable = false,
+            duration = Duration.parse("15s")
+        )
 
         val loggedRequests = fakeAnalyticsRequestExecutor.getExecutedRequests()
 
         assertThat(loggedRequests).hasSize(2)
         val loggedParams = loggedRequests.last().params
         assertThat(loggedParams["event"]).isEqualTo("elements.captcha.passive.success")
-        assertThat(loggedParams["duration"]).isEqualTo(15f)
+        assertThat(loggedParams["duration"]).isEqualTo(15000f)
         assertThat(loggedParams["site_key"]).isEqualTo(SITE_KEY)
+        assertThat(loggedParams["result_immediately_available"]).isEqualTo(false)
     }
 
     @Test
     fun testSuccessWithoutInit() = runScenario { defaultChallengeEventsReporter, fakeAnalyticsRequestExecutor, _ ->
-        defaultChallengeEventsReporter.success(SITE_KEY)
+        defaultChallengeEventsReporter.success(
+            SITE_KEY,
+            resultImmediatelyAvailable = false,
+            duration = null
+        )
 
         val loggedRequests = fakeAnalyticsRequestExecutor.getExecutedRequests()
 
@@ -67,6 +76,7 @@ internal class DefaultCaptchaEventsReporterTest {
         val loggedParams = loggedRequests.first().params
         assertThat(loggedParams["event"]).isEqualTo("elements.captcha.passive.success")
         assertThat(loggedParams["site_key"]).isEqualTo(SITE_KEY)
+        assertThat(loggedParams["result_immediately_available"]).isEqualTo(false)
         assertThat(loggedParams).doesNotContainKey("duration")
     }
 
@@ -75,16 +85,22 @@ internal class DefaultCaptchaEventsReporterTest {
         defaultChallengeEventsReporter.init(SITE_KEY)
         ShadowSystemClock.advanceBy(11, TimeUnit.SECONDS)
 
-        defaultChallengeEventsReporter.error(Throwable("test error"), SITE_KEY)
+        defaultChallengeEventsReporter.error(
+            Throwable("test error"),
+            SITE_KEY,
+            resultImmediatelyAvailable = false,
+            duration = Duration.parse("11s")
+        )
 
         val loggedRequests = fakeAnalyticsRequestExecutor.getExecutedRequests()
 
         assertThat(loggedRequests).hasSize(2)
         val loggedParams = loggedRequests.last().params
         assertThat(loggedParams["event"]).isEqualTo("elements.captcha.passive.error")
-        assertThat(loggedParams["duration"]).isEqualTo(11f)
+        assertThat(loggedParams["duration"]).isEqualTo(11000f)
         assertThat(loggedParams["error_message"]).isEqualTo("test error")
         assertThat(loggedParams["site_key"]).isEqualTo(SITE_KEY)
+        assertThat(loggedParams["result_immediately_available"]).isEqualTo(false)
 
         // Verify unexpected error was reported
         assertThat(fakeErrorReporter.getLoggedErrors())
@@ -97,16 +113,22 @@ internal class DefaultCaptchaEventsReporterTest {
             defaultChallengeEventsReporter.init(SITE_KEY)
             ShadowSystemClock.advanceBy(8, TimeUnit.SECONDS)
 
-            defaultChallengeEventsReporter.error(null, SITE_KEY)
+            defaultChallengeEventsReporter.error(
+                null,
+                SITE_KEY,
+                resultImmediatelyAvailable = false,
+                duration = Duration.parse("8s")
+            )
 
             val loggedRequests = fakeAnalyticsRequestExecutor.getExecutedRequests()
 
             assertThat(loggedRequests).hasSize(2)
             val loggedParams = loggedRequests.last().params
             assertThat(loggedParams["event"]).isEqualTo("elements.captcha.passive.error")
-            assertThat(loggedParams["duration"]).isEqualTo(8f)
+            assertThat(loggedParams["duration"]).isEqualTo(8000f)
             assertThat(loggedParams["error_message"]).isNull()
             assertThat(loggedParams["site_key"]).isEqualTo(SITE_KEY)
+            assertThat(loggedParams["result_immediately_available"]).isEqualTo(false)
 
             // Verify unexpected error was reported for null error
             assertThat(fakeErrorReporter.getLoggedErrors())
@@ -116,7 +138,12 @@ internal class DefaultCaptchaEventsReporterTest {
     @Test
     fun testErrorWithoutInit() =
         runScenario { defaultChallengeEventsReporter, fakeAnalyticsRequestExecutor, fakeErrorReporter ->
-            defaultChallengeEventsReporter.error(Throwable("test error"), SITE_KEY)
+            defaultChallengeEventsReporter.error(
+                Throwable("test error"),
+                SITE_KEY,
+                resultImmediatelyAvailable = false,
+                duration = Duration.ZERO
+            )
 
             val loggedRequests = fakeAnalyticsRequestExecutor.getExecutedRequests()
 
@@ -125,6 +152,7 @@ internal class DefaultCaptchaEventsReporterTest {
             assertThat(loggedParams["event"]).isEqualTo("elements.captcha.passive.error")
             assertThat(loggedParams["error_message"]).isEqualTo("test error")
             assertThat(loggedParams["site_key"]).isEqualTo(SITE_KEY)
+            assertThat(loggedParams["result_immediately_available"]).isEqualTo(false)
             assertThat(loggedParams["duration"]).isEqualTo(0f)
 
             // Verify unexpected error was reported
@@ -139,16 +167,22 @@ internal class DefaultCaptchaEventsReporterTest {
             ShadowSystemClock.advanceBy(12, TimeUnit.SECONDS)
 
             val hCaptchaException = HCaptchaException(HCaptchaError.NETWORK_ERROR, "Network error")
-            defaultChallengeEventsReporter.error(hCaptchaException, SITE_KEY)
+            defaultChallengeEventsReporter.error(
+                hCaptchaException,
+                SITE_KEY,
+                resultImmediatelyAvailable = false,
+                duration = Duration.parse("12s")
+            )
 
             val loggedRequests = fakeAnalyticsRequestExecutor.getExecutedRequests()
 
             assertThat(loggedRequests).hasSize(2)
             val loggedParams = loggedRequests.last().params
             assertThat(loggedParams["event"]).isEqualTo("elements.captcha.passive.error")
-            assertThat(loggedParams["duration"]).isEqualTo(12f)
+            assertThat(loggedParams["duration"]).isEqualTo(12000f)
             assertThat(loggedParams["error_message"]).isEqualTo("Network error")
             assertThat(loggedParams["site_key"]).isEqualTo(SITE_KEY)
+            assertThat(loggedParams["result_immediately_available"]).isEqualTo(false)
 
             // Verify expected error was reported for HCaptchaException
             assertThat(fakeErrorReporter.getLoggedErrors())
@@ -170,7 +204,6 @@ internal class DefaultCaptchaEventsReporterTest {
                 networkTypeProvider = { "" },
                 pluginTypeProvider = { null }
             ),
-            durationProvider = DefaultDurationProvider.instance,
             errorReporter = fakeErrorReporter
         )
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This change
* adds a `result_immediately_available` field to success/error events
* Moves duration to DefaultHCaptchaService because we don't log analytic when a success/error event happens (might be during pre-fetch), but only when the result is requested.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
