### PR TITLE
Add PaymentMethodSelectionFlow to ClientAttributionMetadata

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -2980,6 +2980,7 @@ public final class com/stripe/android/model/PaymentIntent : com/stripe/android/m
 	public final fun component21 ()Ljava/util/List;
 	public final fun component22 ()Ljava/util/List;
 	public final fun component23 ()Lcom/stripe/android/model/StripeIntent$NextActionData;
+	public final fun component25 ()Z
 	public final fun component3 ()Ljava/lang/Long;
 	public final fun component4 ()J
 	public final fun component5 ()Lcom/stripe/android/model/PaymentIntent$CancellationReason;
@@ -2987,8 +2988,8 @@ public final class com/stripe/android/model/PaymentIntent : com/stripe/android/m
 	public final fun component7 ()Ljava/lang/String;
 	public final fun component8 ()Lcom/stripe/android/model/PaymentIntent$ConfirmationMethod;
 	public final fun component9 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;JLcom/stripe/android/model/PaymentIntent$CancellationReason;Lcom/stripe/android/model/PaymentIntent$CaptureMethod;Ljava/lang/String;Lcom/stripe/android/model/PaymentIntent$ConfirmationMethod;Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;ZLcom/stripe/android/model/PaymentMethod;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/StripeIntent$Status;Lcom/stripe/android/model/StripeIntent$Usage;Lcom/stripe/android/model/PaymentIntent$Error;Lcom/stripe/android/model/PaymentIntent$Shipping;Ljava/util/List;Ljava/util/List;Lcom/stripe/android/model/StripeIntent$NextActionData;Ljava/lang/String;)Lcom/stripe/android/model/PaymentIntent;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentIntent;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;JLcom/stripe/android/model/PaymentIntent$CancellationReason;Lcom/stripe/android/model/PaymentIntent$CaptureMethod;Ljava/lang/String;Lcom/stripe/android/model/PaymentIntent$ConfirmationMethod;Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;ZLcom/stripe/android/model/PaymentMethod;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/StripeIntent$Status;Lcom/stripe/android/model/StripeIntent$Usage;Lcom/stripe/android/model/PaymentIntent$Error;Lcom/stripe/android/model/PaymentIntent$Shipping;Ljava/util/List;Ljava/util/List;Lcom/stripe/android/model/StripeIntent$NextActionData;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentIntent;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;JLcom/stripe/android/model/PaymentIntent$CancellationReason;Lcom/stripe/android/model/PaymentIntent$CaptureMethod;Ljava/lang/String;Lcom/stripe/android/model/PaymentIntent$ConfirmationMethod;Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;ZLcom/stripe/android/model/PaymentMethod;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/StripeIntent$Status;Lcom/stripe/android/model/StripeIntent$Usage;Lcom/stripe/android/model/PaymentIntent$Error;Lcom/stripe/android/model/PaymentIntent$Shipping;Ljava/util/List;Ljava/util/List;Lcom/stripe/android/model/StripeIntent$NextActionData;Ljava/lang/String;Z)Lcom/stripe/android/model/PaymentIntent;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentIntent;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;JLcom/stripe/android/model/PaymentIntent$CancellationReason;Lcom/stripe/android/model/PaymentIntent$CaptureMethod;Ljava/lang/String;Lcom/stripe/android/model/PaymentIntent$ConfirmationMethod;Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;ZLcom/stripe/android/model/PaymentMethod;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/StripeIntent$Status;Lcom/stripe/android/model/StripeIntent$Usage;Lcom/stripe/android/model/PaymentIntent$Error;Lcom/stripe/android/model/PaymentIntent$Shipping;Ljava/util/List;Ljava/util/List;Lcom/stripe/android/model/StripeIntent$NextActionData;Ljava/lang/String;ZILjava/lang/Object;)Lcom/stripe/android/model/PaymentIntent;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Lorg/json/JSONObject;)Lcom/stripe/android/model/PaymentIntent;
@@ -5133,6 +5134,7 @@ public final class com/stripe/android/model/SetupIntent : com/stripe/android/mod
 	public final fun component14 ()Ljava/util/List;
 	public final fun component15 ()Ljava/util/List;
 	public final fun component16 ()Lcom/stripe/android/model/StripeIntent$NextActionData;
