### PR TITLE
Fix flaky RadarSessionTest

### DIFF
--- a/payments-core/build.gradle
+++ b/payments-core/build.gradle
@@ -80,6 +80,7 @@ dependencies {
     androidTestImplementation testLibs.espresso.core
     androidTestImplementation testLibs.kotlin.coroutines
     androidTestImplementation testLibs.kotlin.junit
+    androidTestImplementation testLibs.truth
 
     androidTestUtil testLibs.testOrchestrator
 }

--- a/payments-core/src/androidTest/java/com/stripe/android/RadarSessionTest.kt
+++ b/payments-core/src/androidTest/java/com/stripe/android/RadarSessionTest.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 
 class RadarSessionTest {
     private val mockApiRepository: StripeRepository = object : AbsFakeStripeRepository() {
@@ -48,11 +49,12 @@ class RadarSessionTest {
             testDispatcher
         )
 
-    @get:Rule
-    val scenarioRule = ActivityScenarioRule(TestActivity::class.java)
+    private val scenarioRule = ActivityScenarioRule(TestActivity::class.java)
 
     @get:Rule
-    val coroutineTestRule = CoroutineTestRule(testDispatcher)
+    val ruleChain: RuleChain = RuleChain
+        .outerRule(CoroutineTestRule(testDispatcher))
+        .around(scenarioRule)
 
     @Test
     fun ensureRadarSessionsAttachHCaptchaToken(): Unit = runTest(testDispatcher) {

--- a/payments-core/src/androidTest/java/com/stripe/android/RadarSessionTest.kt
+++ b/payments-core/src/androidTest/java/com/stripe/android/RadarSessionTest.kt
@@ -29,7 +29,7 @@ class RadarSessionTest {
             hcaptchaEKey: String?,
             requestOptions: ApiRequest.Options
         ): Result<RadarSessionWithHCaptcha> {
-            if (hcaptchaToken == "10000000-aaaa-bbbb-cccc-000000000001") {
+            if (hcaptchaToken == "20000000-aaaa-bbbb-cccc-000000000002") {
                 return Result.success(RadarSessionWithHCaptcha("rse_id", HCAPTCHA_SITE_KEY, "rqdata"))
             } else {
                 throw RuntimeException("Incorrect hCaptcha token: $hcaptchaToken")
@@ -74,6 +74,6 @@ class RadarSessionTest {
     private companion object {
         private const val FAKE_PUBLISHABLE_KEY = "pk_test_123"
         private const val TEST_STRIPE_ACCOUNT_ID = "test_account_id"
-        private const val HCAPTCHA_SITE_KEY = "10000000-ffff-ffff-ffff-000000000001"
+        private const val HCAPTCHA_SITE_KEY = "20000000-ffff-ffff-ffff-000000000002"
     }
 }

--- a/payments-core/src/androidTest/java/com/stripe/android/RadarSessionTest.kt
+++ b/payments-core/src/androidTest/java/com/stripe/android/RadarSessionTest.kt
@@ -8,6 +8,7 @@ import com.stripe.android.networking.StripeRepository
 import com.stripe.android.testing.AbsFakeStripeRepository
 import com.stripe.android.testing.AbsPaymentController
 import com.stripe.android.testing.CoroutineTestRule
+import com.stripe.android.testing.RetryRule
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -55,6 +56,7 @@ class RadarSessionTest {
     val ruleChain: RuleChain = RuleChain
         .outerRule(CoroutineTestRule(testDispatcher))
         .around(scenarioRule)
+        .around(RetryRule(3))
 
     @Test
     fun ensureRadarSessionsAttachHCaptchaToken(): Unit = runTest(testDispatcher) {

--- a/payments-core/src/androidTest/java/com/stripe/android/TestActivity.kt
+++ b/payments-core/src/androidTest/java/com/stripe/android/TestActivity.kt
@@ -2,4 +2,4 @@ package com.stripe.android
 
 import androidx.fragment.app.FragmentActivity
 
-internal class TestActivity : FragmentActivity()
+class TestActivity : FragmentActivity()

--- a/payments-core/src/androidTest/java/com/stripe/android/TestActivity.kt
+++ b/payments-core/src/androidTest/java/com/stripe/android/TestActivity.kt
@@ -2,4 +2,4 @@ package com.stripe.android
 
 import androidx.fragment.app.FragmentActivity
 
-class TestActivity : FragmentActivity()
+internal class TestActivity : FragmentActivity()

--- a/payments-core/src/main/java/com/stripe/android/hcaptcha/HCaptchaInterface.kt
+++ b/payments-core/src/main/java/com/stripe/android/hcaptcha/HCaptchaInterface.kt
@@ -27,8 +27,9 @@ suspend fun performPassiveHCaptcha(
 ): String {
     // TODO(awush): in the future, we should convert the hCaptcha SDK to use a suspend interface instead of callbacks,
     //  then we can eliminate the {{suspendCancelableCoroutine}} here.
-    return suspendCancellableCoroutine { continuation ->
-        val hCaptcha = HCaptcha.getClient().apply {
+    val hCaptcha = HCaptcha.getClient()
+    val token = suspendCancellableCoroutine { continuation ->
+        hCaptcha.apply {
             addOnSuccessListener(object : OnSuccessListener<HCaptchaTokenResponse> {
                 override fun onSuccess(result: HCaptchaTokenResponse) {
                     continuation.resume(result.tokenResult)
@@ -57,4 +58,6 @@ suspend fun performPassiveHCaptcha(
 
         hCaptcha.setup(activity, config).verifyWithHCaptcha(activity)
     }
+    hCaptcha.reset()
+    return token
 }

--- a/payments-core/src/main/java/com/stripe/android/hcaptcha/HCaptchaInterface.kt
+++ b/payments-core/src/main/java/com/stripe/android/hcaptcha/HCaptchaInterface.kt
@@ -13,6 +13,7 @@ import com.stripe.hcaptcha.config.HCaptchaSize
 import com.stripe.hcaptcha.task.OnFailureListener
 import com.stripe.hcaptcha.task.OnSuccessListener
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
 
 /**
  * Proxy to access hcaptcha android sdk code safely
@@ -26,18 +27,22 @@ suspend fun performPassiveHCaptcha(
 ): String {
     // TODO(awush): in the future, we should convert the hCaptcha SDK to use a suspend interface instead of callbacks,
     //  then we can eliminate the {{suspendCancelableCoroutine}} here.
-    return suspendCancellableCoroutine { coroutine ->
-        val hcaptcha = HCaptcha.getClient().apply {
+    return suspendCancellableCoroutine { continuation ->
+        val hCaptcha = HCaptcha.getClient().apply {
             addOnSuccessListener(object : OnSuccessListener<HCaptchaTokenResponse> {
                 override fun onSuccess(result: HCaptchaTokenResponse) {
-                    coroutine.resume(result.tokenResult) { _ -> }
+                    continuation.resume(result.tokenResult)
                 }
             })
             addOnFailureListener(object : OnFailureListener {
                 override fun onFailure(exception: HCaptchaException) {
-                    coroutine.resume(exception.hCaptchaError.name) { _ -> }
+                    continuation.resume(exception.hCaptchaError.name)
                 }
             })
+        }
+
+        continuation.invokeOnCancellation {
+            hCaptcha.reset()
         }
 
         val config = HCaptchaConfig(
@@ -50,6 +55,6 @@ suspend fun performPassiveHCaptcha(
             retryPredicate = { _, exception -> exception.hCaptchaError == HCaptchaError.SESSION_TIMEOUT }
         )
 
-        hcaptcha.setup(activity, config).verifyWithHCaptcha(activity)
+        hCaptcha.setup(activity, config).verifyWithHCaptcha(activity)
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
The team [reported](https://stripe.slack.com/archives/C02CCKZSB9R/p1758725978400489) that `RadarSessionTest` became flaky. After running  the test with ShampooRule, I noticed that it would sometimes timeout while hCaptcha was still loading (hCapthca logs it's progress with tag `hCaptchaWebView`).

## Root Cause
The original test had no proper waiting mechanism. It launched a coroutine that starts hCaptcha, but never waited for completion or verified results, making the test pass/fail unpredictably based on timing.

HCaptcha not being reset after use also contributed to the tests being flaky when I tested with the ShampooRule.

## This change:
* Introduces a proper waiting mechanism
* asserts that we get the expected result
* Resets hCaptcha on cancellation and when captcha task is complete

### TODO:
We should use `HCaptchaService` in the `createRadarSession` function. We would add it to the `Stripe.kt` constructor.
This would allow us to write unit tests for the `createRadarSession` function, there are none right now. `HCaptchaService` is also well-tested so the behaviour is predictable.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://stripe.slack.com/archives/C02CCKZSB9R/p1758725978400489

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
