### PR TITLE
Warm up passive challenge in Link

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkComponent.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.content.Context
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.cards.CardAccountRangeRepository
+import com.stripe.android.challenge.warmer.PassiveChallengeWarmerModule
 import com.stripe.android.common.di.ApplicationIdModule
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
@@ -48,7 +49,8 @@ internal annotation class NativeLinkScope
         ApplicationIdModule::class,
         DefaultConfirmationModule::class,
         LinkPassthroughConfirmationModule::class,
-        CardScanModule::class
+        CardScanModule::class,
+        PassiveChallengeWarmerModule::class
     ]
 )
 internal interface NativeLinkComponent {

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityTest.kt
@@ -27,6 +27,7 @@ import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentsheet.addresselement.TestAutocompleteLauncher
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.testing.CoroutineTestRule
+import com.stripe.android.utils.FakePassiveChallengeWarmer
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
@@ -161,6 +162,10 @@ internal class LinkActivityTest {
                 linkConfirmationHandlerFactory = { FakeLinkConfirmationHandler() },
                 autocompleteLauncher = TestAutocompleteLauncher.noOp(),
                 addPaymentMethodOptionsFactory = mock(),
+                passiveChallengeWarmer = FakePassiveChallengeWarmer(),
+                passiveCaptchaParams = null,
+                productUsage = setOf("PaymentSheet"),
+                publishableKeyProvider = { "pk_test_123" },
             )
         }
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Warm up passive challenge in Link

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Ensure `PassiveChallengeWarmer` is started in Link, just like it is in PaymentSheet. This will reduce the latency of fetching the passive challenge token during confirmation.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
