### PR TITLE
Use merchant publishable key for Link requests

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/LinkTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/LinkTest.kt
@@ -96,10 +96,6 @@ internal class LinkTest {
              * 2-digit shorthand (should send "2034", not "34")
              */
             bodyPart(urlEncode("card[exp_year]"), "2034"),
-            /*
-             * Should use the consumer's publishable key when creating payment details
-             */
-            header("Authorization", "Bearer pk_545454676767898989"),
         ) { response ->
             response.testBodyFromFile("consumer-payment-details-success.json")
         }
@@ -289,10 +285,6 @@ internal class LinkTest {
              * Ensures card brand choice is passed properly.
              */
             bodyPart(urlEncode("card[preferred_network]"), "cartes_bancaires"),
-            /*
-             * Should use the consumer's publishable key when creating payment details
-             */
-            header("Authorization", "Bearer pk_545454676767898989"),
         ) { response ->
             response.testBodyFromFile("consumer-payment-details-success.json")
         }

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
@@ -87,7 +87,6 @@ internal class DefaultLinkAccountManager @Inject constructor(
                 consumerSessionClientSecret = linkAccount.clientSecret,
                 stripeIntent = config.stripeIntent,
                 linkMode = config.linkMode,
-                consumerPublishableKey = linkAccount.consumerPublishableKey,
             ).getOrThrow()
         }
     }
@@ -212,7 +211,6 @@ internal class DefaultLinkAccountManager @Inject constructor(
                     userEmail = account.email,
                     stripeIntent = config.stripeIntent,
                     consumerSessionClientSecret = account.clientSecret,
-                    consumerPublishableKey = account.consumerPublishableKey.takeIf { !config.passthroughModeEnabled },
                 ).onSuccess {
                     errorReporter.report(ErrorReporter.SuccessEvent.LINK_CREATE_CARD_SUCCESS)
                 }
