### PR TITLE
Expand Link wallet if default payment method not supported

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletUiState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletUiState.kt
@@ -111,9 +111,20 @@ internal data class WalletUiState(
     fun updateWithResponse(
         response: List<LinkPaymentMethod.ConsumerPaymentDetails>,
     ): WalletUiState {
+        val paymentDetails = response.map { it.details }
+
+        val selectedItem = if (selectedItemId != null) {
+            paymentDetails.firstOrNull { it.id == selectedItemId }
+        } else {
+            paymentDetails.firstOrNull { it.isDefault } ?: paymentDetails.firstOrNull()
+        }
+
+        val expanded = (userSetIsExpanded == true) || (selectedItem?.let { !isItemAvailable(it) } == true)
+
         return copy(
-            paymentDetailsList = response.map { it.details },
+            paymentDetailsList = paymentDetails,
             isProcessing = false,
+            userSetIsExpanded = expanded,
             cardBeingUpdated = null
         )
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request aligns Android with iOS and expands the Link wallet if the initial selection is not supported, allowing the user to select a different one.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
