### PR TITLE
Fix returning customer type persistence in playground

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/network/PlaygroundRequester.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/network/PlaygroundRequester.kt
@@ -63,12 +63,16 @@ internal class PlaygroundRequester(
 
                 val customerId = checkoutResponse.customerId
                 val updatedSettings = playgroundSettings.playgroundSettings()
+                val currentCustomerType = playgroundSettings[CustomerSettingsDefinition]
                 if (
-                    playgroundSettings[CustomerSettingsDefinition] == CustomerType.NEW &&
+                    currentCustomerType == CustomerType.NEW &&
                     customerId != null
                 ) {
                     println("Customer $customerId")
                     updatedSettings[CustomerSettingsDefinition] = CustomerType.Existing(customerId)
+                } else if (currentCustomerType == CustomerType.RETURNING) {
+                    // Reset to RETURNING to avoid persisting a specific customer ID
+                    updatedSettings[CustomerSettingsDefinition] = CustomerType.RETURNING
                 }
                 val updatedState = checkoutResponse.asPlaygroundState(
                     snapshot = updatedSettings.snapshot(),


### PR DESCRIPTION
## Summary
- Fixed customer mismatch error when testing with "Returning" customer in the playground
- The issue occurred because customer IDs from "New" customer tests were being persisted and reused on subsequent "Returning" customer tests

## Problem
When testing in the playground with a "Returning" customer:
1. User tests with "New" customer → backend creates `cus_XXX` → playground persists this ID
2. User then selects "Returning" customer → playground still sends `cus_XXX` instead of `"returning"`
3. Backend expects the hardcoded "returning" customer ID → throws customer mismatch error

## Solution
Modified `PlaygroundRequester.kt` to explicitly reset the customer type back to `CustomerType.RETURNING` after receiving the backend response. This prevents the customer ID from being persisted to SharedPreferences.

## Testing
⚠️ **Important**: You must clear app data before testing to remove any previously persisted customer IDs:
```bash
adb shell pm clear com.stripe.android.paymentsheet.example
```

Then:
1. Open the playground app
2. Select "Returning" customer  
3. Click "Checkout"
4. Verify the payment flow works correctly without customer mismatch errors

## Test plan
- [x] Clear app data
- [x] Test "Returning" customer with Payment Sheet
- [x] Test "Returning" customer with Customer Session enabled
- [ ] Verify "New" customer flow still works correctly
- [ ] Verify customer ID persistence still works for "New" customer

🤖 Generated with [Claude Code](https://claude.com/claude-code)