### PR TITLE
Fix name, email, and phone erased after an autocomplete result is returned.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressDetails.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressDetails.kt
@@ -48,14 +48,27 @@ internal fun AddressDetails.toIdentifierMap(
             IdentifierSpec.PostalCode to address?.postalCode,
             IdentifierSpec.Country to address?.country,
             IdentifierSpec.Phone to phoneNumber
-        ).plus(
-            mapOf(
-                IdentifierSpec.SameAsShipping to isCheckboxSelected?.toString()
-            ).takeIf { isCheckboxSelected != null } ?: emptyMap()
         )
+            .plus(billingDetails?.address?.toIdentifierMap() ?: emptyMap())
+            .plus(
+                mapOf(
+                    IdentifierSpec.SameAsShipping to isCheckboxSelected?.toString()
+                ).takeIf { isCheckboxSelected != null } ?: emptyMap()
+            )
     } else {
         emptyMap()
     }
+}
+
+internal fun PaymentSheet.Address.toIdentifierMap(): Map<IdentifierSpec, String?> {
+    return mapOf(
+        IdentifierSpec.Line1 to line1,
+        IdentifierSpec.Line2 to line2,
+        IdentifierSpec.City to city,
+        IdentifierSpec.State to state,
+        IdentifierSpec.PostalCode to postalCode,
+        IdentifierSpec.Country to country,
+    )
 }
 
 internal fun AddressDetails.toConfirmPaymentIntentShipping(): ConfirmPaymentIntentParams.Shipping {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementNavigator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementNavigator.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.addresselement
 
 import android.os.Parcelable
 import androidx.navigation.NavHostController
+import com.stripe.android.paymentsheet.PaymentSheet
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.parcelize.Parcelize
@@ -26,13 +27,13 @@ internal interface AddressElementNavigator {
     fun onBack()
 
     sealed interface AutocompleteEvent : Parcelable {
-        val addressDetails: AddressDetails?
+        val address: PaymentSheet.Address?
 
         @Parcelize
-        data class OnBack(override val addressDetails: AddressDetails?) : AutocompleteEvent
+        data class OnBack(override val address: PaymentSheet.Address?) : AutocompleteEvent
 
         @Parcelize
-        data class OnEnterManually(override val addressDetails: AddressDetails?) : AutocompleteEvent
+        data class OnEnterManually(override val address: PaymentSheet.Address?) : AutocompleteEvent
 
         companion object {
             const val KEY = "AutocompleteEvent"

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressFormController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressFormController.kt
@@ -46,4 +46,6 @@ internal class AddressFormController(
             it.second.isComplete
         }
         .toMap()
+
+    fun setRawValues(values: Map<IdentifierSpec, String?>) = autocompleteAddressElement.setRawValue(values)
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteActivity.kt
@@ -50,11 +50,11 @@ internal class AutocompleteActivity : AppCompatActivity() {
                     val result = when (event) {
                         is AutocompleteViewModel.Event.EnterManually -> AutocompleteContract.Result.EnterManually(
                             id = starterArgs.id,
-                            addressDetails = event.addressDetails,
+                            address = event.address,
                         )
                         is AutocompleteViewModel.Event.GoBack -> AutocompleteContract.Result.Address(
                             id = starterArgs.id,
-                            addressDetails = event.addressDetails,
+                            address = event.address,
                         )
                     }
 
@@ -95,7 +95,7 @@ internal class AutocompleteActivity : AppCompatActivity() {
             setResult(
                 AutocompleteContract.Result.Address(
                     id = starterArgs?.id ?: "",
-                    addressDetails = null,
+                    address = null,
                 )
             )
             finish()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteContract.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.core.os.bundleOf
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.view.ActivityStarter
 import kotlinx.parcelize.Parcelize
 
@@ -37,18 +38,18 @@ internal object AutocompleteContract :
 
     sealed class Result : ActivityStarter.Result {
         abstract val id: String
-        abstract val addressDetails: AddressDetails?
+        abstract val address: PaymentSheet.Address?
 
         @Parcelize
         data class EnterManually(
             override val id: String,
-            override val addressDetails: AddressDetails?,
+            override val address: PaymentSheet.Address?,
         ) : Result()
 
         @Parcelize
         data class Address(
             override val id: String,
-            override val addressDetails: AddressDetails?,
+            override val address: PaymentSheet.Address?,
         ) : Result()
 
         override fun toBundle(): Bundle {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteLauncher.kt
@@ -30,13 +30,13 @@ internal interface AutocompleteLauncher {
     )
 
     sealed interface Result : Parcelable {
-        val addressDetails: AddressDetails?
+        val address: PaymentSheet.Address?
 
         @Parcelize
-        data class EnterManually(override val addressDetails: AddressDetails?) : Result
+        data class EnterManually(override val address: PaymentSheet.Address?) : Result
 
         @Parcelize
-        data class OnBack(override val addressDetails: AddressDetails?) : Result
+        data class OnBack(override val address: PaymentSheet.Address?) : Result
     }
 }
 
@@ -150,10 +150,10 @@ internal class DefaultAutocompleteLauncher(
             registeredAutocompleteListeners[result.id]?.get()?.onAutocompleteLauncherResult(
                 when (result) {
                     is AutocompleteContract.Result.EnterManually -> AutocompleteLauncher.Result.EnterManually(
-                        result.addressDetails,
+                        result.address,
                     )
                     is AutocompleteContract.Result.Address -> AutocompleteLauncher.Result.OnBack(
-                        result.addressDetails
+                        result.address
                     )
                 }
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreen.kt
@@ -87,13 +87,13 @@ internal fun AutocompleteScreenUI(
                 is AutocompleteViewModel.Event.GoBack -> {
                     navigator.setResult(
                         AddressElementNavigator.AutocompleteEvent.KEY,
-                        AddressElementNavigator.AutocompleteEvent.OnBack(event.addressDetails)
+                        AddressElementNavigator.AutocompleteEvent.OnBack(event.address)
                     )
                 }
                 is AutocompleteViewModel.Event.EnterManually -> {
                     navigator.setResult(
                         AddressElementNavigator.AutocompleteEvent.KEY,
-                        AddressElementNavigator.AutocompleteEvent.OnEnterManually(event.addressDetails)
+                        AddressElementNavigator.AutocompleteEvent.OnEnterManually(event.address)
                     )
                 }
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModel.kt
@@ -118,22 +118,20 @@ internal class AutocompleteViewModel @Inject constructor(
 
                     _event.emit(
                         Event.GoBack(
-                            addressDetails = AddressDetails(
-                                address = PaymentSheet.Address(
-                                    city = address.city,
-                                    country = address.country,
-                                    line1 = address.line1,
-                                    line2 = address.line2,
-                                    postalCode = address.postalCode,
-                                    state = address.state
-                                )
+                            address = PaymentSheet.Address(
+                                city = address.city,
+                                country = address.country,
+                                line1 = address.line1,
+                                line2 = address.line2,
+                                postalCode = address.postalCode,
+                                state = address.state
                             )
                         )
                     )
                 },
                 onFailure = {
                     _loading.value = false
-                    _event.emit(Event.GoBack(addressDetails = null))
+                    _event.emit(Event.GoBack(address = null))
                 }
             )
         }
@@ -150,10 +148,8 @@ internal class AutocompleteViewModel @Inject constructor(
             _event.emit(
                 Event.EnterManually(
                     if (queryFlow.value.isNotBlank()) {
-                        AddressDetails(
-                            address = PaymentSheet.Address(
-                                line1 = queryFlow.value,
-                            )
+                        PaymentSheet.Address(
+                            line1 = queryFlow.value,
                         )
                     } else {
                         null
@@ -251,11 +247,11 @@ internal class AutocompleteViewModel @Inject constructor(
     }
 
     sealed interface Event {
-        val addressDetails: AddressDetails?
+        val address: PaymentSheet.Address?
 
-        data class EnterManually(override val addressDetails: AddressDetails?) : Event
+        data class EnterManually(override val address: PaymentSheet.Address?) : Event
 
-        data class GoBack(override val addressDetails: AddressDetails?) : Event
+        data class GoBack(override val address: PaymentSheet.Address?) : Event
     }
 
     data class Args(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
@@ -87,13 +87,12 @@ internal class InputAddressViewModel @Inject constructor(
                 AddressElementNavigator.AutocompleteEvent.KEY
             )?.collect { event ->
                 val oldAddress = _collectedAddress.value
-                val newAddress = event?.addressDetails
+                val newAddress = event?.address
                 val autocompleteAddress = AddressDetails(
-                    name = oldAddress?.name ?: newAddress?.name,
-                    address = newAddress?.address ?: oldAddress?.address,
-                    phoneNumber = oldAddress?.phoneNumber ?: newAddress?.phoneNumber,
+                    name = oldAddress?.name,
+                    address = newAddress ?: oldAddress?.address,
+                    phoneNumber = oldAddress?.phoneNumber,
                     isCheckboxSelected = oldAddress?.isCheckboxSelected
-                        ?: newAddress?.isCheckboxSelected
                 )
 
                 val values = autocompleteAddress.toIdentifierMap()
@@ -206,14 +205,10 @@ internal class InputAddressViewModel @Inject constructor(
 
                 if (newState.isChecked) {
                     initialBillingAddress?.let {
-                        eventListener?.invoke(AutocompleteAddressInteractor.Event.OnValues(it))
+                        addressFormController.setRawValues(it)
                     }
                 } else {
-                    eventListener?.invoke(
-                        AutocompleteAddressInteractor.Event.OnValues(
-                            values = previousUserInput ?: emptyMap()
-                        )
-                    )
+                    addressFormController.setRawValues(previousUserInput ?: emptyMap())
                 }
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
@@ -23,7 +23,7 @@ internal class PaymentElementAutocompleteAddressInteractor(
     }
 
     override fun onAutocompleteLauncherResult(result: AutocompleteLauncher.Result) {
-        val values = result.addressDetails?.toIdentifierMap()
+        val values = result.address?.toIdentifierMap()
 
         val event = when (result) {
             is AutocompleteLauncher.Result.EnterManually -> {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteContractTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteContractTest.kt
@@ -30,15 +30,12 @@ class AutocompleteContractTest {
     fun `should parse out address result`() {
         val expectedResult = AutocompleteContract.Result.Address(
             id = "123",
-            addressDetails = AddressDetails(
-                name = "John Doe",
-                address = PaymentSheet.Address(
-                    line1 = "123 Apple Street",
-                    city = "San Francisco",
-                    state = "CA",
-                    country = "US",
-                    postalCode = "99999"
-                )
+            address = PaymentSheet.Address(
+                line1 = "123 Apple Street",
+                city = "San Francisco",
+                state = "CA",
+                country = "US",
+                postalCode = "99999"
             )
         )
 
@@ -54,15 +51,12 @@ class AutocompleteContractTest {
     fun `should parse out enter manually result`() {
         val expectedResult = AutocompleteContract.Result.EnterManually(
             id = "123",
-            addressDetails = AddressDetails(
-                name = "John Doe",
-                address = PaymentSheet.Address(
-                    line1 = "123 Apple Street",
-                    city = "San Francisco",
-                    state = "CA",
-                    country = "US",
-                    postalCode = "99999"
-                )
+            address = PaymentSheet.Address(
+                line1 = "123 Apple Street",
+                city = "San Francisco",
+                state = "CA",
+                country = "US",
+                postalCode = "99999"
             )
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenTest.kt
@@ -49,7 +49,7 @@ class AutocompleteScreenTest {
 
             assertThat(setResultCall.key).isEqualTo(AddressElementNavigator.AutocompleteEvent.KEY)
             assertThat(setResultCall.value).isEqualTo(
-                AddressElementNavigator.AutocompleteEvent.OnEnterManually(addressDetails = null)
+                AddressElementNavigator.AutocompleteEvent.OnEnterManually(address = null)
             )
 
             assertThat(onBackCalls.awaitItem()).isNotNull()
@@ -72,7 +72,7 @@ class AutocompleteScreenTest {
 
             assertThat(setResultCall.key).isEqualTo(AddressElementNavigator.AutocompleteEvent.KEY)
             assertThat(setResultCall.value).isEqualTo(
-                AddressElementNavigator.AutocompleteEvent.OnBack(addressDetails = null)
+                AddressElementNavigator.AutocompleteEvent.OnBack(address = null)
             )
 
             assertThat(onBackCalls.awaitItem()).isNotNull()
@@ -96,7 +96,7 @@ class AutocompleteScreenTest {
 
             assertThat(setResultCall.key).isEqualTo(AddressElementNavigator.AutocompleteEvent.KEY)
             assertThat(setResultCall.value).isEqualTo(
-                AddressElementNavigator.AutocompleteEvent.OnBack(addressDetails = null)
+                AddressElementNavigator.AutocompleteEvent.OnBack(address = null)
             )
 
             assertThat(onBackCalls.awaitItem()).isNotNull()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModelTest.kt
@@ -105,15 +105,13 @@ class AutocompleteViewModelTest {
 
             assertThat(awaitItem()).isEqualTo(
                 AutocompleteViewModel.Event.GoBack(
-                    addressDetails = AddressDetails(
-                        address = PaymentSheet.Address(
-                            city = "South San Francisco",
-                            country = "US",
-                            line1 = "123 King Street",
-                            line2 = null,
-                            postalCode = "99999",
-                            state = "CA"
-                        )
+                    address = PaymentSheet.Address(
+                        city = "South San Francisco",
+                        country = "US",
+                        line1 = "123 King Street",
+                        line2 = null,
+                        postalCode = "99999",
+                        state = "CA"
                     )
                 )
             )
@@ -141,7 +139,7 @@ class AutocompleteViewModelTest {
 
             assertThat(viewModel.loading.value).isEqualTo(false)
 
-            assertThat(awaitItem()).isEqualTo(AutocompleteViewModel.Event.GoBack(addressDetails = null))
+            assertThat(awaitItem()).isEqualTo(AutocompleteViewModel.Event.GoBack(address = null))
         }
     }
 
@@ -169,10 +167,8 @@ class AutocompleteViewModelTest {
 
             assertThat(awaitItem()).isEqualTo(
                 AutocompleteViewModel.Event.EnterManually(
-                    addressDetails = AddressDetails(
-                        address = PaymentSheet.Address(
-                            line1 = "Some query"
-                        )
+                    address = PaymentSheet.Address(
+                        line1 = "Some query"
                     )
                 )
             )
@@ -188,7 +184,7 @@ class AutocompleteViewModelTest {
 
             assertThat(awaitItem()).isEqualTo(
                 AutocompleteViewModel.Event.EnterManually(
-                    addressDetails = null,
+                    address = null,
                 )
             )
         }
@@ -299,7 +295,7 @@ class AutocompleteViewModelTest {
             viewModel.onBackPressed()
 
             assertThat(awaitItem()).isEqualTo(
-                AutocompleteViewModel.Event.GoBack(addressDetails = null)
+                AutocompleteViewModel.Event.GoBack(address = null)
             )
         }
     }
@@ -313,7 +309,7 @@ class AutocompleteViewModelTest {
             viewModel.onBackPressed()
 
             assertThat(awaitItem()).isEqualTo(
-                AutocompleteViewModel.Event.GoBack(addressDetails = null)
+                AutocompleteViewModel.Event.GoBack(address = null)
             )
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/DefaultAutocompleteLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/DefaultAutocompleteLauncherTest.kt
@@ -21,18 +21,13 @@ class DefaultAutocompleteLauncherTest {
         .colorsLight(PaymentSheet.Colors.defaultDark)
         .build()
 
-    private val addressDetails = AddressDetails(
-        name = "John Doe",
-        address = PaymentSheet.Address(
-            line1 = "123 Main Street",
-            line2 = "Apt 4B",
-            city = "San Francisco",
-            state = "CA",
-            postalCode = "94105",
-            country = "US"
-        ),
-        phoneNumber = "555-123-4567",
-        isCheckboxSelected = true
+    private val address = PaymentSheet.Address(
+        line1 = "123 Main Street",
+        line2 = "Apt 4B",
+        city = "San Francisco",
+        state = "CA",
+        postalCode = "94105",
+        country = "US"
     )
 
     @Test
@@ -198,7 +193,7 @@ class DefaultAutocompleteLauncherTest {
 
         val result = AutocompleteContract.Result.EnterManually(
             id = autocompleteArgs.id,
-            addressDetails = addressDetails
+            address = address
         )
 
         registerCall.callback.asCallbackFor<AutocompleteContract.Result>().onActivityResult(result)
@@ -207,7 +202,7 @@ class DefaultAutocompleteLauncherTest {
 
         val enterManuallyResult = capturedResult as AutocompleteLauncher.Result.EnterManually
 
-        assertThat(enterManuallyResult.addressDetails).isEqualTo(addressDetails)
+        assertThat(enterManuallyResult.address).isEqualTo(address)
     }
 
     @Test
@@ -235,7 +230,7 @@ class DefaultAutocompleteLauncherTest {
 
         val result = AutocompleteContract.Result.Address(
             id = autocompleteArgs.id,
-            addressDetails = addressDetails
+            address = address
         )
 
         registerCall.callback.asCallbackFor<AutocompleteContract.Result>().onActivityResult(result)
@@ -244,7 +239,7 @@ class DefaultAutocompleteLauncherTest {
 
         val onBackResult = capturedResult as AutocompleteLauncher.Result.OnBack
 
-        assertThat(onBackResult.addressDetails).isEqualTo(addressDetails)
+        assertThat(onBackResult.address).isEqualTo(address)
     }
 
     @Test
@@ -271,7 +266,7 @@ class DefaultAutocompleteLauncherTest {
 
         val result = AutocompleteContract.Result.EnterManually(
             id = autocompleteArgs.id,
-            addressDetails = addressDetails
+            address = address,
         )
 
         val callback = registerCall.callback.asCallbackFor<AutocompleteContract.Result>()
@@ -355,14 +350,14 @@ class DefaultAutocompleteLauncherTest {
 
         val firstAutocompleteResult = AutocompleteContract.Result.EnterManually(
             id = firstAutocompleteArgs.id,
-            addressDetails = addressDetails
+            address = address,
         )
 
         callback.onActivityResult(firstAutocompleteResult)
 
         val secondAutocompleteResult = AutocompleteContract.Result.Address(
             id = secondAutocompleteArgs.id,
-            addressDetails = addressDetails
+            address = address,
         )
         callback.onActivityResult(secondAutocompleteResult)
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
@@ -60,7 +60,7 @@ class InputAddressViewModelTest {
 
     @Test
     fun `autocomplete address passed is collected to start`() = runTest(UnconfinedTestDispatcher()) {
-        val expectedAddress = AddressDetails(name = "skyler", address = PaymentSheet.Address(country = "US"))
+        val expectedAddress = PaymentSheet.Address(country = "US")
         val flow = MutableStateFlow<AddressElementNavigator.AutocompleteEvent?>(
             AddressElementNavigator.AutocompleteEvent.OnBack(expectedAddress)
         )
@@ -71,12 +71,16 @@ class InputAddressViewModelTest {
         ).thenReturn(flow)
 
         val viewModel = createViewModel()
-        assertThat(viewModel.collectedAddress.value).isEqualTo(expectedAddress)
+        assertThat(viewModel.collectedAddress.value).isEqualTo(
+            AddressDetails(
+                address = expectedAddress
+            )
+        )
     }
 
     @Test
     fun `takes only fields in new address`() = runTest(UnconfinedTestDispatcher()) {
-        val usAddress = AddressDetails(name = "skyler", address = PaymentSheet.Address(country = "US"))
+        val usAddress = PaymentSheet.Address(country = "US")
         val flow = MutableStateFlow<AddressElementNavigator.AutocompleteEvent?>(
             AddressElementNavigator.AutocompleteEvent.OnBack(usAddress)
         )
@@ -87,14 +91,19 @@ class InputAddressViewModelTest {
         ).thenReturn(flow)
 
         val viewModel = createViewModel()
-        assertThat(viewModel.collectedAddress.value).isEqualTo(usAddress)
-
-        val expectedAddress = AddressDetails(
-            name = "skyler",
-            address = PaymentSheet.Address(country = "CAN", line1 = "foobar")
+        assertThat(viewModel.collectedAddress.value).isEqualTo(
+            AddressDetails(
+                address = usAddress,
+            )
         )
+
+        val expectedAddress = PaymentSheet.Address(country = "CAN", line1 = "foobar")
         flow.tryEmit(AddressElementNavigator.AutocompleteEvent.OnBack(expectedAddress))
-        assertThat(viewModel.collectedAddress.value).isEqualTo(expectedAddress)
+        assertThat(viewModel.collectedAddress.value).isEqualTo(
+            AddressDetails(
+                address = expectedAddress,
+            )
+        )
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractorTest.kt
@@ -57,8 +57,8 @@ class PaymentElementAutocompleteAddressInteractorTest {
 
         val launchCall = scenario.launchCalls.awaitItem()
 
-        val addressDetails = createTestAddressDetails()
-        val result = AutocompleteLauncher.Result.EnterManually(addressDetails)
+        val address = createTestAddress()
+        val result = AutocompleteLauncher.Result.EnterManually(address)
 
         launchCall.resultHandler.onAutocompleteLauncherResult(result)
 
@@ -69,7 +69,16 @@ class PaymentElementAutocompleteAddressInteractorTest {
         val expandFormEvent = event as AutocompleteAddressInteractor.Event.OnExpandForm
 
         assertThat(expandFormEvent.values).isNotNull()
-        assertThat(expandFormEvent.values?.get(IdentifierSpec.Line1)).isEqualTo("123 Main Street")
+        assertThat(expandFormEvent.values).containsExactlyEntriesIn(
+            mapOf(
+                IdentifierSpec.Line1 to "123 Main Street",
+                IdentifierSpec.Line2 to "Apt 4B",
+                IdentifierSpec.City to "San Francisco",
+                IdentifierSpec.State to "CA",
+                IdentifierSpec.PostalCode to "94105",
+                IdentifierSpec.Country to "US",
+            )
+        )
     }
 
     @Test
@@ -85,8 +94,8 @@ class PaymentElementAutocompleteAddressInteractorTest {
 
         val launchCall = scenario.launchCalls.awaitItem()
 
-        val addressDetails = createTestAddressDetails()
-        val result = AutocompleteLauncher.Result.OnBack(addressDetails)
+        val address = createTestAddress()
+        val result = AutocompleteLauncher.Result.OnBack(address)
 
         launchCall.resultHandler.onAutocompleteLauncherResult(result)
 
@@ -96,8 +105,16 @@ class PaymentElementAutocompleteAddressInteractorTest {
 
         val valuesEvent = event as AutocompleteAddressInteractor.Event.OnValues
 
-        assertThat(valuesEvent.values).isNotNull()
-        assertThat(valuesEvent.values[IdentifierSpec.Line1]).isEqualTo("123 Main Street")
+        assertThat(valuesEvent.values).containsExactlyEntriesIn(
+            mapOf(
+                IdentifierSpec.Line1 to "123 Main Street",
+                IdentifierSpec.Line2 to "Apt 4B",
+                IdentifierSpec.City to "San Francisco",
+                IdentifierSpec.State to "CA",
+                IdentifierSpec.PostalCode to "94105",
+                IdentifierSpec.Country to "US",
+            )
+        )
     }
 
     @Test
@@ -218,17 +235,12 @@ class PaymentElementAutocompleteAddressInteractorTest {
         autocompleteConfig = autocompleteConfig
     )
 
-    private fun createTestAddressDetails() = AddressDetails(
-        name = "John Doe",
-        address = PaymentSheet.Address(
-            line1 = "123 Main Street",
-            line2 = "Apt 4B",
-            city = "San Francisco",
-            state = "CA",
-            postalCode = "94105",
-            country = "US"
-        ),
-        phoneNumber = "555-123-4567",
-        isCheckboxSelected = true
+    private fun createTestAddress() = PaymentSheet.Address(
+        line1 = "123 Main Street",
+        line2 = "Apt 4B",
+        city = "San Francisco",
+        state = "CA",
+        postalCode = "94105",
+        country = "US"
     )
 }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressController.kt
@@ -72,6 +72,11 @@ class AutocompleteAddressController(
     init {
         interactor.register { event ->
             val currentValues = getCurrentValues()
+
+            /*
+             * Merges the current and new values together. New value keys will override current
+             * value keys if provided.
+             */
             val newValues = currentValues.plus(event.values ?: emptyMap())
 
             when (event) {

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressController.kt
@@ -72,7 +72,7 @@ class AutocompleteAddressController(
     init {
         interactor.register { event ->
             val currentValues = getCurrentValues()
-            val newValues = event.values ?: currentValues
+            val newValues = currentValues.plus(event.values ?: emptyMap())
 
             when (event) {
                 is AutocompleteAddressInteractor.Event.OnValues -> Unit
@@ -90,6 +90,10 @@ class AutocompleteAddressController(
                     createAddressElement(newValues, toAddressInputMode(expandForm, newValues))
             }
         }
+    }
+
+    fun setRawValue(values: Map<IdentifierSpec, String?>) {
+        _addressElementFlow.value = createAddressElement(values, toAddressInputMode(expandForm, values))
     }
 
     private fun createAddressElement(

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressElement.kt
@@ -48,7 +48,7 @@ class AutocompleteAddressElement(
     override fun sectionFieldErrorController() = controller
 
     override fun setRawValue(rawValuesMap: Map<IdentifierSpec, String?>) {
-        controller.addressElementFlow.value.setRawValue(rawValuesMap)
+        controller.setRawValue(rawValuesMap)
     }
 
     override fun getFormFieldValueFlow() = controller.formFieldValues


### PR DESCRIPTION
# Summary
Fix name, email, and phone erased after an autocomplete result is returned in the `AutocompleteAddressElement`.

# Motivation
Ensure the user's input for email, phone, and name is retained when receiving an autocomplete result which has none of that infomation.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified