### PR TITLE
Add new GooglePay unexpected error for unexpected status codes

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherActivity.kt
@@ -7,6 +7,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.os.bundleOf
 import androidx.lifecycle.lifecycleScope
 import com.google.android.gms.common.api.CommonStatusCodes
+import com.google.android.gms.common.api.Status
 import com.google.android.gms.wallet.PaymentData
 import com.google.android.gms.wallet.contract.ApiTaskResult
 import com.google.android.gms.wallet.contract.TaskResultContracts.GetPaymentDataResult
@@ -128,13 +129,7 @@ internal class GooglePayPaymentMethodLauncherActivity : AppCompatActivity() {
                 val statusMessage = status.statusMessage.orEmpty()
                 val statusCode = status.statusCode.toString()
 
-                errorReporter.report(
-                    ErrorReporter.ExpectedErrorEvent.GOOGLE_PAY_FAILED,
-                    additionalNonPiiParams = mapOf(
-                        "status_message" to statusMessage,
-                        "status_code" to statusCode,
-                    )
-                )
+                sendErrorEvents(statusMessage, statusCode, status)
 
                 viewModel.updateResult(
                     GooglePayPaymentMethodLauncher.Result.Failed(
@@ -145,6 +140,28 @@ internal class GooglePayPaymentMethodLauncherActivity : AppCompatActivity() {
                     )
                 )
             }
+        }
+    }
+
+    @Suppress("MagicNumber")
+    private fun sendErrorEvents(
+        statusMessage: String,
+        statusCode: String,
+        status: Status
+    ) {
+        errorReporter.report(
+            ErrorReporter.ExpectedErrorEvent.GOOGLE_PAY_FAILED,
+            additionalNonPiiParams = mapOf(
+                "status_message" to statusMessage,
+                "status_code" to statusCode,
+            )
+        )
+
+        if (!listOf(8, 10, 17, 20, 405, 409, 412).contains(status.statusCode)) {
+            errorReporter.report(
+                ErrorReporter.UnexpectedErrorEvent.GOOGLE_PAY_UNEXPECTED_STATUS_CODE,
+                additionalNonPiiParams = mapOf("status_code" to statusCode)
+            )
         }
     }
 

--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -204,6 +204,9 @@ interface ErrorReporter : FraudDetectionErrorReporter {
         GOOGLE_PAY_UNEXPECTED_CONFIRM_RESULT(
             partialEventName = "google_pay.confirm.unexpected_result"
         ),
+        GOOGLE_PAY_UNEXPECTED_STATUS_CODE(
+            partialEventName = "google_pay.confirm.unexpected_status_code"
+        ),
         GOOGLE_PAY_MISSING_INTENT_DATA(
             partialEventName = "google_pay.on_result.missing_data"
         ),


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add new GooglePay unexpected error for unexpected status codes

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Migrating [this alert](https://splunk.corp.stripe.com/en-US/app/search/alert?s=%2FservicesNS%2Fnobody%2Fsearch%2Fsaved%2Fsearches%2F%255BElements%2520Mobile%255D%2520Unexpected%2520Google%2520Pay%2520errors%2520detected%2520in%2520last%252024%2520hrs) to prometheus. We currently check within the alert that statusCode != <specific values>. This doesn't play well with allowlisting values into prometheus (we would have to allowlist every status code and there are too many). 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
