### PR TITLE
Add support for custom dark mode to PaymentSelection.IconLoader

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/PaymentOptionDisplayDataFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/PaymentOptionDisplayDataFactory.kt
@@ -8,6 +8,7 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.billingDetails
 import com.stripe.android.paymentsheet.model.darkThemeIconUrl
 import com.stripe.android.paymentsheet.model.drawableResourceId
+import com.stripe.android.paymentsheet.model.drawableResourceIdNight
 import com.stripe.android.paymentsheet.model.label
 import com.stripe.android.paymentsheet.model.lightThemeIconUrl
 import com.stripe.android.paymentsheet.model.mandateTextFromPaymentMethodMetadata
@@ -48,6 +49,7 @@ internal class PaymentOptionDisplayDataFactory @Inject constructor(
             imageLoader = {
                 iconLoader.load(
                     drawableResourceId = selection.drawableResourceId,
+                    drawableResourceIdNight = selection.drawableResourceIdNight,
                     lightThemeIconUrl = selection.lightThemeIconUrl,
                     darkThemeIconUrl = selection.darkThemeIconUrl,
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionFactory.kt
@@ -20,6 +20,7 @@ internal class PaymentOptionFactory @Inject constructor(
             imageLoader = {
                 iconLoader.load(
                     drawableResourceId = selection.drawableResourceId,
+                    drawableResourceIdNight = selection.drawableResourceId,
                     lightThemeIconUrl = selection.lightThemeIconUrl,
                     darkThemeIconUrl = selection.darkThemeIconUrl,
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -8,6 +8,7 @@ import android.graphics.drawable.ShapeDrawable
 import android.os.Parcelable
 import androidx.annotation.DrawableRes
 import androidx.annotation.VisibleForTesting
+import androidx.compose.ui.graphics.luminance
 import androidx.core.content.res.ResourcesCompat
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.orEmpty
@@ -31,11 +32,13 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.BankFormScreenState
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountTextBuilder
+import com.stripe.android.paymentsheet.ui.MIN_LUMINANCE_FOR_LIGHT_ICON
 import com.stripe.android.paymentsheet.ui.createCardLabel
 import com.stripe.android.paymentsheet.ui.getCardBrandIcon
 import com.stripe.android.paymentsheet.ui.getLabel
 import com.stripe.android.paymentsheet.ui.getLinkIcon
 import com.stripe.android.paymentsheet.ui.getSavedPaymentMethodIcon
+import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.image.StripeImageLoader
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
@@ -287,6 +290,7 @@ internal sealed class PaymentSelection : Parcelable {
         data class GenericPaymentMethod(
             val label: ResolvableString,
             @DrawableRes val iconResource: Int,
+            @DrawableRes val iconResourceNight: Int?,
             val lightThemeIconUrl: String?,
             val darkThemeIconUrl: String?,
             override val paymentMethodCreateParams: PaymentMethodCreateParams,
@@ -302,11 +306,20 @@ internal sealed class PaymentSelection : Parcelable {
     ) {
         private fun isDarkTheme(): Boolean {
             return resources.configuration?.uiMode?.and(Configuration.UI_MODE_NIGHT_MASK) ==
-                Configuration.UI_MODE_NIGHT_YES
+                Configuration.UI_MODE_NIGHT_YES ||
+                isCustomDarkTheme()
+        }
+
+        /**
+         * Some users implement a custom dark mode and will pass dark colors into colors light.
+         */
+        private fun isCustomDarkTheme(): Boolean {
+            return StripeTheme.colorsLightMutable.component.luminance() < MIN_LUMINANCE_FOR_LIGHT_ICON
         }
 
         suspend fun load(
             @DrawableRes drawableResourceId: Int,
+            @DrawableRes drawableResourceIdNight: Int?,
             lightThemeIconUrl: String?,
             darkThemeIconUrl: String?,
         ): Drawable {
@@ -315,7 +328,7 @@ internal sealed class PaymentSelection : Parcelable {
                 return runCatching {
                     ResourcesCompat.getDrawable(
                         resources,
-                        drawableResourceId,
+                        if (!isDarkTheme()) drawableResourceId else drawableResourceIdNight ?: drawableResourceId,
                         null
                     )
                 }.getOrNull() ?: emptyDrawable
@@ -371,6 +384,20 @@ internal val PaymentSelection.drawableResourceId: Int
         is PaymentSelection.Link -> getLinkIcon(iconOnly = true)
         is PaymentSelection.New.Card -> brand.getCardBrandIcon()
         is PaymentSelection.New.GenericPaymentMethod -> iconResource
+        is PaymentSelection.New.LinkInline -> brand.getCardBrandIcon()
+        is PaymentSelection.New.USBankAccount -> iconResource
+        is PaymentSelection.Saved -> getSavedIcon(this)
+        is PaymentSelection.ShopPay -> R.drawable.stripe_shop_pay_logo_white
+    }
+
+internal val PaymentSelection.drawableResourceIdNight: Int
+    get() = when (this) {
+        is PaymentSelection.ExternalPaymentMethod -> iconResource
+        is PaymentSelection.CustomPaymentMethod -> 0
+        PaymentSelection.GooglePay -> R.drawable.stripe_google_pay_mark
+        is PaymentSelection.Link -> getLinkIcon(iconOnly = true)
+        is PaymentSelection.New.Card -> brand.getCardBrandIcon()
+        is PaymentSelection.New.GenericPaymentMethod -> iconResourceNight ?: iconResource
         is PaymentSelection.New.LinkInline -> brand.getCardBrandIcon()
         is PaymentSelection.New.USBankAccount -> iconResource
         is PaymentSelection.Saved -> getSavedIcon(this)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -134,6 +134,7 @@ internal fun FormFieldValues.transformToPaymentSelection(
         PaymentSelection.New.GenericPaymentMethod(
             label = paymentMethod.displayName,
             iconResource = paymentMethod.iconResource,
+            iconResourceNight = paymentMethod.iconResourceNight,
             lightThemeIconUrl = paymentMethod.lightThemeIconUrl,
             darkThemeIconUrl = paymentMethod.darkThemeIconUrl,
             paymentMethodCreateParams = params,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/IconHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/IconHelper.kt
@@ -8,7 +8,7 @@ import com.stripe.android.uicore.IconStyle
 import com.stripe.android.uicore.LocalIconStyle
 import com.stripe.android.uicore.stripeColors
 
-private const val MIN_LUMINANCE_FOR_LIGHT_ICON = 0.5
+internal const val MIN_LUMINANCE_FOR_LIGHT_ICON = 0.5
 
 internal object IconHelper {
     @Composable

--- a/paymentsheet/src/test/java/com/stripe/android/model/PaymentMethodFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/model/PaymentMethodFixtures.kt
@@ -469,6 +469,7 @@ internal object PaymentMethodFixtures {
 
     val GENERIC_PAYMENT_SELECTION = PaymentSelection.New.GenericPaymentMethod(
         iconResource = R.drawable.stripe_ic_paymentsheet_pm_paypal,
+        iconResourceNight = null,
         label = "PayPal".resolvableString,
         paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.PAYPAL,
         customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest,
@@ -479,6 +480,7 @@ internal object PaymentMethodFixtures {
     val CASHAPP_PAYMENT_SELECTION = PaymentSelection.New.GenericPaymentMethod(
         label = "Cash App".resolvableString,
         iconResource = 0,
+        iconResourceNight = null,
         lightThemeIconUrl = null,
         darkThemeIconUrl = null,
         paymentMethodCreateParams = PaymentMethodCreateParams.createCashAppPay(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperTest.kt
@@ -83,6 +83,7 @@ internal class FormHelperTest {
                     PaymentSelection.New.GenericPaymentMethod(
                         label = "Cash App".resolvableString,
                         iconResource = 0,
+                        iconResourceNight = null,
                         lightThemeIconUrl = null,
                         darkThemeIconUrl = null,
                         paymentMethodCreateParams = PaymentMethodCreateParams.createCashAppPay(
@@ -114,6 +115,7 @@ internal class FormHelperTest {
                     PaymentSelection.New.GenericPaymentMethod(
                         label = "Klarna".resolvableString,
                         iconResource = 0,
+                        iconResourceNight = null,
                         lightThemeIconUrl = null,
                         darkThemeIconUrl = null,
                         paymentMethodCreateParams = PaymentMethodCreateParams.createKlarna(
@@ -424,6 +426,7 @@ internal class FormHelperTest {
                     customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestNoReuse,
                     label = resolvableString(R.string.stripe_paymentsheet_payment_method_bancontact),
                     iconResource = R.drawable.stripe_ic_paymentsheet_pm_bancontact,
+                    iconResourceNight = null,
                     lightThemeIconUrl = null,
                     darkThemeIconUrl = null,
                 )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -720,6 +720,7 @@ internal class PaymentOptionsViewModelTest {
             viewModel.updateSelection(
                 PaymentSelection.New.GenericPaymentMethod(
                     iconResource = 0,
+                    iconResourceNight = null,
                     label = "".resolvableString,
                     paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.US_BANK_ACCOUNT,
                     customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -1503,6 +1503,7 @@ internal class PaymentSheetViewModelTest {
         viewModel.updateSelection(
             PaymentSelection.New.GenericPaymentMethod(
                 iconResource = 0,
+                iconResourceNight = null,
                 label = "".resolvableString,
                 paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.US_BANK_ACCOUNT,
                 customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest,
@@ -3924,6 +3925,7 @@ internal class PaymentSheetViewModelTest {
         return PaymentSelection.New.GenericPaymentMethod(
             label = "Test".resolvableString,
             iconResource = 0,
+            iconResourceNight = null,
             paymentMethodCreateParams = PaymentMethodCreateParams.create(
                 bacsDebit = PaymentMethodCreateParams.BacsDebit(
                     accountNumber = BACS_ACCOUNT_NUMBER,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -734,6 +734,7 @@ class DefaultEventReporterTest {
             PaymentSelection.New.GenericPaymentMethod(
                 label = "Cash App Pay".resolvableString,
                 iconResource = 0,
+                iconResourceNight = null,
                 lightThemeIconUrl = null,
                 darkThemeIconUrl = null,
                 paymentMethodCreateParams = PaymentMethodCreateParams.createCashAppPay(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -2756,6 +2756,7 @@ internal class DefaultFlowControllerTest {
         return PaymentSelection.New.GenericPaymentMethod(
             label = "Test".resolvableString,
             iconResource = 0,
+            iconResourceNight = null,
             paymentMethodCreateParams = PaymentMethodCreateParams.Companion.create(
                 bacsDebit = PaymentMethodCreateParams.BacsDebit(
                     accountNumber = BACS_ACCOUNT_NUMBER,
@@ -2780,6 +2781,7 @@ internal class DefaultFlowControllerTest {
         )
         private val GENERIC_PAYMENT_SELECTION = PaymentSelection.New.GenericPaymentMethod(
             iconResource = R.drawable.stripe_ic_paymentsheet_card_visa_ref,
+            iconResourceNight = null,
             label = "Bancontact".resolvableString,
             paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.BANCONTACT,
             customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdaterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdaterTest.kt
@@ -53,6 +53,7 @@ class PaymentSelectionUpdaterTest {
         val existingSelection = PaymentSelection.New.GenericPaymentMethod(
             label = "Sofort".resolvableString,
             iconResource = StripeUiCoreR.drawable.stripe_ic_paymentsheet_pm_klarna,
+            iconResourceNight = null,
             lightThemeIconUrl = null,
             darkThemeIconUrl = null,
             paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.SOFORT,
@@ -244,6 +245,7 @@ class PaymentSelectionUpdaterTest {
         val existingSelection = PaymentSelection.New.GenericPaymentMethod(
             label = "paypal".resolvableString,
             iconResource = StripeUiCoreR.drawable.stripe_ic_paymentsheet_pm_paypal,
+            iconResourceNight = null,
             lightThemeIconUrl = null,
             darkThemeIconUrl = null,
             paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.P24,
@@ -274,6 +276,7 @@ class PaymentSelectionUpdaterTest {
         val existingSelection = PaymentSelection.New.GenericPaymentMethod(
             label = "paypal".resolvableString,
             iconResource = StripeUiCoreR.drawable.stripe_ic_paymentsheet_pm_paypal,
+            iconResourceNight = null,
             lightThemeIconUrl = null,
             darkThemeIconUrl = null,
             paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.PAYPAL.copy(
@@ -306,6 +309,7 @@ class PaymentSelectionUpdaterTest {
         val existingSelection = PaymentSelection.New.GenericPaymentMethod(
             label = "paypal".resolvableString,
             iconResource = StripeUiCoreR.drawable.stripe_ic_paymentsheet_pm_paypal,
+            iconResourceNight = null,
             lightThemeIconUrl = null,
             darkThemeIconUrl = null,
             paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.PAYPAL.copy(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentOptionFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentOptionFactoryTest.kt
@@ -201,6 +201,7 @@ class PaymentOptionFactoryTest {
         val paymentOption = factory.create(
             PaymentSelection.New.GenericPaymentMethod(
                 iconResource = R.drawable.stripe_ic_paymentsheet_card_unknown_ref,
+                iconResourceNight = null,
                 label = "Test Payment Method".resolvableString,
                 paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.SOFORT.copy(
                     billingDetails = PAYMENT_METHOD_BILLING_DETAILS

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentSelectionIconLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentSelectionIconLoaderTest.kt
@@ -86,6 +86,7 @@ internal class PaymentSelectionIconLoaderTest {
             },
         ).load(
             drawableResourceId = iconRes ?: 0,
+            drawableResourceIdNight = null,
             lightThemeIconUrl = iconUrl,
             darkThemeIconUrl = null,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -76,6 +76,7 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
             selectionSource.value = PaymentSelection.New.GenericPaymentMethod(
                 label = "CashApp".resolvableString,
                 iconResource = 0,
+                iconResourceNight = null,
                 lightThemeIconUrl = null,
                 darkThemeIconUrl = null,
                 paymentMethodCreateParams = PaymentMethodCreateParams.createCashAppPay(),


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Check `component` luminance to determine if in night mode in `PaymentSelection.IconLoader`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Support custom dark mode

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [X] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| <img width="1080" height="2424" alt="Screenshot_1757085878" src="https://github.com/user-attachments/assets/bf0ea092-216e-4dc4-b35b-e701a8b08b95" />  | <img width="1080" height="2424" alt="Screenshot_1757085752" src="https://github.com/user-attachments/assets/d3c39898-d347-4d24-9fc2-2386cc4798db" /> |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
