### PR TITLE
Add a local passive captcha flag

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/ElementsSession.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ElementsSession.kt
@@ -2,6 +2,7 @@ package com.stripe.android.model
 
 import androidx.annotation.RestrictTo
 import com.stripe.android.core.model.StripeModel
+import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.model.PaymentMethod.Type.Link
 import kotlinx.parcelize.Parcelize
 import java.util.UUID
@@ -67,7 +68,12 @@ data class ElementsSession(
         get() = linkSettings?.linkMobileSkipWalletInFlowController ?: false
 
     val passiveCaptchaParams: PassiveCaptchaParams?
-        get() = passiveCaptcha.takeIf { flags[Flag.ELEMENTS_ENABLE_PASSIVE_CAPTCHA] == true }
+        get() {
+            return passiveCaptcha.takeIf {
+                flags[Flag.ELEMENTS_ENABLE_PASSIVE_CAPTCHA] == true &&
+                    FeatureFlags.enablePassiveCaptcha.isEnabled
+            }
+        }
 
     val linkSignUpOptInFeatureEnabled: Boolean
         get() = linkSettings?.linkSignUpOptInFeatureEnabled ?: false

--- a/payments-core/src/test/java/com/stripe/android/model/ElementsSessionTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/ElementsSessionTest.kt
@@ -1,9 +1,18 @@
 package com.stripe.android.model
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.utils.FeatureFlags
+import com.stripe.android.testing.FeatureFlagTestRule
+import org.junit.Rule
 import org.junit.Test
 
 class ElementsSessionTest {
+
+    @get:Rule
+    val enablePassiveCaptchaRule = FeatureFlagTestRule(
+        featureFlag = FeatureFlags.enablePassiveCaptcha,
+        isEnabled = true
+    )
 
     @Test
     fun `passiveCaptchaParams returns passiveCaptcha when flag is enabled`() {
@@ -21,7 +30,7 @@ class ElementsSessionTest {
     }
 
     @Test
-    fun `passiveCaptchaParams returns null when flag is disabled`() {
+    fun `passiveCaptchaParams returns null when elements flag is disabled`() {
         val passiveCaptcha = PassiveCaptchaParams(
             siteKey = "test_site_key",
             rqData = "test_rq_data"
@@ -36,7 +45,7 @@ class ElementsSessionTest {
     }
 
     @Test
-    fun `passiveCaptchaParams returns null when flag is missing`() {
+    fun `passiveCaptchaParams returns null when elements flag is missing`() {
         val passiveCaptcha = PassiveCaptchaParams(
             siteKey = "test_site_key",
             rqData = "test_rq_data"
@@ -45,6 +54,22 @@ class ElementsSessionTest {
         val session = createElementsSession(
             passiveCaptcha = passiveCaptcha,
             flags = emptyMap()
+        )
+
+        assertThat(session.passiveCaptchaParams).isNull()
+    }
+
+    @Test
+    fun `passiveCaptchaParams returns null when feature flag is disabled`() {
+        enablePassiveCaptchaRule.setEnabled(false)
+        val passiveCaptcha = PassiveCaptchaParams(
+            siteKey = "test_site_key",
+            rqData = "test_rq_data"
+        )
+
+        val session = createElementsSession(
+            passiveCaptcha = passiveCaptcha,
+            flags = mapOf(ElementsSession.Flag.ELEMENTS_ENABLE_PASSIVE_CAPTCHA to true)
         )
 
         assertThat(session.passiveCaptchaParams).isNull()

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
@@ -32,6 +32,12 @@ class ElementsSessionJsonParserTest {
         isEnabled = false,
     )
 
+    @get:Rule
+    val enablePassiveCaptchaRule = FeatureFlagTestRule(
+        featureFlag = FeatureFlags.enablePassiveCaptcha,
+        isEnabled = true
+    )
+
     @Test
     fun parsePaymentIntent_shouldCreateObjectWithOrderedPaymentMethods() {
         val elementsSession = ElementsSessionJsonParser(

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PassiveCaptchaDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PassiveCaptchaDefinition.kt
@@ -1,0 +1,8 @@
+package com.stripe.android.paymentsheet.example.playground.settings
+
+import com.stripe.android.core.utils.FeatureFlags
+
+internal object PassiveCaptchaDefinition : FeatureFlagSettingsDefinition(
+    FeatureFlags.enablePassiveCaptcha,
+    allowedIntegrationTypes = PlaygroundConfigurationData.IntegrationType.paymentFlows().toList(),
+)

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -558,6 +558,7 @@ internal class PlaygroundSettings private constructor(
                 )
             ),
             EnablePayNowSettingsDefinition,
+            PassiveCaptchaDefinition,
         )
 
         private val nonUiSettingDefinitions: List<PlaygroundSettingDefinition<*>> = listOf(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinition.kt
@@ -37,7 +37,7 @@ internal class PassiveChallengeConfirmationDefinition @Inject constructor(
         confirmationOption: PaymentMethodConfirmationOption,
         confirmationParameters: ConfirmationDefinition.Parameters
     ): Boolean {
-        return false
+        return confirmationOption.passiveCaptchaParams != null
     }
 
     override fun toResult(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -5,6 +5,7 @@ import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.common.model.SHOP_PAY_CONFIGURATION
 import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.TestFactory
@@ -31,6 +32,7 @@ import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.utils.LinkTestUtils
+import com.stripe.android.testing.FeatureFlagTestRule
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.R
@@ -47,6 +49,7 @@ import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.SimpleTextElement
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
@@ -57,6 +60,12 @@ import com.stripe.android.uicore.R as UiCoreR
 
 @RunWith(RobolectricTestRunner::class)
 internal class PaymentMethodMetadataTest {
+
+    @get:Rule
+    val enablePassiveCaptchaRule = FeatureFlagTestRule(
+        featureFlag = FeatureFlags.enablePassiveCaptcha,
+        isEnabled = true
+    )
 
     @Test
     fun `hasIntentToSetup returns true for setup_intent`() {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationActivityTest.kt
@@ -16,6 +16,7 @@ import com.stripe.android.challenge.PassiveChallengeActivityContract
 import com.stripe.android.challenge.PassiveChallengeActivityResult
 import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
+import com.stripe.android.model.RadarOptions
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.ConfirmationTestScenario
 import com.stripe.android.paymentelement.confirmation.PaymentElementConfirmationTestActivity
@@ -65,6 +66,23 @@ internal class PassiveChallengeConfirmationActivityTest {
 
             assertThat(confirmingWithChallengeOption.option).isEqualTo(CONFIRMATION_OPTION)
 
+            intendedPassiveChallengeToBeLaunched()
+
+            val confirmingWithNewOption = awaitItem().assertConfirming()
+
+            assertThat(confirmingWithNewOption.option)
+                .isEqualTo(
+                    PaymentMethodConfirmationOption.New(
+                        createParams = CONFIRMATION_OPTION.createParams.copy(
+                            radarOptions = RadarOptions("test_token")
+                        ),
+                        optionsParams = CONFIRMATION_OPTION.optionsParams,
+                        shouldSave = false,
+                        extraParams = null,
+                        passiveCaptchaParams = null
+                    )
+                )
+
             intendedPaymentConfirmationToBeLaunched()
 
             val successResult = awaitItem().assertComplete().result.assertSucceeded()
@@ -91,6 +109,21 @@ internal class PassiveChallengeConfirmationActivityTest {
             val confirmingWithChallengeOption = awaitItem().assertConfirming()
 
             assertThat(confirmingWithChallengeOption.option).isEqualTo(CONFIRMATION_OPTION)
+
+            intendedPassiveChallengeToBeLaunched()
+
+            val confirmingWithNewOption = awaitItem().assertConfirming()
+
+            assertThat(confirmingWithNewOption.option)
+                .isEqualTo(
+                    PaymentMethodConfirmationOption.New(
+                        createParams = CONFIRMATION_OPTION.createParams,
+                        optionsParams = CONFIRMATION_OPTION.optionsParams,
+                        shouldSave = false,
+                        extraParams = null,
+                        passiveCaptchaParams = null
+                    )
+                )
 
             intendedPaymentConfirmationToBeLaunched()
 
@@ -124,6 +157,21 @@ internal class PassiveChallengeConfirmationActivityTest {
 
                 assertThat(confirmingWithChallengeOption.option).isEqualTo(SAVED_CONFIRMATION_OPTION)
 
+                intendedPassiveChallengeToBeLaunched()
+
+                val confirmingWithNewOption = awaitItem().assertConfirming()
+
+                assertThat(confirmingWithNewOption.option)
+                    .isEqualTo(
+                        PaymentMethodConfirmationOption.Saved(
+                            paymentMethod = SAVED_CONFIRMATION_OPTION.paymentMethod,
+                            optionsParams = SAVED_CONFIRMATION_OPTION.optionsParams,
+                            originatedFromWallet = false,
+                            passiveCaptchaParams = null,
+                            hCaptchaToken = "test_token"
+                        )
+                    )
+
                 intendedPaymentConfirmationToBeLaunched()
 
                 val successResult = awaitItem().assertComplete().result.assertSucceeded()
@@ -155,6 +203,10 @@ internal class PassiveChallengeConfirmationActivityTest {
                 Intent().putExtras(bundleOf("extra_args" to result))
             )
         )
+    }
+
+    private fun intendedPassiveChallengeToBeLaunched() {
+        intended(hasComponent(PASSIVE_CHALLENGE_ACTIVITY_NAME))
     }
 
     private fun intendedPaymentConfirmationToBeLaunched() {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinitionTest.kt
@@ -68,7 +68,7 @@ internal class PassiveChallengeConfirmationDefinitionTest {
             confirmationParameters = CONFIRMATION_PARAMETERS
         )
 
-        assertThat(result).isFalse()
+        assertThat(result).isTrue()
     }
 
     @Test
@@ -80,7 +80,7 @@ internal class PassiveChallengeConfirmationDefinitionTest {
             confirmationParameters = CONFIRMATION_PARAMETERS
         )
 
-        assertThat(result).isFalse()
+        assertThat(result).isTrue()
     }
 
     @Test

--- a/stripe-core/src/main/java/com/stripe/android/core/utils/FeatureFlags.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/FeatureFlags.kt
@@ -15,6 +15,7 @@ object FeatureFlags {
     val forceEnableLinkPaymentSelectionHint = FeatureFlag("Force enable payment selection hint")
     val cardScanGooglePayMigration = FeatureFlag("Use Google Payment Card Recognition API for Card Scan")
     val enablePayNow = FeatureFlag("Enable PayNow")
+    val enablePassiveCaptcha = FeatureFlag("Enable Passive Captcha")
 }
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This will allow us to test passive captcha without breaking end-to-end tests

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://stripe.slack.com/archives/CFA2HJ99A/p1757077380966529?thread_ts=1757042812.671149&cid=CFA2HJ99A

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
