### PR TITLE
Disable configuration cache when publishing in release script

### DIFF
--- a/scripts/deploy/publish_to_sonatype.rb
+++ b/scripts/deploy/publish_to_sonatype.rb
@@ -48,9 +48,9 @@ def publish_to_sonatype
 
             # See https://github.com/gradle-nexus/publish-plugin for info on these gradle commands.
             if (@is_dry_run)
-                publish_to_sonatype_commands = ['./gradlew', 'publishToSonatype', 'closeSonatypeStagingRepository', '--stacktrace']
+                publish_to_sonatype_commands = ['./gradlew', 'publishToSonatype', 'closeSonatypeStagingRepository', '--stacktrace', '--no-configuration-cache']
             else
-                publish_to_sonatype_commands = ['./gradlew', 'publishToSonatype', 'closeAndReleaseSonatypeStagingRepository', '--stacktrace']
+                publish_to_sonatype_commands = ['./gradlew', 'publishToSonatype', 'closeAndReleaseSonatypeStagingRepository', '--stacktrace', '--no-configuration-cache']
             end
 
             Subprocess.check_call(


### PR DESCRIPTION
# Summary
Disable configuration cache when publishing in release script

# Motivation
Fixes issue when release. We don't need the config cache during releases.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified