### PR TITLE
Checkout deploy branches gradle.properties, not master.

### DIFF
--- a/scripts/deploy/publish_to_sonatype.rb
+++ b/scripts/deploy/publish_to_sonatype.rb
@@ -81,7 +81,7 @@ private def set_gpg_location
 end
 
 private def reset_gradle_properties
-    execute_or_fail("git checkout origin/master gradle.properties")
+    execute_or_fail("git checkout origin/#{@deploy_branch} gradle.properties")
 end
 
 # Gets the contents of the PATH environment variable, but before it does


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
If you're on an old branch, and try to check out a different gradle.properties, you'll end up with a wrong version being built!