+	public final fun component18 ()Z
 	public final fun component2 ()Lcom/stripe/android/model/SetupIntent$CancellationReason;
 	public final fun component3 ()J
 	public final fun component4 ()Ljava/lang/String;
@@ -5141,8 +5143,8 @@ public final class com/stripe/android/model/SetupIntent : com/stripe/android/mod
 	public final fun component7 ()Z
 	public final fun component8 ()Lcom/stripe/android/model/PaymentMethod;
 	public final fun component9 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Lcom/stripe/android/model/SetupIntent$CancellationReason;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLcom/stripe/android/model/PaymentMethod;Ljava/lang/String;Ljava/util/List;Lcom/stripe/android/model/StripeIntent$Status;Lcom/stripe/android/model/StripeIntent$Usage;Lcom/stripe/android/model/SetupIntent$Error;Ljava/util/List;Ljava/util/List;Lcom/stripe/android/model/StripeIntent$NextActionData;Ljava/lang/String;)Lcom/stripe/android/model/SetupIntent;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/SetupIntent;Ljava/lang/String;Lcom/stripe/android/model/SetupIntent$CancellationReason;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLcom/stripe/android/model/PaymentMethod;Ljava/lang/String;Ljava/util/List;Lcom/stripe/android/model/StripeIntent$Status;Lcom/stripe/android/model/StripeIntent$Usage;Lcom/stripe/android/model/SetupIntent$Error;Ljava/util/List;Ljava/util/List;Lcom/stripe/android/model/StripeIntent$NextActionData;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/SetupIntent;
+	public final fun copy (Ljava/lang/String;Lcom/stripe/android/model/SetupIntent$CancellationReason;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLcom/stripe/android/model/PaymentMethod;Ljava/lang/String;Ljava/util/List;Lcom/stripe/android/model/StripeIntent$Status;Lcom/stripe/android/model/StripeIntent$Usage;Lcom/stripe/android/model/SetupIntent$Error;Ljava/util/List;Ljava/util/List;Lcom/stripe/android/model/StripeIntent$NextActionData;Ljava/lang/String;Z)Lcom/stripe/android/model/SetupIntent;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/SetupIntent;Ljava/lang/String;Lcom/stripe/android/model/SetupIntent$CancellationReason;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLcom/stripe/android/model/PaymentMethod;Ljava/lang/String;Ljava/util/List;Lcom/stripe/android/model/StripeIntent$Status;Lcom/stripe/android/model/StripeIntent$Usage;Lcom/stripe/android/model/SetupIntent$Error;Ljava/util/List;Ljava/util/List;Lcom/stripe/android/model/StripeIntent$NextActionData;Ljava/lang/String;ZILjava/lang/Object;)Lcom/stripe/android/model/SetupIntent;
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Lorg/json/JSONObject;)Lcom/stripe/android/model/SetupIntent;

