### PR TITLE
Save payment method preferences for embedded.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedConfirmationSaver.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedConfirmationSaver.kt
@@ -1,0 +1,56 @@
+package com.stripe.android.paymentelement.embedded
+
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.paymentsheet.PrefsRepository
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.state.PaymentElementLoader
+import com.stripe.android.paymentsheet.utils.canSave
+import javax.inject.Inject
+import javax.inject.Provider
+
+internal fun interface EmbeddedConfirmationSaver {
+    fun save(stripeIntent: StripeIntent)
+}
+
+internal class DefaultEmbeddedConfirmationSaver @Inject constructor(
+    private val prefsRepositoryFactory: PrefsRepository.Factory,
+    private val paymentMethodMetadataProvider: Provider<PaymentMethodMetadata?>,
+    private val selectionHolder: EmbeddedSelectionHolder,
+    private val initializationModeProvider: Provider<PaymentElementLoader.InitializationMode?>,
+) : EmbeddedConfirmationSaver {
+    override fun save(stripeIntent: StripeIntent) {
+        val paymentMethodMetadata = paymentMethodMetadataProvider.get() ?: return
+        val customerId = paymentMethodMetadata.customerMetadata?.id
+
+        val currentSelection = selectionHolder.selection.value
+
+        val selectionToSave = when (currentSelection) {
+            is PaymentSelection.New -> stripeIntent.paymentMethod.takeIf {
+                val initializationMode = initializationModeProvider.get()
+                val alwaysSave = paymentMethodMetadata.forceSetupFutureUseBehaviorAndNewMandate
+                initializationMode != null && (currentSelection.canSave(initializationMode) || alwaysSave)
+            }?.let { method ->
+                PaymentSelection.Saved(method)
+            }
+            is PaymentSelection.Saved -> {
+                when (currentSelection.walletType) {
+                    PaymentSelection.Saved.WalletType.GooglePay -> {
+                        PaymentSelection.GooglePay
+                    }
+                    PaymentSelection.Saved.WalletType.Link -> {
+                        // Don't save as Link, but instead as the actual payment method. If the payment method isn't
+                        // attached to the customer, we will fallback to Link during load.
+                        currentSelection
+                    }
+                    null -> currentSelection
+                }
+            }
+            else -> currentSelection
+        }
+
+        selectionToSave?.let {
+            prefsRepositoryFactory.create(customerId).savePaymentSelection(selectionToSave)
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationStarter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationStarter.kt
@@ -4,6 +4,7 @@ import androidx.activity.result.ActivityResultCaller
 import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.embedded.EmbeddedConfirmationSaver
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.receiveAsFlow
@@ -15,6 +16,7 @@ import javax.inject.Singleton
 internal class EmbeddedConfirmationStarter @Inject constructor(
     private val confirmationHandler: ConfirmationHandler,
     @ViewModelScope private val coroutineScope: CoroutineScope,
+    private val confirmationSaver: EmbeddedConfirmationSaver,
 ) {
     init {
         coroutineScope.launch {
@@ -22,7 +24,11 @@ internal class EmbeddedConfirmationStarter @Inject constructor(
                 when (state) {
                     is ConfirmationHandler.State.Confirming,
                     is ConfirmationHandler.State.Idle -> Unit
+
                     is ConfirmationHandler.State.Complete -> {
+                        if (state.result is ConfirmationHandler.Result.Succeeded) {
+                            confirmationSaver.save(state.result.intent)
+                        }
                         _result.send(state.result)
                     }
                 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModelComponent.kt
@@ -21,8 +21,10 @@ import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentif
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.injection.ExtendedPaymentElementConfirmationModule
+import com.stripe.android.paymentelement.embedded.DefaultEmbeddedConfirmationSaver
 import com.stripe.android.paymentelement.embedded.DefaultEmbeddedRowSelectionImmediateActionHandler
 import com.stripe.android.paymentelement.embedded.EmbeddedCommonModule
+import com.stripe.android.paymentelement.embedded.EmbeddedConfirmationSaver
 import com.stripe.android.paymentelement.embedded.EmbeddedLinkExtrasModule
 import com.stripe.android.paymentelement.embedded.EmbeddedRowSelectionImmediateActionHandler
 import com.stripe.android.paymentelement.embedded.InternalRowSelectionCallback
@@ -164,11 +166,26 @@ internal interface EmbeddedPaymentElementViewModelModule {
         factory: DefaultPrefsRepository.Factory
     ): PrefsRepository.Factory
 
+    @Binds
+    fun bindsConfirmationSaver(saver: DefaultEmbeddedConfirmationSaver): EmbeddedConfirmationSaver
+
     @Suppress("TooManyFunctions")
     companion object {
         @Provides
         fun providesContext(application: Application): Context {
             return application
+        }
+
+        @Provides
+        fun providesPaymentMethodMetadata(stateHolder: EmbeddedConfirmationStateHolder): PaymentMethodMetadata? {
+            return stateHolder.state?.paymentMethodMetadata
+        }
+
+        @Provides
+        fun providesInitializationMode(
+            stateHolder: EmbeddedConfirmationStateHolder
+        ): PaymentElementLoader.InitializationMode? {
+            return stateHolder.state?.initializationMode
         }
 
         @Provides

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityViewModelComponent.kt
@@ -18,10 +18,14 @@ import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.injection.ExtendedPaymentElementConfirmationModule
+import com.stripe.android.paymentelement.embedded.DefaultEmbeddedConfirmationSaver
 import com.stripe.android.paymentelement.embedded.EmbeddedCommonModule
+import com.stripe.android.paymentelement.embedded.EmbeddedConfirmationSaver
 import com.stripe.android.paymentelement.embedded.EmbeddedLinkExtrasModule
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
+import com.stripe.android.paymentsheet.DefaultPrefsRepository
+import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.paymentsheet.verticalmode.DefaultVerticalModeFormInteractor
 import com.stripe.android.ui.core.di.CardScanModule
@@ -88,6 +92,12 @@ internal interface FormActivityViewModelModule {
 
     @Binds
     fun bindsFormActivityStateHelper(helper: DefaultFormActivityStateHelper): FormActivityStateHelper
+
+    @Binds
+    fun bindsPrefsRepositoryFactory(factory: DefaultPrefsRepository.Factory): PrefsRepository.Factory
+
+    @Binds
+    fun bindsConfirmationSaver(saver: DefaultEmbeddedConfirmationSaver): EmbeddedConfirmationSaver
 
     companion object {
         @Provides

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/DefaultEmbeddedConfirmationSaverTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/DefaultEmbeddedConfirmationSaverTest.kt
@@ -1,0 +1,259 @@
+package com.stripe.android.paymentelement.embedded
+
+import androidx.lifecycle.SavedStateHandle
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
+import com.stripe.android.model.CardBrand
+import com.stripe.android.model.PaymentMethodCreateParamsFixtures.DEFAULT_CARD
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.paymentsheet.FakePrefsRepository
+import com.stripe.android.paymentsheet.PrefsRepository
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.state.PaymentElementLoader
+import com.stripe.android.testing.PaymentIntentFactory
+import com.stripe.android.testing.PaymentMethodFactory
+import com.stripe.android.testing.SetupIntentFactory
+import org.junit.Test
+
+class DefaultEmbeddedConfirmationSaverTest {
+    private val newCardPaymentSelection = PaymentSelection.New.Card(
+        DEFAULT_CARD,
+        CardBrand.Discover,
+        customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest
+    )
+
+    @Test
+    fun `when paymentMethodMetadata is null, should not save anything`() = testScenario(
+        paymentMethodMetadataProvider = { null }
+    ) {
+        saver.save(PaymentIntentFactory.create())
+
+        assertThat(prefsRepository.paymentSelectionArgs).isEmpty()
+    }
+
+    @Test
+    fun `when current selection is null, should not save anything`() = testScenario(
+        selection = null
+    ) {
+        saver.save(PaymentIntentFactory.create())
+
+        assertThat(prefsRepository.paymentSelectionArgs).isEmpty()
+    }
+
+    @Test
+    fun `when selection is New Card and can save with SetupIntent, should save as Saved`() = testScenario(
+        selection = newCardPaymentSelection,
+        initializationMode = PaymentElementLoader.InitializationMode.SetupIntent(clientSecret = "si_123")
+    ) {
+        val paymentMethod = PaymentMethodFactory.card()
+
+        saver.save(SetupIntentFactory.create(paymentMethod = paymentMethod))
+
+        assertThat(prefsRepository.paymentSelectionArgs).hasSize(1)
+        val savedSelection = prefsRepository.paymentSelectionArgs[0] as? PaymentSelection.Saved
+        assertThat(savedSelection?.paymentMethod).isEqualTo(paymentMethod)
+    }
+
+    @Test
+    fun `when selection is New Card and can save with PaymentIntent and customer requested, should save as Saved`() =
+        testScenario(
+            selection = newCardPaymentSelection.copy(
+                customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestReuse
+            ),
+            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(clientSecret = "pi_123")
+        ) {
+            val paymentMethod = PaymentMethodFactory.card()
+
+            saver.save(PaymentIntentFactory.create(paymentMethod = paymentMethod))
+
+            assertThat(prefsRepository.paymentSelectionArgs).hasSize(1)
+            val savedSelection = prefsRepository.paymentSelectionArgs[0] as? PaymentSelection.Saved
+            assertThat(savedSelection?.paymentMethod).isEqualTo(paymentMethod)
+        }
+
+    @Test
+    fun `when selection is New Card but cannot save with PaymentIntent, should not save`() = testScenario(
+        selection = newCardPaymentSelection,
+        initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(clientSecret = "pi_123")
+    ) {
+        val paymentMethod = PaymentMethodFactory.card()
+
+        saver.save(PaymentIntentFactory.create(paymentMethod = paymentMethod))
+
+        assertThat(prefsRepository.paymentSelectionArgs).isEmpty()
+    }
+
+    @Test
+    fun `when selection is New Card with force setup future use, should save even if not requested`() = testScenario(
+        selection = newCardPaymentSelection,
+        initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(clientSecret = "pi_123"),
+        forceSetupFutureUseBehaviorAndNewMandate = true
+    ) {
+        val paymentMethod = PaymentMethodFactory.card()
+
+        saver.save(PaymentIntentFactory.create(paymentMethod = paymentMethod))
+
+        assertThat(prefsRepository.paymentSelectionArgs).hasSize(1)
+        val savedSelection = prefsRepository.paymentSelectionArgs[0] as? PaymentSelection.Saved
+        assertThat(savedSelection?.paymentMethod).isEqualTo(paymentMethod)
+    }
+
+    @Test
+    fun `when selection is New Card but payment method is null, should not save`() = testScenario(
+        selection = newCardPaymentSelection.copy(
+            customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestReuse
+        ),
+        initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(clientSecret = "pi_123")
+    ) {
+        saver.save(PaymentIntentFactory.create(paymentMethod = null))
+
+        assertThat(prefsRepository.paymentSelectionArgs).isEmpty()
+    }
+
+    @Test
+    fun `when selection is Saved with GooglePay wallet type, should save as GooglePay`() = testScenario(
+        selection = PaymentSelection.Saved(
+            paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+            walletType = PaymentSelection.Saved.WalletType.GooglePay
+        )
+    ) {
+        saver.save(PaymentIntentFactory.create())
+
+        assertThat(prefsRepository.paymentSelectionArgs).hasSize(1)
+        assertThat(prefsRepository.paymentSelectionArgs[0]).isEqualTo(PaymentSelection.GooglePay)
+    }
+
+    @Test
+    fun `when selection is Saved with Link wallet type, should save the payment method`() = testScenario(
+        selection = PaymentSelection.Saved(
+            paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+            walletType = PaymentSelection.Saved.WalletType.Link
+        )
+    ) {
+        saver.save(PaymentIntentFactory.create())
+
+        assertThat(prefsRepository.paymentSelectionArgs).hasSize(1)
+        val savedSelection = prefsRepository.paymentSelectionArgs[0] as? PaymentSelection.Saved
+        assertThat(savedSelection?.paymentMethod).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+        assertThat(savedSelection?.walletType).isEqualTo(PaymentSelection.Saved.WalletType.Link)
+    }
+
+    @Test
+    fun `when selection is Saved with no wallet type, should save as-is`() = testScenario(
+        selection = PaymentSelection.Saved(
+            paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
+        )
+    ) {
+        saver.save(PaymentIntentFactory.create())
+
+        assertThat(prefsRepository.paymentSelectionArgs).hasSize(1)
+        val savedSelection = prefsRepository.paymentSelectionArgs[0] as? PaymentSelection.Saved
+        assertThat(savedSelection?.paymentMethod).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+        assertThat(savedSelection?.walletType).isNull()
+    }
+
+    @Test
+    fun `when selection is GooglePay, should save as-is`() = testScenario(
+        selection = PaymentSelection.GooglePay
+    ) {
+        saver.save(PaymentIntentFactory.create())
+
+        assertThat(prefsRepository.paymentSelectionArgs).hasSize(1)
+        assertThat(prefsRepository.paymentSelectionArgs[0]).isEqualTo(PaymentSelection.GooglePay)
+    }
+
+    @Test
+    fun `when selection is Link, should save as-is`() = testScenario(
+        selection = PaymentSelection.Link()
+    ) {
+        saver.save(PaymentIntentFactory.create())
+
+        assertThat(prefsRepository.paymentSelectionArgs).hasSize(1)
+        assertThat(prefsRepository.paymentSelectionArgs[0]).isEqualTo(PaymentSelection.Link())
+    }
+
+    @Test
+    fun `when no customer id, should use null customer id for prefs repository`() = testScenario(
+        hasCustomerConfiguration = false
+    ) {
+        saver.save(PaymentIntentFactory.create())
+
+        assertThat(prefsRepositoryFactory.customerIdArgs).containsExactly(null)
+    }
+
+    @Test
+    fun `when has customer id, should use customer id for prefs repository`() = testScenario(
+        hasCustomerConfiguration = true
+    ) {
+        saver.save(PaymentIntentFactory.create())
+
+        assertThat(prefsRepositoryFactory.customerIdArgs).containsExactly("cus_123")
+    }
+
+    private fun testScenario(
+        selection: PaymentSelection? = PaymentSelection.GooglePay,
+        paymentMethodMetadataProvider: () -> PaymentMethodMetadata? = {
+            PaymentMethodMetadataFactory.create(
+                hasCustomerConfiguration = true,
+                forceSetupFutureUseBehaviorAndNewMandate = false
+            )
+        },
+        initializationMode: PaymentElementLoader.InitializationMode? =
+            PaymentElementLoader.InitializationMode.PaymentIntent(
+                clientSecret = "pi_123"
+            ),
+        forceSetupFutureUseBehaviorAndNewMandate: Boolean = false,
+        hasCustomerConfiguration: Boolean = true,
+        block: Scenario.() -> Unit
+    ) {
+        val savedStateHandle = SavedStateHandle()
+        val selectionHolder = EmbeddedSelectionHolder(savedStateHandle)
+        selectionHolder.set(selection)
+
+        val prefsRepository = FakePrefsRepository()
+        val prefsRepositoryFactory = FakePrefsRepositoryFactory(prefsRepository)
+
+        val metadata = paymentMethodMetadataProvider()?.copy(
+            forceSetupFutureUseBehaviorAndNewMandate = forceSetupFutureUseBehaviorAndNewMandate,
+            customerMetadata = if (hasCustomerConfiguration) {
+                PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA
+            } else {
+                null
+            }
+        )
+
+        val saver = DefaultEmbeddedConfirmationSaver(
+            prefsRepositoryFactory = prefsRepositoryFactory,
+            paymentMethodMetadataProvider = { metadata },
+            selectionHolder = selectionHolder,
+            initializationModeProvider = { initializationMode }
+        )
+
+        Scenario(
+            saver = saver,
+            prefsRepository = prefsRepository,
+            prefsRepositoryFactory = prefsRepositoryFactory,
+            selectionHolder = selectionHolder
+        ).block()
+    }
+
+    private data class Scenario(
+        val saver: DefaultEmbeddedConfirmationSaver,
+        val prefsRepository: FakePrefsRepository,
+        val prefsRepositoryFactory: FakePrefsRepositoryFactory,
+        val selectionHolder: EmbeddedSelectionHolder
+    )
+
+    private class FakePrefsRepositoryFactory(
+        private val prefsRepository: PrefsRepository
+    ) : PrefsRepository.Factory {
+        val customerIdArgs = mutableListOf<String?>()
+
+        override fun create(customerId: String?): PrefsRepository {
+            customerIdArgs.add(customerId)
+            return prefsRepository
+        }
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/FakeEmbeddedConfirmationSaver.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/FakeEmbeddedConfirmationSaver.kt
@@ -1,0 +1,18 @@
+package com.stripe.android.paymentelement.embedded
+
+import app.cash.turbine.ReceiveTurbine
+import app.cash.turbine.Turbine
+import com.stripe.android.model.StripeIntent
+
+internal class FakeEmbeddedConfirmationSaver : EmbeddedConfirmationSaver {
+    private val _saveTurbine = Turbine<StripeIntent>()
+    val saveTurbine: ReceiveTurbine<StripeIntent> = _saveTurbine
+
+    override fun save(stripeIntent: StripeIntent) {
+        _saveTurbine.add(stripeIntent)
+    }
+
+    fun validate() {
+        _saveTurbine.ensureAllEventsConsumed()
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfirmationHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfirmationHelperTest.kt
@@ -166,6 +166,7 @@ internal class DefaultEmbeddedConfirmationHelperTest {
             confirmationStarter = EmbeddedConfirmationStarter(
                 confirmationHandler = confirmationHandler,
                 coroutineScope = backgroundScope,
+                confirmationSaver = {},
             ),
             activityResultCaller = mock(),
             lifecycleOwner = TestLifecycleOwner(coroutineDispatcher = Dispatchers.Unconfined),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityScreenShotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityScreenShotTest.kt
@@ -104,7 +104,8 @@ internal class FormActivityScreenShotTest {
             configuration = EmbeddedConfirmationStateFixtures.defaultState().configuration,
             coroutineScope = TestScope(UnconfinedTestDispatcher()),
             onClickDelegate = OnClickDelegateOverrideImpl(),
-            eventReporter = FakeEventReporter()
+            eventReporter = FakeEventReporter(),
+            confirmationSaver = {},
         )
         val formHelperFactory = EmbeddedFormHelperFactory(
             linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultVerticalModeFormInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultVerticalModeFormInteractorTest.kt
@@ -253,7 +253,8 @@ internal class DefaultVerticalModeFormInteractorTest {
             configuration = EmbeddedConfirmationStateFixtures.defaultState().configuration,
             coroutineScope = TestScope(UnconfinedTestDispatcher()),
             onClickDelegate = OnClickDelegateOverrideImpl(),
-            eventReporter = FakeEventReporter()
+            eventReporter = FakeEventReporter(),
+            confirmationSaver = {},
         )
         val formHelperFactory = EmbeddedFormHelperFactory(
             linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
@@ -302,7 +303,8 @@ internal class DefaultVerticalModeFormInteractorTest {
             configuration = EmbeddedConfirmationStateFixtures.defaultStateWithOpenCardScanAutomatically().configuration,
             coroutineScope = TestScope(UnconfinedTestDispatcher()),
             onClickDelegate = OnClickDelegateOverrideImpl(),
-            eventReporter = FakeEventReporter()
+            eventReporter = FakeEventReporter(),
+            confirmationSaver = {},
         )
         val formHelperFactory = EmbeddedFormHelperFactory(
             linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Adds saving of payment methods for embedded integrations to our preferences to be pre selected when loading the next session.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
This was missed during initial implementation. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified
