### PR TITLE
Log result in confirmation handler.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandler.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentelement.confirmation
 import android.os.Parcelable
 import androidx.activity.result.ActivityResultCaller
 import androidx.lifecycle.LifecycleOwner
+import com.stripe.android.core.Logger
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.StripeIntent
@@ -117,6 +118,8 @@ internal interface ConfirmationHandler {
      * Defines the result types that can be returned after completing a confirmation process.
      */
     sealed interface Result {
+        fun log(logger: Logger)
+
         /**
          * Indicates that the confirmation process was canceled by the customer.
          */
@@ -144,6 +147,10 @@ internal interface ConfirmationHandler {
                  */
                 None,
             }
+
+            override fun log(logger: Logger) {
+                logger.info("ConfirmationHandler.Result.Canceled: $action")
+            }
         }
 
         /**
@@ -155,7 +162,11 @@ internal interface ConfirmationHandler {
             val deferredIntentConfirmationType: DeferredIntentConfirmationType?,
             val isConfirmationToken: Boolean,
             val completedFullPaymentFlow: Boolean = true,
-        ) : Result
+        ) : Result {
+            override fun log(logger: Logger) {
+                logger.info("ConfirmationHandler.Result.Succeeded")
+            }
+        }
 
         /**
          * Indicates that the confirmation process has failed. A cause and potentially a resolvable message are
@@ -166,6 +177,10 @@ internal interface ConfirmationHandler {
             val message: ResolvableString,
             val type: ErrorType,
         ) : Result {
+            override fun log(logger: Logger) {
+                logger.error("ConfirmationHandler.Result.Failed", cause)
+            }
+
             /**
              * Types of errors that can occur when confirming a payment.
              */

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandler.kt
@@ -5,6 +5,7 @@ import androidx.activity.result.ActivityResultCaller
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.SavedStateHandle
+import com.stripe.android.core.Logger
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.strings.resolvableString
@@ -31,6 +32,7 @@ internal class DefaultConfirmationHandler(
     private val savedStateHandle: SavedStateHandle,
     private val errorReporter: ErrorReporter,
     private val ioContext: CoroutineContext,
+    private val logger: Logger,
     private val confirmationSaver: ConfirmationHandler.Saver,
 ) : ConfirmationHandler {
     private var initialConfirmationArguments: ConfirmationHandler.Args?
@@ -240,6 +242,8 @@ internal class DefaultConfirmationHandler(
     }
 
     private fun onHandlerResult(result: ConfirmationHandler.Result) {
+        result.log(logger)
+
         _state.value = ConfirmationHandler.State.Complete(result)
 
         if (result is ConfirmationHandler.Result.Succeeded) {
@@ -301,6 +305,7 @@ internal class DefaultConfirmationHandler(
         private val savedStateHandle: SavedStateHandle,
         private val errorReporter: ErrorReporter,
         @IOContext private val ioContext: CoroutineContext,
+        private val logger: Logger,
         private val confirmationSaver: ConfirmationHandler.Saver,
     ) : ConfirmationHandler.Factory {
         override fun create(scope: CoroutineScope): ConfirmationHandler {
@@ -310,6 +315,7 @@ internal class DefaultConfirmationHandler(
                 errorReporter = errorReporter,
                 savedStateHandle = savedStateHandle,
                 ioContext = ioContext,
+                logger = logger,
                 confirmationSaver = confirmationSaver,
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationUtils.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.test.core.app.ApplicationProvider
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.SharedPaymentTokenSessionPreview
+import com.stripe.android.core.Logger
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLauncherFactory
 import com.stripe.android.link.LinkConfigurationCoordinator
@@ -208,6 +209,7 @@ internal fun createTestConfirmationHandlerFactory(
         savedStateHandle = savedStateHandle,
         errorReporter = FakeErrorReporter(),
         ioContext = Dispatchers.Unconfined,
+        logger = Logger.getInstance(true),
         confirmationSaver = { _, _, _ -> },
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandlerTest.kt
@@ -20,6 +20,7 @@ import com.stripe.android.paymentsheet.R
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.DummyActivityResultCaller
 import com.stripe.android.testing.FakeErrorReporter
+import com.stripe.android.testing.FakeLogger
 import com.stripe.android.testing.PaymentMethodFactory
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -815,6 +816,7 @@ class DefaultConfirmationHandlerTest {
                     errorReporter = errorReporter,
                     savedStateHandle = savedStateHandle,
                     ioContext = dispatcher,
+                    logger = FakeLogger(),
                     confirmationSaver = { intent, option, alwaysSave ->
                         confirmationSaverTurbine.add(Pair(intent, option))
                     },


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
I spent an embarrassingly large amount of time debugging an end to end test in #11919 if we had this log, I would have been able to identify the issue quickly.

This is my gift to the next engineer debugging confirmation errors.
