### PR TITLE
Remove Samsung Galaxy Note 9-8.1 from nightly build test

### DIFF
--- a/scripts/browserstack.py
+++ b/scripts/browserstack.py
@@ -270,7 +270,6 @@ def executeTests(appUrl, testUrl, isNightly):
             "Samsung Galaxy S22-12.0",
             "Google Pixel 5-11.0",
             "Samsung Galaxy A10-9.0",
-            "Samsung Galaxy Note 9-8.1",
         ]
     else:
         devices = [


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Remove Samsung Galaxy Note 9-8.1 from nightly build test

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://stripe.slack.com/archives/CFA2HJ99A/p1760383347336189

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
