### PR TITLE
[Identity] Fix identity upload file state is not being  reset when activity gets re-created

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityViewModel.kt
@@ -859,6 +859,13 @@ internal class IdentityViewModel(
                     _missingRequirements.updateStateAndSave {
                         verificationPage.requirements.missing.toSet()
                     }
+
+                    val missingSet = verificationPage.requirements.missing.toSet()
+                    if (missingSet.contains(Requirement.IDDOCUMENTFRONT)) {
+                        _collectedData.updateStateAndSave { it.clearData(Requirement.IDDOCUMENTFRONT) }
+                        _documentFrontUploadedState.updateStateAndSave { SingleSideDocumentUploadState() }
+                    }
+
                     if (shouldRetrieveModel) {
                         downloadModelAndPost(
                             verificationPage.documentCapture.models.idDetectorUrl,


### PR DESCRIPTION
# Summary

Fixes [#11241](https://github.com/stripe/stripe-android/issues/11241)

This resets the state on the upload photo screen when the identity activity is recreated. 

This prevents an error where an invalid upload would occur.

# Testing

1. Turned on `Enable Settings → Developer options → Don't keep activities`
2. Used the identity example android app
3. Made sure the live capture requirement is off 
4. Start verification 
5. Time out on live capture of id card
6. Select upload document button
7. Upload the front of the document
8. background the app 
9. foreground the app 
10. Ensure the state is reset and there nothing marked as uploaded for the front of the document
