### PR TITLE
Clear params in confirmation mediator to avoid hanging onto PANs longer than necessary.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediator.kt
@@ -49,6 +49,7 @@ internal class ConfirmationMediator<
             activityResultCaller
         ) { result ->
             val confirmationResult = persistedParameters?.let { params ->
+                persistedParameters = null
                 definition.toResult(
                     confirmationOption = params.confirmationOption,
                     confirmationParameters = params.confirmationParameters,
@@ -170,7 +171,7 @@ internal class ConfirmationMediator<
         val deferredIntentConfirmationType: DeferredIntentConfirmationType?,
     ) : Parcelable
 
-    private companion object {
-        private const val PARAMETERS_POSTFIX_KEY = "Parameters"
+    companion object {
+        const val PARAMETERS_POSTFIX_KEY = "Parameters"
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediatorTest.kt
@@ -444,8 +444,10 @@ class ConfirmationMediatorTest {
     ) {
         val waitForResultLatch = CountDownLatch(1)
 
+        val savedStateHandle = SavedStateHandle()
+
         val mediator = ConfirmationMediator(
-            savedStateHandle = SavedStateHandle(),
+            savedStateHandle = savedStateHandle,
             definition = definition,
         )
 
@@ -505,6 +507,9 @@ class ConfirmationMediatorTest {
 
         assertThat(successResult.intent).isEqualTo(INTENT)
         assertThat(successResult.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Client)
+
+        // The params should be cleared to avoid keeping the PAN around in memory longer than necessary.
+        assertThat(savedStateHandle.get<Any>(mediator.key + ConfirmationMediator.PARAMETERS_POSTFIX_KEY)).isNull()
     }
 
     @Test


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
The saved state handle was hanging onto confirmation params longer than necessary. This change makes it so that objects that hold onto PANs can be garbage collected even while the host activity remains alive.

