### PR TITLE
Clear passive captcha cache after it is used

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/hcaptcha/DefaultHCaptchaService.kt
+++ b/payments-core/src/main/java/com/stripe/android/hcaptcha/DefaultHCaptchaService.kt
@@ -50,6 +50,7 @@ internal class DefaultHCaptchaService(
         }.getOrElse { e ->
             HCaptchaService.Result.Failure(e)
         }
+        cachedResult.emit(CachedResult.Idle)
         return result
     }
 

--- a/payments-core/src/test/java/com/stripe/android/hcaptcha/DefaultHCaptchaServiceTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/hcaptcha/DefaultHCaptchaServiceTest.kt
@@ -226,6 +226,8 @@ internal class DefaultHCaptchaServiceTest {
                 rqData = null
             )
             hCaptchaProvider.awaitCall() // This would not be called if cache wasn't cleared
+
+            hCaptchaProvider.ensureAllEventsConsumed()
         }
     }
 
@@ -258,6 +260,8 @@ internal class DefaultHCaptchaServiceTest {
                 rqData = null
             )
             hCaptchaProvider.awaitCall() // This would not be called if cache wasn't cleared
+
+            hCaptchaProvider.ensureAllEventsConsumed()
         }
     }
 

--- a/payments-core/src/test/java/com/stripe/android/hcaptcha/DefaultHCaptchaServiceTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/hcaptcha/DefaultHCaptchaServiceTest.kt
@@ -199,6 +199,95 @@ internal class DefaultHCaptchaServiceTest {
     }
 
     @Test
+    fun `performPassiveHCaptcha clears cache to Idle state after successful completion`() = runTest {
+        TestContext.test {
+            hCaptchaProvider.hCaptchaHandler = SetupSuccessfulHCaptcha()
+
+            // First warmUp to populate cache with Success state
+            service.warmUp(
+                activity,
+                siteKey = TEST_SITE_KEY,
+                rqData = null
+            )
+            hCaptchaProvider.awaitCall()
+
+            // Perform the passive hCaptcha which should clear cache
+            service.performPassiveHCaptcha(
+                activity,
+                siteKey = TEST_SITE_KEY,
+                rqData = null
+            )
+
+            // Verify a subsequent warmUp call goes through (would be skipped if cache wasn't cleared)
+            hCaptchaProvider.hCaptchaHandler = SetupSuccessfulHCaptcha("new-token")
+            service.warmUp(
+                activity,
+                siteKey = TEST_SITE_KEY,
+                rqData = null
+            )
+            hCaptchaProvider.awaitCall() // This would not be called if cache wasn't cleared
+        }
+    }
+
+    @Test
+    fun `performPassiveHCaptcha clears cache to Idle state after failed completion`() = runTest {
+        TestContext.test {
+            val exception = HCaptchaException(HCaptchaError.NETWORK_ERROR)
+            hCaptchaProvider.hCaptchaHandler = SetupFailedHCaptcha(exception)
+
+            // First warmUp to populate cache with Failure state
+            service.warmUp(
+                activity,
+                siteKey = TEST_SITE_KEY,
+                rqData = null
+            )
+            hCaptchaProvider.awaitCall()
+
+            // Perform the passive hCaptcha which should clear cache
+            service.performPassiveHCaptcha(
+                activity,
+                siteKey = TEST_SITE_KEY,
+                rqData = null
+            )
+
+            // Verify a subsequent warmUp call goes through (would be skipped if cache wasn't cleared)
+            hCaptchaProvider.hCaptchaHandler = SetupSuccessfulHCaptcha("recovery-token")
+            service.warmUp(
+                activity,
+                siteKey = TEST_SITE_KEY,
+                rqData = null
+            )
+            hCaptchaProvider.awaitCall() // This would not be called if cache wasn't cleared
+        }
+    }
+
+    @Test
+    fun `performPassiveHCaptcha clears cache to Idle state after timeout exception`() = runTest {
+        TestContext.test {
+            // Setup hCaptcha that will hang (causing timeout)
+            hCaptchaProvider.hCaptchaHandler = SetupHangingHCaptcha
+
+            // Perform passive hCaptcha that should timeout and clear cache
+            val result = service.performPassiveHCaptcha(
+                activity,
+                siteKey = TEST_SITE_KEY,
+                rqData = null
+            )
+
+            assertThat(result).isInstanceOf(HCaptchaService.Result.Failure::class.java)
+
+            // Verify a subsequent warmUp call goes through (would be skipped if cache wasn't cleared)
+            hCaptchaProvider.hCaptchaHandler = SetupSuccessfulHCaptcha("recovery-token")
+            service.warmUp(
+                activity,
+                siteKey = TEST_SITE_KEY,
+                rqData = null
+            )
+            hCaptchaProvider.awaitCall() // This would not be called if cache wasn't cleared
+        }
+    }
+
+    @Test
     fun `warmUp calls hCaptchaProvider and updates cache on success`() = runTest {
         TestContext.test {
             val expectedToken = "warm-up-token"


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Clear passive captcha cache after it is used.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
The token is meant to be single-use, so we should clear it after its used.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
