### PR TITLE
Remove deprecated browserstack device

### DIFF
--- a/scripts/browserstack.py
+++ b/scripts/browserstack.py
@@ -267,7 +267,6 @@ def executeTests(appUrl, testUrl, isNightly):
             "Google Pixel 7-13.0",
             "Samsung Galaxy S22-12.0",
             "Google Pixel 5-11.0",
-            "Samsung Galaxy S9-8.0",
         ]
     else:
         devices = [


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Remove deprecated browserstack device

I also checked that the remaining devices we use are not deprecated, via this list: https://www.browserstack.com/list-of-browsers-and-platforms/app_automate

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
This device was deprecated: https://github.com/stripe/stripe-android/actions/runs/18361615115/job/52306260684

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified