### PR TITLE
Simplify confirmation when passing in hcaptcha and client attribution metadata.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -1049,7 +1049,6 @@ internal class CustomerSheetViewModel(
                 confirmationOption = PaymentMethodConfirmationOption.Saved(
                     paymentMethod = paymentMethod,
                     optionsParams = null,
-                    passiveCaptchaParams = metadata.passiveCaptchaParams,
                 ),
                 appearance = configuration.appearance,
                 initializationMode = PaymentElementLoader.InitializationMode.SetupIntent(

--- a/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
@@ -155,7 +155,6 @@ internal class DefaultLinkConfirmationHandler @Inject constructor(
                 cvc = cvc,
                 billingPhone = billingPhone,
                 allowRedisplay = allowRedisplay,
-                passiveCaptchaParams = paymentMethodMetadata.passiveCaptchaParams,
             )
         } else {
             PaymentMethodConfirmationOption.New(
@@ -170,7 +169,6 @@ internal class DefaultLinkConfirmationHandler @Inject constructor(
                 extraParams = null,
                 optionsParams = null,
                 shouldSave = false,
-                passiveCaptchaParams = paymentMethodMetadata.passiveCaptchaParams,
             )
         }
 
@@ -219,7 +217,6 @@ internal class DefaultLinkConfirmationHandler @Inject constructor(
                         configuration.passthroughModeEnabled.not()
                     }
                 ),
-                passiveCaptchaParams = paymentMethodMetadata.passiveCaptchaParams,
             ),
             appearance = PaymentSheet.Appearance(),
             initializationMode = configuration.initializationMode,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/PaymentMethodConfirmationOption.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/PaymentMethodConfirmationOption.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentelement.confirmation
 
