### PR TITLE
Move AfterpayClearpay header info icon to end of the line

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AfterpayClearpayHeaderElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AfterpayClearpayHeaderElement.kt
@@ -34,11 +34,8 @@ data class AfterpayClearpayHeaderElement(
         return resources.getString(
             R.string.stripe_afterpay_clearpay_marketing
         )
-            // The no break space will keep the afterpay logo and (i) on the same line.
-            .replace(
-                "<img/>",
-                "<img/>$NO_BREAK_SPACE<b>ⓘ</b>"
-            )
+            // The no break space will keep the (i) on the same line as the rest of the label.
+            .plus("$NO_BREAK_SPACE<b>ⓘ</b>")
     }
 
     companion object {


### PR DESCRIPTION
# Summary
Move info icon to the end of the line in the afterpay header 

# Motivation
Align with behavior for upcoming Payment Method Messaging Element

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| <img width="419" height="256" alt="Screenshot 2025-10-16 at 11 31 32 AM" src="https://github.com/user-attachments/assets/b93ea6dd-b538-4075-9038-a9ed2fa455a8" /> | <img width="419" height="179" alt="Screenshot 2025-10-16 at 11 32 48 AM" src="https://github.com/user-attachments/assets/1da9562b-4bfa-468b-8f5f-443ad4198d26" /> |
| <img width="419" height="223" alt="Screenshot 2025-10-16 at 11 32 04 AM" src="https://github.com/user-attachments/assets/67eb5b61-d944-48ae-8122-2d806d880840" /> | <img width="419" height="223" alt="Screenshot 2025-10-16 at 11 32 30 AM" src="https://github.com/user-attachments/assets/f421e477-99af-42de-8651-8a14b507fb74" /> |

# Changelog
N/A