### PR TITLE
Add client attribution metadata to confirmation tokens

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/ConfirmationTokenParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConfirmationTokenParams.kt
@@ -16,6 +16,7 @@ data class ConfirmationTokenParams(
     val setAsDefaultPaymentMethod: Boolean? = null,
     val cvc: String? = null,
     val clientContext: ConfirmationTokenClientContextParams? = null,
+    val clientAttributionMetadata: ClientAttributionMetadata? = null,
 ) : StripeParamsModel, Parcelable {
     override fun toParamMap(): Map<String, Any> {
         return buildMap {
@@ -28,6 +29,7 @@ data class ConfirmationTokenParams(
             setAsDefaultPaymentMethod?.let { put(PARAM_SET_AS_DEFAULT_PAYMENT_METHOD, it) }
             cvc?.let { put(PARAM_PAYMENT_METHOD_OPTIONS, mapOf("card" to mapOf("cvc" to it))) }
             clientContext?.let { put(PARAM_CLIENT_CONTEXT, it.toParamMap()) }
+            clientAttributionMetadata?.let { put(PARAM_CLIENT_ATTRIBUTION_METADATA, it.toParamMap()) }
         }
     }
 
@@ -40,6 +42,7 @@ data class ConfirmationTokenParams(
         const val PARAM_SET_AS_DEFAULT_PAYMENT_METHOD = "set_as_default_payment_method"
         const val PARAM_PAYMENT_METHOD_OPTIONS = "payment_method_options"
         const val PARAM_CLIENT_CONTEXT = "client_context"
+        const val PARAM_CLIENT_ATTRIBUTION_METADATA = "client_attribution_metadata"
     }
 }
 

--- a/payments-core/src/test/java/com/stripe/android/model/ConfirmationTokenParamsTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/ConfirmationTokenParamsTest.kt
@@ -330,4 +330,21 @@ class ConfirmationTokenParamsTest {
         val paramMap = params.toParamMap()
         assertThat(paramMap.containsKey("set_as_default_payment_method")).isFalse()
     }
+
+    @Test
+    fun toParamMap_withClientAttributionMetadata_setsClientAttributionMetadataParam() {
+        val clientAttributionMetadata = ClientAttributionMetadata(
+            elementsSessionConfigId = "elements_session_123",
+            paymentIntentCreationFlow = PaymentIntentCreationFlow.Standard,
+            paymentMethodSelectionFlow = PaymentMethodSelectionFlow.Automatic,
+        )
+        val params = ConfirmationTokenParams(
+            clientAttributionMetadata = clientAttributionMetadata
+        )
+
+        assertThat(params.toParamMap()).containsEntry(
+            "client_attribution_metadata",
+            clientAttributionMetadata.toParamMap(),
+        )
+    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/ConfirmationTokenConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/ConfirmationTokenConfirmationInterceptor.kt
@@ -6,6 +6,7 @@ import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.core.utils.UserFacingLogger
+import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmationToken
 import com.stripe.android.model.ConfirmationTokenClientContextParams
@@ -37,6 +38,7 @@ internal class ConfirmationTokenConfirmationInterceptor @AssistedInject construc
     @Assisted private val createIntentCallback: CreateIntentWithConfirmationTokenCallback,
     @Assisted(CUSTOMER_ID) private val customerId: String?,
     @Assisted(EPHEMERAL_KEY_SECRET) private val ephemeralKeySecret: String?,
+    @Assisted(CLIENT_ATTRIBUTION_METADATA) private val clientAttributionMetadata: ClientAttributionMetadata?,
     private val context: Context,
     private val stripeRepository: StripeRepository,
     private val requestOptions: ApiRequest.Options,
@@ -53,6 +55,7 @@ internal class ConfirmationTokenConfirmationInterceptor @AssistedInject construc
             confirmationTokenParams = prepareConfirmationTokenParams(
                 confirmationOption,
                 shippingValues,
+                clientAttributionMetadata,
             ),
             options = requestOptions,
         ).fold(
@@ -86,6 +89,7 @@ internal class ConfirmationTokenConfirmationInterceptor @AssistedInject construc
             confirmationTokenParams = prepareConfirmationTokenParams(
                 confirmationOption,
                 shippingValues,
+                clientAttributionMetadata,
             ),
             options = if (paymentMethod.customerId != null) {
                 requestOptions.copy(
@@ -205,6 +209,7 @@ internal class ConfirmationTokenConfirmationInterceptor @AssistedInject construc
     private fun prepareConfirmationTokenParams(
         confirmationOption: PaymentMethodConfirmationOption,
         shippingValues: ConfirmPaymentIntentParams.Shipping?,
+        clientAttributionMetadata: ClientAttributionMetadata?,
     ): ConfirmationTokenParams {
         val confirmationOption = confirmationOption.updatedForDeferredIntent(intentConfiguration)
         return ConfirmationTokenParams(
@@ -236,7 +241,8 @@ internal class ConfirmationTokenConfirmationInterceptor @AssistedInject construc
                 prepareConfirmationTokenClientContextParams(
                     confirmationOption.optionsParams
                 )
-            }
+            },
+            clientAttributionMetadata = clientAttributionMetadata,
         )
     }
 
@@ -279,12 +285,15 @@ internal class ConfirmationTokenConfirmationInterceptor @AssistedInject construc
             createIntentCallback: CreateIntentWithConfirmationTokenCallback,
             @Assisted(CUSTOMER_ID) customerId: String?,
             @Assisted(EPHEMERAL_KEY_SECRET) ephemeralKeySecret: String?,
+            @Assisted(CLIENT_ATTRIBUTION_METADATA) clientAttributionMetadata: ClientAttributionMetadata?,
         ): ConfirmationTokenConfirmationInterceptor
     }
 
     companion object {
         private const val CUSTOMER_ID = "customerId"
         private const val EPHEMERAL_KEY_SECRET = "ephemeralKeySecret"
+        private const val CLIENT_ATTRIBUTION_METADATA = "clientAttributionMetadata"
+
         private const val ERROR_MISSING_EPHEMERAL_KEY_SECRET =
             "Ephemeral key secret is required to confirm with saved payment method"
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptor.kt
@@ -68,6 +68,7 @@ internal class DefaultIntentConfirmationInterceptorFactory @Inject constructor(
                             createIntentCallback = deferredIntentCallback.callback,
                             customerId = customerId,
                             ephemeralKeySecret = ephemeralKeySecret,
+                            clientAttributionMetadata = clientAttributionMetadata,
                         )
                     }
                     is DeferredIntentCallback.PaymentMethod -> {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationUtils.kt
@@ -107,6 +107,7 @@ internal suspend fun createIntentConfirmationInterceptor(
                 createIntentCallback: CreateIntentWithConfirmationTokenCallback,
                 customerId: String?,
                 ephemeralKeySecret: String?,
+                clientAttributionMetadata: ClientAttributionMetadata?,
             ): ConfirmationTokenConfirmationInterceptor {
                 return ConfirmationTokenConfirmationInterceptor(
                     intentConfiguration = intentConfiguration,
@@ -117,6 +118,7 @@ internal suspend fun createIntentConfirmationInterceptor(
                     stripeRepository = stripeRepository,
                     requestOptions = requestOptions,
                     userFacingLogger = FakeUserFacingLogger(),
+                    clientAttributionMetadata = clientAttributionMetadata,
                 )
             }
         },


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add client attribution metadata to confirmation tokens

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-4080

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified

Once we have CTs network tests, we should add client attribution metadata to the request params that we test there.