### PR TITLE
Remove unnecessary named param in ConfirmationTokenConfirmationInterceptor

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/ConfirmationTokenConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/ConfirmationTokenConfirmationInterceptor.kt
@@ -38,7 +38,7 @@ internal class ConfirmationTokenConfirmationInterceptor @AssistedInject construc
     @Assisted private val createIntentCallback: CreateIntentWithConfirmationTokenCallback,
     @Assisted(CUSTOMER_ID) private val customerId: String?,
     @Assisted(EPHEMERAL_KEY_SECRET) private val ephemeralKeySecret: String?,
-    @Assisted(CLIENT_ATTRIBUTION_METADATA) private val clientAttributionMetadata: ClientAttributionMetadata?,
+    @Assisted private val clientAttributionMetadata: ClientAttributionMetadata?,
     private val context: Context,
     private val stripeRepository: StripeRepository,
     private val requestOptions: ApiRequest.Options,
@@ -285,14 +285,13 @@ internal class ConfirmationTokenConfirmationInterceptor @AssistedInject construc
             createIntentCallback: CreateIntentWithConfirmationTokenCallback,
             @Assisted(CUSTOMER_ID) customerId: String?,
             @Assisted(EPHEMERAL_KEY_SECRET) ephemeralKeySecret: String?,
-            @Assisted(CLIENT_ATTRIBUTION_METADATA) clientAttributionMetadata: ClientAttributionMetadata?,
+            @Assisted clientAttributionMetadata: ClientAttributionMetadata?,
         ): ConfirmationTokenConfirmationInterceptor
     }
 
     companion object {
         private const val CUSTOMER_ID = "customerId"
         private const val EPHEMERAL_KEY_SECRET = "ephemeralKeySecret"
-        private const val CLIENT_ATTRIBUTION_METADATA = "clientAttributionMetadata"
 
         private const val ERROR_MISSING_EPHEMERAL_KEY_SECRET =
             "Ephemeral key secret is required to confirm with saved payment method"


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Remove unnecessary named param in ConfirmationTokenConfirmationInterceptor

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://github.com/stripe/stripe-android/pull/11797#pullrequestreview-3369528240

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

No behavior change, but manually verified that CAM is still sent properly in CTs params