### PR TITLE
Enable confirmation token by default in playground

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/ConfirmationTokenSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/ConfirmationTokenSettingsDefinition.kt
@@ -5,7 +5,7 @@ import com.stripe.android.paymentsheet.example.playground.model.CheckoutRequest
 internal object ConfirmationTokenSettingsDefinition : BooleanSettingsDefinition(
     key = "confirmationToken",
     displayName = "Use Confirmation Token",
-    defaultValue = false,
+    defaultValue = true,
 ) {
     override fun applicable(configurationData: PlaygroundConfigurationData): Boolean {
         return configurationData.integrationType.isPaymentFlow()
@@ -13,5 +13,11 @@ internal object ConfirmationTokenSettingsDefinition : BooleanSettingsDefinition(
 
     override fun configure(value: Boolean, checkoutRequestBuilder: CheckoutRequest.Builder) {
         checkoutRequestBuilder.isConfirmationToken(value)
+    }
+
+    override fun valueUpdated(value: Boolean, playgroundSettings: PlaygroundSettings) {
+        if (value) {
+            playgroundSettings[CustomerSessionSettingsDefinition] = true
+        }
     }
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/SettingsUI.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/SettingsUI.kt
@@ -34,8 +34,22 @@ internal fun SettingsUi(
 ) {
     val configurationData by playgroundSettings.configurationData.collectAsState()
     val displayableDefinitions by playgroundSettings.displayableDefinitions.collectAsState()
-    val filteredDefinitions = remember(displayableDefinitions, searchQuery) {
-        displayableDefinitions.filter { it.displayName.matchesQuery(searchQuery) }
+    val confirmationTokenEnabled by playgroundSettings[ConfirmationTokenSettingsDefinition].collectAsState()
+
+    val filteredDefinitions = remember(
+        displayableDefinitions,
+        searchQuery,
+        confirmationTokenEnabled
+    ) {
+        displayableDefinitions
+            .filter { definition ->
+                // Hide CustomerSessionSettingsDefinition when ConfirmationToken is enabled
+                if (definition == CustomerSessionSettingsDefinition && confirmationTokenEnabled) {
+                    false
+                } else {
+                    definition.displayName.matchesQuery(searchQuery)
+                }
+            }
     }
 
     Column(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
- Set ConfirmationTokenSettingsDefinition default value to true
- Auto-enable CustomerSessionSettingsDefinition when confirmation token is enabled
- Hide CustomerSessionSettingsDefinition from UI when confirmation token is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Committed-By-Agent: claude

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
#11895

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
