### PR TITLE
Remove client attribution metadata from confirmation options

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/LinkTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/LinkTest.kt
@@ -103,7 +103,8 @@ internal class LinkTest {
         networkRule.enqueue(
             method("POST"),
             path("/v1/payment_intents/pi_example/confirm"),
-            linkInformation()
+            linkInformation(),
+            topLevelClientAttributionMetadataParams(),
         ) { response ->
             response.testBodyFromFile("payment-intent-confirm.json")
         }
@@ -210,6 +211,7 @@ internal class LinkTest {
                 method("POST"),
                 path("/v1/payment_intents/pi_example/confirm"),
                 bodyPart(urlEncode("payment_method_options[link][setup_future_usage]"), "off_session"),
+                topLevelClientAttributionMetadataParams(),
             ) { response ->
                 response.testBodyFromFile("payment-intent-confirm.json")
             }
@@ -292,7 +294,8 @@ internal class LinkTest {
         networkRule.enqueue(
             method("POST"),
             path("/v1/payment_intents/pi_example/confirm"),
-            linkInformation()
+            linkInformation(),
+            topLevelClientAttributionMetadataParams(),
         ) { response ->
             response.testBodyFromFile("payment-intent-confirm.json")
         }
@@ -387,7 +390,8 @@ internal class LinkTest {
             method("POST"),
             path("/v1/payment_intents/pi_example/confirm"),
             bodyPart("payment_method", "pm_1234"),
-            not(linkInformation())
+            not(linkInformation()),
+            topLevelClientAttributionMetadataParams(),
         ) { response ->
             response.testBodyFromFile("payment-intent-confirm.json")
         }
@@ -502,6 +506,7 @@ internal class LinkTest {
                 method("POST"),
                 path("/v1/payment_intents/pi_example/confirm"),
                 bodyPart(urlEncode("payment_method_options[card][setup_future_usage]"), "off_session"),
+                topLevelClientAttributionMetadataParams(),
             ) { response ->
                 response.testBodyFromFile("payment-intent-confirm.json")
             }
@@ -601,7 +606,8 @@ internal class LinkTest {
             method("POST"),
             path("/v1/payment_intents/pi_example/confirm"),
             bodyPart("payment_method", "pm_1234"),
-            not(linkInformation())
+            not(linkInformation()),
+            topLevelClientAttributionMetadataParams(),
         ) { response ->
             response.testBodyFromFile("payment-intent-confirm.json")
         }
@@ -666,7 +672,8 @@ internal class LinkTest {
         networkRule.enqueue(
             method("POST"),
             path("/v1/payment_intents/pi_example/confirm"),
-            not(linkInformation())
+            not(linkInformation()),
+            topLevelClientAttributionMetadataParams(),
         ) { response ->
             response.testBodyFromFile("payment-intent-confirm.json")
         }
@@ -732,6 +739,7 @@ internal class LinkTest {
             method("POST"),
             path("/v1/payment_intents/pi_example/confirm"),
             not(bodyPart("payment_method", "pm_1234")),
+            topLevelClientAttributionMetadataParams(),
         ) { response ->
             response.testBodyFromFile("payment-intent-confirm.json")
         }
@@ -805,6 +813,7 @@ internal class LinkTest {
             method("POST"),
             path("/v1/payment_intents/pi_example/confirm"),
             not(bodyPart("payment_method", "pm_1234")),
+            topLevelClientAttributionMetadataParams(),
         ) { response ->
             response.testBodyFromFile("payment-intent-confirm.json")
         }
@@ -861,7 +870,8 @@ internal class LinkTest {
         networkRule.enqueue(
             method("POST"),
             path("/v1/payment_intents/pi_example/confirm"),
-            not(linkInformation())
+            not(linkInformation()),
+            topLevelClientAttributionMetadataParams(),
         ) { response ->
             response.testBodyFromFile("payment-intent-confirm.json")
         }
@@ -901,7 +911,8 @@ internal class LinkTest {
         networkRule.enqueue(
             method("POST"),
             path("/v1/payment_intents/pi_example/confirm"),
-            not(linkInformation())
+            not(linkInformation()),
+            topLevelClientAttributionMetadataParams(),
         ) { response ->
             response.testBodyFromFile("payment-intent-confirm.json")
         }
@@ -964,7 +975,8 @@ internal class LinkTest {
         networkRule.enqueue(
             method("POST"),
             path("/v1/payment_intents/pi_example/confirm"),
-            linkInformation()
+            linkInformation(),
+            topLevelClientAttributionMetadataParams(),
         ) { response ->
             response.testBodyFromFile("payment-intent-confirm.json")
         }
@@ -1039,6 +1051,7 @@ internal class LinkTest {
             method("POST"),
             path("/v1/payment_intents/pi_example/confirm"),
             linkInformation(),
+            topLevelClientAttributionMetadataParams(),
         ) { response ->
             response.testBodyFromFile("payment-intent-confirm.json")
         }
@@ -1146,6 +1159,7 @@ internal class LinkTest {
             method("POST"),
             path("/v1/payment_intents/pi_example/confirm"),
             bodyPart(urlEncode("payment_method_options[card][setup_future_usage]"), "off_session"),
+            topLevelClientAttributionMetadataParams(),
         ) { response ->
             response.testBodyFromFile("payment-intent-confirm.json")
         }

--- a/paymentsheet/src/androidTest/resources/elements-sessions-requires_payment_method_with_cbc.json
+++ b/paymentsheet/src/androidTest/resources/elements-sessions-requires_payment_method_with_cbc.json
@@ -816,7 +816,7 @@
     "client_id": "AeUpkoEbS0RWuyLFfgUAg0TLEKH-22e8VLnZYrdUzMZzlep0mZsX41XE7q8yIh1RcK_PljB0Kd4LUUDa",
     "paypal_merchant_id": "AGPH92J9HME62"
   },
-  "session_id": "elements_session_0oVDkeGVXFs",
+  "session_id": "elements_session_123",
   "shipping_address_settings": {
     "autocomplete_allowed": true
   },

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -1052,7 +1052,6 @@ internal class CustomerSheetViewModel(
                     paymentMethod = paymentMethod,
                     optionsParams = null,
                     passiveCaptchaParams = metadata?.passiveCaptchaParams,
-                    clientAttributionMetadata = metadata?.clientAttributionMetadata,
                 ),
                 intent = stripeIntent,
                 initializationMode = PaymentElementLoader.InitializationMode.SetupIntent(

--- a/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
@@ -209,7 +209,6 @@ internal class DefaultLinkConfirmationHandler @Inject constructor(
                     }
                 ),
                 passiveCaptchaParams = passiveCaptchaParams,
-                clientAttributionMetadata = null,
             ),
             appearance = PaymentSheet.Appearance(),
             initializationMode = configuration.initializationMode,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationOptionKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationOptionKtx.kt
@@ -24,10 +24,10 @@ internal fun PaymentSelection.toConfirmationOption(
     clientAttributionMetadata: ClientAttributionMetadata?
 ): ConfirmationHandler.Option? {
     return when (this) {
-        is PaymentSelection.Saved -> toConfirmationOption(passiveCaptchaParams, clientAttributionMetadata)
+        is PaymentSelection.Saved -> toConfirmationOption(passiveCaptchaParams)
         is PaymentSelection.ExternalPaymentMethod -> toConfirmationOption()
         is PaymentSelection.CustomPaymentMethod -> toConfirmationOption(configuration)
-        is PaymentSelection.New.USBankAccount -> toConfirmationOption(passiveCaptchaParams, clientAttributionMetadata)
+        is PaymentSelection.New.USBankAccount -> toConfirmationOption(passiveCaptchaParams)
         is PaymentSelection.New.LinkInline -> toConfirmationOption(linkConfiguration, passiveCaptchaParams)
         is PaymentSelection.New -> toConfirmationOption(passiveCaptchaParams)
         is PaymentSelection.GooglePay -> toConfirmationOption(
@@ -42,13 +42,11 @@ internal fun PaymentSelection.toConfirmationOption(
 
 private fun PaymentSelection.Saved.toConfirmationOption(
     passiveCaptchaParams: PassiveCaptchaParams?,
-    clientAttributionMetadata: ClientAttributionMetadata?
 ): PaymentMethodConfirmationOption.Saved {
     return PaymentMethodConfirmationOption.Saved(
         paymentMethod = paymentMethod,
         optionsParams = paymentMethodOptionsParams,
         passiveCaptchaParams = passiveCaptchaParams,
-        clientAttributionMetadata = clientAttributionMetadata,
     )
 }
 
@@ -61,7 +59,6 @@ private fun PaymentSelection.ExternalPaymentMethod.toConfirmationOption(): Exter
 
 private fun PaymentSelection.New.USBankAccount.toConfirmationOption(
     passiveCaptchaParams: PassiveCaptchaParams?,
-    clientAttributionMetadata: ClientAttributionMetadata?,
 ): PaymentMethodConfirmationOption {
     return if (instantDebits != null) {
         // For Instant Debits, we create the PaymentMethod inside the bank auth flow. Therefore,
@@ -70,7 +67,6 @@ private fun PaymentSelection.New.USBankAccount.toConfirmationOption(
             paymentMethod = instantDebits.paymentMethod,
             optionsParams = paymentMethodOptionsParams,
             passiveCaptchaParams = passiveCaptchaParams,
-            clientAttributionMetadata = clientAttributionMetadata,
         )
     } else {
         PaymentMethodConfirmationOption.New(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/PaymentMethodConfirmationOption.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/PaymentMethodConfirmationOption.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentelement.confirmation
 
-import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.PassiveCaptchaParams
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodExtraParams
@@ -13,7 +12,6 @@ import kotlinx.parcelize.Parcelize
 internal sealed interface PaymentMethodConfirmationOption : ConfirmationHandler.Option {
     val passiveCaptchaParams: PassiveCaptchaParams?
     val optionsParams: PaymentMethodOptionsParams?
-    val clientAttributionMetadata: ClientAttributionMetadata?
 
     fun updatedForDeferredIntent(
         intentConfiguration: PaymentSheet.IntentConfiguration,
@@ -23,7 +21,6 @@ internal sealed interface PaymentMethodConfirmationOption : ConfirmationHandler.
     data class Saved(
         val paymentMethod: com.stripe.android.model.PaymentMethod,
         override val optionsParams: PaymentMethodOptionsParams?,
-        override val clientAttributionMetadata: ClientAttributionMetadata? = null,
         val originatedFromWallet: Boolean = false,
         override val passiveCaptchaParams: PassiveCaptchaParams?,
         val hCaptchaToken: String? = null,
@@ -49,9 +46,6 @@ internal sealed interface PaymentMethodConfirmationOption : ConfirmationHandler.
         val shouldSave: Boolean,
         override val passiveCaptchaParams: PassiveCaptchaParams?,
     ) : PaymentMethodConfirmationOption {
-
-        override val clientAttributionMetadata
-            get() = createParams.clientAttributionMetadata
 
         override fun updatedForDeferredIntent(
             intentConfiguration: PaymentSheet.IntentConfiguration,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinition.kt
@@ -117,7 +117,6 @@ internal class GooglePayConfirmationDefinition @Inject constructor(
                     optionsParams = null,
                     originatedFromWallet = true,
                     passiveCaptchaParams = confirmationOption.passiveCaptchaParams,
-                    clientAttributionMetadata = confirmationOption.clientAttributionMetadata,
                 )
 
                 ConfirmationDefinition.Result.NextStep(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/DeferredIntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/DeferredIntentConfirmationInterceptor.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentelement.confirmation.intent
 import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodExtraParams
@@ -32,6 +33,7 @@ import javax.inject.Named
 internal class DeferredIntentConfirmationInterceptor @AssistedInject constructor(
     @Assisted private val intentConfiguration: PaymentSheet.IntentConfiguration,
     @Assisted private val createIntentCallback: CreateIntentCallback,
+    @Assisted private val clientAttributionMetadata: ClientAttributionMetadata?,
     private val stripeRepository: StripeRepository,
     private val requestOptions: ApiRequest.Options,
     @Named(ALLOWS_MANUAL_CONFIRMATION) private val allowsManualConfirmation: Boolean,
@@ -223,7 +225,7 @@ internal class DeferredIntentConfirmationInterceptor @AssistedInject constructor
                         intentConfigSetupFutureUsage = intentConfiguration
                             .mode.setupFutureUse?.toConfirmParamsSetupFutureUsage(),
                         radarOptions = hCaptchaToken?.let { RadarOptions(it) },
-                        clientAttributionMetadata = confirmationOption.clientAttributionMetadata,
+                        clientAttributionMetadata = clientAttributionMetadata,
                     )
                 }
             }
@@ -272,7 +274,8 @@ internal class DeferredIntentConfirmationInterceptor @AssistedInject constructor
     interface Factory {
         fun create(
             intentConfiguration: PaymentSheet.IntentConfiguration,
-            createIntentCallback: CreateIntentCallback
+            createIntentCallback: CreateIntentCallback,
+            clientAttributionMetadata: ClientAttributionMetadata?,
         ): DeferredIntentConfirmationInterceptor
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationDefinition.kt
@@ -4,6 +4,7 @@ import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
 import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.ConfirmStripeIntentParams
@@ -35,6 +36,9 @@ internal class IntentConfirmationDefinition(
     @Volatile
     private var ephemeralKeySecret: String? = null
 
+    @Volatile
+    private var clientAttributionMetadata: ClientAttributionMetadata? = null
+
     override fun option(confirmationOption: ConfirmationHandler.Option): PaymentMethodConfirmationOption? {
         return confirmationOption as? PaymentMethodConfirmationOption
     }
@@ -42,6 +46,7 @@ internal class IntentConfirmationDefinition(
     override fun bootstrap(paymentMethodMetadata: PaymentMethodMetadata) {
         customerId = paymentMethodMetadata.customerMetadata?.id
         ephemeralKeySecret = paymentMethodMetadata.customerMetadata?.ephemeralKeySecret
+        clientAttributionMetadata = paymentMethodMetadata.clientAttributionMetadata
     }
 
     override suspend fun action(
@@ -54,6 +59,7 @@ internal class IntentConfirmationDefinition(
                 initializationMode = confirmationArgs.initializationMode,
                 customerId = customerId,
                 ephemeralKeySecret = ephemeralKeySecret,
+                clientAttributionMetadata = clientAttributionMetadata,
             )
         } catch (e: DeferredIntentCallbackNotFoundException) {
             return ConfirmationDefinition.Action.Fail(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentFirstConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentFirstConfirmationInterceptor.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentelement.confirmation.intent
 
 import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.RadarOptions
 import com.stripe.android.model.StripeIntent
@@ -14,6 +15,7 @@ import dagger.assisted.AssistedInject
 
 internal class IntentFirstConfirmationInterceptor @AssistedInject constructor(
     @Assisted private val clientSecret: String,
+    @Assisted private val clientAttributionMetadata: ClientAttributionMetadata?,
     requestOptions: ApiRequest.Options,
 ) : IntentConfirmationInterceptor {
     private val confirmActionHelper: ConfirmActionHelper = ConfirmActionHelper(requestOptions.apiKeyIsLiveMode)
@@ -33,7 +35,7 @@ internal class IntentFirstConfirmationInterceptor @AssistedInject constructor(
                 confirmationOption.createParams,
                 confirmationOption.optionsParams,
                 confirmationOption.extraParams,
-                clientAttributionMetadata = confirmationOption.clientAttributionMetadata,
+                clientAttributionMetadata = clientAttributionMetadata,
             )
         }
     }
@@ -55,13 +57,16 @@ internal class IntentFirstConfirmationInterceptor @AssistedInject constructor(
                 extraParams = null,
                 intentConfigSetupFutureUsage = null,
                 radarOptions = confirmationOption.hCaptchaToken?.let { RadarOptions(it) },
-                clientAttributionMetadata = confirmationOption.clientAttributionMetadata,
+                clientAttributionMetadata = clientAttributionMetadata,
             )
         }
     }
 
     @AssistedFactory
     interface Factory {
-        fun create(clientSecret: String): IntentFirstConfirmationInterceptor
+        fun create(
+            clientSecret: String,
+            clientAttributionMetadata: ClientAttributionMetadata?,
+        ): IntentFirstConfirmationInterceptor
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinition.kt
@@ -84,7 +84,6 @@ internal class LinkConfirmationDefinition @Inject constructor(
                         optionsParams = null,
                         originatedFromWallet = true,
                         passiveCaptchaParams = confirmationOption.passiveCaptchaParams,
-                        clientAttributionMetadata = null,
                     ),
                     arguments = confirmationArgs,
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkPassthroughConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkPassthroughConfirmationDefinition.kt
@@ -96,7 +96,6 @@ internal class LinkPassthroughConfirmationDefinition @Inject constructor(
                 optionsParams = null,
                 originatedFromWallet = true,
                 passiveCaptchaParams = confirmationOption.passiveCaptchaParams,
-                clientAttributionMetadata = null,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinition.kt
@@ -171,7 +171,6 @@ internal class LinkInlineSignupConfirmationDefinition(
             ),
             originatedFromWallet = true,
             passiveCaptchaParams = passiveCaptchaParams,
-            clientAttributionMetadata = null,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -28,6 +28,7 @@ import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContra
 import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLauncherFactory
 import com.stripe.android.lpmfoundations.luxe.LpmRepositoryTestHelpers
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
+import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures.CARD_PAYMENT_METHOD
 import com.stripe.android.networking.StripeRepository
@@ -89,7 +90,8 @@ internal object CustomerSheetTestHelper {
                 override suspend fun create(
                     initializationMode: PaymentElementLoader.InitializationMode,
                     customerId: String?,
-                    ephemeralKeySecret: String?
+                    ephemeralKeySecret: String?,
+                    clientAttributionMetadata: ClientAttributionMetadata?,
                 ): IntentConfirmationInterceptor {
                     return FakeIntentConfirmationInterceptor().apply {
                         enqueueCompleteStep(true)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
@@ -15,17 +15,14 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentB
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilter
 import com.stripe.android.model.Address
 import com.stripe.android.model.CardBrand
-import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.LinkMode
 import com.stripe.android.model.PassiveCaptchaParamsFactory
-import com.stripe.android.model.PaymentIntentCreationFlow
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodOptionsParams
-import com.stripe.android.model.PaymentMethodSelectionFlow
 import com.stripe.android.paymentelement.ExperimentalCustomPaymentMethodsApi
 import com.stripe.android.paymentelement.confirmation.bacs.BacsConfirmationOption
 import com.stripe.android.paymentelement.confirmation.cpms.CustomPaymentMethodConfirmationOption
@@ -201,31 +198,7 @@ class ConfirmationHandlerOptionKtxTest {
                     cvc = "505"
                 ),
                 passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
-                clientAttributionMetadata = null,
             )
-        )
-    }
-
-    @Test
-    fun `On saved selection, client attribution metadata is set properly`() {
-        val paymentSelection = PaymentSelection.Saved(
-            paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
-        )
-        val expectedClientAttributionMetadata = ClientAttributionMetadata(
-            elementsSessionConfigId = "elements_session_123",
-            paymentIntentCreationFlow = PaymentIntentCreationFlow.Standard,
-            paymentMethodSelectionFlow = PaymentMethodSelectionFlow.Automatic
-        )
-
-        val confirmationOption = paymentSelection.toConfirmationOption(
-            configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
-            linkConfiguration = null,
-            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
-            clientAttributionMetadata = expectedClientAttributionMetadata,
-        )
-
-        assertThat(confirmationOption?.asSaved()?.clientAttributionMetadata).isEqualTo(
-            expectedClientAttributionMetadata
         )
     }
 
@@ -420,7 +393,6 @@ class ConfirmationHandlerOptionKtxTest {
                 optionsParams = null,
                 paymentMethod = expectedPaymentMethod,
                 passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
-                clientAttributionMetadata = null,
             )
         )
     }
@@ -443,7 +415,6 @@ class ConfirmationHandlerOptionKtxTest {
                 optionsParams = null,
                 paymentMethod = expectedPaymentMethod,
                 passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
-                clientAttributionMetadata = null,
             )
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationUtils.kt
@@ -12,6 +12,7 @@ import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.link.analytics.FakeLinkAnalyticsHelper
 import com.stripe.android.link.analytics.FakeLinkEventsReporter
 import com.stripe.android.link.analytics.LinkEventsReporter
+import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.paymentelement.CreateIntentWithConfirmationTokenCallback
 import com.stripe.android.paymentelement.PreparePaymentMethodHandler
@@ -73,17 +74,22 @@ internal suspend fun createIntentConfirmationInterceptor(
     return DefaultIntentConfirmationInterceptorFactory(
         deferredIntentCallbackRetriever = deferredIntentCallbackRetriever,
         intentFirstConfirmationInterceptorFactory = object : IntentFirstConfirmationInterceptor.Factory {
-            override fun create(clientSecret: String): IntentFirstConfirmationInterceptor {
+            override fun create(
+                clientSecret: String,
+                clientAttributionMetadata: ClientAttributionMetadata?
+            ): IntentFirstConfirmationInterceptor {
                 return IntentFirstConfirmationInterceptor(
                     clientSecret = clientSecret,
                     requestOptions = requestOptions,
+                    clientAttributionMetadata = clientAttributionMetadata,
                 )
             }
         },
         deferredIntentConfirmationInterceptorFactory = object : DeferredIntentConfirmationInterceptor.Factory {
             override fun create(
                 intentConfiguration: PaymentSheet.IntentConfiguration,
-                createIntentCallback: CreateIntentCallback
+                createIntentCallback: CreateIntentCallback,
+                clientAttributionMetadata: ClientAttributionMetadata?
             ): DeferredIntentConfirmationInterceptor {
                 return DeferredIntentConfirmationInterceptor(
                     intentConfiguration = intentConfiguration,
@@ -91,6 +97,7 @@ internal suspend fun createIntentConfirmationInterceptor(
                     stripeRepository = stripeRepository,
                     allowsManualConfirmation = false,
                     requestOptions = requestOptions,
+                    clientAttributionMetadata = clientAttributionMetadata,
                 )
             }
         },
@@ -131,6 +138,7 @@ internal suspend fun createIntentConfirmationInterceptor(
         initializationMode = initializationMode,
         customerId = customerId,
         ephemeralKeySecret = ephemeralKeySecret,
+        clientAttributionMetadata = null,
     )
 }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationDefinitionTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentelement.confirmation
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.PaymentIntentFixtures
@@ -401,7 +402,8 @@ class IntentConfirmationDefinitionTest {
                 override suspend fun create(
                     initializationMode: PaymentElementLoader.InitializationMode,
                     customerId: String?,
-                    ephemeralKeySecret: String?
+                    ephemeralKeySecret: String?,
+                    clientAttributionMetadata: ClientAttributionMetadata?,
                 ): IntentConfirmationInterceptor {
                     return FakeIntentConfirmationInterceptor()
                 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationFlowTest.kt
@@ -5,6 +5,7 @@ import com.stripe.android.SharedPaymentTokenSessionPreview
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.customersheet.FakeStripeRepository
 import com.stripe.android.model.Address
+import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.ConfirmStripeIntentParams
@@ -287,7 +288,8 @@ internal class IntentConfirmationFlowTest {
                 override suspend fun create(
                     initializationMode: PaymentElementLoader.InitializationMode,
                     customerId: String?,
-                    ephemeralKeySecret: String?
+                    ephemeralKeySecret: String?,
+                    clientAttributionMetadata: ClientAttributionMetadata?,
                 ): IntentConfirmationInterceptor {
                     return createIntentConfirmationInterceptor(
                         initializationMode = initializationMode,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationActivityTest.kt
@@ -81,7 +81,6 @@ internal class GooglePayConfirmationActivityTest {
                         optionsParams = null,
                         originatedFromWallet = true,
                         passiveCaptchaParams = null,
-                        clientAttributionMetadata = GOOGLE_PAY_CONFIRMATION_OPTION.clientAttributionMetadata,
                     )
                 )
 
@@ -156,7 +155,6 @@ internal class GooglePayConfirmationActivityTest {
                         optionsParams = null,
                         originatedFromWallet = true,
                         passiveCaptchaParams = null,
-                        clientAttributionMetadata = GOOGLE_PAY_CONFIRMATION_OPTION.clientAttributionMetadata,
                     )
                 )
 
@@ -218,7 +216,6 @@ internal class GooglePayConfirmationActivityTest {
                         optionsParams = null,
                         originatedFromWallet = true,
                         passiveCaptchaParams = null,
-                        clientAttributionMetadata = GOOGLE_PAY_CONFIRMATION_OPTION.clientAttributionMetadata,
                     )
                 )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinitionTest.kt
@@ -127,9 +127,6 @@ class GooglePayConfirmationDefinitionTest {
         assertThat(savedOption.paymentMethod).isEqualTo(savedOption.paymentMethod)
         assertThat(savedOption.optionsParams).isNull()
         assertThat(savedOption.originatedFromWallet).isTrue()
-        assertThat(savedOption.clientAttributionMetadata).isEqualTo(
-            GOOGLE_PAY_CONFIRMATION_OPTION.clientAttributionMetadata
-        )
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationFlowTest.kt
@@ -93,7 +93,6 @@ class GooglePayConfirmationFlowTest {
                 optionsParams = null,
                 originatedFromWallet = true,
                 passiveCaptchaParams = null,
-                clientAttributionMetadata = GOOGLE_PAY_CONFIRMATION_OPTION.clientAttributionMetadata,
             ),
             arguments = CONFIRMATION_PARAMETERS,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/FakeIntentConfirmationInterceptorFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/FakeIntentConfirmationInterceptorFactory.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentelement.confirmation.interceptor
 
+import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.paymentelement.confirmation.intent.IntentConfirmationInterceptor
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.utils.FakeIntentConfirmationInterceptor
@@ -11,7 +12,8 @@ internal open class FakeIntentConfirmationInterceptorFactory(
     override suspend fun create(
         initializationMode: PaymentElementLoader.InitializationMode,
         customerId: String?,
-        ephemeralKeySecret: String?
+        ephemeralKeySecret: String?,
+        clientAttributionMetadata: ClientAttributionMetadata?,
     ): IntentConfirmationInterceptor {
         interceptor = FakeIntentConfirmationInterceptor().apply(enqueueStep)
         return interceptor

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -48,6 +48,7 @@ import com.stripe.android.link.TestFactory
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.ui.LinkButtonTestTag
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
@@ -1260,7 +1261,8 @@ internal class PaymentSheetActivityTest {
                         override suspend fun create(
                             initializationMode: PaymentElementLoader.InitializationMode,
                             customerId: String?,
-                            ephemeralKeySecret: String?
+                            ephemeralKeySecret: String?,
+                            clientAttributionMetadata: ClientAttributionMetadata?,
                         ): IntentConfirmationInterceptor {
                             return fakeIntentConfirmationInterceptor
                         }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Remove client attribution metadata from confirmation options

Instead set client attribution metadata from the bootstrapped payment method metadata in IntentConfirmationDefinition

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Simplifies the number of places where we need to thread ClientAttributionMetadata through.

- Adds client attribution metadata to the confirm calls for Link for free (added tests to show this)
- Reduces the likelihood that we forget to send client attribution metadata somewhere in the future

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified
