### PR TITLE
[FlowController] Don't open Link on SPMs.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -318,12 +318,10 @@ internal class DefaultFlowController @Inject internal constructor(
         linkAccountInfo: LinkAccountUpdate.Value,
         linkConfiguration: LinkConfiguration
     ): Boolean {
-        val shouldPresentLink = paymentSelection?.isLink == true ||
-            (paymentSelection as? PaymentSelection.Saved)?.paymentMethod?.isLinkPassthroughMode == true
         // If the user has declined to use Link in the past, do not show it again.
         return viewModel.state?.declinedLink2FA != true &&
             // The current payment selection is Link
-            shouldPresentLink &&
+            paymentSelection is Link &&
             // The current user has a Link account (not necessarily logged in)
             linkAccountInfo.account != null &&
             // feature flag and other conditions are met


### PR DESCRIPTION
# Summary

This pull request changes how we treat Link-originated SPMs. We no longer prompt the user to log into their Link account, but instead open the normal payment sheet.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
