### PR TITLE
Build only release APK for Maestro Financial Connections tests

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -156,7 +156,7 @@ workflows:
   run-connections-e2e-payments-tests-on-push:
     envs:
       - MAESTRO_TAGS: testmode-payments
-      - BUILD_VARIANT: debug
+      - BUILD_VARIANT: release
     before_run:
       - _build-connections
       - _run-connections-e2e-tests
@@ -167,7 +167,7 @@ workflows:
   run-connections-e2e-data-tests-on-push:
     envs:
       - MAESTRO_TAGS: testmode-data
-      - BUILD_VARIANT: debug
+      - BUILD_VARIANT: release
     before_run:
       - _build-connections
       - _run-connections-e2e-tests
@@ -178,7 +178,7 @@ workflows:
   run-connections-e2e-token-tests-on-push:
     envs:
       - MAESTRO_TAGS: testmode-token
-      - BUILD_VARIANT: debug
+      - BUILD_VARIANT: release
     before_run:
       - _build-connections
       - _run-connections-e2e-tests


### PR DESCRIPTION
# Summary
Build only release APK for Maestro Financial Connections tests only. Previously was building both debug & release builds.

# Motivation
Faster test build times for Maestro FC tests.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified