### PR TITLE
Migrate to Dokka 2.0

### DIFF
--- a/.github/workflows/dokka.yml
+++ b/.github/workflows/dokka.yml
@@ -17,4 +17,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/stripe_setup
       - name: Generate Dokka Documentation
-        run: ./gradlew dokkaHtmlMultiModule
+        run: ./gradlew :dokkaGenerate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `./gradlew ktlint` - Run Android lint
 
 **Documentation**
-- `./gradlew dokkaHtmlMultiModule` - Generate API documentation (outputs to docs/)
+- `./gradlew :dokkaGenerate` - Generate API documentation (outputs to docs/)
 
 **Testing Individual Modules**
 - Use module names from settings.gradle: `:payments-core`, `:paymentsheet`, `:financial-connections`, `:identity`, `:connect`, etc.

--- a/build.gradle
+++ b/build.gradle
@@ -86,9 +86,10 @@ nexusPublishing {
 apply plugin: 'binary-compatibility-validator'
 apply plugin: 'org.jetbrains.dokka'
 
-
-tasks.dokkaHtmlMultiModule.configure {
-    outputDirectory = new File("${project.rootDir}/docs")
+dokka {
+    dokkaPublications.html {
+        outputDirectory = new File("${project.rootDir}/docs")
+    }
 }
 
 apiValidation {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -30,7 +30,7 @@ ext.versions = [
         dagger                      : '2.55',
         detekt                      : '1.23.7',
         diskLruCache                : '2.0.2',
-        dokka                       : '1.9.20',
+        dokka                       : '2.0.0',
         espresso                    : '3.6.1',
         firebaseAppDistribution     : '5.1.1',
         fuel                        : '2.3.1',

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,5 +20,7 @@ android.useAndroidX=true
 
 org.gradle.jvmargs=-Xms4g -Xmx8g -XX:+UseParallelGC -XX:MaxMetaspaceSize=2g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2EnabledWithHelpers
+
 # Update StripeSdkVersion.VERSION_NAME when publishing a new release
 VERSION_NAME=21.28.0

--- a/hcaptcha/build.gradle
+++ b/hcaptcha/build.gradle
@@ -39,17 +39,28 @@ android.libraryVariants.all { variant ->
     def variantName = variant.name.capitalize()
     def packageName = "com.stripe.hcaptcha"
     def outputDir = file("${project.buildDir}/generated/source/hcaptcha/${variant.name}/${packageName.replaceAll('\\.', '/')}")
-    def generateTask = project.task("generate${variantName}JavaClassFromStaticHtml") {
+    def generateTask = project.tasks.register("generate${variantName}JavaClassFromStaticHtml") {
         group 'Generate'
         description "Generate HTML java class"
 
+        def outputJavaClass = file("$outputDir/HCaptchaHtml.kt")
+        def templateFile = file("$projectDir/src/main/html/HCaptchaHtml.java.tml")
+        def htmlFile = file("$projectDir/src/main/html/hcaptcha.html")
+
+        outputs.file(outputJavaClass)
+
         doFirst {
-            def outputJavaClass = file("$outputDir/HCaptchaHtml.kt")
-            def template = file("$projectDir/src/main/html/HCaptchaHtml.java.tml").text
-            def html = file("$projectDir/src/main/html/hcaptcha.html")
-                    .readLines()
-                    .stream()
-                    .collect(Collectors.joining("\n"))
+            if (!htmlFile.exists() || !templateFile.exists()) {
+                throw new GradleException(
+                        "Required source files not found: ${templateFile} or ${htmlFile}"
+                )
+            }
+
+            def template = templateFile.text
+            def html = htmlFile
+                .readLines()
+                .stream()
+                .collect(Collectors.joining("\n"))
 
             def engine = new SimpleTemplateEngine()
             def src = engine.createTemplate(template).make([

--- a/hcaptcha/build.gradle
+++ b/hcaptcha/build.gradle
@@ -43,24 +43,13 @@ android.libraryVariants.all { variant ->
         group 'Generate'
         description "Generate HTML java class"
 
-        def outputJavaClass = file("$outputDir/HCaptchaHtml.kt")
-        def templateFile = file("$projectDir/src/main/html/HCaptchaHtml.java.tml")
-        def htmlFile = file("$projectDir/src/main/html/hcaptcha.html")
-
-        outputs.file(outputJavaClass)
-
         doFirst {
-            if (!htmlFile.exists() || !templateFile.exists()) {
-                throw new GradleException(
-                        "Required source files not found: ${templateFile} or ${htmlFile}"
-                )
-            }
-
-            def template = templateFile.text
-            def html = htmlFile
-                .readLines()
-                .stream()
-                .collect(Collectors.joining("\n"))
+            def outputJavaClass = file("$outputDir/HCaptchaHtml.kt")
+            def template = file("$projectDir/src/main/html/HCaptchaHtml.java.tml").text
+            def html = file("$projectDir/src/main/html/hcaptcha.html")
+                    .readLines()
+                    .stream()
+                    .collect(Collectors.joining("\n"))
 
             def engine = new SimpleTemplateEngine()
             def src = engine.createTemplate(template).make([

--- a/scripts/deploy/update_dokka.rb
+++ b/scripts/deploy/update_dokka.rb
@@ -13,7 +13,7 @@ def generate_dokka()
     begin
         execute_or_fail("rm -rf docs/")
         execute_or_fail("./gradlew clean")
-        execute_or_fail("./gradlew dokkaHtmlMultiModule")
+        execute_or_fail("./gradlew :dokkaGenerate")
 
         if docs_did_not_change
             rputs "Skipping updating dokka because there are no dokka changes."


### PR DESCRIPTION
# Summary
Migrate to Dokka 2.0

# Motivation
Dokka 1.0 does not allow for Gradle configuration cache to be enable. This PR upgrades to allow for configuration cache to be enabled in Bitrise.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified