### PR TITLE
Allow `uk_` keys for customer ephemeral keys

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
@@ -231,7 +231,8 @@ private fun String.isEKClientSecretValid(): Boolean {
     return Regex(EK_CLIENT_SECRET_VALID_REGEX_PATTERN).matches(this)
 }
 
-private const val EK_CLIENT_SECRET_VALID_REGEX_PATTERN = "^ek_[^_](.)+$"
+// The `uk_` prefix is used by the Stripe Dashboard Mobile App for MOTO
+private const val EK_CLIENT_SECRET_VALID_REGEX_PATTERN = "^(ek_|uk_)[^_](.)+\$"
 
 internal fun CommonConfiguration.containsVolatileDifferences(
     other: CommonConfiguration

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtxTest.kt
@@ -44,6 +44,8 @@ class PaymentSheetConfigurationKtxTest {
     fun `'validate' should succeed when ephemeral key secret is of correct format`() {
         getConfig("ek_askljdlkasfhgasdfjls").validate(isLiveMode = false)
         getConfig("ek_test_iiuwfhdaiuhasdvkcjn32n").validate(isLiveMode = false)
+        getConfig("uk_iiuwfhdaiuhasdvkcjn32n").validate(isLiveMode = false)
+        getConfig("uk_test_iiuwfhdaiuhasdvkcjn32n").validate(isLiveMode = false)
     }
 
     @Test


### PR DESCRIPTION
Related to: https://github.com/stripe/stripe-react-native/pull/2169

# Summary
This is an internal change that's needed by the Stripe Dashboard mobile app.

Fixes a regression that stopped allowing using `uk_` keys as customer ephemeral keys in the Payment Sheet. This key is needed by the Stripe Dashboard mobile app.

Things were working properly in previous versions of the app, so I assume this is a regression.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Needed by the Stripe Dashboard app for MOTO.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->