### PR TITLE
Allow direct control over wallet visibility in MPE & wallet buttons.

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/WalletButtonsSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/WalletButtonsSettingsDefinition.kt
@@ -54,35 +54,74 @@ internal object WalletButtonsSettingsDefinition :
         value: WalletButtonsPlaygroundType,
         configurationBuilder: PaymentSheet.Configuration.Builder,
     ) {
-        val configuration = when (value) {
-            WalletButtonsPlaygroundType.Disabled -> {
-                PaymentSheet.WalletButtonsConfiguration(
-                    willDisplayExternally = false
-                )
-            }
-            WalletButtonsPlaygroundType.Enabled -> {
-                PaymentSheet.WalletButtonsConfiguration(
-                    willDisplayExternally = true
-                )
-            }
-            WalletButtonsPlaygroundType.EnabledWithOnlyLink -> {
-                PaymentSheet.WalletButtonsConfiguration(
-                    willDisplayExternally = true,
-                    walletsToShow = listOf("link")
-                )
-            }
-        }
-
-        configurationBuilder.walletButtons(configuration)
+        configurationBuilder.walletButtons(value.configuration)
     }
 }
 
 enum class WalletButtonsPlaygroundType(
-    val displayName: String
+    val displayName: String,
+    val configuration: PaymentSheet.WalletButtonsConfiguration,
 ) : ValueEnum {
-    Disabled("Disabled"),
-    Enabled("Enabled"),
-    EnabledWithOnlyLink("Enabled w/ only Link");
+    Disabled(
+        displayName = "Disabled",
+        configuration = PaymentSheet.WalletButtonsConfiguration(
+            willDisplayExternally = false,
+        ),
+    ),
+    Automatic(
+        displayName = "Automatic",
+        configuration = PaymentSheet.WalletButtonsConfiguration(
+            willDisplayExternally = true,
+        ),
+    ),
+    Both(
+        displayName = "Always in MPE & Wallets",
+        configuration = PaymentSheet.WalletButtonsConfiguration(
+            willDisplayExternally = true,
+            visibility = PaymentSheet.WalletButtonsConfiguration.Visibility(
+                paymentElement = mapOf(
+                    PaymentSheet.WalletButtonsConfiguration.Wallet.GooglePay to
+                        PaymentSheet.WalletButtonsConfiguration.PaymentElementVisibility.Always,
+                    PaymentSheet.WalletButtonsConfiguration.Wallet.Link to
+                        PaymentSheet.WalletButtonsConfiguration.PaymentElementVisibility.Always,
+                    PaymentSheet.WalletButtonsConfiguration.Wallet.ShopPay to
+                        PaymentSheet.WalletButtonsConfiguration.PaymentElementVisibility.Always,
+                ),
+                walletButtonsView = mapOf(
+                    PaymentSheet.WalletButtonsConfiguration.Wallet.GooglePay to
+                        PaymentSheet.WalletButtonsConfiguration.WalletButtonsViewVisibility.Always,
+                    PaymentSheet.WalletButtonsConfiguration.Wallet.Link to
+                        PaymentSheet.WalletButtonsConfiguration.WalletButtonsViewVisibility.Always,
+                    PaymentSheet.WalletButtonsConfiguration.Wallet.ShopPay to
+                        PaymentSheet.WalletButtonsConfiguration.WalletButtonsViewVisibility.Always,
+                ),
+            )
+        ),
+    ),
+    GPayAlwaysLinkAutoNeverShopPayAuto(
+        displayName = "Google Pay (Always), Link (Never in Wallets, Auto in MPE), Shop Pay (Automatic)",
+        configuration = PaymentSheet.WalletButtonsConfiguration(
+            willDisplayExternally = true,
+            visibility = PaymentSheet.WalletButtonsConfiguration.Visibility(
+                paymentElement = mapOf(
+                    PaymentSheet.WalletButtonsConfiguration.Wallet.GooglePay to
+                        PaymentSheet.WalletButtonsConfiguration.PaymentElementVisibility.Always,
+                    PaymentSheet.WalletButtonsConfiguration.Wallet.Link to
+                        PaymentSheet.WalletButtonsConfiguration.PaymentElementVisibility.Automatic,
+                    PaymentSheet.WalletButtonsConfiguration.Wallet.ShopPay to
+                        PaymentSheet.WalletButtonsConfiguration.PaymentElementVisibility.Automatic,
+                ),
+                walletButtonsView = mapOf(
+                    PaymentSheet.WalletButtonsConfiguration.Wallet.GooglePay to
+                        PaymentSheet.WalletButtonsConfiguration.WalletButtonsViewVisibility.Always,
+                    PaymentSheet.WalletButtonsConfiguration.Wallet.Link to
+                        PaymentSheet.WalletButtonsConfiguration.WalletButtonsViewVisibility.Never,
+                    PaymentSheet.WalletButtonsConfiguration.Wallet.ShopPay to
+                        PaymentSheet.WalletButtonsConfiguration.WalletButtonsViewVisibility.Always,
+                ),
+            )
+        ),
+    );
 
     override val value: String
         get() = name

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -3037,12 +3037,12 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$WalletButtonsCon
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> ()V
-	public fun <init> (ZLjava/util/List;Lcom/stripe/android/paymentsheet/PaymentSheet$ButtonThemes;)V
-	public synthetic fun <init> (ZLjava/util/List;Lcom/stripe/android/paymentsheet/PaymentSheet$ButtonThemes;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZLcom/stripe/android/paymentsheet/PaymentSheet$WalletButtonsConfiguration$Visibility;Lcom/stripe/android/paymentsheet/PaymentSheet$ButtonThemes;)V
+	public synthetic fun <init> (ZLcom/stripe/android/paymentsheet/PaymentSheet$WalletButtonsConfiguration$Visibility;Lcom/stripe/android/paymentsheet/PaymentSheet$ButtonThemes;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getButtonThemes ()Lcom/stripe/android/paymentsheet/PaymentSheet$ButtonThemes;
-	public final fun getWalletsToShow ()Ljava/util/List;
+	public final fun getVisibility ()Lcom/stripe/android/paymentsheet/PaymentSheet$WalletButtonsConfiguration$Visibility;
 	public final fun getWillDisplayExternally ()Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -3055,6 +3055,55 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$WalletButtonsCon
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentSheet$WalletButtonsConfiguration;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/PaymentSheet$WalletButtonsConfiguration$PaymentElementVisibility : java/lang/Enum {
+	public static final field Always Lcom/stripe/android/paymentsheet/PaymentSheet$WalletButtonsConfiguration$PaymentElementVisibility;
+	public static final field Automatic Lcom/stripe/android/paymentsheet/PaymentSheet$WalletButtonsConfiguration$PaymentElementVisibility;
+	public static final field Never Lcom/stripe/android/paymentsheet/PaymentSheet$WalletButtonsConfiguration$PaymentElementVisibility;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentSheet$WalletButtonsConfiguration$PaymentElementVisibility;
+	public static fun values ()[Lcom/stripe/android/paymentsheet/PaymentSheet$WalletButtonsConfiguration$PaymentElementVisibility;
+}
+
+public final class com/stripe/android/paymentsheet/PaymentSheet$WalletButtonsConfiguration$Visibility : android/os/Parcelable {
+	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Map;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/Map;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPaymentElement ()Ljava/util/Map;
+	public final fun getWalletButtonsView ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public final fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/paymentsheet/PaymentSheet$WalletButtonsConfiguration$Visibility$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentSheet$WalletButtonsConfiguration$Visibility;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentSheet$WalletButtonsConfiguration$Visibility;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/PaymentSheet$WalletButtonsConfiguration$Wallet : java/lang/Enum {
+	public static final field GooglePay Lcom/stripe/android/paymentsheet/PaymentSheet$WalletButtonsConfiguration$Wallet;
+	public static final field Link Lcom/stripe/android/paymentsheet/PaymentSheet$WalletButtonsConfiguration$Wallet;
+	public static final field ShopPay Lcom/stripe/android/paymentsheet/PaymentSheet$WalletButtonsConfiguration$Wallet;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentSheet$WalletButtonsConfiguration$Wallet;
+	public static fun values ()[Lcom/stripe/android/paymentsheet/PaymentSheet$WalletButtonsConfiguration$Wallet;
+}
+
+public final class com/stripe/android/paymentsheet/PaymentSheet$WalletButtonsConfiguration$WalletButtonsViewVisibility : java/lang/Enum {
+	public static final field Always Lcom/stripe/android/paymentsheet/PaymentSheet$WalletButtonsConfiguration$WalletButtonsViewVisibility;
+	public static final field Never Lcom/stripe/android/paymentsheet/PaymentSheet$WalletButtonsConfiguration$WalletButtonsViewVisibility;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentSheet$WalletButtonsConfiguration$WalletButtonsViewVisibility;
+	public static fun values ()[Lcom/stripe/android/paymentsheet/PaymentSheet$WalletButtonsConfiguration$WalletButtonsViewVisibility;
 }
 
 public final class com/stripe/android/paymentsheet/PaymentSheetComposeKt {

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
@@ -1199,7 +1199,14 @@ internal class FlowControllerTest {
                     .walletButtons(
                         PaymentSheet.WalletButtonsConfiguration(
                             willDisplayExternally = true,
-                            walletsToShow = listOf("link"),
+                            visibility = PaymentSheet.WalletButtonsConfiguration.Visibility(
+                                walletButtonsView = mapOf(
+                                    PaymentSheet.WalletButtonsConfiguration.Wallet.GooglePay to
+                                        PaymentSheet.WalletButtonsConfiguration.WalletButtonsViewVisibility.Never,
+                                    PaymentSheet.WalletButtonsConfiguration.Wallet.Link to
+                                        PaymentSheet.WalletButtonsConfiguration.WalletButtonsViewVisibility.Always,
+                                ),
+                            )
                         )
                     )
                     .build(),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionContract.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.content.Intent
 import androidx.activity.result.contract.ActivityResultContract
 import com.stripe.android.link.LinkAccountUpdate
-import com.stripe.android.lpmfoundations.paymentmethod.WalletType
 import com.stripe.android.paymentsheet.state.PaymentSheetState
 import com.stripe.android.view.ActivityStarter
 import kotlinx.parcelize.Parcelize
@@ -32,7 +31,7 @@ internal class PaymentOptionContract :
         val configuration: PaymentSheet.Configuration,
         val linkAccountInfo: LinkAccountUpdate.Value,
         val enableLogging: Boolean,
-        val walletsToShow: List<WalletType>,
+        val walletButtonsRendered: Boolean,
         val productUsage: Set<String>,
         val paymentElementCallbackIdentifier: String,
     ) : ActivityStarter.Args {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -3324,17 +3324,79 @@ class PaymentSheet internal constructor(
         val willDisplayExternally: Boolean = false,
 
         /**
-         * Identifies the list of wallets that can be shown in `WalletButtons`. Wallets
-         * are identified by their wallet identifier (google_pay, link, shop_pay). An
-         * empty list means all wallets will be shown.
+         * Controls visibility of wallets within Payment Element and `WalletButtons`.
          */
-        val walletsToShow: List<String> = emptyList(),
+        val visibility: Visibility = Visibility(),
 
         /**
          * Theme configuration for wallet buttons
          */
         val buttonThemes: ButtonThemes = ButtonThemes(),
-    ) : Parcelable
+    ) : Parcelable {
+        @Poko
+        @Parcelize
+        class Visibility(
+            /**
+             * Configures how wallets are shown in Payment Element. Wallets that don't have a provided visibility will
+             * have theirs automatically determined.
+             *
+             * Defaults to an empty map.
+             */
+            val paymentElement: Map<Wallet, PaymentElementVisibility> = emptyMap(),
+
+            /**
+             * Configures how wallets are shown in the wallet buttons view. Wallets that don't have a provided
+             * visibility will have theirs automatically determined.
+             *
+             * Defaults to an empty map.
+             */
+            val walletButtonsView: Map<Wallet, WalletButtonsViewVisibility> = emptyMap(),
+        ) : Parcelable
+
+        /**
+         * Available visibility options within the wallet buttons view
+         */
+        enum class WalletButtonsViewVisibility {
+            /**
+             * Wallet is always shown when the wallet buttons view is rendered.
+             */
+            Always,
+
+            /**
+             * Wallet is never shown when the wallet buttons view is rendered.
+             */
+            Never,
+        }
+
+        /**
+         * Available visibility options for a wallet within Payment Element
+         */
+        enum class PaymentElementVisibility {
+            /**
+             * Wallet visibility is automatically determined based on if the wallet buttons view is rendered.
+             */
+            Automatic,
+
+            /**
+             * Wallet is always shown regardless of if the wallet buttons view is rendered.
+             */
+            Always,
+
+            /**
+             * Wallet is never shown regardless of if the wallet buttons view is rendered.
+             */
+            Never,
+        }
+
+        /**
+         * Definition for a wallet available for use with Payment Element.
+         */
+        enum class Wallet {
+            Link,
+            GooglePay,
+            ShopPay
+        }
+    }
 
     /**
      * Configuration related to Shop Pay, which only applies when using wallet buttons.

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtx.kt
@@ -121,13 +121,11 @@ internal fun PaymentSheet.Appearance.parseAppearance() {
     }
 }
 
-internal val PaymentSheet.WalletButtonsConfiguration.allowedWalletTypes: List<WalletType>
-    get() = if (walletsToShow.isEmpty()) {
-        WalletType.entries
-    } else {
-        WalletType.entries.filter { type ->
-            walletsToShow.contains(type.code)
-        }
+internal val WalletType.configType: PaymentSheet.WalletButtonsConfiguration.Wallet
+    get() = when (this) {
+        WalletType.Link -> PaymentSheet.WalletButtonsConfiguration.Wallet.Link
+        WalletType.GooglePay -> PaymentSheet.WalletButtonsConfiguration.Wallet.GooglePay
+        WalletType.ShopPay -> PaymentSheet.WalletButtonsConfiguration.Wallet.ShopPay
     }
 
 @OptIn(AppearanceAPIAdditionsPreview::class)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -55,7 +55,6 @@ import com.stripe.android.paymentsheet.PaymentSheetResult
 import com.stripe.android.paymentsheet.PaymentSheetResultCallback
 import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
-import com.stripe.android.paymentsheet.allowedWalletTypes
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.PaymentSheetConfirmationError
 import com.stripe.android.paymentsheet.model.PaymentOption
@@ -321,13 +320,7 @@ internal class DefaultFlowController @Inject internal constructor(
             enableLogging = enableLogging,
             productUsage = productUsage,
             linkAccountInfo = linkAccountHolder.linkAccountInfo.value,
-            walletsToShow = if (viewModel.walletButtonsRendered) {
-                WalletType.entries.filterNot {
-                    state.config.walletButtons.allowedWalletTypes.contains(it)
-                }
-            } else {
-                state.config.walletButtons.allowedWalletTypes
-            },
+            walletButtonsRendered = viewModel.walletButtonsRendered,
             paymentElementCallbackIdentifier = paymentElementCallbackIdentifier
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperOpenCardScanAutomaticallyTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperOpenCardScanAutomaticallyTest.kt
@@ -12,7 +12,6 @@ import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.link.gate.FakeLinkGate
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
-import com.stripe.android.lpmfoundations.paymentmethod.WalletType
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures.CARD_PAYMENT_METHOD
@@ -229,6 +228,6 @@ internal class FormHelperOpenCardScanAutomaticallyTest {
             account = null,
             lastUpdateReason = null
         ),
-        walletsToShow = WalletType.entries,
+        walletButtonsRendered = false,
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
@@ -9,7 +9,6 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
-import com.stripe.android.lpmfoundations.paymentmethod.WalletType
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures.BILLING_DETAILS
 import com.stripe.android.model.StripeIntent
@@ -176,7 +175,7 @@ internal object PaymentSheetFixtures {
         productUsage = mock(),
         paymentElementCallbackIdentifier = PAYMENT_SHEET_CALLBACK_TEST_IDENTIFIER,
         linkAccountInfo = LinkAccountUpdate.Value(null),
-        walletsToShow = WalletType.entries,
+        walletButtonsRendered = false,
     )
 
     internal fun PaymentOptionContract.Args.updateState(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -33,7 +33,6 @@ import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.link.ui.inline.LinkSignupMode
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilter
-import com.stripe.android.lpmfoundations.paymentmethod.WalletType
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.CardParams
 import com.stripe.android.model.PassiveCaptchaParams
@@ -47,7 +46,6 @@ import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentelement.ExperimentalCustomPaymentMethodsApi
-import com.stripe.android.paymentelement.WalletButtonsPreview
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbacks
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
@@ -464,7 +462,7 @@ internal class DefaultFlowControllerTest {
             productUsage = PRODUCT_USAGE,
             linkAccountInfo = LinkAccountUpdate.Value(null),
             paymentElementCallbackIdentifier = FLOW_CONTROLLER_CALLBACK_TEST_IDENTIFIER,
-            walletsToShow = WalletType.entries,
+            walletButtonsRendered = false,
         )
 
         verify(paymentOptionActivityLauncher).launch(eq(expectedArgs), anyOrNull())
@@ -1585,7 +1583,25 @@ internal class DefaultFlowControllerTest {
     }
 
     @Test
-    fun `On wallet buttons rendered and options launched, should show no wallets in options screen`() = runTest {
+    fun `On wallet buttons not rendered and options launched, wallets rendered argument should be false`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.walletButtonsRendered = false
+
+        val flowController = createFlowController(viewModel = viewModel)
+
+        flowController.configureExpectingSuccess()
+
+        flowController.presentPaymentOptions()
+
+        verify(paymentOptionActivityLauncher).launch(
+            argWhere { !it.walletButtonsRendered },
+            anyOrNull(),
+        )
+    }
+
+    @Test
+    fun `On wallet buttons rendered and options launched, wallets rendered argument should be true`() = runTest {
         val viewModel = createViewModel()
 
         viewModel.walletButtonsRendered = true
@@ -1597,124 +1613,7 @@ internal class DefaultFlowControllerTest {
         flowController.presentPaymentOptions()
 
         verify(paymentOptionActivityLauncher).launch(
-            argWhere { it.walletsToShow.isEmpty() },
-            anyOrNull(),
-        )
-    }
-
-    @OptIn(WalletButtonsPreview::class)
-    @Test
-    fun `On wallet buttons rendered and options launched, should show only Link in options screen`() = runTest {
-        val viewModel = createViewModel()
-
-        viewModel.walletButtonsRendered = true
-
-        val flowController = createFlowController(viewModel = viewModel)
-
-        flowController.configureExpectingSuccess(
-            configuration = PaymentSheet.Configuration.Builder(
-                merchantDisplayName = "Example, Inc."
-            )
-                .googlePay(
-                    PaymentSheet.GooglePayConfiguration(
-                        environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
-                        countryCode = "US",
-                    )
-                )
-                .walletButtons(
-                    PaymentSheet.WalletButtonsConfiguration(
-                        willDisplayExternally = true,
-                        walletsToShow = listOf("google_pay", "shop_pay")
-                    )
-                )
-                .build()
-        )
-
-        flowController.presentPaymentOptions()
-
-        verify(paymentOptionActivityLauncher).launch(
-            argWhere {
-                it.walletsToShow.size == 1 &&
-                    it.walletsToShow.contains(WalletType.Link)
-            },
-            anyOrNull(),
-        )
-    }
-
-    @OptIn(WalletButtonsPreview::class)
-    @Test
-    fun `On wallet buttons rendered and options launched, should show only GPay in options screen`() = runTest {
-        val viewModel = createViewModel()
-
-        viewModel.walletButtonsRendered = true
-
-        val flowController = createFlowController(viewModel = viewModel)
-
-        flowController.configureExpectingSuccess(
-            configuration = PaymentSheet.Configuration.Builder(
-                merchantDisplayName = "Example, Inc."
-            )
-                .googlePay(
-                    PaymentSheet.GooglePayConfiguration(
-                        environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
-                        countryCode = "US",
-                    )
-                )
-                .walletButtons(
-                    PaymentSheet.WalletButtonsConfiguration(
-                        willDisplayExternally = true,
-                        walletsToShow = listOf("link", "shop_pay")
-                    )
-                )
-                .build()
-        )
-
-        flowController.presentPaymentOptions()
-
-        verify(paymentOptionActivityLauncher).launch(
-            argWhere {
-                it.walletsToShow.size == 1 &&
-                    it.walletsToShow.contains(WalletType.GooglePay)
-            },
-            anyOrNull(),
-        )
-    }
-
-    @OptIn(WalletButtonsPreview::class)
-    @Test
-    fun `On wallet buttons rendered and options launched, should show only Shop Pay in options screen`() = runTest {
-        val viewModel = createViewModel()
-
-        viewModel.walletButtonsRendered = true
-
-        val flowController = createFlowController(viewModel = viewModel)
-
-        flowController.configureExpectingSuccess(
-            configuration = PaymentSheet.Configuration.Builder(
-                merchantDisplayName = "Example, Inc."
-            )
-                .googlePay(
-                    PaymentSheet.GooglePayConfiguration(
-                        environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
-                        countryCode = "US",
-                    )
-                )
-                .walletButtons(
-                    PaymentSheet.WalletButtonsConfiguration(
-                        willDisplayExternally = true,
-                        walletsToShow = listOf("link", "google_pay")
-                    )
-                )
-                .build()
-        )
-
-        flowController.presentPaymentOptions()
-
-        verify(paymentOptionActivityLauncher).launch(
-            argWhere {
-                it.walletsToShow.size == 1 &&
-                    it.walletsToShow.contains(WalletType.ShopPay)
-            },
+            argWhere { it.walletButtonsRendered },
             anyOrNull(),
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdaterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdaterTest.kt
@@ -481,7 +481,7 @@ class PaymentSelectionUpdaterTest {
 
     @OptIn(WalletButtonsPreview::class)
     @Test
-    fun `If using wallet buttons config option with only GPay allowed and selection is Link, should be Link`() {
+    fun `If using wallet buttons config option with only GPay visible and selection is Link, should be Link`() {
         val updater = createUpdater()
 
         val result = updater(
@@ -492,7 +492,14 @@ class PaymentSelectionUpdaterTest {
                 .walletButtons(
                     PaymentSheet.WalletButtonsConfiguration(
                         willDisplayExternally = true,
-                        walletsToShow = listOf("google_pay"),
+                        visibility = PaymentSheet.WalletButtonsConfiguration.Visibility(
+                            walletButtonsView = mapOf(
+                                PaymentSheet.WalletButtonsConfiguration.Wallet.GooglePay to
+                                    PaymentSheet.WalletButtonsConfiguration.WalletButtonsViewVisibility.Always,
+                                PaymentSheet.WalletButtonsConfiguration.Wallet.Link to
+                                    PaymentSheet.WalletButtonsConfiguration.WalletButtonsViewVisibility.Never,
+                            ),
+                        ),
                     ),
                 ).build(),
             walletButtonsAlreadyShown = false,
@@ -503,7 +510,7 @@ class PaymentSelectionUpdaterTest {
 
     @OptIn(WalletButtonsPreview::class)
     @Test
-    fun `If using wallet buttons config option with only Link allowed and selection is GPay, should be GPay`() {
+    fun `If using wallet buttons config option with only Link visible and selection is GPay, should be GPay`() {
         val updater = createUpdater()
 
         val result = updater(
@@ -514,7 +521,14 @@ class PaymentSelectionUpdaterTest {
                 .walletButtons(
                     PaymentSheet.WalletButtonsConfiguration(
                         willDisplayExternally = true,
-                        walletsToShow = listOf("link"),
+                        visibility = PaymentSheet.WalletButtonsConfiguration.Visibility(
+                            walletButtonsView = mapOf(
+                                PaymentSheet.WalletButtonsConfiguration.Wallet.GooglePay to
+                                    PaymentSheet.WalletButtonsConfiguration.WalletButtonsViewVisibility.Never,
+                                PaymentSheet.WalletButtonsConfiguration.Wallet.Link to
+                                    PaymentSheet.WalletButtonsConfiguration.WalletButtonsViewVisibility.Always,
+                            ),
+                        ),
                     ),
                 ).build(),
             walletButtonsAlreadyShown = false,
@@ -536,7 +550,14 @@ class PaymentSelectionUpdaterTest {
                 .walletButtons(
                     PaymentSheet.WalletButtonsConfiguration(
                         willDisplayExternally = true,
-                        walletsToShow = listOf("link"),
+                        visibility = PaymentSheet.WalletButtonsConfiguration.Visibility(
+                            walletButtonsView = mapOf(
+                                PaymentSheet.WalletButtonsConfiguration.Wallet.GooglePay to
+                                    PaymentSheet.WalletButtonsConfiguration.WalletButtonsViewVisibility.Never,
+                                PaymentSheet.WalletButtonsConfiguration.Wallet.Link to
+                                    PaymentSheet.WalletButtonsConfiguration.WalletButtonsViewVisibility.Always,
+                            ),
+                        ),
                     ),
                 ).build(),
             walletButtonsAlreadyShown = false,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultWalletButtonsInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultWalletButtonsInteractorTest.kt
@@ -123,51 +123,86 @@ class DefaultWalletButtonsInteractorTest {
     }
 
     @Test
-    fun `on init with GPay & Link enabled but only Link allowed, state should have only Link`() = runTest {
-        val interactor = createInteractor(
-            arguments = createArguments(
-                availableWallets = listOf(WalletType.Link, WalletType.GooglePay),
-                allowedWalletTypes = listOf(WalletType.Link),
-                linkEmail = null,
-            )
-        )
+    fun `on init with GPay & Link enabled and should always be visible, state should have GPay & Link`() =
+        walletsVisibilityTest(
+            availableWallets = listOf(WalletType.Link, WalletType.GooglePay),
+            walletButtonsViewVisibility = mapOf(
+                PaymentSheet.WalletButtonsConfiguration.Wallet.GooglePay to
+                    PaymentSheet.WalletButtonsConfiguration.WalletButtonsViewVisibility.Always,
+                PaymentSheet.WalletButtonsConfiguration.Wallet.Link to
+                    PaymentSheet.WalletButtonsConfiguration.WalletButtonsViewVisibility.Always,
+            ),
+        ) { state ->
+            assertThat(state.walletButtons).hasSize(2)
+            assertThat(state.walletButtons[0]).isInstanceOf<WalletButtonsInteractor.WalletButton.Link>()
+            assertThat(state.walletButtons[1]).isInstanceOf<WalletButtonsInteractor.WalletButton.GooglePay>()
 
-        interactor.state.test {
-            val state = awaitItem()
+            assertThat(state.buttonsEnabled).isTrue()
+        }
 
+    @Test
+    fun `on init with GPay & Link enabled and automatic visibility, state should have GPay & Link`() =
+        walletsVisibilityTest(
+            availableWallets = listOf(WalletType.Link, WalletType.GooglePay),
+            walletButtonsViewVisibility = mapOf(
+                PaymentSheet.WalletButtonsConfiguration.Wallet.GooglePay to
+                    PaymentSheet.WalletButtonsConfiguration.WalletButtonsViewVisibility.Always,
+                PaymentSheet.WalletButtonsConfiguration.Wallet.Link to
+                    PaymentSheet.WalletButtonsConfiguration.WalletButtonsViewVisibility.Always,
+            ),
+        ) { state ->
+            assertThat(state.walletButtons).hasSize(2)
+            assertThat(state.walletButtons[0]).isInstanceOf<WalletButtonsInteractor.WalletButton.Link>()
+            assertThat(state.walletButtons[1]).isInstanceOf<WalletButtonsInteractor.WalletButton.GooglePay>()
+
+            assertThat(state.buttonsEnabled).isTrue()
+        }
+
+    @Test
+    fun `on init with GPay & Link enabled but only Link allowed to be visible, state should have only Link`() =
+        walletsVisibilityTest(
+            availableWallets = listOf(WalletType.Link, WalletType.GooglePay),
+            walletButtonsViewVisibility = mapOf(
+                PaymentSheet.WalletButtonsConfiguration.Wallet.GooglePay to
+                    PaymentSheet.WalletButtonsConfiguration.WalletButtonsViewVisibility.Never,
+                PaymentSheet.WalletButtonsConfiguration.Wallet.Link to
+                    PaymentSheet.WalletButtonsConfiguration.WalletButtonsViewVisibility.Always,
+            ),
+        ) { state ->
             assertThat(state.walletButtons).hasSize(1)
             assertThat(state.walletButtons[0]).isInstanceOf<WalletButtonsInteractor.WalletButton.Link>()
 
             assertThat(state.buttonsEnabled).isTrue()
         }
-    }
 
     @Test
-    fun `on init with GPay & Link enabled but only GPay allowed, state should have only GPay`() = runTest {
-        val interactor = createInteractor(
-            arguments = createArguments(
-                availableWallets = listOf(WalletType.Link, WalletType.GooglePay),
-                allowedWalletTypes = listOf(WalletType.GooglePay),
-                linkEmail = null,
-            )
-        )
-
-        interactor.state.test {
-            val state = awaitItem()
-
+    fun `on init with GPay & Link enabled but only GPay can be visible, state should have only GPay`() =
+        walletsVisibilityTest(
+            availableWallets = listOf(WalletType.Link, WalletType.GooglePay),
+            walletButtonsViewVisibility = mapOf(
+                PaymentSheet.WalletButtonsConfiguration.Wallet.GooglePay to
+                    PaymentSheet.WalletButtonsConfiguration.WalletButtonsViewVisibility.Always,
+                PaymentSheet.WalletButtonsConfiguration.Wallet.Link to
+                    PaymentSheet.WalletButtonsConfiguration.WalletButtonsViewVisibility.Never,
+            ),
+        ) { state ->
             assertThat(state.walletButtons).hasSize(1)
             assertThat(state.walletButtons[0]).isInstanceOf<WalletButtonsInteractor.WalletButton.GooglePay>()
 
             assertThat(state.buttonsEnabled).isTrue()
         }
-    }
 
     @Test
-    fun `on init with GPay & Link enabled but none allowed, state should no buttons`() = runTest {
+    fun `on init with GPay & Link enabled but cannot be visible, state should no buttons`() = runTest {
         val interactor = createInteractor(
             arguments = createArguments(
                 availableWallets = listOf(WalletType.Link, WalletType.GooglePay),
-                allowedWalletTypes = emptyList(),
+                walletButtonsViewVisibility = mapOf(
+                    PaymentSheet.WalletButtonsConfiguration.Wallet.GooglePay to
+                        PaymentSheet.WalletButtonsConfiguration.WalletButtonsViewVisibility.Never,
+                    PaymentSheet.WalletButtonsConfiguration.Wallet.Link to
+                        PaymentSheet.WalletButtonsConfiguration.WalletButtonsViewVisibility.Never,
+                ),
                 linkEmail = null,
             )
         )
@@ -540,11 +575,18 @@ class DefaultWalletButtonsInteractorTest {
     }
 
     @Test
-    fun `on init with all wallets enabled but only ShopPay allowed, state should have only ShopPay`() = runTest {
+    fun `on init with all wallets enabled but only ShopPay visible, state should have only ShopPay`() = runTest {
         val interactor = createInteractor(
             arguments = createArguments(
                 availableWallets = listOf(WalletType.Link, WalletType.GooglePay, WalletType.ShopPay),
-                allowedWalletTypes = listOf(WalletType.ShopPay),
+                walletButtonsViewVisibility = mapOf(
+                    PaymentSheet.WalletButtonsConfiguration.Wallet.ShopPay to
+                        PaymentSheet.WalletButtonsConfiguration.WalletButtonsViewVisibility.Always,
+                    PaymentSheet.WalletButtonsConfiguration.Wallet.GooglePay to
+                        PaymentSheet.WalletButtonsConfiguration.WalletButtonsViewVisibility.Never,
+                    PaymentSheet.WalletButtonsConfiguration.Wallet.Link to
+                        PaymentSheet.WalletButtonsConfiguration.WalletButtonsViewVisibility.Never,
+                ),
                 linkEmail = null,
             )
         )
@@ -602,59 +644,64 @@ class DefaultWalletButtonsInteractorTest {
     }
 
     @Test
-    fun `on ShopPay available but not allowed by merchant, should not show ShopPay button`() = runTest {
-        val interactor = createInteractor(
-            arguments = createArguments(
-                availableWallets = listOf(WalletType.ShopPay),
-                allowedWalletTypes = emptyList(),
-                linkEmail = null,
-            )
-        )
-
-        interactor.state.test {
-            val state = awaitItem()
-
-            assertThat(state.walletButtons).hasSize(0)
-        }
-    }
-
-    @Test
-    fun `on init with ShopPay not available, state should not have ShopPay button`() = runTest {
-        val interactor = createInteractor(
-            arguments = createArguments(
-                availableWallets = listOf(WalletType.Link, WalletType.GooglePay),
-                allowedWalletTypes = listOf(WalletType.Link, WalletType.GooglePay, WalletType.ShopPay),
-                linkEmail = null,
-            )
-        )
-
-        interactor.state.test {
-            val state = awaitItem()
-
-            assertThat(state.walletButtons).hasSize(2)
-            assertThat(state.walletButtons.none { it is WalletButtonsInteractor.WalletButton.ShopPay }).isTrue()
-            assertThat(state.walletButtons[0]).isInstanceOf<WalletButtonsInteractor.WalletButton.Link>()
-            assertThat(state.walletButtons[1]).isInstanceOf<WalletButtonsInteractor.WalletButton.GooglePay>()
-        }
-    }
-
-    @Test
-    fun `on init with only ShopPay available and allowed, state should have only ShopPay`() = runTest {
-        val interactor = createInteractor(
-            arguments = createArguments(
-                availableWallets = listOf(WalletType.ShopPay),
-                allowedWalletTypes = listOf(WalletType.ShopPay),
-                linkEmail = null,
-            )
-        )
-
-        interactor.state.test {
-            val state = awaitItem()
-
+    fun `on ShopPay available & should always be visible, should show ShopPay button`() =
+        walletsVisibilityTest(
+            availableWallets = listOf(WalletType.ShopPay),
+            walletButtonsViewVisibility = mapOf(
+                PaymentSheet.WalletButtonsConfiguration.Wallet.ShopPay to
+                    PaymentSheet.WalletButtonsConfiguration.WalletButtonsViewVisibility.Always,
+            ),
+        ) { state ->
             assertThat(state.walletButtons).hasSize(1)
             assertThat(state.walletButtons[0]).isInstanceOf<WalletButtonsInteractor.WalletButton.ShopPay>()
             assertThat(state.buttonsEnabled).isTrue()
         }
+
+    @Test
+    fun `on ShopPay available but not allowed to be visible by merchant, should not show ShopPay button`() =
+        walletsVisibilityTest(
+            availableWallets = listOf(WalletType.ShopPay),
+            walletButtonsViewVisibility = mapOf(
+                PaymentSheet.WalletButtonsConfiguration.Wallet.ShopPay to
+                    PaymentSheet.WalletButtonsConfiguration.WalletButtonsViewVisibility.Never,
+            ),
+        ) { state ->
+            assertThat(state.walletButtons).hasSize(0)
+        }
+
+    @Test
+    fun `on init with ShopPay not available, state should not have ShopPay button`() = walletsVisibilityTest(
+        availableWallets = listOf(WalletType.Link, WalletType.GooglePay),
+        walletButtonsViewVisibility = mapOf(
+            PaymentSheet.WalletButtonsConfiguration.Wallet.ShopPay to
+                PaymentSheet.WalletButtonsConfiguration.WalletButtonsViewVisibility.Always,
+            PaymentSheet.WalletButtonsConfiguration.Wallet.GooglePay to
+                PaymentSheet.WalletButtonsConfiguration.WalletButtonsViewVisibility.Always,
+            PaymentSheet.WalletButtonsConfiguration.Wallet.Link to
+                PaymentSheet.WalletButtonsConfiguration.WalletButtonsViewVisibility.Always,
+        ),
+    ) { state ->
+        assertThat(state.walletButtons).hasSize(2)
+        assertThat(state.walletButtons.none { it is WalletButtonsInteractor.WalletButton.ShopPay }).isTrue()
+        assertThat(state.walletButtons[0]).isInstanceOf<WalletButtonsInteractor.WalletButton.Link>()
+        assertThat(state.walletButtons[1]).isInstanceOf<WalletButtonsInteractor.WalletButton.GooglePay>()
+    }
+
+    @Test
+    fun `on init with only ShopPay available and visible, state should have only ShopPay`() = walletsVisibilityTest(
+        availableWallets = listOf(WalletType.ShopPay),
+        walletButtonsViewVisibility = mapOf(
+            PaymentSheet.WalletButtonsConfiguration.Wallet.ShopPay to
+                PaymentSheet.WalletButtonsConfiguration.WalletButtonsViewVisibility.Always,
+            PaymentSheet.WalletButtonsConfiguration.Wallet.GooglePay to
+                PaymentSheet.WalletButtonsConfiguration.WalletButtonsViewVisibility.Never,
+            PaymentSheet.WalletButtonsConfiguration.Wallet.Link to
+                PaymentSheet.WalletButtonsConfiguration.WalletButtonsViewVisibility.Never,
+        ),
+    ) { state ->
+        assertThat(state.walletButtons).hasSize(1)
+        assertThat(state.walletButtons[0]).isInstanceOf<WalletButtonsInteractor.WalletButton.ShopPay>()
+        assertThat(state.buttonsEnabled).isTrue()
     }
 
     @Test
@@ -735,7 +782,6 @@ class DefaultWalletButtonsInteractorTest {
         val interactor = createInteractor(
             arguments = createArguments(
                 availableWallets = listOf(WalletType.GooglePay, WalletType.ShopPay, WalletType.Link),
-                allowedWalletTypes = listOf(WalletType.GooglePay, WalletType.ShopPay, WalletType.Link),
                 linkEmail = null,
             )
         )
@@ -755,7 +801,6 @@ class DefaultWalletButtonsInteractorTest {
         val interactor = createInteractor(
             arguments = createArguments(
                 availableWallets = listOf(WalletType.ShopPay),
-                allowedWalletTypes = listOf(WalletType.ShopPay),
                 linkEmail = null,
             ),
             confirmationHandler = FakeConfirmationHandler().apply {
@@ -775,6 +820,26 @@ class DefaultWalletButtonsInteractorTest {
             assertThat(state.walletButtons).hasSize(1)
             assertThat(state.walletButtons[0]).isInstanceOf<WalletButtonsInteractor.WalletButton.ShopPay>()
             assertThat(state.buttonsEnabled).isFalse()
+        }
+    }
+
+    private fun walletsVisibilityTest(
+        availableWallets: List<WalletType>,
+        walletButtonsViewVisibility: Map<
+            PaymentSheet.WalletButtonsConfiguration.Wallet,
+            PaymentSheet.WalletButtonsConfiguration.WalletButtonsViewVisibility
+            >,
+        test: (WalletButtonsInteractor.State) -> Unit
+    ) = runTest {
+        val interactor = createInteractor(
+            arguments = createArguments(
+                availableWallets = availableWallets,
+                walletButtonsViewVisibility = walletButtonsViewVisibility,
+            )
+        )
+
+        interactor.state.test {
+            test(awaitItem())
         }
     }
 
@@ -807,12 +872,15 @@ class DefaultWalletButtonsInteractorTest {
 
     private fun createArguments(
         availableWallets: List<WalletType> = listOf(WalletType.Link, WalletType.GooglePay, WalletType.ShopPay),
-        allowedWalletTypes: List<WalletType> = listOf(WalletType.Link, WalletType.GooglePay, WalletType.ShopPay),
         linkEmail: String? = null,
         appearance: PaymentSheet.Appearance = PaymentSheet.Appearance(),
         googlePay: PaymentSheet.GooglePayConfiguration? = null,
         linkState: LinkState? = null,
         cardBrandAcceptance: PaymentSheet.CardBrandAcceptance = PaymentSheet.CardBrandAcceptance.all(),
+        walletButtonsViewVisibility: Map<
+            PaymentSheet.WalletButtonsConfiguration.Wallet,
+            PaymentSheet.WalletButtonsConfiguration.WalletButtonsViewVisibility
+            > = emptyMap(),
         billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration =
             PaymentSheet.BillingDetailsCollectionConfiguration(),
         initializationMode: PaymentElementLoader.InitializationMode =
@@ -828,11 +896,15 @@ class DefaultWalletButtonsInteractorTest {
                 billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration,
                 googlePay = googlePay,
                 cardBrandAcceptance = cardBrandAcceptance,
+                walletButtons = PaymentSheet.WalletButtonsConfiguration(
+                    visibility = PaymentSheet.WalletButtonsConfiguration.Visibility(
+                        walletButtonsView = walletButtonsViewVisibility,
+                    )
+                ),
             ),
             appearance = appearance,
             initializationMode = initializationMode,
             paymentSelection = null,
-            walletsAllowedByMerchant = allowedWalletTypes,
         )
     }
 


### PR DESCRIPTION
# Summary
Allow direct control over wallet visibility in MPE & wallet buttons.

# Motivation
Merchant ask to control wallet visibility across MPE & wallet buttons,

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified