### PR TITLE
Fix updating Link-originated saved payment methods

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -286,7 +286,9 @@ internal class SavedPaymentMethodMutator(
                 expiryYear = cardUpdateParams.expiryYear,
                 productUsageTokens = setOf("PaymentSheet"),
             )
-        ).onSuccess { updatedMethod ->
+        ).map { updatedMethod ->
+            updatedMethod.withUpdatedLocalFields(original = paymentMethod)
+        }.onSuccess { updatedMethod ->
             withContext(uiContext) {
                 customerStateHolder.updateMostRecentlySelectedSavedPaymentMethod(updatedMethod)
                 customerStateHolder.setCustomerState(
@@ -470,4 +472,12 @@ internal class SavedPaymentMethodMutator(
             }
         }
     }
+}
+
+private fun PaymentMethod.withUpdatedLocalFields(original: PaymentMethod): PaymentMethod {
+    // We don't receive the following fields as part of the update response, so we need to copy them over
+    return copy(
+        linkPaymentDetails = original.linkPaymentDetails,
+        isLinkPassthroughMode = original.isLinkPassthroughMode,
+    )
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where updating a Link-originated saved payment method (added via passthrough mode) made it lose its Link branding.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Same as https://github.com/stripe/stripe-ios/pull/5587.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
