### PR TITLE
Make CustomerConfiguration.id internal.

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCard.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCard.kt
@@ -116,7 +116,7 @@ internal class TestCard : BasePlaygroundTest() {
         )
 
         testDriver.confirmCompleteWithDefaultSavedPaymentMethod(
-            customerId = state?.asPaymentState()?.customerConfig?.id,
+            customerId = state?.customerId(),
             testParameters = testParameters,
             beforeBuyAction = { selectors ->
                 selectors.composeTestRule.waitUntilExactlyOneExists(
@@ -154,7 +154,7 @@ internal class TestCard : BasePlaygroundTest() {
         )
 
         testDriver.confirmExistingComplete(
-            customerId = state?.asPaymentState()?.customerConfig?.id,
+            customerId = state?.customerId(),
             testParameters = testParameters,
             values = FieldPopulator.Values(
                 cardNumber = secondCardNumber,
@@ -165,7 +165,7 @@ internal class TestCard : BasePlaygroundTest() {
         )
 
         testDriver.confirmCompleteWithDefaultSavedPaymentMethod(
-            customerId = state?.asPaymentState()?.customerConfig?.id,
+            customerId = state?.customerId(),
             testParameters = testParameters,
             beforeBuyAction = { selectors ->
                 selectors.composeTestRule.waitUntilExactlyOneExists(
@@ -202,7 +202,7 @@ internal class TestCard : BasePlaygroundTest() {
         )
 
         testDriver.confirmCustomWithDefaultSavedPaymentMethod(
-            customerId = state?.asPaymentState()?.customerConfig?.id,
+            customerId = state?.customerId(),
             testParameters = testParameters,
             beforeBuyAction = { selectors ->
                 selectors.composeTestRule.waitUntilExactlyOneExists(
@@ -238,7 +238,7 @@ internal class TestCard : BasePlaygroundTest() {
             },
         )
 
-        val customerId = state?.asPaymentState()?.customerConfig?.id
+        val customerId = state?.customerId()
 
         testDriver.confirmCustomAndBuy(
             customerId = customerId,
@@ -279,7 +279,7 @@ internal class TestCard : BasePlaygroundTest() {
         )
 
         testDriver.confirmCompleteWithSavePaymentMethodAndCvcRecollection(
-            customerId = state?.asPaymentState()?.customerConfig?.id,
+            customerId = state?.customerId(),
             testParameters = testParameters
         )
     }
@@ -299,7 +299,7 @@ internal class TestCard : BasePlaygroundTest() {
         )
 
         testDriver.confirmCustomWithSavePaymentMethodAndCvcRecollection(
-            customerId = state?.asPaymentState()?.customerConfig?.id,
+            customerId = state?.customerId(),
             testParameters = testParameters
         )
     }
@@ -369,7 +369,7 @@ internal class TestCard : BasePlaygroundTest() {
 
         // Verify card was save and re-displays
         testDriver.confirmCompleteWithDefaultSavedPaymentMethod(
-            customerId = state?.asPaymentState()?.customerConfig?.id,
+            customerId = state?.customerId(),
             testParameters = testParameters,
             beforeBuyAction = { selectors ->
                 selectors.composeTestRule.waitUntilExactlyOneExists(
@@ -399,7 +399,7 @@ internal class TestCard : BasePlaygroundTest() {
 
         // Verify card was save and re-displays
         testDriver.confirmCompleteWithDefaultSavedPaymentMethod(
-            customerId = state?.asPaymentState()?.customerConfig?.id,
+            customerId = state?.customerId(),
             testParameters = testParameters,
             beforeBuyAction = { selectors ->
                 selectors.composeTestRule.waitUntilExactlyOneExists(

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestConfirmationToken.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestConfirmationToken.kt
@@ -82,7 +82,7 @@ internal class TestConfirmationToken : BasePlaygroundTest() {
         )
 
         testDriver.confirmCompleteWithDefaultSavedPaymentMethod(
-            customerId = state?.asPaymentState()?.customerConfig?.id,
+            customerId = state?.customerId(),
             testParameters = testParameters,
             beforeBuyAction = { selectors ->
                 selectors.composeTestRule.waitUntilExactlyOneExists(

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestSepaDebit.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestSepaDebit.kt
@@ -96,7 +96,7 @@ internal class TestSepaDebit : BasePlaygroundTest() {
         )
 
         testDriver.confirmCompleteWithDefaultSavedPaymentMethod(
-            customerId = state?.asPaymentState()?.customerConfig?.id,
+            customerId = state?.customerId(),
             testParameters = testParameters,
             beforeBuyAction = { selectors ->
                 selectors.composeTestRule.waitUntilExactlyOneExists(
@@ -124,7 +124,7 @@ internal class TestSepaDebit : BasePlaygroundTest() {
         }
 
         testDriver.confirmCustomWithDefaultSavedPaymentMethod(
-            customerId = playgroundState?.asPaymentState()?.customerConfig?.id,
+            customerId = playgroundState?.customerId(),
             testParameters = testParameters,
             afterBuyAction = {
                 ComposeButton(rules.compose, hasTestTag("SEPA_MANDATE_CONTINUE_BUTTON"))
@@ -149,7 +149,7 @@ internal class TestSepaDebit : BasePlaygroundTest() {
         }
 
         testDriver.confirmCustomWithDefaultSavedPaymentMethod(
-            customerId = playgroundState?.asPaymentState()?.customerConfig?.id,
+            customerId = playgroundState?.customerId(),
             testParameters = testParameters,
             beforeBuyAction = { selectors ->
                 selectors.multiStepSelect.click()

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestUSBankAccount.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestUSBankAccount.kt
@@ -102,7 +102,7 @@ internal class TestUSBankAccount : BasePlaygroundTest() {
         )
 
         testDriver.confirmCompleteWithDefaultSavedPaymentMethod(
-            customerId = state?.asPaymentState()?.customerConfig?.id,
+            customerId = state?.customerId(),
             testParameters = testParameters.copy(
                 authorizationAction = null
             ),
@@ -134,7 +134,7 @@ internal class TestUSBankAccount : BasePlaygroundTest() {
         )
 
         testDriver.confirmCompleteWithDefaultSavedPaymentMethod(
-            customerId = state?.asPaymentState()?.customerConfig?.id,
+            customerId = state?.customerId(),
             testParameters = testParameters.copy(
                 authorizationAction = null
             ),

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PlaygroundState.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PlaygroundState.kt
@@ -213,6 +213,10 @@ internal sealed interface PlaygroundState : Parcelable {
         return this as? Customer
     }
 
+    fun customerId(): String? {
+        return (snapshot[CustomerSettingsDefinition] as? CustomerType.Existing)?.value
+    }
+
     companion object {
         fun CheckoutResponse.asPlaygroundState(
             snapshot: PlaygroundSettings.Snapshot,

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -2127,7 +2127,6 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$CustomerConfigur
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getId ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public final fun writeToParcel (Landroid/os/Parcel;I)V

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -3049,7 +3049,7 @@ class PaymentSheet internal constructor(
          * The identifier of the Stripe Customer object.
          * See [Stripe's documentation](https://stripe.com/docs/api/customers/object#customer_object-id).
          */
-        val id: String,
+        internal val id: String,
 
         /**
          * A short-lived token that allows the SDK to access a Customer's payment methods.


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
I missed this when doing the first round of these changes.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Major version -- we already updated all the other properties that merchants pass in to be internal.