### PR TITLE
Remove NextStep usages and replace them with ConfirmationDefinition.Action directly

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationDefinition.kt
@@ -233,10 +233,6 @@ internal interface ConfirmationDefinition<
              */
             val intent: StripeIntent,
             /**
-             * The [ConfirmationHandler.Option] used when determining the action to take
-             */
-            val confirmationOption: ConfirmationHandler.Option,
-            /**
              * DO NOT USE OUTSIDE OF INTENT CONFIRMATION
              */
             val deferredIntentConfirmationType: DeferredIntentConfirmationType?,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediator.kt
@@ -134,7 +134,6 @@ internal class ConfirmationMediator<
             is ConfirmationDefinition.Action.Complete -> {
                 Action.Complete(
                     intent = action.intent,
-                    confirmationOption = action.confirmationOption,
                     deferredIntentConfirmationType = action.deferredIntentConfirmationType,
                     completedFullPaymentFlow = action.completedFullPaymentFlow,
                 )
@@ -163,7 +162,6 @@ internal class ConfirmationMediator<
 
         data class Complete(
             val intent: StripeIntent,
-            val confirmationOption: ConfirmationHandler.Option,
             val deferredIntentConfirmationType: DeferredIntentConfirmationType? = null,
             val completedFullPaymentFlow: Boolean,
         ) : Action

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationDefinition.kt
@@ -35,46 +35,12 @@ internal class IntentConfirmationDefinition(
         confirmationOption: PaymentMethodConfirmationOption,
         confirmationParameters: ConfirmationDefinition.Parameters,
     ): ConfirmationDefinition.Action<Args> {
-        val nextStep = intentConfirmationInterceptor.intercept(
+        return intentConfirmationInterceptor.intercept(
             confirmationOption = confirmationOption,
             intent = confirmationParameters.intent,
             initializationMode = confirmationParameters.initializationMode,
             shippingDetails = confirmationParameters.shippingDetails,
         )
-
-        val deferredIntentConfirmationType = nextStep.deferredIntentConfirmationType
-
-        return when (nextStep) {
-            is IntentConfirmationInterceptor.NextStep.HandleNextAction -> {
-                ConfirmationDefinition.Action.Launch(
-                    launcherArguments = Args.NextAction(nextStep.clientSecret),
-                    deferredIntentConfirmationType = deferredIntentConfirmationType,
-                    receivesResultInProcess = false,
-                )
-            }
-            is IntentConfirmationInterceptor.NextStep.Confirm -> {
-                ConfirmationDefinition.Action.Launch(
-                    launcherArguments = Args.Confirm(nextStep.confirmParams),
-                    deferredIntentConfirmationType = deferredIntentConfirmationType,
-                    receivesResultInProcess = false,
-                )
-            }
-            is IntentConfirmationInterceptor.NextStep.Fail -> {
-                ConfirmationDefinition.Action.Fail(
-                    cause = nextStep.cause,
-                    message = nextStep.message,
-                    errorType = ConfirmationHandler.Result.Failed.ErrorType.Payment,
-                )
-            }
-            is IntentConfirmationInterceptor.NextStep.Complete -> {
-                ConfirmationDefinition.Action.Complete(
-                    intent = confirmationParameters.intent,
-                    confirmationOption = confirmationOption,
-                    deferredIntentConfirmationType = deferredIntentConfirmationType,
-                    completedFullPaymentFlow = nextStep.completedFullPaymentFlow,
-                )
-            }
-        }
     }
 
     override fun createLauncher(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptor.kt
@@ -8,11 +8,9 @@ import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.core.networking.ApiRequest
-import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.link.utils.errorMessage
 import com.stripe.android.model.ConfirmPaymentIntentParams
-import com.stripe.android.model.ConfirmStripeIntentParams
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
@@ -28,7 +26,9 @@ import com.stripe.android.networking.StripeRepository
 import com.stripe.android.paymentelement.PaymentMethodOptionsSetupFutureUsagePreview
 import com.stripe.android.paymentelement.PreparePaymentMethodHandler
 import com.stripe.android.paymentelement.confirmation.ALLOWS_MANUAL_CONFIRMATION
-import com.stripe.android.paymentelement.confirmation.intent.IntentConfirmationInterceptor.NextStep
+import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.intent.IntentConfirmationDefinition.Args
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.CreateIntentCallback
 import com.stripe.android.paymentsheet.CreateIntentResult
@@ -48,48 +48,6 @@ import com.stripe.android.R as PaymentsCoreR
 
 internal interface IntentConfirmationInterceptor {
 
-    sealed interface NextStep {
-
-        val deferredIntentConfirmationType: DeferredIntentConfirmationType?
-
-        data class Fail(
-            val cause: Throwable,
-            val message: ResolvableString,
-        ) : NextStep {
-
-            override val deferredIntentConfirmationType: DeferredIntentConfirmationType?
-                get() = null
-        }
-
-        data class Confirm(
-            val confirmParams: ConfirmStripeIntentParams,
-            val isDeferred: Boolean,
-        ) : NextStep {
-
-            override val deferredIntentConfirmationType: DeferredIntentConfirmationType?
-                get() = DeferredIntentConfirmationType.Client.takeIf { isDeferred }
-        }
-
-        data class HandleNextAction(val clientSecret: String) : NextStep {
-
-            override val deferredIntentConfirmationType: DeferredIntentConfirmationType
-                get() = DeferredIntentConfirmationType.Server
-        }
-
-        data class Complete(
-            val isForceSuccess: Boolean,
-            val completedFullPaymentFlow: Boolean = true,
-        ) : NextStep {
-
-            override val deferredIntentConfirmationType: DeferredIntentConfirmationType
-                get() = if (isForceSuccess) {
-                    DeferredIntentConfirmationType.None
-                } else {
-                    DeferredIntentConfirmationType.Server
-                }
-        }
-    }
-
     suspend fun intercept(
         initializationMode: PaymentElementLoader.InitializationMode,
         intent: StripeIntent,
@@ -98,7 +56,7 @@ internal interface IntentConfirmationInterceptor {
         paymentMethodExtraParams: PaymentMethodExtraParams? = null,
         shippingValues: ConfirmPaymentIntentParams.Shipping?,
         customerRequestedSave: Boolean,
-    ): NextStep
+    ): ConfirmationDefinition.Action<Args>
 
     suspend fun intercept(
         initializationMode: PaymentElementLoader.InitializationMode,
@@ -108,7 +66,7 @@ internal interface IntentConfirmationInterceptor {
         paymentMethodExtraParams: PaymentMethodExtraParams? = null,
         shippingValues: ConfirmPaymentIntentParams.Shipping?,
         hCaptchaToken: String?,
-    ): NextStep
+    ): ConfirmationDefinition.Action<Args>
 
     companion object {
         var createIntentCallback: CreateIntentCallback? = null
@@ -177,7 +135,7 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
         paymentMethodExtraParams: PaymentMethodExtraParams?,
         shippingValues: ConfirmPaymentIntentParams.Shipping?,
         customerRequestedSave: Boolean,
-    ): NextStep {
+    ): ConfirmationDefinition.Action<Args> {
         return when (initializationMode) {
             is PaymentElementLoader.InitializationMode.DeferredIntent -> {
                 /*
@@ -186,6 +144,7 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
                  * `PaymentSheet.Configuration` in order to populate `Payment Element` data.
                  */
                 handleDeferred(
+                    intent = intent,
                     intentConfiguration = initializationMode.intentConfiguration,
                     shippingValues = shippingValues,
                     paymentMethodCreateParams = paymentMethodCreateParams,
@@ -230,7 +189,7 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
         paymentMethodExtraParams: PaymentMethodExtraParams?,
         shippingValues: ConfirmPaymentIntentParams.Shipping?,
         hCaptchaToken: String?
-    ): NextStep {
+    ): ConfirmationDefinition.Action<Args> {
         return when (initializationMode) {
             is PaymentElementLoader.InitializationMode.DeferredIntent -> {
                 val updatedPaymentMethodOptionsParams = updatePaymentMethodOptionsParams(
@@ -239,6 +198,7 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
                     paymentMethodOptionsParams = paymentMethodOptionsParams
                 )
                 handleDeferred(
+                    intent = intent,
                     intentConfiguration = initializationMode.intentConfiguration,
                     paymentMethod = paymentMethod,
                     paymentMethodOptionsParams = updatedPaymentMethodOptionsParams,
@@ -283,13 +243,14 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
     }
 
     private suspend fun handleDeferred(
+        intent: StripeIntent,
         intentConfiguration: PaymentSheet.IntentConfiguration,
         paymentMethodCreateParams: PaymentMethodCreateParams,
         paymentMethodOptionsParams: PaymentMethodOptionsParams?,
         paymentMethodExtraParams: PaymentMethodExtraParams?,
         shippingValues: ConfirmPaymentIntentParams.Shipping?,
         customerRequestedSave: Boolean,
-    ): NextStep {
+    ): ConfirmationDefinition.Action<Args> {
         val productUsage = buildSet {
             addAll(paymentMethodCreateParams.attribution)
             add("deferred-intent")
@@ -305,6 +266,7 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
         return createPaymentMethod(params).fold(
             onSuccess = { paymentMethod ->
                 handleDeferred(
+                    intent = intent,
                     intentConfiguration = intentConfiguration,
                     paymentMethod = paymentMethod,
                     paymentMethodOptionsParams = paymentMethodOptionsParams,
@@ -318,15 +280,17 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
                 )
             },
             onFailure = { error ->
-                NextStep.Fail(
+                ConfirmationDefinition.Action.Fail(
                     cause = error,
                     message = error.stripeErrorMessage(),
+                    errorType = ConfirmationHandler.Result.Failed.ErrorType.Payment,
                 )
             }
         )
     }
 
     private suspend fun handleDeferred(
+        intent: StripeIntent,
         intentConfiguration: PaymentSheet.IntentConfiguration,
         paymentMethod: PaymentMethod,
         paymentMethodOptionsParams: PaymentMethodOptionsParams?,
@@ -334,9 +298,10 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
         shippingValues: ConfirmPaymentIntentParams.Shipping?,
         shouldSavePaymentMethod: Boolean,
         hCaptchaToken: String?
-    ): NextStep {
+    ): ConfirmationDefinition.Action<Args> {
         return when (intentConfiguration.intentBehavior) {
             is PaymentSheet.IntentConfiguration.IntentBehavior.Default -> handleDeferredIntent(
+                intent = intent,
                 intentConfiguration = intentConfiguration,
                 paymentMethod = paymentMethod,
                 paymentMethodOptionsParams = paymentMethodOptionsParams,
@@ -346,6 +311,7 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
                 hCaptchaToken = hCaptchaToken
             )
             is PaymentSheet.IntentConfiguration.IntentBehavior.SharedPaymentToken -> handlePreparePaymentMethod(
+                intent = intent,
                 paymentMethod = paymentMethod,
                 shippingValues = shippingValues,
             )
@@ -353,6 +319,7 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
     }
 
     private suspend fun handleDeferredIntent(
+        intent: StripeIntent,
         intentConfiguration: PaymentSheet.IntentConfiguration,
         paymentMethod: PaymentMethod,
         paymentMethodOptionsParams: PaymentMethodOptionsParams?,
@@ -360,10 +327,11 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
         shippingValues: ConfirmPaymentIntentParams.Shipping?,
         shouldSavePaymentMethod: Boolean,
         hCaptchaToken: String?
-    ): NextStep {
+    ): ConfirmationDefinition.Action<Args> {
         return when (val callback = waitForIntentCallback()) {
             is CreateIntentCallback -> {
                 handleDeferredIntentCreationFromPaymentMethod(
+                    intent = intent,
                     createIntentCallback = callback,
                     intentConfiguration = intentConfiguration,
                     paymentMethod = paymentMethod,
@@ -381,22 +349,24 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
 
                 errorReporter.report(ErrorReporter.ExpectedErrorEvent.CREATE_INTENT_CALLBACK_NULL)
 
-                NextStep.Fail(
+                ConfirmationDefinition.Action.Fail(
                     cause = IllegalStateException(error),
                     message = if (requestOptions.apiKeyIsLiveMode) {
                         PaymentsCoreR.string.stripe_internal_error.resolvableString
                     } else {
                         error.resolvableString
-                    }
+                    },
+                    errorType = ConfirmationHandler.Result.Failed.ErrorType.Payment,
                 )
             }
         }
     }
 
     private suspend fun handlePreparePaymentMethod(
+        intent: StripeIntent,
         paymentMethod: PaymentMethod,
         shippingValues: ConfirmPaymentIntentParams.Shipping?,
-    ): NextStep {
+    ): ConfirmationDefinition.Action<Args> {
         runCatching {
             stripeRepository.createSavedPaymentMethodRadarSession(
                 paymentMethodId = paymentMethod.id
@@ -423,11 +393,16 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
                         shippingAddress = shippingValues?.toAddressDetails(),
                     )
 
-                    NextStep.Complete(isForceSuccess = true, completedFullPaymentFlow = false)
+                    ConfirmationDefinition.Action.Complete(
+                        intent = intent,
+                        deferredIntentConfirmationType = DeferredIntentConfirmationType.None,
+                        completedFullPaymentFlow = false,
+                    )
                 } catch (exception: Exception) {
-                    NextStep.Fail(
+                    ConfirmationDefinition.Action.Fail(
                         cause = exception,
                         message = exception.errorMessage,
+                        errorType = ConfirmationHandler.Result.Failed.ErrorType.Payment,
                     )
                 }
             }
@@ -438,13 +413,14 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
 
                 errorReporter.report(ErrorReporter.ExpectedErrorEvent.PREPARE_PAYMENT_METHOD_HANDLER_NULL)
 
-                NextStep.Fail(
+                ConfirmationDefinition.Action.Fail(
                     cause = IllegalStateException(error),
                     message = if (requestOptions.apiKeyIsLiveMode) {
                         PaymentsCoreR.string.stripe_internal_error.resolvableString
                     } else {
                         error.resolvableString
-                    }
+                    },
+                    errorType = ConfirmationHandler.Result.Failed.ErrorType.Payment,
                 )
             }
         }
@@ -510,6 +486,7 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
     }
 
     private suspend fun handleDeferredIntentCreationFromPaymentMethod(
+        intent: StripeIntent,
         createIntentCallback: CreateIntentCallback,
         intentConfiguration: PaymentSheet.IntentConfiguration,
         paymentMethod: PaymentMethod,
@@ -518,7 +495,7 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
         shouldSavePaymentMethod: Boolean,
         shippingValues: ConfirmPaymentIntentParams.Shipping?,
         hCaptchaToken: String?
-    ): NextStep {
+    ): ConfirmationDefinition.Action<Args> {
         val result = createIntentCallback.onCreateIntent(
             paymentMethod = paymentMethod,
             shouldSavePaymentMethod = shouldSavePaymentMethod,
@@ -527,7 +504,11 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
         return when (result) {
             is CreateIntentResult.Success -> {
                 if (result.clientSecret == IntentConfirmationInterceptor.COMPLETE_WITHOUT_CONFIRMING_INTENT) {
-                    NextStep.Complete(isForceSuccess = true)
+                    ConfirmationDefinition.Action.Complete(
+                        intent = intent,
+                        deferredIntentConfirmationType = DeferredIntentConfirmationType.None,
+                        completedFullPaymentFlow = true,
+                    )
                 } else {
                     handleDeferredIntentCreationSuccess(
                         clientSecret = result.clientSecret,
@@ -543,10 +524,11 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
 
             is CreateIntentResult.Failure -> {
                 val exception = CreateIntentCallbackFailureException(result.cause)
-                NextStep.Fail(
+                ConfirmationDefinition.Action.Fail(
                     cause = exception,
                     message = result.displayMessage?.resolvableString
                         ?: exception.stripeErrorMessage(),
+                    errorType = ConfirmationHandler.Result.Failed.ErrorType.Payment,
                 )
             }
         }
@@ -560,11 +542,16 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
         paymentMethodExtraParams: PaymentMethodExtraParams?,
         shippingValues: ConfirmPaymentIntentParams.Shipping?,
         hCaptchaToken: String?
-    ): NextStep {
+    ): ConfirmationDefinition.Action<Args> {
         return retrieveStripeIntent(clientSecret).mapCatching { intent ->
             if (intent.isConfirmed) {
                 failIfSetAsDefaultFeatureIsEnabled(paymentMethodExtraParams)
-                NextStep.Complete(isForceSuccess = false)
+
+                ConfirmationDefinition.Action.Complete(
+                    intent = intent,
+                    deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
+                    completedFullPaymentFlow = true,
+                )
             } else if (intent.requiresAction()) {
                 createHandleNextActionStep(clientSecret, intent, paymentMethod)
             } else {
@@ -583,9 +570,10 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
                 )
             }
         }.getOrElse { error ->
-            NextStep.Fail(
+            ConfirmationDefinition.Action.Fail(
                 cause = error,
                 message = error.stripeErrorMessage(),
+                errorType = ConfirmationHandler.Result.Failed.ErrorType.Payment,
             )
         }
     }
@@ -594,14 +582,20 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
         clientSecret: String,
         intent: StripeIntent,
         paymentMethod: PaymentMethod
-    ): NextStep {
-        return runCatching {
+    ): ConfirmationDefinition.Action<Args> {
+        return runCatching<ConfirmationDefinition.Action<Args>> {
             DeferredIntentValidator.validatePaymentMethod(intent, paymentMethod)
-            NextStep.HandleNextAction(clientSecret)
+
+            ConfirmationDefinition.Action.Launch(
+                launcherArguments = Args.NextAction(clientSecret),
+                deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
+                receivesResultInProcess = false,
+            )
         }.getOrElse {
-            NextStep.Fail(
+            ConfirmationDefinition.Action.Fail(
                 cause = InvalidDeferredIntentUsageException(),
                 message = resolvableString(R.string.stripe_paymentsheet_invalid_deferred_intent_usage),
+                errorType = ConfirmationHandler.Result.Failed.ErrorType.Payment,
             )
         }
     }
@@ -623,7 +617,7 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
         isDeferred: Boolean,
         intentConfigSetupFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage?,
         hCaptchaToken: String?
-    ): NextStep {
+    ): ConfirmationDefinition.Action<Args> {
         val factory = ConfirmStripeIntentParamsFactory.createFactory(
             clientSecret = clientSecret,
             intent = intent,
@@ -641,9 +635,10 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
             intentConfigSetupFutureUsage = intentConfigSetupFutureUsage,
             radarOptions = hCaptchaToken?.let { RadarOptions(it) }
         )
-        return NextStep.Confirm(
-            confirmParams = confirmParams,
-            isDeferred = isDeferred,
+        return ConfirmationDefinition.Action.Launch(
+            launcherArguments = Args.Confirm(confirmParams),
+            deferredIntentConfirmationType = DeferredIntentConfirmationType.Client.takeIf { isDeferred },
+            receivesResultInProcess = false,
         )
     }
 
@@ -654,7 +649,7 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
         paymentMethodCreateParams: PaymentMethodCreateParams,
         paymentMethodOptionsParams: PaymentMethodOptionsParams? = null,
         paymentMethodExtraParams: PaymentMethodExtraParams? = null,
-    ): NextStep {
+    ): ConfirmationDefinition.Action<Args> {
         val paramsFactory = ConfirmStripeIntentParamsFactory.createFactory(
             clientSecret = clientSecret,
             intent = intent,
@@ -671,23 +666,25 @@ internal class DefaultIntentConfirmationInterceptor @Inject constructor(
             paymentMethodExtraParams,
         )
 
-        return NextStep.Confirm(
-            confirmParams = confirmParams,
-            isDeferred = false,
+        return ConfirmationDefinition.Action.Launch(
+            launcherArguments = Args.Confirm(confirmParams),
+            deferredIntentConfirmationType = null,
+            receivesResultInProcess = false,
         )
     }
 
     private fun createFailStep(
         exception: Exception,
         message: String,
-    ): NextStep.Fail {
-        return NextStep.Fail(
+    ): ConfirmationDefinition.Action<Args> {
+        return ConfirmationDefinition.Action.Fail(
             cause = exception,
             message = if (requestOptions.apiKeyIsLiveMode) {
                 PaymentsCoreR.string.stripe_internal_error.resolvableString
             } else {
                 message.resolvableString
-            }
+            },
+            errorType = ConfirmationHandler.Result.Failed.ErrorType.Payment,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptorKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptorKtx.kt
@@ -1,7 +1,9 @@
 package com.stripe.android.paymentelement.confirmation.intent
 
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
+import com.stripe.android.paymentelement.confirmation.intent.IntentConfirmationDefinition.Args
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.addresselement.toConfirmPaymentIntentShipping
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
@@ -11,7 +13,7 @@ internal suspend fun IntentConfirmationInterceptor.intercept(
     intent: StripeIntent,
     initializationMode: PaymentElementLoader.InitializationMode,
     shippingDetails: AddressDetails?
-): IntentConfirmationInterceptor.NextStep {
+): ConfirmationDefinition.Action<Args> {
     return when (confirmationOption) {
         is PaymentMethodConfirmationOption.New -> {
             intercept(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediatorTest.kt
@@ -159,7 +159,6 @@ class ConfirmationMediatorTest {
     @Test
     fun `On complete confirmation action, should return mediator complete action`() = test(
         action = ConfirmationDefinition.Action.Complete(
-            confirmationOption = TestConfirmationDefinition.Option,
             intent = INTENT,
             deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
             completedFullPaymentFlow = true,
@@ -184,7 +183,6 @@ class ConfirmationMediatorTest {
 
         val completeAction = action.asComplete()
 
-        assertThat(completeAction.confirmationOption).isEqualTo(TestConfirmationDefinition.Option)
         assertThat(completeAction.intent).isEqualTo(INTENT)
         assertThat(completeAction.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Client)
         assertThat(completeAction.completedFullPaymentFlow).isTrue()
@@ -193,7 +191,6 @@ class ConfirmationMediatorTest {
     @Test
     fun `On complete confirmation action with uncompleted flow, should return expected action`() = test(
         action = ConfirmationDefinition.Action.Complete(
-            confirmationOption = TestConfirmationDefinition.Option,
             intent = INTENT,
             deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
             completedFullPaymentFlow = false,
@@ -218,7 +215,6 @@ class ConfirmationMediatorTest {
 
         val completeAction = action.asComplete()
 
-        assertThat(completeAction.confirmationOption).isEqualTo(TestConfirmationDefinition.Option)
         assertThat(completeAction.intent).isEqualTo(INTENT)
         assertThat(completeAction.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Client)
         assertThat(completeAction.completedFullPaymentFlow).isFalse()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandlerTest.kt
@@ -224,7 +224,6 @@ class DefaultConfirmationHandlerTest {
     fun `On complete action, should complete with success result`() = test(
         someDefinitionAction = ConfirmationDefinition.Action.Complete(
             intent = UPDATED_PAYMENT_INTENT,
-            confirmationOption = SomeConfirmationDefinition.Option,
             deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
             completedFullPaymentFlow = true,
         ),
@@ -253,7 +252,6 @@ class DefaultConfirmationHandlerTest {
     fun `On complete action with uncompleted flow, should complete with success result`() = test(
         someDefinitionAction = ConfirmationDefinition.Action.Complete(
             intent = UPDATED_PAYMENT_INTENT,
-            confirmationOption = SomeConfirmationDefinition.Option,
             deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
             completedFullPaymentFlow = false,
         ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultIntentConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultIntentConfirmationInterceptorTest.kt
@@ -1659,8 +1659,7 @@ class DefaultIntentConfirmationInterceptorTest {
 
     @Suppress("UNCHECKED_CAST")
     private fun <T : ConfirmStripeIntentParams>
-        ConfirmationDefinition.Action<IntentConfirmationDefinition.Args>
-        .asConfirmParams(): T? {
+        ConfirmationDefinition.Action<IntentConfirmationDefinition.Args>.asConfirmParams(): T? {
         return (
             (this as? ConfirmationDefinition.Action.Launch)
                 ?.launcherArguments as? IntentConfirmationDefinition.Args.Confirm

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultIntentConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultIntentConfirmationInterceptorTest.kt
@@ -28,6 +28,8 @@ import com.stripe.android.paymentelement.PaymentMethodOptionsSetupFutureUsagePre
 import com.stripe.android.paymentelement.PreparePaymentMethodHandler
 import com.stripe.android.paymentelement.confirmation.intent.CreateIntentCallbackFailureException
 import com.stripe.android.paymentelement.confirmation.intent.DefaultIntentConfirmationInterceptor
+import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
+import com.stripe.android.paymentelement.confirmation.intent.IntentConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.intent.IntentConfirmationInterceptor
 import com.stripe.android.paymentelement.confirmation.intent.InvalidDeferredIntentUsageException
 import com.stripe.android.paymentelement.confirmation.intent.intercept
@@ -77,8 +79,7 @@ class DefaultIntentConfirmationInterceptorTest {
                 hCaptchaToken = null,
             )
 
-            val confirmNextStep = nextStep as? IntentConfirmationInterceptor.NextStep.Confirm
-            val confirmParams = confirmNextStep?.confirmParams as? ConfirmPaymentIntentParams
+            val confirmParams = nextStep.asConfirmParams<ConfirmPaymentIntentParams>()
 
             assertThat(confirmParams?.paymentMethodId).isEqualTo(paymentMethod.id)
             assertThat(confirmParams?.paymentMethodCreateParams).isNull()
@@ -98,8 +99,7 @@ class DefaultIntentConfirmationInterceptorTest {
                 customerRequestedSave = false,
             )
 
-            val confirmNextStep = nextStep as? IntentConfirmationInterceptor.NextStep.Confirm
-            val confirmParams = confirmNextStep?.confirmParams as? ConfirmPaymentIntentParams
+            val confirmParams = nextStep.asConfirmParams<ConfirmPaymentIntentParams>()
 
             assertThat(confirmParams?.paymentMethodId).isNull()
             assertThat(confirmParams?.paymentMethodCreateParams).isEqualTo(createParams)
@@ -121,8 +121,7 @@ class DefaultIntentConfirmationInterceptorTest {
                 shippingDetails = null,
             )
 
-            val confirmNextStep = nextStep as? IntentConfirmationInterceptor.NextStep.Confirm
-            val confirmParams = confirmNextStep?.confirmParams as? ConfirmPaymentIntentParams
+            val confirmParams = nextStep.asConfirmParams<ConfirmPaymentIntentParams>()
 
             assertThat(
                 confirmParams?.paymentMethodOptions
@@ -289,7 +288,9 @@ class DefaultIntentConfirmationInterceptorTest {
 
             val nextStep = interceptJob.await()
 
-            assertThat(nextStep).isInstanceOf<IntentConfirmationInterceptor.NextStep.Complete>()
+            assertThat(nextStep).isInstanceOf<
+                ConfirmationDefinition.Action.Complete<IntentConfirmationDefinition.Args>
+                >()
 
             assertThat(errorReporter.getLoggedErrors()).containsExactly(
                 ErrorReporter.SuccessEvent.FOUND_CREATE_INTENT_CALLBACK_WHILE_POLLING.eventName,
@@ -336,9 +337,10 @@ class DefaultIntentConfirmationInterceptorTest {
         )
 
         assertThat(nextStep).isEqualTo(
-            IntentConfirmationInterceptor.NextStep.Fail(
+            ConfirmationDefinition.Action.Fail<IntentConfirmationDefinition.Args>(
                 cause = invalidRequestException,
                 message = "Your card is not supported.".resolvableString,
+                errorType = ConfirmationHandler.Result.Failed.ErrorType.Payment,
             )
         )
     }
@@ -386,9 +388,10 @@ class DefaultIntentConfirmationInterceptorTest {
         )
 
         assertThat(nextStep).isEqualTo(
-            IntentConfirmationInterceptor.NextStep.Fail(
+            ConfirmationDefinition.Action.Fail<IntentConfirmationDefinition.Args>(
                 cause = apiException,
                 message = resolvableString(R.string.stripe_something_went_wrong),
+                errorType = ConfirmationHandler.Result.Failed.ErrorType.Payment,
             )
         )
     }
@@ -423,9 +426,10 @@ class DefaultIntentConfirmationInterceptorTest {
         )
 
         assertThat(nextStep).isEqualTo(
-            IntentConfirmationInterceptor.NextStep.Fail(
+            ConfirmationDefinition.Action.Fail<IntentConfirmationDefinition.Args>(
                 cause = CreateIntentCallbackFailureException(TestException("that didn't work…")),
                 message = resolvableString("that didn't work…"),
+                errorType = ConfirmationHandler.Result.Failed.ErrorType.Payment,
             )
         )
     }
@@ -457,9 +461,10 @@ class DefaultIntentConfirmationInterceptorTest {
         )
 
         assertThat(nextStep).isEqualTo(
-            IntentConfirmationInterceptor.NextStep.Fail(
+            ConfirmationDefinition.Action.Fail<IntentConfirmationDefinition.Args>(
                 cause = CreateIntentCallbackFailureException(TestException()),
                 message = resolvableString(R.string.stripe_something_went_wrong),
+                errorType = ConfirmationHandler.Result.Failed.ErrorType.Payment,
             )
         )
     }
@@ -505,7 +510,7 @@ class DefaultIntentConfirmationInterceptorTest {
             hCaptchaToken = null,
         )
 
-        assertThat(nextStep).isInstanceOf<IntentConfirmationInterceptor.NextStep.Confirm>()
+        assertThat(nextStep).isInstanceOf<ConfirmationDefinition.Action.Launch<IntentConfirmationDefinition.Args>>()
     }
 
     @Test
@@ -546,7 +551,11 @@ class DefaultIntentConfirmationInterceptorTest {
         )
 
         assertThat(nextStep).isEqualTo(
-            IntentConfirmationInterceptor.NextStep.Complete(isForceSuccess = false)
+            ConfirmationDefinition.Action.Complete<IntentConfirmationDefinition.Args>(
+                intent = PaymentIntentFixtures.PI_SUCCEEDED,
+                deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
+                completedFullPaymentFlow = true,
+            )
         )
     }
 
@@ -595,7 +604,11 @@ class DefaultIntentConfirmationInterceptorTest {
             )
 
             assertThat(nextStep).isEqualTo(
-                IntentConfirmationInterceptor.NextStep.HandleNextAction("pi_123_secret_456")
+                ConfirmationDefinition.Action.Launch<IntentConfirmationDefinition.Args>(
+                    launcherArguments = IntentConfirmationDefinition.Args.NextAction("pi_123_secret_456"),
+                    deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
+                    receivesResultInProcess = false,
+                )
             )
         }
 
@@ -761,6 +774,7 @@ class DefaultIntentConfirmationInterceptorTest {
             },
         )
 
+        val intent = PaymentIntentFactory.create()
         val nextStep = interceptor.intercept(
             initializationMode = InitializationMode.DeferredIntent(
                 intentConfiguration = PaymentSheet.IntentConfiguration(
@@ -770,7 +784,7 @@ class DefaultIntentConfirmationInterceptorTest {
                     ),
                 ),
             ),
-            intent = PaymentIntentFactory.create(),
+            intent = intent,
             paymentMethod = paymentMethod,
             paymentMethodOptionsParams = null,
             paymentMethodExtraParams = null,
@@ -781,7 +795,11 @@ class DefaultIntentConfirmationInterceptorTest {
         verify(stripeRepository, never()).retrieveStripeIntent(any(), any(), any())
 
         assertThat(nextStep).isEqualTo(
-            IntentConfirmationInterceptor.NextStep.Complete(isForceSuccess = true)
+            ConfirmationDefinition.Action.Complete<IntentConfirmationDefinition.Args>(
+                intent = intent,
+                deferredIntentConfirmationType = DeferredIntentConfirmationType.None,
+                completedFullPaymentFlow = true,
+            )
         )
     }
 
@@ -819,7 +837,7 @@ class DefaultIntentConfirmationInterceptorTest {
                 hCaptchaToken = null,
             )
 
-            val failedStep = nextStep.asFail()
+            val failedStep = nextStep as ConfirmationDefinition.Action.Fail
 
             assertThat(failedStep.cause).isInstanceOf(InvalidDeferredIntentUsageException::class.java)
             assertThat(failedStep.message).isEqualTo(
@@ -891,6 +909,7 @@ class DefaultIntentConfirmationInterceptorTest {
                 },
             )
 
+            val intent = PaymentIntentFactory.create()
             val nextStep = interceptor.intercept(
                 initializationMode = InitializationMode.DeferredIntent(
                     intentConfiguration = PaymentSheet.IntentConfiguration(
@@ -905,7 +924,7 @@ class DefaultIntentConfirmationInterceptorTest {
                         )
                     ),
                 ),
-                intent = PaymentIntentFactory.create(),
+                intent = intent,
                 paymentMethod = providedPaymentMethod,
                 paymentMethodOptionsParams = null,
                 paymentMethodExtraParams = null,
@@ -914,8 +933,9 @@ class DefaultIntentConfirmationInterceptorTest {
             )
 
             assertThat(nextStep).isEqualTo(
-                IntentConfirmationInterceptor.NextStep.Complete(
-                    isForceSuccess = true,
+                ConfirmationDefinition.Action.Complete<IntentConfirmationDefinition.Args>(
+                    intent = intent,
+                    deferredIntentConfirmationType = DeferredIntentConfirmationType.None,
                     completedFullPaymentFlow = false,
                 )
             )
@@ -958,6 +978,7 @@ class DefaultIntentConfirmationInterceptorTest {
                 },
             )
 
+            val intent = PaymentIntentFactory.create()
             val nextStep = interceptor.intercept(
                 initializationMode = InitializationMode.DeferredIntent(
                     intentConfiguration = PaymentSheet.IntentConfiguration(
@@ -972,7 +993,7 @@ class DefaultIntentConfirmationInterceptorTest {
                         )
                     ),
                 ),
-                intent = PaymentIntentFactory.create(),
+                intent = intent,
                 paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                 paymentMethodOptionsParams = null,
                 paymentMethodExtraParams = null,
@@ -981,8 +1002,9 @@ class DefaultIntentConfirmationInterceptorTest {
             )
 
             assertThat(nextStep).isEqualTo(
-                IntentConfirmationInterceptor.NextStep.Complete(
-                    isForceSuccess = true,
+                ConfirmationDefinition.Action.Complete<IntentConfirmationDefinition.Args>(
+                    intent = intent,
+                    deferredIntentConfirmationType = DeferredIntentConfirmationType.None,
                     completedFullPaymentFlow = false,
                 )
             )
@@ -1024,6 +1046,7 @@ class DefaultIntentConfirmationInterceptorTest {
                 },
             )
 
+            val intent = PaymentIntentFactory.create()
             val nextStep = interceptor.intercept(
                 initializationMode = InitializationMode.DeferredIntent(
                     intentConfiguration = PaymentSheet.IntentConfiguration(
@@ -1038,7 +1061,7 @@ class DefaultIntentConfirmationInterceptorTest {
                         )
                     ),
                 ),
-                intent = PaymentIntentFactory.create(),
+                intent = intent,
                 paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                 paymentMethodOptionsParams = null,
                 paymentMethodExtraParams = null,
@@ -1047,8 +1070,9 @@ class DefaultIntentConfirmationInterceptorTest {
             )
 
             assertThat(nextStep).isEqualTo(
-                IntentConfirmationInterceptor.NextStep.Complete(
-                    isForceSuccess = true,
+                ConfirmationDefinition.Action.Complete<IntentConfirmationDefinition.Args>(
+                    intent = intent,
+                    deferredIntentConfirmationType = DeferredIntentConfirmationType.None,
                     completedFullPaymentFlow = false,
                 )
             )
@@ -1123,8 +1147,7 @@ class DefaultIntentConfirmationInterceptorTest {
                 shippingDetails = null,
             )
 
-            val confirmNextStep = nextStep as? IntentConfirmationInterceptor.NextStep.Confirm
-            val confirmParams = confirmNextStep?.confirmParams as? ConfirmPaymentIntentParams
+            val confirmParams = nextStep.asConfirmParams<ConfirmPaymentIntentParams>()
 
             assertThat(
                 confirmParams?.setupFutureUsage
@@ -1188,8 +1211,7 @@ class DefaultIntentConfirmationInterceptorTest {
                 shippingDetails = null,
             )
 
-            val confirmNextStep = nextStep as? IntentConfirmationInterceptor.NextStep.Confirm
-            val confirmParams = confirmNextStep?.confirmParams as? ConfirmPaymentIntentParams
+            val confirmParams = nextStep.asConfirmParams<ConfirmPaymentIntentParams>()
 
             assertThat(
                 confirmParams?.paymentMethodOptions
@@ -1362,7 +1384,8 @@ class DefaultIntentConfirmationInterceptorTest {
         event: ErrorReporter.ErrorEvent,
         failureMessage: String,
         userMessage: ResolvableString,
-        interceptCall: suspend (errorReporter: ErrorReporter) -> IntentConfirmationInterceptor.NextStep
+        interceptCall: suspend (errorReporter: ErrorReporter) ->
+        ConfirmationDefinition.Action<IntentConfirmationDefinition.Args>
     ) {
         val errorReporter = FakeErrorReporter()
         val dispatcher = StandardTestDispatcher()
@@ -1388,9 +1411,9 @@ class DefaultIntentConfirmationInterceptorTest {
 
             val nextStep = interceptJob.await()
 
-            assertThat(nextStep).isInstanceOf<IntentConfirmationInterceptor.NextStep.Fail>()
+            assertThat(nextStep).isInstanceOf<ConfirmationDefinition.Action.Fail<IntentConfirmationDefinition.Args>>()
 
-            val failedStep = nextStep.asFail()
+            val failedStep = nextStep as ConfirmationDefinition.Action.Fail<IntentConfirmationDefinition.Args>
 
             assertThat(failedStep.cause).isInstanceOf<IllegalStateException>()
             assertThat(failedStep.cause.message).isEqualTo(failureMessage)
@@ -1547,10 +1570,6 @@ class DefaultIntentConfirmationInterceptorTest {
         ensureAllEventsConsumed()
     }
 
-    private fun IntentConfirmationInterceptor.NextStep.asFail(): IntentConfirmationInterceptor.NextStep.Fail {
-        return this as IntentConfirmationInterceptor.NextStep.Fail
-    }
-
     private class TestException(message: String? = null) : Exception(message) {
 
         override fun hashCode(): Int {
@@ -1639,9 +1658,13 @@ class DefaultIntentConfirmationInterceptorTest {
     }
 
     @Suppress("UNCHECKED_CAST")
-    private fun <T : ConfirmStripeIntentParams> IntentConfirmationInterceptor.NextStep.asConfirmParams(): T? {
-        val confirmNextStep = this as? IntentConfirmationInterceptor.NextStep.Confirm
-        return confirmNextStep?.confirmParams as? T
+    private fun <T : ConfirmStripeIntentParams>
+        ConfirmationDefinition.Action<IntentConfirmationDefinition.Args>
+        .asConfirmParams(): T? {
+        return (
+            (this as? ConfirmationDefinition.Action.Launch)
+                ?.launcherArguments as? IntentConfirmationDefinition.Args.Confirm
+            ) ?.confirmNextParams as? T
     }
 
     private fun ConfirmStripeIntentParams.radarOptions(): RadarOptions? {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationDefinitionTest.kt
@@ -133,7 +133,6 @@ class IntentConfirmationDefinitionTest {
         val completeAction = action.asComplete()
 
         assertThat(completeAction.intent).isEqualTo(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
-        assertThat(completeAction.confirmationOption).isEqualTo(SAVED_PAYMENT_CONFIRMATION_OPTION)
         assertThat(completeAction.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Server)
     }
 
@@ -158,7 +157,6 @@ class IntentConfirmationDefinitionTest {
             val completeAction = action.asComplete()
 
             assertThat(completeAction.intent).isEqualTo(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
-            assertThat(completeAction.confirmationOption).isEqualTo(SAVED_PAYMENT_CONFIRMATION_OPTION)
             assertThat(completeAction.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Server)
             assertThat(completeAction.completedFullPaymentFlow).isFalse()
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationFlowTest.kt
@@ -115,7 +115,6 @@ internal class IntentConfirmationFlowTest {
         val completeAction = action.asComplete()
 
         assertThat(completeAction.intent).isEqualTo(SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD)
-        assertThat(completeAction.confirmationOption).isEqualTo(CONFIRMATION_OPTION)
         assertThat(completeAction.deferredIntentConfirmationType)
             .isEqualTo(DeferredIntentConfirmationType.None)
         assertThat(completeAction.completedFullPaymentFlow).isTrue()
@@ -146,7 +145,6 @@ internal class IntentConfirmationFlowTest {
         val completeAction = action.asComplete()
 
         assertThat(completeAction.intent).isEqualTo(SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD)
-        assertThat(completeAction.confirmationOption).isEqualTo(CONFIRMATION_OPTION)
         assertThat(completeAction.deferredIntentConfirmationType)
             .isEqualTo(DeferredIntentConfirmationType.None)
         assertThat(completeAction.completedFullPaymentFlow).isFalse()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
1. Remove `NextStep` in `IntentConfirmationInterceptor`
2. Remove `confirmationOption` in `ConfirmationDefinition.Action.Complete`. The field is never used.
```
ConfirmationDefinition.Action.Complete(
    intent = confirmationParameters.intent,
    confirmationOption = confirmationOption,
    deferredIntentConfirmationType = deferredIntentConfirmationType,
    completedFullPaymentFlow = nextStep.completedFullPaymentFlow,
)
```

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
#11623

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