-import com.stripe.android.model.PassiveCaptchaParams
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.PaymentMethodOptionsParams
@@ -10,7 +9,7 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import kotlinx.parcelize.Parcelize
 
 internal sealed interface PaymentMethodConfirmationOption : ConfirmationHandler.Option {
-    val passiveCaptchaParams: PassiveCaptchaParams?
+    val passiveChallengeComplete: Boolean
     val optionsParams: PaymentMethodOptionsParams?
 
     fun updatedForDeferredIntent(
@@ -24,9 +23,9 @@ internal sealed interface PaymentMethodConfirmationOption : ConfirmationHandler.
         val paymentMethod: com.stripe.android.model.PaymentMethod,
         override val optionsParams: PaymentMethodOptionsParams?,
         val originatedFromWallet: Boolean = false,
-        override val passiveCaptchaParams: PassiveCaptchaParams?,
         val hCaptchaToken: String? = null,
         val attestationToken: String? = null,
+        override val passiveChallengeComplete: Boolean = false,
     ) : PaymentMethodConfirmationOption {
         override fun updatedForDeferredIntent(
             intentConfiguration: PaymentSheet.IntentConfiguration,
@@ -47,7 +46,7 @@ internal sealed interface PaymentMethodConfirmationOption : ConfirmationHandler.
         override val optionsParams: PaymentMethodOptionsParams?,
         val extraParams: PaymentMethodExtraParams?,
         val shouldSave: Boolean,
-        override val passiveCaptchaParams: PassiveCaptchaParams?,
+        override val passiveChallengeComplete: Boolean = false,
     ) : PaymentMethodConfirmationOption {
 
         override fun updatedForDeferredIntent(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationDefinition.kt
@@ -87,7 +87,6 @@ internal class BacsConfirmationDefinition @Inject constructor(
                     optionsParams = null,
                     extraParams = null,
                     shouldSave = false,
-                    passiveCaptchaParams = confirmationOption.passiveCaptchaParams,
                 )
 
                 ConfirmationDefinition.Result.NextStep(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationOption.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationOption.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentelement.confirmation.bacs
 
-import com.stripe.android.model.PassiveCaptchaParams
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
@@ -10,5 +9,4 @@ import kotlinx.parcelize.Parcelize
 internal data class BacsConfirmationOption(
     val createParams: PaymentMethodCreateParams,
     val optionsParams: PaymentMethodOptionsParams?,
-    val passiveCaptchaParams: PassiveCaptchaParams?
 ) : ConfirmationHandler.Option

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinition.kt
@@ -49,7 +49,8 @@ internal class PassiveChallengeConfirmationDefinition @Inject constructor(
         confirmationOption: PaymentMethodConfirmationOption,
         confirmationArgs: ConfirmationHandler.Args
     ): Boolean {
-        return confirmationOption.passiveCaptchaParams != null
+        return confirmationArgs.paymentMethodMetadata.passiveCaptchaParams != null &&
+            !confirmationOption.passiveChallengeComplete
     }
 
     override fun toResult(
@@ -96,7 +97,7 @@ internal class PassiveChallengeConfirmationDefinition @Inject constructor(
         confirmationOption: PaymentMethodConfirmationOption,
         confirmationArgs: ConfirmationHandler.Args
     ): ConfirmationDefinition.Action<PassiveChallengeActivityContract.Args> {
-        val passiveCaptchaParams = confirmationOption.passiveCaptchaParams
+        val passiveCaptchaParams = confirmationArgs.paymentMethodMetadata.passiveCaptchaParams
         if (passiveCaptchaParams != null) {
             return ConfirmationDefinition.Action.Launch(
                 launcherArguments = PassiveChallengeActivityContract.Args(
@@ -135,13 +136,13 @@ internal class PassiveChallengeConfirmationDefinition @Inject constructor(
                             )
                         }
                     ),
-                    passiveCaptchaParams = null
+                    passiveChallengeComplete = true,
                 )
             }
             is PaymentMethodConfirmationOption.Saved -> {
                 copy(
                     hCaptchaToken = token,
-                    passiveCaptchaParams = null
+                    passiveChallengeComplete = true,
                 )
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinition.kt
@@ -100,7 +100,7 @@ internal class GooglePayConfirmationDefinition @Inject constructor(
             },
             transactionId = intent.id,
             label = config.customLabel,
-            clientAttributionMetadata = confirmationOption.clientAttributionMetadata,
+            clientAttributionMetadata = confirmationArgs.paymentMethodMetadata.clientAttributionMetadata,
         )
     }
 
@@ -117,7 +117,6 @@ internal class GooglePayConfirmationDefinition @Inject constructor(
                     paymentMethod = result.paymentMethod,
                     optionsParams = null,
                     originatedFromWallet = true,
-                    passiveCaptchaParams = confirmationOption.passiveCaptchaParams,
                 )
 
                 ConfirmationDefinition.Result.NextStep(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationOption.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationOption.kt
@@ -2,8 +2,6 @@ package com.stripe.android.paymentelement.confirmation.gpay
 
 import android.os.Parcelable
 import com.stripe.android.CardBrandFilter
-import com.stripe.android.model.ClientAttributionMetadata
-import com.stripe.android.model.PassiveCaptchaParams
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentsheet.PaymentSheet
 import kotlinx.parcelize.Parcelize
@@ -11,8 +9,6 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 internal data class GooglePayConfirmationOption(
     val config: Config,
-    val passiveCaptchaParams: PassiveCaptchaParams?,
-    val clientAttributionMetadata: ClientAttributionMetadata?,
 ) : ConfirmationHandler.Option {
     @Parcelize
     data class Config(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinition.kt
@@ -85,7 +85,6 @@ internal class LinkConfirmationDefinition @Inject constructor(
                         paymentMethod = result.paymentMethod,
                         optionsParams = null,
                         originatedFromWallet = true,
-                        passiveCaptchaParams = confirmationOption.passiveCaptchaParams,
                     ),
                     arguments = confirmationArgs,
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationOption.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationOption.kt
@@ -3,7 +3,6 @@ package com.stripe.android.paymentelement.confirmation.link
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.link.LinkLaunchMode
-import com.stripe.android.model.PassiveCaptchaParams
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import kotlinx.parcelize.Parcelize
 
@@ -12,5 +11,4 @@ internal data class LinkConfirmationOption(
     val configuration: LinkConfiguration,
     val linkLaunchMode: LinkLaunchMode = LinkLaunchMode.Full,
     val linkExpressMode: LinkExpressMode,
-    val passiveCaptchaParams: PassiveCaptchaParams?
 ) : ConfirmationHandler.Option

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkPassthroughConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkPassthroughConfirmationDefinition.kt
@@ -97,7 +97,6 @@ internal class LinkPassthroughConfirmationDefinition @Inject constructor(
                 paymentMethod = paymentMethod,
                 optionsParams = null,
                 originatedFromWallet = true,
-                passiveCaptchaParams = confirmationOption.passiveCaptchaParams,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkPassthroughConfirmationOption.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkPassthroughConfirmationOption.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentelement.confirmation.link
 
-import com.stripe.android.model.PassiveCaptchaParams
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import kotlinx.parcelize.Parcelize
@@ -12,5 +11,4 @@ internal data class LinkPassthroughConfirmationOption(
     val cvc: String?,
     val billingPhone: String?,
     val allowRedisplay: PaymentMethod.AllowRedisplay? = null,
-    val passiveCaptchaParams: PassiveCaptchaParams?,
 ) : ConfirmationHandler.Option

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinition.kt
@@ -10,7 +10,6 @@ import com.stripe.android.link.analytics.LinkAnalyticsHelper
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.model.ConfirmPaymentIntentParams
-import com.stripe.android.model.PassiveCaptchaParams
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodExtraParams
@@ -125,7 +124,6 @@ internal class LinkInlineSignupConfirmationDefinition(
         val saveOption = linkInlineSignupConfirmationOption.saveOption
         val extraParams = linkInlineSignupConfirmationOption.extraParams
         val configuration = linkInlineSignupConfirmationOption.linkConfiguration
-        val passiveCaptchaParams = linkInlineSignupConfirmationOption.passiveCaptchaParams
 
         val linkPaymentDetails = linkConfigurationCoordinator.attachNewCardToAccount(
             configuration,
@@ -136,12 +134,12 @@ internal class LinkInlineSignupConfirmationDefinition(
             is LinkPaymentDetails.New -> {
                 linkStore.markLinkAsUsed()
 
-                linkPaymentDetails.toNewOption(saveOption, configuration, extraParams, passiveCaptchaParams)
+                linkPaymentDetails.toNewOption(saveOption, configuration, extraParams)
             }
             is LinkPaymentDetails.Saved -> {
                 linkStore.markLinkAsUsed()
 
-                linkPaymentDetails.toSavedOption(createParams, saveOption, passiveCaptchaParams)
+                linkPaymentDetails.toSavedOption(createParams, saveOption)
             }
             null -> linkInlineSignupConfirmationOption.toNewOption()
         }
@@ -150,7 +148,6 @@ internal class LinkInlineSignupConfirmationDefinition(
     private fun LinkPaymentDetails.Saved.toSavedOption(
         createParams: PaymentMethodCreateParams,
         saveOption: LinkInlineSignupConfirmationOption.PaymentMethodSaveOption,
-        passiveCaptchaParams: PassiveCaptchaParams?
     ): PaymentMethodConfirmationOption.Saved {
         val last4 = paymentDetails.last4
 
@@ -172,7 +169,6 @@ internal class LinkInlineSignupConfirmationDefinition(
                 } ?: ConfirmPaymentIntentParams.SetupFutureUsage.Blank
             ),
             originatedFromWallet = true,
-            passiveCaptchaParams = passiveCaptchaParams,
         )
     }
 
@@ -180,7 +176,6 @@ internal class LinkInlineSignupConfirmationDefinition(
         saveOption: LinkInlineSignupConfirmationOption.PaymentMethodSaveOption,
         configuration: LinkConfiguration,
         extraParams: PaymentMethodExtraParams?,
-        passiveCaptchaParams: PassiveCaptchaParams?
     ): PaymentMethodConfirmationOption.New {
         val passthroughMode = configuration.passthroughModeEnabled
 
@@ -195,7 +190,6 @@ internal class LinkInlineSignupConfirmationDefinition(
             optionsParams = optionsParams,
             extraParams = extraParams,
             shouldSave = saveOption.shouldSave(),
-            passiveCaptchaParams = passiveCaptchaParams
         )
     }
 
@@ -205,7 +199,6 @@ internal class LinkInlineSignupConfirmationDefinition(
             optionsParams = optionsParams,
             extraParams = extraParams,
             shouldSave = saveOption.shouldSave(),
-            passiveCaptchaParams = passiveCaptchaParams
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationOption.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationOption.kt
@@ -3,7 +3,6 @@ package com.stripe.android.paymentelement.confirmation.linkinline
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.model.ConfirmPaymentIntentParams
-import com.stripe.android.model.PassiveCaptchaParams
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.PaymentMethodOptionsParams
@@ -18,7 +17,6 @@ internal data class LinkInlineSignupConfirmationOption(
     val saveOption: PaymentMethodSaveOption,
     val linkConfiguration: LinkConfiguration,
     private val userInput: UserInput,
-    val passiveCaptchaParams: PassiveCaptchaParams?
 ) : ConfirmationHandler.Option {
     enum class PaymentMethodSaveOption(val setupFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage?) {
         RequestedReuse(ConfirmPaymentIntentParams.SetupFutureUsage.OffSession),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationHelper.kt
@@ -55,8 +55,6 @@ internal class DefaultEmbeddedConfirmationHelper @Inject constructor(
         val confirmationOption = confirmationState.selection?.toConfirmationOption(
             configuration = confirmationState.configuration.asCommonConfiguration(),
             linkConfiguration = confirmationState.paymentMethodMetadata.linkState?.configuration,
-            passiveCaptchaParams = confirmationState.paymentMethodMetadata.passiveCaptchaParams,
-            clientAttributionMetadata = confirmationState.paymentMethodMetadata.clientAttributionMetadata,
         ) ?: return null
 
         return ConfirmationHandler.Args(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityConfirmationHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityConfirmationHelper.kt
@@ -80,8 +80,6 @@ internal class DefaultFormActivityConfirmationHelper @Inject constructor(
         val confirmationOption = selectionHolder.selection.value?.toConfirmationOption(
             configuration = configuration.asCommonConfiguration(),
             linkConfiguration = paymentMethodMetadata.linkState?.configuration,
-            passiveCaptchaParams = paymentMethodMetadata.passiveCaptchaParams,
-            clientAttributionMetadata = paymentMethodMetadata.clientAttributionMetadata,
         ) ?: return null
         return ConfirmationHandler.Args(
             confirmationOption = confirmationOption,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -514,8 +514,6 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                     ?.toConfirmationOption(
                         configuration = config.asCommonConfiguration(),
                         linkConfiguration = linkHandler.linkConfiguration.value,
-                        passiveCaptchaParams = paymentMethodMetadata.passiveCaptchaParams,
-                        clientAttributionMetadata = paymentMethodMetadata.clientAttributionMetadata,
                     )
             }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -543,8 +543,6 @@ internal class DefaultFlowController @Inject internal constructor(
             val confirmationOption = paymentSelection?.toConfirmationOption(
                 configuration = state.config,
                 linkConfiguration = state.linkConfiguration,
-                passiveCaptchaParams = state.paymentMethodMetadata.passiveCaptchaParams,
-                clientAttributionMetadata = state.paymentMethodMetadata.clientAttributionMetadata,
             )
 
             confirmationOption?.let { option ->

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
@@ -314,8 +314,6 @@ internal class DefaultWalletButtonsInteractor constructor(
         val confirmationOption = selection.toConfirmationOption(
             configuration = arguments.configuration,
             linkConfiguration = arguments.paymentMethodMetadata.linkState?.configuration,
-            passiveCaptchaParams = arguments.paymentMethodMetadata.passiveCaptchaParams,
-            clientAttributionMetadata = arguments.paymentMethodMetadata.clientAttributionMetadata,
         ) ?: return null
 
         return ConfirmationHandler.Args(

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -24,7 +24,6 @@ import com.stripe.android.customersheet.utils.FakeCustomerSheetLoader
 import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.luxe.LpmRepositoryTestHelpers
 import com.stripe.android.model.CardBrand
-import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures.CARD_PAYMENT_METHOD
 import com.stripe.android.model.PaymentMethodFixtures.CARD_WITH_NETWORKS_PAYMENT_METHOD
@@ -35,7 +34,6 @@ import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.networking.PaymentAnalyticsEvent
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
-import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.interceptor.FakeIntentConfirmationInterceptorFactory
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -68,9 +66,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.kotlin.any
 import org.mockito.kotlin.argThat
-import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -3203,64 +3199,6 @@ class CustomerSheetViewModelTest {
         viewModel.handleViewAction(CustomerSheetViewAction.OnDisallowedCardBrandEntered(CardBrand.AmericanExpress))
 
         verify(eventReporter).onDisallowedCardBrandEntered(CardBrand.AmericanExpress)
-    }
-
-    @Test
-    fun `When starting confirmation, should pass passiveCaptchaParams when available`() = runTest(testDispatcher) {
-        val passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
-
-        val mockConfirmationHandler = mock<ConfirmationHandler>()
-        val confirmationHandlerFactory = ConfirmationHandler.Factory { mockConfirmationHandler }
-
-        val viewModel = createViewModel(
-            workContext = testDispatcher,
-            customerPaymentMethods = listOf(),
-            isGooglePayAvailable = false,
-            confirmationHandlerFactory = confirmationHandlerFactory,
-            customerSheetLoader = FakeCustomerSheetLoader(
-                customerPaymentMethods = emptyList(),
-                isGooglePayAvailable = false,
-                passiveCaptchaParams = passiveCaptchaParams
-            ),
-            intentDataSource = FakeCustomerSheetIntentDataSource(
-                canCreateSetupIntents = true,
-                onRetrieveSetupIntentClientSecret = {
-                    CustomerSheetDataResult.success("seti_123")
-                }
-            ),
-            paymentMethodDataSource = FakeCustomerSheetPaymentMethodDataSource(
-                onAttachPaymentMethod = {
-                    CustomerSheetDataResult.success(CARD_PAYMENT_METHOD)
-                }
-            ),
-            stripeRepository = FakeStripeRepository(
-                createPaymentMethodResult = Result.success(CARD_PAYMENT_METHOD),
-                retrieveSetupIntent = Result.success(SetupIntentFixtures.SI_SUCCEEDED),
-            ),
-        ).apply {
-            handleViewAction(
-                CustomerSheetViewAction.OnFormFieldValuesCompleted(
-                    formFieldValues = TEST_FORM_VALUES,
-                )
-            )
-        }
-
-        viewModel.viewState.test {
-            assertThat(awaitItem()).isInstanceOf<AddPaymentMethod>()
-        }
-
-        viewModel.handleViewAction(CustomerSheetViewAction.OnPrimaryButtonPressed)
-
-        verify(mockConfirmationHandler).start(any())
-
-        val captor = argumentCaptor<ConfirmationHandler.Args>()
-        verify(mockConfirmationHandler).start(captor.capture())
-
-        val capturedArgs = captor.firstValue
-        assertThat(capturedArgs.confirmationOption).isInstanceOf<PaymentMethodConfirmationOption.Saved>()
-
-        val savedOption = capturedArgs.confirmationOption as PaymentMethodConfirmationOption.Saved
-        assertThat(savedOption.passiveCaptchaParams).isEqualTo(passiveCaptchaParams)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandlerTest.kt
@@ -626,7 +626,7 @@ internal class DefaultLinkConfirmationHandlerTest {
                 clientAttributionMetadata = configuration.clientAttributionMetadata,
             )
         )
-        assertThat(option.passiveCaptchaParams).isEqualTo(passiveCaptchaParams)
+        assertThat(paymentMethodMetadata.passiveCaptchaParams).isEqualTo(passiveCaptchaParams)
         assertThat(paymentMethodMetadata.shippingDetails).isEqualTo(configuration.shippingDetails)
         assertThat(initializationMode).isEqualTo(configuration.initializationMode)
     }
@@ -640,7 +640,7 @@ internal class DefaultLinkConfirmationHandlerTest {
         assertThat(intent).isEqualTo(configuration.stripeIntent)
         val option = confirmationOption as PaymentMethodConfirmationOption.Saved
         assertThat(option.paymentMethod.id).isEqualTo(paymentDetails.paymentDetails.paymentMethodId)
-        assertThat(option.passiveCaptchaParams).isEqualTo(passiveCaptchaParams)
+        assertThat(paymentMethodMetadata.passiveCaptchaParams).isEqualTo(passiveCaptchaParams)
 
         val optionsCard = option.optionsParams as? PaymentMethodOptionsParams.Card
         assertThat(optionsCard?.cvc).isEqualTo(cvc)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
@@ -16,7 +16,6 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilt
 import com.stripe.android.model.Address
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.LinkMode
-import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
@@ -55,8 +54,6 @@ class ConfirmationHandlerOptionKtxTest {
             paymentSelection.toConfirmationOption(
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
                 linkConfiguration = null,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
-                clientAttributionMetadata = null,
             )
         ).isEqualTo(
             PaymentMethodConfirmationOption.New(
@@ -64,7 +61,6 @@ class ConfirmationHandlerOptionKtxTest {
                 optionsParams = PaymentMethodOptionsParams.Card(network = "cartes_bancaires"),
                 shouldSave = false,
                 extraParams = null,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
     }
@@ -79,8 +75,6 @@ class ConfirmationHandlerOptionKtxTest {
             paymentSelection.toConfirmationOption(
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
                 linkConfiguration = null,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
-                clientAttributionMetadata = null,
             )
         ).isEqualTo(
             PaymentMethodConfirmationOption.New(
@@ -88,7 +82,6 @@ class ConfirmationHandlerOptionKtxTest {
                 optionsParams = null,
                 shouldSave = false,
                 extraParams = null,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
     }
@@ -103,8 +96,6 @@ class ConfirmationHandlerOptionKtxTest {
             paymentSelection.toConfirmationOption(
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
                 linkConfiguration = null,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
-                clientAttributionMetadata = null,
             )
         ).isEqualTo(
             PaymentMethodConfirmationOption.New(
@@ -112,7 +103,6 @@ class ConfirmationHandlerOptionKtxTest {
                 optionsParams = null,
                 shouldSave = true,
                 extraParams = null,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
     }
@@ -138,14 +128,11 @@ class ConfirmationHandlerOptionKtxTest {
             paymentSelection.toConfirmationOption(
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
                 linkConfiguration = null,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
-                clientAttributionMetadata = null,
             )
         ).isEqualTo(
             BacsConfirmationOption(
                 createParams = bacsDebitParams,
                 optionsParams = null,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
     }
@@ -160,8 +147,6 @@ class ConfirmationHandlerOptionKtxTest {
             paymentSelection.toConfirmationOption(
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
                 linkConfiguration = null,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
-                clientAttributionMetadata = null,
             )
         ).isEqualTo(
             PaymentMethodConfirmationOption.New(
@@ -169,7 +154,6 @@ class ConfirmationHandlerOptionKtxTest {
                 optionsParams = null,
                 shouldSave = false,
                 extraParams = null,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
     }
@@ -187,8 +171,6 @@ class ConfirmationHandlerOptionKtxTest {
             paymentSelection.toConfirmationOption(
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
                 linkConfiguration = null,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
-                clientAttributionMetadata = null,
             )
         ).isEqualTo(
             PaymentMethodConfirmationOption.Saved(
@@ -196,7 +178,6 @@ class ConfirmationHandlerOptionKtxTest {
                 optionsParams = PaymentMethodOptionsParams.Card(
                     cvc = "505"
                 ),
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
             )
         )
     }
@@ -221,8 +202,6 @@ class ConfirmationHandlerOptionKtxTest {
             paymentSelection.toConfirmationOption(
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
                 linkConfiguration = null,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
-                clientAttributionMetadata = null,
             )
         ).isEqualTo(
             ExternalPaymentMethodConfirmationOption(
@@ -243,16 +222,12 @@ class ConfirmationHandlerOptionKtxTest {
             PaymentSelection.GooglePay.toConfirmationOption(
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
                 linkConfiguration = null,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
-                clientAttributionMetadata = null,
             )
         ).isNull()
     }
 
     @Test
     fun `On Google Pay selection with config with google pay config, should return expected option`() {
-        val expectedClientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA
-
         assertThat(
             PaymentSelection.GooglePay.toConfirmationOption(
                 configuration = PaymentSheetFixtures.CONFIG_GOOGLEPAY.newBuilder()
@@ -268,8 +243,6 @@ class ConfirmationHandlerOptionKtxTest {
                     .build()
                     .asCommonConfiguration(),
                 linkConfiguration = null,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
-                clientAttributionMetadata = expectedClientAttributionMetadata,
             )
         ).isEqualTo(
             GooglePayConfirmationOption(
@@ -285,8 +258,6 @@ class ConfirmationHandlerOptionKtxTest {
                         cardBrandAcceptance = PaymentSheet.CardBrandAcceptance.All
                     )
                 ),
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
-                clientAttributionMetadata = expectedClientAttributionMetadata,
             )
         )
     }
@@ -297,8 +268,6 @@ class ConfirmationHandlerOptionKtxTest {
             PaymentSelection.Link().toConfirmationOption(
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
                 linkConfiguration = null,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
-                clientAttributionMetadata = null,
             )
         ).isNull()
     }
@@ -309,14 +278,11 @@ class ConfirmationHandlerOptionKtxTest {
             PaymentSelection.Link().toConfirmationOption(
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
                 linkConfiguration = LINK_CONFIGURATION,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
-                clientAttributionMetadata = null,
             )
         ).isEqualTo(
             LinkConfirmationOption(
                 configuration = LINK_CONFIGURATION,
                 linkExpressMode = LinkExpressMode.DISABLED,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
     }
@@ -329,14 +295,11 @@ class ConfirmationHandlerOptionKtxTest {
             ).toConfirmationOption(
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
                 linkConfiguration = LINK_CONFIGURATION,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
-                clientAttributionMetadata = null,
             )
         ).isEqualTo(
             LinkConfirmationOption(
                 configuration = LINK_CONFIGURATION,
                 linkExpressMode = LinkExpressMode.ENABLED,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
     }
@@ -347,8 +310,6 @@ class ConfirmationHandlerOptionKtxTest {
             PaymentMethodFixtures.LINK_INLINE_PAYMENT_SELECTION.toConfirmationOption(
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
                 linkConfiguration = null,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
-                clientAttributionMetadata = null,
             )
         ).isNull()
     }
@@ -384,14 +345,11 @@ class ConfirmationHandlerOptionKtxTest {
             paymentSelection.toConfirmationOption(
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
                 linkConfiguration = null,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
-                clientAttributionMetadata = null,
             )
         ).isEqualTo(
             PaymentMethodConfirmationOption.Saved(
                 optionsParams = null,
                 paymentMethod = expectedPaymentMethod,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
             )
         )
     }
@@ -406,14 +364,11 @@ class ConfirmationHandlerOptionKtxTest {
             paymentSelection.toConfirmationOption(
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
                 linkConfiguration = null,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
-                clientAttributionMetadata = null,
             )
         ).isEqualTo(
             PaymentMethodConfirmationOption.Saved(
                 optionsParams = null,
                 paymentMethod = expectedPaymentMethod,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
             )
         )
     }
@@ -428,8 +383,6 @@ class ConfirmationHandlerOptionKtxTest {
         val confirmationOption = linkInlinePaymentSelection.toConfirmationOption(
             configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
             linkConfiguration = LINK_CONFIGURATION,
-            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
-            clientAttributionMetadata = null,
         )
 
         assertThat(confirmationOption).isInstanceOf<LinkInlineSignupConfirmationOption>()
@@ -454,8 +407,6 @@ class ConfirmationHandlerOptionKtxTest {
                 .build()
                 .asCommonConfiguration(),
             linkConfiguration = null,
-            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
-            clientAttributionMetadata = null,
         )
 
         assertThat(confirmationOption).isNull()
@@ -485,8 +436,6 @@ class ConfirmationHandlerOptionKtxTest {
                 .build()
                 .asCommonConfiguration(),
             linkConfiguration = null,
-            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
-            clientAttributionMetadata = null,
         )
 
         assertThat(confirmationOption).isInstanceOf<CustomPaymentMethodConfirmationOption>()
@@ -502,8 +451,6 @@ class ConfirmationHandlerOptionKtxTest {
             PaymentSelection.ShopPay.toConfirmationOption(
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
                 linkConfiguration = null,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
-                clientAttributionMetadata = null,
             )
         ).isNull()
     }
@@ -517,8 +464,6 @@ class ConfirmationHandlerOptionKtxTest {
                     customer = null
                 ),
                 linkConfiguration = null,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
-                clientAttributionMetadata = null,
             )
         ).isNull()
     }
@@ -537,8 +482,6 @@ class ConfirmationHandlerOptionKtxTest {
                         shopPayConfiguration = SHOP_PAY_CONFIGURATION
                     ),
                 linkConfiguration = null,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
-                clientAttributionMetadata = null,
             )
         ).isEqualTo(
             ShopPayConfirmationOption(
@@ -567,8 +510,6 @@ class ConfirmationHandlerOptionKtxTest {
                 .toConfirmationOption(
                     configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
                     linkConfiguration = LINK_CONFIGURATION,
-                    passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
-                    clientAttributionMetadata = null,
                 )
         ).isEqualTo(
             LinkInlineSignupConfirmationOption(
@@ -578,7 +519,6 @@ class ConfirmationHandlerOptionKtxTest {
                 saveOption = expectedSaveOption,
                 linkConfiguration = LINK_CONFIGURATION,
                 userInput = userInput,
-                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
             )
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationTestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationTestUtils.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.SavedStateHandle
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.paymentelement.confirmation.ConfirmationMediator.Parameters
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
@@ -196,7 +197,10 @@ internal fun ConfirmationHandler.Result?.assertCanceled(): ConfirmationHandler.R
 internal val PAYMENT_INTENT = PaymentIntentFactory.create()
 
 internal val CONFIRMATION_PARAMETERS = ConfirmationHandler.Args(
-    paymentMethodMetadata = PaymentMethodMetadataFactory.create(stripeIntent = PAYMENT_INTENT),
+    paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+        stripeIntent = PAYMENT_INTENT,
+        passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
+    ),
     initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
         clientSecret = "pi_123_secret_123",
     ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationDefinitionTest.kt
@@ -71,7 +71,6 @@ class IntentConfirmationDefinitionTest {
                     optionsParams = null,
                     shouldSave = true,
                     extraParams = null,
-                    passiveCaptchaParams = null
                 ),
                 confirmationArgs = CONFIRMATION_PARAMETERS,
             )
@@ -459,7 +458,6 @@ class IntentConfirmationDefinitionTest {
             optionsParams = PaymentMethodOptionsParams.Card(
                 cvc = "505",
             ),
-            passiveCaptchaParams = null
         )
 
         private val CONFIRMATION_PARAMETERS =

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationFlowTest.kt
@@ -43,7 +43,6 @@ internal class IntentConfirmationFlowTest {
                 optionsParams = null,
                 shouldSave = false,
                 extraParams = null,
-                passiveCaptchaParams = null
             ),
             confirmationArgs = defaultConfirmationDefinitionParams(
                 initializationMode = defaultPaymentIntentInitializationMode,
@@ -80,7 +79,6 @@ internal class IntentConfirmationFlowTest {
                 optionsParams = null,
                 shouldSave = false,
                 extraParams = null,
-                passiveCaptchaParams = null
             ),
             confirmationArgs = defaultConfirmationDefinitionParams(
                 initializationMode = defaultSetupIntentInitializationMode,
@@ -232,7 +230,6 @@ internal class IntentConfirmationFlowTest {
                 extraParams = PaymentMethodExtraParams.Card(
                     setAsDefault = true
                 ),
-                passiveCaptchaParams = null
             ),
             confirmationArgs = defaultConfirmationDefinitionParams(
                 initializationMode = defaultSetupIntentInitializationMode,
@@ -259,7 +256,6 @@ internal class IntentConfirmationFlowTest {
                 extraParams = PaymentMethodExtraParams.Card(
                     setAsDefault = true
                 ),
-                passiveCaptchaParams = null
             ),
             confirmationArgs = defaultConfirmationDefinitionParams(
                 initializationMode = defaultPaymentIntentInitializationMode,
@@ -368,7 +364,6 @@ internal class IntentConfirmationFlowTest {
             optionsParams = null,
             shouldSave = false,
             extraParams = null,
-            passiveCaptchaParams = null
         )
 
         val DEFERRED_CONFIRMATION_PARAMETERS = ConfirmationHandler.Args(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/PaymentMethodConfirmationOptionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/PaymentMethodConfirmationOptionTest.kt
@@ -15,7 +15,6 @@ class PaymentMethodConfirmationOptionTest {
         val option = PaymentMethodConfirmationOption.Saved(
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             optionsParams = null,
-            passiveCaptchaParams = null,
         )
 
         assertThat(option.shouldSaveAsDefault()).isFalse()
@@ -28,7 +27,6 @@ class PaymentMethodConfirmationOptionTest {
             optionsParams = null,
             extraParams = null,
             shouldSave = false,
-            passiveCaptchaParams = null,
         )
 
         assertThat(option.shouldSaveAsDefault()).isFalse()
@@ -41,7 +39,6 @@ class PaymentMethodConfirmationOptionTest {
             optionsParams = null,
             extraParams = PaymentMethodExtraParams.Card(setAsDefault = true),
             shouldSave = true,
-            passiveCaptchaParams = null,
         )
 
         assertThat(option.shouldSaveAsDefault()).isTrue()
@@ -54,7 +51,6 @@ class PaymentMethodConfirmationOptionTest {
             optionsParams = null,
             extraParams = PaymentMethodExtraParams.Card(setAsDefault = false),
             shouldSave = true,
-            passiveCaptchaParams = null,
         )
 
         assertThat(option.shouldSaveAsDefault()).isFalse()
@@ -67,7 +63,6 @@ class PaymentMethodConfirmationOptionTest {
             optionsParams = null,
             extraParams = PaymentMethodExtraParams.Card(setAsDefault = null),
             shouldSave = true,
-            passiveCaptchaParams = null,
         )
 
         assertThat(option.shouldSaveAsDefault()).isFalse()
@@ -80,7 +75,6 @@ class PaymentMethodConfirmationOptionTest {
             optionsParams = null,
             extraParams = PaymentMethodExtraParams.USBankAccount(setAsDefault = true),
             shouldSave = true,
-            passiveCaptchaParams = null,
         )
 
         assertThat(option.shouldSaveAsDefault()).isTrue()
@@ -93,7 +87,6 @@ class PaymentMethodConfirmationOptionTest {
             optionsParams = null,
             extraParams = PaymentMethodExtraParams.USBankAccount(setAsDefault = false),
             shouldSave = true,
-            passiveCaptchaParams = null,
         )
 
         assertThat(option.shouldSaveAsDefault()).isFalse()
@@ -110,7 +103,6 @@ class PaymentMethodConfirmationOptionTest {
             optionsParams = null,
             extraParams = PaymentMethodExtraParams.Link(setAsDefault = true),
             shouldSave = true,
-            passiveCaptchaParams = null,
         )
 
         assertThat(option.shouldSaveAsDefault()).isTrue()
@@ -127,7 +119,6 @@ class PaymentMethodConfirmationOptionTest {
             optionsParams = null,
             extraParams = PaymentMethodExtraParams.Link(setAsDefault = false),
             shouldSave = true,
-            passiveCaptchaParams = null,
         )
 
         assertThat(option.shouldSaveAsDefault()).isFalse()
@@ -140,7 +131,6 @@ class PaymentMethodConfirmationOptionTest {
             optionsParams = null,
             extraParams = PaymentMethodExtraParams.SepaDebit(setAsDefault = true),
             shouldSave = true,
-            passiveCaptchaParams = null,
         )
 
         assertThat(option.shouldSaveAsDefault()).isTrue()
@@ -153,7 +143,6 @@ class PaymentMethodConfirmationOptionTest {
             optionsParams = null,
             extraParams = PaymentMethodExtraParams.SepaDebit(setAsDefault = false),
             shouldSave = true,
-            passiveCaptchaParams = null,
         )
 
         assertThat(option.shouldSaveAsDefault()).isFalse()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/attestation/AttestationConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/attestation/AttestationConfirmationActivityTest.kt
@@ -248,14 +248,12 @@ internal class AttestationConfirmationActivityTest {
             optionsParams = null,
             extraParams = null,
             shouldSave = false,
-            passiveCaptchaParams = null,
         )
 
         private val SAVED_CONFIRMATION_OPTION = PaymentMethodConfirmationOption.Saved(
             paymentMethod = PaymentMethodFactory.card(),
             optionsParams = null,
             originatedFromWallet = false,
-            passiveCaptchaParams = null,
             hCaptchaToken = null,
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/attestation/AttestationConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/attestation/AttestationConfirmationDefinitionTest.kt
@@ -682,14 +682,12 @@ internal class AttestationConfirmationDefinitionTest {
             optionsParams = null,
             extraParams = null,
             shouldSave = false,
-            passiveCaptchaParams = null,
         )
 
         private val PAYMENT_METHOD_CONFIRMATION_OPTION_SAVED = PaymentMethodConfirmationOption.Saved(
             paymentMethod = PAYMENT_INTENT.paymentMethod!!,
             optionsParams = null,
             originatedFromWallet = false,
-            passiveCaptchaParams = null,
             hCaptchaToken = null,
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationActivityTest.kt
@@ -78,7 +78,6 @@ internal class BacsConfirmationActivityTest {
                         optionsParams = CONFIRMATION_OPTION.optionsParams,
                         shouldSave = false,
                         extraParams = null,
-                        passiveCaptchaParams = null
                     )
                 )
 
@@ -193,7 +192,6 @@ internal class BacsConfirmationActivityTest {
                 )
             ),
             optionsParams = null,
-            passiveCaptchaParams = null
         )
 
         val CONFIRMATION_ARGUMENTS = ConfirmationHandler.Args(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationDefinitionTest.kt
@@ -4,7 +4,6 @@ import androidx.activity.result.ActivityResultCallback
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.isInstanceOf
-import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentelement.confirmation.CONFIRMATION_PARAMETERS
@@ -114,7 +113,6 @@ class BacsConfirmationDefinitionTest {
 
         assertThat(newPaymentMethodOption.createParams).isEqualTo(bacsConfirmationOption.createParams)
         assertThat(newPaymentMethodOption.optionsParams).isEqualTo(bacsConfirmationOption.optionsParams)
-        assertThat(newPaymentMethodOption.passiveCaptchaParams).isEqualTo(bacsConfirmationOption.passiveCaptchaParams)
         assertThat(newPaymentMethodOption.shouldSave).isFalse()
     }
 
@@ -288,7 +286,6 @@ class BacsConfirmationDefinitionTest {
                 )
             ),
             optionsParams = null,
-            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationFlowTest.kt
@@ -35,7 +35,6 @@ class BacsConfirmationFlowTest {
                 optionsParams = BACS_CONFIRMATION_OPTION.optionsParams,
                 shouldSave = false,
                 extraParams = null,
-                passiveCaptchaParams = null
             ),
             arguments = CONFIRMATION_PARAMETERS,
         ),
@@ -54,7 +53,6 @@ class BacsConfirmationFlowTest {
                 )
             ),
             optionsParams = null,
-            passiveCaptchaParams = null
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationActivityTest.kt
@@ -82,7 +82,7 @@ internal class PassiveChallengeConfirmationActivityTest {
                         optionsParams = CONFIRMATION_OPTION.optionsParams,
                         shouldSave = false,
                         extraParams = null,
-                        passiveCaptchaParams = null
+                        passiveChallengeComplete = true,
                     )
                 )
 
@@ -124,7 +124,7 @@ internal class PassiveChallengeConfirmationActivityTest {
                         optionsParams = CONFIRMATION_OPTION.optionsParams,
                         shouldSave = false,
                         extraParams = null,
-                        passiveCaptchaParams = null
+                        passiveChallengeComplete = true,
                     )
                 )
 
@@ -170,8 +170,8 @@ internal class PassiveChallengeConfirmationActivityTest {
                             paymentMethod = SAVED_CONFIRMATION_OPTION.paymentMethod,
                             optionsParams = SAVED_CONFIRMATION_OPTION.optionsParams,
                             originatedFromWallet = false,
-                            passiveCaptchaParams = null,
-                            hCaptchaToken = "test_token"
+                            hCaptchaToken = "test_token",
+                            passiveChallengeComplete = true,
                         )
                     )
 
@@ -221,21 +221,17 @@ internal class PassiveChallengeConfirmationActivityTest {
 
         val PAYMENT_METHOD = PaymentMethodFactory.card()
 
-        val PASSIVE_CAPTCHA_PARAMS = PassiveCaptchaParamsFactory.passiveCaptchaParams()
-
         val CONFIRMATION_OPTION = PaymentMethodConfirmationOption.New(
             createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
             optionsParams = null,
             extraParams = null,
             shouldSave = false,
-            passiveCaptchaParams = PASSIVE_CAPTCHA_PARAMS
         )
 
         val SAVED_CONFIRMATION_OPTION = PaymentMethodConfirmationOption.Saved(
             paymentMethod = PAYMENT_METHOD,
             optionsParams = null,
             originatedFromWallet = false,
-            passiveCaptchaParams = PASSIVE_CAPTCHA_PARAMS,
             hCaptchaToken = null
         )
 
@@ -247,6 +243,7 @@ internal class PassiveChallengeConfirmationActivityTest {
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                 stripeIntent = PAYMENT_INTENT,
                 shippingDetails = AddressDetails(),
+                passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
             ),
             appearance = PaymentSheet.Appearance(),
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinitionTest.kt
@@ -88,13 +88,12 @@ internal class PassiveChallengeConfirmationDefinitionTest {
     @Test
     fun `'canConfirm' should return false when passiveCaptchaParams is null for New option`() {
         val definition = createPassiveChallengeConfirmationDefinition()
-        val optionWithoutCaptcha = PAYMENT_METHOD_CONFIRMATION_OPTION_NEW.copy(
-            passiveCaptchaParams = null
-        )
 
         val result = definition.canConfirm(
-            confirmationOption = optionWithoutCaptcha,
-            confirmationArgs = CONFIRMATION_PARAMETERS
+            confirmationOption = PAYMENT_METHOD_CONFIRMATION_OPTION_NEW,
+            confirmationArgs = CONFIRMATION_PARAMETERS.copy(
+                paymentMethodMetadata = PaymentMethodMetadataFactory.create(passiveCaptchaParams = null)
+            )
         )
 
         assertThat(result).isFalse()
@@ -103,13 +102,12 @@ internal class PassiveChallengeConfirmationDefinitionTest {
     @Test
     fun `'canConfirm' should return false when passiveCaptchaParams is null for Saved option`() {
         val definition = createPassiveChallengeConfirmationDefinition()
-        val optionWithoutCaptcha = PAYMENT_METHOD_CONFIRMATION_OPTION_SAVED.copy(
-            passiveCaptchaParams = null
-        )
 
         val result = definition.canConfirm(
-            confirmationOption = optionWithoutCaptcha,
-            confirmationArgs = CONFIRMATION_PARAMETERS
+            confirmationOption = PAYMENT_METHOD_CONFIRMATION_OPTION_SAVED,
+            confirmationArgs = CONFIRMATION_PARAMETERS.copy(
+                paymentMethodMetadata = PaymentMethodMetadataFactory.create(passiveCaptchaParams = null)
+            )
         )
 
         assertThat(result).isFalse()
@@ -177,7 +175,8 @@ internal class PassiveChallengeConfirmationDefinitionTest {
 
         val launchAction = action.asLaunch()
 
-        assertThat(launchAction.launcherArguments.passiveCaptchaParams).isEqualTo(PASSIVE_CAPTCHA_PARAMS)
+        assertThat(launchAction.launcherArguments.passiveCaptchaParams)
+            .isEqualTo(CONFIRMATION_PARAMETERS.paymentMethodMetadata.passiveCaptchaParams)
         assertThat(launchAction.receivesResultInProcess).isFalse()
         assertThat(launchAction.deferredIntentConfirmationType).isNull()
     }
@@ -185,13 +184,12 @@ internal class PassiveChallengeConfirmationDefinitionTest {
     @Test
     fun `'action' should return 'Fail' action when passiveCaptchaParams is null`() = runTest {
         val definition = createPassiveChallengeConfirmationDefinition()
-        val optionWithoutCaptcha = PAYMENT_METHOD_CONFIRMATION_OPTION_NEW.copy(
-            passiveCaptchaParams = null
-        )
 
         val action = definition.action(
-            confirmationOption = optionWithoutCaptcha,
-            confirmationArgs = CONFIRMATION_PARAMETERS,
+            confirmationOption = PAYMENT_METHOD_CONFIRMATION_OPTION_NEW,
+            confirmationArgs = CONFIRMATION_PARAMETERS.copy(
+                paymentMethodMetadata = PaymentMethodMetadataFactory.create(passiveCaptchaParams = null)
+            ),
         )
 
         assertThat(action)
@@ -209,13 +207,12 @@ internal class PassiveChallengeConfirmationDefinitionTest {
     fun `'action' should report error when passiveCaptchaParams is null`() = runTest {
         val fakeErrorReporter = FakeErrorReporter()
         val definition = createPassiveChallengeConfirmationDefinition(fakeErrorReporter)
-        val optionWithoutCaptcha = PAYMENT_METHOD_CONFIRMATION_OPTION_NEW.copy(
-            passiveCaptchaParams = null
-        )
 
         definition.action(
-            confirmationOption = optionWithoutCaptcha,
-            confirmationArgs = CONFIRMATION_PARAMETERS,
+            confirmationOption = PAYMENT_METHOD_CONFIRMATION_OPTION_NEW,
+            confirmationArgs = CONFIRMATION_PARAMETERS.copy(
+                paymentMethodMetadata = PaymentMethodMetadataFactory.create(passiveCaptchaParams = null)
+            )
         )
 
         val reportedErrors = fakeErrorReporter.getLoggedErrors()
@@ -238,15 +235,18 @@ internal class PassiveChallengeConfirmationDefinitionTest {
 
         definition.launch(
             confirmationOption = PAYMENT_METHOD_CONFIRMATION_OPTION_NEW,
-            confirmationArgs = CONFIRMATION_PARAMETERS,
+            confirmationArgs = CONFIRMATION_PARAMETERS.copy(
+                paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                    passiveCaptchaParams = PASSIVE_CAPTCHA_PARAMS,
+                )
+            ),
             launcher = launcher,
             arguments = launcherArgs,
         )
 
         val launchCall = launcher.calls.awaitItem()
 
-        assertThat(launchCall.input.passiveCaptchaParams)
-            .isEqualTo(PAYMENT_METHOD_CONFIRMATION_OPTION_NEW.passiveCaptchaParams)
+        assertThat(launchCall.input.passiveCaptchaParams).isEqualTo(PASSIVE_CAPTCHA_PARAMS)
     }
 
     @Test
@@ -270,7 +270,7 @@ internal class PassiveChallengeConfirmationDefinitionTest {
     }
 
     @Test
-    fun `'toResult' should return 'NextStep' with passiveCaptchaParams removed for Success result with New option`() {
+    fun `'toResult' should return 'NextStep' with passiveChallengeComplete=true for Success result with New option`() {
         val definition = createPassiveChallengeConfirmationDefinition()
         val testToken = "test_token"
 
@@ -287,7 +287,7 @@ internal class PassiveChallengeConfirmationDefinitionTest {
         val nextStepResult = result.asNextStep()
 
         val expectedOption = PAYMENT_METHOD_CONFIRMATION_OPTION_NEW.copy(
-            passiveCaptchaParams = null,
+            passiveChallengeComplete = true,
             createParams = PAYMENT_METHOD_CONFIRMATION_OPTION_NEW.createParams.copy(
                 radarOptions = RadarOptions(
                     hCaptchaToken = testToken,
@@ -301,7 +301,7 @@ internal class PassiveChallengeConfirmationDefinitionTest {
     }
 
     @Test
-    fun `'toResult' should return 'NextStep' with passiveCaptchaParams removed for Success result with Saved option`() {
+    fun `'toResult' should return 'NextStep' for Success result with Saved option`() {
         val definition = createPassiveChallengeConfirmationDefinition()
         val testToken = "test_token"
 
@@ -318,7 +318,7 @@ internal class PassiveChallengeConfirmationDefinitionTest {
         val nextStepResult = result.asNextStep()
 
         val expectedOption = PAYMENT_METHOD_CONFIRMATION_OPTION_SAVED.copy(
-            passiveCaptchaParams = null,
+            passiveChallengeComplete = true,
             hCaptchaToken = testToken
         )
 
@@ -327,7 +327,7 @@ internal class PassiveChallengeConfirmationDefinitionTest {
     }
 
     @Test
-    fun `'toResult' should return 'NextStep' with passiveCaptchaParams removed for Failed result with New option`() {
+    fun `'toResult' should return 'NextStep' with passiveChallengeComplete=true for Failed result with New option`() {
         val definition = createPassiveChallengeConfirmationDefinition()
         val exception = RuntimeException("Captcha failed")
 
@@ -344,13 +344,13 @@ internal class PassiveChallengeConfirmationDefinitionTest {
         val nextStepResult = result.asNextStep()
 
         assertThat(nextStepResult.confirmationOption).isEqualTo(
-            PAYMENT_METHOD_CONFIRMATION_OPTION_NEW.copy(passiveCaptchaParams = null)
+            PAYMENT_METHOD_CONFIRMATION_OPTION_NEW.copy(passiveChallengeComplete = true)
         )
         assertThat(nextStepResult.arguments).isEqualTo(CONFIRMATION_PARAMETERS)
     }
 
     @Test
-    fun `'toResult' should return 'NextStep' with passiveCaptchaParams removed for Failed result with Saved option`() {
+    fun `'toResult' should return 'NextStep' with passiveChallengeComplete=true for Failed result with Saved option`() {
         val definition = createPassiveChallengeConfirmationDefinition()
         val exception = RuntimeException("Captcha failed")
 
@@ -367,7 +367,10 @@ internal class PassiveChallengeConfirmationDefinitionTest {
         val nextStepResult = result.asNextStep()
 
         assertThat(nextStepResult.confirmationOption).isEqualTo(
-            PAYMENT_METHOD_CONFIRMATION_OPTION_SAVED.copy(passiveCaptchaParams = null, hCaptchaToken = null)
+            PAYMENT_METHOD_CONFIRMATION_OPTION_SAVED.copy(
+                passiveChallengeComplete = true,
+                hCaptchaToken = null
+            )
         )
         assertThat(nextStepResult.arguments).isEqualTo(CONFIRMATION_PARAMETERS)
     }
@@ -387,7 +390,8 @@ internal class PassiveChallengeConfirmationDefinitionTest {
 
             val launchAction = action.asLaunch()
 
-            assertThat(launchAction.launcherArguments.passiveCaptchaParams).isEqualTo(PASSIVE_CAPTCHA_PARAMS)
+            assertThat(launchAction.launcherArguments.passiveCaptchaParams)
+                .isEqualTo(CONFIRMATION_PARAMETERS.paymentMethodMetadata.passiveCaptchaParams)
             assertThat(launchAction.receivesResultInProcess).isFalse()
             assertThat(launchAction.deferredIntentConfirmationType).isNull()
         }
@@ -400,7 +404,11 @@ internal class PassiveChallengeConfirmationDefinitionTest {
 
         definition.launch(
             confirmationOption = PAYMENT_METHOD_CONFIRMATION_OPTION_SAVED,
-            confirmationArgs = CONFIRMATION_PARAMETERS,
+            confirmationArgs = CONFIRMATION_PARAMETERS.copy(
+                paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                    passiveCaptchaParams = PASSIVE_CAPTCHA_PARAMS,
+                )
+            ),
             launcher = launcher,
             arguments = launcherArgs,
         )
@@ -408,7 +416,7 @@ internal class PassiveChallengeConfirmationDefinitionTest {
         val launchCall = launcher.calls.awaitItem()
 
         assertThat(launchCall.input.passiveCaptchaParams)
-            .isEqualTo(PAYMENT_METHOD_CONFIRMATION_OPTION_SAVED.passiveCaptchaParams)
+            .isEqualTo(PASSIVE_CAPTCHA_PARAMS)
     }
 
     @Test
@@ -504,7 +512,7 @@ internal class PassiveChallengeConfirmationDefinitionTest {
 
         // Verify that radarOptions is not set by checking equality with expected option
         val expectedOption = PAYMENT_METHOD_CONFIRMATION_OPTION_NEW.copy(
-            passiveCaptchaParams = null,
+            passiveChallengeComplete = true,
             createParams = PAYMENT_METHOD_CONFIRMATION_OPTION_NEW.createParams.copy(
                 radarOptions = null
             )
@@ -570,14 +578,12 @@ internal class PassiveChallengeConfirmationDefinitionTest {
             optionsParams = null,
             extraParams = null,
             shouldSave = false,
-            passiveCaptchaParams = PASSIVE_CAPTCHA_PARAMS,
         )
 
         private val PAYMENT_METHOD_CONFIRMATION_OPTION_SAVED = PaymentMethodConfirmationOption.Saved(
             paymentMethod = PAYMENT_INTENT.paymentMethod!!,
             optionsParams = null,
             originatedFromWallet = false,
-            passiveCaptchaParams = PASSIVE_CAPTCHA_PARAMS,
             hCaptchaToken = null,
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationFlowTest.kt
@@ -2,7 +2,6 @@ package com.stripe.android.paymentelement.confirmation.challenge
 
 import com.stripe.android.challenge.passive.PassiveChallengeActivityResult
 import com.stripe.android.challenge.passive.warmer.PassiveChallengeWarmer
-import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.paymentelement.confirmation.CONFIRMATION_PARAMETERS
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
@@ -46,7 +45,7 @@ internal class PassiveChallengeConfirmationFlowTest {
                 optionsParams = NEW_CONFIRMATION_OPTION.optionsParams,
                 shouldSave = false,
                 extraParams = null,
-                passiveCaptchaParams = null
+                passiveChallengeComplete = true,
             ),
             arguments = CONFIRMATION_PARAMETERS,
         ),
@@ -63,7 +62,7 @@ internal class PassiveChallengeConfirmationFlowTest {
                 paymentMethod = SAVED_CONFIRMATION_OPTION.paymentMethod,
                 optionsParams = SAVED_CONFIRMATION_OPTION.optionsParams,
                 originatedFromWallet = false,
-                passiveCaptchaParams = null,
+                passiveChallengeComplete = true,
                 hCaptchaToken = "test_token"
             ),
             arguments = CONFIRMATION_PARAMETERS,
@@ -82,7 +81,7 @@ internal class PassiveChallengeConfirmationFlowTest {
                 optionsParams = NEW_CONFIRMATION_OPTION.optionsParams,
                 shouldSave = false,
                 extraParams = null,
-                passiveCaptchaParams = null
+                passiveChallengeComplete = true,
             ),
             arguments = CONFIRMATION_PARAMETERS,
         ),
@@ -99,7 +98,7 @@ internal class PassiveChallengeConfirmationFlowTest {
                 paymentMethod = SAVED_CONFIRMATION_OPTION.paymentMethod,
                 optionsParams = SAVED_CONFIRMATION_OPTION.optionsParams,
                 originatedFromWallet = false,
-                passiveCaptchaParams = null,
+                passiveChallengeComplete = true,
                 hCaptchaToken = null
             ),
             arguments = CONFIRMATION_PARAMETERS,
@@ -109,21 +108,17 @@ internal class PassiveChallengeConfirmationFlowTest {
     private companion object {
         private val PAYMENT_METHOD = PaymentMethodFactory.card()
 
-        private val PASSIVE_CAPTCHA_PARAMS = PassiveCaptchaParamsFactory.passiveCaptchaParams()
-
         private val NEW_CONFIRMATION_OPTION = PaymentMethodConfirmationOption.New(
             createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
             optionsParams = null,
             extraParams = null,
             shouldSave = false,
-            passiveCaptchaParams = PASSIVE_CAPTCHA_PARAMS,
         )
 
         private val SAVED_CONFIRMATION_OPTION = PaymentMethodConfirmationOption.Saved(
             paymentMethod = PAYMENT_METHOD,
             optionsParams = null,
             originatedFromWallet = false,
-            passiveCaptchaParams = PASSIVE_CAPTCHA_PARAMS,
             hCaptchaToken = null,
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationActivityTest.kt
@@ -74,7 +74,6 @@ internal class CvcRecollectionConfirmationActivityTest {
                     PaymentMethodConfirmationOption.Saved(
                         paymentMethod = PAYMENT_METHOD,
                         optionsParams = PaymentMethodOptionsParams.Card(cvc = "444"),
-                        passiveCaptchaParams = null
                     )
                 )
 
@@ -113,7 +112,6 @@ internal class CvcRecollectionConfirmationActivityTest {
                     PaymentMethodConfirmationOption.Saved(
                         paymentMethod = PAYMENT_METHOD,
                         optionsParams = null,
-                        passiveCaptchaParams = null
                     )
                 )
 
@@ -177,7 +175,6 @@ internal class CvcRecollectionConfirmationActivityTest {
         val CONFIRMATION_OPTION = PaymentMethodConfirmationOption.Saved(
             paymentMethod = PAYMENT_METHOD,
             optionsParams = null,
-            passiveCaptchaParams = null
         )
 
         val CONFIRMATION_ARGUMENTS = ConfirmationHandler.Args(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationDefinitionTest.kt
@@ -3,7 +3,6 @@ package com.stripe.android.paymentelement.confirmation.cvc
 import androidx.activity.result.ActivityResultCallback
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.isInstanceOf
-import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
@@ -298,7 +297,6 @@ class CvcRecollectionConfirmationDefinitionTest {
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             optionsParams = optionsParams,
             originatedFromWallet = originatedFromWallet,
-            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationActivityTest.kt
@@ -17,7 +17,6 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
-import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.ConfirmationTestScenario
 import com.stripe.android.paymentelement.confirmation.PaymentElementConfirmationTestActivity
@@ -81,7 +80,6 @@ internal class GooglePayConfirmationActivityTest {
                         paymentMethod = paymentMethod,
                         optionsParams = null,
                         originatedFromWallet = true,
-                        passiveCaptchaParams = null,
                     )
                 )
 
@@ -155,7 +153,6 @@ internal class GooglePayConfirmationActivityTest {
                         paymentMethod = paymentMethod,
                         optionsParams = null,
                         originatedFromWallet = true,
-                        passiveCaptchaParams = null,
                     )
                 )
 
@@ -216,7 +213,6 @@ internal class GooglePayConfirmationActivityTest {
                         paymentMethod = paymentMethod,
                         optionsParams = null,
                         originatedFromWallet = true,
-                        passiveCaptchaParams = null,
                     )
                 )
 
@@ -281,8 +277,6 @@ internal class GooglePayConfirmationActivityTest {
                     .BillingDetailsCollectionConfiguration(),
                 cardBrandFilter = DefaultCardBrandFilter,
             ),
-            passiveCaptchaParams = null,
-            clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
         )
 
         val CONFIRMATION_ARGUMENTS = ConfirmationHandler.Args(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinitionTest.kt
@@ -13,9 +13,7 @@ import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContra
 import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLauncherFactory
 import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
-import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
 import com.stripe.android.model.CardBrand
-import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.wallets.Wallet
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
@@ -456,7 +454,7 @@ class GooglePayConfirmationDefinitionTest {
                 amount = 1000L,
                 transactionId = "pi_12345",
                 label = null,
-                clientAttributionMetadata = GOOGLE_PAY_CONFIRMATION_OPTION.clientAttributionMetadata,
+                clientAttributionMetadata = CONFIRMATION_PARAMETERS.paymentMethodMetadata.clientAttributionMetadata,
             )
         }
     }
@@ -492,7 +490,7 @@ class GooglePayConfirmationDefinitionTest {
                 amount = 1000L,
                 transactionId = "pi_12345",
                 label = "Merchant Inc.",
-                clientAttributionMetadata = GOOGLE_PAY_CONFIRMATION_OPTION.clientAttributionMetadata,
+                clientAttributionMetadata = CONFIRMATION_PARAMETERS.paymentMethodMetadata.clientAttributionMetadata,
             )
         }
     }
@@ -529,7 +527,7 @@ class GooglePayConfirmationDefinitionTest {
                 amount = 2099L,
                 transactionId = "pi_12345",
                 label = "Merchant Inc.",
-                clientAttributionMetadata = GOOGLE_PAY_CONFIRMATION_OPTION.clientAttributionMetadata,
+                clientAttributionMetadata = CONFIRMATION_PARAMETERS.paymentMethodMetadata.clientAttributionMetadata,
             )
         }
     }
@@ -681,8 +679,6 @@ class GooglePayConfirmationDefinitionTest {
                 ),
                 cardBrandFilter = DefaultCardBrandFilter,
             ),
-            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
-            clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
         )
 
         private val APPEARANCE = PaymentSheet.Appearance.Builder()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationFlowTest.kt
@@ -5,7 +5,6 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.isInstanceOf
-import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
 import com.stripe.android.paymentelement.confirmation.CONFIRMATION_PARAMETERS
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationMediator
@@ -72,7 +71,7 @@ class GooglePayConfirmationFlowTest {
                     amount = 1000L,
                     transactionId = "pi_12345",
                     label = null,
-                    clientAttributionMetadata = GOOGLE_PAY_CONFIRMATION_OPTION.clientAttributionMetadata,
+                    clientAttributionMetadata = CONFIRMATION_PARAMETERS.paymentMethodMetadata.clientAttributionMetadata,
                 )
             }
         }
@@ -92,7 +91,6 @@ class GooglePayConfirmationFlowTest {
                 paymentMethod = PAYMENT_METHOD,
                 optionsParams = null,
                 originatedFromWallet = true,
-                passiveCaptchaParams = null,
             ),
             arguments = CONFIRMATION_PARAMETERS,
         )
@@ -112,8 +110,6 @@ class GooglePayConfirmationFlowTest {
                 ),
                 cardBrandFilter = DefaultCardBrandFilter,
             ),
-            passiveCaptchaParams = null,
-            clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
         )
 
         private val PAYMENT_METHOD = PaymentMethodFactory.card()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/ConfirmationInterceptorTestUtil.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/ConfirmationInterceptorTestUtil.kt
@@ -74,7 +74,6 @@ internal suspend fun IntentConfirmationInterceptor.interceptDefaultNewPaymentMet
         optionsParams = null,
         extraParams = null,
         shouldSave = false,
-        passiveCaptchaParams = null
     ),
     shippingValues = null,
 )
@@ -85,7 +84,6 @@ internal suspend fun IntentConfirmationInterceptor.interceptDefaultSavedPaymentM
     confirmationOption = PaymentMethodConfirmationOption.Saved(
         paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
         optionsParams = null,
-        passiveCaptchaParams = null,
         hCaptchaToken = null,
     ),
     shippingValues = null,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/ConfirmationTokenConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/ConfirmationTokenConfirmationInterceptorTest.kt
@@ -483,7 +483,6 @@ class ConfirmationTokenConfirmationInterceptorTest {
                 confirmationOption = PaymentMethodConfirmationOption.Saved(
                     paymentMethod = PaymentMethodFixtures.AU_BECS_DEBIT,
                     optionsParams = null,
-                    passiveCaptchaParams = null,
                     hCaptchaToken = null,
                 ),
                 shippingValues = null,
@@ -669,7 +668,6 @@ class ConfirmationTokenConfirmationInterceptorTest {
             optionsParams = null,
             extraParams = null,
             shouldSave = false,
-            passiveCaptchaParams = null,
         )
 
         interceptor.intercept(
@@ -717,7 +715,6 @@ class ConfirmationTokenConfirmationInterceptorTest {
             optionsParams = null,
             extraParams = null,
             shouldSave = false,
-            passiveCaptchaParams = null,
         )
 
         interceptor.intercept(
@@ -764,7 +761,6 @@ class ConfirmationTokenConfirmationInterceptorTest {
         val confirmationOption = PaymentMethodConfirmationOption.Saved(
             paymentMethod = PaymentMethodFixtures.SEPA_DEBIT_PAYMENT_METHOD,
             optionsParams = null,
-            passiveCaptchaParams = null,
             hCaptchaToken = null,
         )
 
@@ -812,7 +808,6 @@ class ConfirmationTokenConfirmationInterceptorTest {
         val confirmationOption = PaymentMethodConfirmationOption.Saved(
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             optionsParams = null,
-            passiveCaptchaParams = null,
             hCaptchaToken = null,
         )
 
@@ -868,7 +863,6 @@ class ConfirmationTokenConfirmationInterceptorTest {
         val confirmationOption = PaymentMethodConfirmationOption.Saved(
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             optionsParams = PaymentMethodOptionsParams.Card(cvc = "123"),
-            passiveCaptchaParams = null,
             hCaptchaToken = null,
         )
 
@@ -924,7 +918,6 @@ class ConfirmationTokenConfirmationInterceptorTest {
         val confirmationOption = PaymentMethodConfirmationOption.Saved(
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             optionsParams = PaymentMethodOptionsParams.Card(cvc = "123"),
-            passiveCaptchaParams = null,
             hCaptchaToken = null,
         )
 
@@ -981,7 +974,6 @@ class ConfirmationTokenConfirmationInterceptorTest {
         val confirmationOption = PaymentMethodConfirmationOption.Saved(
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             optionsParams = PaymentMethodOptionsParams.Card(cvc = "123"),
-            passiveCaptchaParams = null,
             hCaptchaToken = null,
         )
 
@@ -1060,7 +1052,6 @@ class ConfirmationTokenConfirmationInterceptorTest {
                 optionsParams = null,
                 extraParams = PaymentMethodExtraParams.Card(setAsDefault = true),
                 shouldSave = true,
-                passiveCaptchaParams = null,
             )
 
             interceptor.intercept(
@@ -1093,7 +1084,6 @@ class ConfirmationTokenConfirmationInterceptorTest {
             val confirmationOption = PaymentMethodConfirmationOption.Saved(
                 paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
                 optionsParams = null,
-                passiveCaptchaParams = null,
                 hCaptchaToken = "test_token",
             )
 
@@ -1116,7 +1106,6 @@ class ConfirmationTokenConfirmationInterceptorTest {
             val confirmationOption = PaymentMethodConfirmationOption.Saved(
                 paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
                 optionsParams = null,
-                passiveCaptchaParams = null,
                 hCaptchaToken = null,
             )
 
@@ -1204,7 +1193,6 @@ class ConfirmationTokenConfirmationInterceptorTest {
                     ),
                     extraParams = null,
                     shouldSave = true,
-                    passiveCaptchaParams = null,
                 )
                 interceptor.intercept(
                     intent = PaymentIntentFactory.create(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/DeferredIntentConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/DeferredIntentConfirmationInterceptorTest.kt
@@ -302,7 +302,6 @@ class DeferredIntentConfirmationInterceptorTest {
                     optionsParams = PaymentMethodOptionsParams.Card(
                         setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
                     ).takeIf { input },
-                    passiveCaptchaParams = null,
                     hCaptchaToken = null,
                 ),
                 shippingValues = null,
@@ -398,7 +397,6 @@ class DeferredIntentConfirmationInterceptorTest {
             confirmationOption = PaymentMethodConfirmationOption.Saved(
                 paymentMethod = paymentMethod,
                 optionsParams = null,
-                passiveCaptchaParams = null,
                 hCaptchaToken = hCaptchaToken,
                 attestationToken = attestationToken,
             ),
@@ -448,7 +446,6 @@ class DeferredIntentConfirmationInterceptorTest {
             confirmationOption = PaymentMethodConfirmationOption.Saved(
                 paymentMethod = paymentMethod,
                 optionsParams = null,
-                passiveCaptchaParams = null,
                 hCaptchaToken = hCaptchaToken,
                 attestationToken = null,
             ),
@@ -495,7 +492,6 @@ class DeferredIntentConfirmationInterceptorTest {
             confirmationOption = PaymentMethodConfirmationOption.Saved(
                 paymentMethod = paymentMethod,
                 optionsParams = null,
-                passiveCaptchaParams = null,
                 hCaptchaToken = null,
                 attestationToken = null,
             ),
@@ -546,7 +542,6 @@ class DeferredIntentConfirmationInterceptorTest {
             confirmationOption = PaymentMethodConfirmationOption.Saved(
                 paymentMethod = paymentMethod,
                 optionsParams = null,
-                passiveCaptchaParams = null,
                 hCaptchaToken = null,
                 attestationToken = attestationToken,
             ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/HCaptchaConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/HCaptchaConfirmationInterceptorTest.kt
@@ -92,7 +92,6 @@ class HCaptchaConfirmationInterceptorTest {
             confirmationOption = PaymentMethodConfirmationOption.Saved(
                 paymentMethod = paymentMethod,
                 optionsParams = null,
-                passiveCaptchaParams = null,
                 hCaptchaToken = hCaptchaToken,
             ),
             shippingValues = null,
@@ -136,7 +135,6 @@ class HCaptchaConfirmationInterceptorTest {
             confirmationOption = PaymentMethodConfirmationOption.Saved(
                 paymentMethod = paymentMethod,
                 optionsParams = null,
-                passiveCaptchaParams = null,
                 hCaptchaToken = hCaptchaToken,
             ),
             shippingValues = null,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/IntentFirstConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/IntentFirstConfirmationInterceptorTest.kt
@@ -33,7 +33,6 @@ class IntentFirstConfirmationInterceptorTest {
                 confirmationOption = PaymentMethodConfirmationOption.Saved(
                     paymentMethod = paymentMethod,
                     optionsParams = null,
-                    passiveCaptchaParams = null,
                     hCaptchaToken = null,
                 ),
                 shippingValues = null,
@@ -59,7 +58,6 @@ class IntentFirstConfirmationInterceptorTest {
                     optionsParams = null,
                     extraParams = null,
                     shouldSave = false,
-                    passiveCaptchaParams = null
                 ),
                 shippingValues = null,
             )
@@ -81,7 +79,6 @@ class IntentFirstConfirmationInterceptorTest {
                     optionsParams = PaymentMethodOptionsParams.Card(
                         setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
                     ),
-                    passiveCaptchaParams = null
                 ),
                 shippingValues = null,
             )
@@ -133,7 +130,6 @@ class IntentFirstConfirmationInterceptorTest {
                     optionsParams = null,
                     extraParams = null,
                     shouldSave = false,
-                    passiveCaptchaParams = null
                 ),
                 intent = PaymentIntentFactory.create(),
                 shippingValues = null,
@@ -172,7 +168,6 @@ class IntentFirstConfirmationInterceptorTest {
                     paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
                     optionsParams = null,
                     hCaptchaToken = hCaptchaToken,
-                    passiveCaptchaParams = null
                 ),
                 shippingValues = null,
             )
@@ -204,7 +199,6 @@ class IntentFirstConfirmationInterceptorTest {
                 paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
                 optionsParams = null,
                 hCaptchaToken = hCaptchaToken,
-                passiveCaptchaParams = null
             ),
             shippingValues = null,
         )
@@ -226,7 +220,6 @@ class IntentFirstConfirmationInterceptorTest {
                 paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
                 optionsParams = null,
                 hCaptchaToken = hCaptchaToken,
-                passiveCaptchaParams = null
             ),
             shippingValues = null,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/PaymentMethodOptionsSetupFutureUsageConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/PaymentMethodOptionsSetupFutureUsageConfirmationInterceptorTest.kt
@@ -156,7 +156,6 @@ class PaymentMethodOptionsSetupFutureUsageConfirmationInterceptorTest {
                     optionsParams = PaymentMethodOptionsParams.Card(),
                     extraParams = null,
                     shouldSave = false,
-                    passiveCaptchaParams = null
                 ),
                 intent = PaymentIntentFactory.create(),
                 shippingValues = null,
@@ -224,7 +223,6 @@ class PaymentMethodOptionsSetupFutureUsageConfirmationInterceptorTest {
                     ),
                     extraParams = null,
                     shouldSave = false,
-                    passiveCaptchaParams = null
                 ),
                 intent = PaymentIntentFactory.create(),
                 shippingValues = null,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/SharedPaymentTokenConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/SharedPaymentTokenConfirmationInterceptorTest.kt
@@ -59,7 +59,6 @@ class SharedPaymentTokenConfirmationInterceptorTest {
                 confirmationOption = PaymentMethodConfirmationOption.Saved(
                     paymentMethod = providedPaymentMethod,
                     optionsParams = null,
-                    passiveCaptchaParams = null,
                     hCaptchaToken = null,
                 ),
                 shippingValues = providedShippingAddress,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationActivityTest.kt
@@ -97,11 +97,13 @@ internal class LinkConfirmationActivityTest(private val nativeLinkEnabled: Boole
         confirmationHandler.state.test {
             awaitItem().assertIdle()
 
+            val paymentMethodMetadata = CONFIRMATION_PARAMETERS.paymentMethodMetadata.copy(passiveCaptchaParams = null)
+
             confirmationHandler.start(
                 ConfirmationHandler.Args(
                     confirmationOption = LINK_CONFIRMATION_OPTION,
                     appearance = CONFIRMATION_PARAMETERS.appearance,
-                    paymentMethodMetadata = CONFIRMATION_PARAMETERS.paymentMethodMetadata,
+                    paymentMethodMetadata = paymentMethodMetadata,
                     initializationMode = CONFIRMATION_PARAMETERS.initializationMode,
                 )
             )
@@ -110,7 +112,7 @@ internal class LinkConfirmationActivityTest(private val nativeLinkEnabled: Boole
 
             assertThat(confirmingWithLink.option).isEqualTo(LINK_CONFIRMATION_OPTION)
 
-            intendedLinkToBeLaunched(CONFIRMATION_PARAMETERS.paymentMethodMetadata)
+            intendedLinkToBeLaunched(paymentMethodMetadata)
 
             val confirmingWithSavedPaymentMethod = awaitItem().assertConfirming()
 
@@ -120,7 +122,6 @@ internal class LinkConfirmationActivityTest(private val nativeLinkEnabled: Boole
                         paymentMethod = paymentMethod,
                         optionsParams = null,
                         originatedFromWallet = true,
-                        passiveCaptchaParams = null
                     )
                 )
 
@@ -227,7 +228,6 @@ internal class LinkConfirmationActivityTest(private val nativeLinkEnabled: Boole
         val LINK_CONFIRMATION_OPTION = LinkConfirmationOption(
             configuration = TestFactory.LINK_CONFIGURATION,
             linkExpressMode = LinkExpressMode.ENABLED,
-            passiveCaptchaParams = null
         )
 
         const val LINK_COMPLETE_CODE = 49871

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinitionTest.kt
@@ -12,7 +12,6 @@ import com.stripe.android.link.TestFactory
 import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.link.account.LinkStore
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
-import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.paymentelement.confirmation.CONFIRMATION_PARAMETERS
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
@@ -395,7 +394,6 @@ internal class LinkConfirmationDefinitionTest {
         private val LINK_CONFIRMATION_OPTION = LinkConfirmationOption(
             configuration = TestFactory.LINK_CONFIGURATION,
             linkExpressMode = LinkExpressMode.ENABLED,
-            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationFlowTest.kt
@@ -121,7 +121,6 @@ class LinkConfirmationFlowTest {
                     paymentMethod = PAYMENT_METHOD,
                     optionsParams = null,
                     originatedFromWallet = true,
-                    passiveCaptchaParams = null
                 ),
                 arguments = CONFIRMATION_PARAMETERS,
             )
@@ -142,7 +141,6 @@ class LinkConfirmationFlowTest {
         private val LINK_CONFIRMATION_OPTION = LinkConfirmationOption(
             configuration = TestFactory.LINK_CONFIGURATION,
             linkExpressMode = LinkExpressMode.ENABLED,
-            passiveCaptchaParams = null
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
@@ -27,7 +27,6 @@ import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.ConsumerSession
 import com.stripe.android.model.CvcCheck
 import com.stripe.android.model.LinkMode
-import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
@@ -300,7 +299,6 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
             optionsParams = PaymentMethodOptionsParams.Card(
                 setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OnSession,
             ),
-            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
         )
 
         definition.launch(
@@ -326,7 +324,6 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
             optionsParams = PaymentMethodOptionsParams.Card(
                 setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OnSession,
             ),
-            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
         )
 
         val result = definition.toResult(
@@ -720,7 +717,6 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
                 clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
             ),
             userInput = userInput,
-            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/foundations/LpmTestAssertions.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/foundations/LpmTestAssertions.kt
@@ -37,7 +37,6 @@ internal suspend fun assertIntentConfirmed(
         optionsParams = params.optionsParams,
         extraParams = params.extraParams,
         shouldSave = params.customerRequestedSave,
-        passiveCaptchaParams = null
     )
 
     activity.confirmationHandler.state.test {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/ConfirmationStateHelpers.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/ConfirmationStateHelpers.kt
@@ -2,7 +2,6 @@ package com.stripe.android.paymentelement.embedded.form
 
 import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.core.strings.resolvableString
-import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.toConfirmationOption
@@ -13,8 +12,6 @@ internal fun confirmationStateConfirming(selection: PaymentSelection): Confirmat
     val confirmationOption = selection.toConfirmationOption(
         configuration = EmbeddedConfirmationStateFixtures.defaultState().configuration.asCommonConfiguration(),
         linkConfiguration = null,
-        passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
-        clientAttributionMetadata = null,
     )
     return ConfirmationHandler.State.Confirming(requireNotNull(confirmationOption))
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -20,7 +20,6 @@ import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.isInstanceOf
 import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.link.LinkExpressMode
-import com.stripe.android.link.LinkLaunchMode
 import com.stripe.android.link.TestFactory
 import com.stripe.android.link.attestation.FakeLinkAttestationCheck
 import com.stripe.android.link.attestation.LinkAttestationCheck
@@ -31,14 +30,12 @@ import com.stripe.android.link.ui.inline.SignUpConsentAction
 import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.link.utils.errorMessage
 import com.stripe.android.lpmfoundations.luxe.LpmRepositoryTestHelpers
-import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilter
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.CardDefinition
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.PassiveCaptchaParams
-import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
@@ -349,7 +346,7 @@ internal class PaymentSheetViewModelTest {
             paramsCaptor.capture()
         )
 
-        assertThat(idCaptor.firstValue).isEqualTo(firstPaymentMethod.id!!)
+        assertThat(idCaptor.firstValue).isEqualTo(firstPaymentMethod.id)
 
         assertThat(
             paramsCaptor.firstValue.toParamMap()
@@ -441,7 +438,6 @@ internal class PaymentSheetViewModelTest {
                 paymentMethod = CARD_PAYMENT_METHOD,
                 optionsParams = optionsParams,
                 originatedFromWallet = false,
-                passiveCaptchaParams = null
             )
         )
         assertThat(arguments.intent).isEqualTo(stripeIntent)
@@ -516,7 +512,6 @@ internal class PaymentSheetViewModelTest {
                 paymentMethod = PaymentMethodFixtures.US_BANK_ACCOUNT,
                 optionsParams = optionsParams,
                 originatedFromWallet = false,
-                passiveCaptchaParams = null
             )
         )
         assertThat(arguments.intent).isEqualTo(stripeIntent)
@@ -543,8 +538,7 @@ internal class PaymentSheetViewModelTest {
                 PaymentMethodConfirmationOption.Saved(
                     paymentMethod = SEPA_DEBIT_PAYMENT_METHOD,
                     optionsParams = null,
-                    originatedFromWallet = false,
-                    passiveCaptchaParams = null
+                    originatedFromWallet = false
                 )
             )
             assertThat(arguments.intent).isEqualTo(stripeIntent)
@@ -579,7 +573,6 @@ internal class PaymentSheetViewModelTest {
                 ),
                 extraParams = null,
                 shouldSave = true,
-                passiveCaptchaParams = null
             )
         )
         assertThat(arguments.intent).isEqualTo(stripeIntent)
@@ -626,7 +619,6 @@ internal class PaymentSheetViewModelTest {
                 optionsParams = optionsParams,
                 extraParams = null,
                 shouldSave = true,
-                passiveCaptchaParams = null
             )
         )
         assertThat(arguments.intent).isEqualTo(stripeIntent)
@@ -979,8 +971,7 @@ internal class PaymentSheetViewModelTest {
             assertThat(arguments.confirmationOption).isEqualTo(
                 LinkConfirmationOption(
                     linkExpressMode = LinkExpressMode.DISABLED,
-                    configuration = TestFactory.LINK_CONFIGURATION,
-                    passiveCaptchaParams = null
+                    configuration = TestFactory.LINK_CONFIGURATION
                 )
             )
 
@@ -1018,7 +1009,6 @@ internal class PaymentSheetViewModelTest {
             PaymentMethodConfirmationOption.Saved(
                 paymentMethod = CARD_PAYMENT_METHOD,
                 optionsParams = null,
-                passiveCaptchaParams = null
             )
         )
 
@@ -1060,7 +1050,7 @@ internal class PaymentSheetViewModelTest {
                     isLinkAvailable = true
                 )
             ).isEqualTo(
-                SavedSelection.PaymentMethod(selection.paymentMethod.id.orEmpty())
+                SavedSelection.PaymentMethod(selection.paymentMethod.id)
             )
 
             resultTurbine.cancel()
@@ -1090,7 +1080,6 @@ internal class PaymentSheetViewModelTest {
                 optionsParams = null,
                 extraParams = null,
                 shouldSave = true,
-                passiveCaptchaParams = null
             )
         )
 
@@ -1152,7 +1141,6 @@ internal class PaymentSheetViewModelTest {
             PaymentMethodConfirmationOption.Saved(
                 paymentMethod = CARD_PAYMENT_METHOD,
                 optionsParams = null,
-                passiveCaptchaParams = null
             )
         )
 
@@ -1631,8 +1619,7 @@ internal class PaymentSheetViewModelTest {
             assertThat(arguments.confirmationOption).isEqualTo(
                 LinkConfirmationOption(
                     configuration = TestFactory.LINK_CONFIGURATION,
-                    linkExpressMode = LinkExpressMode.ENABLED_NO_WEB_FALLBACK,
-                    passiveCaptchaParams = null
+                    linkExpressMode = LinkExpressMode.ENABLED_NO_WEB_FALLBACK
                 )
             )
 
@@ -2134,8 +2121,7 @@ internal class PaymentSheetViewModelTest {
                 PaymentMethodConfirmationOption.Saved(
                     paymentMethod = CARD_PAYMENT_METHOD,
                     optionsParams = null,
-                    originatedFromWallet = false,
-                    passiveCaptchaParams = null
+                    originatedFromWallet = false
                 )
             )
 
@@ -2174,8 +2160,7 @@ internal class PaymentSheetViewModelTest {
                 PaymentMethodConfirmationOption.Saved(
                     paymentMethod = CARD_PAYMENT_METHOD,
                     optionsParams = null,
-                    originatedFromWallet = false,
-                    passiveCaptchaParams = null
+                    originatedFromWallet = false
                 )
             )
 
@@ -2274,7 +2259,6 @@ internal class PaymentSheetViewModelTest {
             PaymentMethodConfirmationOption.Saved(
                 paymentMethod = paymentMethod,
                 optionsParams = null,
-                passiveCaptchaParams = null
             )
         )
 
@@ -2310,8 +2294,7 @@ internal class PaymentSheetViewModelTest {
                 PaymentMethodConfirmationOption.Saved(
                     paymentMethod = CARD_PAYMENT_METHOD,
                     optionsParams = null,
-                    originatedFromWallet = false,
-                    passiveCaptchaParams = null
+                    originatedFromWallet = false
                 )
             )
 
@@ -2347,8 +2330,7 @@ internal class PaymentSheetViewModelTest {
                 PaymentMethodConfirmationOption.Saved(
                     paymentMethod = CARD_PAYMENT_METHOD,
                     optionsParams = null,
-                    originatedFromWallet = false,
-                    passiveCaptchaParams = null
+                    originatedFromWallet = false
                 )
             )
 
@@ -2384,8 +2366,7 @@ internal class PaymentSheetViewModelTest {
                 PaymentMethodConfirmationOption.Saved(
                     paymentMethod = CARD_PAYMENT_METHOD,
                     optionsParams = null,
-                    originatedFromWallet = false,
-                    passiveCaptchaParams = null
+                    originatedFromWallet = false
                 )
             )
 
@@ -2491,28 +2472,6 @@ internal class PaymentSheetViewModelTest {
     }
 
     @Test
-    fun `Launches Google Pay with correct client attribution metadata`() = confirmationTest {
-        val expectedClientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA
-        val args = ARGS_CUSTOMER_WITH_GOOGLEPAY
-
-        val viewModel = createViewModel(
-            args = args,
-            isGooglePayReady = true,
-            clientAttributionMetadata = expectedClientAttributionMetadata,
-        )
-
-        viewModel.checkoutWithGooglePay()
-
-        val arguments = startTurbine.awaitItem()
-
-        assertThat(arguments.confirmationOption).isInstanceOf<GooglePayConfirmationOption>()
-
-        val googlePayConfirmationOption = arguments.confirmationOption as GooglePayConfirmationOption
-
-        assertThat(googlePayConfirmationOption.clientAttributionMetadata).isEqualTo(expectedClientAttributionMetadata)
-    }
-
-    @Test
     fun `Launches Google Pay with custom label and amount if provided for setup intent`() = confirmationTest {
         val expectedLabel = "My custom label"
         val expectedAmount = 1234L
@@ -2563,7 +2522,6 @@ internal class PaymentSheetViewModelTest {
             BacsConfirmationOption(
                 createParams = bacsPaymentSelection.paymentMethodCreateParams,
                 optionsParams = bacsPaymentSelection.paymentMethodOptionsParams,
-                passiveCaptchaParams = null
             )
         )
     }
@@ -2734,8 +2692,6 @@ internal class PaymentSheetViewModelTest {
                     billingDetailsCollectionConfiguration = config.billingDetailsCollectionConfiguration,
                     cardBrandFilter = PaymentSheetCardBrandFilter(config.cardBrandAcceptance),
                 ),
-                passiveCaptchaParams = null,
-                clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
             )
         )
 
@@ -2780,8 +2736,6 @@ internal class PaymentSheetViewModelTest {
                     billingDetailsCollectionConfiguration = config.billingDetailsCollectionConfiguration,
                     cardBrandFilter = PaymentSheetCardBrandFilter(config.cardBrandAcceptance),
                 ),
-                passiveCaptchaParams = null,
-                clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
             )
         )
 
@@ -2819,7 +2773,6 @@ internal class PaymentSheetViewModelTest {
             LinkConfirmationOption(
                 linkExpressMode = LinkExpressMode.DISABLED,
                 configuration = LINK_CONFIG,
-                passiveCaptchaParams = null
             )
         )
 
@@ -2858,7 +2811,6 @@ internal class PaymentSheetViewModelTest {
             LinkConfirmationOption(
                 linkExpressMode = LinkExpressMode.DISABLED,
                 configuration = LINK_CONFIG,
-                passiveCaptchaParams = null
             )
         )
 
@@ -2897,7 +2849,6 @@ internal class PaymentSheetViewModelTest {
             LinkConfirmationOption(
                 linkExpressMode = LinkExpressMode.ENABLED_NO_WEB_FALLBACK,
                 configuration = LINK_CONFIG,
-                passiveCaptchaParams = null
             )
         )
 
@@ -2936,7 +2887,6 @@ internal class PaymentSheetViewModelTest {
             LinkConfirmationOption(
                 linkExpressMode = LinkExpressMode.ENABLED_NO_WEB_FALLBACK,
                 configuration = LINK_CONFIG,
-                passiveCaptchaParams = null
             )
         )
 
@@ -3272,125 +3222,6 @@ internal class PaymentSheetViewModelTest {
                 paymentMethod = CARD_PAYMENT_METHOD,
                 optionsParams = null,
                 originatedFromWallet = false,
-                passiveCaptchaParams = null
-            )
-        )
-    }
-
-    @Test
-    fun `confirmation with saved card pm should include passive captcha params when available`() = confirmationTest {
-        val passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
-        val optionsParams = PaymentMethodOptionsParams.Card(
-            setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession,
-        )
-
-        testPassiveCaptchaParams(
-            paymentSelection = PaymentSelection.Saved(
-                paymentMethod = CARD_PAYMENT_METHOD,
-            ),
-            optionsParams = optionsParams,
-            expectedConfirmationOption = PaymentMethodConfirmationOption.Saved(
-                paymentMethod = CARD_PAYMENT_METHOD,
-                optionsParams = optionsParams,
-                originatedFromWallet = false,
-                passiveCaptchaParams = passiveCaptchaParams
-            )
-        )
-    }
-
-    @Test
-    fun `confirmation with USBankAccount pm should include passive captcha params when available`() = confirmationTest {
-        val passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
-        val optionsParams = PaymentMethodOptionsParams.USBankAccount(
-            setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession,
-        )
-
-        testPassiveCaptchaParams(
-            paymentSelection = PaymentMethodFixtures.US_BANK_PAYMENT_SELECTION,
-            optionsParams = optionsParams,
-            expectedConfirmationOption = PaymentMethodConfirmationOption.New(
-                createParams = PaymentMethodCreateParamsFixtures.US_BANK_ACCOUNT,
-                optionsParams = optionsParams,
-                extraParams = null,
-                shouldSave = false,
-                passiveCaptchaParams = passiveCaptchaParams
-            )
-        )
-    }
-
-    @Test
-    fun `confirmation with LinkInline pm should include passive captcha params when available`() = confirmationTest {
-        val passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
-
-        testPassiveCaptchaParams(
-            paymentSelection = PaymentMethodFixtures.LINK_INLINE_PAYMENT_SELECTION,
-            expectedConfirmationOption = LinkInlineSignupConfirmationOption(
-                createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
-                optionsParams = null,
-                extraParams = null,
-                saveOption = LinkInlineSignupConfirmationOption.PaymentMethodSaveOption.NoRequest,
-                linkConfiguration = LINK_CONFIG,
-                userInput = PaymentMethodFixtures.LINK_INLINE_PAYMENT_SELECTION.input,
-                passiveCaptchaParams = passiveCaptchaParams
-            ),
-            linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
-            paymentElementLoader = FakePaymentElementLoader(
-                stripeIntent = PAYMENT_INTENT,
-                linkState = LinkState(
-                    configuration = LINK_CONFIG,
-                    loginState = LinkState.LoginState.LoggedOut,
-                    signupMode = null,
-                ),
-                passiveCaptchaParams = passiveCaptchaParams
-            )
-        )
-    }
-
-    @Test
-    fun `confirmation with New pm should include passive captcha params when available`() = confirmationTest {
-        val passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
-        val optionsParams = PaymentMethodOptionsParams.Card(
-            setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession,
-        )
-
-        testPassiveCaptchaParams(
-            paymentSelection = PaymentSelection.New.Card(
-                paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
-                brand = CardBrand.Visa,
-                customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest,
-            ),
-            optionsParams = optionsParams,
-            expectedConfirmationOption = PaymentMethodConfirmationOption.New(
-                createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
-                optionsParams = optionsParams,
-                extraParams = null,
-                shouldSave = false,
-                passiveCaptchaParams = passiveCaptchaParams
-            )
-        )
-    }
-
-    @Test
-    fun `confirmation with Link pm should include passive captcha params when available`() = confirmationTest {
-        val passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
-
-        testPassiveCaptchaParams(
-            paymentSelection = PaymentSelection.Link(),
-            expectedConfirmationOption = LinkConfirmationOption(
-                configuration = LINK_CONFIG,
-                linkExpressMode = LinkExpressMode.DISABLED,
-                linkLaunchMode = LinkLaunchMode.Full,
-                passiveCaptchaParams = passiveCaptchaParams
-            ),
-            linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
-            paymentElementLoader = FakePaymentElementLoader(
-                stripeIntent = PAYMENT_INTENT,
-                linkState = LinkState(
-                    configuration = LINK_CONFIG,
-                    loginState = LinkState.LoginState.LoggedOut,
-                    signupMode = null,
-                ),
-                passiveCaptchaParams = passiveCaptchaParams
             )
         )
     }
@@ -3737,7 +3568,6 @@ internal class PaymentSheetViewModelTest {
                 createParams = createParams,
                 optionsParams = null,
                 extraParams = null,
-                passiveCaptchaParams = null
             )
         )
 
@@ -3762,7 +3592,7 @@ internal class PaymentSheetViewModelTest {
                     isLinkAvailable = true
                 )
             ).isEqualTo(
-                SavedSelection.PaymentMethod(savedSelection.paymentMethod.id.orEmpty())
+                SavedSelection.PaymentMethod(savedSelection.paymentMethod.id)
             )
         } else {
             assertThat(prefsRepository.paymentSelectionArgs).isEmpty()
@@ -4033,44 +3863,6 @@ internal class PaymentSheetViewModelTest {
                 bootstrapTurbine.awaitItem()
             }
         }
-    }
-
-    private suspend fun FakeConfirmationHandler.Scenario.testPassiveCaptchaParams(
-        paymentSelection: PaymentSelection,
-        optionsParams: PaymentMethodOptionsParams? = null,
-        expectedConfirmationOption: ConfirmationHandler.Option,
-        linkConfigurationCoordinator: LinkConfigurationCoordinator =
-            this@PaymentSheetViewModelTest.linkConfigurationCoordinator,
-        paymentElementLoader: PaymentElementLoader? = null
-    ) {
-        val passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
-        val stripeIntent = PAYMENT_INTENT
-        val viewModel = createViewModel(
-            stripeIntent = stripeIntent,
-            linkConfigurationCoordinator = linkConfigurationCoordinator,
-            paymentElementLoader = paymentElementLoader ?: FakePaymentElementLoader(
-                stripeIntent = stripeIntent,
-                passiveCaptchaParams = passiveCaptchaParams
-            )
-        )
-
-        val finalPaymentSelection = if (optionsParams != null) {
-            when (paymentSelection) {
-                is PaymentSelection.Saved -> paymentSelection.copy(paymentMethodOptionsParams = optionsParams)
-                is PaymentSelection.New.USBankAccount ->
-                    paymentSelection.copy(paymentMethodOptionsParams = optionsParams)
-                is PaymentSelection.New.Card -> paymentSelection.copy(paymentMethodOptionsParams = optionsParams)
-                else -> paymentSelection
-            }
-        } else {
-            paymentSelection
-        }
-
-        viewModel.updateSelection(finalPaymentSelection)
-        viewModel.checkout()
-
-        val arguments = startTurbine.awaitItem()
-        assertThat(arguments.confirmationOption).isEqualTo(expectedConfirmationOption)
     }
 
     private fun getPaymentMethodOptionJsonStringWithCvcRecollectionValue(enabled: Boolean): String {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -33,7 +33,6 @@ import com.stripe.android.link.gate.FakeLinkGate
 import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.link.ui.inline.LinkSignupMode
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
-import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilter
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.CardParams
@@ -307,7 +306,6 @@ internal class DefaultFlowControllerTest {
                     extraParams = selection.paymentMethodExtraParams,
                     shouldSave = selection.customerRequestedSave == PaymentSelection
                         .CustomerRequestedSave.RequestReuse,
-                    passiveCaptchaParams = null
                 )
             )
 
@@ -355,8 +353,6 @@ internal class DefaultFlowControllerTest {
                     billingDetailsCollectionConfiguration = config.billingDetailsCollectionConfiguration,
                     cardBrandFilter = PaymentSheetCardBrandFilter(config.cardBrandAcceptance),
                 ),
-                passiveCaptchaParams = null,
-                clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
             )
         )
 
@@ -1033,7 +1029,6 @@ internal class DefaultFlowControllerTest {
             LinkConfirmationOption(
                 linkExpressMode = LinkExpressMode.DISABLED,
                 configuration = TestFactory.LINK_CONFIGURATION,
-                passiveCaptchaParams = null
             )
         )
     }
@@ -1083,7 +1078,6 @@ internal class DefaultFlowControllerTest {
                     saveOption = LinkInlineSignupConfirmationOption.PaymentMethodSaveOption.NoRequest,
                     linkConfiguration = TestFactory.LINK_CONFIGURATION,
                     userInput = paymentSelection.input,
-                    passiveCaptchaParams = null
                 )
             )
 
@@ -1142,7 +1136,6 @@ internal class DefaultFlowControllerTest {
                     userInput = paymentSelection.input,
                     linkConfiguration = linkConfiguration,
                     saveOption = LinkInlineSignupConfirmationOption.PaymentMethodSaveOption.NoRequest,
-                    passiveCaptchaParams = null
                 )
             )
             assertThat(arguments.intent).isEqualTo(intent)
@@ -1197,7 +1190,6 @@ internal class DefaultFlowControllerTest {
                     saveOption = LinkInlineSignupConfirmationOption.PaymentMethodSaveOption.NoRequest,
                     linkConfiguration = linkConfig,
                     userInput = paymentSelection.input,
-                    passiveCaptchaParams = null
                 )
             )
             assertThat(arguments.intent).isEqualTo(intent)
@@ -1232,7 +1224,6 @@ internal class DefaultFlowControllerTest {
             PaymentMethodConfirmationOption.Saved(
                 paymentMethod = PaymentMethodFixtures.SEPA_DEBIT_PAYMENT_METHOD,
                 optionsParams = null,
-                passiveCaptchaParams = null
             )
         )
     }
@@ -1294,7 +1285,6 @@ internal class DefaultFlowControllerTest {
             PaymentMethodConfirmationOption.Saved(
                 paymentMethod = PaymentMethodFixtures.SEPA_DEBIT_PAYMENT_METHOD,
                 optionsParams = null,
-                passiveCaptchaParams = null
             )
         )
     }
@@ -1312,7 +1302,6 @@ internal class DefaultFlowControllerTest {
                 optionsParams = expectedPaymentMethodOptions,
                 extraParams = null,
                 shouldSave = false,
-                passiveCaptchaParams = null
             )
         )
         assertThat(arguments.intent).isEqualTo(intent)
@@ -1350,34 +1339,8 @@ internal class DefaultFlowControllerTest {
                     billingDetailsCollectionConfiguration = config.billingDetailsCollectionConfiguration,
                     cardBrandFilter = PaymentSheetCardBrandFilter(config.cardBrandAcceptance),
                 ),
-                passiveCaptchaParams = null,
-                clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
             )
         )
-    }
-
-    @Test
-    fun `confirmPayment() with GooglePay sets client attribution metadata correctly`() = confirmationTest {
-        val expectedClientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA
-        val flowController = createFlowController(
-            clientAttributionMetadata = expectedClientAttributionMetadata,
-        )
-
-        flowController.configureExpectingSuccess(
-            configuration = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY
-        )
-        flowController.onPaymentOptionResult(
-            PaymentOptionsActivityResult.Succeeded(
-                PaymentSelection.GooglePay,
-                linkAccountInfo = LinkAccountUpdate.Value(null)
-            )
-        )
-        flowController.confirm()
-
-        val arguments = startTurbine.awaitItem()
-
-        val googlePayConfirmationOption = arguments.confirmationOption as GooglePayConfirmationOption
-        assertThat(googlePayConfirmationOption.clientAttributionMetadata).isEqualTo(expectedClientAttributionMetadata)
     }
 
     @Test
@@ -1434,7 +1397,6 @@ internal class DefaultFlowControllerTest {
                 extraParams = GENERIC_PAYMENT_SELECTION.paymentMethodExtraParams,
                 shouldSave = GENERIC_PAYMENT_SELECTION.customerRequestedSave ==
                     PaymentSelection.CustomerRequestedSave.RequestReuse,
-                passiveCaptchaParams = null
             )
         )
 
@@ -1476,7 +1438,6 @@ internal class DefaultFlowControllerTest {
             LinkConfirmationOption(
                 linkExpressMode = LinkExpressMode.DISABLED,
                 configuration = TestFactory.LINK_CONFIGURATION,
-                passiveCaptchaParams = null
             )
         )
     }
@@ -1682,7 +1643,6 @@ internal class DefaultFlowControllerTest {
             PaymentMethodConfirmationOption.Saved(
                 paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
                 optionsParams = null,
-                passiveCaptchaParams = null
             )
         )
         assertThat(arguments.initializationMode)
@@ -2023,8 +1983,6 @@ internal class DefaultFlowControllerTest {
                     billingDetailsCollectionConfiguration = config.billingDetailsCollectionConfiguration,
                     cardBrandFilter = PaymentSheetCardBrandFilter(config.cardBrandAcceptance),
                 ),
-                passiveCaptchaParams = null,
-                clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
             )
         )
     }
@@ -2063,7 +2021,6 @@ internal class DefaultFlowControllerTest {
             BacsConfirmationOption(
                 createParams = selection.paymentMethodCreateParams,
                 optionsParams = selection.paymentMethodOptionsParams,
-                passiveCaptchaParams = null
             )
         )
         assertThat(arguments.appearance).isEqualTo(appearance)
@@ -2350,7 +2307,6 @@ internal class DefaultFlowControllerTest {
                     cvc = "505"
                 ),
                 originatedFromWallet = false,
-                passiveCaptchaParams = null
             )
         )
         assertThat(arguments.paymentMethodMetadata.shippingDetails).isEqualTo(shippingDetails)
@@ -2399,7 +2355,6 @@ internal class DefaultFlowControllerTest {
                 optionsParams = null,
                 extraParams = null,
                 shouldSave = true,
-                passiveCaptchaParams = null
             )
         )
         assertThat(arguments.paymentMethodMetadata.shippingDetails).isNull()
@@ -2453,7 +2408,6 @@ internal class DefaultFlowControllerTest {
                 createParams = createParams,
                 optionsParams = null,
                 extraParams = null,
-                passiveCaptchaParams = null
             )
         )
 
@@ -2476,7 +2430,7 @@ internal class DefaultFlowControllerTest {
                     isLinkAvailable = true
                 )
             ).isEqualTo(
-                SavedSelection.PaymentMethod(savedSelection.paymentMethod.id.orEmpty())
+                SavedSelection.PaymentMethod(savedSelection.paymentMethod.id)
             )
         } else {
             assertThat(prefsRepository.paymentSelectionArgs).isEmpty()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateDataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateDataTest.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentsheet.paymentdatacollection.bacs
 
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentelement.confirmation.bacs.BacsConfirmationOption
@@ -66,7 +65,6 @@ class BacsMandateDataTest {
         return BacsConfirmationOption(
             createParams = createParams,
             optionsParams = null,
-            passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultWalletButtonsInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultWalletButtonsInteractorTest.kt
@@ -23,7 +23,6 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixt
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilter
 import com.stripe.android.lpmfoundations.paymentmethod.WalletType
 import com.stripe.android.model.DisplayablePaymentDetails
-import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.paymentelement.AnalyticEvent
 import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
 import com.stripe.android.paymentelement.WalletButtonsPreview
@@ -326,7 +325,6 @@ class DefaultWalletButtonsInteractorTest {
                     LinkConfirmationOption(
                         linkExpressMode = LinkExpressMode.DISABLED,
                         configuration = mock(),
-                        passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams()
                     )
                 )
             }
@@ -577,8 +575,6 @@ class DefaultWalletButtonsInteractorTest {
                         billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration,
                         cardBrandFilter = PaymentSheetCardBrandFilter(cardBrandAcceptance)
                     ),
-                    passiveCaptchaParams = null,
-                    clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
                 )
             )
         }
@@ -885,7 +881,6 @@ class DefaultWalletButtonsInteractorTest {
                     LinkConfirmationOption(
                         linkExpressMode = LinkExpressMode.DISABLED,
                         configuration = mock(),
-                        passiveCaptchaParams = null
                     )
                 )
             }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Now that we have PaymentMethodMetadata in the confirmation flow, we don't need to pass these through 8 million places.