### PR TITLE
Add attestation flag to PaymentMethodMetadata

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivity.kt
@@ -141,6 +141,7 @@ internal class LinkActivity : ComponentActivity() {
                 ),
                 launchMode = LinkLaunchMode.Full,
                 passiveCaptchaParams = null,
+                attestOnIntentConfirmation = false,
             )
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityContract.kt
@@ -41,7 +41,8 @@ internal class LinkActivityContract @Inject internal constructor(
         internal val linkExpressMode: LinkExpressMode,
         internal val linkAccountInfo: LinkAccountUpdate.Value,
         internal val launchMode: LinkLaunchMode,
-        internal val passiveCaptchaParams: PassiveCaptchaParams?
+        internal val passiveCaptchaParams: PassiveCaptchaParams?,
+        internal val attestOnIntentConfirmation: Boolean,
     )
 
     data class Result(

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
@@ -538,6 +538,7 @@ internal class LinkActivityViewModel @Inject constructor(
                     .builder()
                     .configuration(args.configuration)
                     .passiveCaptchaParams(args.passiveCaptchaParams)
+                    .attestOnIntentConfirmation(args.attestOnIntentConfirmation)
                     .requestSurface(args.requestSurface)
                     .publishableKeyProvider { args.publishableKey }
                     .stripeAccountIdProvider { args.stripeAccountId }

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
@@ -551,7 +551,8 @@ internal class LinkControllerInteractor @Inject constructor(
                         linkExpressMode = LinkExpressMode.ENABLED,
                         linkAccountInfo = linkAccountHolder.linkAccountInfo.value,
                         launchMode = launchMode,
-                        passiveCaptchaParams = null
+                        passiveCaptchaParams = null,
+                        attestOnIntentConfirmation = false,
                     )
                 )
             }

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
@@ -79,14 +79,16 @@ internal class LinkPaymentLauncher @Inject internal constructor(
         linkAccountInfo: LinkAccountUpdate.Value,
         launchMode: LinkLaunchMode,
         linkExpressMode: LinkExpressMode,
-        passiveCaptchaParams: PassiveCaptchaParams?
+        passiveCaptchaParams: PassiveCaptchaParams?,
+        attestOnIntentConfirmation: Boolean,
     ) {
         val args = LinkActivityContract.Args(
             configuration = configuration,
             linkExpressMode = linkExpressMode,
             linkAccountInfo = linkAccountInfo,
             launchMode = launchMode,
-            passiveCaptchaParams = passiveCaptchaParams
+            passiveCaptchaParams = passiveCaptchaParams,
+            attestOnIntentConfirmation = attestOnIntentConfirmation
         )
         linkActivityResultLauncher?.launch(args)
         analyticsHelper.onLinkLaunched()

--- a/paymentsheet/src/main/java/com/stripe/android/link/NativeLinkActivityContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/NativeLinkActivityContract.kt
@@ -31,7 +31,8 @@ internal class NativeLinkActivityContract @Inject constructor(
                 launchMode = input.launchMode,
                 paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
                 linkAccountInfo = input.linkAccountInfo,
-                passiveCaptchaParams = input.passiveCaptchaParams
+                passiveCaptchaParams = input.passiveCaptchaParams,
+                attestOnIntentConfirmation = input.attestOnIntentConfirmation,
             )
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/link/NativeLinkArgs.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/NativeLinkArgs.kt
@@ -15,5 +15,6 @@ internal data class NativeLinkArgs(
     val linkAccountInfo: LinkAccountUpdate.Value,
     val paymentElementCallbackIdentifier: String,
     val launchMode: LinkLaunchMode,
-    val passiveCaptchaParams: PassiveCaptchaParams?
+    val passiveCaptchaParams: PassiveCaptchaParams?,
+    val attestOnIntentConfirmation: Boolean,
 ) : Parcelable

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkComponent.kt
@@ -57,6 +57,9 @@ internal interface NativeLinkComponent {
     val linkAccountManager: LinkAccountManager
     val configuration: LinkConfiguration
     val passiveCaptchaParams: PassiveCaptchaParams?
+
+    @get:Named(ATTEST_ON_INTENT_CONFIRMATION)
+    val attestOnIntentConfirmation: Boolean
     val linkEventsReporter: LinkEventsReporter
     val errorReporter: ErrorReporter
     val logger: Logger
@@ -81,6 +84,11 @@ internal interface NativeLinkComponent {
 
         @BindsInstance
         fun passiveCaptchaParams(passiveCaptchaParams: PassiveCaptchaParams?): Builder
+
+        @BindsInstance
+        fun attestOnIntentConfirmation(
+            @Named(ATTEST_ON_INTENT_CONFIRMATION) attestOnIntentConfirmation: Boolean
+        ): Builder
 
         @BindsInstance
         fun publishableKeyProvider(@Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String): Builder

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkDIConsts.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkDIConsts.kt
@@ -1,3 +1,4 @@
 package com.stripe.android.link.injection
 
 internal const val LINK_EXPRESS_MODE = "link_express_mode"
+internal const val ATTEST_ON_INTENT_CONFIRMATION = "attest_on_intent_confirmation"

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
@@ -203,6 +203,7 @@ internal class PaymentMethodViewModel @Inject constructor(
                                 configuration = parentComponent.configuration.withLinkRequiredSettings(),
                                 linkAccount = linkAccount,
                                 passiveCaptchaParams = parentComponent.passiveCaptchaParams,
+                                attestOnIntentConfirmation = parentComponent.attestOnIntentConfirmation,
                             ),
                             eventReporter = parentComponent.eventReporter,
                             savedStateHandle = parentComponent.viewModel.savedStateHandle,

--- a/paymentsheet/src/main/java/com/stripe/android/link/verification/DefaultLinkInlineInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/verification/DefaultLinkInlineInteractor.kt
@@ -42,7 +42,8 @@ internal class DefaultLinkInlineInteractor @Inject constructor(
         key = LINK_EMBEDDED_STATE_KEY,
         initialValue = LinkInlineState(
             verificationState = VerificationState.Loading,
-            passiveCaptchaParams = null
+            passiveCaptchaParams = null,
+            attestOnIntentConfirmation = false,
         )
     )
 
@@ -50,7 +51,12 @@ internal class DefaultLinkInlineInteractor @Inject constructor(
      * Sets up Link verification domain logic (should be called once when initializing)
      */
     override fun setup(paymentMethodMetadata: PaymentMethodMetadata) {
-        updateState { it.copy(passiveCaptchaParams = paymentMethodMetadata.passiveCaptchaParams) }
+        updateState {
+            it.copy(
+                passiveCaptchaParams = paymentMethodMetadata.passiveCaptchaParams,
+                attestOnIntentConfirmation = paymentMethodMetadata.attestOnIntentConfirmation,
+            )
+        }
         val linkConfiguration = paymentMethodMetadata.linkState?.configuration
         if (linkConfiguration == null) {
             // If there is no Link account manager, we don't need to handle verification.
@@ -110,7 +116,8 @@ internal class DefaultLinkInlineInteractor @Inject constructor(
                     linkAccountInfo = accountManager.linkAccountInfo.value,
                     launchMode = LinkLaunchMode.PaymentMethodSelection(null),
                     linkExpressMode = LinkExpressMode.ENABLED,
-                    passiveCaptchaParams = state.value.passiveCaptchaParams
+                    passiveCaptchaParams = state.value.passiveCaptchaParams,
+                    attestOnIntentConfirmation = state.value.attestOnIntentConfirmation
                 )
                 // No UI changes - keep the 2FA until we get a result from the Link payment selection flow.
             }.onFailure { error ->

--- a/paymentsheet/src/main/java/com/stripe/android/link/verification/LinkInlineState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/verification/LinkInlineState.kt
@@ -15,7 +15,8 @@ internal data class LinkInlineState(
      * Current verification state representing the different stages in the verification process.
      */
     val verificationState: VerificationState,
-    val passiveCaptchaParams: PassiveCaptchaParams?
+    val passiveCaptchaParams: PassiveCaptchaParams?,
+    val attestOnIntentConfirmation: Boolean,
 ) : Parcelable
 
 /**

--- a/paymentsheet/src/main/java/com/stripe/android/link/verification/NoOpLinkInlineInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/verification/NoOpLinkInlineInteractor.kt
@@ -14,7 +14,8 @@ internal class NoOpLinkInlineInteractor : LinkInlineInteractor {
     override val state: StateFlow<LinkInlineState> = MutableStateFlow(
         value = LinkInlineState(
             verificationState = VerificationState.RenderButton,
-            passiveCaptchaParams = null
+            passiveCaptchaParams = null,
+            attestOnIntentConfirmation = false,
         )
     )
     override val otpElement: OTPElement = OTPSpec.transform()

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -84,6 +84,7 @@ internal data class PaymentMethodMetadata(
     val passiveCaptchaParams: PassiveCaptchaParams?,
     val openCardScanAutomatically: Boolean,
     val clientAttributionMetadata: ClientAttributionMetadata?,
+    val attestOnIntentConfirmation: Boolean,
 ) : Parcelable {
 
     @IgnoredOnParcel
@@ -371,6 +372,7 @@ internal data class PaymentMethodMetadata(
                 passiveCaptchaParams = elementsSession.passiveCaptchaParams,
                 openCardScanAutomatically = configuration.opensCardScannerAutomatically,
                 clientAttributionMetadata = clientAttributionMetadata,
+                attestOnIntentConfirmation = elementsSession.enableAttestationOnIntentConfirmation
             )
         }
 
@@ -430,13 +432,15 @@ internal data class PaymentMethodMetadata(
                     paymentMethodSelectionFlow = null,
                     paymentIntentCreationFlow = null,
                 ),
+                attestOnIntentConfirmation = elementsSession.enableAttestationOnIntentConfirmation,
             )
         }
 
         internal fun createForNativeLink(
             configuration: LinkConfiguration,
             linkAccount: LinkAccount,
-            passiveCaptchaParams: PassiveCaptchaParams?
+            passiveCaptchaParams: PassiveCaptchaParams?,
+            attestOnIntentConfirmation: Boolean,
         ): PaymentMethodMetadata {
             return PaymentMethodMetadata(
                 stripeIntent = configuration.stripeIntent,
@@ -483,6 +487,7 @@ internal data class PaymentMethodMetadata(
                 passiveCaptchaParams = passiveCaptchaParams,
                 openCardScanAutomatically = false,
                 clientAttributionMetadata = configuration.clientAttributionMetadata,
+                attestOnIntentConfirmation = attestOnIntentConfirmation,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinition.kt
@@ -7,6 +7,7 @@ import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.link.account.LinkStore
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
@@ -20,8 +21,15 @@ internal class LinkConfirmationDefinition @Inject constructor(
 ) : ConfirmationDefinition<LinkConfirmationOption, LinkPaymentLauncher, Unit, LinkActivityResult> {
     override val key: String = "Link"
 
+    @Volatile
+    private var attestOnIntentConfirmation: Boolean = false
+
     override fun option(confirmationOption: ConfirmationHandler.Option): LinkConfirmationOption? {
         return confirmationOption as? LinkConfirmationOption
+    }
+
+    override fun bootstrap(paymentMethodMetadata: PaymentMethodMetadata) {
+        this.attestOnIntentConfirmation = paymentMethodMetadata.attestOnIntentConfirmation
     }
 
     override fun createLauncher(
@@ -59,7 +67,8 @@ internal class LinkConfirmationDefinition @Inject constructor(
             linkAccountInfo = linkAccountHolder.linkAccountInfo.value,
             launchMode = confirmationOption.linkLaunchMode,
             linkExpressMode = confirmationOption.linkExpressMode,
-            passiveCaptchaParams = confirmationOption.passiveCaptchaParams
+            passiveCaptchaParams = confirmationOption.passiveCaptchaParams,
+            attestOnIntentConfirmation = attestOnIntentConfirmation
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -307,7 +307,8 @@ internal class PaymentOptionsViewModel @Inject constructor(
                     launchMode = LinkLaunchMode.PaymentMethodSelection(selectedPayment = null),
                     linkAccountInfo = linkAccountHolder.linkAccountInfo.value,
                     linkExpressMode = LinkExpressMode.ENABLED,
-                    passiveCaptchaParams = args.state.paymentMethodMetadata.passiveCaptchaParams
+                    passiveCaptchaParams = args.state.paymentMethodMetadata.passiveCaptchaParams,
+                    attestOnIntentConfirmation = args.state.paymentMethodMetadata.attestOnIntentConfirmation,
                 )
             } else {
                 _paymentOptionsActivityResult.tryEmit(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -289,6 +289,7 @@ internal class DefaultFlowController @Inject internal constructor(
             )
 
             if (shouldPresentLink) {
+                val paymentMethodMetadata = state.paymentSheetState.paymentMethodMetadata
                 flowControllerLinkLauncher.present(
                     configuration = linkConfiguration,
                     linkAccountInfo = linkAccountInfo,
@@ -296,7 +297,8 @@ internal class DefaultFlowController @Inject internal constructor(
                     launchMode = LinkLaunchMode.PaymentMethodSelection(
                         selectedPayment = (paymentSelection as? Link)?.selectedPayment?.details
                     ),
-                    passiveCaptchaParams = state.paymentSheetState.paymentMethodMetadata.passiveCaptchaParams
+                    passiveCaptchaParams = paymentMethodMetadata.passiveCaptchaParams,
+                    attestOnIntentConfirmation = paymentMethodMetadata.attestOnIntentConfirmation,
                 )
             } else {
                 showPaymentOptionList(state, paymentSelection)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
@@ -270,7 +270,8 @@ internal class DefaultWalletButtonsInteractor constructor(
                 linkAccountInfo = linkAccountHolder.linkAccountInfo.value,
                 launchMode = LinkLaunchMode.PaymentMethodSelection(selectedPayment?.details),
                 linkExpressMode = LinkExpressMode.ENABLED,
-                passiveCaptchaParams = arguments.paymentMethodMetadata.passiveCaptchaParams
+                passiveCaptchaParams = arguments.paymentMethodMetadata.passiveCaptchaParams,
+                attestOnIntentConfirmation = arguments.paymentMethodMetadata.attestOnIntentConfirmation
             )
         } else {
             handleButtonPressed(

--- a/paymentsheet/src/test/java/com/stripe/android/link/FakeNativeLinkComponent.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/FakeNativeLinkComponent.kt
@@ -51,4 +51,5 @@ internal class FakeNativeLinkComponent(
     override val oAuthConsentViewModelComponentFactory: OAuthConsentViewModelComponent.Factory = mock(),
     override val webLinkAuthChannel: WebLinkAuthChannel = WebLinkAuthChannel(),
     override val passiveCaptchaParams: PassiveCaptchaParams? = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
+    override val attestOnIntentConfirmation: Boolean = false,
 ) : NativeLinkComponent

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityContractTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityContractTest.kt
@@ -28,7 +28,8 @@ class LinkActivityContractTest {
             lastUpdateReason = null
         ),
         launchMode = LinkLaunchMode.Full,
-        passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+        passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
+        attestOnIntentConfirmation = false,
     )
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
@@ -155,7 +155,8 @@ internal class LinkActivityViewModelTest {
             ),
             paymentElementCallbackIdentifier = "LinkNativeTestIdentifier",
             launchMode = LinkLaunchMode.Full,
-            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
+            attestOnIntentConfirmation = false,
         )
         val savedStateHandle = SavedStateHandle()
         val factory = LinkActivityViewModel.factory(savedStateHandle)

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerCoordinatorTest.kt
@@ -148,7 +148,8 @@ internal class LinkControllerCoordinatorTest {
                 linkExpressMode = LinkExpressMode.DISABLED,
                 linkAccountInfo = LinkAccountUpdate.Value(null),
                 launchMode = LinkLaunchMode.PaymentMethodSelection(null),
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
+                attestOnIntentConfirmation = false,
             )
         )
         verify(viewModel).onLinkActivityResult(

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkPaymentLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkPaymentLauncherTest.kt
@@ -93,7 +93,8 @@ internal class LinkPaymentLauncherTest {
                 linkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
                 linkExpressMode = LinkExpressMode.ENABLED,
                 launchMode = LinkLaunchMode.Full,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
+                attestOnIntentConfirmation = false,
             )
 
             val launchCall = awaitLaunchCall()
@@ -105,7 +106,8 @@ internal class LinkPaymentLauncherTest {
                         linkExpressMode = LinkExpressMode.ENABLED,
                         linkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
                         launchMode = LinkLaunchMode.Full,
-                        passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                        passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
+                        attestOnIntentConfirmation = false,
                     )
                 )
 
@@ -128,11 +130,46 @@ internal class LinkPaymentLauncherTest {
                 linkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
                 linkExpressMode = LinkExpressMode.DISABLED,
                 launchMode = LinkLaunchMode.Full,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
+                attestOnIntentConfirmation = false,
             )
 
             val launchCall = awaitLaunchCall() as? LinkActivityContract.Args
             assertThat(launchCall?.linkExpressMode).isEqualTo(LinkExpressMode.DISABLED)
+            awaitNextRegisteredLauncher()
+        }
+    }
+
+    @Test
+    fun `present should launch with correct args when attestOnIntentConfirmation is true`() = runTest {
+        testPresentWithAttestOnIntentConfirmation(attestOnIntentConfirmation = true)
+    }
+
+    @Test
+    fun `present should launch with correct args when attestOnIntentConfirmation is false`() = runTest {
+        testPresentWithAttestOnIntentConfirmation(attestOnIntentConfirmation = false)
+    }
+
+    private suspend fun testPresentWithAttestOnIntentConfirmation(attestOnIntentConfirmation: Boolean) {
+        DummyActivityResultCaller.test {
+            val linkPaymentLauncher = createLinkPaymentLauncher()
+
+            linkPaymentLauncher.register(activityResultCaller) {}
+
+            val registerCall = awaitRegisterCall()
+            assertThat(registerCall).isNotNull()
+
+            linkPaymentLauncher.present(
+                configuration = TestFactory.LINK_CONFIGURATION,
+                linkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
+                linkExpressMode = LinkExpressMode.ENABLED,
+                launchMode = LinkLaunchMode.Full,
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
+                attestOnIntentConfirmation = attestOnIntentConfirmation,
+            )
+
+            val launchCall = awaitLaunchCall() as? LinkActivityContract.Args
+            assertThat(launchCall?.attestOnIntentConfirmation).isEqualTo(attestOnIntentConfirmation)
             awaitNextRegisteredLauncher()
         }
     }
@@ -238,7 +275,8 @@ internal class LinkPaymentLauncherTest {
                 linkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
                 linkExpressMode = LinkExpressMode.ENABLED,
                 launchMode = LinkLaunchMode.Full,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
+                attestOnIntentConfirmation = false,
             )
 
             verifyActivityResultCallback(
@@ -271,7 +309,8 @@ internal class LinkPaymentLauncherTest {
                     linkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
                     linkExpressMode = LinkExpressMode.ENABLED,
                     launchMode = LinkLaunchMode.Full,
-                    passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                    passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
+                    attestOnIntentConfirmation = false,
                 )
 
                 val registerCall = awaitRegisterCall()

--- a/paymentsheet/src/test/java/com/stripe/android/link/NativeLinkActivityContractTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/NativeLinkActivityContractTest.kt
@@ -43,7 +43,8 @@ class NativeLinkActivityContractTest {
             linkExpressMode = LinkExpressMode.DISABLED,
             linkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
             launchMode = LinkLaunchMode.Full,
-            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
+            attestOnIntentConfirmation = false,
         )
 
         val intent = contract.createIntent(ApplicationProvider.getApplicationContext(), args)
@@ -63,7 +64,8 @@ class NativeLinkActivityContractTest {
                 linkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
                 paymentElementCallbackIdentifier = LINK_CALLBACK_TEST_IDENTIFIER,
                 launchMode = LinkLaunchMode.Full,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
+                attestOnIntentConfirmation = false,
             )
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
@@ -295,7 +295,8 @@ internal object TestFactory {
         linkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
         paymentElementCallbackIdentifier = "LinkNativeTestIdentifier",
         launchMode = LinkLaunchMode.Full,
-        passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+        passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
+        attestOnIntentConfirmation = false,
     )
 
     val FINANCIAL_CONNECTIONS_CHECKING_ACCOUNT = FinancialConnectionsAccount(

--- a/paymentsheet/src/test/java/com/stripe/android/link/WebLinkActivityContractTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/WebLinkActivityContractTest.kt
@@ -45,7 +45,8 @@ class WebLinkActivityContractTest {
             linkExpressMode = LinkExpressMode.DISABLED,
             linkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
             launchMode = LinkLaunchMode.Full,
-            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
+            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
+            attestOnIntentConfirmation = false,
         )
 
         val intent = contract.createIntent(ApplicationProvider.getApplicationContext(), args)

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
@@ -56,6 +56,7 @@ internal object PaymentMethodMetadataFactory {
         passiveCaptchaParams: PassiveCaptchaParams? = null,
         openCardScanAutomatically: Boolean = false,
         clientAttributionMetadata: ClientAttributionMetadata? = null,
+        attestOnIntentConfirmation: Boolean = false,
     ): PaymentMethodMetadata {
         return PaymentMethodMetadata(
             stripeIntent = stripeIntent,
@@ -97,6 +98,7 @@ internal object PaymentMethodMetadataFactory {
             passiveCaptchaParams = passiveCaptchaParams,
             openCardScanAutomatically = openCardScanAutomatically,
             clientAttributionMetadata = clientAttributionMetadata,
+            attestOnIntentConfirmation = attestOnIntentConfirmation,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationActivityTest.kt
@@ -192,7 +192,8 @@ internal class LinkConfirmationActivityTest(private val nativeLinkEnabled: Boole
                             linkAccountInfo = LinkAccountUpdate.Value(null),
                             paymentElementCallbackIdentifier = "ConfirmationTestIdentifier",
                             launchMode = LinkLaunchMode.Full,
-                            passiveCaptchaParams = null
+                            passiveCaptchaParams = null,
+                            attestOnIntentConfirmation = false,
                         )
                     )
                 )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -242,7 +242,8 @@ internal class PaymentOptionsViewModelTest {
             linkAccountInfo = eq(LinkAccountUpdate.Value(unverifiedAccount)),
             launchMode = eq(LinkLaunchMode.PaymentMethodSelection(selectedPayment = null)),
             linkExpressMode = eq(LinkExpressMode.ENABLED),
-            passiveCaptchaParams = anyOrNull()
+            passiveCaptchaParams = anyOrNull(),
+            attestOnIntentConfirmation = eq(false),
         )
     }
 
@@ -281,7 +282,8 @@ internal class PaymentOptionsViewModelTest {
             linkAccountInfo = any(),
             launchMode = any(),
             linkExpressMode = any(),
-            passiveCaptchaParams = any()
+            passiveCaptchaParams = any(),
+            attestOnIntentConfirmation = any(),
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -528,7 +528,8 @@ internal class DefaultFlowControllerTest {
             linkAccountInfo = anyOrNull(),
             launchMode = any(),
             linkExpressMode = any(),
-            passiveCaptchaParams = anyOrNull()
+            passiveCaptchaParams = anyOrNull(),
+            attestOnIntentConfirmation = any(),
         )
 
         verify(paymentOptionActivityLauncher, never()).launch(any(), anyOrNull())
@@ -569,7 +570,8 @@ internal class DefaultFlowControllerTest {
             linkAccountInfo = anyOrNull(),
             launchMode = any(),
             linkExpressMode = any(),
-            passiveCaptchaParams = anyOrNull()
+            passiveCaptchaParams = anyOrNull(),
+            attestOnIntentConfirmation = any(),
         )
 
         // Simulate user dismissing 2FA with back press
@@ -592,7 +594,8 @@ internal class DefaultFlowControllerTest {
             linkAccountInfo = anyOrNull(),
             linkExpressMode = any(),
             launchMode = any(),
-            passiveCaptchaParams = any()
+            passiveCaptchaParams = any(),
+            attestOnIntentConfirmation = any(),
         )
 
         // Verify payment option launcher was called instead

--- a/paymentsheet/src/test/java/com/stripe/android/utils/RecordingLinkPaymentLauncher.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/RecordingLinkPaymentLauncher.kt
@@ -42,7 +42,7 @@ internal object RecordingLinkPaymentLauncher {
                 unregisterCalls.add(Unit)
             }
 
-            on { present(any(), anyOrNull(), any(), any(), anyOrNull()) } doAnswer { invocation ->
+            on { present(any(), anyOrNull(), any(), any(), anyOrNull(), any()) } doAnswer { invocation ->
                 val arguments = invocation.arguments
 
                 presentCalls.add(
@@ -52,6 +52,7 @@ internal object RecordingLinkPaymentLauncher {
                         launchMode = arguments[2] as LinkLaunchMode,
                         linkExpressMode = arguments[3] as LinkExpressMode,
                         passiveCaptchaParams = arguments[4] as? PassiveCaptchaParams,
+                        attestOnIntentConfirmation = arguments[5] as Boolean,
                     )
                 )
             }
@@ -88,6 +89,7 @@ internal object RecordingLinkPaymentLauncher {
         val linkAccount: LinkAccount?,
         val launchMode: LinkLaunchMode,
         val linkExpressMode: LinkExpressMode,
-        val passiveCaptchaParams: PassiveCaptchaParams?
+        val passiveCaptchaParams: PassiveCaptchaParams?,
+        val attestOnIntentConfirmation: Boolean,
     )
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add attestation flag to PaymentMethodMetadata

Also, Native Link can create a new `PaymentMethodMetadata`, so we have to pass the flag into Link so it's available when creating the  `PaymentMethodMetadata`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-4131

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
