### PR TITLE
Fix card scan launcher rebuilt on re-render.

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionElementUI.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -37,11 +38,7 @@ fun CardDetailsSectionElementUI(
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
-    val options = ActivityOptionsCompat.makeCustomAnimation(
-        context,
-        AnimationConstants.FADE_IN,
-        AnimationConstants.FADE_OUT,
-    )
+    val options = rememberActivityOptions()
 
     // Only create launcher if ActivityResultRegistry is available (e.g., not in screenshot tests)
     val activityResultRegistryOwner = LocalActivityResultRegistryOwner.current
@@ -95,6 +92,19 @@ fun CardDetailsSectionElementUI(
             ),
             hiddenIdentifiers = hiddenIdentifiers,
             lastTextFieldIdentifier = lastTextFieldIdentifier
+        )
+    }
+}
+
+@Composable
+private fun rememberActivityOptions(): ActivityOptionsCompat {
+    val context = LocalContext.current
+
+    return remember(context) {
+        ActivityOptionsCompat.makeCustomAnimation(
+            context,
+            AnimationConstants.FADE_IN,
+            AnimationConstants.FADE_OUT,
         )
     }
 }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementAnalyticsTest.kt
@@ -152,8 +152,6 @@ internal class EmbeddedPaymentElementAnalyticsTest {
             query("payment_method_type", "card"),
         )
         validateAnalyticsRequest(eventName = "mc_confirm_button_tapped")
-        // cardscan is not available in test mode
-        validateAnalyticsRequest(eventName = "mc_cardscan_api_check_failed")
         validateAnalyticsRequest(eventName = "mc_embedded_payment_success")
 
         formPage.clickPrimaryButton()
@@ -256,8 +254,6 @@ internal class EmbeddedPaymentElementAnalyticsTest {
             query("payment_method_type", "card"),
         )
         validateAnalyticsRequest(eventName = "mc_confirm_button_tapped")
-        // cardscan is not available in test mode
-        validateAnalyticsRequest(eventName = "mc_cardscan_api_check_failed")
         validateAnalyticsRequest(
             eventName = "mc_embedded_payment_success",
             query("is_confirmation_tokens", "true")

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetAnalyticsTest.kt
@@ -87,7 +87,6 @@ internal class CustomerSheetAnalyticsTest {
         )
 
         validateAnalyticsRequest(eventName = "stripe_android.payment_method_creation")
-        validateAnalyticsRequest(eventName = "cs_cardscan_api_check_failed")
         validateAnalyticsRequest(
             eventName = "stripe_android.paymenthandler.confirm.started",
             query("intent_id", "seti_12345"),


### PR DESCRIPTION
# Summary
Fix card scan launcher rebuilt on re-render.

# Motivation
Noticed during Jetpack Compose 1.9 migration which was showing errors in analytics tests. `ActivityOptionsCompat` is not a comparable object and produces a different instance every render.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified