### PR TITLE
Allow re-showing Link inline signup in test mode

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CreateLinkState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CreateLinkState.kt
@@ -148,7 +148,9 @@ internal class DefaultCreateLinkState @Inject constructor(
             add(LinkSignupDisabledReason.SignupOptInFeatureNoEmailProvided)
         }
 
-        if (linkStore.hasUsedLink()) {
+        if (linkStore.hasUsedLink() && elementsSession.stripeIntent.isLiveMode) {
+            // In live mode, we only show the signup if the customer hasn't used Link in the merchant app before.
+            // In test mode, we continue to show it to make testing easier.
             add(LinkSignupDisabledReason.LinkUsedBefore)
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -1545,9 +1545,14 @@ internal class DefaultPaymentElementLoaderTest {
             on { hasUsedLink() } doReturn true
         }
 
+        val stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+            isLiveMode = true,
+        )
+
         val loader = createPaymentElementLoader(
             linkAccountState = AccountStatus.SignedOut,
             linkStore = linkStore,
+            stripeIntent = stripeIntent,
         )
 
         val result = loader.load(
@@ -1750,9 +1755,14 @@ internal class DefaultPaymentElementLoaderTest {
         val linkStore = mock<LinkStore>()
         whenever(linkStore.hasUsedLink()).thenReturn(true)
 
+        val stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+            isLiveMode = true,
+        )
+
         val loader = createPaymentElementLoader(
             linkAccountState = AccountStatus.SignedOut,
             linkStore = linkStore,
+            stripeIntent = stripeIntent,
             linkSettings = createLinkSettings(
                 passthroughModeEnabled = false,
                 linkSignUpOptInFeatureEnabled = true


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request updates the logic for showing the Link inline signup. While we continue to hide the signup after a user has successfully used Link, we now continue to show it if the user is in test mode. This is intended to cause less confusion with merchants during integration and make testing easier.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

https://github.com/stripe/stripe-ios/pull/5477

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