--- a/payments-core/src/main/java/com/stripe/android/model/ClientAttributionMetadata.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ClientAttributionMetadata.kt
@@ -12,12 +12,14 @@ import kotlinx.parcelize.Parcelize
 data class ClientAttributionMetadata(
     @get:VisibleForTesting val elementsSessionConfigId: String,
     @get:VisibleForTesting val paymentIntentCreationFlow: PaymentIntentCreationFlow,
+    @get:VisibleForTesting val paymentMethodSelectionFlow: PaymentMethodSelectionFlow,
 ) : StripeParamsModel, Parcelable {
 
     override fun toParamMap(): Map<String, Any> {
         return mapOf(
             "elements_session_config_id" to elementsSessionConfigId,
             "payment_intent_creation_flow" to paymentIntentCreationFlow.paramValue,
+            "payment_method_selection_flow" to paymentMethodSelectionFlow.paramValue,
             "merchant_integration_source" to "elements",
             "merchant_integration_subtype" to "mobile",
             "merchant_integration_version" to "stripe-android/${StripeSdkVersion.VERSION_NAME}",
@@ -32,4 +34,9 @@ data class ClientAttributionMetadata(
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 enum class PaymentIntentCreationFlow(internal val paramValue: String) {
     Standard(paramValue = "standard"), Deferred(paramValue = "deferred")
+}
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+enum class PaymentMethodSelectionFlow(internal val paramValue: String) {
+    Automatic(paramValue = "automatic"), MerchantSpecified(paramValue = "merchant_specified")
 }

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentIntent.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentIntent.kt
@@ -154,6 +154,9 @@ constructor(
 
     private val paymentMethodOptionsJsonString: String? = null,
 
+    @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    override val automaticPaymentMethodsEnabled: Boolean = false,
+
 ) : StripeIntent {
 
     override fun getPaymentMethodOptions() = paymentMethodOptionsJsonString?.let {

--- a/payments-core/src/main/java/com/stripe/android/model/SetupIntent.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/SetupIntent.kt
@@ -109,6 +109,9 @@ constructor(
     override val nextActionData: StripeIntent.NextActionData?,
 
     private val paymentMethodOptionsJsonString: String? = null,
+
+    @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    override val automaticPaymentMethodsEnabled: Boolean = false,
 ) : StripeIntent {
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/payments-core/src/main/java/com/stripe/android/model/StripeIntent.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/StripeIntent.kt
@@ -76,6 +76,9 @@ sealed interface StripeIntent : StripeModel {
     @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     val countryCode: String?
 
+    @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    val automaticPaymentMethodsEnabled: Boolean
+
     fun requiresAction(): Boolean
 
     fun requiresConfirmation(): Boolean

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/DeferredPaymentIntentJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/DeferredPaymentIntentJsonParser.kt
@@ -48,7 +48,8 @@ class DeferredPaymentIntentJsonParser(
             setupFutureUsage = paymentMode.setupFutureUsage,
             amount = paymentMode.amount,
             currency = paymentMode.currency,
-            paymentMethodOptionsJsonString = paymentMode.paymentMethodOptionsJsonString
+            paymentMethodOptionsJsonString = paymentMode.paymentMethodOptionsJsonString,
+            automaticPaymentMethodsEnabled = paymentMethodTypes.isEmpty(),
         )
     }
 

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/DeferredSetupIntentJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/DeferredSetupIntentJsonParser.kt
@@ -44,6 +44,7 @@ class DeferredSetupIntentJsonParser(
             created = timeProvider(),
             status = null,
             usage = setupMode.setupFutureUsage,
+            automaticPaymentMethodsEnabled = paymentMethodTypes.isEmpty(),
         )
     }
 

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/PaymentIntentJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/PaymentIntentJsonParser.kt
@@ -77,6 +77,9 @@ class PaymentIntentJsonParser : ModelJsonParser<PaymentIntent> {
 
         val countryCode = optString(json, FIELD_COUNTRY_CODE)
 
+        val automaticPaymentMethodsEnabled =
+            json.optJSONObject(FIELD_AUTOMATIC_PAYMENT_METHODS)?.optBoolean(FIELD_ENABLED) == true
+
         return PaymentIntent(
             id = id,
             paymentMethodTypes = paymentMethodTypes,
@@ -101,7 +104,8 @@ class PaymentIntentJsonParser : ModelJsonParser<PaymentIntent> {
             unactivatedPaymentMethods = unactivatedPaymentMethods,
             linkFundingSources = linkFundingSources,
             nextActionData = nextActionData,
-            paymentMethodOptionsJsonString = paymentMethodOptions
+            paymentMethodOptionsJsonString = paymentMethodOptions,
+            automaticPaymentMethodsEnabled = automaticPaymentMethodsEnabled,
         )
     }
 
@@ -163,6 +167,7 @@ class PaymentIntentJsonParser : ModelJsonParser<PaymentIntent> {
         private const val FIELD_ID = "id"
         private const val FIELD_OBJECT = "object"
         private const val FIELD_AMOUNT = "amount"
+        private const val FIELD_AUTOMATIC_PAYMENT_METHODS = "automatic_payment_methods"
         private const val FIELD_CREATED = "created"
         private const val FIELD_CANCELED_AT = "canceled_at"
         private const val FIELD_CANCELLATION_REASON = "cancellation_reason"
@@ -172,6 +177,7 @@ class PaymentIntentJsonParser : ModelJsonParser<PaymentIntent> {
         private const val FIELD_COUNTRY_CODE = "country_code"
         private const val FIELD_CURRENCY = "currency"
         private const val FIELD_DESCRIPTION = "description"
+        private const val FIELD_ENABLED = "enabled"
         private const val FIELD_LAST_PAYMENT_ERROR = "last_payment_error"
         private const val FIELD_LIVEMODE = "livemode"
         private const val FIELD_NEXT_ACTION = "next_action"

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/SetupIntentJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/SetupIntentJsonParser.kt
@@ -32,6 +32,9 @@ class SetupIntentJsonParser : ModelJsonParser<SetupIntent> {
 
         val paymentMethodOptions = json.optJSONObject(FIELD_PAYMENT_METHOD_OPTIONS)?.toString()
 
+        val automaticPaymentMethodsEnabled =
+            json.optJSONObject(FIELD_AUTOMATIC_PAYMENT_METHODS)?.optBoolean(FIELD_ENABLED) == true
+
         return SetupIntent(
             id = optString(json, FIELD_ID),
             created = json.optLong(FIELD_CREATED),
@@ -57,7 +60,8 @@ class SetupIntentJsonParser : ModelJsonParser<SetupIntent> {
             nextActionData = json.optJSONObject(FIELD_NEXT_ACTION)?.let {
                 NextActionDataParser().parse(it)
             },
-            paymentMethodOptionsJsonString = paymentMethodOptions
+            paymentMethodOptionsJsonString = paymentMethodOptions,
+            automaticPaymentMethodsEnabled = automaticPaymentMethodsEnabled,
         )
     }
 
@@ -92,11 +96,13 @@ class SetupIntentJsonParser : ModelJsonParser<SetupIntent> {
 
         private const val FIELD_ID = "id"
         private const val FIELD_OBJECT = "object"
+        private const val FIELD_AUTOMATIC_PAYMENT_METHODS = "automatic_payment_methods"
         private const val FIELD_CANCELLATION_REASON = "cancellation_reason"
         private const val FIELD_CREATED = "created"
         private const val FIELD_CLIENT_SECRET = "client_secret"
         private const val FIELD_COUNTRY_CODE = "country_code"
         private const val FIELD_DESCRIPTION = "description"
+        private const val FIELD_ENABLED = "enabled"
         private const val FIELD_LAST_SETUP_ERROR = "last_setup_error"
         private const val FIELD_LIVEMODE = "livemode"
         private const val FIELD_NEXT_ACTION = "next_action"

--- a/payments-core/src/test/java/com/stripe/android/model/ClientAttributionMetadataTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/ClientAttributionMetadataTest.kt
@@ -12,9 +12,10 @@ class ClientAttributionMetadataTest {
         val clientAttributionMetadataParams = ClientAttributionMetadata(
             elementsSessionConfigId = "elements_session_123",
             paymentIntentCreationFlow = PaymentIntentCreationFlow.Standard,
+            paymentMethodSelectionFlow = PaymentMethodSelectionFlow.MerchantSpecified,
         ).toParamMap()
 
-        assertThat(clientAttributionMetadataParams).hasSize(6)
+        assertThat(clientAttributionMetadataParams).hasSize(7)
         assertThat(clientAttributionMetadataParams).containsEntry(
             "elements_session_config_id",
             "elements_session_123"
@@ -38,6 +39,10 @@ class ClientAttributionMetadataTest {
         assertThat(clientAttributionMetadataParams).containsEntry(
             "client_session_id",
             AnalyticsRequestFactory.sessionId.toString()
+        )
+        assertThat(clientAttributionMetadataParams).containsEntry(
+            "payment_method_selection_flow",
+            "merchant_specified",
         )
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/model/PaymentIntentFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/PaymentIntentFixtures.kt
@@ -2441,4 +2441,86 @@ internal object PaymentIntentFixtures {
     internal val PI_WITH_COUNTRY_CODE by lazy {
         PARSER.parse(PI_WITH_COUNTRY_CODE_JSON)!!
     }
+
+    private val PI_WITH_AUTOMATIC_PAYMENT_METHODS_NOT_ENABLED_JSON by lazy {
+        JSONObject(
+            """
+            {
+                "id": "pi_1F7J1aCRMbs6FrXfaJcvbxF6",
+                "object": "payment_intent",
+                "amount": 1099,
+                "canceled_at": null,
+                "cancellation_reason": null,
+                "capture_method": "manual",
+                "client_secret": "pi_1F7J1aCRMbs6FrXfaJcvbxF6_secret_mIuDLsSfoo1m6s",
+                "confirmation_method": "automatic",
+                "created": 1565775850,
+                "currency": "usd",
+                "description": "Example PaymentIntent",
+                "livemode": false,
+                "next_action": null,
+                "payment_method": null,
+                "payment_method_types": [
+                    "card"
+                ],
+                "receipt_email": null,
+                "setup_future_usage": null,
+                "shipping": null,
+                "source": null,
+                "status": "requires_payment_method",
+                "link_funding_sources": [
+                  "CARD", "BANK_ACCOUNT"
+                ],
+                "automatic_payment_methods": {
+                    "enabled": false
+                }
+            }
+            """.trimIndent()
+        )
+    }
+
+    internal val PI_WITH_AUTOMATIC_PAYMENT_METHODS_NOT_ENABLED by lazy {
+        PARSER.parse(PI_WITH_AUTOMATIC_PAYMENT_METHODS_NOT_ENABLED_JSON)!!
+    }
+
+    private val PI_WITH_AUTOMATIC_PAYMENT_METHODS_ENABLED_JSON by lazy {
+        JSONObject(
+            """
+            {
+                "id": "pi_1F7J1aCRMbs6FrXfaJcvbxF6",
+                "object": "payment_intent",
+                "amount": 1099,
+                "canceled_at": null,
+                "cancellation_reason": null,
+                "capture_method": "manual",
+                "client_secret": "pi_1F7J1aCRMbs6FrXfaJcvbxF6_secret_mIuDLsSfoo1m6s",
+                "confirmation_method": "automatic",
+                "created": 1565775850,
+                "currency": "usd",
+                "description": "Example PaymentIntent",
+                "livemode": false,
+                "next_action": null,
+                "payment_method": null,
+                "payment_method_types": [
+                    "card"
+                ],
+                "receipt_email": null,
+                "setup_future_usage": null,
+                "shipping": null,
+                "source": null,
+                "status": "requires_payment_method",
+                "link_funding_sources": [
+                  "CARD", "BANK_ACCOUNT"
+                ],
+                "automatic_payment_methods": {
+                    "enabled": true
+                }
+            }
+            """.trimIndent()
+        )
+    }
+
+    internal val PI_WITH_AUTOMATIC_PAYMENT_METHODS_ENABLED by lazy {
+        PARSER.parse(PI_WITH_AUTOMATIC_PAYMENT_METHODS_ENABLED_JSON)!!
+    }
 }

--- a/payments-core/src/test/java/com/stripe/android/model/SetupIntentFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/SetupIntentFixtures.kt
@@ -673,6 +673,54 @@ internal object SetupIntentFixtures {
         """.trimIndent()
     )
 
+    internal val SI_WITH_AUTOMATIC_PAYMENT_METHODS_ENABLED = JSONObject(
+        """
+        {
+            "id": "seti_1EqTSZGMT9dGPIDGVzCUs6dV",
+            "object": "setup_intent",
+            "cancellation_reason": null,
+            "client_secret": "seti_1EqTSZGMT9dGPIDGVzCUs6dV_secret_FL9mS9ILygVyGEOSmVNqHT83rxkqy0Y",
+            "created": 1561677666,
+            "description": "a description",
+            "last_setup_error": null,
+            "livemode": false,
+            "payment_method": "pm_1EqTSoGMT9dGPIDG7dgafX1H",
+            "payment_method_types": [
+                "card"
+            ],
+            "status": "requires_action",
+            "usage": "off_session",
+            "automatic_payment_methods": {
+                "enabled": true
+            }
+        }
+        """.trimIndent()
+    )
+
+    internal val SI_WITH_AUTOMATIC_PAYMENT_METHODS_NOT_ENABLED = JSONObject(
+        """
+        {
+            "id": "seti_1EqTSZGMT9dGPIDGVzCUs6dV",
+            "object": "setup_intent",
+            "cancellation_reason": null,
+            "client_secret": "seti_1EqTSZGMT9dGPIDGVzCUs6dV_secret_FL9mS9ILygVyGEOSmVNqHT83rxkqy0Y",
+            "created": 1561677666,
+            "description": "a description",
+            "last_setup_error": null,
+            "livemode": false,
+            "payment_method": "pm_1EqTSoGMT9dGPIDG7dgafX1H",
+            "payment_method_types": [
+                "card"
+            ],
+            "status": "requires_action",
+            "usage": "off_session",
+            "automatic_payment_methods": {
+                "enabled": false
+            }
+        }
+        """.trimIndent()
+    )
+
     val CASH_APP_PAY_REQUIRES_ACTION_JSON by lazy {
         JSONObject(
             """

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/PaymentIntentJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/PaymentIntentJsonParserTest.kt
@@ -175,4 +175,25 @@ class PaymentIntentJsonParserTest {
         val paymentIntent = PaymentIntentFixtures.PI_WITH_COUNTRY_CODE
         assertThat(paymentIntent.countryCode).isEqualTo("US")
     }
+
+    @Test
+    fun `automaticPaymentMethodsEnabled=false when automatic payment methods field is not present`() {
+        val paymentIntent = PaymentIntentFixtures.PI_WITH_COUNTRY_CODE
+
+        assertThat(paymentIntent.automaticPaymentMethodsEnabled).isFalse()
+    }
+
+    @Test
+    fun `automaticPaymentMethodsEnabled=false when automatic payments field enabled=false`() {
+        val paymentIntent = PaymentIntentFixtures.PI_WITH_AUTOMATIC_PAYMENT_METHODS_NOT_ENABLED
+
+        assertThat(paymentIntent.automaticPaymentMethodsEnabled).isFalse()
+    }
+
+    @Test
+    fun `automaticPaymentMethodsEnabled=true when automatic payments field enabled=true`() {
+        val paymentIntent = PaymentIntentFixtures.PI_WITH_AUTOMATIC_PAYMENT_METHODS_ENABLED
+
+        assertThat(paymentIntent.automaticPaymentMethodsEnabled).isTrue()
+    }
 }

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/SetupIntentJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/SetupIntentJsonParserTest.kt
@@ -37,4 +37,37 @@ class SetupIntentJsonParserTest {
         )
         assertThat(setupIntent.countryCode).isEqualTo("CA")
     }
+
+    @Test
+    fun `automaticPaymentMethodsEnabled=false when automatic payment methods field is not present`() {
+        val setupIntent = requireNotNull(
+            SetupIntentJsonParser().parse(SetupIntentFixtures.SI_WITH_COUNTRY_CODE)
+        )
+
+        assertThat(setupIntent.automaticPaymentMethodsEnabled).isFalse()
+    }
+
+    @Test
+    fun `automaticPaymentMethodsEnabled=false when automatic payments field enabled=false`() {
+        val setupIntent =
+            requireNotNull(
+                SetupIntentJsonParser().parse(
+                    SetupIntentFixtures.SI_WITH_AUTOMATIC_PAYMENT_METHODS_NOT_ENABLED
+                )
+            )
+
+        assertThat(setupIntent.automaticPaymentMethodsEnabled).isFalse()
+    }
+
+    @Test
+    fun `automaticPaymentMethodsEnabled=true when automatic payments field enabled=true`() {
+        val setupIntent =
+            requireNotNull(
+                SetupIntentJsonParser().parse(
+                    SetupIntentFixtures.SI_WITH_AUTOMATIC_PAYMENT_METHODS_ENABLED
+                )
+            )
+
+        assertThat(setupIntent.automaticPaymentMethodsEnabled).isTrue()
+    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/ClientAttributionMetadataKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/ClientAttributionMetadataKtx.kt
@@ -2,11 +2,13 @@ package com.stripe.android.lpmfoundations.paymentmethod
 
 import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.PaymentIntentCreationFlow
+import com.stripe.android.model.PaymentMethodSelectionFlow
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 
 internal fun ClientAttributionMetadata.Companion.create(
     elementsSessionConfigId: String,
     initializationMode: PaymentElementLoader.InitializationMode,
+    automaticPaymentMethodsEnabled: Boolean,
 ): ClientAttributionMetadata {
     val paymentIntentCreationFlow = when (initializationMode) {
         is PaymentElementLoader.InitializationMode.DeferredIntent -> PaymentIntentCreationFlow.Deferred
@@ -14,8 +16,15 @@ internal fun ClientAttributionMetadata.Companion.create(
         is PaymentElementLoader.InitializationMode.SetupIntent -> PaymentIntentCreationFlow.Standard
     }
 
+    val paymentMethodSelectionFlow = if (automaticPaymentMethodsEnabled) {
+        PaymentMethodSelectionFlow.Automatic
+    } else {
+        PaymentMethodSelectionFlow.MerchantSpecified
+    }
+
     return ClientAttributionMetadata(
-        elementsSessionConfigId,
-        paymentIntentCreationFlow,
+        elementsSessionConfigId = elementsSessionConfigId,
+        paymentIntentCreationFlow = paymentIntentCreationFlow,
+        paymentMethodSelectionFlow = paymentMethodSelectionFlow,
     )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -361,6 +361,7 @@ internal data class PaymentMethodMetadata(
                 clientAttributionMetadata = ClientAttributionMetadata.create(
                     elementsSessionConfigId = elementsSession.elementsSessionId,
                     initializationMode = initializationMode,
+                    automaticPaymentMethodsEnabled = elementsSession.stripeIntent.automaticPaymentMethodsEnabled,
                 ),
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
@@ -221,7 +221,8 @@ private fun ElementsSessionParams.DeferredIntentType.toStripeIntent(options: Api
             currency = deferredIntentParams.mode.currency,
             isLiveMode = options.apiKeyIsLiveMode,
             unactivatedPaymentMethods = emptyList(),
-            paymentMethodOptionsJsonString = deferredIntentMode.paymentMethodOptionsJsonString
+            paymentMethodOptionsJsonString = deferredIntentMode.paymentMethodOptionsJsonString,
+            automaticPaymentMethodsEnabled = deferredIntentParams.paymentMethodTypes.isEmpty(),
         )
         is DeferredIntentParams.Mode.Setup -> SetupIntent(
             id = deferredIntentParams.paymentMethodConfigurationId,
@@ -238,6 +239,7 @@ private fun ElementsSessionParams.DeferredIntentType.toStripeIntent(options: Api
             status = null,
             unactivatedPaymentMethods = emptyList(),
             usage = null,
+            automaticPaymentMethodsEnabled = deferredIntentParams.paymentMethodTypes.isEmpty(),
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/ClientAttributionMetadataKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/ClientAttributionMetadataKtxTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.lpmfoundations.paymentmethod
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.PaymentIntentCreationFlow
+import com.stripe.android.model.PaymentMethodSelectionFlow
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import org.junit.Test
@@ -13,8 +14,7 @@ class ClientAttributionMetadataKtxTest {
     fun `payment intent creation flow is standard for payment intent`() {
         val initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent("cs_123")
 
-        val clientAttributionMetadata = ClientAttributionMetadata.create(
-            elementsSessionConfigId = "elements_session_123",
+        val clientAttributionMetadata = createClientAttributionMetadata(
             initializationMode = initializationMode,
         )
 
@@ -26,8 +26,7 @@ class ClientAttributionMetadataKtxTest {
     fun `payment intent creation flow is standard for setup intent`() {
         val initializationMode = PaymentElementLoader.InitializationMode.SetupIntent("cs_123")
 
-        val clientAttributionMetadata = ClientAttributionMetadata.create(
-            elementsSessionConfigId = "elements_session_123",
+        val clientAttributionMetadata = createClientAttributionMetadata(
             initializationMode = initializationMode,
         )
 
@@ -46,8 +45,7 @@ class ClientAttributionMetadataKtxTest {
             )
         )
 
-        val clientAttributionMetadata = ClientAttributionMetadata.create(
-            elementsSessionConfigId = "elements_session_123",
+        val clientAttributionMetadata = createClientAttributionMetadata(
             initializationMode = initializationMode,
         )
 
@@ -59,15 +57,49 @@ class ClientAttributionMetadataKtxTest {
     fun `elements session config ID is set properly`() {
         val expectedElementsSessionConfigId = "elements_session_123"
 
-        val clientAttributionMetadata = ClientAttributionMetadata.create(
+        val clientAttributionMetadata = createClientAttributionMetadata(
             elementsSessionConfigId = expectedElementsSessionConfigId,
-            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
-                "cs_123"
-            ),
         )
 
         assertThat(clientAttributionMetadata.elementsSessionConfigId).isEqualTo(
             expectedElementsSessionConfigId
+        )
+    }
+
+    @Test
+    fun `payment method selection flow is automatic when automatic payment methods are enabled`() {
+        val clientAttributionMetadata = createClientAttributionMetadata(
+            automaticPaymentMethodsEnabled = true,
+        )
+
+        assertThat(clientAttributionMetadata.paymentMethodSelectionFlow).isEqualTo(
+            PaymentMethodSelectionFlow.Automatic
+        )
+    }
+
+    @Test
+    fun `payment method selection flow is merchant specified when automatic payment methods are not enabled`() {
+        val clientAttributionMetadata = createClientAttributionMetadata(
+            automaticPaymentMethodsEnabled = false,
+        )
+
+        assertThat(clientAttributionMetadata.paymentMethodSelectionFlow).isEqualTo(
+            PaymentMethodSelectionFlow.MerchantSpecified
+        )
+    }
+
+    private fun createClientAttributionMetadata(
+        elementsSessionConfigId: String = "elements_session_123",
+        initializationMode: PaymentElementLoader.InitializationMode =
+            PaymentElementLoader.InitializationMode.PaymentIntent(
+                "cs_123"
+            ),
+        automaticPaymentMethodsEnabled: Boolean = false
+    ): ClientAttributionMetadata {
+        return ClientAttributionMetadata.create(
+            elementsSessionConfigId = elementsSessionConfigId,
+            initializationMode = initializationMode,
+            automaticPaymentMethodsEnabled = automaticPaymentMethodsEnabled,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -25,6 +25,7 @@ import com.stripe.android.model.PaymentIntentCreationFlow
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.model.PaymentMethodSelectionFlow
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
@@ -1172,6 +1173,7 @@ internal class PaymentMethodMetadataTest {
             clientAttributionMetadata = ClientAttributionMetadata(
                 elementsSessionConfigId = elementsSession.elementsSessionId,
                 paymentIntentCreationFlow = PaymentIntentCreationFlow.Standard,
+                paymentMethodSelectionFlow = PaymentMethodSelectionFlow.MerchantSpecified,
             ),
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -34,6 +34,7 @@ import com.stripe.android.model.PaymentIntentCreationFlow
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.model.PaymentMethodSelectionFlow
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.StripeIntent.Status.Canceled
 import com.stripe.android.model.StripeIntent.Status.Succeeded
@@ -175,6 +176,7 @@ internal class DefaultPaymentElementLoaderTest {
                     clientAttributionMetadata = ClientAttributionMetadata(
                         elementsSessionConfigId = DEFAULT_ELEMENTS_SESSION_ID,
                         paymentIntentCreationFlow = PaymentIntentCreationFlow.Standard,
+                        paymentMethodSelectionFlow = PaymentMethodSelectionFlow.MerchantSpecified,
                     )
                 ),
             )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add PaymentMethodSelectionFlow to ClientAttributionMetadata

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
From [plan](https://docs.google.com/document/d/1ytKxasTMw-iEj6UMKB2ULdC-B5h8bKP_t6ucBdsSnYg/edit?tab=t.0): Parse automatic_payment_methods on the PaymentIntent/SetupIntent retrieved from elements session in order to properly set payment_method_selection_flow

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified