### PR TITLE
[onramp] Analytics params `session_id` and `mobile_session_id`

### DIFF
--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/analytics/OnrampAnalyticsService.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/analytics/OnrampAnalyticsService.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.crypto.onramp.analytics
 
 import android.content.Context
+import com.stripe.android.common.di.MOBILE_SESSION_ID
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.networking.AnalyticsRequestV2Executor
 import com.stripe.android.core.networking.AnalyticsRequestV2Factory
@@ -9,6 +10,8 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import javax.inject.Named
+import javax.inject.Provider
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
@@ -27,6 +30,7 @@ internal class OnrampAnalyticsServiceImpl @AssistedInject constructor(
     @Assisted override val elementsSessionId: String,
     private val requestExecutor: AnalyticsRequestV2Executor,
     @IOContext private val workContext: CoroutineContext,
+    @Named(MOBILE_SESSION_ID) private val mobileSessionIdProvider: Provider<String>,
 ) : OnrampAnalyticsService {
 
     private val requestFactory = AnalyticsRequestV2Factory(
@@ -40,7 +44,8 @@ internal class OnrampAnalyticsServiceImpl @AssistedInject constructor(
             val request = requestFactory.createRequest(
                 eventName = event.eventName,
                 additionalParams = buildMap {
-                    put("elements_session_id", elementsSessionId)
+                    put("session_id", elementsSessionId)
+                    put("mobile_session_id", mobileSessionIdProvider.get())
                     event.params?.let { putAll(it) }
                 },
                 includeSDKParams = true,

--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/di/OnrampModule.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/di/OnrampModule.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.BuildConfig
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.Stripe
+import com.stripe.android.common.di.MobileSessionIdModule
 import com.stripe.android.core.ApiVersion
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.ENABLE_LOGGING
@@ -28,6 +29,7 @@ import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
 @Module(
+    includes = [MobileSessionIdModule::class],
     subcomponents = [OnrampPresenterComponent::class]
 )
 internal class OnrampModule {

--- a/paymentsheet/src/main/java/com/stripe/android/common/di/MobileSessionIdModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/di/MobileSessionIdModule.kt
@@ -1,12 +1,14 @@
 package com.stripe.android.common.di
 
+import androidx.annotation.RestrictTo
 import com.stripe.android.core.networking.AnalyticsRequestFactory
 import dagger.Module
 import dagger.Provides
 import javax.inject.Named
 
 @Module
-internal class MobileSessionIdModule {
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class MobileSessionIdModule {
     @Provides
     @Named(MOBILE_SESSION_ID)
     fun mobileSessionIdProvider(): String {
@@ -14,4 +16,5 @@ internal class MobileSessionIdModule {
     }
 }
 
-internal const val MOBILE_SESSION_ID = "mobile_session_id"
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+const val MOBILE_SESSION_ID = "mobile_session_id"


### PR DESCRIPTION
# Summary
Update analytics to include params `session_id` and `mobile_session_id`.

# Motivation
👻 

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots

<img width="756" height="680" alt="Screenshot 2025-09-16 at 3 47 48 PM" src="https://github.com/user-attachments/assets/f8fe9420-723a-489e-9dc6-82140d95b3ea" />
