### PR TITLE
Add client attribution metadata to Link PaymentMethodCreateParams

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
@@ -1403,6 +1403,7 @@ constructor(
         fun createLink(
             paymentDetailsId: String,
             consumerSessionClientSecret: String,
+            clientAttributionMetadata: ClientAttributionMetadata,
             billingDetails: PaymentMethod.BillingDetails? = null,
             extraParams: Map<String, @RawValue Any>? = null,
             allowRedisplay: PaymentMethod.AllowRedisplay? = null,
@@ -1416,6 +1417,7 @@ constructor(
                 ),
                 allowRedisplay = allowRedisplay,
                 billingDetails = billingDetails,
+                clientAttributionMetadata = clientAttributionMetadata,
             )
         }
 

--- a/payments-core/src/test/java/com/stripe/android/model/PaymentMethodCreateParamsTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/PaymentMethodCreateParamsTest.kt
@@ -259,8 +259,9 @@ class PaymentMethodCreateParamsTest {
             PaymentMethodCreateParams.createLink(
                 paymentDetailsId,
                 consumerSessionClientSecret,
+                clientAttributionMetadata,
                 billingDetails,
-                extraParams
+                extraParams,
             ).toParamMap()
         ).isEqualTo(
             mapOf(
@@ -286,6 +287,7 @@ class PaymentMethodCreateParamsTest {
                     "email" to "john@doe.com",
                     "phone" to "+15555555555",
                 ),
+                "client_attribution_metadata" to clientAttributionMetadata.toParamMap(),
             )
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
@@ -196,6 +196,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
             linkRepository.createPaymentMethod(
                 consumerSessionClientSecret = account.clientSecret,
                 paymentMethod = linkPaymentMethod,
+                clientAttributionMetadata = config.clientAttributionMetadata,
             ).getOrThrow()
         }
     }
@@ -211,6 +212,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
                     userEmail = account.email,
                     stripeIntent = config.stripeIntent,
                     consumerSessionClientSecret = account.clientSecret,
