### PR TITLE
Fix Compose Clock stall during e2e tests

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -1262,6 +1262,7 @@ internal class PlaygroundTestDriver(
      */
     private fun waitForPlaygroundActivity() {
         while (currentActivity !is PaymentSheetPlaygroundActivity) {
+            composeTestRule.waitForIdle()
             TimeUnit.MILLISECONDS.sleep(250)
         }
         Espresso.onIdle()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Fix Compose Clock stall during e2e tests

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
E2E tests could stall (`TestEmbedded.testIsBankAccount()`) specifically times out because the primary button animation is stalled.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
