### PR TITLE
Refactor ConfirmationTokenConfirmationInterceptorTest to reduce boilerplate code

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/ConfirmationTokenConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/ConfirmationTokenConfirmationInterceptor.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentelement.confirmation.intent
 
 import android.content.Context
+import androidx.annotation.VisibleForTesting
 import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.networking.ApiRequest
@@ -186,7 +187,8 @@ internal class ConfirmationTokenConfirmationInterceptor @AssistedInject construc
         }
     }
 
-    private fun prepareConfirmationTokenParams(
+    @VisibleForTesting
+    fun prepareConfirmationTokenParams(
         confirmationOption: PaymentMethodConfirmationOption,
         shippingValues: ConfirmPaymentIntentParams.Shipping?,
     ): ConfirmationTokenParams {
@@ -222,7 +224,8 @@ internal class ConfirmationTokenConfirmationInterceptor @AssistedInject construc
         )
     }
 
-    private fun prepareConfirmationTokenClientContextParams(paymentMethodOptions: PaymentMethodOptionsParams?):
+    @VisibleForTesting
+    fun prepareConfirmationTokenClientContextParams(paymentMethodOptions: PaymentMethodOptionsParams?):
         ConfirmationTokenClientContextParams {
         return with(intentConfiguration.toDeferredIntentParams()) {
             ConfirmationTokenClientContextParams(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
1. Expose `prepareConfirmationTokenParams` and `prepareConfirmationTokenClientContextParams` for the tests
2. Add `runConfirmationTokenInterceptorScenario`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://github.com/stripe/stripe-android/pull/11734#discussion_r2433518323

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
