### PR TITLE
Fix `AddressTextFieldElement` not having a text field identifier

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -143,6 +143,16 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
         null
     }
 
+    private val lastNonAddressTextFieldIdentifier = if (collectingPhone) {
+        IdentifierSpec.Phone
+    } else if (collectingEmail) {
+        IdentifierSpec.Email
+    } else if (collectingName) {
+        IdentifierSpec.Name
+    } else {
+        null
+    }
+
     val phoneController = PhoneNumberController.createPhoneNumberController(
         initiallySelectedCountryCode = defaultPhoneCountry,
         initialValue = defaultPhone ?: "",
@@ -202,15 +212,11 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
     }
 
     val lastTextFieldIdentifier: StateFlow<IdentifierSpec?> = if (collectingAddress) {
-        addressElement.getTextFieldIdentifiers().mapAsStateFlow { it.last() }
-    } else if (collectingPhone) {
-        stateFlowOf(IdentifierSpec.Phone)
-    } else if (collectingEmail) {
-        stateFlowOf(IdentifierSpec.Email)
-    } else if (collectingName) {
-        stateFlowOf(IdentifierSpec.Name)
+        addressElement.getTextFieldIdentifiers().mapAsStateFlow {
+            it.lastOrNull() ?: lastNonAddressTextFieldIdentifier
+        }
     } else {
-        stateFlowOf(null)
+        stateFlowOf(lastNonAddressTextFieldIdentifier)
     }
 
     private val saveForFutureUseInitialValue: Boolean =

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
@@ -1879,6 +1879,36 @@ class USBankAccountFormViewModelTest {
     }
 
     @Test
+    fun `If autocomplete & no billing, last text field identifier should be the autocomplete text field`() = runTest {
+        val viewModel = createViewModel(
+            args = defaultArgs.copy(
+                formArgs = defaultArgs.formArgs.copy(
+                    billingDetails = null,
+                    billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                        name = CollectionMode.Always,
+                        phone = CollectionMode.Always,
+                        email = CollectionMode.Always,
+                        address = AddressCollectionMode.Full,
+                    ),
+                )
+            ),
+            autocompleteAddressInteractorFactory = {
+                TestAutocompleteAddressInteractor.noOp(
+                    autocompleteConfig = AutocompleteAddressInteractor.Config(
+                        googlePlacesApiKey = "gi_123",
+                        autocompleteCountries = setOf("US"),
+                        isPlacesAvailable = true,
+                    )
+                )
+            }
+        )
+
+        viewModel.lastTextFieldIdentifier.test {
+            assertThat(expectMostRecentItem()).isEqualTo(IdentifierSpec.OneLineAddress)
+        }
+    }
+
+    @Test
     fun `If missing required fields, 'validate' should validate fields & reset validation on 'reset'`() = runTest {
         val viewModel = createViewModel(
             args = defaultArgs.run {

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldElement.kt
@@ -2,6 +2,8 @@ package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
 import com.stripe.android.core.strings.ResolvableString
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class AddressTextFieldElement(
@@ -17,4 +19,8 @@ class AddressTextFieldElement(
             label = label,
             onNavigation = onNavigation
         )
+
+    override fun getTextFieldIdentifiers(): StateFlow<List<IdentifierSpec>> {
+        return MutableStateFlow(listOf(identifier))
+    }
 }

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/AddressTextFieldElementTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/AddressTextFieldElementTest.kt
@@ -1,0 +1,24 @@
+package com.stripe.android.uicore.elements
+
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.strings.resolvableString
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class AddressTextFieldElementTest {
+    @Test
+    fun `Element should have a text field identifier`() = runTest {
+        val element = AddressTextFieldElement(
+            identifier = IdentifierSpec.OneLineAddress,
+            label = "Address".resolvableString,
+            onNavigation = null,
+        )
+
+        element.getTextFieldIdentifiers().test {
+            assertThat(awaitItem()).containsExactly(
+                IdentifierSpec.OneLineAddress
+            )
+        }
+    }
+}


### PR DESCRIPTION
# Summary
Fix `AddressTextFieldElement` not having a text field identifier

# Motivation
Resolves an issue in `USBankAccount` flow where an explicit ask for the last text field identifier causes a crash when no text field identifiers are found in `AddressElement`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified