### PR TITLE
Reduce overhead of checking mutually exclusive callbacks

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/callbacks/PaymentElementCallbacks.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/callbacks/PaymentElementCallbacks.kt
@@ -87,17 +87,23 @@ internal data class PaymentElementCallbacks private constructor(
         }
 
         fun build(): PaymentElementCallbacks {
-            setOf(createIntentCallback, createIntentWithConfirmationTokenCallback, preparePaymentMethodHandler)
-                .count { it != null }
-                .let {
-                    if (it > 1) {
-                        throw IllegalArgumentException(
-                            "Only one of createIntentCallback, " +
-                                "createIntentWithConfirmationTokenCallback or " +
-                                "preparePaymentMethodHandler can be set"
-                        )
-                    }
-                }
+            var mutualExclusiveCallbackCount = 0
+            if (createIntentCallback != null) {
+                mutualExclusiveCallbackCount++
+            }
+            if (createIntentWithConfirmationTokenCallback != null) {
+                mutualExclusiveCallbackCount++
+            }
+            if (preparePaymentMethodHandler != null) {
+                mutualExclusiveCallbackCount++
+            }
+            if (mutualExclusiveCallbackCount > 1) {
+                throw IllegalArgumentException(
+                    "Only one of createIntentCallback, " +
+                        "createIntentWithConfirmationTokenCallback or " +
+                        "preparePaymentMethodHandler can be set"
+                )
+            }
 
             return PaymentElementCallbacks(
                 createIntentCallback = createIntentCallback,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Use a counter instead of set + count function.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://github.com/stripe/stripe-android/pull/11679#discussion_r2411408969

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
