### PR TITLE
[Identity] Requiring live capture to be false to show upload

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityNavGraph.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityNavGraph.kt
@@ -61,7 +61,7 @@ import kotlinx.coroutines.launch
 
 @Composable
 @ExperimentalMaterialApi
-@Suppress("CyclomaticComplexMethod")
+@Suppress("CyclomaticComplexMethod", "LongMethod")
 internal fun IdentityNavGraph(
     navController: NavHostController = rememberNavController(),
     identityViewModel: IdentityViewModel,


### PR DESCRIPTION
## Summary

Fixes [#11547](https://github.com/stripe/stripe-android/issues/11547)

Enforce live capture by hiding the “Upload a Photo” fallback whenever requireLiveCapture is true. This removes the upload option in camera error and timeout states (leaving only “Try Again”), aligning the iOS UI with the verification session’s live capture requirement.

## Testing

Easiest way to test this is to timeout on the live capture screen.

Then you can see the error screen and verify that the upload photo button does not show up if it is not supposed.

