### PR TITLE
Fix PaymentAuthWebViewActivityViewModel cancellationResult

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModel.kt
@@ -66,7 +66,7 @@ internal class PaymentAuthWebViewActivityViewModel(
                     flowOutcome = if (args.shouldCancelIntentOnUserNavigation) {
                         StripeIntentResult.Outcome.CANCELED
                     } else {
-                        StripeIntentResult.Outcome.SUCCEEDED
+                        StripeIntentResult.Outcome.UNKNOWN
                     },
                     canCancelSource = args.shouldCancelSource
                 ).toBundle()

--- a/payments-core/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModelTest.kt
@@ -52,7 +52,7 @@ class PaymentAuthWebViewActivityViewModelTest {
         val intent = viewModel.cancellationResult
         val resultIntent = PaymentFlowResult.Unvalidated.fromIntent(intent)
         assertThat(resultIntent.flowOutcome)
-            .isEqualTo(StripeIntentResult.Outcome.SUCCEEDED)
+            .isEqualTo(StripeIntentResult.Outcome.UNKNOWN)
         assertThat(resultIntent.canCancelSource)
             .isTrue()
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Update `PaymentAuthWebViewActivityViewModel` to default to `StripeIntent.Outcome.UNKNOWN` if user cancels

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Prevent WeChatPay incorrectly showing successful payment after closing auth web view.
This matches the behavior in [StripeBrowserLauncherViewModel](https://github.com/stripe/stripe-android/blob/8f2f209fe30e/payments-core/src/main/java/com/stripe/android/payments/StripeBrowserLauncherViewModel.kt#L82) which uses the default value for `PaymentFlowResult.Unvalidated` outcome which is [UNKNOWN](https://github.com/stripe/stripe-android/blob/8f2f209fe30e/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResult.kt#L28)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| https://github.com/user-attachments/assets/879299df-e8a0-4d29-ae03-06410d0fa0a0  | https://github.com/user-attachments/assets/33b74b3c-61d5-4115-bd66-28b6e7573832 |


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
