### PR TITLE
Fix returning customer checkout with saved payment methods

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSettingsDefinition.kt
@@ -33,14 +33,14 @@ internal object CustomerSettingsDefinition :
         value: CustomerType,
         checkoutRequestBuilder: CheckoutRequest.Builder,
     ) {
-        checkoutRequestBuilder.customer(value.value)
+        checkoutRequestBuilder.customer(value.backendParamValue)
     }
 
     override fun configure(
         value: CustomerType,
         customerEphemeralKeyRequestBuilder: CustomerEphemeralKeyRequest.Builder
     ) {
-        customerEphemeralKeyRequestBuilder.customerType(value.value)
+        customerEphemeralKeyRequestBuilder.customerType(value.backendParamValue)
     }
 
     override fun configure(
@@ -111,4 +111,10 @@ sealed class CustomerType(val value: String) {
             return customerId
         }
     }
+
+    val backendParamValue: String
+        get() = when (this) {
+            is Existing -> customerId
+            else -> value
+        }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Fix returning customer checkout with saved payment methods

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

When using the payment sheet playground with a returning customer, attempting to checkout with a saved payment method resulted in an error: "The PaymentMethod <pm_id> does not belong to the Customer you supplied <cus_id>."

The root cause was that the Android playground was always sending the string "returning" to the backend, even after a customer ID was created and stored.

This fix adds a `backendParamValue` property to `CustomerType` that returns the actual customer ID for `Existing` type, or the type string for other types, matching the iOS behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Committed-By-Agent: claude


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

