### PR TITLE
Refactor DefaultIntentConfirmationInterceptorTest initialization

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultIntentConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultIntentConfirmationInterceptorTest.kt
@@ -422,13 +422,13 @@ class DefaultIntentConfirmationInterceptorTest {
             hCaptchaToken = null,
         )
 
-            assertThat(nextStep).isEqualTo(
-                IntentConfirmationInterceptor.NextStep.Fail(
-                    cause = CreateIntentCallbackFailureException(TestException("that didn't work…")),
-                    message = resolvableString("that didn't work…"),
-                )
+        assertThat(nextStep).isEqualTo(
+            IntentConfirmationInterceptor.NextStep.Fail(
+                cause = CreateIntentCallbackFailureException(TestException("that didn't work…")),
+                message = resolvableString("that didn't work…"),
             )
-        }
+        )
+    }
 
     @Test
     fun `Fails if callback returns failure without custom error message`() = runTest {
@@ -551,52 +551,53 @@ class DefaultIntentConfirmationInterceptorTest {
     }
 
     @Test
-    fun `Returns handleNextAction as next step after creating and confirming a non-succeeded intent`() = runInterceptorScenario(
-        scenario = InterceptorTestScenario(
-            stripeRepository = object : AbsFakeStripeRepository() {
-                override suspend fun retrieveStripeIntent(
-                    clientSecret: String,
-                    options: ApiRequest.Options,
-                    expandFields: List<String>
-                ): Result<StripeIntent> {
-                    val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
-                    return Result.success(
-                        PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2.copy(
-                            paymentMethodId = paymentMethod.id,
-                            paymentMethod = paymentMethod,
+    fun `Returns handleNextAction as next step after creating and confirming a non-succeeded intent`() =
+        runInterceptorScenario(
+            scenario = InterceptorTestScenario(
+                stripeRepository = object : AbsFakeStripeRepository() {
+                    override suspend fun retrieveStripeIntent(
+                        clientSecret: String,
+                        options: ApiRequest.Options,
+                        expandFields: List<String>
+                    ): Result<StripeIntent> {
+                        val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
+                        return Result.success(
+                            PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2.copy(
+                                paymentMethodId = paymentMethod.id,
+                                paymentMethod = paymentMethod,
+                            )
                         )
-                    )
-                }
-            },
-            intentCreationCallbackProvider = {
-                val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
-                succeedingCreateIntentCallback(paymentMethod)
-            },
-        )
-    ) { interceptor ->
-        val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
+                    }
+                },
+                intentCreationCallbackProvider = {
+                    val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
+                    succeedingCreateIntentCallback(paymentMethod)
+                },
+            )
+        ) { interceptor ->
+            val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
 
-        val nextStep = interceptor.intercept(
-            initializationMode = InitializationMode.DeferredIntent(
-                intentConfiguration = PaymentSheet.IntentConfiguration(
-                    mode = PaymentSheet.IntentConfiguration.Mode.Payment(
-                        amount = 1099L,
-                        currency = "usd",
+            val nextStep = interceptor.intercept(
+                initializationMode = InitializationMode.DeferredIntent(
+                    intentConfiguration = PaymentSheet.IntentConfiguration(
+                        mode = PaymentSheet.IntentConfiguration.Mode.Payment(
+                            amount = 1099L,
+                            currency = "usd",
+                        ),
                     ),
                 ),
-            ),
-            intent = PaymentIntentFactory.create(),
-            paymentMethod = paymentMethod,
-            paymentMethodOptionsParams = null,
-            paymentMethodExtraParams = null,
-            shippingValues = null,
-            hCaptchaToken = null,
-        )
+                intent = PaymentIntentFactory.create(),
+                paymentMethod = paymentMethod,
+                paymentMethodOptionsParams = null,
+                paymentMethodExtraParams = null,
+                shippingValues = null,
+                hCaptchaToken = null,
+            )
 
-        assertThat(nextStep).isEqualTo(
-            IntentConfirmationInterceptor.NextStep.HandleNextAction("pi_123_secret_456")
-        )
-    }
+            assertThat(nextStep).isEqualTo(
+                IntentConfirmationInterceptor.NextStep.HandleNextAction("pi_123_secret_456")
+            )
+        }
 
     @Test
     fun `Passes correct shouldSavePaymentMethod to CreateIntentCallback`() = runTest {
@@ -777,12 +778,12 @@ class DefaultIntentConfirmationInterceptorTest {
             hCaptchaToken = null,
         )
 
-            verify(stripeRepository, never()).retrieveStripeIntent(any(), any(), any())
+        verify(stripeRepository, never()).retrieveStripeIntent(any(), any(), any())
 
-            assertThat(nextStep).isEqualTo(
-                IntentConfirmationInterceptor.NextStep.Complete(isForceSuccess = true)
-            )
-        }
+        assertThat(nextStep).isEqualTo(
+            IntentConfirmationInterceptor.NextStep.Complete(isForceSuccess = true)
+        )
+    }
 
     @Test
     fun `If requires next action with an attached payment method different then the created one, throw error`() =
@@ -893,8 +894,10 @@ class DefaultIntentConfirmationInterceptorTest {
             val nextStep = interceptor.intercept(
                 initializationMode = InitializationMode.DeferredIntent(
                     intentConfiguration = PaymentSheet.IntentConfiguration(
-                        sharedPaymentTokenSessionWithMode =
-                        PaymentSheet.IntentConfiguration.Mode.Payment(amount = 1099L, currency = "usd"),
+                        sharedPaymentTokenSessionWithMode = PaymentSheet.IntentConfiguration.Mode.Payment(
+                            amount = 1099L,
+                            currency = "usd"
+                        ),
                         sellerDetails = PaymentSheet.IntentConfiguration.SellerDetails(
                             businessName = "My business, Inc.",
                             networkId = "network_id",
@@ -1239,24 +1242,24 @@ class DefaultIntentConfirmationInterceptorTest {
     }
 
     @Test
-    fun `hCaptchaToken is not set for new payment method confirmation option`() = runInterceptorScenario {
-            interceptor ->
-        val nextStep = interceptor.intercept(
-            confirmationOption = PaymentMethodConfirmationOption.New(
-                createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
-                optionsParams = null,
-                extraParams = null,
-                shouldSave = false,
-                passiveCaptchaParams = null
-            ),
-            intent = PaymentIntentFactory.create(),
-            initializationMode = InitializationMode.PaymentIntent("pi_1234_secret_4321"),
-            shippingDetails = null,
-        )
+    fun `hCaptchaToken is not set for new payment method confirmation option`() =
+        runInterceptorScenario { interceptor ->
+            val nextStep = interceptor.intercept(
+                confirmationOption = PaymentMethodConfirmationOption.New(
+                    createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                    optionsParams = null,
+                    extraParams = null,
+                    shouldSave = false,
+                    passiveCaptchaParams = null
+                ),
+                intent = PaymentIntentFactory.create(),
+                initializationMode = InitializationMode.PaymentIntent("pi_1234_secret_4321"),
+                shippingDetails = null,
+            )
 
-        val confirmParams = nextStep.asConfirmParams<ConfirmPaymentIntentParams>()
-        assertRadarOptionsIsNull(confirmParams)
-    }
+            val confirmParams = nextStep.asConfirmParams<ConfirmPaymentIntentParams>()
+            assertRadarOptionsIsNull(confirmParams)
+        }
 
     @Test
     fun `Returns confirm params with hCaptchaToken set as RadarOptions for setup intent with client secret`() =


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Wrapping up `DefaultIntentConfirmationInterceptor` initialization with `runScenario` and `createIntentConfirmationInterceptor ` to avoid boilerplate code. 

This does not change `testNoProvider`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
[#11623
](https://github.com/stripe/stripe-android/pull/11623#discussion_r2376741387)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
