### PR TITLE
Revert "Revert adding the payment method header when there is a single payment method type"

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/EmbeddedFormInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/EmbeddedFormInteractorFactory.kt
@@ -14,6 +14,7 @@ import com.stripe.android.paymentsheet.ui.transformToPaymentSelection
 import com.stripe.android.paymentsheet.verticalmode.DefaultVerticalModeFormInteractor
 import com.stripe.android.paymentsheet.verticalmode.PaymentMethodIncentiveInteractor
 import com.stripe.android.uicore.utils.mapAsStateFlow
+import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -81,6 +82,8 @@ internal class EmbeddedFormInteractorFactory @Inject constructor(
             ),
             isLiveMode = paymentMethodMetadata.stripeIntent.isLiveMode,
             processing = formActivityStateHelper.state.mapAsStateFlow { it.isProcessing },
+            // Should never show wallets header in Embedded form
+            showsWalletHeader = stateFlowOf(false),
             paymentMethodIncentive = PaymentMethodIncentiveInteractor(
                 paymentMethodMetadata.paymentMethodIncentive
             ).displayedIncentive,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityUI.kt
@@ -61,7 +61,6 @@ internal fun FormActivityUI(
             content = {
                 VerticalModeFormUI(
                     interactor = interactor,
-                    showsWalletHeader = false
                 )
                 USBankAccountMandate(state)
                 FormActivityError(state)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
@@ -328,7 +328,6 @@ internal sealed interface PaymentSheetScreen {
 
     class VerticalModeForm(
         private val interactor: VerticalModeFormInteractor,
-        private val showsWalletHeader: Boolean = false,
     ) : PaymentSheetScreen, Closeable {
 
         override val buyButtonState = stateFlowOf(
@@ -354,12 +353,12 @@ internal sealed interface PaymentSheetScreen {
         }
 
         override fun showsWalletsHeader(isCompleteFlow: Boolean): StateFlow<Boolean> {
-            return stateFlowOf(showsWalletHeader)
+            return interactor.state.mapAsStateFlow { it.showsWalletHeader }
         }
 
         @Composable
         override fun Content(modifier: Modifier) {
-            VerticalModeFormUI(interactor, showsWalletHeader, modifier)
+            VerticalModeFormUI(interactor, modifier)
         }
 
         override fun close() {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUI.kt
@@ -34,7 +34,6 @@ const val TEST_TAG_HEADER_TITLE = "TEST_TAG_HEADER_TITLE"
 @Composable
 internal fun VerticalModeFormUI(
     interactor: VerticalModeFormInteractor,
-    showsWalletHeader: Boolean,
     modifier: Modifier = Modifier
 ) {
     val horizontalPadding = StripeTheme.getOuterFormInsets()
@@ -43,9 +42,9 @@ internal fun VerticalModeFormUI(
     val state by interactor.state.collectAsState()
 
     Column(modifier) {
-        val headerInformation = state.headerInformation
+        val headerInformation = state.formHeader
         val enabled = !state.isProcessing
-        if (headerInformation != null && !showsWalletHeader) {
+        if (headerInformation != null) {
             VerticalModeFormHeaderUI(isEnabled = enabled, formHeaderInformation = headerInformation)
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactory.kt
@@ -32,7 +32,6 @@ internal object VerticalModeInitialScreenFactory {
                         customerStateHolder = customerStateHolder,
                         bankFormInteractor = bankFormInteractor,
                     ),
-                    showsWalletHeader = true,
                 )
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenVerticalModeFormTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenVerticalModeFormTest.kt
@@ -2,6 +2,8 @@ package com.stripe.android.paymentsheet.navigation
 
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.paymentsheet.forms.FormArgumentsFactory
 import com.stripe.android.paymentsheet.verticalmode.VerticalModeFormInteractor
 import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.flow.StateFlow
@@ -41,6 +43,58 @@ internal class PaymentSheetScreenVerticalModeFormTest {
         val interactor = FakeVerticalModeFormInteractor(onClose = { hasCalledOnClose = true })
         PaymentSheetScreen.VerticalModeForm(interactor).close()
         assertThat(hasCalledOnClose).isTrue()
+    }
+
+    @Test
+    fun `showWalletsHeader is true when interactor state is true`() = runTest {
+        val interactor = FakeVerticalModeFormInteractor(
+            state = stateFlowOf(
+                VerticalModeFormInteractor.State(
+                    selectedPaymentMethodCode = "card",
+                    isProcessing = false,
+                    isValidating = false,
+                    usBankAccountFormArguments = mock(),
+                    formArguments = FormArgumentsFactory.create(
+                        paymentMethodCode = "card",
+                        metadata = PaymentMethodMetadataFactory.create(),
+                    ),
+                    formElements = emptyList(),
+                    showsWalletHeader = false,
+                    paymentMethodIncentive = null,
+                    headerInformation = null,
+                )
+            )
+        )
+
+        PaymentSheetScreen.VerticalModeForm(interactor).showsWalletsHeader(isCompleteFlow = true).test {
+            assertThat(awaitItem()).isFalse()
+        }
+    }
+
+    @Test
+    fun `showWalletsHeader is false when interactor state is false`() = runTest {
+        val interactor = FakeVerticalModeFormInteractor(
+            state = stateFlowOf(
+                VerticalModeFormInteractor.State(
+                    selectedPaymentMethodCode = "card",
+                    isProcessing = false,
+                    isValidating = false,
+                    usBankAccountFormArguments = mock(),
+                    formArguments = FormArgumentsFactory.create(
+                        paymentMethodCode = "card",
+                        metadata = PaymentMethodMetadataFactory.create(),
+                    ),
+                    formElements = emptyList(),
+                    showsWalletHeader = true,
+                    paymentMethodIncentive = null,
+                    headerInformation = null,
+                )
+            )
+        )
+
+        PaymentSheetScreen.VerticalModeForm(interactor).showsWalletsHeader(isCompleteFlow = true).test {
+            assertThat(awaitItem()).isTrue()
+        }
     }
 
     private class FakeVerticalModeFormInteractor(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultVerticalModeFormInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultVerticalModeFormInteractorTest.kt
@@ -7,6 +7,7 @@ import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.isInstanceOf
+import com.stripe.android.lpmfoundations.FormHeaderInformation
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.model.PaymentMethodFixtures
@@ -229,6 +230,62 @@ internal class DefaultVerticalModeFormInteractorTest {
         }
     }
 
+    @Test
+    fun `'headerInformation' is not null if 'showWalletsHeaders' is false`() {
+        val headerInformation = FormHeaderInformation(
+            displayName = "Card".resolvableString,
+            shouldShowIcon = false,
+            iconResource = 0,
+            iconResourceNight = null,
+            lightThemeIconUrl = null,
+            darkThemeIconUrl = null,
+            iconRequiresTinting = false,
+            promoBadge = null,
+        )
+
+        runScenario(
+            selectedPaymentMethodCode = "card",
+            headerInformation = headerInformation,
+        ) {
+            showWalletsHeaderSource.emit(false)
+
+            interactor.state.test {
+                val state = awaitItem()
+
+                assertThat(state.showsWalletHeader).isFalse()
+                assertThat(state.formHeader).isEqualTo(headerInformation)
+            }
+        }
+    }
+
+    @Test
+    fun `'headerInformation' is null if 'showWalletsHeaders' is true`() {
+        val headerInformation = FormHeaderInformation(
+            displayName = "Card".resolvableString,
+            shouldShowIcon = false,
+            iconResource = 0,
+            iconResourceNight = null,
+            lightThemeIconUrl = null,
+            darkThemeIconUrl = null,
+            iconRequiresTinting = false,
+            promoBadge = null,
+        )
+
+        runScenario(
+            selectedPaymentMethodCode = "card",
+            headerInformation = headerInformation,
+        ) {
+            showWalletsHeaderSource.emit(true)
+
+            interactor.state.test {
+                val state = awaitItem()
+
+                assertThat(state.showsWalletHeader).isTrue()
+                assertThat(state.formHeader).isNull()
+            }
+        }
+    }
+
     private fun testSetAsDefaultElements(
         hasSavedPaymentMethods: Boolean,
         block: (SaveForFutureUseElement?, SetAsDefaultPaymentMethodElement?) -> Unit
@@ -325,11 +382,13 @@ internal class DefaultVerticalModeFormInteractorTest {
     private fun runScenario(
         selectedPaymentMethodCode: String,
         formElements: List<FormElement> = emptyList(),
+        headerInformation: FormHeaderInformation? = null,
         testBlock: suspend TestParams.() -> Unit,
     ) {
         val formArguments = mock<FormArguments>()
         val usBankAccountArguments = mock<USBankAccountFormArguments>()
         val processing: MutableStateFlow<Boolean> = MutableStateFlow(false)
+        val showWalletsHeader: MutableStateFlow<Boolean> = MutableStateFlow(false)
         val validationRequested = MutableSharedFlow<Unit>()
 
         val onFormFieldValuesChangedTurbine = Turbine<Pair<FormFieldValues?, String>>()
@@ -346,18 +405,20 @@ internal class DefaultVerticalModeFormInteractorTest {
             reportFieldInteraction = {
                 reportFieldInteractionTurbine.add(it)
             },
-            headerInformation = null,
+            headerInformation = headerInformation,
             isLiveMode = true,
             processing = processing,
             validationRequested = validationRequested,
             coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
             paymentMethodIncentive = stateFlowOf(null),
+            showsWalletHeader = showWalletsHeader,
             uiContext = UnconfinedTestDispatcher(),
         )
 
         TestParams(
             interactor = interactor,
             processingSource = processing,
+            showWalletsHeaderSource = showWalletsHeader,
             validationRequestedSource = validationRequested,
             onFormFieldValuesChangedTurbine = onFormFieldValuesChangedTurbine,
             reportFieldInteractionTurbine = reportFieldInteractionTurbine,
@@ -375,6 +436,7 @@ internal class DefaultVerticalModeFormInteractorTest {
     private class TestParams(
         val interactor: DefaultVerticalModeFormInteractor,
         val processingSource: MutableStateFlow<Boolean>,
+        val showWalletsHeaderSource: MutableStateFlow<Boolean>,
         val validationRequestedSource: MutableSharedFlow<Unit>,
         val onFormFieldValuesChangedTurbine: ReceiveTurbine<Pair<FormFieldValues?, String>>,
         val reportFieldInteractionTurbine: ReceiveTurbine<String>,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakeVerticalModeFormInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakeVerticalModeFormInteractor.kt
@@ -29,6 +29,7 @@ internal class FakeVerticalModeFormInteractor private constructor(
             metadata: PaymentMethodMetadata,
             isProcessing: Boolean = false,
             isValidating: Boolean = false,
+            showsWalletHeader: Boolean = false,
         ): VerticalModeFormInteractor {
             val formArguments = FormArgumentsFactory.create(
                 paymentMethodCode = paymentMethodCode,
@@ -53,6 +54,8 @@ internal class FakeVerticalModeFormInteractor private constructor(
                         uiDefinitionFactoryArgumentsFactory = uiDefinitionArgumentsFactory,
                     )!!,
                     isValidating = isValidating,
+                    showsWalletHeader = showsWalletHeader,
+                    paymentMethodIncentive = null,
                     headerInformation = metadata.formHeaderInformationForCode(
                         code = paymentMethodCode,
                         customerHasSavedPaymentMethods = false,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUIScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUIScreenshotTest.kt
@@ -368,8 +368,8 @@ internal class VerticalModeFormUIScreenshotTest {
             FakeVerticalModeFormInteractor.create(
                 paymentMethodCode = "card",
                 metadata = metadata,
+                showsWalletHeader = true,
             ),
-            showsWalletHeader = true,
         )
         val viewModel = FakeBaseSheetViewModel.create(metadata, initialScreen, canGoBack = false)
         viewModel.walletsStateSource.value = WalletsState(
@@ -464,8 +464,8 @@ internal class VerticalModeFormUIScreenshotTest {
                     paymentMethodCode = paymentMethodCode,
                     metadata = metadata,
                     isProcessing = isProcessing,
+                    showsWalletHeader = showsWalletHeader,
                 ),
-                showsWalletHeader = showsWalletHeader,
             )
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUITest.kt
@@ -130,7 +130,7 @@ internal class VerticalModeFormUITest {
                 LocalCardNumberCompletedEventReporter provides { },
                 LocalCardBrandDisallowedReporter provides { }
             ) {
-                VerticalModeFormUI(interactor, showsWalletHeader = false)
+                VerticalModeFormUI(interactor)
             }
         }
 
@@ -178,6 +178,8 @@ internal class VerticalModeFormUITest {
             ),
             formElements = CardDefinition.formElements(),
             isValidating = false,
+            showsWalletHeader = false,
+            paymentMethodIncentive = null,
             headerInformation = headerInformation,
         )
     }
@@ -208,6 +210,8 @@ internal class VerticalModeFormUITest {
             ),
             formElements = emptyList(),
             isValidating = false,
+            showsWalletHeader = false,
+            paymentMethodIncentive = null,
             headerInformation = headerInformation,
         )
     }
@@ -242,6 +246,8 @@ internal class VerticalModeFormUITest {
             ),
             formElements = KlarnaDefinition.formElements(paymentMethodMetadata),
             isValidating = false,
+            showsWalletHeader = false,
+            paymentMethodIncentive = null,
             headerInformation = headerInformation,
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactoryTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.verticalmode
 
 import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.isInstanceOf
 import com.stripe.android.link.TestFactory
@@ -38,6 +39,10 @@ class VerticalModeInitialScreenFactoryTest {
     ) {
         assertThat(screens).hasSize(1)
         assertThat(screens[0]).isInstanceOf<PaymentSheetScreen.VerticalModeForm>()
+
+        screens[0].showsWalletsHeader(isCompleteFlow = false).test {
+            assertThat(awaitItem()).isFalse()
+        }
     }
 
     @Test


### PR DESCRIPTION
Reverts stripe/stripe-android#11672 to make it easier to revert stripe/stripe-android#11582