### PR TITLE
Don't fetch the setup intent before confirming in CustomerSheet.

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSessionCustomerSheetTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSessionCustomerSheetTest.kt
@@ -64,7 +64,6 @@ internal class CustomerSessionCustomerSheetTest {
         page.fillOutCardDetails()
 
         enqueuePaymentMethodCreation()
-        enqueueSetupIntentRetrieval()
         enqueueSetupIntentConfirmation()
 
         enqueueElementsSession(
@@ -112,7 +111,6 @@ internal class CustomerSessionCustomerSheetTest {
         page.changeCardBrandChoice()
 
         enqueueCbcPaymentMethodCreation()
-        enqueueSetupIntentRetrieval()
         enqueueSetupIntentConfirmation()
 
         enqueueElementsSession(
@@ -154,7 +152,6 @@ internal class CustomerSessionCustomerSheetTest {
         page.fillOutCardDetails()
 
         enqueuePaymentMethodCreation()
-        enqueueSetupIntentRetrieval()
         enqueueSetupIntentConfirmation()
 
         val paymentMethodId = "pm_12345"
@@ -336,15 +333,6 @@ internal class CustomerSessionCustomerSheetTest {
             clientAttributionMetadataParams(),
         ) { response ->
             response.testBodyFromFile("payment-methods-create.json")
-        }
-    }
-
-    private fun enqueueSetupIntentRetrieval() {
-        networkRule.enqueue(
-            retrieveSetupIntentRequest(),
-            retrieveSetupIntentParams(),
-        ) { response ->
-            response.testBodyFromFile("setup-intent-get.json")
         }
     }
 

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetAnalyticsTest.kt
@@ -88,7 +88,6 @@ internal class CustomerSheetAnalyticsTest {
 
         validateAnalyticsRequest(eventName = "stripe_android.payment_method_creation")
         validateAnalyticsRequest(eventName = "cs_cardscan_api_check_failed")
-        validateAnalyticsRequest(eventName = "stripe_android.setup_intent_retrieval")
         validateAnalyticsRequest(
             eventName = "stripe_android.paymenthandler.confirm.started",
             query("intent_id", "seti_12345"),

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetTest.kt
@@ -302,13 +302,6 @@ internal class CustomerSheetTest {
         }
 
         networkRule.enqueue(
-            retrieveSetupIntentRequest(),
-            retrieveSetupIntentParams(),
-        ) { response ->
-            response.testBodyFromFile("setup-intent-get.json")
-        }
-
-        networkRule.enqueue(
             confirmSetupIntentRequest(),
             confirmSetupIntentParams()
         ) { response ->

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/CustomerSheetUtils.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/CustomerSheetUtils.kt
@@ -10,8 +10,6 @@ import com.stripe.android.networktesting.RequestMatchers.query
 import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentsheet.confirmSetupIntentParams
 import com.stripe.android.paymentsheet.confirmSetupIntentRequest
-import com.stripe.android.paymentsheet.retrieveSetupIntentParams
-import com.stripe.android.paymentsheet.retrieveSetupIntentRequest
 
 internal object CustomerSheetUtils {
     fun enqueueFetchRequests(
@@ -52,13 +50,6 @@ internal object CustomerSheetUtils {
                 }
             }
             CustomerSheetTestType.AttachToSetupIntent -> {
-                enqueue(
-                    retrieveSetupIntentRequest(),
-                    retrieveSetupIntentParams(),
-                ) { response ->
-                    response.testBodyFromFile("setup-intent-get.json")
-                }
-
                 enqueue(
                     confirmSetupIntentRequest(),
                     confirmSetupIntentParams()

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -1015,15 +1015,7 @@ internal class CustomerSheetViewModel(
     private suspend fun attachWithSetupIntent(paymentMethod: PaymentMethod) {
         awaitIntentDataSource().retrieveSetupIntentClientSecret()
             .mapCatching { clientSecret ->
-                val intent = stripeRepository.retrieveSetupIntent(
-                    clientSecret = clientSecret,
-                    options = ApiRequest.Options(
-                        apiKey = paymentConfigurationProvider.get().publishableKey,
-                        stripeAccount = paymentConfigurationProvider.get().stripeAccountId,
-                    ),
-                ).getOrThrow()
-
-                handleStripeIntent(intent, clientSecret, paymentMethod)
+                handleStripeIntent(clientSecret, paymentMethod)
             }.onFailure { cause, displayMessage ->
                 eventReporter.onAttachPaymentMethodFailed(
                     style = CustomerSheetEventReporter.AddPaymentMethodStyle.SetupIntent
@@ -1048,19 +1040,18 @@ internal class CustomerSheetViewModel(
     }
 
     private suspend fun handleStripeIntent(
-        stripeIntent: StripeIntent,
         clientSecret: String,
         paymentMethod: PaymentMethod
     ) {
-        val metadata = customerState.value.metadata
+        val metadata = requireNotNull(customerState.value.metadata)
         confirmationHandler.start(
             arguments = ConfirmationHandler.Args(
                 confirmationOption = PaymentMethodConfirmationOption.Saved(
                     paymentMethod = paymentMethod,
                     optionsParams = null,
-                    passiveCaptchaParams = metadata?.passiveCaptchaParams,
+                    passiveCaptchaParams = metadata.passiveCaptchaParams,
                 ),
-                intent = stripeIntent,
+                intent = metadata.stripeIntent,
                 initializationMode = PaymentElementLoader.InitializationMode.SetupIntent(
                     clientSecret = clientSecret
                 ),

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -964,47 +964,6 @@ class CustomerSheetViewModelTest {
         }
 
     @Test
-    fun `When payment method cannot be attached with setup intent, error message is visible`() = runTest(testDispatcher) {
-        val viewModel = createViewModel(
-            workContext = testDispatcher,
-            isGooglePayAvailable = false,
-            customerPaymentMethods = listOf(),
-            intentDataSource = FakeCustomerSheetIntentDataSource(
-                canCreateSetupIntents = true,
-                onRetrieveSetupIntentClientSecret = {
-                    CustomerSheetDataResult.success("invalid setup intent")
-                },
-            ),
-            stripeRepository = FakeStripeRepository(
-                createPaymentMethodResult = Result.success(CARD_PAYMENT_METHOD),
-                retrieveSetupIntent = Result.failure(
-                    IllegalArgumentException("Invalid setup intent")
-                ),
-            ),
-        )
-
-        viewModel.handleViewAction(
-            CustomerSheetViewAction.OnFormFieldValuesCompleted(
-                formFieldValues = TEST_FORM_VALUES,
-            )
-        )
-
-        viewModel.viewState.test {
-            var viewState = awaitViewState<AddPaymentMethod>()
-            assertThat(viewState.errorMessage).isNull()
-
-            viewModel.handleViewAction(CustomerSheetViewAction.OnPrimaryButtonPressed)
-
-            assertThat(awaitViewState<AddPaymentMethod>().isProcessing).isTrue()
-
-            viewState = awaitViewState()
-            assertThat(viewState.errorMessage).isEqualTo(R.string.stripe_something_went_wrong.resolvableString)
-            assertThat(viewState.enabled).isTrue()
-            assertThat(viewState.isProcessing).isFalse()
-        }
-    }
-
-    @Test
     fun `When setup intent provider error, error message is visible`() = runTest(testDispatcher) {
         val viewModel = createViewModel(
             workContext = testDispatcher,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This is a behavior change/optimization. We shouldn't need to call fetch before confirming.
