### PR TITLE
Remove Pixel 3 from BrowserStack nightly test devices

### DIFF
--- a/scripts/browserstack.py
+++ b/scripts/browserstack.py
@@ -268,7 +268,6 @@ def executeTests(appUrl, testUrl, isNightly):
             "Samsung Galaxy S22-12.0",
             "Google Pixel 5-11.0",
             "Google Pixel 4 XL-10.0",
-            "Google Pixel 3-9.0",
             "Samsung Galaxy S9-8.0",
         ]
     else:


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Remove Google Pixel 3-9.0 from the nightly test device list as it is being deprecated by BrowserStack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Committed-By-Agent: claude

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-4714

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

Didn't explicitly test this -- our nightly run will verify this works as expected