@@ -346,7 +344,6 @@ internal class DefaultLinkAccountManager @Inject constructor(
         linkEventsReporter.on2FAStart()
         return linkRepository.startVerification(
             consumerSessionClientSecret = linkAccount.clientSecret,
-            consumerPublishableKey = linkAccount.consumerPublishableKey
         )
             .onFailure {
                 linkEventsReporter.on2FAStartFailure()
@@ -364,7 +361,6 @@ internal class DefaultLinkAccountManager @Inject constructor(
         return linkRepository.confirmVerification(
             verificationCode = code,
             consumerSessionClientSecret = linkAccount.clientSecret,
-            consumerPublishableKey = linkAccount.consumerPublishableKey,
             consentGranted = consentGranted,
         )
             .onSuccess {
@@ -383,7 +379,6 @@ internal class DefaultLinkAccountManager @Inject constructor(
         return linkRepository.postConsentUpdate(
             consumerSessionClientSecret = linkAccount.clientSecret,
             consentGranted = consentGranted,
-            consumerPublishableKey = linkAccount.consumerPublishableKey
         )
     }
 
@@ -393,7 +388,6 @@ internal class DefaultLinkAccountManager @Inject constructor(
         return linkRepository.listPaymentDetails(
             paymentMethodTypes = paymentMethodTypes,
             consumerSessionClientSecret = linkAccount.clientSecret,
-            consumerPublishableKey = linkAccount.consumerPublishableKey
         ).onSuccess { paymentDetailsList ->
             _consumerState.value = _consumerState.value
                 ?.withPaymentDetailsResponse(paymentDetailsList)
@@ -406,7 +400,6 @@ internal class DefaultLinkAccountManager @Inject constructor(
             ?: return Result.failure(NoLinkAccountFoundException())
         return linkRepository.listShippingAddresses(
             consumerSessionClientSecret = linkAccount.clientSecret,
-            consumerPublishableKey = linkAccount.consumerPublishableKey,
         )
     }
 
@@ -416,7 +409,6 @@ internal class DefaultLinkAccountManager @Inject constructor(
         return linkRepository.deletePaymentDetails(
             paymentDetailsId = paymentDetailsId,
             consumerSessionClientSecret = linkAccount.clientSecret,
-            consumerPublishableKey = linkAccount.consumerPublishableKey
         )
     }
 
@@ -429,7 +421,6 @@ internal class DefaultLinkAccountManager @Inject constructor(
         return linkRepository.updatePaymentDetails(
             updateParams = updateParams,
             consumerSessionClientSecret = linkAccount.clientSecret,
-            consumerPublishableKey = linkAccount.consumerPublishableKey
         ).map { updatedPaymentDetails ->
             updatedPaymentDetails.also {
                 _consumerState.value = _consumerState.value?.withUpdatedPaymentDetail(
@@ -446,7 +437,6 @@ internal class DefaultLinkAccountManager @Inject constructor(
         return linkRepository.updatePhoneNumber(
             consumerSessionClientSecret = linkAccount.clientSecret,
             phoneNumber = phoneNumber,
-            consumerPublishableKey = linkAccount.consumerPublishableKey
         ).map { consumerSession ->
             setAccount(consumerSession = consumerSession)
         }

--- a/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
@@ -37,6 +37,7 @@ import com.stripe.android.repository.ConsumersApiService
 import kotlinx.coroutines.withContext
 import java.util.Locale
 import javax.inject.Inject
+import javax.inject.Provider
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -46,7 +47,7 @@ import kotlin.coroutines.CoroutineContext
 internal class LinkApiRepository @Inject constructor(
     application: Application,
     private val requestSurface: RequestSurface,
-    private val apiRequestOptions: ApiRequest.Options,
+    private val apiRequestOptionsProvider: Provider<ApiRequest.Options>,
     private val stripeRepository: StripeRepository,
     private val consumersApiService: ConsumersApiService,
     @IOContext private val workContext: CoroutineContext,
@@ -56,6 +57,10 @@ internal class LinkApiRepository @Inject constructor(
 
     private val fraudDetectionDataRepository: FraudDetectionDataRepository =
         DefaultFraudDetectionDataRepository(application, workContext)
+
+    private val apiRequestOptions: ApiRequest.Options by lazy {
+        apiRequestOptionsProvider.get()
+    }
 
     init {
         fraudDetectionDataRepository.refresh()

--- a/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
@@ -61,10 +61,11 @@ internal class LinkApiRepository @Inject constructor(
     private val fraudDetectionDataRepository: FraudDetectionDataRepository =
         DefaultFraudDetectionDataRepository(application, workContext)
 
-    private val apiRequestOptions = ApiRequest.Options(
-        publishableKeyProvider = publishableKeyProvider,
-        stripeAccountIdProvider = stripeAccountIdProvider,
-    )
+    private val apiRequestOptions: ApiRequest.Options
+        get() = ApiRequest.Options(
+            publishableKeyProvider = publishableKeyProvider,
+            stripeAccountIdProvider = stripeAccountIdProvider,
+        )
 
     init {
         fraudDetectionDataRepository.refresh()

--- a/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
@@ -328,11 +328,15 @@ internal class LinkApiRepository @Inject constructor(
             mapOf("allow_redisplay" to allowRedisplay)
         } ?: emptyMap()
 
+        // Allow using a custom API key so that payment methods can be created under the
+        // merchant-of-record if necessary.
+        val requestOptions = buildCustomRequestOptions(apiKey)
+
         consumersApiService.sharePaymentDetails(
             consumerSessionClientSecret = consumerSessionClientSecret,
             paymentDetailsId = paymentDetailsId,
             expectedPaymentMethodType = expectedPaymentMethodType,
-            requestOptions = buildRequestOptions(apiKey),
+            requestOptions = requestOptions,
             requestSurface = requestSurface.value,
             extraParams = paymentMethodParams + fraudParams + optionsParams + allowRedisplayParams,
             billingPhone = billingPhone,
@@ -483,7 +487,7 @@ internal class LinkApiRepository @Inject constructor(
         )
     }
 
-    private fun buildRequestOptions(
+    private fun buildCustomRequestOptions(
         apiKey: String? = null,
     ): ApiRequest.Options {
         return if (apiKey != null) {

--- a/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
@@ -109,7 +109,6 @@ internal interface LinkRepository {
         userEmail: String,
         stripeIntent: StripeIntent,
         consumerSessionClientSecret: String,
-        consumerPublishableKey: String?,
     ): Result<LinkPaymentDetails.New>
 
     suspend fun createBankAccountPaymentDetails(
@@ -149,7 +148,6 @@ internal interface LinkRepository {
      */
     suspend fun startVerification(
         consumerSessionClientSecret: String,
-        consumerPublishableKey: String?,
     ): Result<ConsumerSession>
 
     /**
@@ -158,7 +156,6 @@ internal interface LinkRepository {
     suspend fun confirmVerification(
         verificationCode: String,
         consumerSessionClientSecret: String,
-        consumerPublishableKey: String?,
         consentGranted: Boolean?,
     ): Result<ConsumerSession>
 
@@ -168,7 +165,6 @@ internal interface LinkRepository {
     suspend fun postConsentUpdate(
         consumerSessionClientSecret: String,
         consentGranted: Boolean,
-        consumerPublishableKey: String?
     ): Result<Unit>
 
     /**
@@ -177,7 +173,6 @@ internal interface LinkRepository {
     suspend fun listPaymentDetails(
         paymentMethodTypes: Set<String>,
         consumerSessionClientSecret: String,
-        consumerPublishableKey: String?
     ): Result<ConsumerPaymentDetails>
 
     /**
@@ -185,7 +180,6 @@ internal interface LinkRepository {
      */
     suspend fun listShippingAddresses(
         consumerSessionClientSecret: String,
-        consumerPublishableKey: String?
     ): Result<ConsumerShippingAddresses>
 
     /**
@@ -194,7 +188,6 @@ internal interface LinkRepository {
     suspend fun deletePaymentDetails(
         paymentDetailsId: String,
         consumerSessionClientSecret: String,
-        consumerPublishableKey: String?
     ): Result<Unit>
 
     /**
@@ -203,14 +196,12 @@ internal interface LinkRepository {
     suspend fun updatePaymentDetails(
         updateParams: ConsumerPaymentDetailsUpdateParams,
         consumerSessionClientSecret: String,
-        consumerPublishableKey: String?
     ): Result<ConsumerPaymentDetails>
 
     suspend fun createLinkAccountSession(
         consumerSessionClientSecret: String,
         stripeIntent: StripeIntent,
         linkMode: LinkMode?,
-        consumerPublishableKey: String?
     ): Result<LinkAccountSession>
 
     /**
@@ -219,6 +210,5 @@ internal interface LinkRepository {
     suspend fun updatePhoneNumber(
         consumerSessionClientSecret: String,
         phoneNumber: String,
-        consumerPublishableKey: String?
     ): Result<ConsumerSession>
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/LinkHoldbackExposureModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/LinkHoldbackExposureModule.kt
@@ -6,8 +6,7 @@ import com.stripe.android.common.analytics.experiment.DefaultLogLinkHoldbackExpe
 import com.stripe.android.common.analytics.experiment.LogLinkHoldbackExperiment
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.IOContext
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
-import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
+import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.networking.DefaultStripeNetworkClient
 import com.stripe.android.core.version.StripeSdkVersion
 import com.stripe.android.link.repositories.LinkApiRepository
@@ -19,7 +18,6 @@ import com.stripe.android.repository.ConsumersApiServiceImpl
 import dagger.Module
 import dagger.Provides
 import java.util.Locale
-import javax.inject.Named
 import javax.inject.Qualifier
 import kotlin.coroutines.CoroutineContext
 
@@ -52,8 +50,7 @@ internal class LinkHoldbackExposureModule {
     @LinkDisabledApiRepository
     fun providesLinkRepository(
         application: Application,
-        @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
-        @Named(STRIPE_ACCOUNT_ID) stripeAccountIdProvider: () -> String?,
+        apiRequestOptions: ApiRequest.Options,
         requestSurface: RequestSurface,
         stripeRepository: StripeRepository,
         @IOContext workContext: CoroutineContext,
@@ -73,8 +70,7 @@ internal class LinkHoldbackExposureModule {
         return LinkApiRepository(
             application = application,
             requestSurface = requestSurface,
-            publishableKeyProvider = publishableKeyProvider,
-            stripeAccountIdProvider = stripeAccountIdProvider,
+            apiRequestOptions = apiRequestOptions,
             stripeRepository = stripeRepository,
             consumersApiService = consumersApiService,
             workContext = workContext,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/LinkHoldbackExposureModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/LinkHoldbackExposureModule.kt
@@ -6,7 +6,8 @@ import com.stripe.android.common.analytics.experiment.DefaultLogLinkHoldbackExpe
 import com.stripe.android.common.analytics.experiment.LogLinkHoldbackExperiment
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.IOContext
-import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.core.injection.PUBLISHABLE_KEY
+import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.core.networking.DefaultStripeNetworkClient
 import com.stripe.android.core.version.StripeSdkVersion
 import com.stripe.android.link.repositories.LinkApiRepository
@@ -18,7 +19,7 @@ import com.stripe.android.repository.ConsumersApiServiceImpl
 import dagger.Module
 import dagger.Provides
 import java.util.Locale
-import javax.inject.Provider
+import javax.inject.Named
 import javax.inject.Qualifier
 import kotlin.coroutines.CoroutineContext
 
@@ -51,7 +52,8 @@ internal class LinkHoldbackExposureModule {
     @LinkDisabledApiRepository
     fun providesLinkRepository(
         application: Application,
-        apiRequestOptionsProvider: Provider<ApiRequest.Options>,
+        @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
+        @Named(STRIPE_ACCOUNT_ID) stripeAccountIdProvider: () -> String?,
         requestSurface: RequestSurface,
         stripeRepository: StripeRepository,
         @IOContext workContext: CoroutineContext,
@@ -71,7 +73,8 @@ internal class LinkHoldbackExposureModule {
         return LinkApiRepository(
             application = application,
             requestSurface = requestSurface,
-            apiRequestOptionsProvider = apiRequestOptionsProvider,
+            publishableKeyProvider = publishableKeyProvider,
+            stripeAccountIdProvider = stripeAccountIdProvider,
             stripeRepository = stripeRepository,
             consumersApiService = consumersApiService,
             workContext = workContext,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/LinkHoldbackExposureModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/LinkHoldbackExposureModule.kt
@@ -18,6 +18,7 @@ import com.stripe.android.repository.ConsumersApiServiceImpl
 import dagger.Module
 import dagger.Provides
 import java.util.Locale
+import javax.inject.Provider
 import javax.inject.Qualifier
 import kotlin.coroutines.CoroutineContext
 
@@ -50,7 +51,7 @@ internal class LinkHoldbackExposureModule {
     @LinkDisabledApiRepository
     fun providesLinkRepository(
         application: Application,
-        apiRequestOptions: ApiRequest.Options,
+        apiRequestOptionsProvider: Provider<ApiRequest.Options>,
         requestSurface: RequestSurface,
         stripeRepository: StripeRepository,
         @IOContext workContext: CoroutineContext,
@@ -70,7 +71,7 @@ internal class LinkHoldbackExposureModule {
         return LinkApiRepository(
             application = application,
             requestSurface = requestSurface,
-            apiRequestOptions = apiRequestOptions,
+            apiRequestOptionsProvider = apiRequestOptionsProvider,
             stripeRepository = stripeRepository,
             consumersApiService = consumersApiService,
             workContext = workContext,

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
@@ -146,7 +146,7 @@ internal class LinkActivityViewModelTest {
         val mockArgs = NativeLinkArgs(
             configuration = mock(),
             requestSurface = RequestSurface.PaymentElement,
-            publishableKey = "",
+            publishableKey = "pk_123",
             stripeAccountId = null,
             linkExpressMode = LinkExpressMode.DISABLED,
             linkAccountInfo = LinkAccountUpdate.Value(

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAccountManagerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAccountManagerTest.kt
@@ -407,7 +407,6 @@ class DefaultLinkAccountManagerTest {
                 userEmail: String,
                 stripeIntent: StripeIntent,
                 consumerSessionClientSecret: String,
-                consumerPublishableKey: String?,
             ): Result<LinkPaymentDetails.New> {
                 val details = result.first()
                 if (result.size > 1) {
@@ -500,10 +499,9 @@ class DefaultLinkAccountManagerTest {
             var callCount = 0
             override suspend fun startVerification(
                 consumerSessionClientSecret: String,
-                consumerPublishableKey: String?
             ): Result<ConsumerSession> {
                 callCount += 1
-                return super.startVerification(consumerSessionClientSecret, consumerPublishableKey)
+                return super.startVerification(consumerSessionClientSecret)
             }
         }
         val accountManager = accountManager(linkRepository = linkRepository)
@@ -534,29 +532,6 @@ class DefaultLinkAccountManagerTest {
 
         assertThat(accountManager.linkAccountInfo.value.account).isNotNull()
         assertThat(linkEventsReporter.callCount).isEqualTo(1)
-    }
-
-    @Test
-    fun `startVerification uses consumerPublishableKey`() = runSuspendTest {
-        val linkRepository = object : FakeLinkRepository() {
-            var consumerPublishableKey: String? = null
-            var callCount = 0
-            override suspend fun startVerification(
-                consumerSessionClientSecret: String,
-                consumerPublishableKey: String?
-            ): Result<ConsumerSession> {
-                callCount += 1
-                this.consumerPublishableKey = consumerPublishableKey
-                return super.startVerification(consumerSessionClientSecret, consumerPublishableKey)
-            }
-        }
-        val accountManager = accountManager(linkRepository = linkRepository)
-        accountManager.setTestAccount(TestFactory.CONSUMER_SESSION, TestFactory.PUBLISHABLE_KEY)
-
-        accountManager.startVerification()
-
-        assertThat(linkRepository.callCount).isEqualTo(1)
-        assertThat(linkRepository.consumerPublishableKey).isEqualTo(TestFactory.PUBLISHABLE_KEY)
     }
 
     @Test
@@ -599,14 +574,12 @@ class DefaultLinkAccountManagerTest {
             override suspend fun confirmVerification(
                 verificationCode: String,
                 consumerSessionClientSecret: String,
-                consumerPublishableKey: String?,
                 consentGranted: Boolean?
             ): Result<ConsumerSession> {
                 callCount += 1
                 return super.confirmVerification(
                     verificationCode = verificationCode,
                     consumerSessionClientSecret = consumerSessionClientSecret,
-                    consumerPublishableKey = consumerPublishableKey,
                     consentGranted = consentGranted
                 )
             }
@@ -637,7 +610,6 @@ class DefaultLinkAccountManagerTest {
             override suspend fun confirmVerification(
                 verificationCode: String,
                 consumerSessionClientSecret: String,
-                consumerPublishableKey: String?,
                 consentGranted: Boolean?
             ): Result<ConsumerSession> {
                 callCount += 1
@@ -668,7 +640,6 @@ class DefaultLinkAccountManagerTest {
             override suspend fun listPaymentDetails(
                 paymentMethodTypes: Set<String>,
                 consumerSessionClientSecret: String,
-                consumerPublishableKey: String?
             ): Result<ConsumerPaymentDetails> {
                 this.paymentMethodTypes = paymentMethodTypes
                 return Result.failure(error)
@@ -691,7 +662,6 @@ class DefaultLinkAccountManagerTest {
             override suspend fun listPaymentDetails(
                 paymentMethodTypes: Set<String>,
                 consumerSessionClientSecret: String,
-                consumerPublishableKey: String?
             ): Result<ConsumerPaymentDetails> {
                 this.paymentMethodTypes = paymentMethodTypes
                 return Result.success(TestFactory.CONSUMER_PAYMENT_DETAILS)
@@ -892,7 +862,6 @@ class DefaultLinkAccountManagerTest {
                 consumerSessionClientSecret: String,
                 stripeIntent: StripeIntent,
                 linkMode: LinkMode?,
-                consumerPublishableKey: String?
             ): Result<LinkAccountSession> {
                 return Result.success(TestFactory.LINK_ACCOUNT_SESSION)
             }

--- a/paymentsheet/src/test/java/com/stripe/android/link/repositories/FakeLinkRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/repositories/FakeLinkRepository.kt
@@ -156,7 +156,6 @@ internal open class FakeLinkRepository : LinkRepository {
         userEmail: String,
         stripeIntent: StripeIntent,
         consumerSessionClientSecret: String,
-        consumerPublishableKey: String?,
     ) = createCardPaymentDetailsResult
 
     override suspend fun createBankAccountPaymentDetails(
@@ -193,56 +192,47 @@ internal open class FakeLinkRepository : LinkRepository {
 
     override suspend fun startVerification(
         consumerSessionClientSecret: String,
-        consumerPublishableKey: String?
     ) = startVerificationResult
 
     override suspend fun confirmVerification(
         verificationCode: String,
         consumerSessionClientSecret: String,
-        consumerPublishableKey: String?,
         consentGranted: Boolean?
     ): Result<ConsumerSession> = confirmVerificationResult
 
     override suspend fun postConsentUpdate(
         consumerSessionClientSecret: String,
         consentGranted: Boolean,
-        consumerPublishableKey: String?
     ): Result<Unit> = postConsentUpdateResult
 
     override suspend fun listPaymentDetails(
         paymentMethodTypes: Set<String>,
         consumerSessionClientSecret: String,
-        consumerPublishableKey: String?
     ): Result<ConsumerPaymentDetails> = listPaymentDetailsResult
 
     override suspend fun listShippingAddresses(
         consumerSessionClientSecret: String,
-        consumerPublishableKey: String?
     ): Result<ConsumerShippingAddresses> = listShippingAddressesResult
 
     override suspend fun deletePaymentDetails(
         paymentDetailsId: String,
         consumerSessionClientSecret: String,
-        consumerPublishableKey: String?
     ): Result<Unit> = deletePaymentDetailsResult
 
     override suspend fun updatePaymentDetails(
         updateParams: ConsumerPaymentDetailsUpdateParams,
         consumerSessionClientSecret: String,
-        consumerPublishableKey: String?
     ): Result<ConsumerPaymentDetails> = updatePaymentDetailsResult
 
     override suspend fun createLinkAccountSession(
         consumerSessionClientSecret: String,
         stripeIntent: StripeIntent,
         linkMode: LinkMode?,
-        consumerPublishableKey: String?
     ): Result<LinkAccountSession> = createLinkAccountSessionResult
 
     override suspend fun updatePhoneNumber(
         consumerSessionClientSecret: String,
         phoneNumber: String,
-        consumerPublishableKey: String?
     ): Result<ConsumerSession> = updatePhoneNumberResult
 
     suspend fun awaitMobileLookup(): MobileLookupCall {

--- a/paymentsheet/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
@@ -776,12 +776,8 @@ class LinkApiRepositoryTest {
         return LinkApiRepository(
             application = ApplicationProvider.getApplicationContext(),
             requestSurface = RequestSurface.PaymentElement,
-            apiRequestOptionsProvider = {
-                ApiRequest.Options(
-                    apiKey = PUBLISHABLE_KEY,
-                    stripeAccount = STRIPE_ACCOUNT_ID,
-                )
-            },
+            publishableKeyProvider = { PUBLISHABLE_KEY },
+            stripeAccountIdProvider = { STRIPE_ACCOUNT_ID },
             stripeRepository = stripeRepository,
             consumersApiService = consumersApiService,
             workContext = Dispatchers.IO,

--- a/paymentsheet/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
@@ -776,8 +776,12 @@ class LinkApiRepositoryTest {
         return LinkApiRepository(
             application = ApplicationProvider.getApplicationContext(),
             requestSurface = RequestSurface.PaymentElement,
-            publishableKeyProvider = { PUBLISHABLE_KEY },
-            stripeAccountIdProvider = { STRIPE_ACCOUNT_ID },
+            apiRequestOptionsProvider = {
+                ApiRequest.Options(
+                    apiKey = PUBLISHABLE_KEY,
+                    stripeAccount = STRIPE_ACCOUNT_ID,
+                )
+            },
             stripeRepository = stripeRepository,
             consumersApiService = consumersApiService,
             workContext = Dispatchers.IO,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request switches to using the merchant publishable key (together with the consumer session client secret) for consumer API requests. This aligns Android with other platforms.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
