### PR TITLE
Add validation to reject restricted keys in ApiKeyValidator

### DIFF
--- a/stripe-core/src/main/java/com/stripe/android/core/ApiKeyValidator.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/ApiKeyValidator.kt
@@ -18,6 +18,12 @@ class ApiKeyValidator {
                 "For more info, see https://stripe.com/docs/keys"
         }
 
+        require(!apiKey.startsWith("rk_")) {
+            "Invalid Publishable Key: " +
+                "You are using a restricted key instead of a publishable one. " +
+                "For more info, see https://stripe.com/docs/keys"
+        }
+
         return apiKey
     }
 


### PR DESCRIPTION
Restricted keys (rk_ prefix) should not be used as publishable keys. Added validation check alongside existing secret key validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Committed-By-Agent: claude

# Motivation
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-4723
iOS PR here: https://github.com/stripe/stripe-ios/pull/5664

# Testing
Untested

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
Don't think this is worth calling out.