### PR TITLE
Revert adding the payment method header when there is a single payment method type

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/EmbeddedFormInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/EmbeddedFormInteractorFactory.kt
@@ -14,7 +14,6 @@ import com.stripe.android.paymentsheet.ui.transformToPaymentSelection
 import com.stripe.android.paymentsheet.verticalmode.DefaultVerticalModeFormInteractor
 import com.stripe.android.paymentsheet.verticalmode.PaymentMethodIncentiveInteractor
 import com.stripe.android.uicore.utils.mapAsStateFlow
-import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -82,8 +81,6 @@ internal class EmbeddedFormInteractorFactory @Inject constructor(
             ),
             isLiveMode = paymentMethodMetadata.stripeIntent.isLiveMode,
             processing = formActivityStateHelper.state.mapAsStateFlow { it.isProcessing },
-            // Should never show wallets header in Embedded form
-            showsWalletHeader = stateFlowOf(false),
             paymentMethodIncentive = PaymentMethodIncentiveInteractor(
                 paymentMethodMetadata.paymentMethodIncentive
             ).displayedIncentive,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityUI.kt
@@ -61,6 +61,7 @@ internal fun FormActivityUI(
             content = {
                 VerticalModeFormUI(
                     interactor = interactor,
+                    showsWalletHeader = false
                 )
                 USBankAccountMandate(state)
                 FormActivityError(state)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
@@ -328,6 +328,7 @@ internal sealed interface PaymentSheetScreen {
 
     class VerticalModeForm(
         private val interactor: VerticalModeFormInteractor,
+        private val showsWalletHeader: Boolean = false,
     ) : PaymentSheetScreen, Closeable {
 
         override val buyButtonState = stateFlowOf(
@@ -353,12 +354,12 @@ internal sealed interface PaymentSheetScreen {
         }
 
         override fun showsWalletsHeader(isCompleteFlow: Boolean): StateFlow<Boolean> {
-            return interactor.state.mapAsStateFlow { it.showsWalletHeader }
+            return stateFlowOf(showsWalletHeader)
         }
 
         @Composable
         override fun Content(modifier: Modifier) {
-            VerticalModeFormUI(interactor, modifier)
+            VerticalModeFormUI(interactor, showsWalletHeader, modifier)
         }
 
         override fun close() {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUI.kt
@@ -34,6 +34,7 @@ const val TEST_TAG_HEADER_TITLE = "TEST_TAG_HEADER_TITLE"
 @Composable
 internal fun VerticalModeFormUI(
     interactor: VerticalModeFormInteractor,
+    showsWalletHeader: Boolean,
     modifier: Modifier = Modifier
 ) {
     val horizontalPadding = StripeTheme.getOuterFormInsets()
@@ -42,9 +43,9 @@ internal fun VerticalModeFormUI(
     val state by interactor.state.collectAsState()
 
     Column(modifier) {
-        val headerInformation = state.formHeader
+        val headerInformation = state.headerInformation
         val enabled = !state.isProcessing
-        if (headerInformation != null) {
+        if (headerInformation != null && !showsWalletHeader) {
             VerticalModeFormHeaderUI(isEnabled = enabled, formHeaderInformation = headerInformation)
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactory.kt
@@ -32,6 +32,7 @@ internal object VerticalModeInitialScreenFactory {
                         customerStateHolder = customerStateHolder,
                         bankFormInteractor = bankFormInteractor,
                     ),
+                    showsWalletHeader = true,
                 )
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenVerticalModeFormTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenVerticalModeFormTest.kt
@@ -2,8 +2,6 @@ package com.stripe.android.paymentsheet.navigation
 
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
-import com.stripe.android.paymentsheet.forms.FormArgumentsFactory
 import com.stripe.android.paymentsheet.verticalmode.VerticalModeFormInteractor
 import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.flow.StateFlow
@@ -43,58 +41,6 @@ internal class PaymentSheetScreenVerticalModeFormTest {
         val interactor = FakeVerticalModeFormInteractor(onClose = { hasCalledOnClose = true })
         PaymentSheetScreen.VerticalModeForm(interactor).close()
         assertThat(hasCalledOnClose).isTrue()
-    }
-
-    @Test
-    fun `showWalletsHeader is true when interactor state is true`() = runTest {
-        val interactor = FakeVerticalModeFormInteractor(
-            state = stateFlowOf(
-                VerticalModeFormInteractor.State(
-                    selectedPaymentMethodCode = "card",
-                    isProcessing = false,
-                    isValidating = false,
-                    usBankAccountFormArguments = mock(),
-                    formArguments = FormArgumentsFactory.create(
-                        paymentMethodCode = "card",
-                        metadata = PaymentMethodMetadataFactory.create(),
-                    ),
-                    formElements = emptyList(),
-                    showsWalletHeader = false,
-                    paymentMethodIncentive = null,
-                    headerInformation = null,
-                )
-            )
-        )
-
-        PaymentSheetScreen.VerticalModeForm(interactor).showsWalletsHeader(isCompleteFlow = true).test {
-            assertThat(awaitItem()).isFalse()
-        }
-    }
-
-    @Test
-    fun `showWalletsHeader is false when interactor state is false`() = runTest {
-        val interactor = FakeVerticalModeFormInteractor(
-            state = stateFlowOf(
-                VerticalModeFormInteractor.State(
-                    selectedPaymentMethodCode = "card",
-                    isProcessing = false,
-                    isValidating = false,
-                    usBankAccountFormArguments = mock(),
-                    formArguments = FormArgumentsFactory.create(
-                        paymentMethodCode = "card",
-                        metadata = PaymentMethodMetadataFactory.create(),
-                    ),
-                    formElements = emptyList(),
-                    showsWalletHeader = true,
-                    paymentMethodIncentive = null,
-                    headerInformation = null,
-                )
-            )
-        )
-
-        PaymentSheetScreen.VerticalModeForm(interactor).showsWalletsHeader(isCompleteFlow = true).test {
-            assertThat(awaitItem()).isTrue()
-        }
     }
 
     private class FakeVerticalModeFormInteractor(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultVerticalModeFormInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultVerticalModeFormInteractorTest.kt
@@ -8,7 +8,6 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.isInstanceOf
-import com.stripe.android.lpmfoundations.FormHeaderInformation
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.model.PaymentMethodFixtures
@@ -235,62 +234,6 @@ internal class DefaultVerticalModeFormInteractorTest {
         FeatureFlags.cardScanGooglePayMigration.setEnabled(false)
     }
 
-    @Test
-    fun `'headerInformation' is not null if 'showWalletsHeaders' is false`() {
-        val headerInformation = FormHeaderInformation(
-            displayName = "Card".resolvableString,
-            shouldShowIcon = false,
-            iconResource = 0,
-            iconResourceNight = null,
-            lightThemeIconUrl = null,
-            darkThemeIconUrl = null,
-            iconRequiresTinting = false,
-            promoBadge = null,
-        )
-
-        runScenario(
-            selectedPaymentMethodCode = "card",
-            headerInformation = headerInformation,
-        ) {
-            showWalletsHeaderSource.emit(false)
-
-            interactor.state.test {
-                val state = awaitItem()
-
-                assertThat(state.showsWalletHeader).isFalse()
-                assertThat(state.formHeader).isEqualTo(headerInformation)
-            }
-        }
-    }
-
-    @Test
-    fun `'headerInformation' is null if 'showWalletsHeaders' is true`() {
-        val headerInformation = FormHeaderInformation(
-            displayName = "Card".resolvableString,
-            shouldShowIcon = false,
-            iconResource = 0,
-            iconResourceNight = null,
-            lightThemeIconUrl = null,
-            darkThemeIconUrl = null,
-            iconRequiresTinting = false,
-            promoBadge = null,
-        )
-
-        runScenario(
-            selectedPaymentMethodCode = "card",
-            headerInformation = headerInformation,
-        ) {
-            showWalletsHeaderSource.emit(true)
-
-            interactor.state.test {
-                val state = awaitItem()
-
-                assertThat(state.showsWalletHeader).isTrue()
-                assertThat(state.formHeader).isNull()
-            }
-        }
-    }
-
     private fun testSetAsDefaultElements(
         hasSavedPaymentMethods: Boolean,
         block: (SaveForFutureUseElement?, SetAsDefaultPaymentMethodElement?) -> Unit
@@ -385,13 +328,11 @@ internal class DefaultVerticalModeFormInteractorTest {
     private fun runScenario(
         selectedPaymentMethodCode: String,
         formElements: List<FormElement> = emptyList(),
-        headerInformation: FormHeaderInformation? = null,
         testBlock: suspend TestParams.() -> Unit,
     ) {
         val formArguments = mock<FormArguments>()
         val usBankAccountArguments = mock<USBankAccountFormArguments>()
         val processing: MutableStateFlow<Boolean> = MutableStateFlow(false)
-        val showWalletsHeader: MutableStateFlow<Boolean> = MutableStateFlow(false)
         val validationRequested = MutableSharedFlow<Unit>()
 
         val onFormFieldValuesChangedTurbine = Turbine<Pair<FormFieldValues?, String>>()
@@ -408,20 +349,18 @@ internal class DefaultVerticalModeFormInteractorTest {
             reportFieldInteraction = {
                 reportFieldInteractionTurbine.add(it)
             },
-            headerInformation = headerInformation,
+            headerInformation = null,
             isLiveMode = true,
             processing = processing,
             validationRequested = validationRequested,
             coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
             paymentMethodIncentive = stateFlowOf(null),
-            showsWalletHeader = showWalletsHeader,
             uiContext = UnconfinedTestDispatcher(),
         )
 
         TestParams(
             interactor = interactor,
             processingSource = processing,
-            showWalletsHeaderSource = showWalletsHeader,
             validationRequestedSource = validationRequested,
             onFormFieldValuesChangedTurbine = onFormFieldValuesChangedTurbine,
             reportFieldInteractionTurbine = reportFieldInteractionTurbine,
@@ -439,7 +378,6 @@ internal class DefaultVerticalModeFormInteractorTest {
     private class TestParams(
         val interactor: DefaultVerticalModeFormInteractor,
         val processingSource: MutableStateFlow<Boolean>,
-        val showWalletsHeaderSource: MutableStateFlow<Boolean>,
         val validationRequestedSource: MutableSharedFlow<Unit>,
         val onFormFieldValuesChangedTurbine: ReceiveTurbine<Pair<FormFieldValues?, String>>,
         val reportFieldInteractionTurbine: ReceiveTurbine<String>,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakeVerticalModeFormInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakeVerticalModeFormInteractor.kt
@@ -29,7 +29,6 @@ internal class FakeVerticalModeFormInteractor private constructor(
             metadata: PaymentMethodMetadata,
             isProcessing: Boolean = false,
             isValidating: Boolean = false,
-            showsWalletHeader: Boolean = false,
         ): VerticalModeFormInteractor {
             val formArguments = FormArgumentsFactory.create(
                 paymentMethodCode = paymentMethodCode,
@@ -54,8 +53,6 @@ internal class FakeVerticalModeFormInteractor private constructor(
                         uiDefinitionFactoryArgumentsFactory = uiDefinitionArgumentsFactory,
                     )!!,
                     isValidating = isValidating,
-                    showsWalletHeader = showsWalletHeader,
-                    paymentMethodIncentive = null,
                     headerInformation = metadata.formHeaderInformationForCode(
                         code = paymentMethodCode,
                         customerHasSavedPaymentMethods = false,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUIScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUIScreenshotTest.kt
@@ -368,8 +368,8 @@ internal class VerticalModeFormUIScreenshotTest {
             FakeVerticalModeFormInteractor.create(
                 paymentMethodCode = "card",
                 metadata = metadata,
-                showsWalletHeader = true,
             ),
+            showsWalletHeader = true,
         )
         val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen, canGoBack = false)
         viewModel.walletsStateSource.value = WalletsState(
@@ -464,8 +464,8 @@ internal class VerticalModeFormUIScreenshotTest {
                     paymentMethodCode = paymentMethodCode,
                     metadata = metadata,
                     isProcessing = isProcessing,
-                    showsWalletHeader = showsWalletHeader,
                 ),
+                showsWalletHeader = showsWalletHeader,
             )
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUITest.kt
@@ -127,7 +127,7 @@ internal class VerticalModeFormUITest {
                 LocalCardNumberCompletedEventReporter provides { },
                 LocalCardBrandDisallowedReporter provides { }
             ) {
-                VerticalModeFormUI(interactor)
+                VerticalModeFormUI(interactor, showsWalletHeader = false)
             }
         }
 
@@ -175,8 +175,6 @@ internal class VerticalModeFormUITest {
             ),
             formElements = CardDefinition.formElements(),
             isValidating = false,
-            showsWalletHeader = false,
-            paymentMethodIncentive = null,
             headerInformation = headerInformation,
         )
     }
@@ -207,8 +205,6 @@ internal class VerticalModeFormUITest {
             ),
             formElements = emptyList(),
             isValidating = false,
-            showsWalletHeader = false,
-            paymentMethodIncentive = null,
             headerInformation = headerInformation,
         )
     }
@@ -243,8 +239,6 @@ internal class VerticalModeFormUITest {
             ),
             formElements = KlarnaDefinition.formElements(paymentMethodMetadata),
             isValidating = false,
-            showsWalletHeader = false,
-            paymentMethodIncentive = null,
             headerInformation = headerInformation,
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactoryTest.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentsheet.verticalmode
 
 import androidx.lifecycle.SavedStateHandle
-import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.isInstanceOf
 import com.stripe.android.link.TestFactory
@@ -39,10 +38,6 @@ class VerticalModeInitialScreenFactoryTest {
     ) {
         assertThat(screens).hasSize(1)
         assertThat(screens[0]).isInstanceOf<PaymentSheetScreen.VerticalModeForm>()
-
-        screens[0].showsWalletsHeader(isCompleteFlow = false).test {
-            assertThat(awaitItem()).isFalse()
-        }
     }
 
     @Test


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Revert adding the payment method header when there is a single payment method type

Reverts this part of https://github.com/stripe/stripe-android/pull/11582: "Also adds the payment method header when there is a single payment method type"

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Introduces a bug where wallet buttons are shown more often than expected

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified

# Screen recording

https://github.com/user-attachments/assets/69d4dd82-99b4-4312-9b99-7cff87270969

