### PR TITLE
Don't send analytics during network tests.

### DIFF
--- a/network-testing/src/main/java/com/stripe/android/networktesting/NetworkRule.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/NetworkRule.kt
@@ -1,5 +1,7 @@
 package com.stripe.android.networktesting
 
+import com.stripe.android.core.networking.AnalyticsRequest
+import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.networking.ConnectionFactory
 import com.stripe.android.core.networking.StripeRequest
@@ -93,10 +95,14 @@ private class NetworkStatement(
 ) : Statement() {
     override fun evaluate() {
         try {
+            if (!hostsToTrack.contains(AnalyticsRequest.HOST.hostFromUrl())) {
+                AnalyticsRequestExecutor.ENABLED = false
+            }
             setup()
             baseStatement.evaluate()
             mockWebServer.dispatcher.validate()
         } finally {
+            AnalyticsRequestExecutor.ENABLED = true
             tearDown()
         }
     }

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestExecutor.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestExecutor.kt
@@ -8,4 +8,9 @@ fun interface AnalyticsRequestExecutor {
      * Execute the fire-and-forget request asynchronously.
      */
     fun executeAsync(request: AnalyticsRequest)
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    companion object {
+        var ENABLED: Boolean = true
+    }
 }

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestV2Executor.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestV2Executor.kt
@@ -26,6 +26,8 @@ class DefaultAnalyticsRequestV2Executor @Inject constructor(
 ) : AnalyticsRequestV2Executor {
 
     override suspend fun enqueue(request: AnalyticsRequestV2) {
+        if (!AnalyticsRequestExecutor.ENABLED) return
+
         val isEnqueued = isWorkManagerAvailable() && enqueueRequest(request)
         if (!isEnqueued) {
             executeRequest(request)

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/DefaultAnalyticsRequestExecutor.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/DefaultAnalyticsRequestExecutor.kt
@@ -38,6 +38,8 @@ class DefaultAnalyticsRequestExecutor(
      * Make the request and ignore the response.
      */
     override fun executeAsync(request: AnalyticsRequest) {
+        if (!AnalyticsRequestExecutor.ENABLED) return
+
         logger.info("Event: ${request.params[FIELD_EVENT]}")
 
         CoroutineScope(workContext).launch {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
There's a lot of logs, and we don't care about these, so I think it's reasonable to turn them off. It makes debugging much harder.
