### PR TITLE
Re expose billing details, which was accidentally made internal.

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -1831,6 +1831,10 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$BillingDetails :
 	public synthetic fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$Address;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAddress ()Lcom/stripe/android/paymentsheet/PaymentSheet$Address;
+	public final fun getEmail ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getPhone ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public final fun writeToParcel (Landroid/os/Parcel;I)V

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -2649,21 +2649,21 @@ class PaymentSheet internal constructor(
         /**
          * The customer's billing address.
          */
-        internal val address: Address? = null,
+        val address: Address? = null,
         /**
          * The customer's email.
          * The value set is displayed in the payment sheet as-is. Depending on the payment method, the customer may be required to edit this value.
          */
-        internal val email: String? = null,
+        val email: String? = null,
         /**
          * The customer's full name.
          * The value set is displayed in the payment sheet as-is. Depending on the payment method, the customer may be required to edit this value.
          */
-        internal val name: String? = null,
+        val name: String? = null,
         /**
          * The customer's phone number without formatting e.g. 5551234567
          */
-        internal val phone: String? = null
+        val phone: String? = null
     ) : Parcelable {
         internal fun isFilledOut(): Boolean {
             return address != null ||


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
We explicitly expose this back to merchants via FlowController PaymentOption.

This was accidentally made private in the major version via: https://github.com/stripe/stripe-android/commit/5ca555ec7f228c923e410e5555e5e8fd306394d6
