### PR TITLE
Fix remove last feature being disabled when `payment_method_remove_last` is not provided through `CustomerSession`

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/ElementsSession.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ElementsSession.kt
@@ -170,10 +170,13 @@ data class ElementsSession(
                 data class Enabled(
                     val isPaymentMethodSaveEnabled: Boolean,
                     val paymentMethodRemove: PaymentMethodRemoveFeature,
-                    val canRemoveLastPaymentMethod: Boolean,
+                    val paymentMethodRemoveLast: PaymentMethodRemoveLastFeature,
                     val allowRedisplayOverride: PaymentMethod.AllowRedisplay?,
                     val isPaymentMethodSetAsDefaultEnabled: Boolean,
-                ) : MobilePaymentElement
+                ) : MobilePaymentElement {
+                    val canRemoveLastPaymentMethod: Boolean
+                        get() = paymentMethodRemoveLast.canRemoveLastPaymentMethod
+                }
             }
 
             @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -186,9 +189,12 @@ data class ElementsSession(
                 @Parcelize
                 data class Enabled(
                     val paymentMethodRemove: PaymentMethodRemoveFeature,
-                    val canRemoveLastPaymentMethod: Boolean,
+                    val paymentMethodRemoveLast: PaymentMethodRemoveLastFeature,
                     val isPaymentMethodSyncDefaultEnabled: Boolean,
-                ) : CustomerSheet
+                ) : CustomerSheet {
+                    val canRemoveLastPaymentMethod: Boolean
+                        get() = paymentMethodRemoveLast.canRemoveLastPaymentMethod
+                }
             }
 
             @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -196,6 +202,16 @@ data class ElementsSession(
                 Enabled,
                 Partial,
                 Disabled,
+            }
+
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            enum class PaymentMethodRemoveLastFeature {
+                Enabled,
+                Disabled,
+                NotProvided;
+
+                val canRemoveLastPaymentMethod: Boolean
+                    get() = this == Enabled || this == NotProvided
             }
         }
     }

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/ElementsSessionJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/ElementsSessionJsonParser.kt
@@ -334,7 +334,7 @@ internal class ElementsSessionJsonParser(
 
             val paymentMethodSaveFeature = paymentSheetFeatures.optString(FIELD_PAYMENT_METHOD_SAVE)
             val paymentMethodRemoveFeature = paymentSheetFeatures.optString(FIELD_PAYMENT_METHOD_REMOVE)
-            val paymentMethodRemoveLastFeature = paymentSheetFeatures.optString(FIELD_PAYMENT_METHOD_REMOVE_LAST)
+            val paymentMethodRemoveLastFeature = parsePaymentMethodRemoveLastFeatures(paymentSheetFeatures)
             val paymentMethodSetAsDefaultFeature = paymentSheetFeatures.optString(FIELD_PAYMENT_METHOD_SET_AS_DEFAULT)
             val allowRedisplayOverrideValue = paymentSheetFeatures
                 .optString(FIELD_PAYMENT_METHOD_ALLOW_REDISPLAY_OVERRIDE)
@@ -350,7 +350,7 @@ internal class ElementsSessionJsonParser(
                     VALUE_PARTIAL -> ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Partial
                     else -> ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Disabled
                 },
-                canRemoveLastPaymentMethod = paymentMethodRemoveLastFeature == VALUE_ENABLED,
+                paymentMethodRemoveLast = paymentMethodRemoveLastFeature,
                 isPaymentMethodSetAsDefaultEnabled = paymentMethodSetAsDefaultFeature == VALUE_ENABLED,
                 allowRedisplayOverride = allowRedisplayOverride,
             )
