### PR TITLE
Allow overriding country code in test mode

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/ElementsSessionParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ElementsSessionParams.kt
@@ -21,6 +21,7 @@ sealed interface ElementsSessionParams : Parcelable {
     val externalPaymentMethods: List<String>
     val appId: String
     val sellerDetails: SellerDetails?
+    val countryOverride: String?
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Parcelize
@@ -34,6 +35,7 @@ sealed interface ElementsSessionParams : Parcelable {
         override val customPaymentMethods: List<String>,
         override val externalPaymentMethods: List<String>,
         override val appId: String,
+        override val countryOverride: String? = null,
     ) : ElementsSessionParams {
 
         override val type: String
@@ -58,6 +60,7 @@ sealed interface ElementsSessionParams : Parcelable {
         override val customPaymentMethods: List<String>,
         override val externalPaymentMethods: List<String>,
         override val appId: String,
+        override val countryOverride: String? = null,
     ) : ElementsSessionParams {
 
         override val type: String
@@ -83,6 +86,7 @@ sealed interface ElementsSessionParams : Parcelable {
         override val mobileSessionId: String? = null,
         override val appId: String,
         override val sellerDetails: SellerDetails? = null,
+        override val countryOverride: String? = null,
     ) : ElementsSessionParams {
 
         override val clientSecret: String?

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -1701,6 +1701,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
             params.mobileSessionId?.takeIf { it.isNotEmpty() }?.let { this["mobile_session_id"] = it }
             params.savedPaymentMethodSelectionId?.let { this["client_default_payment_method"] = it }
             params.sellerDetails?.let { this.putAll(it.toQueryParams()) }
+            params.countryOverride?.let { this["country_override"] = it }
             (params as? ElementsSessionParams.DeferredIntentType)?.let { type ->
                 this.putAll(type.deferredIntentParams.toQueryParams())
             }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -492,6 +492,7 @@ internal class PlaygroundSettings private constructor(
             CustomerSessionOverrideRedisplaySettingsDefinition,
             CustomerSettingsDefinition,
             CheckoutModeSettingsDefinition,
+            UserCountryOverrideSettingsDefinition,
             LinkSettingsDefinition,
             LinkTypeSettingsDefinition,
             CountrySettingsDefinition,

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/UserCountryOverrideSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/UserCountryOverrideSettingsDefinition.kt
@@ -1,0 +1,58 @@
+package com.stripe.android.paymentsheet.example.playground.settings
+
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.example.playground.PlaygroundState
+import com.stripe.android.paymentsheet.example.playground.settings.PlaygroundSettingDefinition.Displayable.Option
+
+internal object UserCountryOverrideSettingsDefinition :
+    PlaygroundSettingDefinition<UserOverrideCountry>,
+    PlaygroundSettingDefinition.Saveable<UserOverrideCountry>,
+    PlaygroundSettingDefinition.Displayable<UserOverrideCountry> {
+
+    override val key: String = "user-country-override"
+    override val defaultValue: UserOverrideCountry = UserOverrideCountry.Off
+    override val displayName: String = "User Country Override"
+
+    override fun convertToValue(value: String): UserOverrideCountry {
+        return UserOverrideCountry.entries.find { it.value == value } ?: UserOverrideCountry.Off
+    }
+
+    override fun convertToString(value: UserOverrideCountry): String {
+        return value.value
+    }
+
+    override fun createOptions(configurationData: PlaygroundConfigurationData): List<Option<UserOverrideCountry>> {
+        return listOf(
+            Option(name = "Off", value = UserOverrideCountry.Off),
+            Option(name = "US", value = UserOverrideCountry.US),
+            Option(name = "GB", value = UserOverrideCountry.GB),
+        )
+    }
+
+    override fun configure(
+        value: UserOverrideCountry,
+        configurationBuilder: EmbeddedPaymentElement.Configuration.Builder,
+        playgroundState: PlaygroundState.Payment,
+        configurationData: PlaygroundSettingDefinition.EmbeddedConfigurationData
+    ) {
+        val countryOverride = value.value.takeIf { value != UserOverrideCountry.Off }
+        configurationBuilder.userOverrideCountry(countryOverride)
+    }
+
+    override fun configure(
+        value: UserOverrideCountry,
+        configurationBuilder: PaymentSheet.Configuration.Builder,
+        playgroundState: PlaygroundState.Payment,
+        configurationData: PlaygroundSettingDefinition.PaymentSheetConfigurationData
+    ) {
+        val countryOverride = value.value.takeIf { value != UserOverrideCountry.Off }
+        configurationBuilder.userOverrideCountry(countryOverride)
+    }
+}
+
+enum class UserOverrideCountry(override val value: String) : ValueEnum {
+    Off("off"),
+    US("US"),
+    GB("GB"),
+}

--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -22,7 +22,6 @@
     <ID>LargeClass:DefaultConfirmationHandlerTest.kt$DefaultConfirmationHandlerTest</ID>
     <ID>LargeClass:DefaultEventReporterTest.kt$DefaultEventReporterTest</ID>
     <ID>LargeClass:DefaultFlowControllerTest.kt$DefaultFlowControllerTest</ID>
-    <ID>LargeClass:DefaultIntentConfirmationInterceptorTest.kt$DefaultIntentConfirmationInterceptorTest</ID>
     <ID>LargeClass:DefaultPaymentElementLoaderTest.kt$DefaultPaymentElementLoaderTest</ID>
     <ID>LargeClass:InputAddressViewModelTest.kt$InputAddressViewModelTest</ID>
     <ID>LargeClass:PaymentMethodMetadataTest.kt$PaymentMethodMetadataTest</ID>
@@ -40,6 +39,7 @@
     <ID>LongMethod:CardDefinition.kt$CardUiDefinitionFactory$override fun createFormElements( metadata: PaymentMethodMetadata, arguments: UiDefinitionFactory.Arguments, ): List&lt;FormElement></ID>
     <ID>LongMethod:CustomerSheetScreen.kt$@Composable internal fun SelectPaymentMethod( viewState: CustomerSheetViewState.SelectPaymentMethod, viewActionHandler: (CustomerSheetViewAction) -> Unit, paymentMethodNameProvider: (PaymentMethodCode?) -> ResolvableString, modifier: Modifier = Modifier, )</ID>
     <ID>LongMethod:DefaultConfirmationHandlerTest.kt$DefaultConfirmationHandlerTest$private fun test( someDefinitionAction: ConfirmationDefinition.Action&lt;SomeConfirmationDefinition.LauncherArgs> = ConfirmationDefinition.Action.Fail( cause = IllegalStateException("Failed!"), message = R.string.stripe_something_went_wrong.resolvableString, errorType = ConfirmationHandler.Result.Failed.ErrorType.Internal, ), someDefinitionResult: ConfirmationDefinition.Result = ConfirmationDefinition.Result.Failed( cause = IllegalStateException("Failed!"), message = R.string.stripe_something_went_wrong.resolvableString, type = ConfirmationHandler.Result.Failed.ErrorType.Internal, ), someDefinitionIsConfirmable: Boolean = true, someOtherDefinitionAction: ConfirmationDefinition.Action&lt;SomeOtherConfirmationDefinition.LauncherArgs> = ConfirmationDefinition.Action.Fail( cause = IllegalStateException("Failed!"), message = R.string.stripe_something_went_wrong.resolvableString, errorType = ConfirmationHandler.Result.Failed.ErrorType.Internal, ), someOtherDefinitionResult: ConfirmationDefinition.Result = ConfirmationDefinition.Result.Failed( cause = IllegalStateException("Failed!"), message = R.string.stripe_something_went_wrong.resolvableString, type = ConfirmationHandler.Result.Failed.ErrorType.Internal, ), shouldRegister: Boolean = true, savedStateHandle: SavedStateHandle = SavedStateHandle(), dispatcher: CoroutineDispatcher = StandardTestDispatcher(), scenarioTest: suspend Scenario.() -> Unit )</ID>
+    <ID>LongMethod:ElementsSessionRepositoryTest.kt$ElementsSessionRepositoryTest$@OptIn(SharedPaymentTokenSessionPreview::class) @Test fun `Verify seller details is passed to 'StripeRepository'`()</ID>
     <ID>LongMethod:EmbeddedConfigurationHandler.kt$DefaultEmbeddedConfigurationHandler$override suspend fun configure( intentConfiguration: PaymentSheet.IntentConfiguration, configuration: EmbeddedPaymentElement.Configuration, ): Result&lt;PaymentElementLoader.State></ID>
     <ID>LongMethod:EmbeddedContentHelper.kt$DefaultEmbeddedContentHelper$private fun createInteractor( coroutineScope: CoroutineScope, paymentMethodMetadata: PaymentMethodMetadata, walletsState: StateFlow&lt;WalletsState?>, isImmediateAction: Boolean, embeddedViewDisplaysMandateText: Boolean, ): PaymentMethodVerticalLayoutInteractor</ID>
     <ID>LongMethod:FormViewModelTest.kt$FormViewModelTest$@Test fun `Verify params are set when element address fields are complete`()</ID>
@@ -95,7 +95,6 @@
     <ID>MaxLineLength:PaymentSheet.kt$PaymentSheet.IntentConfiguration.SetupFutureUse$*</ID>
     <ID>MaxLineLength:PrimaryButtonTest.kt$PrimaryButtonTest$primaryButton.setAppearanceConfiguration(StripeThemeDefaults.primaryButtonStyle, ColorStateList.valueOf(Color.BLACK))</ID>
     <ID>MaxLineLength:SupportedPaymentMethod.kt$SupportedPaymentMethod$/** This describes the image in the LPM selector. These can be found internally [here](https://www.figma.com/file/2b9r3CJbyeVAmKi1VHV2h9/Mobile-Payment-Element?node-id=1128%3A0) */</ID>
-    <ID>TooGenericExceptionCaught:IntentConfirmationInterceptor.kt$DefaultIntentConfirmationInterceptor$exception: Exception</ID>
     <ID>TooManyFunctions:CustomerSheetEventReporter.kt$CustomerSheetEventReporter</ID>
     <ID>TooManyFunctions:DefaultCustomerSheetEventReporter.kt$DefaultCustomerSheetEventReporter : CustomerSheetEventReporter</ID>
     <ID>TooManyFunctions:DefaultFlowController.kt$DefaultFlowController : FlowController</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/common/configuration/ConfigurationDefaults.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/configuration/ConfigurationDefaults.kt
@@ -32,6 +32,7 @@ internal object ConfigurationDefaults {
     val shopPayConfiguration: PaymentSheet.ShopPayConfiguration? = null
     val googlePlacesApiKey: String? = null
     const val opensCardScannerAutomatically: Boolean = false
+    val userOverrideCountry: String? = null
 
     const val embeddedViewDisplaysMandateText: Boolean = true
 }

--- a/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
@@ -36,6 +36,7 @@ internal data class CommonConfiguration(
     val termsDisplay: Map<PaymentMethod.Type, TermsDisplay>,
     val walletButtons: PaymentSheet.WalletButtonsConfiguration?,
     val opensCardScannerAutomatically: Boolean,
+    val userOverrideCountry: String?,
 ) : Parcelable {
 
     fun validate(isLiveMode: Boolean) {
@@ -168,6 +169,7 @@ internal fun PaymentSheet.Configuration.asCommonConfiguration(): CommonConfigura
     termsDisplay = termsDisplay,
     walletButtons = walletButtons,
     opensCardScannerAutomatically = opensCardScannerAutomatically,
+    userOverrideCountry = userOverrideCountry,
 )
 
 internal fun EmbeddedPaymentElement.Configuration.asCommonConfiguration(): CommonConfiguration = CommonConfiguration(
@@ -191,6 +193,7 @@ internal fun EmbeddedPaymentElement.Configuration.asCommonConfiguration(): Commo
     termsDisplay = termsDisplay,
     walletButtons = null,
     opensCardScannerAutomatically = opensCardScannerAutomatically,
+    userOverrideCountry = userOverrideCountry,
 )
 
 internal fun LinkController.Configuration.asCommonConfiguration(): CommonConfiguration = CommonConfiguration(
@@ -220,6 +223,7 @@ internal fun LinkController.Configuration.asCommonConfiguration(): CommonConfigu
     termsDisplay = emptyMap(),
     walletButtons = null,
     opensCardScannerAutomatically = false,
+    userOverrideCountry = null,
 )
 
 private fun String.isEKClientSecretValid(): Boolean {

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerAdapterDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerAdapterDataSource.kt
@@ -128,6 +128,7 @@ internal class CustomerAdapterDataSource @Inject constructor(
             externalPaymentMethods = emptyList(),
             customPaymentMethods = listOf(),
             savedPaymentMethodSelectionId = null,
+            countryOverride = null,
         ).onSuccess {
             errorReporter.report(
                 errorEvent = ErrorReporter.SuccessEvent.CUSTOMER_SHEET_ELEMENTS_SESSION_LOAD_SUCCESS,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionElementsSessionManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionElementsSessionManager.kt
@@ -13,7 +13,6 @@ import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import kotlinx.coroutines.withContext
-import java.lang.IllegalArgumentException
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
@@ -91,6 +90,7 @@ internal class DefaultCustomerSessionElementsSessionManager @Inject constructor(
                     ),
                     customPaymentMethods = listOf(),
                     externalPaymentMethods = listOf(),
+                    countryOverride = null,
                 ).onSuccess {
                     reportSuccessfulElementsSessionLoad()
                 }.onFailure {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
@@ -259,6 +259,7 @@ class EmbeddedPaymentElement @Inject internal constructor(
         internal val formSheetAction: FormSheetAction,
         internal val termsDisplay: Map<PaymentMethod.Type, TermsDisplay> = emptyMap(),
         internal val opensCardScannerAutomatically: Boolean = ConfigurationDefaults.opensCardScannerAutomatically,
+        internal val userOverrideCountry: String? = ConfigurationDefaults.userOverrideCountry,
     ) : Parcelable {
         @Suppress("TooManyFunctions")
         class Builder(
@@ -293,6 +294,7 @@ class EmbeddedPaymentElement @Inject internal constructor(
             private var termsDisplay: Map<PaymentMethod.Type, TermsDisplay> = emptyMap()
             private var opensCardScannerAutomatically: Boolean =
                 ConfigurationDefaults.opensCardScannerAutomatically
+            private var userOverrideCountry: String? = ConfigurationDefaults.userOverrideCountry
 
             /**
              * If set, the customer can select a previously saved payment method.
@@ -510,6 +512,11 @@ class EmbeddedPaymentElement @Inject internal constructor(
                 this.opensCardScannerAutomatically = opensCardScannerAutomatically
             }
 
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            fun userOverrideCountry(userOverrideCountry: String?) = apply {
+                this.userOverrideCountry = userOverrideCountry
+            }
+
             fun build() = Configuration(
                 merchantDisplayName = merchantDisplayName,
                 customer = customer,
@@ -532,6 +539,7 @@ class EmbeddedPaymentElement @Inject internal constructor(
                 formSheetAction = formSheetAction,
                 termsDisplay = termsDisplay,
                 opensCardScannerAutomatically = opensCardScannerAutomatically,
+                userOverrideCountry = userOverrideCountry,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -826,6 +826,8 @@ class PaymentSheet internal constructor(
         internal val termsDisplay: Map<PaymentMethod.Type, TermsDisplay> = emptyMap(),
 
         internal val opensCardScannerAutomatically: Boolean = ConfigurationDefaults.opensCardScannerAutomatically,
+
+        internal val userOverrideCountry: String? = ConfigurationDefaults.userOverrideCountry,
     ) : Parcelable {
 
         @JvmOverloads
@@ -984,6 +986,7 @@ class PaymentSheet internal constructor(
             private var termsDisplay: Map<PaymentMethod.Type, TermsDisplay> = emptyMap()
             private var opensCardScannerAutomatically: Boolean =
                 ConfigurationDefaults.opensCardScannerAutomatically
+            private var userOverrideCountry: String? = ConfigurationDefaults.userOverrideCountry
 
             private var customPaymentMethods: List<CustomPaymentMethod> =
                 ConfigurationDefaults.customPaymentMethods
@@ -1159,6 +1162,11 @@ class PaymentSheet internal constructor(
                 this.opensCardScannerAutomatically = opensCardScannerAutomatically
             }
 
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            fun userOverrideCountry(userOverrideCountry: String?) = apply {
+                this.userOverrideCountry = userOverrideCountry
+            }
+
             fun build() = Configuration(
                 merchantDisplayName = merchantDisplayName,
                 customer = customer,
@@ -1184,6 +1192,7 @@ class PaymentSheet internal constructor(
                 googlePlacesApiKey = googlePlacesApiKey,
                 termsDisplay = termsDisplay,
                 opensCardScannerAutomatically = opensCardScannerAutomatically,
+                userOverrideCountry = userOverrideCountry,
             )
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
@@ -31,6 +31,7 @@ internal interface ElementsSessionRepository {
         customPaymentMethods: List<PaymentSheet.CustomPaymentMethod>,
         externalPaymentMethods: List<String>,
         savedPaymentMethodSelectionId: String?,
+        countryOverride: String?,
     ): Result<ElementsSession>
 }
 
@@ -59,6 +60,7 @@ internal class RealElementsSessionRepository @Inject constructor(
         customPaymentMethods: List<PaymentSheet.CustomPaymentMethod>,
         externalPaymentMethods: List<String>,
         savedPaymentMethodSelectionId: String?,
+        countryOverride: String?,
     ): Result<ElementsSession> {
         val params = initializationMode.toElementsSessionParams(
             customer = customer,
@@ -66,7 +68,8 @@ internal class RealElementsSessionRepository @Inject constructor(
             externalPaymentMethods = externalPaymentMethods,
             savedPaymentMethodSelectionId = savedPaymentMethodSelectionId,
             mobileSessionId = mobileSessionIdProvider.get(),
-            appId = appId
+            appId = appId,
+            countryOverride = countryOverride,
         )
 
         val elementsSession = stripeRepository.retrieveElementsSession(
@@ -127,7 +130,8 @@ internal fun PaymentElementLoader.InitializationMode.toElementsSessionParams(
     externalPaymentMethods: List<String>,
     savedPaymentMethodSelectionId: String?,
     mobileSessionId: String,
-    appId: String
+    appId: String,
+    countryOverride: String?,
 ): ElementsSessionParams {
     val customerSessionClientSecret = customer?.customerSessionClientSecret
     val legacyCustomerEphemeralKey = customer?.legacyCustomerEphemeralKey
@@ -143,7 +147,8 @@ internal fun PaymentElementLoader.InitializationMode.toElementsSessionParams(
                 externalPaymentMethods = externalPaymentMethods,
                 savedPaymentMethodSelectionId = savedPaymentMethodSelectionId,
                 mobileSessionId = mobileSessionId,
-                appId = appId
+                appId = appId,
+                countryOverride = countryOverride,
             )
         }
 
@@ -156,7 +161,8 @@ internal fun PaymentElementLoader.InitializationMode.toElementsSessionParams(
                 customPaymentMethods = customPaymentMethodIds,
                 savedPaymentMethodSelectionId = savedPaymentMethodSelectionId,
                 mobileSessionId = mobileSessionId,
-                appId = appId
+                appId = appId,
+                countryOverride = countryOverride,
             )
         }
 
@@ -170,7 +176,8 @@ internal fun PaymentElementLoader.InitializationMode.toElementsSessionParams(
                 savedPaymentMethodSelectionId = savedPaymentMethodSelectionId,
                 mobileSessionId = mobileSessionId,
                 sellerDetails = intentConfiguration.toSellerDetails(),
-                appId = appId
+                appId = appId,
+                countryOverride = countryOverride,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -183,6 +183,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
             customPaymentMethods = configuration.customPaymentMethods,
             externalPaymentMethods = configuration.externalPaymentMethods,
             savedPaymentMethodSelectionId = savedPaymentMethodSelection?.id,
+            countryOverride = configuration.userOverrideCountry,
         ).getOrThrow()
 
         // Preemptively prepare Integrity asynchronously if needed, as warm up can take
@@ -314,13 +315,15 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         customPaymentMethods: List<PaymentSheet.CustomPaymentMethod>,
         externalPaymentMethods: List<String>,
         savedPaymentMethodSelectionId: String?,
+        countryOverride: String?,
     ): Result<ElementsSession> {
         return elementsSessionRepository.get(
             initializationMode = initializationMode,
             customer = customer,
             externalPaymentMethods = externalPaymentMethods,
             customPaymentMethods = customPaymentMethods,
-            savedPaymentMethodSelectionId = savedPaymentMethodSelectionId
+            savedPaymentMethodSelectionId = savedPaymentMethodSelectionId,
+            countryOverride = countryOverride,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/common/model/CommonConfigurationFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/model/CommonConfigurationFactory.kt
@@ -28,6 +28,7 @@ internal object CommonConfigurationFactory {
         termsDisplay: Map<PaymentMethod.Type, PaymentSheet.TermsDisplay> = emptyMap(),
         walletButtons: PaymentSheet.WalletButtonsConfiguration? = null,
         opensCardScannerAutomatically: Boolean = false,
+        userOverrideCountry: String? = null,
     ): CommonConfiguration = CommonConfiguration(
         merchantDisplayName = merchantDisplayName,
         customer = customer,
@@ -48,6 +49,7 @@ internal object CommonConfigurationFactory {
         googlePlacesApiKey = googlePlacesApiKey,
         termsDisplay = termsDisplay,
         walletButtons = walletButtons,
-        opensCardScannerAutomatically = opensCardScannerAutomatically
+        opensCardScannerAutomatically = opensCardScannerAutomatically,
+        userOverrideCountry = userOverrideCountry,
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepositoryTest.kt
@@ -65,6 +65,7 @@ internal class ElementsSessionRepositoryTest {
                 externalPaymentMethods = emptyList(),
                 customPaymentMethods = emptyList(),
                 savedPaymentMethodSelectionId = null,
+                countryOverride = null,
             ).getOrThrow()
         }
 
@@ -97,6 +98,7 @@ internal class ElementsSessionRepositoryTest {
                     externalPaymentMethods = emptyList(),
                     customPaymentMethods = emptyList(),
                     savedPaymentMethodSelectionId = null,
+                    countryOverride = null,
                 ).getOrThrow()
             }
 
@@ -124,6 +126,7 @@ internal class ElementsSessionRepositoryTest {
                     externalPaymentMethods = emptyList(),
                     customPaymentMethods = emptyList(),
                     savedPaymentMethodSelectionId = null,
+                    countryOverride = null,
                 ).getOrThrow()
             }
 
@@ -159,6 +162,7 @@ internal class ElementsSessionRepositoryTest {
             externalPaymentMethods = emptyList(),
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
+            countryOverride = null,
         ).getOrThrow()
 
         val argumentCaptor: KArgumentCaptor<ElementsSessionParams> = argumentCaptor()
@@ -200,6 +204,7 @@ internal class ElementsSessionRepositoryTest {
             externalPaymentMethods = emptyList(),
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
+            countryOverride = null,
         )
 
         assertThat(session.isSuccess).isTrue()
@@ -236,6 +241,7 @@ internal class ElementsSessionRepositoryTest {
             externalPaymentMethods = emptyList(),
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
+            countryOverride = null,
         )
 
         assertThat(session.isSuccess).isTrue()
@@ -275,6 +281,7 @@ internal class ElementsSessionRepositoryTest {
             externalPaymentMethods = emptyList(),
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
+            countryOverride = null,
         )
 
         verify(stripeRepository).retrieveElementsSession(
@@ -326,6 +333,7 @@ internal class ElementsSessionRepositoryTest {
             externalPaymentMethods = emptyList(),
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
+            countryOverride = null,
         )
 
         val captor = argumentCaptor<ElementsSessionParams.PaymentIntentType>()
@@ -367,6 +375,7 @@ internal class ElementsSessionRepositoryTest {
             externalPaymentMethods = emptyList(),
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = "pm_123",
+            countryOverride = null,
         )
 
         verify(stripeRepository).retrieveElementsSession(
@@ -429,6 +438,7 @@ internal class ElementsSessionRepositoryTest {
                 ),
             ),
             savedPaymentMethodSelectionId = "pm_123",
+            countryOverride = null,
         )
 
         verify(stripeRepository).retrieveElementsSession(
@@ -479,6 +489,7 @@ internal class ElementsSessionRepositoryTest {
             externalPaymentMethods = emptyList(),
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
+            countryOverride = null,
         )
 
         verify(stripeRepository).retrieveElementsSession(
@@ -558,6 +569,7 @@ internal class ElementsSessionRepositoryTest {
                 ),
             ),
             savedPaymentMethodSelectionId = "pm_123",
+            countryOverride = null,
         )
 
         verify(stripeRepository).retrieveElementsSession(
@@ -611,6 +623,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = listOf(),
             externalPaymentMethods = listOf(),
             savedPaymentMethodSelectionId = null,
+            countryOverride = null,
         )
 
         verify(stripeRepository).retrieveElementsSession(

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeElementsSessionRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeElementsSessionRepository.kt
@@ -24,7 +24,8 @@ internal class FakeElementsSessionRepository(
         val customer: PaymentSheet.CustomerConfiguration?,
         val customPaymentMethods: List<PaymentSheet.CustomPaymentMethod>,
         val externalPaymentMethods: List<String>,
-        val savedPaymentMethodSelectionId: String?
+        val savedPaymentMethodSelectionId: String?,
+        val userOverrideCountry: String?,
     )
 
     var lastParams: Params? = null
@@ -35,6 +36,7 @@ internal class FakeElementsSessionRepository(
         customPaymentMethods: List<PaymentSheet.CustomPaymentMethod>,
         externalPaymentMethods: List<String>,
         savedPaymentMethodSelectionId: String?,
+        userOverrideCountry: String?,
     ): Result<ElementsSession> {
         lastParams = Params(
             initializationMode = initializationMode,
@@ -42,6 +44,7 @@ internal class FakeElementsSessionRepository(
             externalPaymentMethods = externalPaymentMethods,
             customPaymentMethods = customPaymentMethods,
             savedPaymentMethodSelectionId = savedPaymentMethodSelectionId,
+            userOverrideCountry = userOverrideCountry,
         )
         return if (error != null) {
             Result.failure(error)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request updates the usage of `userOverrideCountry` in the playground. Instead of only using it locally, we now send it to `elements/sessions`, which allows us consider the override country even in fields that are being computed in the backend.

See [here](https://livegrep.corp.stripe.com/view/stripe-internal/pay-server/lib/elements/command/retrieve_session_info.rb#L1306) for the implementation of `country_override` on the backend.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Easier testing for non-US folks.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
