### PR TITLE
Update PaymentFlowResultProcessor to separate Poll and Refresh logic

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
@@ -272,7 +272,7 @@ constructor(
             requiresMandate = false,
             requiresMandateForPaymentIntent = false,
             hasDelayedSettlement = false,
-            afterRedirectAction = AfterRedirectAction.Refresh(),
+            afterRedirectAction = AfterRedirectAction.Refresh,
         ),
         P24(
             "p24",
@@ -374,7 +374,7 @@ constructor(
             requiresMandate = false,
             requiresMandateForPaymentIntent = false,
             hasDelayedSettlement = false,
-            afterRedirectAction = AfterRedirectAction.Refresh(pollingDuration = MAX_POLLING_DURATION),
+            afterRedirectAction = AfterRedirectAction.Poll(pollingDuration = MAX_POLLING_DURATION),
         ),
         Klarna(
             "klarna",
@@ -383,7 +383,7 @@ constructor(
             requiresMandate = true,
             requiresMandateForPaymentIntent = false,
             hasDelayedSettlement = false,
-            afterRedirectAction = AfterRedirectAction.Refresh(),
+            afterRedirectAction = AfterRedirectAction.Refresh,
         ),
         Affirm(
             "affirm",
@@ -490,7 +490,7 @@ constructor(
             requiresMandate = true,
             requiresMandateForPaymentIntent = false,
             hasDelayedSettlement = false,
-            afterRedirectAction = AfterRedirectAction.Refresh(),
+            afterRedirectAction = AfterRedirectAction.Refresh,
         ),
         Boleto(
             code = "boleto",
@@ -597,9 +597,12 @@ constructor(
         }
 
         @Parcelize
-        data class Refresh(override val pollingDuration: Long = 0L) : AfterRedirectAction {
+        data object Refresh : AfterRedirectAction {
             @IgnoredOnParcel
             override val shouldRefreshOrRetrieve: Boolean = true
+
+            @IgnoredOnParcel
+            override val pollingDuration: Long = 0L
         }
     }
 

--- a/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
@@ -66,13 +66,22 @@ internal sealed class PaymentFlowResultProcessor<T : StripeIntent, out S : Strip
                         failureMessageFactory.create(stripeIntent, result.flowOutcome)
                     )
                 }
-                shouldRefreshIntent(stripeIntent, result.flowOutcome) -> {
-                    val intent = refreshStripeIntentUntilTerminalState(
-                        stripeIntent,
-                        result.clientSecret,
-                        requestOptions,
-                        initialRetrieveIntentStartTime
-                    ).getOrThrow()
+                shouldRefreshOrPollIntent(stripeIntent, result.flowOutcome) -> {
+                    val intent = if (shouldCallRefreshIntent(stripeIntent)) {
+                        refreshStripeIntent(
+                            clientSecret = result.clientSecret,
+                            requestOptions = requestOptions,
+                            expandFields = EXPAND_PAYMENT_METHOD
+                        ).getOrThrow()
+                    } else {
+                        pollStripeIntentUntilTerminalState(
+                            originalIntent = stripeIntent,
+                            clientSecret = result.clientSecret,
+                            requestOptions = requestOptions,
+                            initialRetrieveIntentStartTime = initialRetrieveIntentStartTime
+                        ).getOrThrow()
+                    }
+
                     val flowOutcome = determineFlowOutcome(intent, result.flowOutcome)
                     createStripeIntentResult(
                         intent,
@@ -127,7 +136,7 @@ internal sealed class PaymentFlowResultProcessor<T : StripeIntent, out S : Strip
         return shouldCancelSource && stripeIntent.requiresAction()
     }
 
-    private fun shouldRefreshIntent(
+    private fun shouldRefreshOrPollIntent(
         stripeIntent: StripeIntent,
         @StripeIntentResult.Outcome flowOutcome: Int
     ): Boolean {
@@ -190,7 +199,7 @@ internal sealed class PaymentFlowResultProcessor<T : StripeIntent, out S : Strip
     ): Result<T>
 
     /**
-     * Keeps polling refresh endpoint for this [StripeIntent] until its status is no longer
+     * Keeps polling retrieve endpoint for this [StripeIntent] until its status is no longer
      * "requires_action".
      *
      * @param clientSecret for the intent
@@ -199,57 +208,49 @@ internal sealed class PaymentFlowResultProcessor<T : StripeIntent, out S : Strip
      *
      * @return a [StripeIntent] object with a deterministic state.
      */
-    private suspend fun refreshStripeIntentUntilTerminalState(
+    private suspend fun pollStripeIntentUntilTerminalState(
         originalIntent: StripeIntent,
         clientSecret: String,
         requestOptions: ApiRequest.Options,
         initialRetrieveIntentStartTime: Long
     ): Result<T> {
-        var timeOfLastRequest = System.currentTimeMillis()
-        var stripeIntentResult = refreshOrRetrieveIntent(originalIntent, clientSecret, requestOptions)
+        var timeOfLastRequest = initialRetrieveIntentStartTime
+        var stripeIntentResult: Result<T>? = null
 
         val timeRemaining = getPollingDurationForPaymentMethod(originalIntent) -
             (System.currentTimeMillis() - initialRetrieveIntentStartTime)
 
         withTimeoutOrNull(timeRemaining) {
+            stripeIntentResult = retrieveStripeIntent(clientSecret, requestOptions, EXPAND_PAYMENT_METHOD)
             while (shouldRetry(stripeIntentResult)) {
                 // We want to delay a maximum of 1s between requests, including the time the request took.
                 // e.g. if the previous request took 250ms, the delay will be 750ms
                 delay(POLLING_DELAY - (System.currentTimeMillis() - timeOfLastRequest))
                 timeOfLastRequest = System.currentTimeMillis()
-                stripeIntentResult = refreshOrRetrieveIntent(originalIntent, clientSecret, requestOptions)
+                stripeIntentResult = retrieveStripeIntent(clientSecret, requestOptions, EXPAND_PAYMENT_METHOD)
             }
         }
 
-        if (shouldRetry(stripeIntentResult)) {
-            stripeIntentResult = refreshOrRetrieveIntent(originalIntent, clientSecret, requestOptions)
+        // Retrieve final time if intent not in terminal state OR result is null which is possible if the initial
+        // request took longer than the polling duration for the payment method. Ensures we always call retrieve
+        // at least once after the polling duration
+        if (shouldRetry(stripeIntentResult) || stripeIntentResult == null) {
+            stripeIntentResult = retrieveStripeIntent(clientSecret, requestOptions, EXPAND_PAYMENT_METHOD)
         }
 
-        return stripeIntentResult
+        return stripeIntentResult as Result<T>
+    }
+
+    private fun shouldRetry(stripeIntentResult: Result<StripeIntent>?): Boolean {
+        val stripeIntent = stripeIntentResult?.getOrNull() ?: return true
+        val requiresAction = stripeIntent.requiresAction()
+        val isCardPaymentProcessing = stripeIntent.status == StripeIntent.Status.Processing &&
+            stripeIntent.paymentMethod?.type == PaymentMethod.Type.Card
+        return requiresAction || isCardPaymentProcessing
     }
 
     private fun getPollingDurationForPaymentMethod(stripeIntent: StripeIntent): Long {
         return stripeIntent.paymentMethod?.type?.afterRedirectAction?.pollingDuration ?: MAX_POLLING_DURATION
-    }
-
-    private suspend fun refreshOrRetrieveIntent(
-        originalIntent: StripeIntent,
-        clientSecret: String,
-        requestOptions: ApiRequest.Options,
-    ): Result<T> {
-        return if (shouldCallRefreshIntent(originalIntent)) {
-            refreshStripeIntent(
-                clientSecret = clientSecret,
-                requestOptions = requestOptions,
-                expandFields = EXPAND_PAYMENT_METHOD
-            )
-        } else {
-            retrieveStripeIntent(
-                clientSecret = clientSecret,
-                requestOptions = requestOptions,
-                expandFields = EXPAND_PAYMENT_METHOD
-            )
-        }
     }
 
     /**

--- a/payments-core/src/test/java/com/stripe/android/payments/SetupIntentFlowResultProcessorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/SetupIntentFlowResultProcessorTest.kt
@@ -7,11 +7,9 @@ import com.stripe.android.SetupIntentResult
 import com.stripe.android.StripeIntentResult
 import com.stripe.android.core.Logger
 import com.stripe.android.core.networking.ApiRequest
-import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.StripeRepository
-import com.stripe.android.payments.PaymentIntentFlowResultProcessorTest.Companion.MINIMUM_RETRIEVE_CALLS
 import com.stripe.android.testing.PaymentMethodFactory
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -20,7 +18,6 @@ import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.atLeast
 import org.mockito.kotlin.atLeastOnce
-import org.mockito.kotlin.atMost
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -162,16 +159,7 @@ internal class SetupIntentFlowResultProcessorTest {
 
             verify(
                 mockStripeRepository,
-                atLeast(MINIMUM_RETRIEVE_CALLS)
-            ).retrieveSetupIntent(
-                eq(clientSecret),
-                eq(requestOptions),
-                eq(PaymentFlowResultProcessor.EXPAND_PAYMENT_METHOD)
-            )
-
-            verify(
-                mockStripeRepository,
-                atMost(getMaxNumberOfInvocations(PaymentMethod.Type.Card))
+                atLeast(2)
             ).retrieveSetupIntent(
                 eq(clientSecret),
                 eq(requestOptions),
@@ -221,16 +209,7 @@ internal class SetupIntentFlowResultProcessorTest {
 
             verify(
                 mockStripeRepository,
-                atLeast(MINIMUM_RETRIEVE_CALLS)
-            ).retrieveSetupIntent(
-                any(),
-                any(),
-                any(),
-            )
-
-            verify(
-                mockStripeRepository,
-                atMost(getMaxNumberOfInvocations(paymentMethod.type!!))
+                atLeast(2)
             ).retrieveSetupIntent(
                 any(),
                 any(),
@@ -343,16 +322,7 @@ internal class SetupIntentFlowResultProcessorTest {
 
             verify(
                 mockStripeRepository,
-                atLeast(MINIMUM_RETRIEVE_CALLS)
-            ).retrieveSetupIntent(
-                any(),
-                any(),
-                any(),
-            )
-
-            verify(
-                mockStripeRepository,
-                atMost(getMaxNumberOfInvocations(paymentMethod.type!!))
+                atLeast(2)
             ).retrieveSetupIntent(
                 any(),
                 any(),
@@ -396,7 +366,7 @@ internal class SetupIntentFlowResultProcessorTest {
         }
 
     @Test
-    fun `Stops polling after max retries when encountering a Revolut Pay payment that still requires action`() =
+    fun `Stops polling after max time when encountering a Revolut Pay payment that still requires action`() =
         runTest(testDispatcher) {
             val paymentMethod = PaymentMethodFactory.revolutPay()
             val requiresActionIntent = SetupIntentFixtures.SI_SUCCEEDED.copy(
@@ -428,16 +398,7 @@ internal class SetupIntentFlowResultProcessorTest {
 
             verify(
                 mockStripeRepository,
-                atLeast(MINIMUM_RETRIEVE_CALLS)
-            ).retrieveSetupIntent(
-                any(),
-                any(),
-                any(),
-            )
-
-            verify(
-                mockStripeRepository,
-                atMost(getMaxNumberOfInvocations(paymentMethod.type!!))
+                atLeast(2)
             ).retrieveSetupIntent(
                 any(),
                 any(),


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Rename `shouldRefreshIntent` to `shouldRefreshOrPollIntent`
Move refresh logic out of `refreshStripeIntentUntilTerminalState`
- Call `shouldCallRefreshIntent` in `processResult`, if true, call refresh endpoint and return result, else enter polling flow
Rename `refreshStripeIntentUntilTerminalState` to `pollStripeIntentUntilTerminalState`
Change WeChatPay AfterRedirectAction to Poll from Refresh

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
## Improve polling behavior under slow network conditions for cancels e.g. assuming network requests take 5s
Before:
- Initial retrieve (5s)
- First retrieve in `refreshStripeIntentUntilTerminalState` (renamed to `pollStripeIntentUntilTerminalState`) (5s)
- withTimeoutOrNull returns null immediately as we've reached the polling duration
- Final retrieve in `refreshStripeIntentUntilTerminalState` (5s)
- Total time: 15s

After:
- Initial retrieve (5s)
- withTimeoutOrNull returns null immediately, first retrieve skipped as well as it has been moved into withTimeoutOrNull
- final retrieve (5s)
- Total time: 10s

## WeChatPay
WeChatPay was marked as `AfterRedirectAction.Refresh` and did call the refresh endpoint, but the intent did not actually update successfully on the first try, so we would enter a polling loop for WeChatPay unlike all other refresh LPMs. This was controlled by having a polling duration (previously [max retries](https://github.com/stripe/stripe-android/pull/11593)) set for WeChatPay. This necessitated some weird logic in the polling/refresh flow. By setting WeChatPay to Poll we get the same result but are able to better separate polling and refresh logic.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
