### PR TITLE
Move appearance into PaymentMethodMetadata.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
@@ -37,6 +37,7 @@ internal data class CommonConfiguration(
     val walletButtons: PaymentSheet.WalletButtonsConfiguration?,
     val opensCardScannerAutomatically: Boolean,
     val userOverrideCountry: String?,
+    val appearance: PaymentSheet.Appearance,
 ) : Parcelable {
 
     fun validate(isLiveMode: Boolean) {
@@ -170,6 +171,7 @@ internal fun PaymentSheet.Configuration.asCommonConfiguration(): CommonConfigura
     walletButtons = walletButtons,
     opensCardScannerAutomatically = opensCardScannerAutomatically,
     userOverrideCountry = userOverrideCountry,
+    appearance = appearance,
 )
 
 internal fun EmbeddedPaymentElement.Configuration.asCommonConfiguration(): CommonConfiguration = CommonConfiguration(
@@ -194,6 +196,7 @@ internal fun EmbeddedPaymentElement.Configuration.asCommonConfiguration(): Commo
     walletButtons = null,
     opensCardScannerAutomatically = opensCardScannerAutomatically,
     userOverrideCountry = userOverrideCountry,
+    appearance = appearance,
 )
 
 internal fun LinkController.Configuration.asCommonConfiguration(): CommonConfiguration = CommonConfiguration(
@@ -225,6 +228,7 @@ internal fun LinkController.Configuration.asCommonConfiguration(): CommonConfigu
     walletButtons = null,
     opensCardScannerAutomatically = false,
     userOverrideCountry = null,
+    appearance = PaymentSheet.Appearance(),
 )
 
 private fun String.isEKClientSecretValid(): Boolean {

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -1050,7 +1050,6 @@ internal class CustomerSheetViewModel(
                     paymentMethod = paymentMethod,
                     optionsParams = null,
                 ),
-                appearance = configuration.appearance,
                 initializationMode = PaymentElementLoader.InitializationMode.SetupIntent(
                     clientSecret = clientSecret
                 ),

--- a/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
@@ -22,7 +22,6 @@ import com.stripe.android.model.wallets.Wallet
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.link.LinkPassthroughConfirmationOption
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
 import javax.inject.Inject
 
@@ -174,7 +173,6 @@ internal class DefaultLinkConfirmationHandler @Inject constructor(
 
         return ConfirmationHandler.Args(
             confirmationOption = confirmationOption,
-            appearance = PaymentSheet.Appearance(),
             initializationMode = configuration.initializationMode,
             paymentMethodMetadata = paymentMethodMetadata,
         )
@@ -218,7 +216,6 @@ internal class DefaultLinkConfirmationHandler @Inject constructor(
                     }
                 ),
             ),
-            appearance = PaymentSheet.Appearance(),
             initializationMode = configuration.initializationMode,
             paymentMethodMetadata = paymentMethodMetadata,
         )

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -79,6 +79,7 @@ internal data class PaymentMethodMetadata(
     val openCardScanAutomatically: Boolean,
     val clientAttributionMetadata: ClientAttributionMetadata,
     val attestOnIntentConfirmation: Boolean,
+    val appearance: PaymentSheet.Appearance,
 ) : Parcelable {
 
     @IgnoredOnParcel
@@ -366,7 +367,8 @@ internal data class PaymentMethodMetadata(
                 passiveCaptchaParams = elementsSession.passiveCaptchaParams,
                 openCardScanAutomatically = configuration.opensCardScannerAutomatically,
                 clientAttributionMetadata = clientAttributionMetadata,
-                attestOnIntentConfirmation = elementsSession.enableAttestationOnIntentConfirmation
+                attestOnIntentConfirmation = elementsSession.enableAttestationOnIntentConfirmation,
+                appearance = configuration.appearance,
             )
         }
 
@@ -427,6 +429,7 @@ internal data class PaymentMethodMetadata(
                     paymentIntentCreationFlow = null,
                 ),
                 attestOnIntentConfirmation = elementsSession.enableAttestationOnIntentConfirmation,
