### PR TITLE
[onramp] Allows PaymentMethodPreview To Be Created From Limited Info

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkController.kt
@@ -11,11 +11,15 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.common.configuration.ConfigurationDefaults
+import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.link.injection.DaggerLinkControllerComponent
 import com.stripe.android.link.injection.LinkControllerPresenterComponent
+import com.stripe.android.link.ui.wallet.makeFallbackCardName
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.networking.RequestSurface
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.uicore.isSystemDarkTheme
 import dev.drewhamilton.poko.Poko
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.parcelize.Parcelize
@@ -742,6 +746,45 @@ class LinkController @Inject internal constructor(
         val iconPainter: Painter
             @Composable
             get() = painterResource(iconRes)
+
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        companion object {
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            @JvmStatic
+            fun createOnrampPreview(
+                context: Context,
+                iconType: PaymentIconDetails
+            ): PaymentMethodPreview {
+                val label = context.getString(com.stripe.android.R.string.stripe_link)
+                val drawableResourceId = getIconDrawableRes(iconType, context.isSystemDarkTheme())
+                val sublabel = buildString {
+                    val name: ResolvableString
+                    val last4: String
+
+                    when (iconType) {
+                        is PaymentIconDetails.Card -> {
+                            name = makeFallbackCardName(iconType.funding, iconType.brand.displayName)
+                            last4 = iconType.last4
+                        }
+                        is PaymentIconDetails.BankAccount -> {
+                            name = iconType.bankName?.resolvableString
+                                ?: com.stripe.android.ui.core.R.string.stripe_payment_method_bank.resolvableString
+                            last4 = iconType.last4
+                        }
+                    }
+
+                    append(name.resolve(context))
+                    append(" •••• ")
+                    append(last4)
+                }
+
+                return PaymentMethodPreview(
+                    iconRes = drawableResourceId,
+                    label = label,
+                    sublabel = sublabel,
+                )
+            }
+        }
     }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/PaymentDetailsNickname.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/PaymentDetailsNickname.kt
@@ -54,6 +54,16 @@ internal val ConsumerPaymentDetails.PaymentDetails.paymentOptionLabel: Resolvabl
         return components.joinToString(separator = " ")
     }
 
+internal fun makeFallbackCardName(funding: String, brand: String): ResolvableString {
+    return when (funding) {
+        "CREDIT" -> resolvableString(R.string.stripe_link_card_type_credit, brand)
+        "DEBIT" -> resolvableString(R.string.stripe_link_card_type_debit, brand)
+        "PREPAID" -> resolvableString(R.string.stripe_link_card_type_prepaid, brand)
+        "CHARGE", "FUNDING_INVALID" -> resolvableString(R.string.stripe_link_card_type_unknown, brand)
+        else -> resolvableString(R.string.stripe_link_card_type_unknown, brand)
+    }
+}
+
 private fun makeCardDisplayName(nickname: String?, funding: String, brand: CardBrand): ResolvableString {
     return nickname?.resolvableString ?: makeFallbackCardName(funding, brand.displayName)
 }
@@ -62,16 +72,6 @@ private fun makeBankAccountDisplayName(nickname: String?, bankName: String?): Re
     return nickname?.resolvableString
         ?: bankName?.resolvableString
         ?: StripeUiCoreR.string.stripe_payment_method_bank.resolvableString
-}
-
-private fun makeFallbackCardName(funding: String, brand: String): ResolvableString {
-    return when (funding) {
-        "CREDIT" -> resolvableString(R.string.stripe_link_card_type_credit, brand)
-        "DEBIT" -> resolvableString(R.string.stripe_link_card_type_debit, brand)
-        "PREPAID" -> resolvableString(R.string.stripe_link_card_type_prepaid, brand)
-        "CHARGE", "FUNDING_INVALID" -> resolvableString(R.string.stripe_link_card_type_unknown, brand)
-        else -> resolvableString(R.string.stripe_link_card_type_unknown, brand)
-    }
 }
 
 private fun List<ResolvableString>.joinToString(separator: String): ResolvableString {


### PR DESCRIPTION
# Summary
Adds new API to allow for the creation of payment method preview from specific info.

# Motivation
Improvement to allow for clients to re-create payment previews from api responses.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified