### PR TITLE
Prototype for On_behalf_of in CustomerSheet, and Intents

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/PaymentIntent.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentIntent.kt
@@ -157,6 +157,8 @@ constructor(
     @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     override val automaticPaymentMethodsEnabled: Boolean = false,
 
+    override val onBehalfOf: String? = null,
+
 ) : StripeIntent {
 
     override fun getPaymentMethodOptions() = paymentMethodOptionsJsonString?.let {

--- a/payments-core/src/main/java/com/stripe/android/model/SetupIntent.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/SetupIntent.kt
@@ -110,6 +110,8 @@ constructor(
 
     private val paymentMethodOptionsJsonString: String? = null,
 
+    override val onBehalfOf: String? = null,
+
     @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     override val automaticPaymentMethodsEnabled: Boolean = false,
 ) : StripeIntent {

--- a/payments-core/src/main/java/com/stripe/android/model/StripeIntent.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/StripeIntent.kt
@@ -79,6 +79,8 @@ sealed interface StripeIntent : StripeModel {
     @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     val automaticPaymentMethodsEnabled: Boolean
 
+    val onBehalfOf: String?
+
     fun requiresAction(): Boolean
 
     fun requiresConfirmation(): Boolean

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/DeferredPaymentIntentJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/DeferredPaymentIntentJsonParser.kt
@@ -13,6 +13,7 @@ class DeferredPaymentIntentJsonParser(
     private val elementsSessionId: String?,
     private val paymentMode: DeferredIntentParams.Mode.Payment,
     private val isLiveMode: Boolean,
+    private val onBehalfOf: String?,
     private val timeProvider: () -> Long
 ) : ModelJsonParser<PaymentIntent> {
     override fun parse(json: JSONObject): PaymentIntent {
@@ -50,6 +51,7 @@ class DeferredPaymentIntentJsonParser(
             currency = paymentMode.currency,
             paymentMethodOptionsJsonString = paymentMode.paymentMethodOptionsJsonString,
             automaticPaymentMethodsEnabled = paymentMethodTypes.isEmpty(),
+            onBehalfOf = onBehalfOf,
         )
     }
 

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/DeferredSetupIntentJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/DeferredSetupIntentJsonParser.kt
@@ -13,6 +13,7 @@ class DeferredSetupIntentJsonParser(
     private val elementsSessionId: String?,
     private val setupMode: DeferredIntentParams.Mode.Setup,
     private val isLiveMode: Boolean,
+    private val onBehalfOf: String?,
     private val timeProvider: () -> Long
 ) : ModelJsonParser<SetupIntent> {
     override fun parse(json: JSONObject): SetupIntent {
@@ -45,6 +46,7 @@ class DeferredSetupIntentJsonParser(
             status = null,
             usage = setupMode.setupFutureUsage,
             automaticPaymentMethodsEnabled = paymentMethodTypes.isEmpty(),
+            onBehalfOf = onBehalfOf,
         )
     }
 

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/ElementsSessionJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/ElementsSessionJsonParser.kt
@@ -151,6 +151,7 @@ internal class ElementsSessionJsonParser(
                                 elementsSessionId = elementsSessionId,
                                 paymentMode = params.deferredIntentParams.mode,
                                 isLiveMode = isLiveMode,
+                                onBehalfOf = params.deferredIntentParams.onBehalfOf,
                                 timeProvider = timeProvider
                             ).parse(json)
                         }
@@ -159,6 +160,7 @@ internal class ElementsSessionJsonParser(
                                 elementsSessionId = elementsSessionId,
                                 setupMode = params.deferredIntentParams.mode,
                                 isLiveMode = isLiveMode,
+                                onBehalfOf = params.deferredIntentParams.onBehalfOf,
                                 timeProvider = timeProvider
                             ).parse(json)
                         }

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/PaymentIntentJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/PaymentIntentJsonParser.kt
@@ -80,6 +80,8 @@ class PaymentIntentJsonParser : ModelJsonParser<PaymentIntent> {
         val automaticPaymentMethodsEnabled =
             json.optJSONObject(FIELD_AUTOMATIC_PAYMENT_METHODS)?.optBoolean(FIELD_ENABLED) == true
 
+        val onBehalfOf = optString(json, FIELD_ON_BEHALF_OF)
+
         return PaymentIntent(
             id = id,
             paymentMethodTypes = paymentMethodTypes,
@@ -106,6 +108,7 @@ class PaymentIntentJsonParser : ModelJsonParser<PaymentIntent> {
             nextActionData = nextActionData,
             paymentMethodOptionsJsonString = paymentMethodOptions,
             automaticPaymentMethodsEnabled = automaticPaymentMethodsEnabled,
+            onBehalfOf = onBehalfOf,
         )
     }
 
@@ -191,5 +194,6 @@ class PaymentIntentJsonParser : ModelJsonParser<PaymentIntent> {
         private const val FIELD_UNACTIVATED_PAYMENT_METHOD_TYPES =
             "unactivated_payment_method_types"
         private const val FIELD_LINK_FUNDING_SOURCES = "link_funding_sources"
+        private const val FIELD_ON_BEHALF_OF = "on_behalf_of"
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/SetupIntentJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/SetupIntentJsonParser.kt
@@ -35,6 +35,8 @@ class SetupIntentJsonParser : ModelJsonParser<SetupIntent> {
         val automaticPaymentMethodsEnabled =
             json.optJSONObject(FIELD_AUTOMATIC_PAYMENT_METHODS)?.optBoolean(FIELD_ENABLED) == true
 
+        val onBehalfOf = optString(json, FIELD_ON_BEHALF_OF)
+
         return SetupIntent(
             id = optString(json, FIELD_ID),
             created = json.optLong(FIELD_CREATED),
@@ -62,6 +64,7 @@ class SetupIntentJsonParser : ModelJsonParser<SetupIntent> {
             },
             paymentMethodOptionsJsonString = paymentMethodOptions,
             automaticPaymentMethodsEnabled = automaticPaymentMethodsEnabled,
+            onBehalfOf = onBehalfOf,
         )
     }
 
@@ -114,5 +117,6 @@ class SetupIntentJsonParser : ModelJsonParser<SetupIntent> {
             "unactivated_payment_method_types"
         private const val FIELD_LINK_FUNDING_SOURCES = "link_funding_sources"
         private const val FIELD_PAYMENT_METHOD_OPTIONS = "payment_method_options"
+        private const val FIELD_ON_BEHALF_OF = "on_behalf_of"
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
@@ -377,6 +377,7 @@ class CustomerSheet internal constructor(
     @ExperimentalCustomerSessionApi
     class IntentConfiguration internal constructor(
         internal val paymentMethodTypes: List<String>,
+        internal val onBehalfOf: String?,
     ) {
         /**
          * Builder for creating a [IntentConfiguration]
@@ -384,6 +385,7 @@ class CustomerSheet internal constructor(
         @ExperimentalCustomerSessionApi
         class Builder {
             private var paymentMethodTypes = listOf<String>()
+            private var onBehalfOf: String? = null
 
             /**
              * The payment methods types to display. If empty, we dynamically determine the
@@ -394,12 +396,17 @@ class CustomerSheet internal constructor(
                 this.paymentMethodTypes = paymentMethodTypes
             }
 
+            fun onBehalfOf(connectedAccountId: String) = apply {
+                this.onBehalfOf = connectedAccountId
+            }
+
             /**
              * Creates the [IntentConfiguration] instance.
              */
             fun build(): IntentConfiguration {
                 return IntentConfiguration(
                     paymentMethodTypes = paymentMethodTypes,
+                    onBehalfOf = onBehalfOf,
                 )
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -866,7 +866,7 @@ internal class CustomerSheetViewModel(
             incentive = null,
             linkMode = null,
             showCheckbox = false,
-            onBehalfOf = null,
+            onBehalfOf = stripeIntent?.onBehalfOf,
             isCompleteFlow = false,
             isPaymentFlow = false,
             stripeIntentId = stripeIntent?.id,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionElementsSessionManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionElementsSessionManager.kt
@@ -82,6 +82,7 @@ internal class DefaultCustomerSessionElementsSessionManager @Inject constructor(
                         intentConfiguration = PaymentSheet.IntentConfiguration(
                             mode = PaymentSheet.IntentConfiguration.Mode.Setup(),
                             paymentMethodTypes = intentConfiguration.paymentMethodTypes,
+                            onBehalfOf = intentConfiguration.onBehalfOf,
                         )
                     ),
                     savedPaymentMethodSelectionId = savedSelection?.id,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptor.kt
@@ -522,6 +522,7 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
         val result = createIntentCallback.onCreateIntent(
             paymentMethod = paymentMethod,
             shouldSavePaymentMethod = shouldSavePaymentMethod,
+            onBehalfOf = intentConfiguration.onBehalfOf,
         )
 
         return when (result) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/CreateIntentCallback.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/CreateIntentCallback.kt
@@ -31,6 +31,7 @@ fun interface CreateIntentCallback {
     suspend fun onCreateIntent(
         paymentMethod: PaymentMethod,
         shouldSavePaymentMethod: Boolean,
+        onBehalfOf: String?,
     ): CreateIntentResult
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DeferredIntentValidator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DeferredIntentValidator.kt
@@ -64,6 +64,10 @@ internal object DeferredIntentValidator {
             }
         }
 
+        require(stripeIntent.onBehalfOf == params.onBehalfOf) {
+            "Your PaymentIntent onBehalfOf must match the PaymentSheet.IntentConfiguration onBehalfOf"
+        }
+
         return stripeIntent
     }
 


### PR DESCRIPTION
# Summary
Added On_behalf_of to CustomerSheet.IntentConfiguration
Added On_Behalf_of to createIntentCallback, so merchants can use client provided On_Behalf_of to properly create Payment/SetupIntents 

Parsing onBehalfOf when parsing Intents.

# Motivation
Will create tickets

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
N.A.

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
