### PR TITLE
[onramp] Bank and saved payment fixes

### DIFF
--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampInteractor.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampInteractor.kt
@@ -315,7 +315,6 @@ internal class OnrampInteractor @Inject constructor(
             // Create a crypto payment token
             .flatMapCatching { paymentMethod ->
                 cryptoApiRepository.createPaymentToken(
-                    consumerSessionClientSecret = secret,
                     paymentMethod = paymentMethod.id!!,
                 )
             }

--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampInteractor.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampInteractor.kt
@@ -79,7 +79,7 @@ internal class OnrampInteractor @Inject constructor(
         return when (linkResult) {
             is ConfigureResult.Success -> OnrampConfigurationResult.Completed(success = true)
             is ConfigureResult.Failed -> {
-                track(
+                analyticsService?.track(
                     OnrampAnalyticsEvent.ErrorOccurred(
                         operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.Configure,
                         error = linkResult.error,
@@ -93,7 +93,7 @@ internal class OnrampInteractor @Inject constructor(
     suspend fun hasLinkAccount(email: String): OnrampHasLinkAccountResult {
         return when (val result = linkController.lookupConsumer(email)) {
             is LinkController.LookupConsumerResult.Success -> {
-                track(
+                analyticsService?.track(
                     OnrampAnalyticsEvent.LinkAccountLookupCompleted(
                         hasLinkAccount = result.isConsumer
                     )
@@ -103,7 +103,7 @@ internal class OnrampInteractor @Inject constructor(
                 )
             }
             is LinkController.LookupConsumerResult.Failed -> {
-                track(
+                analyticsService?.track(
                     OnrampAnalyticsEvent.ErrorOccurred(
                         operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.HasLinkAccount,
                         error = result.error,
@@ -131,11 +131,11 @@ internal class OnrampInteractor @Inject constructor(
                     cryptoApiRepository.createCryptoCustomer(secret).fold(
                         onSuccess = { customerResponse ->
                             _state.update { it.copy(cryptoCustomerId = customerResponse.id) }
-                            track(OnrampAnalyticsEvent.LinkRegistrationCompleted)
+                            analyticsService?.track(OnrampAnalyticsEvent.LinkRegistrationCompleted)
                             OnrampRegisterLinkUserResult.Completed(customerResponse.id)
                         },
                         onFailure = { error ->
-                            track(
+                            analyticsService?.track(
                                 OnrampAnalyticsEvent.ErrorOccurred(
                                     operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.RegisterLinkUser,
                                     error = error,
@@ -146,7 +146,7 @@ internal class OnrampInteractor @Inject constructor(
                     )
                 } else {
                     val error = MissingConsumerSecretException()
-                    track(
+                    analyticsService?.track(
                         OnrampAnalyticsEvent.ErrorOccurred(
                             operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.RegisterLinkUser,
                             error = error,
@@ -156,7 +156,7 @@ internal class OnrampInteractor @Inject constructor(
                 }
             }
             is LinkController.RegisterConsumerResult.Failed -> {
-                track(
+                analyticsService?.track(
                     OnrampAnalyticsEvent.ErrorOccurred(
                         operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.RegisterLinkUser,
                         error = result.error,
@@ -172,11 +172,11 @@ internal class OnrampInteractor @Inject constructor(
     suspend fun updatePhoneNumber(phoneNumber: String): OnrampUpdatePhoneNumberResult {
         return when (val result = linkController.updatePhoneNumber(phoneNumber)) {
             is LinkController.UpdatePhoneNumberResult.Success -> {
-                track(OnrampAnalyticsEvent.LinkPhoneNumberUpdated)
+                analyticsService?.track(OnrampAnalyticsEvent.LinkPhoneNumberUpdated)
                 OnrampUpdatePhoneNumberResult.Completed
             }
             is LinkController.UpdatePhoneNumberResult.Failed -> {
-                track(
+                analyticsService?.track(
                     OnrampAnalyticsEvent.ErrorOccurred(
                         operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.UpdatePhoneNumber,
                         error = result.error,
@@ -198,11 +198,11 @@ internal class OnrampInteractor @Inject constructor(
             val result = cryptoApiRepository.setWalletAddress(walletAddress, network, secret)
             result.fold(
                 onSuccess = {
-                    track(OnrampAnalyticsEvent.WalletRegistered(network))
+                    analyticsService?.track(OnrampAnalyticsEvent.WalletRegistered(network))
                     OnrampRegisterWalletAddressResult.Completed()
                 },
                 onFailure = { error ->
-                    track(
+                    analyticsService?.track(
                         OnrampAnalyticsEvent.ErrorOccurred(
                             operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.RegisterWalletAddress,
                             error = error,
@@ -213,7 +213,7 @@ internal class OnrampInteractor @Inject constructor(
             )
         } else {
             val error = MissingConsumerSecretException()
-            track(
+            analyticsService?.track(
                 OnrampAnalyticsEvent.ErrorOccurred(
                     operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.RegisterWalletAddress,
                     error = error,
@@ -227,7 +227,7 @@ internal class OnrampInteractor @Inject constructor(
         val secret = consumerSessionClientSecret()
         if (secret == null) {
             val error = MissingConsumerSecretException()
-            track(
+            analyticsService?.track(
                 OnrampAnalyticsEvent.ErrorOccurred(
                     operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.AttachKycInfo,
                     error = error,
@@ -239,11 +239,11 @@ internal class OnrampInteractor @Inject constructor(
         return cryptoApiRepository.collectKycData(kycInfo, secret)
             .fold(
                 onSuccess = {
-                    track(OnrampAnalyticsEvent.KycInfoSubmitted)
+                    analyticsService?.track(OnrampAnalyticsEvent.KycInfoSubmitted)
                     OnrampAttachKycInfoResult.Completed
                 },
                 onFailure = { error ->
-                    track(
+                    analyticsService?.track(
                         OnrampAnalyticsEvent.ErrorOccurred(
                             operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.AttachKycInfo,
                             error = error,
@@ -258,7 +258,7 @@ internal class OnrampInteractor @Inject constructor(
         val secret = consumerSessionClientSecret()
         if (secret == null) {
             val error = MissingConsumerSecretException()
-            track(
+            analyticsService?.track(
                 OnrampAnalyticsEvent.ErrorOccurred(
                     operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.VerifyIdentity,
                     error = error,
@@ -270,11 +270,11 @@ internal class OnrampInteractor @Inject constructor(
         return cryptoApiRepository.startIdentityVerification(secret)
             .fold(
                 onSuccess = { result ->
-                    track(OnrampAnalyticsEvent.IdentityVerificationStarted)
+                    analyticsService?.track(OnrampAnalyticsEvent.IdentityVerificationStarted)
                     OnrampStartVerificationResult.Completed(result)
                 },
                 onFailure = { error ->
-                    track(
+                    analyticsService?.track(
                         OnrampAnalyticsEvent.ErrorOccurred(
                             operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.VerifyIdentity,
                             error = error,
@@ -290,7 +290,7 @@ internal class OnrampInteractor @Inject constructor(
         val secret = consumerSessionClientSecret()
         if (secret == null) {
             val error = MissingConsumerSecretException()
-            track(
+            analyticsService?.track(
                 OnrampAnalyticsEvent.ErrorOccurred(
                     operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.CreateCryptoPaymentToken,
                     error = error,
@@ -321,7 +321,7 @@ internal class OnrampInteractor @Inject constructor(
             }
             .fold(
                 onSuccess = { cryptoPaymentToken ->
-                    track(
+                    analyticsService?.track(
                         OnrampAnalyticsEvent.CryptoPaymentTokenCreated(
                             paymentMethodType = _state.value.collectingPaymentMethodType
                         )
@@ -329,7 +329,7 @@ internal class OnrampInteractor @Inject constructor(
                     OnrampCreateCryptoPaymentTokenResult.Completed(cryptoPaymentToken.id)
                 },
                 onFailure = { error ->
-                    track(
+                    analyticsService?.track(
                         OnrampAnalyticsEvent.ErrorOccurred(
                             operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.CreateCryptoPaymentToken,
                             error = error,
@@ -343,11 +343,11 @@ internal class OnrampInteractor @Inject constructor(
     suspend fun logOut(): OnrampLogOutResult {
         return when (val result = linkController.logOut()) {
             is LinkController.LogOutResult.Success -> {
-                track(OnrampAnalyticsEvent.LinkLogout)
+                analyticsService?.track(OnrampAnalyticsEvent.LinkLogout)
                 OnrampLogOutResult.Completed
             }
             is LinkController.LogOutResult.Failed -> {
-                track(
+                analyticsService?.track(
                     OnrampAnalyticsEvent.ErrorOccurred(
                         operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.LogOut,
                         error = result.error,
@@ -367,11 +367,11 @@ internal class OnrampInteractor @Inject constructor(
                 cryptoApiRepository.createCryptoCustomer(secret).fold(
                     onSuccess = { customerResponse ->
                         _state.update { it.copy(cryptoCustomerId = customerResponse.id) }
-                        track(OnrampAnalyticsEvent.LinkUserAuthenticationCompleted)
+                        analyticsService?.track(OnrampAnalyticsEvent.LinkUserAuthenticationCompleted)
                         OnrampAuthenticateResult.Completed(customerResponse.id)
                     },
                     onFailure = { error ->
-                        track(
+                        analyticsService?.track(
                             OnrampAnalyticsEvent.ErrorOccurred(
                                 operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.AuthenticateUser,
                                 error = error,
@@ -382,7 +382,7 @@ internal class OnrampInteractor @Inject constructor(
                 )
             } else {
                 val error = MissingConsumerSecretException()
-                track(
+                analyticsService?.track(
                     OnrampAnalyticsEvent.ErrorOccurred(
                         operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.AuthenticateUser,
                         error = error,
@@ -392,7 +392,7 @@ internal class OnrampInteractor @Inject constructor(
             }
         }
         is LinkController.AuthenticationResult.Failed -> {
-            track(
+            analyticsService?.track(
                 OnrampAnalyticsEvent.ErrorOccurred(
                     operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.AuthenticateUser,
                     error = result.error,
@@ -412,11 +412,11 @@ internal class OnrampInteractor @Inject constructor(
                 cryptoApiRepository.createCryptoCustomer(secret).fold(
                     onSuccess = { customerResponse ->
                         _state.update { it.copy(cryptoCustomerId = customerResponse.id) }
-                        track(OnrampAnalyticsEvent.LinkAuthorizationCompleted(consented = true))
+                        analyticsService?.track(OnrampAnalyticsEvent.LinkAuthorizationCompleted(consented = true))
                         OnrampAuthorizeResult.Consented(customerResponse.id)
                     },
                     onFailure = { error ->
-                        track(
+                        analyticsService?.track(
                             OnrampAnalyticsEvent.ErrorOccurred(
                                 operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.Authorize,
                                 error = error,
@@ -427,7 +427,7 @@ internal class OnrampInteractor @Inject constructor(
                 )
             } else {
                 val error = MissingConsumerSecretException()
-                track(
+                analyticsService?.track(
                     OnrampAnalyticsEvent.ErrorOccurred(
                         operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.Authorize,
                         error = error,
@@ -437,13 +437,13 @@ internal class OnrampInteractor @Inject constructor(
             }
         }
         is LinkController.AuthorizeResult.Denied -> {
-            track(OnrampAnalyticsEvent.LinkAuthorizationCompleted(consented = false))
+            analyticsService?.track(OnrampAnalyticsEvent.LinkAuthorizationCompleted(consented = false))
             OnrampAuthorizeResult.Denied()
         }
         is LinkController.AuthorizeResult.Canceled ->
             OnrampAuthorizeResult.Canceled()
         is LinkController.AuthorizeResult.Failed -> {
-            track(
+            analyticsService?.track(
                 OnrampAnalyticsEvent.ErrorOccurred(
                     operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.Authorize,
                     error = result.error,
@@ -457,11 +457,11 @@ internal class OnrampInteractor @Inject constructor(
         result: IdentityVerificationSheet.VerificationFlowResult
     ): OnrampVerifyIdentityResult = when (result) {
         is IdentityVerificationSheet.VerificationFlowResult.Completed -> {
-            track(OnrampAnalyticsEvent.IdentityVerificationCompleted)
+            analyticsService?.track(OnrampAnalyticsEvent.IdentityVerificationCompleted)
             OnrampVerifyIdentityResult.Completed()
         }
         is IdentityVerificationSheet.VerificationFlowResult.Failed -> {
-            track(
+            analyticsService?.track(
                 OnrampAnalyticsEvent.ErrorOccurred(
                     operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.VerifyIdentity,
                     error = result.throwable,
@@ -478,7 +478,7 @@ internal class OnrampInteractor @Inject constructor(
         context: Context,
     ): OnrampCollectPaymentMethodResult = when (result) {
         is LinkController.PresentPaymentMethodsResult.Success -> {
-            track(
+            analyticsService?.track(
                 OnrampAnalyticsEvent.CollectPaymentMethodCompleted(
                     paymentMethodType = _state.value.collectingPaymentMethodType
                 )
@@ -496,7 +496,7 @@ internal class OnrampInteractor @Inject constructor(
             }
         }
         is LinkController.PresentPaymentMethodsResult.Failed -> {
-            track(
+            analyticsService?.track(
                 OnrampAnalyticsEvent.ErrorOccurred(
                     operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.CollectPaymentMethod,
                     error = result.error,
@@ -516,28 +516,28 @@ internal class OnrampInteractor @Inject constructor(
         if (analyticsService?.elementsSessionId != linkState.elementsSessionId) {
             analyticsService = linkState.elementsSessionId
                 ?.let { analyticsServiceFactory.create(it) }
-            track(OnrampAnalyticsEvent.SessionCreated)
+            analyticsService?.track(OnrampAnalyticsEvent.SessionCreated)
         }
         _state.value = _state.value.copy(linkControllerState = linkState)
     }
 
     fun onAuthorize() {
-        track(OnrampAnalyticsEvent.LinkAuthorizationStarted)
+        analyticsService?.track(OnrampAnalyticsEvent.LinkAuthorizationStarted)
     }
 
     fun onAuthenticateUser() {
-        track(OnrampAnalyticsEvent.LinkUserAuthenticationStarted)
+        analyticsService?.track(OnrampAnalyticsEvent.LinkUserAuthenticationStarted)
     }
 
     fun onCollectPaymentMethod(type: PaymentMethodType) {
         _state.update { it.copy(collectingPaymentMethodType = type) }
-        track(
+        analyticsService?.track(
             OnrampAnalyticsEvent.CollectPaymentMethodStarted(type)
         )
     }
 
     fun onHandleNextActionError(error: Throwable) {
-        track(
+        analyticsService?.track(
             OnrampAnalyticsEvent.ErrorOccurred(
                 operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.PerformCheckout,
                 error = error,
@@ -570,7 +570,7 @@ internal class OnrampInteractor @Inject constructor(
                 )
             )
         }
-        track(
+        analyticsService?.track(
             OnrampAnalyticsEvent.CheckoutStarted(
                 onrampSessionId = onrampSessionId,
                 paymentMethodType = _state.value.collectingPaymentMethodType
@@ -644,7 +644,7 @@ internal class OnrampInteractor @Inject constructor(
                     // which is handled by PaymentLauncher in the presenter.
                     paymentIntent.toCheckoutResult()
                         ?.let { checkoutResult ->
-                            track(
+                            analyticsService?.track(
                                 OnrampAnalyticsEvent.CheckoutCompleted(
                                     onrampSessionId = onrampSessionId,
                                     paymentMethodType = _state.value.collectingPaymentMethodType,
@@ -661,7 +661,7 @@ internal class OnrampInteractor @Inject constructor(
                         )
                 },
                 onFailure = { error ->
-                    track(
+                    analyticsService?.track(
                         OnrampAnalyticsEvent.ErrorOccurred(
                             operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.PerformCheckout,
                             error = error,
@@ -755,10 +755,6 @@ internal class OnrampInteractor @Inject constructor(
                     )
                 }
             }
-    }
-
-    private fun track(event: OnrampAnalyticsEvent) {
-        analyticsService?.track(event)
     }
 }
 

--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampInteractor.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampInteractor.kt
@@ -79,7 +79,7 @@ internal class OnrampInteractor @Inject constructor(
         return when (linkResult) {
             is ConfigureResult.Success -> OnrampConfigurationResult.Completed(success = true)
             is ConfigureResult.Failed -> {
-                analyticsService?.track(
+                track(
                     OnrampAnalyticsEvent.ErrorOccurred(
                         operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.Configure,
                         error = linkResult.error,
@@ -93,7 +93,7 @@ internal class OnrampInteractor @Inject constructor(
     suspend fun hasLinkAccount(email: String): OnrampHasLinkAccountResult {
         return when (val result = linkController.lookupConsumer(email)) {
             is LinkController.LookupConsumerResult.Success -> {
-                analyticsService?.track(
+                track(
                     OnrampAnalyticsEvent.LinkAccountLookupCompleted(
                         hasLinkAccount = result.isConsumer
                     )
@@ -103,7 +103,7 @@ internal class OnrampInteractor @Inject constructor(
                 )
             }
             is LinkController.LookupConsumerResult.Failed -> {
-                analyticsService?.track(
+                track(
                     OnrampAnalyticsEvent.ErrorOccurred(
                         operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.HasLinkAccount,
                         error = result.error,
@@ -131,11 +131,11 @@ internal class OnrampInteractor @Inject constructor(
                     cryptoApiRepository.createCryptoCustomer(secret).fold(
                         onSuccess = { customerResponse ->
                             _state.update { it.copy(cryptoCustomerId = customerResponse.id) }
-                            analyticsService?.track(OnrampAnalyticsEvent.LinkRegistrationCompleted)
+                            track(OnrampAnalyticsEvent.LinkRegistrationCompleted)
                             OnrampRegisterLinkUserResult.Completed(customerResponse.id)
                         },
                         onFailure = { error ->
-                            analyticsService?.track(
+                            track(
                                 OnrampAnalyticsEvent.ErrorOccurred(
                                     operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.RegisterLinkUser,
                                     error = error,
@@ -146,7 +146,7 @@ internal class OnrampInteractor @Inject constructor(
                     )
                 } else {
                     val error = MissingConsumerSecretException()
-                    analyticsService?.track(
+                    track(
                         OnrampAnalyticsEvent.ErrorOccurred(
                             operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.RegisterLinkUser,
                             error = error,
@@ -156,7 +156,7 @@ internal class OnrampInteractor @Inject constructor(
                 }
             }
             is LinkController.RegisterConsumerResult.Failed -> {
-                analyticsService?.track(
+                track(
                     OnrampAnalyticsEvent.ErrorOccurred(
                         operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.RegisterLinkUser,
                         error = result.error,
@@ -172,11 +172,11 @@ internal class OnrampInteractor @Inject constructor(
     suspend fun updatePhoneNumber(phoneNumber: String): OnrampUpdatePhoneNumberResult {
         return when (val result = linkController.updatePhoneNumber(phoneNumber)) {
             is LinkController.UpdatePhoneNumberResult.Success -> {
-                analyticsService?.track(OnrampAnalyticsEvent.LinkPhoneNumberUpdated)
+                track(OnrampAnalyticsEvent.LinkPhoneNumberUpdated)
                 OnrampUpdatePhoneNumberResult.Completed
             }
             is LinkController.UpdatePhoneNumberResult.Failed -> {
-                analyticsService?.track(
+                track(
                     OnrampAnalyticsEvent.ErrorOccurred(
                         operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.UpdatePhoneNumber,
                         error = result.error,
@@ -198,11 +198,11 @@ internal class OnrampInteractor @Inject constructor(
             val result = cryptoApiRepository.setWalletAddress(walletAddress, network, secret)
             result.fold(
                 onSuccess = {
-                    analyticsService?.track(OnrampAnalyticsEvent.WalletRegistered(network))
+                    track(OnrampAnalyticsEvent.WalletRegistered(network))
                     OnrampRegisterWalletAddressResult.Completed()
                 },
                 onFailure = { error ->
-                    analyticsService?.track(
+                    track(
                         OnrampAnalyticsEvent.ErrorOccurred(
                             operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.RegisterWalletAddress,
                             error = error,
@@ -213,7 +213,7 @@ internal class OnrampInteractor @Inject constructor(
             )
         } else {
             val error = MissingConsumerSecretException()
-            analyticsService?.track(
+            track(
                 OnrampAnalyticsEvent.ErrorOccurred(
                     operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.RegisterWalletAddress,
                     error = error,
@@ -227,7 +227,7 @@ internal class OnrampInteractor @Inject constructor(
         val secret = consumerSessionClientSecret()
         if (secret == null) {
             val error = MissingConsumerSecretException()
-            analyticsService?.track(
+            track(
                 OnrampAnalyticsEvent.ErrorOccurred(
                     operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.AttachKycInfo,
                     error = error,
@@ -239,11 +239,11 @@ internal class OnrampInteractor @Inject constructor(
         return cryptoApiRepository.collectKycData(kycInfo, secret)
             .fold(
                 onSuccess = {
-                    analyticsService?.track(OnrampAnalyticsEvent.KycInfoSubmitted)
+                    track(OnrampAnalyticsEvent.KycInfoSubmitted)
                     OnrampAttachKycInfoResult.Completed
                 },
                 onFailure = { error ->
-                    analyticsService?.track(
+                    track(
                         OnrampAnalyticsEvent.ErrorOccurred(
                             operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.AttachKycInfo,
                             error = error,
@@ -258,7 +258,7 @@ internal class OnrampInteractor @Inject constructor(
         val secret = consumerSessionClientSecret()
         if (secret == null) {
             val error = MissingConsumerSecretException()
-            analyticsService?.track(
+            track(
                 OnrampAnalyticsEvent.ErrorOccurred(
                     operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.VerifyIdentity,
                     error = error,
@@ -270,11 +270,11 @@ internal class OnrampInteractor @Inject constructor(
         return cryptoApiRepository.startIdentityVerification(secret)
             .fold(
                 onSuccess = { result ->
-                    analyticsService?.track(OnrampAnalyticsEvent.IdentityVerificationStarted)
+                    track(OnrampAnalyticsEvent.IdentityVerificationStarted)
                     OnrampStartVerificationResult.Completed(result)
                 },
                 onFailure = { error ->
-                    analyticsService?.track(
+                    track(
                         OnrampAnalyticsEvent.ErrorOccurred(
                             operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.VerifyIdentity,
                             error = error,
@@ -290,7 +290,7 @@ internal class OnrampInteractor @Inject constructor(
         val secret = consumerSessionClientSecret()
         if (secret == null) {
             val error = MissingConsumerSecretException()
-            analyticsService?.track(
+            track(
                 OnrampAnalyticsEvent.ErrorOccurred(
                     operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.CreateCryptoPaymentToken,
                     error = error,
@@ -321,7 +321,7 @@ internal class OnrampInteractor @Inject constructor(
             }
             .fold(
                 onSuccess = { cryptoPaymentToken ->
-                    analyticsService?.track(
+                    track(
                         OnrampAnalyticsEvent.CryptoPaymentTokenCreated(
                             paymentMethodType = _state.value.collectingPaymentMethodType
                         )
@@ -329,7 +329,7 @@ internal class OnrampInteractor @Inject constructor(
                     OnrampCreateCryptoPaymentTokenResult.Completed(cryptoPaymentToken.id)
                 },
                 onFailure = { error ->
-                    analyticsService?.track(
+                    track(
                         OnrampAnalyticsEvent.ErrorOccurred(
                             operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.CreateCryptoPaymentToken,
                             error = error,
@@ -343,11 +343,11 @@ internal class OnrampInteractor @Inject constructor(
     suspend fun logOut(): OnrampLogOutResult {
         return when (val result = linkController.logOut()) {
             is LinkController.LogOutResult.Success -> {
-                analyticsService?.track(OnrampAnalyticsEvent.LinkLogout)
+                track(OnrampAnalyticsEvent.LinkLogout)
                 OnrampLogOutResult.Completed
             }
             is LinkController.LogOutResult.Failed -> {
-                analyticsService?.track(
+                track(
                     OnrampAnalyticsEvent.ErrorOccurred(
                         operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.LogOut,
                         error = result.error,
@@ -367,11 +367,11 @@ internal class OnrampInteractor @Inject constructor(
                 cryptoApiRepository.createCryptoCustomer(secret).fold(
                     onSuccess = { customerResponse ->
                         _state.update { it.copy(cryptoCustomerId = customerResponse.id) }
-                        analyticsService?.track(OnrampAnalyticsEvent.LinkUserAuthenticationCompleted)
+                        track(OnrampAnalyticsEvent.LinkUserAuthenticationCompleted)
                         OnrampAuthenticateResult.Completed(customerResponse.id)
                     },
                     onFailure = { error ->
-                        analyticsService?.track(
+                        track(
                             OnrampAnalyticsEvent.ErrorOccurred(
                                 operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.AuthenticateUser,
                                 error = error,
@@ -382,7 +382,7 @@ internal class OnrampInteractor @Inject constructor(
                 )
             } else {
                 val error = MissingConsumerSecretException()
-                analyticsService?.track(
+                track(
                     OnrampAnalyticsEvent.ErrorOccurred(
                         operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.AuthenticateUser,
                         error = error,
@@ -392,7 +392,7 @@ internal class OnrampInteractor @Inject constructor(
             }
         }
         is LinkController.AuthenticationResult.Failed -> {
-            analyticsService?.track(
+            track(
                 OnrampAnalyticsEvent.ErrorOccurred(
                     operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.AuthenticateUser,
                     error = result.error,
@@ -412,11 +412,11 @@ internal class OnrampInteractor @Inject constructor(
                 cryptoApiRepository.createCryptoCustomer(secret).fold(
                     onSuccess = { customerResponse ->
                         _state.update { it.copy(cryptoCustomerId = customerResponse.id) }
-                        analyticsService?.track(OnrampAnalyticsEvent.LinkAuthorizationCompleted(consented = true))
+                        track(OnrampAnalyticsEvent.LinkAuthorizationCompleted(consented = true))
                         OnrampAuthorizeResult.Consented(customerResponse.id)
                     },
                     onFailure = { error ->
-                        analyticsService?.track(
+                        track(
                             OnrampAnalyticsEvent.ErrorOccurred(
                                 operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.Authorize,
                                 error = error,
@@ -427,7 +427,7 @@ internal class OnrampInteractor @Inject constructor(
                 )
             } else {
                 val error = MissingConsumerSecretException()
-                analyticsService?.track(
+                track(
                     OnrampAnalyticsEvent.ErrorOccurred(
                         operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.Authorize,
                         error = error,
@@ -437,13 +437,13 @@ internal class OnrampInteractor @Inject constructor(
             }
         }
         is LinkController.AuthorizeResult.Denied -> {
-            analyticsService?.track(OnrampAnalyticsEvent.LinkAuthorizationCompleted(consented = false))
+            track(OnrampAnalyticsEvent.LinkAuthorizationCompleted(consented = false))
             OnrampAuthorizeResult.Denied()
         }
         is LinkController.AuthorizeResult.Canceled ->
             OnrampAuthorizeResult.Canceled()
         is LinkController.AuthorizeResult.Failed -> {
-            analyticsService?.track(
+            track(
                 OnrampAnalyticsEvent.ErrorOccurred(
                     operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.Authorize,
                     error = result.error,
@@ -457,11 +457,11 @@ internal class OnrampInteractor @Inject constructor(
         result: IdentityVerificationSheet.VerificationFlowResult
     ): OnrampVerifyIdentityResult = when (result) {
         is IdentityVerificationSheet.VerificationFlowResult.Completed -> {
-            analyticsService?.track(OnrampAnalyticsEvent.IdentityVerificationCompleted)
+            track(OnrampAnalyticsEvent.IdentityVerificationCompleted)
             OnrampVerifyIdentityResult.Completed()
         }
         is IdentityVerificationSheet.VerificationFlowResult.Failed -> {
-            analyticsService?.track(
+            track(
                 OnrampAnalyticsEvent.ErrorOccurred(
                     operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.VerifyIdentity,
                     error = result.throwable,
@@ -478,7 +478,7 @@ internal class OnrampInteractor @Inject constructor(
         context: Context,
     ): OnrampCollectPaymentMethodResult = when (result) {
         is LinkController.PresentPaymentMethodsResult.Success -> {
-            analyticsService?.track(
+            track(
                 OnrampAnalyticsEvent.CollectPaymentMethodCompleted(
                     paymentMethodType = _state.value.collectingPaymentMethodType
                 )
@@ -496,7 +496,7 @@ internal class OnrampInteractor @Inject constructor(
             }
         }
         is LinkController.PresentPaymentMethodsResult.Failed -> {
-            analyticsService?.track(
+            track(
                 OnrampAnalyticsEvent.ErrorOccurred(
                     operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.CollectPaymentMethod,
                     error = result.error,
@@ -516,28 +516,28 @@ internal class OnrampInteractor @Inject constructor(
         if (analyticsService?.elementsSessionId != linkState.elementsSessionId) {
             analyticsService = linkState.elementsSessionId
                 ?.let { analyticsServiceFactory.create(it) }
-            analyticsService?.track(OnrampAnalyticsEvent.SessionCreated)
+            track(OnrampAnalyticsEvent.SessionCreated)
         }
         _state.value = _state.value.copy(linkControllerState = linkState)
     }
 
     fun onAuthorize() {
-        analyticsService?.track(OnrampAnalyticsEvent.LinkAuthorizationStarted)
+        track(OnrampAnalyticsEvent.LinkAuthorizationStarted)
     }
 
     fun onAuthenticateUser() {
-        analyticsService?.track(OnrampAnalyticsEvent.LinkUserAuthenticationStarted)
+        track(OnrampAnalyticsEvent.LinkUserAuthenticationStarted)
     }
 
     fun onCollectPaymentMethod(type: PaymentMethodType) {
         _state.update { it.copy(collectingPaymentMethodType = type) }
-        analyticsService?.track(
+        track(
             OnrampAnalyticsEvent.CollectPaymentMethodStarted(type)
         )
     }
 
     fun onHandleNextActionError(error: Throwable) {
-        analyticsService?.track(
+        track(
             OnrampAnalyticsEvent.ErrorOccurred(
                 operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.PerformCheckout,
                 error = error,
@@ -570,7 +570,7 @@ internal class OnrampInteractor @Inject constructor(
                 )
             )
         }
-        analyticsService?.track(
+        track(
             OnrampAnalyticsEvent.CheckoutStarted(
                 onrampSessionId = onrampSessionId,
                 paymentMethodType = _state.value.collectingPaymentMethodType
@@ -644,7 +644,7 @@ internal class OnrampInteractor @Inject constructor(
                     // which is handled by PaymentLauncher in the presenter.
                     paymentIntent.toCheckoutResult()
                         ?.let { checkoutResult ->
-                            analyticsService?.track(
+                            track(
                                 OnrampAnalyticsEvent.CheckoutCompleted(
                                     onrampSessionId = onrampSessionId,
                                     paymentMethodType = _state.value.collectingPaymentMethodType,
@@ -661,7 +661,7 @@ internal class OnrampInteractor @Inject constructor(
                         )
                 },
                 onFailure = { error ->
-                    analyticsService?.track(
+                    track(
                         OnrampAnalyticsEvent.ErrorOccurred(
                             operation = OnrampAnalyticsEvent.ErrorOccurred.Operation.PerformCheckout,
                             error = error,
@@ -755,6 +755,10 @@ internal class OnrampInteractor @Inject constructor(
                     )
                 }
             }
+    }
+
+    private fun track(event: OnrampAnalyticsEvent) {
+        analyticsService?.track(event)
     }
 }
 

--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampPresenterCoordinator.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampPresenterCoordinator.kt
@@ -118,7 +118,7 @@ internal class OnrampPresenterCoordinator @Inject constructor(
 
     fun collectPaymentMethod(type: PaymentMethodType) {
         interactor.onCollectPaymentMethod(type)
-        linkPresenter.presentPaymentMethods(
+        linkPresenter.presentPaymentMethodsForOnramp(
             email = clientEmail(),
             paymentMethodType = type.toLinkType()
         )

--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/analytics/OnrampAnalyticsEvent.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/analytics/OnrampAnalyticsEvent.kt
@@ -3,6 +3,7 @@ package com.stripe.android.crypto.onramp.analytics
 import com.stripe.android.core.exception.safeAnalyticsMessage
 import com.stripe.android.crypto.onramp.model.CryptoNetwork
 import com.stripe.android.crypto.onramp.model.PaymentMethodType
+import com.stripe.android.utils.filterNotNullValues
 
 /**
  * Event definitions for Crypto Onramp.
@@ -82,8 +83,8 @@ internal sealed class OnrampAnalyticsEvent(
     ) : OnrampAnalyticsEvent(
         name = "collect_payment_method_started",
         params = mapOf(
-            "payment_method_type" to (paymentMethodType?.value ?: "")
-        )
+            "payment_method_type" to paymentMethodType?.value
+        ).filterNotNullValues()
     )
 
     class CollectPaymentMethodCompleted(
@@ -91,8 +92,8 @@ internal sealed class OnrampAnalyticsEvent(
     ) : OnrampAnalyticsEvent(
         name = "collect_payment_method_completed",
         params = mapOf(
-            "payment_method_type" to (paymentMethodType?.value ?: "")
-        )
+            "payment_method_type" to paymentMethodType?.value
+        ).filterNotNullValues()
     )
 
     class CryptoPaymentTokenCreated(
@@ -100,8 +101,8 @@ internal sealed class OnrampAnalyticsEvent(
     ) : OnrampAnalyticsEvent(
         name = "crypto_payment_token_created",
         params = mapOf(
-            "payment_method_type" to (paymentMethodType?.value ?: "")
-        )
+            "payment_method_type" to paymentMethodType?.value
+        ).filterNotNullValues()
     )
 
     class CheckoutStarted(
@@ -111,8 +112,8 @@ internal sealed class OnrampAnalyticsEvent(
         name = "checkout_started",
         params = mapOf(
             "onramp_session_id" to onrampSessionId,
-            "payment_method_type" to (paymentMethodType?.value ?: "")
-        )
+            "payment_method_type" to paymentMethodType?.value
+        ).filterNotNullValues()
     )
 
     class CheckoutCompleted(
@@ -123,9 +124,9 @@ internal sealed class OnrampAnalyticsEvent(
         name = "checkout_completed",
         params = mapOf(
             "onramp_session_id" to onrampSessionId,
-            "payment_method_type" to (paymentMethodType?.value ?: ""),
+            "payment_method_type" to paymentMethodType?.value,
             "required_action" to requiredAction.toString()
-        )
+        ).filterNotNullValues()
     )
 
     data object LinkLogout : OnrampAnalyticsEvent(

--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/exception/MissingCryptoCustomerException.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/exception/MissingCryptoCustomerException.kt
@@ -1,0 +1,6 @@
+package com.stripe.android.crypto.onramp.exception
+
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class MissingCryptoCustomerException : IllegalStateException("Missing crypto customer ID")

--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/model/CreatePaymentTokenRequest.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/model/CreatePaymentTokenRequest.kt
@@ -5,8 +5,6 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 internal data class CreatePaymentTokenRequest(
-    val credentials: CryptoCustomerRequestParams.Credentials,
-
     @SerialName("payment_method")
     val paymentMethod: String,
 )

--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/model/CreatePaymentTokenRequest.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/model/CreatePaymentTokenRequest.kt
@@ -5,6 +5,9 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 internal data class CreatePaymentTokenRequest(
+    @SerialName("crypto_customer_id")
+    val cryptoCustomerId: String,
+
     @SerialName("payment_method")
     val paymentMethod: String,
 )

--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/model/OnrampConfiguration.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/model/OnrampConfiguration.kt
@@ -17,6 +17,6 @@ import kotlinx.parcelize.Parcelize
 class OnrampConfiguration(
     val merchantDisplayName: String,
     val publishableKey: String,
-    val stripeAccountId: String? = null,
-    val appearance: LinkAppearance
+    val appearance: LinkAppearance,
+    val cryptoCustomerId: String? = null,
 ) : Parcelable

--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/repositories/CryptoApiRepository.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/repositories/CryptoApiRepository.kt
@@ -163,9 +163,11 @@ internal class CryptoApiRepository @Inject constructor(
     }
 
     suspend fun createPaymentToken(
+        cryptoCustomerId: String,
         paymentMethod: String,
     ): Result<CreatePaymentTokenResponse> {
         val params = CreatePaymentTokenRequest(
+            cryptoCustomerId = cryptoCustomerId,
             paymentMethod = paymentMethod,
         )
         return executePost(

--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/repositories/CryptoApiRepository.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/repositories/CryptoApiRepository.kt
@@ -163,11 +163,9 @@ internal class CryptoApiRepository @Inject constructor(
     }
 
     suspend fun createPaymentToken(
-        consumerSessionClientSecret: String,
         paymentMethod: String,
     ): Result<CreatePaymentTokenResponse> {
         val params = CreatePaymentTokenRequest(
-            credentials = CryptoCustomerRequestParams.Credentials(consumerSessionClientSecret),
             paymentMethod = paymentMethod,
         )
         return executePost(

--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/repositories/CryptoApiRepository.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/repositories/CryptoApiRepository.kt
@@ -69,13 +69,13 @@ internal class CryptoApiRepository @Inject constructor(
      *
      * @param consumerSessionClientSecret The client session secret to attach permissions to.
      */
-    suspend fun grantPartnerMerchantPermissions(
+    suspend fun createCryptoCustomer(
         consumerSessionClientSecret: String
     ): Result<CryptoCustomerResponse> {
         val params = CryptoCustomerRequestParams(CryptoCustomerRequestParams.Credentials(consumerSessionClientSecret))
 
-        return execute(
-            getGrantPartnerMerchantPermissionsUrl,
+        return executePost(
+            customersUrl,
             Json.encodeToJsonElement(params).jsonObject,
             CryptoCustomerResponse.serializer()
         )
@@ -95,7 +95,7 @@ internal class CryptoApiRepository @Inject constructor(
             credentials = CryptoCustomerRequestParams.Credentials(consumerSessionClientSecret)
         )
 
-        return execute(
+        return executePost(
             collectKycDataUrl,
             Json.encodeToJsonElement(apiRequest).jsonObject,
             Unit.serializer()
@@ -120,7 +120,7 @@ internal class CryptoApiRepository @Inject constructor(
             credentials = CryptoCustomerRequestParams.Credentials(consumerSessionClientSecret)
         )
 
-        return execute(
+        return executePost(
             setWalletAddressUrl,
             Json.encodeToJsonElement(params).jsonObject,
             Unit.serializer()
@@ -136,7 +136,7 @@ internal class CryptoApiRepository @Inject constructor(
 
         val json = Json { encodeDefaults = true }
 
-        return execute(
+        return executePost(
             startIdentityVerificationUrl,
             json.encodeToJsonElement(request).jsonObject,
             StartIdentityVerificationResponse.serializer()
@@ -144,14 +144,14 @@ internal class CryptoApiRepository @Inject constructor(
     }
 
     suspend fun getPlatformSettings(
-        consumerSessionClientSecret: String?,
+        cryptoCustomerId: String,
         countryHint: String?
     ): Result<GetPlatformSettingsResponse> {
         val request = apiRequestFactory.createGet(
             url = platformSettings,
             options = buildRequestOptions(),
             params = mapOf(
-                "credentials[consumer_session_client_secret]" to consumerSessionClientSecret,
+                "crypto_customer_id" to cryptoCustomerId,
                 "country_hint" to countryHint
             ).filterNotNullValues()
         )
@@ -170,7 +170,7 @@ internal class CryptoApiRepository @Inject constructor(
             credentials = CryptoCustomerRequestParams.Credentials(consumerSessionClientSecret),
             paymentMethod = paymentMethod,
         )
-        return execute(
+        return executePost(
             url = paymentToken,
             paramsJson = Json.encodeToJsonElement(params).jsonObject,
             responseSerializer = CreatePaymentTokenResponse.serializer()
@@ -233,7 +233,7 @@ internal class CryptoApiRepository @Inject constructor(
         )
     }
 
-    private suspend fun <Response> execute(
+    private suspend fun <Response> executePost(
         url: String,
         paramsJson: JsonObject,
         responseSerializer: KSerializer<Response>,
@@ -272,7 +272,7 @@ internal class CryptoApiRepository @Inject constructor(
         /**
          * @return `https://api.stripe.com/v1/crypto/internal/customers`
          */
-        internal val getGrantPartnerMerchantPermissionsUrl: String = getApiUrl("crypto/internal/customers")
+        internal val customersUrl: String = getApiUrl("crypto/internal/customers")
 
         /**
          * @return `https://api.stripe.com/v1/crypto/internal/kyc_data_collection`

--- a/crypto-onramp/src/test/java/com/stripe/android/crypto/onramp/CryptoApiRepositoryTest.kt
+++ b/crypto-onramp/src/test/java/com/stripe/android/crypto/onramp/CryptoApiRepositoryTest.kt
@@ -59,7 +59,7 @@ class CryptoApiRepositoryTest {
             whenever(stripeNetworkClient.executeRequest(any<ApiRequest>()))
                 .thenReturn(stripeResponse)
 
-            val result = cryptoApiRepository.grantPartnerMerchantPermissions(
+            val result = cryptoApiRepository.createCryptoCustomer(
                 consumerSessionClientSecret = "test-secret"
             )
 
@@ -95,7 +95,7 @@ class CryptoApiRepositoryTest {
             whenever(stripeNetworkClient.executeRequest(any<ApiRequest>()))
                 .thenReturn(stripeResponse)
 
-            val result = cryptoApiRepository.grantPartnerMerchantPermissions(
+            val result = cryptoApiRepository.createCryptoCustomer(
                 consumerSessionClientSecret = "test-secret"
             )
 

--- a/crypto-onramp/src/test/java/com/stripe/android/crypto/onramp/OnrampInteractorTest.kt
+++ b/crypto-onramp/src/test/java/com/stripe/android/crypto/onramp/OnrampInteractorTest.kt
@@ -217,7 +217,7 @@ class OnrampInteractorTest {
 
         val createPaymentTokenResponse = CreatePaymentTokenResponse(id = "crypto_token_123")
         whenever(
-            cryptoApiRepository.createPaymentToken(any(), any())
+            cryptoApiRepository.createPaymentToken(any())
         ).thenReturn(Result.success(createPaymentTokenResponse))
 
         val result = interactor.createCryptoPaymentToken()

--- a/crypto-onramp/src/test/java/com/stripe/android/crypto/onramp/OnrampInteractorTest.kt
+++ b/crypto-onramp/src/test/java/com/stripe/android/crypto/onramp/OnrampInteractorTest.kt
@@ -217,7 +217,7 @@ class OnrampInteractorTest {
 
         val createPaymentTokenResponse = CreatePaymentTokenResponse(id = "crypto_token_123")
         whenever(
-            cryptoApiRepository.createPaymentToken(any())
+            cryptoApiRepository.createPaymentToken(cryptoCustomerId = any(), paymentMethod = any())
         ).thenReturn(Result.success(createPaymentTokenResponse))
 
         val result = interactor.createCryptoPaymentToken()

--- a/crypto-onramp/src/test/java/com/stripe/android/crypto/onramp/OnrampInteractorTest.kt
+++ b/crypto-onramp/src/test/java/com/stripe/android/crypto/onramp/OnrampInteractorTest.kt
@@ -105,7 +105,7 @@ class OnrampInteractorTest {
         )
         whenever(linkController.state(any())).thenReturn(MutableStateFlow(mockLinkStateWithAccount()))
         val permissionsResult = CryptoCustomerResponse(id = "customer_123")
-        whenever(cryptoApiRepository.grantPartnerMerchantPermissions(any()))
+        whenever(cryptoApiRepository.createCryptoCustomer(any()))
             .thenReturn(Result.success(permissionsResult))
 
         interactor.onLinkControllerState(mockLinkStateWithAccount())
@@ -243,7 +243,7 @@ class OnrampInteractorTest {
     fun testHandleAuthenticationResultSuccess() = runTest {
         whenever(linkController.state(any())).thenReturn(MutableStateFlow(mockLinkStateWithAccount()))
         val permissionsResult = CryptoCustomerResponse(id = "customer_123")
-        whenever(cryptoApiRepository.grantPartnerMerchantPermissions(any()))
+        whenever(cryptoApiRepository.createCryptoCustomer(any()))
             .thenReturn(Result.success(permissionsResult))
 
         interactor.onLinkControllerState(mockLinkStateWithAccount())
@@ -260,7 +260,7 @@ class OnrampInteractorTest {
     fun testHandleAuthorizeResultConsented() = runTest {
         whenever(linkController.state(any())).thenReturn(MutableStateFlow(mockLinkStateWithAccount()))
         val permissionsResult = CryptoCustomerResponse(id = "customer_123")
-        whenever(cryptoApiRepository.grantPartnerMerchantPermissions(any()))
+        whenever(cryptoApiRepository.createCryptoCustomer(any()))
             .thenReturn(Result.success(permissionsResult))
 
         interactor.onLinkControllerState(mockLinkStateWithAccount())

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/LinkControllerPlaygroundViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/LinkControllerPlaygroundViewModel.kt
@@ -91,7 +91,7 @@ internal class LinkControllerPlaygroundViewModel(
     }
 
     fun onPaymentMethodClick(email: String, paymentMethodType: LinkController.PaymentMethodType?) {
-        linkControllerPresenter?.presentPaymentMethods(
+        linkControllerPresenter?.presentPaymentMethodsForOnramp(
             email = email.takeIf { it.isNotBlank() },
             paymentMethodType = paymentMethodType,
         )

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkConfigurationLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkConfigurationLoader.kt
@@ -34,10 +34,13 @@ internal class DefaultLinkConfigurationLoader @Inject constructor(
         ).mapCatching { state ->
             @Suppress("TooGenericExceptionCaught")
             try {
-                checkNotNull(state.paymentMethodMetadata.linkState?.configuration).also {
-                    val linkGate = linkGateFactory.create(it)
-                    check(linkGate.useNativeLink) { "Native Link is not available" }
+                val config = checkNotNull(state.paymentMethodMetadata.linkState?.configuration) {
+                    "Link is not available"
                 }
+                check(linkGateFactory.create(config).useNativeLink) {
+                    "Native Link is not available"
+                }
+                config
             } catch (e: Throwable) {
                 throw LinkUnavailableException(e)
             }

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkController.kt
@@ -349,11 +349,21 @@ class LinkController @Inject internal constructor(
          * @param email The email address to use for Link account lookup. If provided and the email
          * matches an existing Link account, the account's payment methods will be available for selection.
          * If null, the user will need to sign in or create a Link account.
-         * @param paymentMethodType Optional filter for the type of payment methods to present.
          */
         fun presentPaymentMethods(
             email: String?,
-            paymentMethodType: PaymentMethodType? = null
+        ) {
+            interactor.presentPaymentMethods(
+                launcher = coordinator.linkActivityResultLauncher,
+                email = email,
+                paymentMethodType = null,
+            )
+        }
+
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        fun presentPaymentMethodsForOnramp(
+            email: String?,
+            paymentMethodType: PaymentMethodType?
         ) {
             interactor.presentPaymentMethods(
                 launcher = coordinator.linkActivityResultLauncher,

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
@@ -217,10 +217,11 @@ internal class LinkControllerInteractor @Inject constructor(
                     val customerInfo = config.customerInfo
                         .copy(email = email ?: config.customerInfo.email)
                     val nameCollectionConfig =
-                        if (paymentMethodType == LinkController.PaymentMethodType.BankAccount)
+                        if (paymentMethodType == LinkController.PaymentMethodType.BankAccount) {
                             PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always
-                        else
+                        } else {
                             config.billingDetailsCollectionConfiguration.name
+                        }
                     val billingDetailsCollectionConfiguration = config.billingDetailsCollectionConfiguration
                         .copy(name = nameCollectionConfig)
                     config.copy(

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
@@ -30,6 +30,7 @@ import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.EmailSource
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.parsers.PaymentMethodJsonParser
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.TransformToBankIcon
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.transformBankIconCodeToBankIcon
@@ -143,6 +144,7 @@ internal class LinkControllerInteractor @Inject constructor(
         present(
             launcher = launcher,
             email = email,
+            paymentMethodType = paymentMethodType,
             onConfigurationError = { error ->
                 _presentPaymentMethodsResultFlow.tryEmit(
                     LinkController.PresentPaymentMethodsResult.Failed(error)
@@ -201,15 +203,31 @@ internal class LinkControllerInteractor @Inject constructor(
 
     private fun withConfiguration(
         email: String?,
+        paymentMethodType: LinkController.PaymentMethodType?,
         onError: (Throwable) -> Unit,
         onSuccess: (LinkConfiguration) -> Unit
     ) {
         val configuration = requireLinkComponent()
             .map { it.configuration }
             .map { config ->
-                email
-                    ?.let { config.copy(customerInfo = config.customerInfo.copy(email = email)) }
-                    ?: config
+                if (email == null && paymentMethodType == null) {
+                    // No change needed.
+                    config
+                } else {
+                    val customerInfo = config.customerInfo
+                        .copy(email = email ?: config.customerInfo.email)
+                    val nameCollectionConfig =
+                        if (paymentMethodType == LinkController.PaymentMethodType.BankAccount)
+                            PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always
+                        else
+                            config.billingDetailsCollectionConfiguration.name
+                    val billingDetailsCollectionConfiguration = config.billingDetailsCollectionConfiguration
+                        .copy(name = nameCollectionConfig)
+                    config.copy(
+                        customerInfo = customerInfo,
+                        billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration,
+                    )
+                }
             }
 
         configuration.fold(
@@ -464,7 +482,6 @@ internal class LinkControllerInteractor @Inject constructor(
     ) {
         present(
             launcher = launcher,
-            email = null,
             onConfigurationError = { error ->
                 _authorizeResultFlow.tryEmit(
                     LinkController.AuthorizeResult.Failed(error)
@@ -484,7 +501,8 @@ internal class LinkControllerInteractor @Inject constructor(
 
     private fun present(
         launcher: ActivityResultLauncher<LinkActivityContract.Args>,
-        email: String?,
+        email: String? = null,
+        paymentMethodType: LinkController.PaymentMethodType? = null,
         onConfigurationError: (Throwable) -> Unit,
         getLaunchMode: (linkAccount: LinkAccount?, state: State) -> LinkLaunchMode?
     ) {
@@ -492,6 +510,7 @@ internal class LinkControllerInteractor @Inject constructor(
 
         withConfiguration(
             email = email,
+            paymentMethodType = paymentMethodType,
             onError = onConfigurationError,
             onSuccess = { configuration ->
                 updateStateOnNewEmail(email)

--- a/paymentsheet/src/main/java/com/stripe/android/link/exceptions/LinkUnavailableException.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/exceptions/LinkUnavailableException.kt
@@ -4,6 +4,11 @@ import androidx.annotation.RestrictTo
 import com.stripe.android.core.exception.StripeException
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-class LinkUnavailableException(cause: Throwable? = null) : StripeException(cause = cause) {
+class LinkUnavailableException(
+    cause: Throwable? = null
+) : StripeException(
+    cause = cause,
+    message = cause?.message,
+) {
     override fun analyticsValue(): String = "linkUnavailable"
 }

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerInteractorTest.kt
@@ -507,6 +507,23 @@ class LinkControllerInteractorTest {
     }
 
     @Test
+    fun `onPresentPaymentMethods() with BankAccount payment method requires name collection`() = runTest {
+        val interactor = createInteractor()
+        configure(interactor)
+
+        val launcher = FakeActivityResultLauncher<LinkActivityContract.Args>()
+        interactor.presentPaymentMethods(
+            launcher = launcher,
+            email = null,
+            paymentMethodType = LinkController.PaymentMethodType.BankAccount
+        )
+
+        val collectionConfig = launcher.calls.awaitItem().input.configuration.billingDetailsCollectionConfiguration
+        assertThat(collectionConfig.name)
+            .isEqualTo(PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always)
+    }
+
+    @Test
     fun `onLinkActivityResult() with PaymentMethodObtained result does nothing`() = runTest {
         val interactor = createInteractor()
         configure(interactor)


### PR DESCRIPTION
# Summary
A mix of onramp fixes combined for expediency (sorry), mainly:
 1. Add `crypto_customer_id` onramp configuration option (akin to Customer configuration in PE)
 2. Update requests per [this Slack thread](http://go/lng/2025-09-22-onramp-requests)
 3. Always collect billing name when getting Link bank account for onramp
 4. Improve error handling

See comments for more details.

# Motivation
👻 

# Testing
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
See Slack
