### PR TITLE
Client attribution metadata isn't nullable in the confirmation flow.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/ConfirmationTokenConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/ConfirmationTokenConfirmationInterceptor.kt
@@ -38,7 +38,7 @@ internal class ConfirmationTokenConfirmationInterceptor @AssistedInject construc
     @Assisted private val createIntentCallback: CreateIntentWithConfirmationTokenCallback,
     @Assisted(CUSTOMER_ID) private val customerId: String?,
     @Assisted(EPHEMERAL_KEY_SECRET) private val ephemeralKeySecret: String?,
-    @Assisted private val clientAttributionMetadata: ClientAttributionMetadata?,
+    @Assisted private val clientAttributionMetadata: ClientAttributionMetadata,
     private val context: Context,
     private val stripeRepository: StripeRepository,
     private val requestOptions: ApiRequest.Options,
@@ -290,7 +290,7 @@ internal class ConfirmationTokenConfirmationInterceptor @AssistedInject construc
             createIntentCallback: CreateIntentWithConfirmationTokenCallback,
             @Assisted(CUSTOMER_ID) customerId: String?,
             @Assisted(EPHEMERAL_KEY_SECRET) ephemeralKeySecret: String?,
-            @Assisted clientAttributionMetadata: ClientAttributionMetadata?,
+            @Assisted clientAttributionMetadata: ClientAttributionMetadata,
         ): ConfirmationTokenConfirmationInterceptor
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/DeferredIntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/DeferredIntentConfirmationInterceptor.kt
@@ -33,7 +33,7 @@ import javax.inject.Named
 internal class DeferredIntentConfirmationInterceptor @AssistedInject constructor(
     @Assisted private val intentConfiguration: PaymentSheet.IntentConfiguration,
     @Assisted private val createIntentCallback: CreateIntentCallback,
-    @Assisted private val clientAttributionMetadata: ClientAttributionMetadata?,
+    @Assisted private val clientAttributionMetadata: ClientAttributionMetadata,
     private val stripeRepository: StripeRepository,
     private val requestOptions: ApiRequest.Options,
     @Named(ALLOWS_MANUAL_CONFIRMATION) private val allowsManualConfirmation: Boolean,
@@ -312,7 +312,7 @@ internal class DeferredIntentConfirmationInterceptor @AssistedInject constructor
         fun create(
             intentConfiguration: PaymentSheet.IntentConfiguration,
             createIntentCallback: CreateIntentCallback,
-            clientAttributionMetadata: ClientAttributionMetadata?,
+            clientAttributionMetadata: ClientAttributionMetadata,
         ): DeferredIntentConfirmationInterceptor
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentFirstConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentFirstConfirmationInterceptor.kt
@@ -16,7 +16,7 @@ import dagger.assisted.AssistedInject
 
 internal class IntentFirstConfirmationInterceptor @AssistedInject constructor(
     @Assisted private val clientSecret: String,
-    @Assisted private val clientAttributionMetadata: ClientAttributionMetadata?,
+    @Assisted private val clientAttributionMetadata: ClientAttributionMetadata,
     requestOptions: ApiRequest.Options,
 ) : IntentConfirmationInterceptor {
     private val confirmActionHelper: ConfirmActionHelper = ConfirmActionHelper(requestOptions.apiKeyIsLiveMode)
@@ -74,7 +74,7 @@ internal class IntentFirstConfirmationInterceptor @AssistedInject constructor(
     interface Factory {
         fun create(
             clientSecret: String,
-            clientAttributionMetadata: ClientAttributionMetadata?,
+            clientAttributionMetadata: ClientAttributionMetadata,
         ): IntentFirstConfirmationInterceptor
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -91,7 +91,7 @@ internal object CustomerSheetTestHelper {
                     initializationMode: PaymentElementLoader.InitializationMode,
                     customerId: String?,
                     ephemeralKeySecret: String?,
-                    clientAttributionMetadata: ClientAttributionMetadata?,
+                    clientAttributionMetadata: ClientAttributionMetadata,
                 ): IntentConfirmationInterceptor {
                     return FakeIntentConfirmationInterceptor().apply {
                         enqueueCompleteStep(true)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationUtils.kt
@@ -77,7 +77,7 @@ internal suspend fun createIntentConfirmationInterceptor(
         intentFirstConfirmationInterceptorFactory = object : IntentFirstConfirmationInterceptor.Factory {
             override fun create(
                 clientSecret: String,
-                clientAttributionMetadata: ClientAttributionMetadata?
+                clientAttributionMetadata: ClientAttributionMetadata,
             ): IntentFirstConfirmationInterceptor {
                 return IntentFirstConfirmationInterceptor(
                     clientSecret = clientSecret,
@@ -90,7 +90,7 @@ internal suspend fun createIntentConfirmationInterceptor(
             override fun create(
                 intentConfiguration: PaymentSheet.IntentConfiguration,
                 createIntentCallback: CreateIntentCallback,
-                clientAttributionMetadata: ClientAttributionMetadata?
+                clientAttributionMetadata: ClientAttributionMetadata,
             ): DeferredIntentConfirmationInterceptor {
                 return DeferredIntentConfirmationInterceptor(
                     intentConfiguration = intentConfiguration,
@@ -108,7 +108,7 @@ internal suspend fun createIntentConfirmationInterceptor(
                 createIntentCallback: CreateIntentWithConfirmationTokenCallback,
                 customerId: String?,
                 ephemeralKeySecret: String?,
-                clientAttributionMetadata: ClientAttributionMetadata?,
+                clientAttributionMetadata: ClientAttributionMetadata,
             ): ConfirmationTokenConfirmationInterceptor {
                 return ConfirmationTokenConfirmationInterceptor(
                     intentConfiguration = intentConfiguration,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationDefinitionTest.kt
@@ -409,7 +409,7 @@ class IntentConfirmationDefinitionTest {
                     initializationMode: PaymentElementLoader.InitializationMode,
                     customerId: String?,
                     ephemeralKeySecret: String?,
-                    clientAttributionMetadata: ClientAttributionMetadata?,
+                    clientAttributionMetadata: ClientAttributionMetadata,
                 ): IntentConfirmationInterceptor {
                     return FakeIntentConfirmationInterceptor()
                 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationFlowTest.kt
@@ -266,7 +266,7 @@ internal class IntentConfirmationFlowTest {
                     initializationMode: PaymentElementLoader.InitializationMode,
                     customerId: String?,
                     ephemeralKeySecret: String?,
-                    clientAttributionMetadata: ClientAttributionMetadata?,
+                    clientAttributionMetadata: ClientAttributionMetadata,
                 ): IntentConfirmationInterceptor {
                     return createIntentConfirmationInterceptor(
                         initializationMode = initializationMode,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/FakeIntentConfirmationInterceptorFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/FakeIntentConfirmationInterceptorFactory.kt
@@ -13,7 +13,7 @@ internal open class FakeIntentConfirmationInterceptorFactory(
         initializationMode: PaymentElementLoader.InitializationMode,
         customerId: String?,
         ephemeralKeySecret: String?,
-        clientAttributionMetadata: ClientAttributionMetadata?,
+        clientAttributionMetadata: ClientAttributionMetadata,
     ): IntentConfirmationInterceptor {
         interceptor = FakeIntentConfirmationInterceptor().apply(enqueueStep)
         return interceptor

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -1263,7 +1263,7 @@ internal class PaymentSheetActivityTest {
                             initializationMode: PaymentElementLoader.InitializationMode,
                             customerId: String?,
                             ephemeralKeySecret: String?,
-                            clientAttributionMetadata: ClientAttributionMetadata?,
+                            clientAttributionMetadata: ClientAttributionMetadata,
                         ): IntentConfirmationInterceptor {
                             return fakeIntentConfirmationInterceptor
                         }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
A few recent refactors have enabled this more accurate modeling, so just finishing it out.