### PR TITLE
Revert "Block Konbini and Blik payment methods with ConfirmationTokens in test mode"

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/ConfirmationTokenConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/ConfirmationTokenConfirmationInterceptor.kt
@@ -12,7 +12,6 @@ import com.stripe.android.model.ConfirmationTokenClientContextParams
 import com.stripe.android.model.ConfirmationTokenParams
 import com.stripe.android.model.DeferredIntentParams
 import com.stripe.android.model.MandateDataParams
-import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.model.RadarOptions
 import com.stripe.android.model.StripeIntent
@@ -49,8 +48,6 @@ internal class ConfirmationTokenConfirmationInterceptor @AssistedInject construc
         confirmationOption: PaymentMethodConfirmationOption.New,
         shippingValues: ConfirmPaymentIntentParams.Shipping?
     ): ConfirmationDefinition.Action<Args> {
-        failIfUnsupportedPaymentMethod(confirmationOption.createParams.typeCode)
-
         return stripeRepository.createConfirmationToken(
             confirmationTokenParams = prepareConfirmationTokenParams(
                 confirmationOption,
@@ -84,8 +81,6 @@ internal class ConfirmationTokenConfirmationInterceptor @AssistedInject construc
         shippingValues: ConfirmPaymentIntentParams.Shipping?
     ): ConfirmationDefinition.Action<Args> {
         val paymentMethod = confirmationOption.paymentMethod
-        failIfUnsupportedPaymentMethod(paymentMethod.type?.code)
-
         return stripeRepository.createConfirmationToken(
             confirmationTokenParams = prepareConfirmationTokenParams(
                 confirmationOption,
@@ -254,21 +249,6 @@ internal class ConfirmationTokenConfirmationInterceptor @AssistedInject construc
                 customer = customerId,
                 paymentMethodOptions = paymentMethodOptions,
                 requireCvcRecollection = intentConfiguration.requireCvcRecollection
-            )
-        }
-    }
-
-    private fun failIfUnsupportedPaymentMethod(paymentMethodCode: String?) {
-        val unsupportedPaymentMethods = setOf(
-            PaymentMethod.Type.Konbini.code,
-            PaymentMethod.Type.Blik.code,
-        )
-
-        if (paymentMethodCode in unsupportedPaymentMethods && !requestOptions.apiKeyIsLiveMode) {
-            throw IllegalStateException(
-                "(Test-mode only error) The payment method '$paymentMethodCode' is not yet supported with " +
-                    "confirmation tokens. Please contact us if you'd like to use this feature via a GitHub " +
-                    "issue on stripe-android."
             )
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/ConfirmationTokenConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/ConfirmationTokenConfirmationInterceptorTest.kt
@@ -1111,138 +1111,6 @@ class ConfirmationTokenConfirmationInterceptorTest {
     }
 
     @Test
-    fun `Fails with Konbini payment method in test mode`() {
-        val konbiniCreateParams = PaymentMethodCreateParams(
-            code = "konbini",
-            requiresMandate = false,
-            billingDetails = PaymentMethodCreateParamsFixtures.BILLING_DETAILS,
-        )
-
-        runConfirmationTokenInterceptorScenario { interceptor ->
-            val confirmationOption = PaymentMethodConfirmationOption.New(
-                createParams = konbiniCreateParams,
-                optionsParams = null,
-                extraParams = null,
-                shouldSave = false,
-                passiveCaptchaParams = null,
-            )
-
-            val exception = runCatching {
-                interceptor.intercept(
-                    intent = PaymentIntentFactory.create(),
-                    confirmationOption = confirmationOption,
-                    shippingValues = null,
-                )
-            }.exceptionOrNull()
-
-            assertThat(exception).isInstanceOf<IllegalStateException>()
-            assertThat(exception?.message).isEqualTo(
-                "(Test-mode only error) The payment method 'konbini' " +
-                    "is not yet supported with confirmation tokens. " +
-                    "Please contact us if you'd like to use this feature via a GitHub " +
-                    "issue on stripe-android."
-            )
-        }
-    }
-
-    @Test
-    fun `Fails with Blik payment method in test mode`() {
-        val blikCreateParams = PaymentMethodCreateParams.createBlik(
-            billingDetails = PaymentMethodCreateParamsFixtures.BILLING_DETAILS,
-        )
-
-        runConfirmationTokenInterceptorScenario { interceptor ->
-            val confirmationOption = PaymentMethodConfirmationOption.New(
-                createParams = blikCreateParams,
-                optionsParams = null,
-                extraParams = null,
-                shouldSave = false,
-                passiveCaptchaParams = null,
-            )
-
-            val exception = runCatching {
-                interceptor.intercept(
-                    intent = PaymentIntentFactory.create(),
-                    confirmationOption = confirmationOption,
-                    shippingValues = null,
-                )
-            }.exceptionOrNull()
-
-            assertThat(exception).isInstanceOf<IllegalStateException>()
-            assertThat(exception?.message).isEqualTo(
-                "(Test-mode only error) The payment method 'blik' " +
-                    "is not yet supported with confirmation tokens. " +
-                    "Please contact us if you'd like to use this feature via a GitHub " +
-                    "issue on stripe-android."
-            )
-        }
-    }
-
-    @Test
-    fun `Succeeds with Konbini payment method in live mode`() {
-        val konbiniCreateParams = PaymentMethodCreateParams(
-            code = "konbini",
-            requiresMandate = false,
-            billingDetails = PaymentMethodCreateParamsFixtures.BILLING_DETAILS,
-        )
-
-        runConfirmationTokenInterceptorScenario(isLiveMode = true) { interceptor ->
-            val confirmationOption = PaymentMethodConfirmationOption.New(
-                createParams = konbiniCreateParams,
-                optionsParams = null,
-                extraParams = null,
-                shouldSave = false,
-                passiveCaptchaParams = null,
-            )
-
-            val nextStep = interceptor.intercept(
-                intent = PaymentIntentFactory.create(),
-                confirmationOption = confirmationOption,
-                shippingValues = null,
-            )
-
-            assertThat(nextStep).isEqualTo(
-                ConfirmationDefinition.Action.Complete<IntentConfirmationDefinition.Args>(
-                    intent = PaymentIntentFixtures.PI_SUCCEEDED,
-                    deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
-                    completedFullPaymentFlow = true,
-                )
-            )
-        }
-    }
-
-    @Test
-    fun `Succeeds with Blik payment method in live mode`() {
-        val blikCreateParams = PaymentMethodCreateParams.createBlik(
-            billingDetails = PaymentMethodCreateParamsFixtures.BILLING_DETAILS,
-        )
-
-        runConfirmationTokenInterceptorScenario(isLiveMode = true) { interceptor ->
-            val confirmationOption = PaymentMethodConfirmationOption.New(
-                createParams = blikCreateParams,
-                optionsParams = null,
-                extraParams = null,
-                shouldSave = false,
-                passiveCaptchaParams = null,
-            )
-
-            val nextStep = interceptor.intercept(
-                intent = PaymentIntentFactory.create(),
-                confirmationOption = confirmationOption,
-                shippingValues = null,
-            )
-
-            assertThat(nextStep).isEqualTo(
-                ConfirmationDefinition.Action.Complete<IntentConfirmationDefinition.Args>(
-                    intent = PaymentIntentFixtures.PI_SUCCEEDED,
-                    deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
-                    completedFullPaymentFlow = true,
-                )
-            )
-        }
-    }
-
-    @Test
     fun `Saved PM - includes radarOptions when hCaptchaToken is provided for CSC flow`() {
         runConfirmationTokenInterceptorScenario(
             retrievedIntentStatus = StripeIntent.Status.RequiresConfirmation,
@@ -1293,14 +1161,12 @@ class ConfirmationTokenConfirmationInterceptorTest {
         observedParams: Turbine<ConfirmationTokenParams> = Turbine(),
         retrievedIntentStatus: StripeIntent.Status = StripeIntent.Status.Succeeded,
         initializationMode: PaymentElementLoader.InitializationMode = DEFAULT_DEFERRED_INTENT,
-        isLiveMode: Boolean = false,
         block: suspend (IntentConfirmationInterceptor) -> Unit
     ) {
         runInterceptorScenario(
             initializationMode = initializationMode,
             scenario = InterceptorTestScenario(
                 ephemeralKeySecret = "ek_test_123",
-                publishableKeyProvider = { if (isLiveMode) "pk_live_123" else "pk_test_123" },
                 stripeRepository = createFakeStripeRepositoryForConfirmationToken(
                     observedParams,
                     retrievedIntentStatus,


### PR DESCRIPTION
Reverts stripe/stripe-android#11756

- Blik is filtered out in deferred flow by element session
- Konbini’s phone number field is optional, making it actually work with CT

Context: https://stripe.slack.com/archives/C09BL4ZT2RM/p1760722868369979