### PR TITLE
Clear previous selections after successfully confirming an intent.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedStateHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedStateHelper.kt
@@ -78,6 +78,7 @@ internal class DefaultEmbeddedStateHelper @Inject constructor(
         embeddedContentHelper.clearEmbeddedContent()
         confirmationStateHolder.state = null
         selectionHolder.set(null)
+        selectionHolder.previousNewSelections.clear()
         customerStateHolder.setCustomerState(null)
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedStateHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedStateHelperTest.kt
@@ -8,6 +8,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
+import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.InternalRowSelectionCallback
@@ -83,6 +84,7 @@ internal class DefaultEmbeddedStateHelperTest {
             selection = PaymentSelection.GooglePay,
             customer = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE,
         )
+        selectionHolder.previousNewSelections.putParcelable("card", PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
 
         assertThat(stateHelper.state).isNotNull()
         assertThat(confirmationStateHolder.state).isNotNull()
@@ -96,6 +98,7 @@ internal class DefaultEmbeddedStateHelperTest {
         assertThat(confirmationStateHolder.state).isNull()
         assertThat(customerStateHolder.customer.value).isNull()
         assertThat(selectionHolder.selection.value).isNull()
+        assertThat(selectionHolder.previousNewSelections.isEmpty).isTrue()
         assertThat(embeddedContentHelper.clearEmbeddedContentTurbine.awaitItem()).isEqualTo(Unit)
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This makes it so that `EmbeddedPaymentElement` doesn't reference PANs longer than necessary (after a successful confirmation).
