### PR TITLE
Read seller business name from PaymentMethodMetadata.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinition.kt
@@ -15,7 +15,6 @@ import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
-import com.stripe.android.paymentelement.confirmation.utils.sellerBusinessName
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
 import kotlinx.coroutines.CoroutineScope
@@ -157,7 +156,7 @@ internal class GooglePayConfirmationDefinition @Inject constructor(
                     else -> GooglePayEnvironment.Test
                 },
                 merchantCountryCode = config.merchantCountryCode,
-                merchantName = confirmationArgs.initializationMode.sellerBusinessName
+                merchantName = confirmationArgs.paymentMethodMetadata.sellerBusinessName
                     ?: config.merchantName,
                 isEmailRequired = config.billingDetailsCollectionConfiguration.collectsEmail,
                 billingAddressConfig = config.billingDetailsCollectionConfiguration.toBillingAddressConfig(),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/shoppay/ShopPayConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/shoppay/ShopPayConfirmationDefinition.kt
@@ -6,7 +6,6 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
-import com.stripe.android.paymentelement.confirmation.utils.sellerBusinessName
 import com.stripe.android.shoppay.ShopPayActivityContract
 import com.stripe.android.shoppay.ShopPayActivityResult
 import javax.inject.Inject
@@ -77,7 +76,7 @@ internal class ShopPayConfirmationDefinition @Inject constructor(
             ShopPayActivityContract.Args(
                 shopPayConfiguration = confirmationOption.shopPayConfiguration,
                 customerSessionClientSecret = confirmationOption.customerSessionClientSecret,
-                businessName = confirmationArgs.initializationMode.sellerBusinessName
+                businessName = confirmationArgs.paymentMethodMetadata.sellerBusinessName
                     ?: confirmationOption.merchantDisplayName
             )
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinitionTest.kt
@@ -411,7 +411,10 @@ class GooglePayConfirmationDefinitionTest {
                                 externalId = "external_123"
                             )
                         )
-                    )
+                    ),
+                    paymentMethodMetadata = CONFIRMATION_PARAMETERS.paymentMethodMetadata.copy(
+                        sellerBusinessName = "My business, Inc.",
+                    ),
                 ),
                 arguments = Unit,
                 launcher = launcher,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/shoppay/ShopPayConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/shoppay/ShopPayConfirmationDefinitionTest.kt
@@ -134,7 +134,10 @@ internal class ShopPayConfirmationDefinitionTest {
                             externalId = "external_123"
                         )
                     )
-                )
+                ),
+                paymentMethodMetadata = CONFIRMATION_PARAMETERS.paymentMethodMetadata.copy(
+                    sellerBusinessName = "My business, Inc.",
+                ),
             ),
             launcher = launcher,
             arguments = Unit,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
My trying to tease out usage of initializationMode from the confirmation pipeline. Ideally we won't have access to this type directly long term in the confirmation pipeline.

In practice, these values are exactly the same all the time.
