### PR TITLE
Update CardScan README to highlight 16KB page size fix

### DIFF
--- a/stripecardscan/README.md
+++ b/stripecardscan/README.md
@@ -26,11 +26,13 @@ See the `stripecardscan-example` directory for an example application that you c
     }
     ```
 
-## Use TFLite in Google play to reduce binary size
+## Use TFLite in Google Play to reduce binary size and fix 16KB page size issues
 
-CardScan Android SDK uses a portable TFLite runtime to execute machine learning models, if your application is released through Google play, you could instead use the Google play runtime, this would reduce the SDK size by ~400kb.
+CardScan Android SDK uses a portable TFLite runtime to execute machine learning models. If your application is released through Google Play, you should use the Google Play runtime instead, which will:
+- Reduce the SDK size by ~400KB
+- **Fix 16KB page size compatibility issues** (required for devices with 16KB memory pages)
 
-To do so, configure your app's dependency on stripecardscan as follows.
+To do so, configure your app's dependency on stripecardscan as follows:
 ```
     implementation('com.stripe:stripecardscan:$stripeVersion') {
       exclude group: 'com.stripe', module: 'ml-core-cardscan' // exclude the cardscan-specific portable tflite runtime


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
- Updated the CardScan README section about using Google Play TFLite variant to prominently highlight that it fixes 16KB page size compatibility issues
- Added bold emphasis on the 16KB fix to make the solution more discoverable for users encountering this issue
- Clarified that the Google Play variant both reduces binary size (~400KB) and resolves 16KB page size problems

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
We've been receiving duplicate reports about 16KB page size issues with the CardScan module . The solution has been documented in the README, but users were having difficulty finding it. This update makes the 16KB fix more prominent in the documentation.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
