### PR TITLE
Add flag to enable attestation on intent confirmation

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/ElementsSession.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ElementsSession.kt
@@ -81,6 +81,9 @@ data class ElementsSession(
     val linkSignUpOptInInitialValue: Boolean
         get() = linkSettings?.linkSignUpOptInInitialValue ?: false
 
+    val enableAttestationOnIntentConfirmation: Boolean
+        get() = flags[Flag.ELEMENTS_MOBILE_ATTEST_ON_INTENT_CONFIRMATION] == true
+
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Parcelize
     data class LinkSettings(
@@ -228,7 +231,8 @@ data class ElementsSession(
         ELEMENTS_ENABLE_PASSIVE_CAPTCHA("elements_enable_passive_captcha"),
         ELEMENTS_MOBILE_FORCE_SETUP_FUTURE_USE_BEHAVIOR_AND_NEW_MANDATE_TEXT(
             "elements_mobile_force_setup_future_use_behavior_and_new_mandate_text"
-        )
+        ),
+        ELEMENTS_MOBILE_ATTEST_ON_INTENT_CONFIRMATION("elements_mobile_attest_on_intent_confirmation")
     }
 
     /**

--- a/payments-core/src/test/java/com/stripe/android/model/ElementsSessionTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/ElementsSessionTest.kt
@@ -91,6 +91,42 @@ class ElementsSessionTest {
             .isEqualTo("elements_enable_passive_captcha")
     }
 
+    @Test
+    fun `ELEMENTS_MOBILE_ATTEST_ON_INTENT_CONFIRMATION flag has correct value`() {
+        assertThat(ElementsSession.Flag.ELEMENTS_MOBILE_ATTEST_ON_INTENT_CONFIRMATION.flagValue)
+            .isEqualTo("elements_mobile_attest_on_intent_confirmation")
+    }
+
+    @Test
+    fun `enableAttestationOnIntentConfirmation returns true when flag is enabled`() {
+        val session = createElementsSession(
+            passiveCaptcha = null,
+            flags = mapOf(ElementsSession.Flag.ELEMENTS_MOBILE_ATTEST_ON_INTENT_CONFIRMATION to true)
+        )
+
+        assertThat(session.enableAttestationOnIntentConfirmation).isTrue()
+    }
+
+    @Test
+    fun `enableAttestationOnIntentConfirmation returns false when flag is disabled`() {
+        val session = createElementsSession(
+            passiveCaptcha = null,
+            flags = mapOf(ElementsSession.Flag.ELEMENTS_MOBILE_ATTEST_ON_INTENT_CONFIRMATION to false)
+        )
+
+        assertThat(session.enableAttestationOnIntentConfirmation).isFalse()
+    }
+
+    @Test
+    fun `enableAttestationOnIntentConfirmation returns false when flag is missing`() {
+        val session = createElementsSession(
+            passiveCaptcha = null,
+            flags = emptyMap()
+        )
+
+        assertThat(session.enableAttestationOnIntentConfirmation).isFalse()
+    }
+
     private fun createElementsSession(
         passiveCaptcha: PassiveCaptchaParams?,
         flags: Map<ElementsSession.Flag, Boolean>

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
@@ -1520,6 +1520,104 @@ class ElementsSessionJsonParserTest {
         assertThat(session?.passiveCaptchaParams).isNull()
     }
 
+    @Test
+    fun `Parses elements_mobile_attest_on_intent_confirmation flag when present`() {
+        val parser = ElementsSessionJsonParser(
+            ElementsSessionParams.PaymentIntentType(
+                clientSecret = "secret",
+                externalPaymentMethods = emptyList(),
+                customPaymentMethods = emptyList(),
+                appId = APP_ID
+            ),
+            isLiveMode = false,
+        )
+
+        val json = JSONObject(
+            """
+            {
+              "payment_method_preference": {
+                "object": "payment_method_preference",
+                "country_code": "US",
+                "payment_intent": {
+                  "id": "pi_123",
+                  "object": "payment_intent",
+                  "amount": 1099,
+                  "currency": "usd",
+                  "status": "requires_payment_method"
+                },
+                "ordered_payment_method_types": ["card"]
+              },
+              "flags": {
+                "elements_mobile_attest_on_intent_confirmation": true
+              }
+            }
+            """.trimIndent()
+        )
+
+        val session = parser.parse(json)
+
+        assertThat(session?.flags?.get(ElementsSession.Flag.ELEMENTS_MOBILE_ATTEST_ON_INTENT_CONFIRMATION))
+            .isTrue()
+    }
+
+    @Test
+    fun `Parses elements_mobile_attest_on_intent_confirmation flag as false when disabled`() {
+        val parser = ElementsSessionJsonParser(
+            ElementsSessionParams.PaymentIntentType(
+                clientSecret = "secret",
+                externalPaymentMethods = emptyList(),
+                customPaymentMethods = emptyList(),
+                appId = APP_ID
+            ),
+            isLiveMode = false,
+        )
+
+        val json = JSONObject(
+            """
+            {
+              "payment_method_preference": {
+                "object": "payment_method_preference",
+                "country_code": "US",
+                "payment_intent": {
+                  "id": "pi_123",
+                  "object": "payment_intent",
+                  "amount": 1099,
+                  "currency": "usd",
+                  "status": "requires_payment_method"
+                },
+                "ordered_payment_method_types": ["card"]
+              },
+              "flags": {
+                "elements_mobile_attest_on_intent_confirmation": false
+              }
+            }
+            """.trimIndent()
+        )
+
+        val session = parser.parse(json)
+
+        assertThat(session?.flags?.get(ElementsSession.Flag.ELEMENTS_MOBILE_ATTEST_ON_INTENT_CONFIRMATION))
+            .isFalse()
+    }
+
+    @Test
+    fun `Returns null for elements_mobile_attest_on_intent_confirmation flag when not present`() {
+        val parser = ElementsSessionJsonParser(
+            ElementsSessionParams.PaymentIntentType(
+                clientSecret = "secret",
+                externalPaymentMethods = emptyList(),
+                customPaymentMethods = emptyList(),
+                appId = APP_ID
+            ),
+            isLiveMode = false,
+        )
+
+        val session = parser.parse(ElementsSessionFixtures.EXPANDED_PAYMENT_INTENT_JSON)
+
+        assertThat(session?.flags?.get(ElementsSession.Flag.ELEMENTS_MOBILE_ATTEST_ON_INTENT_CONFIRMATION))
+            .isNull()
+    }
+
     companion object {
         private const val APP_ID = "com.app.id"
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add flag to enable attestation on intent confirmation in `ElementsSession`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-4111
`elements_mobile_attest_on_intent_confirmation` current defaults to false on pay-server.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
