### PR TITLE
Save returning customer as existing in playground.

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/network/PlaygroundRequester.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/network/PlaygroundRequester.kt
@@ -65,14 +65,11 @@ internal class PlaygroundRequester(
                 val updatedSettings = playgroundSettings.playgroundSettings()
                 val currentCustomerType = playgroundSettings[CustomerSettingsDefinition]
                 if (
-                    currentCustomerType == CustomerType.NEW &&
+                    (currentCustomerType == CustomerType.NEW || currentCustomerType == CustomerType.RETURNING) &&
                     customerId != null
                 ) {
                     println("Customer $customerId")
                     updatedSettings[CustomerSettingsDefinition] = CustomerType.Existing(customerId)
-                } else if (currentCustomerType == CustomerType.RETURNING) {
-                    // Reset to RETURNING to avoid persisting a specific customer ID
-                    updatedSettings[CustomerSettingsDefinition] = CustomerType.RETURNING
                 }
                 val updatedState = checkoutResponse.asPlaygroundState(
                     snapshot = updatedSettings.snapshot(),


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
We fetch the playground info again (which creates a new PI + customer + PM for returning users). This was causing the playground to error that the customer didn't have access to the PM since it would generate another new customer.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://stripe.slack.com/archives/C02CCKZSB9R/p1761849146136169

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
