### PR TITLE
Strip of `elements_enable_blik` flag

### DIFF
--- a/payments-core/src/test/java/com/stripe/android/model/ElementsSessionFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/ElementsSessionFixtures.kt
@@ -1396,7 +1396,6 @@ internal object ElementsSessionFixtures {
               },
               "flags": {
                 "elements_disable_paypal_express": true,
-                "elements_enable_blik": true,
                 "elements_enable_br_card_installments": false,
                 "elements_enable_deferred_intent": false,
                 "elements_enable_demo_pay": false,
@@ -1581,8 +1580,7 @@ internal object ElementsSessionFixtures {
                     "elements_disable_recurring_express_checkout_button_amazon_pay": false,
                     "elements_enable_affirm_unified_offer": true,
                     "elements_enable_afterpay_clearpay_unified_offer": true,
-                    "elements_enable_blik": true,
-                    "elements_enable_br_card_installments": false,
+                        "elements_enable_br_card_installments": false,
                     "elements_enable_card_brand_choice_payment_element_link": false,
                     "elements_enable_card_brand_choice_payment_element_payment_method_data": true,
                     "elements_enable_client_attribution_metadata": true,

--- a/payments-core/src/test/java/com/stripe/android/model/ElementsSessionFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/ElementsSessionFixtures.kt
@@ -1580,7 +1580,7 @@ internal object ElementsSessionFixtures {
                     "elements_disable_recurring_express_checkout_button_amazon_pay": false,
                     "elements_enable_affirm_unified_offer": true,
                     "elements_enable_afterpay_clearpay_unified_offer": true,
-                        "elements_enable_br_card_installments": false,
+                    "elements_enable_br_card_installments": false,
                     "elements_enable_card_brand_choice_payment_element_link": false,
                     "elements_enable_card_brand_choice_payment_element_payment_method_data": true,
                     "elements_enable_client_attribution_metadata": true,

--- a/paymentsheet/src/androidTest/resources/elements-sessions-cpms.json
+++ b/paymentsheet/src/androidTest/resources/elements-sessions-cpms.json
@@ -9,7 +9,6 @@
   },
   "flags": {
     "elements_disable_paypal_express": true,
-    "elements_enable_blik": true,
     "elements_enable_br_card_installments": false,
     "elements_enable_deferred_intent": false,
     "elements_enable_demo_pay": false,

--- a/paymentsheet/src/androidTest/resources/elements-sessions-deferred_payment_intent.json
+++ b/paymentsheet/src/androidTest/resources/elements-sessions-deferred_payment_intent.json
@@ -16,7 +16,6 @@
   },
   "flags": {
     "elements_disable_paypal_express": true,
-    "elements_enable_blik": true,
     "elements_enable_br_card_installments": false,
     "elements_enable_deferred_intent": false,
     "elements_enable_demo_pay": false,

--- a/paymentsheet/src/androidTest/resources/elements-sessions-payment_intent_success.json
+++ b/paymentsheet/src/androidTest/resources/elements-sessions-payment_intent_success.json
@@ -9,7 +9,6 @@
   },
   "flags": {
     "elements_disable_paypal_express": true,
-    "elements_enable_blik": true,
     "elements_enable_br_card_installments": false,
     "elements_enable_deferred_intent": false,
     "elements_enable_demo_pay": false,

--- a/paymentsheet/src/androidTest/resources/elements-sessions-requires_cvc_recollection.json
+++ b/paymentsheet/src/androidTest/resources/elements-sessions-requires_cvc_recollection.json
@@ -9,7 +9,6 @@
   },
   "flags": {
     "elements_disable_paypal_express": true,
-    "elements_enable_blik": true,
     "elements_enable_br_card_installments": false,
     "elements_enable_deferred_intent": false,
     "elements_enable_demo_pay": false,

--- a/paymentsheet/src/androidTest/resources/elements-sessions-requires_payment_method.json
+++ b/paymentsheet/src/androidTest/resources/elements-sessions-requires_payment_method.json
@@ -9,7 +9,6 @@
   },
   "flags": {
     "elements_disable_paypal_express": true,
-    "elements_enable_blik": true,
     "elements_enable_br_card_installments": false,
     "elements_enable_deferred_intent": false,
     "elements_enable_demo_pay": false,

--- a/paymentsheet/src/androidTest/resources/elements-sessions-requires_payment_method_with_cbc.json
+++ b/paymentsheet/src/androidTest/resources/elements-sessions-requires_payment_method_with_cbc.json
@@ -20,7 +20,6 @@
     "elements_disable_link_email_otp": false,
     "elements_disable_payment_element_card_country_zip_validations": false,
     "elements_disable_paypal_express": false,
-    "elements_enable_blik": true,
     "elements_enable_br_card_installments": false,
     "elements_enable_card_brand_choice_payment_element": true,
     "elements_enable_deferred_intent": true,

--- a/paymentsheet/src/androidTest/resources/elements-sessions-requires_pm_with_link_ps_mode.json
+++ b/paymentsheet/src/androidTest/resources/elements-sessions-requires_pm_with_link_ps_mode.json
@@ -9,7 +9,6 @@
   },
   "flags": {
     "elements_disable_paypal_express": true,
-    "elements_enable_blik": true,
     "elements_enable_br_card_installments": false,
     "elements_enable_deferred_intent": false,
     "elements_enable_demo_pay": false,

--- a/paymentsheet/src/androidTest/resources/elements-sessions-requires_pm_with_link_ps_mode_and_cbc.json
+++ b/paymentsheet/src/androidTest/resources/elements-sessions-requires_pm_with_link_ps_mode_and_cbc.json
@@ -13,7 +13,6 @@
   },
   "flags": {
     "elements_disable_paypal_express": true,
-    "elements_enable_blik": true,
     "elements_enable_br_card_installments": false,
     "elements_enable_deferred_intent": false,
     "elements_enable_demo_pay": false,


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Remove unused `elements_enable_blik` feature flag from test data and mock files.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
The `elements_enable_blik` feature flag is no longer needed and was never actually used in the Android SDK codebase. It only existed in test mock data and JSON fixture files, but no Kotlin/Java code ever referenced or checked this flag.

Since it's always set to `true` internally and provides no functional gating, removing it simplifies the test data without any impact on SDK functionality.

BLIK payment method support continues to work exactly as before - this flag was not part of the actual implementation.

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->
- Validated JSON syntax remains correct in all modified files
- Confirmed zero references to `elements_enable_blik` remain in codebase
- Verified BLIK payment functionality is implemented independently of this flag
- All detekt and ktlint checks passed
- No functional tests affected since flag was unused in business logic

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
No changelog entry needed - this is an internal cleanup of unused test data that doesn't affect external SDK behavior or APIs.