### PR TITLE
Don't reference selection in PaymentOptionFactory lambda.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionFactory.kt
@@ -10,8 +10,12 @@ internal class PaymentOptionFactory @Inject constructor(
     private val context: Context,
 ) {
     fun create(selection: PaymentSelection): PaymentOption {
+        val drawableResourceId = selection.drawableResourceId
+        val lightThemeIconUrl = selection.lightThemeIconUrl
+        val darkThemeIconUrl = selection.darkThemeIconUrl
+
         return PaymentOption(
-            drawableResourceId = selection.drawableResourceId,
+            drawableResourceId = drawableResourceId,
             label = selection.label.resolve(context),
             paymentMethodType = selection.paymentMethodType,
             _labels = PaymentOptionLabelsFactory.create(context, selection),
@@ -19,10 +23,10 @@ internal class PaymentOptionFactory @Inject constructor(
             _shippingDetails = selection.shippingDetails,
             imageLoader = {
                 iconLoader.load(
-                    drawableResourceId = selection.drawableResourceId,
-                    drawableResourceIdNight = selection.drawableResourceId,
-                    lightThemeIconUrl = selection.lightThemeIconUrl,
-                    darkThemeIconUrl = selection.darkThemeIconUrl,
+                    drawableResourceId = drawableResourceId,
+                    drawableResourceIdNight = drawableResourceId,
+                    lightThemeIconUrl = lightThemeIconUrl,
+                    darkThemeIconUrl = darkThemeIconUrl,
                 )
             },
         )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This makes it so we don't retain a reference to selection in the lambda, which could contain the PAN, which once vended to the merchant, has a lifecycle outside of our control.
