### PR TITLE
[Link] Adds `disableFundingSources` field to client configuration

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
@@ -213,6 +213,7 @@ internal fun LinkController.Configuration.asCommonConfiguration(): CommonConfigu
         collectMissingBillingDetailsForExistingPaymentMethods = true,
         allowUserEmailEdits = allowUserEmailEdits,
         allowLogOut = allowLogOut,
+        disableFundingSources = emptyList()
     ),
     shopPayConfiguration = null,
     googlePlacesApiKey = null,

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkConfiguration.kt
@@ -47,6 +47,7 @@ internal data class LinkConfiguration(
     val saveConsentBehavior: PaymentMethodSaveConsentBehavior,
     val forceSetupFutureUseBehaviorAndNewMandate: Boolean,
     val linkSupportedPaymentMethodsOnboardingEnabled: List<String>,
+    val disableFundingSources: List<String>,
 ) : Parcelable {
 
     val customerIdForEceDefaultValues: String?

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/AddPaymentMethodRequirement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/AddPaymentMethodRequirement.kt
@@ -4,7 +4,6 @@ import com.stripe.android.model.LinkMode
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod.Type.USBankAccount
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode
-import kotlin.text.contains
 
 internal enum class AddPaymentMethodRequirement {
     /** A special case that indicates the payment method is always unsupported by PaymentSheet. */
@@ -90,7 +89,9 @@ internal enum class AddPaymentMethodRequirement {
 private val PaymentMethodMetadata.supportsMobileInstantDebitsFlow: Boolean
     get() {
         val supportsInstantDebitsOnboarding = linkState?.configuration?.supportsInstantDebitsOnboarding == true
-        val instantDebitsDisabledViaConfig = linkConfiguration.disableFundingSources.contains("BANK")
+        val instantDebitsDisabledViaConfig = linkConfiguration.disableFundingSources.any {
+            it.equals("BANK_ACCOUNT", ignoreCase = true)
+        }
         return supportsInstantDebitsOnboarding && canShowBankForm && instantDebitsDisabledViaConfig.not()
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/AddPaymentMethodRequirement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/AddPaymentMethodRequirement.kt
@@ -4,6 +4,7 @@ import com.stripe.android.model.LinkMode
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod.Type.USBankAccount
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode
+import kotlin.text.contains
 
 internal enum class AddPaymentMethodRequirement {
     /** A special case that indicates the payment method is always unsupported by PaymentSheet. */
@@ -89,7 +90,8 @@ internal enum class AddPaymentMethodRequirement {
 private val PaymentMethodMetadata.supportsMobileInstantDebitsFlow: Boolean
     get() {
         val supportsInstantDebitsOnboarding = linkState?.configuration?.supportsInstantDebitsOnboarding == true
-        return supportsInstantDebitsOnboarding && canShowBankForm
+        val instantDebitsDisabledViaConfig = linkConfiguration.disableFundingSources.contains("BANK")
+        return supportsInstantDebitsOnboarding && canShowBankForm && instantDebitsDisabledViaConfig.not()
     }
 
 private val PaymentMethodMetadata.canShowBankForm: Boolean

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -3217,16 +3217,22 @@ class PaymentSheet internal constructor(
         internal val collectMissingBillingDetailsForExistingPaymentMethods: Boolean,
         internal val allowUserEmailEdits: Boolean,
         internal val allowLogOut: Boolean,
+        /**
+         * The Link funding sources that should be disabled. Defaults to an empty list.
+         */
+        val disableFundingSources: List<String>,
     ) : Parcelable {
 
         @JvmOverloads
         constructor(
-            display: Display = Display.Automatic
+            display: Display = Display.Automatic,
+            disableFundingSources: List<String> = emptyList()
         ) : this(
             display = display,
             collectMissingBillingDetailsForExistingPaymentMethods = true,
             allowUserEmailEdits = true,
             allowLogOut = true,
+            disableFundingSources = disableFundingSources,
         )
 
         internal val shouldDisplay: Boolean
@@ -3238,6 +3244,7 @@ class PaymentSheet internal constructor(
         class Builder {
             private var display: Display = Display.Automatic
             private var collectMissingBillingDetailsForExistingPaymentMethods: Boolean = true
+            private var disableFundingSources: List<String> = emptyList()
 
             fun display(display: Display) = apply {
                 this.display = display
@@ -3251,12 +3258,17 @@ class PaymentSheet internal constructor(
                     collectMissingBillingDetailsForExistingPaymentMethods
             }
 
+            fun disableFundingSources(disableFundingSources: List<String>) = apply {
+                this.disableFundingSources = disableFundingSources
+            }
+
             fun build() = LinkConfiguration(
                 display = display,
                 collectMissingBillingDetailsForExistingPaymentMethods =
                 collectMissingBillingDetailsForExistingPaymentMethods,
                 allowUserEmailEdits = true,
                 allowLogOut = true,
+                disableFundingSources = disableFundingSources,
             )
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -657,6 +657,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                 .flags[ELEMENTS_MOBILE_FORCE_SETUP_FUTURE_USE_BEHAVIOR_AND_NEW_MANDATE_TEXT] == true,
             linkSupportedPaymentMethodsOnboardingEnabled =
             elementsSession.linkSettings?.linkSupportedPaymentMethodsOnboardingEnabled.orEmpty(),
+            disableFundingSources = configuration.link.disableFundingSources,
         )
 
         val useWebLink = !linkGateFactory.create(linkConfiguration).useNativeLink

--- a/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
@@ -239,6 +239,7 @@ internal object TestFactory {
         saveConsentBehavior = PaymentMethodSaveConsentBehavior.Disabled(null),
         forceSetupFutureUseBehaviorAndNewMandate = false,
         linkSupportedPaymentMethodsOnboardingEnabled = listOf("CARD"),
+        disableFundingSources = emptyList(),
     )
 
     val LINK_CONFIGURATION_WITH_INSTANT_DEBITS_ONBOARDING = LINK_CONFIGURATION.copy(

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenStateTest.kt
@@ -114,6 +114,7 @@ class SignUpScreenStateTest {
             saveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
             forceSetupFutureUseBehaviorAndNewMandate = false,
             linkSupportedPaymentMethodsOnboardingEnabled = listOf("CARD"),
+            disableFundingSources = emptyList(),
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/AddPaymentMethodRequirementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/AddPaymentMethodRequirementTest.kt
@@ -292,12 +292,12 @@ internal class AddPaymentMethodRequirementTest {
     }
 
     @Test
-    fun testInstantDebitsReturnsFalseWhenBankDisabledInFundingSources() {
+    fun testInstantDebitsReturnsFalseWhenBankAccountDisabledInFundingSources() {
         val metadata = PaymentMethodMetadataFactory.create(
             stripeIntent = createValidInstantDebitsPaymentIntent(),
             linkConfiguration = PaymentSheet.LinkConfiguration(
                 display = PaymentSheet.LinkConfiguration.Display.Automatic,
-                disableFundingSources = listOf("BANK"),
+                disableFundingSources = listOf("BANK_ACCOUNT"),
             ),
             linkState = LinkState(
                 configuration = TestFactory.LINK_CONFIGURATION_WITH_INSTANT_DEBITS_ONBOARDING,
@@ -310,12 +310,12 @@ internal class AddPaymentMethodRequirementTest {
     }
 
     @Test
-    fun testInstantDebitsReturnsTrueWhenBankNotInDisabledFundingSources() {
+    fun testInstantDebitsReturnsTrueWhenBankAccountNotInDisabledFundingSources() {
         val metadata = PaymentMethodMetadataFactory.create(
             stripeIntent = createValidInstantDebitsPaymentIntent(),
             linkConfiguration = PaymentSheet.LinkConfiguration(
                 display = PaymentSheet.LinkConfiguration.Display.Automatic,
-                disableFundingSources = listOf("CARD"), // Disable something else, not BANK
+                disableFundingSources = listOf("CARD"), // Disable something else, not BANK_ACCOUNT
             ),
             linkState = LinkState(
                 configuration = TestFactory.LINK_CONFIGURATION_WITH_INSTANT_DEBITS_ONBOARDING,

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/AddPaymentMethodRequirementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/AddPaymentMethodRequirementTest.kt
@@ -292,6 +292,42 @@ internal class AddPaymentMethodRequirementTest {
     }
 
     @Test
+    fun testInstantDebitsReturnsFalseWhenBankDisabledInFundingSources() {
+        val metadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = createValidInstantDebitsPaymentIntent(),
+            linkConfiguration = PaymentSheet.LinkConfiguration(
+                display = PaymentSheet.LinkConfiguration.Display.Automatic,
+                disableFundingSources = listOf("BANK"),
+            ),
+            linkState = LinkState(
+                configuration = TestFactory.LINK_CONFIGURATION_WITH_INSTANT_DEBITS_ONBOARDING,
+                loginState = LinkState.LoginState.LoggedOut,
+                signupMode = null,
+            ),
+        )
+
+        assertThat(InstantDebits.isMetBy(metadata, "")).isFalse()
+    }
+
+    @Test
+    fun testInstantDebitsReturnsTrueWhenBankNotInDisabledFundingSources() {
+        val metadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = createValidInstantDebitsPaymentIntent(),
+            linkConfiguration = PaymentSheet.LinkConfiguration(
+                display = PaymentSheet.LinkConfiguration.Display.Automatic,
+                disableFundingSources = listOf("CARD"), // Disable something else, not BANK
+            ),
+            linkState = LinkState(
+                configuration = TestFactory.LINK_CONFIGURATION_WITH_INSTANT_DEBITS_ONBOARDING,
+                loginState = LinkState.LoginState.LoggedOut,
+                signupMode = null,
+            ),
+        )
+
+        assertThat(InstantDebits.isMetBy(metadata, "")).isTrue()
+    }
+
+    @Test
     fun testLinkCardBrandReturnsTrueForCorrectLinkMode() {
         val metadata = PaymentMethodMetadataFactory.create(
             stripeIntent = createValidInstantDebitsPaymentIntent(),

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -2148,6 +2148,7 @@ internal class PaymentMethodMetadataTest {
             saveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
             forceSetupFutureUseBehaviorAndNewMandate = false,
             linkSupportedPaymentMethodsOnboardingEnabled = listOf("CARD"),
+            disableFundingSources = emptyList(),
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElementTest.kt
@@ -169,6 +169,7 @@ class LinkFormElementTest {
             saveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
             forceSetupFutureUseBehaviorAndNewMandate = false,
             linkSupportedPaymentMethodsOnboardingEnabled = listOf("CARD"),
+            disableFundingSources = emptyList(),
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
@@ -665,6 +665,7 @@ class ConfirmationHandlerOptionKtxTest {
             saveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
             forceSetupFutureUseBehaviorAndNewMandate = false,
             linkSupportedPaymentMethodsOnboardingEnabled = listOf("CARD"),
+            disableFundingSources = emptyList(),
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
@@ -714,6 +714,7 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
                 saveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
                 forceSetupFutureUseBehaviorAndNewMandate = false,
                 linkSupportedPaymentMethodsOnboardingEnabled = listOf("CARD"),
+                disableFundingSources = emptyList(),
             ),
             userInput = userInput,
             passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
@@ -104,6 +104,7 @@ internal object LinkTestUtils {
             saveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
             forceSetupFutureUseBehaviorAndNewMandate = false,
             linkSupportedPaymentMethodsOnboardingEnabled = listOf("CARD"),
+            disableFundingSources = emptyList(),
         )
     }
 }


### PR DESCRIPTION
# Summary

- Adds disableFundingSources field to client configuration
- Rely on it to show the bank tab

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
