### PR TITLE
Skip test if selected browser doesn't exist

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -1380,7 +1380,7 @@ internal class PlaygroundTestDriver(
                         browserIconAtPrompt(selectedBrowser).click()
                     }
 
-                    assertThat(browserWindow(selectedBrowser)?.exists()).isTrue()
+                    assumeTrue(browserWindow(selectedBrowser)?.exists() == true)
 
                     blockUntilAuthorizationPageLoaded(isSetup = testParameters.isSetupMode)
                 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Skip test if selected browser doesn't exist

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Our nightly test runs have been failing and this line is at least one cause -- we shouldn't fail the test if the browser doesn't exist (it's not what we're trying to test), we should skip the test instead. This is in line with what we do in other cases (e.g. in [verifyDeviceSupportsTestAuthorization](https://github.com/stripe/stripe-android/blob/2c4a432d99a832c9bc1b4a5e9752a82b48d42bb6/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt#L1295-L1309))