### PR TITLE
Enable Gradle configuration cache in repo & Bitrise

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -424,7 +424,8 @@ workflows:
       - activate-ssh-key@4:
           run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
       - git-clone@8: { }
-      - restore-gradle-cache@1: { }
+      - restore-gradle-configuration-cache@1: { }
+      - restore-gradle-cache@2: { }
       - set-java-version@1:
           inputs:
             - set_java_version: 21
@@ -452,6 +453,7 @@ workflows:
             - deploy_path: /tmp/test_results
             - is_enable_public_page: "false"
           title: Deploy test results artifacts
+      - save-gradle-configuration-cache@1: { }
       - save-gradle-cache@1: { }
 meta:
   bitrise.io:

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,5 +20,8 @@ android.useAndroidX=true
 
 org.gradle.jvmargs=-Xms4g -Xmx8g -XX:+UseParallelGC -XX:MaxMetaspaceSize=2g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
+org.gradle.configuration-cache=true
+org.gradle.configuration-cache.problems=warn
+
 # Update StripeSdkVersion.VERSION_NAME when publishing a new release
 VERSION_NAME=21.28.2

--- a/hcaptcha/build.gradle
+++ b/hcaptcha/build.gradle
@@ -43,10 +43,12 @@ android.libraryVariants.all { variant ->
         group 'Generate'
         description "Generate HTML java class"
 
+        def outputJavaClass = file("$outputDir/HCaptchaHtml.kt")
+        def template = file("$projectDir/src/main/html/HCaptchaHtml.java.tml").text
+        def htmlFile = file("$projectDir/src/main/html/hcaptcha.html")
+
         doFirst {
-            def outputJavaClass = file("$outputDir/HCaptchaHtml.kt")
-            def template = file("$projectDir/src/main/html/HCaptchaHtml.java.tml").text
-            def html = file("$projectDir/src/main/html/hcaptcha.html")
+            def html = htmlFile
                     .readLines()
                     .stream()
                     .collect(Collectors.joining("\n"))


### PR DESCRIPTION
# Summary
Enable Gradle configuration cache in repo & Bitrise

# Motivation
Slightly faster build times

https://bitrise.io/blog/post/accelerate-your-gradle-builds-with-gradle-config-cache

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified