### PR TITLE
Fix analytics event status values for payment confirmation

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
@@ -332,9 +332,15 @@ internal class PaymentLauncherViewModel @Inject constructor(
                 PaymentAnalyticsEvent.PaymentLauncherNextActionFinished
             }
 
+            val resultStatus = when (stripeInternalResult) {
+                is InternalPaymentResult.Completed -> "succeeded"
+                is InternalPaymentResult.Canceled -> "canceled"
+                is InternalPaymentResult.Failed -> "failed"
+            }
+
             val intentParams = mapOf(
                 "intent_id" to intent?.clientSecret?.toStripeId(),
-                "status" to intent?.status?.code,
+                "status" to resultStatus,
                 "payment_method_type" to intent?.paymentMethod?.type?.code,
             ).filterNotNullValues()
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Send correct `status` for `stripe_android.paymenthandler.confirm.finished` event.
The status field should only be 'succeeded', 'canceled', or 'failed'. That is not the case on android today (see [query](https://hubble.corp.stripe.com/saved-queries/2beb8dd1-2b31-4d05-9881-e4c3efeae8d8?filter-status=))

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
[android event status types](https://hubble.corp.stripe.com/saved-queries/2beb8dd1-2b31-4d05-9881-e4c3efeae8d8?filter-status=)

[ios event statuses](https://hubble.corp.stripe.com/saved-queries/11928613-4d9b-4d6e-8da8-8ff57ab61c30)

https://jira.corp.stripe.com/browse/RUN_MOBILESDK-4730

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
