### PR TITLE
Revert "Disable `testLinkPaymentWithBankAccountInPassthroughMode`"

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestLink.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestLink.kt
@@ -11,7 +11,6 @@ import com.stripe.android.paymentsheet.example.playground.settings.LinkType
 import com.stripe.android.paymentsheet.example.playground.settings.LinkTypeSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.SupportedPaymentMethodsSettingsDefinition
 import com.stripe.android.test.core.TestParameters
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -24,7 +23,6 @@ internal class TestLink : BasePlaygroundTest() {
         testDriver.confirmWithBankAccountInLink(testParameters)
     }
 
-    @Ignore("Disabled due to #ir-draft-remote")
     @Test
     fun testLinkPaymentWithBankAccountInPassthroughMode() {
         val testParameters = makeLinkTestParameters(passthroughMode = true)


### PR DESCRIPTION
Reverts stripe/stripe-android#11897

Turning this test back on now that #ir-draft-remote has been mitigated.