### PR TITLE
Use Gradle managed devices for `run-instrumentation-tests` pipeline

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -247,27 +247,17 @@ workflows:
             - integration_key: $AUX_PAGERDUTY_INTEGRATION_KEY
   run-instrumentation-tests:
     before_run:
-      - start_emulator
       - prepare_all
     after_run:
       - conclude_all
     steps:
       - script@1:
-          title: Assemble Instrumentation tests
-          timeout: 600
-          inputs:
-            - content: ./gradlew assembleAndroidTest -x :paymentsheet-example:assembleAndroidTest -x :paymentsheet:assembleAndroidTest -x :example:assembleAndroidTest -x :financial-connections:assembleAndroidTest -x :financial-connections-example:assembleAndroidTest -x :camera-core:assembleAndroidTest -x :stripecardscan:assembleAndroidTest -x :stripecardscan-example:assembleAndroidTest
-      - wait-for-android-emulator@1:
-          inputs:
-            - boot_timeout: 600
-      - script@1:
           title: Execute instrumentation tests
           timeout: 1200
           inputs:
-            - content: ./gradlew connectedAndroidTest -x :paymentsheet-example:connectedAndroidTest -x :paymentsheet:connectedAndroidTest -x :example:connectedAndroidTest -x :financial-connections:connectedAndroidTest -x :financial-connections-example:connectedAndroidTest -x :camera-core:connectedAndroidTest -x :stripecardscan:connectedAndroidTest -x :stripecardscan-example:connectedAndroidTest
+            - content: ./gradlew -Pandroid.experimental.androidTest.numManagedDeviceShards=1 pixel2api33DebugAndroidTest -x :paymentsheet-example:pixel2api33DebugAndroidTest -x :paymentsheet:pixel2api33DebugAndroidTest -x :example:pixel2api33DebugAndroidTest -x :financial-connections:pixel2api33DebugAndroidTest -x :financial-connections-example:pixel2api33DebugAndroidTest -x :camera-core:pixel2api33DebugAndroidTest -x :stripecardscan:pixel2api33DebugAndroidTest -x :stripecardscan-example:pixel2api33DebugAndroidTest
   run-paymentsheet-instrumentation-tests:
     before_run:
-      - start_emulator
       - prepare_all
     after_run:
       - conclude_all
@@ -276,7 +266,7 @@ workflows:
           title: Execute instrumentation tests
           timeout: 1200
           inputs:
-            - content: ./scripts/retry.sh 3 ./gradlew :paymentsheet:pixel2api33DebugAndroidTest
+            - content: ./scripts/retry.sh 3 ./gradlew -Pandroid.experimental.androidTest.numManagedDeviceShards=6 -Pandroid.experimental.testOptions.managedDevices.maxConcurrentDevices=6 :paymentsheet:pixel2api33DebugAndroidTest
     meta:
       bitrise.io:
         stack: linux-docker-android-22.04

--- a/build-configuration/android-application.gradle
+++ b/build-configuration/android-application.gradle
@@ -48,6 +48,16 @@ android {
     testOptions {
         // Make sure animations are off when we run espresso tests
         animationsDisabled = true
+
+        managedDevices {
+            localDevices {
+                register("pixel2api33") {
+                    device = "Pixel 2"
+                    apiLevel = 33
+                    systemImageSource = "aosp-atd"
+                }
+            }
+        }
     }
 
     lintOptions {

--- a/build-configuration/android-library.gradle
+++ b/build-configuration/android-library.gradle
@@ -47,6 +47,18 @@ android {
         testInstrumentationRunnerArguments clearPackageData: 'true'
     }
 
+    testOptions {
+        managedDevices {
+            localDevices {
+                register("pixel2api33") {
+                    device = "Pixel 2"
+                    apiLevel = 33
+                    systemImageSource = "aosp-atd"
+                }
+            }
+        }
+    }
+
     sourceSets {
         main {
             res.srcDirs = ['res']

--- a/connect-example/build.gradle
+++ b/connect-example/build.gradle
@@ -113,16 +113,6 @@ android {
         kotlinOptions {
             freeCompilerArgs += ["-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"]
         }
-
-        managedDevices {
-            localDevices {
-                register("pixel2api33") {
-                    device = "Pixel 2"
-                    apiLevel = 33
-                    systemImageSource = "aosp"
-                }
-            }
-        }
     }
 
     kotlinOptions {

--- a/connect/build.gradle
+++ b/connect/build.gradle
@@ -101,16 +101,6 @@ android {
         kotlinOptions {
             freeCompilerArgs += ["-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"]
         }
-
-        managedDevices {
-            localDevices {
-                register("pixel2api33") {
-                    device = "Pixel 2"
-                    apiLevel = 33
-                    systemImageSource = "aosp"
-                }
-            }
-        }
     }
 
     kotlinOptions {

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,9 +17,6 @@ android.enableR8.fullMode=true
 android.nonFinalResIds=true
 android.nonTransitiveRClass=true
 android.useAndroidX=true
-android.experimental.androidTest.numManagedDeviceShards=6
-# Setting a negative number removes the default 4 maximum concurrent devices limit
-android.experimental.testOptions.managedDevices.maxConcurrentDevices=6
 
 org.gradle.jvmargs=-Xms4g -Xmx8g -XX:+UseParallelGC -XX:MaxMetaspaceSize=2g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 

--- a/paymentsheet/build.gradle
+++ b/paymentsheet/build.gradle
@@ -144,16 +144,6 @@ android {
         kotlinOptions {
             freeCompilerArgs += ["-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"]
         }
-
-        managedDevices {
-            localDevices {
-                register("pixel2api33") {
-                    device = "Pixel 2"
-                    apiLevel = 33
-                    systemImageSource = "aosp-atd"
-                }
-            }
-        }
     }
 
     kotlinOptions {


### PR DESCRIPTION
# Summary
Use Gradle managed devices for `run-instrumentation-tests` pipeline

# Motivation
Faster run time

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified