### PR TITLE
Send client attribution metadata on top-level of confirm requests for new PMs

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
@@ -75,6 +75,7 @@ internal class PaymentSheetTest {
             method("POST"),
             path("/v1/payment_intents/pi_example/confirm"),
             clientAttributionMetadataParamsInPaymentMethodData(),
+            clientAttributionMetadataParamsForPaymentIntent(),
         ) { response ->
             response.testBodyFromFile("payment-intent-confirm.json")
         }
@@ -109,6 +110,7 @@ internal class PaymentSheetTest {
             method("POST"),
             path("/v1/payment_intents/pi_example/confirm"),
             clientAttributionMetadataParamsInPaymentMethodData(),
+            clientAttributionMetadataParamsForPaymentIntent(),
         ) { response ->
             response.testBodyFromFile("payment-intent-confirm.json")
         }
@@ -154,6 +156,7 @@ internal class PaymentSheetTest {
             method("POST"),
             path("/v1/payment_intents/pi_example/confirm"),
             clientAttributionMetadataParamsInPaymentMethodData(),
+            clientAttributionMetadataParamsForPaymentIntent(),
         ) { response ->
             response.testBodyFromFile("payment-intent-confirm.json")
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationOptionKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationOptionKtx.kt
@@ -27,9 +27,9 @@ internal fun PaymentSelection.toConfirmationOption(
         is PaymentSelection.Saved -> toConfirmationOption(passiveCaptchaParams, clientAttributionMetadata)
         is PaymentSelection.ExternalPaymentMethod -> toConfirmationOption()
         is PaymentSelection.CustomPaymentMethod -> toConfirmationOption(configuration)
-        is PaymentSelection.New.USBankAccount -> toConfirmationOption(passiveCaptchaParams)
+        is PaymentSelection.New.USBankAccount -> toConfirmationOption(passiveCaptchaParams, clientAttributionMetadata)
         is PaymentSelection.New.LinkInline -> toConfirmationOption(linkConfiguration, passiveCaptchaParams)
-        is PaymentSelection.New -> toConfirmationOption(passiveCaptchaParams)
+        is PaymentSelection.New -> toConfirmationOption(passiveCaptchaParams, clientAttributionMetadata)
         is PaymentSelection.GooglePay -> toConfirmationOption(configuration, passiveCaptchaParams)
         is PaymentSelection.Link -> toConfirmationOption(linkConfiguration, passiveCaptchaParams)
         is PaymentSelection.ShopPay -> toConfirmationOption(configuration)
@@ -56,7 +56,8 @@ private fun PaymentSelection.ExternalPaymentMethod.toConfirmationOption(): Exter
 }
 
 private fun PaymentSelection.New.USBankAccount.toConfirmationOption(
-    passiveCaptchaParams: PassiveCaptchaParams?
+    passiveCaptchaParams: PassiveCaptchaParams?,
+    clientAttributionMetadata: ClientAttributionMetadata?,
 ): PaymentMethodConfirmationOption {
     return if (instantDebits != null) {
         // For Instant Debits, we create the PaymentMethod inside the bank auth flow. Therefore,
@@ -65,7 +66,7 @@ private fun PaymentSelection.New.USBankAccount.toConfirmationOption(
             paymentMethod = instantDebits.paymentMethod,
             optionsParams = paymentMethodOptionsParams,
             passiveCaptchaParams = passiveCaptchaParams,
-            clientAttributionMetadata = null,
+            clientAttributionMetadata = clientAttributionMetadata,
         )
     } else {
         PaymentMethodConfirmationOption.New(
@@ -73,7 +74,8 @@ private fun PaymentSelection.New.USBankAccount.toConfirmationOption(
             optionsParams = paymentMethodOptionsParams,
             extraParams = paymentMethodExtraParams,
             shouldSave = customerRequestedSave == PaymentSelection.CustomerRequestedSave.RequestReuse,
-            passiveCaptchaParams = passiveCaptchaParams
+            passiveCaptchaParams = passiveCaptchaParams,
+            clientAttributionMetadata = clientAttributionMetadata,
         )
     }
 }
@@ -103,13 +105,14 @@ private fun PaymentSelection.New.LinkInline.toConfirmationOption(
 }
 
 private fun PaymentSelection.New.toConfirmationOption(
-    passiveCaptchaParams: PassiveCaptchaParams?
+    passiveCaptchaParams: PassiveCaptchaParams?,
+    clientAttributionMetadata: ClientAttributionMetadata?,
 ): ConfirmationHandler.Option {
     return if (paymentMethodCreateParams.typeCode == PaymentMethod.Type.BacsDebit.code) {
         BacsConfirmationOption(
             createParams = paymentMethodCreateParams,
             optionsParams = paymentMethodOptionsParams,
-            passiveCaptchaParams = passiveCaptchaParams
+            passiveCaptchaParams = passiveCaptchaParams,
         )
     } else {
         PaymentMethodConfirmationOption.New(
@@ -117,7 +120,8 @@ private fun PaymentSelection.New.toConfirmationOption(
             optionsParams = paymentMethodOptionsParams,
             extraParams = paymentMethodExtraParams,
             shouldSave = customerRequestedSave == PaymentSelection.CustomerRequestedSave.RequestReuse,
-            passiveCaptchaParams = passiveCaptchaParams
+            passiveCaptchaParams = passiveCaptchaParams,
+            clientAttributionMetadata = clientAttributionMetadata,
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/PaymentMethodConfirmationOption.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/PaymentMethodConfirmationOption.kt
@@ -48,10 +48,8 @@ internal sealed interface PaymentMethodConfirmationOption : ConfirmationHandler.
         val extraParams: PaymentMethodExtraParams?,
         val shouldSave: Boolean,
         override val passiveCaptchaParams: PassiveCaptchaParams?,
+        override val clientAttributionMetadata: ClientAttributionMetadata? = null,
     ) : PaymentMethodConfirmationOption {
-
-        override val clientAttributionMetadata: ClientAttributionMetadata?
-            get() = null
 
         override fun updatedForDeferredIntent(
             intentConfiguration: PaymentSheet.IntentConfiguration,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Send client attribution metadata on top-level of confirm requests for new PMs

This doesn't cover the following PM types which I will update in follow up PRs:
- Link
- Google Pay
- Bacs
- Shop Pay

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Per [slack conversation](https://stripe.slack.com/archives/C07PXHWQMP0/p1759855549689139?thread_ts=1759767628.494939&cid=C07PXHWQMP0) we want to send this in payment method data _and_ on the top-level of confirm requests

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified