### PR TITLE
Add zoolander config update release step

### DIFF
--- a/scripts/deploy/deploy.rb
+++ b/scripts/deploy/deploy.rb
@@ -100,5 +100,4 @@ if (@is_dry_run)
     revert_version_bump_changes()
     revert_dokka_changes()
     delete_pay_server_branch()
-    delete_zoolander_branch()
 end


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This adds a new release step to update the zoolander repository's client_config.yaml file with the new Android SDK version.

The update_zoolander_config.rb script:
- Updates the bindings_version list for stripe-mobile-payments-sdk-legacy
- Adds the new version to the top of the list if not already present
- Creates a PR in zoolander for review
- Follows the same pattern as update_pay_server_docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Committed-By-Agent: claude

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
We need to allowlist values of our metrics fields so they show up in prometheus. This ensures each new release version is included in the allowlisted bindings versions. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

Did a release with the dry run flag to verify this works as expected