### PR TITLE
Clear selection info when closing PaymentSheet.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -223,6 +223,12 @@ internal abstract class BaseSheetViewModel(
 
     abstract fun onError(error: ResolvableString? = null)
 
+    override fun onCleared() {
+        super.onCleared()
+        newPaymentSelection = null
+        savedStateHandle.set<PaymentSelection?>(SAVE_SELECTION, null)
+    }
+
     companion object {
         internal const val SAVE_SELECTION = "selection"
         internal const val SAVE_PROCESSING = "processing"


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
If PaymentSheetActivity is leaked, we want to clear anything that would be holding onto sensitive information. 