+                appearance = configuration.appearance,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandler.kt
@@ -7,7 +7,6 @@ import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
@@ -71,11 +70,6 @@ internal interface ConfirmationHandler {
          * The confirmation option used to in order to potentially confirm the intent
          */
         val confirmationOption: Option,
-
-        /**
-         * Appearance values to be used when styling the launched activities
-         */
-        val appearance: PaymentSheet.Appearance,
 
         /**
          * The mode that a Payment Element product was initialized with

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationDefinition.kt
@@ -69,7 +69,7 @@ internal class BacsConfirmationDefinition @Inject constructor(
     ) {
         launcher.launch(
             data = arguments,
-            appearance = confirmationArgs.appearance
+            appearance = confirmationArgs.paymentMethodMetadata.appearance
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationDefinition.kt
@@ -73,7 +73,7 @@ internal class CvcRecollectionConfirmationDefinition @Inject constructor(
         handler.launch(confirmationOption.paymentMethod) { recollectionData ->
             launcher.launch(
                 data = recollectionData,
-                appearance = confirmationArgs.appearance,
+                appearance = confirmationArgs.paymentMethodMetadata.appearance,
                 isLiveMode = confirmationArgs.intent.isLiveMode,
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationHelper.kt
@@ -60,7 +60,6 @@ internal class DefaultEmbeddedConfirmationHelper @Inject constructor(
         return ConfirmationHandler.Args(
             confirmationOption = confirmationOption,
             initializationMode = confirmationState.initializationMode,
-            appearance = confirmationState.configuration.appearance,
             paymentMethodMetadata = confirmationState.paymentMethodMetadata,
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityConfirmationHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityConfirmationHelper.kt
@@ -83,7 +83,6 @@ internal class DefaultFormActivityConfirmationHelper @Inject constructor(
         ) ?: return null
         return ConfirmationHandler.Args(
             confirmationOption = confirmationOption,
-            appearance = configuration.appearance,
             initializationMode = initializationMode,
             paymentMethodMetadata = paymentMethodMetadata,
         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -522,7 +522,6 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                     arguments = ConfirmationHandler.Args(
                         confirmationOption = option,
                         initializationMode = args.initializationMode,
-                        appearance = config.appearance,
                         paymentMethodMetadata = paymentMethodMetadata,
                     ),
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -498,13 +498,11 @@ internal class DefaultFlowController @Inject internal constructor(
             null -> confirmPaymentSelection(
                 paymentSelection = paymentSelection,
                 state = state.paymentSheetState,
-                appearance = state.config.appearance,
                 initializationMode = initializationMode,
             )
             is PaymentSelection.Saved -> confirmSavedPaymentMethod(
                 paymentSelection = paymentSelection,
                 state = state.paymentSheetState,
-                appearance = state.config.appearance,
                 initializationMode = initializationMode,
             )
         }
@@ -513,7 +511,6 @@ internal class DefaultFlowController @Inject internal constructor(
     private fun confirmSavedPaymentMethod(
         paymentSelection: PaymentSelection.Saved,
         state: PaymentSheetState.Full,
-        appearance: PaymentSheet.Appearance,
         initializationMode: PaymentElementLoader.InitializationMode,
     ) {
         if (paymentSelection.paymentMethod.type == PaymentMethod.Type.SepaDebit &&
@@ -528,7 +525,7 @@ internal class DefaultFlowController @Inject internal constructor(
                 )
             )
         } else {
-            confirmPaymentSelection(paymentSelection, state, appearance, initializationMode)
+            confirmPaymentSelection(paymentSelection, state, initializationMode)
         }
     }
 
@@ -536,7 +533,6 @@ internal class DefaultFlowController @Inject internal constructor(
     fun confirmPaymentSelection(
         paymentSelection: PaymentSelection?,
         state: PaymentSheetState.Full,
-        appearance: PaymentSheet.Appearance,
         initializationMode: PaymentElementLoader.InitializationMode,
     ) {
         viewModelScope.launch {
@@ -550,7 +546,6 @@ internal class DefaultFlowController @Inject internal constructor(
                     arguments = ConfirmationHandler.Args(
                         confirmationOption = option,
                         initializationMode = initializationMode,
-                        appearance = appearance,
                         paymentMethodMetadata = state.paymentMethodMetadata,
                     )
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
@@ -319,7 +319,6 @@ internal class DefaultWalletButtonsInteractor constructor(
         return ConfirmationHandler.Args(
             confirmationOption = confirmationOption,
             initializationMode = arguments.initializationMode,
-            appearance = arguments.appearance,
             paymentMethodMetadata = arguments.paymentMethodMetadata,
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/common/model/CommonConfigurationFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/model/CommonConfigurationFactory.kt
@@ -29,6 +29,7 @@ internal object CommonConfigurationFactory {
         walletButtons: PaymentSheet.WalletButtonsConfiguration? = null,
         opensCardScannerAutomatically: Boolean = false,
         userOverrideCountry: String? = null,
+        appearance: PaymentSheet.Appearance = PaymentSheet.Appearance(),
     ): CommonConfiguration = CommonConfiguration(
         merchantDisplayName = merchantDisplayName,
         customer = customer,
@@ -51,5 +52,6 @@ internal object CommonConfigurationFactory {
         walletButtons = walletButtons,
         opensCardScannerAutomatically = opensCardScannerAutomatically,
         userOverrideCountry = userOverrideCountry,
+        appearance = appearance,
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
@@ -57,6 +57,7 @@ internal object PaymentMethodMetadataFactory {
         openCardScanAutomatically: Boolean = false,
         clientAttributionMetadata: ClientAttributionMetadata? = null,
         attestOnIntentConfirmation: Boolean = false,
+        appearance: PaymentSheet.Appearance = PaymentSheet.Appearance(),
     ): PaymentMethodMetadata {
         return PaymentMethodMetadata(
             stripeIntent = stripeIntent,
@@ -100,6 +101,7 @@ internal object PaymentMethodMetadataFactory {
             clientAttributionMetadata =
             clientAttributionMetadata ?: PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
             attestOnIntentConfirmation = attestOnIntentConfirmation,
+            appearance = appearance,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -1175,6 +1175,7 @@ internal class PaymentMethodMetadataTest {
             openCardScanAutomatically = false,
             clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
             attestOnIntentConfirmation = false,
+            appearance = configuration.appearance,
         )
 
         assertThat(metadata).isEqualTo(expectedMetadata)
@@ -1259,6 +1260,7 @@ internal class PaymentMethodMetadataTest {
                 paymentIntentCreationFlow = null,
             ),
             attestOnIntentConfirmation = false,
+            appearance = configuration.appearance,
         )
         assertThat(metadata).isEqualTo(expectedMetadata)
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediatorTest.kt
@@ -9,7 +9,6 @@ import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import kotlinx.coroutines.test.runTest
@@ -654,7 +653,6 @@ class ConfirmationMediatorTest {
             initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
                 clientSecret = "pi_123_secret_123",
             ),
-            appearance = PaymentSheet.Appearance(),
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationTestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationTestUtils.kt
@@ -8,7 +8,6 @@ import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.paymentelement.confirmation.ConfirmationMediator.Parameters
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.DummyActivityResultCaller
 import com.stripe.android.testing.PaymentIntentFactory
@@ -205,5 +204,4 @@ internal val CONFIRMATION_PARAMETERS = ConfirmationHandler.Args(
         clientSecret = "pi_123_secret_123",
     ),
     confirmationOption = FakeConfirmationOption(),
-    appearance = PaymentSheet.Appearance()
 )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationFlowTest.kt
@@ -331,7 +331,6 @@ internal class IntentConfirmationFlowTest {
                 ),
             ),
             confirmationOption = FakeConfirmationOption(),
-            appearance = PaymentSheet.Appearance(),
         )
     }
 
@@ -382,7 +381,6 @@ internal class IntentConfirmationFlowTest {
                     phoneNumber = "1234567890"
                 ),
             ),
-            appearance = PaymentSheet.Appearance(),
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/attestation/AttestationConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/attestation/AttestationConfirmationActivityTest.kt
@@ -26,7 +26,6 @@ import com.stripe.android.paymentelement.confirmation.assertIdle
 import com.stripe.android.paymentelement.confirmation.assertSucceeded
 import com.stripe.android.paymentelement.confirmation.paymentElementConfirmationTest
 import com.stripe.android.payments.paymentlauncher.InternalPaymentResult
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.createTestActivityRule
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
@@ -266,7 +265,6 @@ internal class AttestationConfirmationActivityTest {
                 shippingDetails = AddressDetails(),
                 stripeIntent = PAYMENT_INTENT,
             ),
-            appearance = PaymentSheet.Appearance(),
         )
 
         private val CONFIRMATION_ARGUMENTS_SAVED = ConfirmationHandler.Args(
@@ -278,7 +276,6 @@ internal class AttestationConfirmationActivityTest {
                 shippingDetails = AddressDetails(),
                 stripeIntent = PAYMENT_INTENT,
             ),
-            appearance = PaymentSheet.Appearance(),
         )
 
         const val ATTESTATION_ACTIVITY_NAME =

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationActivityTest.kt
@@ -26,7 +26,6 @@ import com.stripe.android.paymentelement.confirmation.assertIdle
 import com.stripe.android.paymentelement.confirmation.assertSucceeded
 import com.stripe.android.paymentelement.confirmation.paymentElementConfirmationTest
 import com.stripe.android.payments.paymentlauncher.InternalPaymentResult
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.createTestActivityRule
 import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateConfirmationResult
@@ -203,7 +202,6 @@ internal class BacsConfirmationActivityTest {
                 stripeIntent = PAYMENT_INTENT,
                 shippingDetails = AddressDetails(),
             ),
-            appearance = PaymentSheet.Appearance(),
         )
 
         const val BACS_ACTIVITY_NAME =

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationDefinitionTest.kt
@@ -4,6 +4,7 @@ import androidx.activity.result.ActivityResultCallback
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.isInstanceOf
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentelement.confirmation.CONFIRMATION_PARAMETERS
@@ -250,7 +251,11 @@ class BacsConfirmationDefinitionTest {
 
         definition.launch(
             confirmationOption = createBacsConfirmationOption(),
-            confirmationArgs = CONFIRMATION_PARAMETERS.copy(appearance = appearance),
+            confirmationArgs = CONFIRMATION_PARAMETERS.copy(
+                paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                    appearance = appearance
+                )
+            ),
             arguments = bacsMandateData,
             launcher = launcher,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationActivityTest.kt
@@ -27,7 +27,6 @@ import com.stripe.android.paymentelement.confirmation.assertIdle
 import com.stripe.android.paymentelement.confirmation.assertSucceeded
 import com.stripe.android.paymentelement.confirmation.paymentElementConfirmationTest
 import com.stripe.android.payments.paymentlauncher.InternalPaymentResult
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.createTestActivityRule
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
@@ -245,7 +244,6 @@ internal class PassiveChallengeConfirmationActivityTest {
                 shippingDetails = AddressDetails(),
                 passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
             ),
-            appearance = PaymentSheet.Appearance(),
         )
 
         const val PASSIVE_CHALLENGE_ACTIVITY_NAME =

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cpms/CustomPaymentMethodConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cpms/CustomPaymentMethodConfirmationActivityTest.kt
@@ -175,7 +175,6 @@ internal class CustomPaymentMethodConfirmationActivityTest {
                 stripeIntent = PAYMENT_INTENT,
                 shippingDetails = AddressDetails(),
             ),
-            appearance = PaymentSheet.Appearance(),
         )
 
         const val CPM_ACTIVITY_NAME =

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cpms/CustomPaymentMethodConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cpms/CustomPaymentMethodConfirmationDefinitionTest.kt
@@ -252,9 +252,6 @@ class CustomPaymentMethodConfirmationDefinitionTest {
             initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
                 clientSecret = "pi_123_secret_123",
             ),
-            appearance = PaymentSheet.Appearance.Builder()
-                .colorsDark(PaymentSheet.Colors.defaultLight)
-                .build(),
         )
 
         private val CUSTOM_PAYMENT_METHOD_TYPE = PaymentSheet.CustomPaymentMethod(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationActivityTest.kt
@@ -24,7 +24,6 @@ import com.stripe.android.paymentelement.confirmation.assertIdle
 import com.stripe.android.paymentelement.confirmation.assertSucceeded
 import com.stripe.android.paymentelement.confirmation.extendedPaymentElementConfirmationTest
 import com.stripe.android.payments.paymentlauncher.InternalPaymentResult
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.createTestActivityRule
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcRecollectionResult
@@ -186,7 +185,6 @@ internal class CvcRecollectionConfirmationActivityTest {
                 stripeIntent = PAYMENT_INTENT,
                 shippingDetails = AddressDetails(),
             ),
-            appearance = PaymentSheet.Appearance(),
         )
 
         const val CVC_RECOLLECTION_ACTIVITY_NAME =

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationDefinitionTest.kt
@@ -14,7 +14,6 @@ import com.stripe.android.paymentelement.confirmation.asCanceled
 import com.stripe.android.paymentelement.confirmation.asLaunch
 import com.stripe.android.paymentelement.confirmation.asNextStep
 import com.stripe.android.paymentelement.confirmation.asSaved
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.cvcrecollection.CvcRecollectionHandler
 import com.stripe.android.paymentsheet.cvcrecollection.FakeCvcRecollectionHandler
 import com.stripe.android.paymentsheet.cvcrecollection.RecordingCvcRecollectionLauncher
@@ -161,7 +160,7 @@ class CvcRecollectionConfirmationDefinitionTest {
 
         val launchCall = launcherScenario.awaitLaunchCall()
 
-        assertThat(launchCall.appearance).isEqualTo(CONFIRMATION_PARAMETERS.appearance)
+        assertThat(launchCall.appearance).isEqualTo(CONFIRMATION_PARAMETERS.paymentMethodMetadata.appearance)
         assertThat(launchCall.data.brand).isEqualTo(option.paymentMethod.card?.brand)
         assertThat(launchCall.data.lastFour).isEqualTo(option.paymentMethod.card?.last4)
         assertThat(launchCall.isLiveMode).isEqualTo(CONFIRMATION_PARAMETERS.intent.isLiveMode)
@@ -312,10 +311,6 @@ class CvcRecollectionConfirmationDefinitionTest {
 
     companion object {
         private val CONFIRMATION_PARAMETERS =
-            com.stripe.android.paymentelement.confirmation.CONFIRMATION_PARAMETERS.copy(
-                appearance = PaymentSheet.Appearance.Builder()
-                    .colorsDark(PaymentSheet.Colors.defaultLight)
-                    .build(),
-            )
+            com.stripe.android.paymentelement.confirmation.CONFIRMATION_PARAMETERS
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationActivityTest.kt
@@ -29,7 +29,6 @@ import com.stripe.android.paymentelement.confirmation.assertIdle
 import com.stripe.android.paymentelement.confirmation.assertSucceeded
 import com.stripe.android.paymentelement.confirmation.paymentElementConfirmationTest
 import com.stripe.android.paymentsheet.ExternalPaymentMethodResult
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.createTestActivityRule
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
@@ -200,7 +199,6 @@ internal class ExternalPaymentMethodConfirmationActivityTest {
                 stripeIntent = PAYMENT_INTENT,
                 shippingDetails = AddressDetails(),
             ),
-            appearance = PaymentSheet.Appearance(),
         )
 
         const val EPM_ACTIVITY_NAME =

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationActivityTest.kt
@@ -288,7 +288,6 @@ internal class GooglePayConfirmationActivityTest {
                 stripeIntent = PAYMENT_INTENT,
                 shippingDetails = AddressDetails(),
             ),
-            appearance = PaymentSheet.Appearance(),
         )
 
         const val GOOGLE_PAY_ACTIVITY_NAME =

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinitionTest.kt
@@ -681,13 +681,7 @@ class GooglePayConfirmationDefinitionTest {
             ),
         )
 
-        private val APPEARANCE = PaymentSheet.Appearance.Builder()
-            .colorsDark(PaymentSheet.Colors.defaultLight)
-            .build()
-
         private val CONFIRMATION_PARAMETERS =
-            com.stripe.android.paymentelement.confirmation.CONFIRMATION_PARAMETERS.copy(
-                appearance = APPEARANCE
-            )
+            com.stripe.android.paymentelement.confirmation.CONFIRMATION_PARAMETERS
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationActivityTest.kt
@@ -102,7 +102,6 @@ internal class LinkConfirmationActivityTest(private val nativeLinkEnabled: Boole
             confirmationHandler.start(
                 ConfirmationHandler.Args(
                     confirmationOption = LINK_CONFIRMATION_OPTION,
-                    appearance = CONFIRMATION_PARAMETERS.appearance,
                     paymentMethodMetadata = paymentMethodMetadata,
                     initializationMode = CONFIRMATION_PARAMETERS.initializationMode,
                 )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/foundations/LpmTestAssertions.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/foundations/LpmTestAssertions.kt
@@ -23,7 +23,6 @@ import com.stripe.android.paymentelement.confirmation.assertIdle
 import com.stripe.android.paymentelement.confirmation.assertSucceeded
 import com.stripe.android.payments.paymentlauncher.InternalPaymentResult
 import com.stripe.android.payments.paymentlauncher.PaymentLauncherContract
-import com.stripe.android.paymentsheet.PaymentSheet
 import kotlin.test.fail
 
 internal suspend fun assertIntentConfirmed(
@@ -50,7 +49,6 @@ internal suspend fun assertIntentConfirmed(
                     shippingDetails = params.shippingDetails,
                 ),
                 initializationMode = params.initializationMode,
-                appearance = PaymentSheet.Appearance.Builder().build(),
             )
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationStarterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationStarterTest.kt
@@ -11,7 +11,6 @@ import com.stripe.android.paymentelement.confirmation.FakeConfirmationOption
 import com.stripe.android.paymentelement.confirmation.assertCanceled
 import com.stripe.android.paymentelement.confirmation.assertSucceeded
 import com.stripe.android.paymentelement.embedded.FakeEmbeddedConfirmationSaver
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.DummyActivityResultCaller
 import com.stripe.android.testing.PaymentIntentFactory
@@ -49,7 +48,6 @@ class EmbeddedConfirmationStarterTest {
                 )
             ),
             confirmationOption = FakeConfirmationOption(),
-            appearance = PaymentSheet.Appearance(),
             initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
                 clientSecret = "pi_123_secret_123",
             ),
@@ -61,7 +59,6 @@ class EmbeddedConfirmationStarterTest {
 
         assertThat(startCall.confirmationOption).isEqualTo(arguments.confirmationOption)
         assertThat(startCall.intent).isEqualTo(arguments.intent)
-        assertThat(startCall.appearance).isEqualTo(arguments.appearance)
         assertThat(startCall.initializationMode).isEqualTo(arguments.initializationMode)
         assertThat(startCall.paymentMethodMetadata).isEqualTo(arguments.paymentMethodMetadata)
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -872,7 +872,6 @@ internal class DefaultFlowControllerTest {
                 validationError = null,
                 paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
             ),
-            appearance = PaymentSheetFixtures.CONFIG_CUSTOMER.appearance,
             initializationMode = INITIALIZATION_MODE,
         )
 
@@ -905,7 +904,6 @@ internal class DefaultFlowControllerTest {
                 validationError = null,
                 paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
             ),
-            appearance = PaymentSheetFixtures.CONFIG_CUSTOMER.appearance,
             initializationMode = INITIALIZATION_MODE,
         )
 
@@ -944,7 +942,6 @@ internal class DefaultFlowControllerTest {
                     validationError = null,
                     paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
                 ),
-                appearance = PaymentSheetFixtures.CONFIG_CUSTOMER.appearance,
                 initializationMode = INITIALIZATION_MODE,
             )
 
@@ -969,7 +966,6 @@ internal class DefaultFlowControllerTest {
         flowController.confirmPaymentSelection(
             paymentSelection = null,
             state = PAYMENT_SHEET_STATE_FULL,
-            appearance = PaymentSheetFixtures.CONFIG_CUSTOMER.appearance,
             initializationMode = INITIALIZATION_MODE,
         )
 
@@ -992,7 +988,6 @@ internal class DefaultFlowControllerTest {
         flowController.confirmPaymentSelection(
             paymentSelection = PaymentSelection.Link(),
             state = PAYMENT_SHEET_STATE_FULL,
-            appearance = PaymentSheetFixtures.CONFIG_CUSTOMER.appearance,
             initializationMode = INITIALIZATION_MODE,
         )
 
@@ -2023,7 +2018,6 @@ internal class DefaultFlowControllerTest {
                 optionsParams = selection.paymentMethodOptionsParams,
             )
         )
-        assertThat(arguments.appearance).isEqualTo(appearance)
     }
 
     @Test


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Appearance is part of the concept of PaymentMethodMetadata, all the things that are ready after configuration.