+                    clientAttributionMetadata = config.clientAttributionMetadata,
                 ).onSuccess {
                     errorReporter.report(ErrorReporter.SuccessEvent.LINK_CREATE_CARD_SUCCESS)
                 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
@@ -7,6 +7,7 @@ import com.stripe.android.link.LinkPaymentDetails
 import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.model.Address
+import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.LinkMode
@@ -154,6 +155,7 @@ internal class DefaultLinkConfirmationHandler @Inject constructor(
                     cvc = cvc,
                     billingPhone = billingPhone,
                     allowRedisplay = allowRedisplay,
+                    clientAttributionMetadata = configuration.clientAttributionMetadata,
                 ),
                 extraParams = null,
                 optionsParams = null,
@@ -237,6 +239,7 @@ internal fun createPaymentMethodCreateParams(
     consumerSessionClientSecret: String,
     cvc: String?,
     billingPhone: String?,
+    clientAttributionMetadata: ClientAttributionMetadata,
     allowRedisplay: PaymentMethod.AllowRedisplay? = null,
 ): PaymentMethodCreateParams {
     val billingDetails = PaymentMethod.BillingDetails(
@@ -261,6 +264,7 @@ internal fun createPaymentMethodCreateParams(
         billingDetails = billingDetails.takeIf { it != PaymentMethod.BillingDetails() },
         extraParams = cvc?.let { mapOf("card" to mapOf("cvc" to cvc)) },
         allowRedisplay = allowRedisplay,
+        clientAttributionMetadata = clientAttributionMetadata,
     )
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
@@ -220,6 +220,7 @@ internal class LinkApiRepository @Inject constructor(
         userEmail: String,
         stripeIntent: StripeIntent,
         consumerSessionClientSecret: String,
+        clientAttributionMetadata: ClientAttributionMetadata,
     ): Result<LinkPaymentDetails.New> = withContext(workContext) {
         consumersApiService.createPaymentDetails(
             consumerSessionClientSecret = consumerSessionClientSecret,
@@ -237,7 +238,8 @@ internal class LinkApiRepository @Inject constructor(
                 paymentDetailsId = paymentDetails.id,
                 consumerSessionClientSecret = consumerSessionClientSecret,
                 extraParams = extraParams,
-                allowRedisplay = paymentMethodCreateParams.allowRedisplay
+                allowRedisplay = paymentMethodCreateParams.allowRedisplay,
+                clientAttributionMetadata = clientAttributionMetadata,
             )
 
             LinkPaymentDetails.New(
@@ -316,7 +318,8 @@ internal class LinkApiRepository @Inject constructor(
                 paymentMethodCreateParams = PaymentMethodCreateParams.createLink(
                     paymentDetailsId = paymentMethodId,
                     consumerSessionClientSecret = consumerSessionClientSecret,
-                    extraParams = extraConfirmationParams(paymentMethodCreateParams.toParamMap())
+                    extraParams = extraConfirmationParams(paymentMethodCreateParams.toParamMap()),
+                    clientAttributionMetadata = clientAttributionMetadata,
                 ),
             )
         }
@@ -365,12 +368,14 @@ internal class LinkApiRepository @Inject constructor(
     override suspend fun createPaymentMethod(
         consumerSessionClientSecret: String,
         paymentMethod: LinkPaymentMethod,
+        clientAttributionMetadata: ClientAttributionMetadata,
     ): Result<PaymentMethod> = withContext(workContext) {
         val params = createPaymentMethodCreateParams(
             selectedPaymentDetails = paymentMethod.details,
             consumerSessionClientSecret = consumerSessionClientSecret,
             cvc = paymentMethod.collectedCvc,
             billingPhone = paymentMethod.billingPhone,
+            clientAttributionMetadata = clientAttributionMetadata,
         )
         stripeRepository.createPaymentMethod(
             paymentMethodCreateParams = params,

--- a/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
@@ -111,6 +111,7 @@ internal interface LinkRepository {
         userEmail: String,
         stripeIntent: StripeIntent,
         consumerSessionClientSecret: String,
+        clientAttributionMetadata: ClientAttributionMetadata,
     ): Result<LinkPaymentDetails.New>
 
     suspend fun createBankAccountPaymentDetails(
@@ -140,7 +141,8 @@ internal interface LinkRepository {
 
     suspend fun createPaymentMethod(
         consumerSessionClientSecret: String,
-        paymentMethod: LinkPaymentMethod
+        paymentMethod: LinkPaymentMethod,
+        clientAttributionMetadata: ClientAttributionMetadata
     ): Result<PaymentMethod>
 
     suspend fun logOut(

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAccountManagerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAccountManagerTest.kt
@@ -409,6 +409,7 @@ class DefaultLinkAccountManagerTest {
                 userEmail: String,
                 stripeIntent: StripeIntent,
                 consumerSessionClientSecret: String,
+                clientAttributionMetadata: ClientAttributionMetadata,
             ): Result<LinkPaymentDetails.New> {
                 val details = result.first()
                 if (result.size > 1) {

--- a/paymentsheet/src/test/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandlerTest.kt
@@ -610,6 +610,7 @@ internal class DefaultLinkConfirmationHandlerTest {
                 extraParams = cvc?.let { mapOf("card" to mapOf("cvc" to cvc)) },
                 billingDetails = billingDetails,
                 allowRedisplay = allowRedisplay,
+                clientAttributionMetadata = configuration.clientAttributionMetadata,
             )
         )
         assertThat(option.passiveCaptchaParams).isEqualTo(passiveCaptchaParams)

--- a/paymentsheet/src/test/java/com/stripe/android/link/repositories/FakeLinkRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/repositories/FakeLinkRepository.kt
@@ -158,6 +158,7 @@ internal open class FakeLinkRepository : LinkRepository {
         userEmail: String,
         stripeIntent: StripeIntent,
         consumerSessionClientSecret: String,
+        clientAttributionMetadata: ClientAttributionMetadata,
     ) = createCardPaymentDetailsResult
 
     override suspend fun createBankAccountPaymentDetails(
@@ -187,7 +188,8 @@ internal open class FakeLinkRepository : LinkRepository {
 
     override suspend fun createPaymentMethod(
         consumerSessionClientSecret: String,
-        paymentMethod: LinkPaymentMethod
+        paymentMethod: LinkPaymentMethod,
+        clientAttributionMetadata: ClientAttributionMetadata,
     ) = createPaymentMethod
 
     override suspend fun logOut(

--- a/paymentsheet/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
@@ -305,6 +305,7 @@ class LinkApiRepositoryTest {
             userEmail = email,
             stripeIntent = paymentIntent,
             consumerSessionClientSecret = secret,
+            clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
         )
 
         verify(consumersApiService).createPaymentDetails(
@@ -345,6 +346,7 @@ class LinkApiRepositoryTest {
             userEmail = email,
             stripeIntent = paymentIntent,
             consumerSessionClientSecret = secret,
+            clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
         )
 
         val argCaptor = argumentCaptor<ConsumerPaymentDetailsCreateParams>()
@@ -383,6 +385,7 @@ class LinkApiRepositoryTest {
                 userEmail = email,
                 stripeIntent = paymentIntent,
                 consumerSessionClientSecret = secret,
+                clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
             ).getOrThrow()
 
             assertThat(linkDetails.paymentMethodCreateParams.allowRedisplay).isEqualTo(allowRedisplay)
@@ -400,6 +403,7 @@ class LinkApiRepositoryTest {
                 userEmail = email,
                 stripeIntent = paymentIntent,
                 consumerSessionClientSecret = secret,
+                clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
             )
 
             verify(consumersApiService).createPaymentDetails(
@@ -433,6 +437,7 @@ class LinkApiRepositoryTest {
         val consumerSessionSecret = "consumer_session_secret"
         val email = "email@stripe.com"
         val paymentDetails = PaymentDetailsFixtures.CONSUMER_SINGLE_PAYMENT_DETAILS
+        val clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA
         whenever(
             consumersApiService.createPaymentDetails(
                 consumerSessionClientSecret = any(),
@@ -447,6 +452,7 @@ class LinkApiRepositoryTest {
             userEmail = email,
             stripeIntent = paymentIntent,
             consumerSessionClientSecret = consumerSessionSecret,
+            clientAttributionMetadata = clientAttributionMetadata,
         )
 
         assertThat(result.isSuccess).isTrue()
@@ -460,8 +466,8 @@ class LinkApiRepositoryTest {
                 PaymentMethodCreateParams.createLink(
                     paymentDetails.paymentDetails.first().id,
                     consumerSessionSecret,
-                    null,
-                    mapOf("card" to mapOf("cvc" to "123"))
+                    extraParams = mapOf("card" to mapOf("cvc" to "123")),
+                    clientAttributionMetadata = clientAttributionMetadata,
                 )
             )
         val formValues = newLinkPaymentDetails.buildFormValues()
@@ -511,6 +517,7 @@ class LinkApiRepositoryTest {
             userEmail = "email@stripe.com",
             stripeIntent = paymentIntent,
             consumerSessionClientSecret = "secret",
+            clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
         )
         val loggedErrors = errorReporter.getLoggedErrors()
 
@@ -627,8 +634,8 @@ class LinkApiRepositoryTest {
                 PaymentMethodCreateParams.createLink(
                     PaymentMethodFixtures.CARD_PAYMENT_METHOD.id!!,
                     consumerSessionSecret,
-                    null,
-                    mapOf("card" to mapOf("cvc" to "123"))
+                    PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
+                    extraParams = mapOf("card" to mapOf("cvc" to "123")),
                 )
             )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/PaymentMethodConfirmationOptionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/PaymentMethodConfirmationOptionTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentelement.confirmation
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.model.PaymentMethodExtraParams
@@ -103,7 +104,8 @@ class PaymentMethodConfirmationOptionTest {
         val option = PaymentMethodConfirmationOption.New(
             createParams = PaymentMethodCreateParams.createLink(
                 paymentDetailsId = "payment_details_id",
-                consumerSessionClientSecret = "consumer_secret"
+                consumerSessionClientSecret = "consumer_secret",
+                clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
             ),
             optionsParams = null,
             extraParams = PaymentMethodExtraParams.Link(setAsDefault = true),
@@ -119,7 +121,8 @@ class PaymentMethodConfirmationOptionTest {
         val option = PaymentMethodConfirmationOption.New(
             createParams = PaymentMethodCreateParams.createLink(
                 paymentDetailsId = "payment_details_id",
-                consumerSessionClientSecret = "consumer_secret"
+                consumerSessionClientSecret = "consumer_secret",
+                clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
             ),
             optionsParams = null,
             extraParams = PaymentMethodExtraParams.Link(setAsDefault = false),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
@@ -406,6 +406,7 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
                     consumerSessionClientSecret = "secret",
                     extraParams = null,
                     allowRedisplay = PaymentMethod.AllowRedisplay.ALWAYS,
+                    clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
                 )
             }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add client attribution metadata to Link PaymentMethodCreateParams

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-4078

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [ ] Manually verified

We have tests that when ClientAttributionMetadata is included in PaymentMethodCreateParams, then ClientAttributionMetadata is included in the params maps correctly and sent in the v1/payment_methods call. Since ClientAttributionMetadata is not nullable in PaymentMethodCreateParams.createLink, we don't need to have tests that it is always set when creating PaymentMethodCreateParams for Link (because the type ensures that it is!).