### PR TITLE
Ensure we only have one copy of IntentConfirmationDefinition

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationDefinition.kt
@@ -166,4 +166,23 @@ internal class IntentConfirmationDefinition(
 
         data class Confirm(val confirmNextParams: ConfirmStripeIntentParams) : Args
     }
+
+    internal companion object {
+        @Volatile
+        private var instance: IntentConfirmationDefinition? = null
+
+        fun getInstance(
+            interceptorFactory: IntentConfirmationInterceptor.Factory,
+            paymentLauncherFactory: (ActivityResultLauncher<PaymentLauncherContract. Args>) -> PaymentLauncher,
+        ): IntentConfirmationDefinition {
+            return instance ?: synchronized(this) {
+                IntentConfirmationDefinition(
+                    intentConfirmationInterceptorFactory = interceptorFactory,
+                    paymentLauncherFactory = paymentLauncherFactory,
+                ).also {
+                    instance = it
+                }
+            }
+        }
+    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationModule.kt
@@ -58,8 +58,8 @@ internal interface IntentConfirmationModule {
             @Named(STATUS_BAR_COLOR) @ColorInt statusBarColor: Int?,
             paymentConfigurationProvider: Provider<PaymentConfiguration>,
         ): ConfirmationDefinition<*, *, *, *> {
-            return IntentConfirmationDefinition(
-                intentConfirmationInterceptorFactory = interceptorFactory,
+            return IntentConfirmationDefinition.getInstance(
+                interceptorFactory = interceptorFactory,
                 paymentLauncherFactory = { hostActivityLauncher ->
                     stripePaymentLauncherAssistedFactory.create(
                         publishableKey = { paymentConfigurationProvider.get().publishableKey },


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Ensure we only have one copy of IntentConfirmationDefinition

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fixes a bug where client attribution metadata was not included for Native Link PI/SI confirmation, because client attribution metadata was null.

We had multiple copies of IntentConfirmationDefinition. `bootstrap` was not called on all of them -- so clientAttributionMetadata was null when actually confirming.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

We don't currently have mock network tests for Link. 

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
