### PR TITLE
Add Shapes builder with default

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -2196,20 +2196,8 @@ class PaymentSheet internal constructor(
     @Parcelize
     @Poko
     class Shapes @AppearanceAPIAdditionsPreview constructor(
-        /**
-         * The corner radius used for tabs, inputs, buttons, and other components in PaymentSheet.
-         */
         internal val cornerRadiusDp: Float,
-
-        /**
-         * The border used for inputs, tabs, and other components in PaymentSheet.
-         */
         internal val borderStrokeWidthDp: Float,
-
-        /**
-         * The corner radius used for specifically for the sheets displayed by Payment Element. Be default, this is
-         * set to the same value as [cornerRadiusDp].
-         */
         internal val bottomSheetCornerRadiusDp: Float = cornerRadiusDp,
     ) : Parcelable {
         @OptIn(AppearanceAPIAdditionsPreview::class)
@@ -2240,11 +2228,89 @@ class PaymentSheet internal constructor(
             bottomSheetCornerRadiusDp = context.getRawValueFromDimenResource(cornerRadiusDp),
         )
 
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        class Builder {
+            private var cornerRadiusDp: Float = StripeThemeDefaults.shapes.cornerRadius
+            private var borderStrokeWidthDp: Float = StripeThemeDefaults.shapes.borderStrokeWidth
+            private var bottomSheetCornerRadiusDp: Float? = null
+
+            /**
+             * The corner radius used for tabs, inputs, buttons, and other components in PaymentSheet.
+             *
+             * @param cornerRadiusDp The corner radius in dp.
+             */
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            fun cornerRadiusDp(cornerRadiusDp: Float) = apply {
+                this.cornerRadiusDp = cornerRadiusDp
+            }
+
+            /**
+             * The corner radius used for tabs, inputs, buttons, and other components in PaymentSheet.
+             *
+             * @param cornerRadiusRes The corner radius resource ID.
+             */
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            fun cornerRadiusDp(context: Context, @DimenRes cornerRadiusRes: Int) = apply {
+                this.cornerRadiusDp = context.getRawValueFromDimenResource(cornerRadiusRes)
+            }
+
+            /**
+             * The border used for inputs, tabs, and other components in PaymentSheet.
+             *
+             * @param borderStrokeWidthDp The border width in dp.
+             */
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            fun borderStrokeWidthDp(borderStrokeWidthDp: Float) = apply {
+                this.borderStrokeWidthDp = borderStrokeWidthDp
+            }
+
+            /**
+             * The border used for inputs, tabs, and other components in PaymentSheet.
+             *
+             * @param borderStrokeWidthRes The border width resource ID.
+             */
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            fun borderStrokeWidthDp(context: Context, @DimenRes borderStrokeWidthRes: Int) = apply {
+                this.borderStrokeWidthDp = context.getRawValueFromDimenResource(borderStrokeWidthRes)
+            }
+
+            /**
+             * The corner radius used for specifically for the sheets displayed by Payment Element. Be default, this is
+             * set to the same value as [cornerRadiusDp].
+             */
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            fun bottomSheetCornerRadiusDp(bottomSheetCornerRadiusDp: Float) = apply {
+                this.bottomSheetCornerRadiusDp = bottomSheetCornerRadiusDp
+            }
+
+            /**
+             * The corner radius used for specifically for the sheets displayed by Payment Element. Be default, this is
+             * set to the same value as [cornerRadiusDp].
+             *
+             * @param bottomSheetCornerRadiusRes The bottom sheet corner radius resource ID.
+             */
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            fun bottomSheetCornerRadiusDp(
+                context: Context,
+                @DimenRes bottomSheetCornerRadiusRes: Int
+            ) = apply {
+                this.bottomSheetCornerRadiusDp =
+                    context.getRawValueFromDimenResource(bottomSheetCornerRadiusRes)
+            }
+
+            @OptIn(AppearanceAPIAdditionsPreview::class)
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            fun build(): Shapes {
+                return Shapes(
+                    cornerRadiusDp = cornerRadiusDp,
+                    borderStrokeWidthDp = borderStrokeWidthDp,
+                    bottomSheetCornerRadiusDp = bottomSheetCornerRadiusDp ?: cornerRadiusDp,
+                )
+            }
+        }
+
         companion object {
-            val default = Shapes(
-                cornerRadiusDp = StripeThemeDefaults.shapes.cornerRadius,
-                borderStrokeWidthDp = StripeThemeDefaults.shapes.borderStrokeWidth
-            )
+            val default: Shapes = Builder().build()
         }
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add builder with two sets of APIs that accept either resource ID or dp value.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
#11900 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