@@ -371,7 +371,7 @@ internal class ElementsSessionJsonParser(
                 ?: return ElementsSession.Customer.Components.CustomerSheet.Disabled
 
             val paymentMethodRemoveFeature = customerSheetFeatures.optString(FIELD_PAYMENT_METHOD_REMOVE)
-            val paymentMethodRemoveLastFeature = customerSheetFeatures.optString(FIELD_PAYMENT_METHOD_REMOVE_LAST)
+            val paymentMethodRemoveLastFeature = parsePaymentMethodRemoveLastFeatures(customerSheetFeatures)
             val paymentMethodSyncDefaultFeature = customerSheetFeatures.optString(FIELD_PAYMENT_METHOD_SYNC_DEFAULT)
 
             ElementsSession.Customer.Components.CustomerSheet.Enabled(
@@ -380,7 +380,7 @@ internal class ElementsSessionJsonParser(
                     VALUE_PARTIAL -> ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Partial
                     else -> ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Disabled
                 },
-                canRemoveLastPaymentMethod = paymentMethodRemoveLastFeature == VALUE_ENABLED,
+                paymentMethodRemoveLast = paymentMethodRemoveLastFeature,
                 isPaymentMethodSyncDefaultEnabled = paymentMethodSyncDefaultFeature == VALUE_ENABLED,
             )
         } else {
@@ -418,6 +418,21 @@ internal class ElementsSessionJsonParser(
         }
 
         return flags.toMap()
+    }
+
+    private fun parsePaymentMethodRemoveLastFeatures(
+        json: JSONObject
+    ): ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature {
+        val paymentMethodRemoveLastFeature = StripeJsonUtils.optString(
+            jsonObject = json,
+            fieldName = FIELD_PAYMENT_METHOD_REMOVE_LAST
+        )
+
+        return when (paymentMethodRemoveLastFeature) {
+            null -> ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.NotProvided
+            VALUE_ENABLED -> ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Enabled
+            else -> ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Disabled
+        }
     }
 
     /**

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
@@ -4,6 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.model.StripeJsonUtils
 import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.core.utils.FeatureFlags
+import com.stripe.android.isInstanceOf
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.DeferredIntentParams
 import com.stripe.android.model.ElementsSession
@@ -720,14 +721,16 @@ class ElementsSessionJsonParserTest {
                             isPaymentMethodSaveEnabled = false,
                             paymentMethodRemove =
                             ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled,
-                            canRemoveLastPaymentMethod = true,
+                            paymentMethodRemoveLast =
+                            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Enabled,
                             allowRedisplayOverride = PaymentMethod.AllowRedisplay.LIMITED,
                             isPaymentMethodSetAsDefaultEnabled = false,
                         ),
                         customerSheet = ElementsSession.Customer.Components.CustomerSheet.Enabled(
                             paymentMethodRemove =
                             ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled,
-                            canRemoveLastPaymentMethod = true,
+                            paymentMethodRemoveLast =
+                            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Enabled,
                             isPaymentMethodSyncDefaultEnabled = false,
                         ),
                     )
@@ -766,6 +769,44 @@ class ElementsSessionJsonParserTest {
     }
 
     @Test
+    fun `ElementsSession sets remove last permissions to 'NotProvided' if null`() {
+        val parser = ElementsSessionJsonParser(
+            ElementsSessionParams.PaymentIntentType(
+                clientSecret = "secret",
+                customerSessionClientSecret = "customer_session_client_secret",
+                externalPaymentMethods = emptyList(),
+                customPaymentMethods = emptyList(),
+                appId = APP_ID
+            ),
+            isLiveMode = false,
+        )
+
+        val intent = createPaymentIntentWithCustomerSession(
+            paymentMethodRemoveLastFeature = "null",
+        )
+        val elementsSession = parser.parse(intent)
+
+        val mobilePaymentElement = elementsSession?.customer?.session?.components?.mobilePaymentElement
+        val customerSheet = elementsSession?.customer?.session?.components?.customerSheet
+
+        assertThat(mobilePaymentElement).isNotNull()
+        assertThat(mobilePaymentElement)
+            .isInstanceOf<ElementsSession.Customer.Components.MobilePaymentElement.Enabled>()
+        assertThat(customerSheet).isNotNull()
+        assertThat(customerSheet).isInstanceOf<ElementsSession.Customer.Components.CustomerSheet.Enabled>()
+
+        val enabledMobilePaymentElement =
+            mobilePaymentElement as ElementsSession.Customer.Components.MobilePaymentElement.Enabled
+        val enabledCustomerSheet =
+            customerSheet as ElementsSession.Customer.Components.CustomerSheet.Enabled
+
+        assertThat(enabledMobilePaymentElement.paymentMethodRemoveLast)
+            .isEqualTo(ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.NotProvided)
+        assertThat(enabledCustomerSheet.paymentMethodRemoveLast)
+            .isEqualTo(ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.NotProvided)
+    }
+
+    @Test
     fun `ElementsSession has expected CS information in the response if 'mobile_payment_element' is null`() {
         val parser = ElementsSessionJsonParser(
             ElementsSessionParams.PaymentIntentType(
@@ -796,7 +837,8 @@ class ElementsSessionJsonParserTest {
                         customerSheet = ElementsSession.Customer.Components.CustomerSheet.Enabled(
                             paymentMethodRemove =
                             ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled,
-                            canRemoveLastPaymentMethod = true,
+                            paymentMethodRemoveLast =
+                            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Enabled,
                             isPaymentMethodSyncDefaultEnabled = false,
                         ),
                     )
@@ -865,7 +907,8 @@ class ElementsSessionJsonParserTest {
                             isPaymentMethodSaveEnabled = false,
                             paymentMethodRemove =
                             ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled,
-                            canRemoveLastPaymentMethod = true,
+                            paymentMethodRemoveLast =
+                            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Enabled,
                             allowRedisplayOverride = PaymentMethod.AllowRedisplay.LIMITED,
                             isPaymentMethodSetAsDefaultEnabled = false,
                         ),
@@ -1139,7 +1182,8 @@ class ElementsSessionJsonParserTest {
                         customerSheet = ElementsSession.Customer.Components.CustomerSheet.Enabled(
                             paymentMethodRemove =
                             ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled,
-                            canRemoveLastPaymentMethod = true,
+                            paymentMethodRemoveLast =
+                            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Enabled,
                             isPaymentMethodSyncDefaultEnabled = false,
                         ),
                     )

--- a/paymentsheet/src/test/java/com/stripe/android/common/analytics/experiment/LogLinkGlobalHoldbackExposureTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/analytics/experiment/LogLinkGlobalHoldbackExposureTest.kt
@@ -364,7 +364,7 @@ class LogLinkGlobalHoldbackExposureTest {
                 MobilePaymentElement.Enabled(
                     isPaymentMethodSaveEnabled = true,
                     paymentMethodRemove = Components.PaymentMethodRemoveFeature.Enabled,
-                    canRemoveLastPaymentMethod = true,
+                    paymentMethodRemoveLast = Components.PaymentMethodRemoveLastFeature.Enabled,
                     isPaymentMethodSetAsDefaultEnabled = true,
                     allowRedisplayOverride = null
                 )

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetFixtures.kt
@@ -85,7 +85,8 @@ internal object CustomerSheetFixtures {
                         customerSheet = ElementsSession.Customer.Components.CustomerSheet.Enabled(
                             paymentMethodRemove =
                             ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Disabled,
-                            canRemoveLastPaymentMethod = true,
+                            paymentMethodRemoveLast =
+                            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Enabled,
                             isPaymentMethodSyncDefaultEnabled = isPaymentMethodSyncDefaultEnabled,
                         ),
                     )

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionInitializationDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionInitializationDataSourceTest.kt
@@ -30,7 +30,8 @@ class CustomerSessionInitializationDataSourceTest {
                 customerSheetComponent = createEnabledCustomerSheetComponent(
                     paymentMethodRemoveFeature =
                     ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled,
-                    canRemoveLastPaymentMethod = true,
+                    paymentMethodRemoveLastFeature =
+                    ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Enabled,
                     isPaymentMethodSyncDefaultEnabled = false,
                 ),
             ),
@@ -67,7 +68,8 @@ class CustomerSessionInitializationDataSourceTest {
                 customerSheetComponent = createEnabledCustomerSheetComponent(
                     paymentMethodRemoveFeature =
                     ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Disabled,
-                    canRemoveLastPaymentMethod = false,
+                    paymentMethodRemoveLastFeature =
+                    ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Disabled,
                 ),
             ),
         )
@@ -199,7 +201,8 @@ class CustomerSessionInitializationDataSourceTest {
     fun `When config value is false & server value is false, remove last PM permissions should be false`() =
         runRemoveLastPaymentMethodPermissionsTest(
             allowsRemovalOfLastSavedPaymentMethod = false,
-            canRemoveLastPaymentMethod = false,
+            paymentMethodRemoveLastFeature =
+            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Disabled,
             customerSheetComponentIsDisabled = false,
             expected = false,
         )
@@ -208,7 +211,8 @@ class CustomerSessionInitializationDataSourceTest {
     fun `When config value is false & server component is disabled, remove last PM permissions should be false`() =
         runRemoveLastPaymentMethodPermissionsTest(
             allowsRemovalOfLastSavedPaymentMethod = false,
-            canRemoveLastPaymentMethod = false,
+            paymentMethodRemoveLastFeature =
+            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Disabled,
             customerSheetComponentIsDisabled = true,
             expected = false,
         )
@@ -217,7 +221,8 @@ class CustomerSessionInitializationDataSourceTest {
     fun `When config value is false & server value is true, remove last PM permissions should be false`() =
         runRemoveLastPaymentMethodPermissionsTest(
             allowsRemovalOfLastSavedPaymentMethod = false,
-            canRemoveLastPaymentMethod = true,
+            paymentMethodRemoveLastFeature =
+            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Enabled,
             customerSheetComponentIsDisabled = false,
             expected = false,
         )
@@ -226,7 +231,8 @@ class CustomerSessionInitializationDataSourceTest {
     fun `When config value is true & server value is false, remove last PM permissions should be false`() =
         runRemoveLastPaymentMethodPermissionsTest(
             allowsRemovalOfLastSavedPaymentMethod = true,
-            canRemoveLastPaymentMethod = false,
+            paymentMethodRemoveLastFeature =
+            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Disabled,
             customerSheetComponentIsDisabled = false,
             expected = false,
         )
@@ -235,7 +241,8 @@ class CustomerSessionInitializationDataSourceTest {
     fun `When config value is true & server component is disabled, remove last PM permissions should be false`() =
         runRemoveLastPaymentMethodPermissionsTest(
             allowsRemovalOfLastSavedPaymentMethod = true,
-            canRemoveLastPaymentMethod = false,
+            paymentMethodRemoveLastFeature =
+            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Disabled,
             customerSheetComponentIsDisabled = true,
             expected = false,
         )
@@ -244,7 +251,18 @@ class CustomerSessionInitializationDataSourceTest {
     fun `When config value is true & server value is true, remove last PM permissions should be true`() =
         runRemoveLastPaymentMethodPermissionsTest(
             allowsRemovalOfLastSavedPaymentMethod = true,
-            canRemoveLastPaymentMethod = true,
+            paymentMethodRemoveLastFeature =
+            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Enabled,
+            customerSheetComponentIsDisabled = false,
+            expected = true,
+        )
+
+    @Test
+    fun `When config value is true & server value is not provided, remove last PM permissions should be true`() =
+        runRemoveLastPaymentMethodPermissionsTest(
+            allowsRemovalOfLastSavedPaymentMethod = true,
+            paymentMethodRemoveLastFeature =
+            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.NotProvided,
             customerSheetComponentIsDisabled = false,
             expected = true,
         )
@@ -252,7 +270,7 @@ class CustomerSessionInitializationDataSourceTest {
     private fun runRemoveLastPaymentMethodPermissionsTest(
         allowsRemovalOfLastSavedPaymentMethod: Boolean,
         customerSheetComponentIsDisabled: Boolean,
-        canRemoveLastPaymentMethod: Boolean,
+        paymentMethodRemoveLastFeature: ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature,
         expected: Boolean,
     ) = runTest {
         val dataSource = createInitializationDataSource(
@@ -263,7 +281,7 @@ class CustomerSessionInitializationDataSourceTest {
                     createEnabledCustomerSheetComponent(
                         paymentMethodRemoveFeature =
                         ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled,
-                        canRemoveLastPaymentMethod = canRemoveLastPaymentMethod,
+                        paymentMethodRemoveLastFeature = paymentMethodRemoveLastFeature,
                     )
                 },
             ),
@@ -305,12 +323,13 @@ class CustomerSessionInitializationDataSourceTest {
     private fun createEnabledCustomerSheetComponent(
         paymentMethodRemoveFeature: ElementsSession.Customer.Components.PaymentMethodRemoveFeature =
             ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled,
-        canRemoveLastPaymentMethod: Boolean = true,
+        paymentMethodRemoveLastFeature: ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature =
+            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Enabled,
         isPaymentMethodSyncDefaultEnabled: Boolean = false,
     ): ElementsSession.Customer.Components.CustomerSheet.Enabled {
         return ElementsSession.Customer.Components.CustomerSheet.Enabled(
             paymentMethodRemove = paymentMethodRemoveFeature,
-            canRemoveLastPaymentMethod = canRemoveLastPaymentMethod,
+            paymentMethodRemoveLast = paymentMethodRemoveLastFeature,
             isPaymentMethodSyncDefaultEnabled = isPaymentMethodSyncDefaultEnabled,
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/FakeCustomerSessionElementsSessionManager.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/FakeCustomerSessionElementsSessionManager.kt
@@ -22,7 +22,8 @@ internal class FakeCustomerSessionElementsSessionManager(
         ElementsSession.Customer.Components.CustomerSheet.Enabled(
             paymentMethodRemove =
             ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled,
-            canRemoveLastPaymentMethod = true,
+            paymentMethodRemoveLast =
+            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.NotProvided,
             isPaymentMethodSyncDefaultEnabled = isPaymentMethodSyncDefaultEnabled,
         ),
     private val customer: ElementsSession.Customer = ElementsSession.Customer(

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -700,7 +700,8 @@ internal class DefaultCustomerSheetLoaderTest {
                         customerSheet = ElementsSession.Customer.Components.CustomerSheet.Enabled(
                             paymentMethodRemove =
                             ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Disabled,
-                            canRemoveLastPaymentMethod = true,
+                            paymentMethodRemoveLast =
+                            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.NotProvided,
                             isPaymentMethodSyncDefaultEnabled = isPaymentMethodSyncDefaultEnabled,
                         ),
                     )

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/CustomerMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/CustomerMetadataTest.kt
@@ -33,7 +33,7 @@ internal class CustomerMetadataTest {
     fun `Should create 'Permissions' for customer session properly with remove permissions enabled`() {
         customerSessionPermissionsTest(
             canRemoveLastPaymentMethodConfigValue = true,
-            canRemoveLastPaymentMethod = true,
+            paymentMethodRemoveLast = ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Enabled,
             paymentMethodRemove = ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled,
         ) { permissions ->
             assertThat(permissions.removePaymentMethod).isEqualTo(PaymentMethodRemovePermission.Full)
@@ -48,7 +48,7 @@ internal class CustomerMetadataTest {
     fun `Should create 'Permissions' for customer session properly with partial remove permissions`() {
         customerSessionPermissionsTest(
             canRemoveLastPaymentMethodConfigValue = true,
-            canRemoveLastPaymentMethod = true,
+            paymentMethodRemoveLast = ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Enabled,
             paymentMethodRemove = ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Partial,
         ) { permissions ->
             assertThat(permissions.removePaymentMethod).isEqualTo(PaymentMethodRemovePermission.Partial)
@@ -63,7 +63,7 @@ internal class CustomerMetadataTest {
     fun `Should create 'Permissions' for customer session properly with disabled remove permissions`() {
         customerSessionPermissionsTest(
             canRemoveLastPaymentMethodConfigValue = true,
-            canRemoveLastPaymentMethod = true,
+            paymentMethodRemoveLast = ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Enabled,
             paymentMethodRemove = ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Disabled
         ) { permissions ->
             assertThat(permissions.removePaymentMethod).isEqualTo(PaymentMethodRemovePermission.None)
@@ -95,7 +95,7 @@ internal class CustomerMetadataTest {
     @Test
     fun `Should set 'canRemoveLastPaymentMethod' to false if config value & server value are false`() =
         customerSessionPermissionsTest(
-            canRemoveLastPaymentMethod = false,
+            paymentMethodRemoveLast = ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Disabled,
             canRemoveLastPaymentMethodConfigValue = false,
         ) { permissions ->
             assertThat(permissions.canRemoveLastPaymentMethod).isFalse()
@@ -122,8 +122,17 @@ internal class CustomerMetadataTest {
     @Test
     fun `Should set 'canRemoveLastPaymentMethod' to false if config value is true but server value is false`() =
         customerSessionPermissionsTest(
-            canRemoveLastPaymentMethod = false,
+            paymentMethodRemoveLast = ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Disabled,
             canRemoveLastPaymentMethodConfigValue = true,
+        ) { permissions ->
+            assertThat(permissions.canRemoveLastPaymentMethod).isFalse()
+        }
+
+    @Test
+    fun `Should set 'canRemoveLastPaymentMethod' to false if config value is false & server value is not provided`() =
+        customerSessionPermissionsTest(
+            paymentMethodRemoveLast = ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.NotProvided,
+            canRemoveLastPaymentMethodConfigValue = false,
         ) { permissions ->
             assertThat(permissions.canRemoveLastPaymentMethod).isFalse()
         }
@@ -131,16 +140,25 @@ internal class CustomerMetadataTest {
     @Test
     fun `Should set 'canRemoveLastPaymentMethod' to false if config value is false but server value is true`() =
         customerSessionPermissionsTest(
-            canRemoveLastPaymentMethod = true,
+            paymentMethodRemoveLast = ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Enabled,
             canRemoveLastPaymentMethodConfigValue = false,
         ) { permissions ->
             assertThat(permissions.canRemoveLastPaymentMethod).isFalse()
         }
 
     @Test
+    fun `Should set 'canRemoveLastPaymentMethod' to true if config value is true & server value is not provided`() =
+        customerSessionPermissionsTest(
+            paymentMethodRemoveLast = ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.NotProvided,
+            canRemoveLastPaymentMethodConfigValue = true,
+        ) { permissions ->
+            assertThat(permissions.canRemoveLastPaymentMethod).isTrue()
+        }
+
+    @Test
     fun `Should set 'canRemoveLastPaymentMethod' to true if config value & server value are true`() =
         customerSessionPermissionsTest(
-            canRemoveLastPaymentMethod = true,
+            paymentMethodRemoveLast = ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Enabled,
             canRemoveLastPaymentMethodConfigValue = true,
         ) { permissions ->
             assertThat(permissions.canRemoveLastPaymentMethod).isTrue()
@@ -188,13 +206,14 @@ internal class CustomerMetadataTest {
     private fun createEnabledMobilePaymentElement(
         paymentMethodRemove: ElementsSession.Customer.Components.PaymentMethodRemoveFeature =
             ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled,
-        canRemoveLastPaymentMethod: Boolean = true,
+        paymentMethodRemoveLast: ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature =
+            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Enabled,
         isPaymentMethodSetAsDefaultEnabled: Boolean = true,
     ): ElementsSession.Customer.Components.MobilePaymentElement.Enabled {
         return ElementsSession.Customer.Components.MobilePaymentElement.Enabled(
             isPaymentMethodSaveEnabled = true,
             paymentMethodRemove = paymentMethodRemove,
-            canRemoveLastPaymentMethod = canRemoveLastPaymentMethod,
+            paymentMethodRemoveLast = paymentMethodRemoveLast,
             allowRedisplayOverride = null,
             isPaymentMethodSetAsDefaultEnabled = isPaymentMethodSetAsDefaultEnabled
         )
@@ -255,7 +274,8 @@ internal class CustomerMetadataTest {
     private fun customerSessionPermissionsTest(
         paymentElementDisabled: Boolean = false,
         canRemoveLastPaymentMethodConfigValue: Boolean = true,
-        canRemoveLastPaymentMethod: Boolean = true,
+        paymentMethodRemoveLast: ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature =
+            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Enabled,
         paymentMethodRemove: ElementsSession.Customer.Components.PaymentMethodRemoveFeature =
             ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled,
         block: (CustomerMetadata.Permissions) -> Unit
@@ -265,7 +285,7 @@ internal class CustomerMetadataTest {
         } else {
             createEnabledMobilePaymentElement(
                 paymentMethodRemove = paymentMethodRemove,
-                canRemoveLastPaymentMethod = canRemoveLastPaymentMethod,
+                paymentMethodRemoveLast = paymentMethodRemoveLast,
             )
         }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -1253,7 +1253,8 @@ internal class PaymentMethodMetadataTest {
             mobilePaymentElementComponent = ElementsSession.Customer.Components.MobilePaymentElement.Enabled(
                 isPaymentMethodSaveEnabled = true,
                 paymentMethodRemove = ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled,
-                canRemoveLastPaymentMethod = true,
+                paymentMethodRemoveLast =
+                ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.NotProvided,
                 allowRedisplayOverride = null,
                 isPaymentMethodSetAsDefaultEnabled = false,
             )
@@ -1268,7 +1269,8 @@ internal class PaymentMethodMetadataTest {
             mobilePaymentElementComponent = ElementsSession.Customer.Components.MobilePaymentElement.Enabled(
                 isPaymentMethodSaveEnabled = false,
                 paymentMethodRemove = ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled,
-                canRemoveLastPaymentMethod = true,
+                paymentMethodRemoveLast =
+                ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.NotProvided,
                 allowRedisplayOverride = null,
                 isPaymentMethodSetAsDefaultEnabled = false,
             ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/CustomerSessionPaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/CustomerSessionPaymentSheetActivityTest.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatchers
@@ -59,7 +60,8 @@ internal class CustomerSessionPaymentSheetActivityTest {
             ),
             isPaymentMethodRemoveEnabled = true,
             canRemoveLastPaymentMethodConfig = true,
-            canRemoveLastPaymentMethodServer = true,
+            paymentMethodRemoveLastFeature =
+            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Enabled,
         ) {
             composeTestRule.onEditButton().performClick()
 
@@ -75,7 +77,24 @@ internal class CustomerSessionPaymentSheetActivityTest {
             ),
             isPaymentMethodRemoveEnabled = true,
             canRemoveLastPaymentMethodConfig = true,
-            canRemoveLastPaymentMethodServer = true,
+            paymentMethodRemoveLastFeature =
+            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Enabled,
+        ) {
+            composeTestRule.onEditButton().performClick()
+
+            composeTestRule.onSavedPaymentMethod(last4 = "4242").assertIsDisplayed()
+        }
+
+    @Test
+    fun `When single PM with remove permissions, can remove last from config with no server value, can remove`() =
+        runTest(
+            cards = listOf(
+                PaymentMethodFactory.card(last4 = "4242"),
+            ),
+            isPaymentMethodRemoveEnabled = true,
+            canRemoveLastPaymentMethodConfig = true,
+            paymentMethodRemoveLastFeature =
+            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.NotProvided,
         ) {
             composeTestRule.onEditButton().performClick()
 
@@ -90,7 +109,8 @@ internal class CustomerSessionPaymentSheetActivityTest {
             ),
             isPaymentMethodRemoveEnabled = true,
             canRemoveLastPaymentMethodConfig = true,
-            canRemoveLastPaymentMethodServer = false,
+            paymentMethodRemoveLastFeature =
+            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Disabled,
         ) {
             composeTestRule.onEditButton().assertIsDisplayed()
         }
@@ -103,7 +123,8 @@ internal class CustomerSessionPaymentSheetActivityTest {
             ),
             isPaymentMethodRemoveEnabled = true,
             canRemoveLastPaymentMethodConfig = false,
-            canRemoveLastPaymentMethodServer = true,
+            paymentMethodRemoveLastFeature =
+            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Enabled,
         ) {
             composeTestRule.onEditButton().assertIsDisplayed()
         }
@@ -116,7 +137,8 @@ internal class CustomerSessionPaymentSheetActivityTest {
             ),
             isPaymentMethodRemoveEnabled = true,
             canRemoveLastPaymentMethodConfig = false,
-            canRemoveLastPaymentMethodServer = false,
+            paymentMethodRemoveLastFeature =
+            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Disabled,
         ) {
             composeTestRule.onEditButton().assertExists()
         }
@@ -130,7 +152,8 @@ internal class CustomerSessionPaymentSheetActivityTest {
             ),
             isPaymentMethodRemoveEnabled = false,
             canRemoveLastPaymentMethodConfig = true,
-            canRemoveLastPaymentMethodServer = false,
+            paymentMethodRemoveLastFeature =
+            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Disabled,
         ) {
             composeTestRule.onEditButton().assertIsDisplayed()
         }
@@ -144,7 +167,8 @@ internal class CustomerSessionPaymentSheetActivityTest {
             ),
             isPaymentMethodRemoveEnabled = false,
             canRemoveLastPaymentMethodConfig = true,
-            canRemoveLastPaymentMethodServer = false,
+            paymentMethodRemoveLastFeature =
+            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Disabled,
         ) {
             composeTestRule.onEditButton().performClick()
 
@@ -167,7 +191,8 @@ internal class CustomerSessionPaymentSheetActivityTest {
             ),
             isPaymentMethodRemoveEnabled = true,
             canRemoveLastPaymentMethodConfig = true,
-            canRemoveLastPaymentMethodServer = false,
+            paymentMethodRemoveLastFeature =
+            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Disabled,
         ) {
             composeTestRule.onEditButton().performClick()
 
@@ -191,7 +216,8 @@ internal class CustomerSessionPaymentSheetActivityTest {
             ),
             isPaymentMethodRemoveEnabled = true,
             canRemoveLastPaymentMethodConfig = true,
-            canRemoveLastPaymentMethodServer = false,
+            paymentMethodRemoveLastFeature =
+            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Disabled,
         ) {
             composeTestRule.onEditButton().performClick()
 
@@ -213,7 +239,8 @@ internal class CustomerSessionPaymentSheetActivityTest {
             ),
             isPaymentMethodRemoveEnabled = true,
             canRemoveLastPaymentMethodConfig = false,
-            canRemoveLastPaymentMethodServer = true,
+            paymentMethodRemoveLastFeature =
+            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Enabled,
         ) {
             composeTestRule.onEditButton().performClick()
 
@@ -235,7 +262,8 @@ internal class CustomerSessionPaymentSheetActivityTest {
             ),
             isPaymentMethodRemoveEnabled = true,
             canRemoveLastPaymentMethodConfig = true,
-            canRemoveLastPaymentMethodServer = true,
+            paymentMethodRemoveLastFeature =
+            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Enabled,
         ) {
             composeTestRule.onEditButton().performClick()
 
@@ -257,7 +285,8 @@ internal class CustomerSessionPaymentSheetActivityTest {
             ),
             isPaymentMethodRemoveEnabled = false,
             canRemoveLastPaymentMethodConfig = true,
-            canRemoveLastPaymentMethodServer = false,
+            paymentMethodRemoveLastFeature =
+            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Disabled,
         ) {
             composeTestRule.onEditButton().performClick()
 
@@ -279,7 +308,8 @@ internal class CustomerSessionPaymentSheetActivityTest {
             ),
             isPaymentMethodRemoveEnabled = true,
             canRemoveLastPaymentMethodConfig = false,
-            canRemoveLastPaymentMethodServer = false,
+            paymentMethodRemoveLastFeature =
+            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Disabled,
         ) {
             composeTestRule.onEditButton().performClick()
 
@@ -297,7 +327,8 @@ internal class CustomerSessionPaymentSheetActivityTest {
         cards: List<PaymentMethod>,
         isPaymentMethodRemoveEnabled: Boolean = true,
         canRemoveLastPaymentMethodConfig: Boolean = true,
-        canRemoveLastPaymentMethodServer: Boolean = true,
+        paymentMethodRemoveLastFeature: ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature =
+            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Enabled,
         defaultPaymentMethod: String? = null,
         test: (PaymentSheetActivity) -> Unit,
     ) {
@@ -310,7 +341,7 @@ internal class CustomerSessionPaymentSheetActivityTest {
                 createElementsSessionResponse(
                     cards = cards,
                     isPaymentMethodRemoveEnabled = isPaymentMethodRemoveEnabled,
-                    canRemoveLastPaymentMethod = canRemoveLastPaymentMethodServer,
+                    paymentMethodRemoveLastFeature = paymentMethodRemoveLastFeature,
                     defaultPaymentMethod = defaultPaymentMethod,
                 )
             )
@@ -393,7 +424,7 @@ internal class CustomerSessionPaymentSheetActivityTest {
         fun createElementsSessionResponse(
             cards: List<PaymentMethod>,
             isPaymentMethodRemoveEnabled: Boolean,
-            canRemoveLastPaymentMethod: Boolean,
+            paymentMethodRemoveLastFeature: ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature,
             defaultPaymentMethod: String?,
         ): String {
             val cardsArray = JSONArray()
@@ -405,7 +436,11 @@ internal class CustomerSessionPaymentSheetActivityTest {
             val cardsStringified = cardsArray.toString(2)
 
             val isPaymentMethodRemoveStringified = isPaymentMethodRemoveEnabled.toFeatureState()
-            val canRemoveLastPaymentMethodStringified = canRemoveLastPaymentMethod.toFeatureState()
+            val canRemoveLastPaymentMethodStringified = when (paymentMethodRemoveLastFeature) {
+                ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Enabled -> "enabled"
+                ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Disabled -> "disabled"
+                ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.NotProvided -> null
+            }
 
             return """
                 {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CustomerStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CustomerStateTest.kt
@@ -83,7 +83,8 @@ class CustomerStateTest {
                 mobilePaymentElementComponent = createEnabledMobilePaymentElement(
                     isPaymentMethodSaveEnabled = false,
                     paymentMethodRemove = ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Disabled,
-                    canRemoveLastPaymentMethod = false,
+                    paymentMethodRemoveLast =
+                    ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Disabled,
                     allowRedisplayOverride = null,
                 ),
             )
@@ -101,14 +102,15 @@ class CustomerStateTest {
         isPaymentMethodSaveEnabled: Boolean = true,
         paymentMethodRemove: ElementsSession.Customer.Components.PaymentMethodRemoveFeature =
             ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Disabled,
-        canRemoveLastPaymentMethod: Boolean = false,
+        paymentMethodRemoveLast: ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature =
+            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Disabled,
         allowRedisplayOverride: PaymentMethod.AllowRedisplay? = null,
         isPaymentMethodSetAsDefaultEnabled: Boolean = false,
     ): ElementsSession.Customer.Components.MobilePaymentElement {
         return ElementsSession.Customer.Components.MobilePaymentElement.Enabled(
             isPaymentMethodSaveEnabled = isPaymentMethodSaveEnabled,
             paymentMethodRemove = paymentMethodRemove,
-            canRemoveLastPaymentMethod = canRemoveLastPaymentMethod,
+            paymentMethodRemoveLast = paymentMethodRemoveLast,
             allowRedisplayOverride = allowRedisplayOverride,
             isPaymentMethodSetAsDefaultEnabled = isPaymentMethodSetAsDefaultEnabled,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -2095,7 +2095,8 @@ internal class DefaultPaymentElementLoaderTest {
                         createEnabledMobilePaymentElement(
                             paymentMethodRemove =
                             ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled,
-                            canRemoveLastPaymentMethod = true,
+                            paymentMethodRemoveLast =
+                            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Enabled,
                             isPaymentMethodSaveEnabled = false,
                             allowRedisplayOverride = null,
                         )
@@ -2142,7 +2143,8 @@ internal class DefaultPaymentElementLoaderTest {
                             paymentMethodRemove =
                             ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Disabled,
                             isPaymentMethodSaveEnabled = false,
-                            canRemoveLastPaymentMethod = true,
+                            paymentMethodRemoveLast =
+                            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Enabled,
                             allowRedisplayOverride = null,
                         )
                     ),
@@ -2188,7 +2190,8 @@ internal class DefaultPaymentElementLoaderTest {
                             paymentMethodRemove =
                             ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Disabled,
                             isPaymentMethodSaveEnabled = false,
-                            canRemoveLastPaymentMethod = true,
+                            paymentMethodRemoveLast =
+                            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Enabled,
                             allowRedisplayOverride = null,
                         )
                     ),
@@ -2234,7 +2237,8 @@ internal class DefaultPaymentElementLoaderTest {
                             paymentMethodRemove =
                             ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Partial,
                             isPaymentMethodSaveEnabled = false,
-                            canRemoveLastPaymentMethod = true,
+                            paymentMethodRemoveLast =
+                            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Enabled,
                             allowRedisplayOverride = null,
                         )
                     ),
@@ -2280,7 +2284,8 @@ internal class DefaultPaymentElementLoaderTest {
                             paymentMethodRemove =
                             ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Disabled,
                             isPaymentMethodSaveEnabled = false,
-                            canRemoveLastPaymentMethod = true,
+                            paymentMethodRemoveLast =
+                            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Enabled,
                             allowRedisplayOverride = null,
                         )
                     ),
@@ -3168,7 +3173,23 @@ internal class DefaultPaymentElementLoaderTest {
                 id = "cus_1",
                 clientSecret = "cuss_123",
             ),
-            canRemoveLastPaymentMethodFromServer = true,
+            paymentMethodRemoveLastFeature =
+            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Enabled,
+            canRemoveLastPaymentMethodFromConfig = true,
+        ) { permissions ->
+            assertThat(permissions.canRemoveLastPaymentMethod).isTrue()
+        }
+
+    @OptIn(ExperimentalCustomerSessionApi::class)
+    @Test
+    fun `When using 'CustomerSession', last PM permission should be true if config value is true & no server value`() =
+        removeLastPaymentMethodTest(
+            customer = PaymentSheet.CustomerConfiguration.createWithCustomerSession(
+                id = "cus_1",
+                clientSecret = "cuss_123",
+            ),
+            paymentMethodRemoveLastFeature =
+            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.NotProvided,
             canRemoveLastPaymentMethodFromConfig = true,
         ) { permissions ->
             assertThat(permissions.canRemoveLastPaymentMethod).isTrue()
@@ -3515,7 +3536,8 @@ internal class DefaultPaymentElementLoaderTest {
     private fun removeLastPaymentMethodTest(
         customer: PaymentSheet.CustomerConfiguration,
         shouldDisableMobilePaymentElement: Boolean = false,
-        canRemoveLastPaymentMethodFromServer: Boolean = true,
+        paymentMethodRemoveLastFeature: ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature =
+            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.NotProvided,
         canRemoveLastPaymentMethodFromConfig: Boolean = true,
         test: (CustomerMetadata.Permissions) -> Unit,
     ) = runTest {
@@ -3530,7 +3552,7 @@ internal class DefaultPaymentElementLoaderTest {
                             paymentMethodRemove =
                             ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Disabled,
                             isPaymentMethodSaveEnabled = false,
-                            canRemoveLastPaymentMethod = canRemoveLastPaymentMethodFromServer,
+                            paymentMethodRemoveLast = paymentMethodRemoveLastFeature,
                             allowRedisplayOverride = null,
                         )
                     }
@@ -3754,7 +3776,8 @@ internal class DefaultPaymentElementLoaderTest {
                 createEnabledMobilePaymentElement(
                     isPaymentMethodSaveEnabled = it,
                     paymentMethodRemove = ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled,
-                    canRemoveLastPaymentMethod = true,
+                    paymentMethodRemoveLast =
+                    ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.NotProvided,
                     allowRedisplayOverride = null,
                     isPaymentMethodSetAsDefaultEnabled = false,
                 )
@@ -3949,7 +3972,8 @@ internal class DefaultPaymentElementLoaderTest {
                         isPaymentMethodSetAsDefaultEnabled = true,
                         isPaymentMethodSaveEnabled = true,
                         paymentMethodRemove = ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled,
-                        canRemoveLastPaymentMethod = true,
+                        paymentMethodRemoveLast =
+                        ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.NotProvided,
                         allowRedisplayOverride = null,
                     ),
                 ),
@@ -3977,14 +4001,15 @@ internal class DefaultPaymentElementLoaderTest {
         isPaymentMethodSaveEnabled: Boolean = true,
         paymentMethodRemove: ElementsSession.Customer.Components.PaymentMethodRemoveFeature =
             ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Disabled,
-        canRemoveLastPaymentMethod: Boolean = false,
+        paymentMethodRemoveLast: ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature =
+            ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.NotProvided,
         allowRedisplayOverride: PaymentMethod.AllowRedisplay? = null,
         isPaymentMethodSetAsDefaultEnabled: Boolean = false,
     ): ElementsSession.Customer.Components.MobilePaymentElement {
         return ElementsSession.Customer.Components.MobilePaymentElement.Enabled(
             isPaymentMethodSaveEnabled = isPaymentMethodSaveEnabled,
             paymentMethodRemove = paymentMethodRemove,
-            canRemoveLastPaymentMethod = canRemoveLastPaymentMethod,
+            paymentMethodRemoveLast = paymentMethodRemoveLast,
             allowRedisplayOverride = allowRedisplayOverride,
             isPaymentMethodSetAsDefaultEnabled = isPaymentMethodSetAsDefaultEnabled,
         )

--- a/paymentsheet/src/test/resources/elements-sessions-customer_sheet_customer_session.json
+++ b/paymentsheet/src/test/resources/elements-sessions-customer_sheet_customer_session.json
@@ -30,7 +30,7 @@
           "enabled": true,
           "features": {
             "payment_method_remove": "PAYMENT_METHOD_REMOVE_FEATURE",
-            "payment_method_remove_last": "PAYMENT_METHOD_REMOVE_LAST_FEATURE"
+            "payment_method_remove_last": PAYMENT_METHOD_REMOVE_LAST_FEATURE
           }
         }
       }


### PR DESCRIPTION
# Summary
Fix remove last feature being disabled when `payment_method_remove_last` is not provided through `CustomerSession`

# Motivation
`payment_method_remove_last` is a gated feature. When using `CustomerSession`, by default we should have the remove last feature enabled if the merchant is not gated in.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified