### PR TITLE
Add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
     name: End-to-end tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/stripe_setup
@@ -30,6 +32,8 @@ jobs:
     name: Build paymentsheet example project
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/stripe_setup
@@ -45,6 +49,8 @@ jobs:
 
   payment-sheet-apk-size-analysis:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/stripe_setup
@@ -58,6 +64,8 @@ jobs:
     name: Check for untranslated strings
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Check for untranslated strings

--- a/.github/workflows/dokka.yml
+++ b/.github/workflows/dokka.yml
@@ -13,6 +13,8 @@ jobs:
   generate-dokka:
     name: Generate Dokka
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/stripe_setup

--- a/.github/workflows/end_to_end_tests.yml
+++ b/.github/workflows/end_to_end_tests.yml
@@ -7,7 +7,8 @@ jobs:
   end-to-end-tests:
     name: End-to-end tests
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/stripe_setup

--- a/.github/workflows/fetch_translations.yml
+++ b/.github/workflows/fetch_translations.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   fetch-lokalize-translations:
     runs-on: macos-latest
+    permissions:
+      contents: read
     steps:
       - name: Check out the current state
         uses: actions/checkout@v4

--- a/.github/workflows/financialconnections_pull_request.yml
+++ b/.github/workflows/financialconnections_pull_request.yml
@@ -5,6 +5,8 @@ jobs:
   # Use emerge tools to analyze the example app size
   apk-size-analysis:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/stripe_setup

--- a/.github/workflows/identity_pull_request.yml
+++ b/.github/workflows/identity_pull_request.yml
@@ -6,6 +6,8 @@ jobs:
   build-base:
     name: Build base
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -24,6 +26,8 @@ jobs:
   build-pr:
     name: Build PR
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/stripe_setup
@@ -85,6 +89,8 @@ jobs:
   # Use emerge tools to analyze the example app size
   apk-size-analysis:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/stripe_setup

--- a/.github/workflows/instrumentation_tests.yml
+++ b/.github/workflows/instrumentation_tests.yml
@@ -10,6 +10,8 @@ jobs:
     name: Browserstack Instrumentation tests
     runs-on: ubuntu-latest
     timeout-minutes: 240
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/stripe_setup

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,6 +14,8 @@ jobs:
   # Checkout master branch and build the APK
   build-master:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -30,6 +32,8 @@ jobs:
   # Checkout PR branch and build the APK
   build-pr:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/stripe_setup

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   upload-identity:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/stripe_setup
@@ -21,6 +23,8 @@ jobs:
           EMERGE_TAG: push
   upload-financial-connections:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/stripe_setup
@@ -40,6 +44,8 @@ jobs:
           groups: financial-connections-testers
   upload-payment-sheet:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/stripe_setup


### PR DESCRIPTION
Sets explicit `permissions: contents: read` for all workflow jobs that only need to checkout code and run builds. This follows the principle of least privilege and resolves CodeQL security alerts about missing workflow permissions.

Updated workflows:
- ci.yml (4 jobs)
- dokka.yml
- end_to_end_tests.yml
- fetch_translations.yml
- financialconnections_pull_request.yml
- identity_pull_request.yml (3 jobs)
- instrumentation_tests.yml
- pull_request.yml (2 jobs)
- push.yml (3 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Committed-By-Agent: claude

# Summary
<!-- Simple summary of what was changed. -->

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-4763

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
