### PR TITLE
Use OBO from ElementsSession.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/ElementsSession.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ElementsSession.kt
@@ -29,6 +29,8 @@ data class ElementsSession(
     val elementsSessionId: String,
     private val passiveCaptcha: PassiveCaptchaParams?,
     val elementsSessionConfigId: String?,
+    val accountId: String?,
+    val merchantId: String?,
 ) : StripeModel {
 
     val linkPassthroughModeEnabled: Boolean
@@ -87,6 +89,9 @@ data class ElementsSession(
             return flags[Flag.ELEMENTS_MOBILE_ATTEST_ON_INTENT_CONFIRMATION] == true &&
                 FeatureFlags.enableAttestationOnIntentConfirmation.isEnabled
         }
+
+    val onBehalfOf: String?
+        get() = accountId.takeIf { !it.equals(merchantId) }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Parcelize
@@ -274,6 +279,8 @@ data class ElementsSession(
                 elementsSessionId = elementsSessionId,
                 passiveCaptcha = null,
                 elementsSessionConfigId = null,
+                accountId = null,
+                merchantId = null,
             )
         }
     }

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/ElementsSessionJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/ElementsSessionJsonParser.kt
@@ -87,6 +87,9 @@ internal class ElementsSessionJsonParser(
             PassiveCaptchaJsonParser().parse(it)
         }
 
+        val accountId = json.optString("account_id")
+        val merchantId = json.optString("merchant_id")
+
         return if (stripeIntent != null) {
             ElementsSession(
                 linkSettings = parseLinkSettings(linkSettings, linkFundingSources),
@@ -105,6 +108,8 @@ internal class ElementsSessionJsonParser(
                 elementsSessionId = elementsSessionId.takeIf { it.isNotBlank() } ?: UUID.randomUUID().toString(),
                 passiveCaptcha = passiveCaptcha,
                 elementsSessionConfigId = elementsSessionConfigId,
+                accountId = accountId,
+                merchantId = merchantId,
             )
         } else {
             null

--- a/payments-core/src/test/java/com/stripe/android/model/ElementsSessionTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/ElementsSessionTest.kt
@@ -144,9 +144,29 @@ class ElementsSessionTest {
         assertThat(session.enableAttestationOnIntentConfirmation).isFalse()
     }
 
+    @Test
+    fun `onBehalfOf is null when account and merchant are the same`() {
+        val session = createElementsSession(
+            accountId = "acct_1SGP1sPvdtoA7EjP",
+            merchantId = "acct_1SGP1sPvdtoA7EjP",
+        )
+        assertThat(session.onBehalfOf).isNull()
+    }
+
+    @Test
+    fun `onBehalfOf is accountId when account and merchant are not the same`() {
+        val session = createElementsSession(
+            accountId = "acct_1SGP1sPvdtoA7EjP",
+            merchantId = "acct_1HvTI7Lu5o3P18Zp",
+        )
+        assertThat(session.onBehalfOf).isEqualTo("acct_1SGP1sPvdtoA7EjP")
+    }
+
     private fun createElementsSession(
-        passiveCaptcha: PassiveCaptchaParams?,
-        flags: Map<ElementsSession.Flag, Boolean>
+        passiveCaptcha: PassiveCaptchaParams? = null,
+        flags: Map<ElementsSession.Flag, Boolean> = emptyMap(),
+        accountId: String? = "acct_1SGP1sPvdtoA7EjP",
+        merchantId: String? = "acct_1SGP1sPvdtoA7EjP",
     ): ElementsSession {
         return ElementsSession(
             linkSettings = null,
@@ -166,6 +186,8 @@ class ElementsSessionTest {
             elementsSessionId = "elements_session_test",
             passiveCaptcha = passiveCaptcha,
             elementsSessionConfigId = null,
+            accountId = accountId,
+            merchantId = merchantId,
         )
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
@@ -1624,6 +1624,24 @@ class ElementsSessionJsonParserTest {
             .isNull()
     }
 
+    @Test
+    fun `returns accountId and merchantId`() {
+        val parser = ElementsSessionJsonParser(
+            ElementsSessionParams.PaymentIntentType(
+                clientSecret = "secret",
+                externalPaymentMethods = emptyList(),
+                customPaymentMethods = emptyList(),
+                appId = APP_ID
+            ),
+            isLiveMode = false,
+        )
+
+        val session = parser.parse(ElementsSessionFixtures.PAYMENT_INTENT_WITH_EXTERNAL_VENMO_JSON)!!
+
+        assertThat(session.accountId).isEqualTo("acct_1HvTI7Lu5o3P18Zp")
+        assertThat(session.merchantId).isEqualTo("acct_1HvTI7Lu5o3P18Zp")
+    }
+
     companion object {
         private const val APP_ID = "com.app.id"
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -80,6 +80,7 @@ internal data class PaymentMethodMetadata(
     val clientAttributionMetadata: ClientAttributionMetadata,
     val attestOnIntentConfirmation: Boolean,
     val appearance: PaymentSheet.Appearance,
+    val onBehalfOf: String?,
 ) : Parcelable {
 
     @IgnoredOnParcel
@@ -369,6 +370,7 @@ internal data class PaymentMethodMetadata(
                 clientAttributionMetadata = clientAttributionMetadata,
                 attestOnIntentConfirmation = elementsSession.enableAttestationOnIntentConfirmation,
                 appearance = configuration.appearance,
+                onBehalfOf = elementsSession.onBehalfOf,
             )
         }
 
@@ -430,6 +432,7 @@ internal data class PaymentMethodMetadata(
                 ),
                 attestOnIntentConfirmation = elementsSession.enableAttestationOnIntentConfirmation,
                 appearance = configuration.appearance,
+                onBehalfOf = elementsSession.onBehalfOf,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/EmbeddedFormInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/EmbeddedFormInteractorFactory.kt
@@ -10,7 +10,6 @@ import com.stripe.android.payments.bankaccount.CollectBankAccountLauncher.Compan
 import com.stripe.android.paymentsheet.FormHelper
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormArguments
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.paymentsheet.ui.transformToPaymentSelection
 import com.stripe.android.paymentsheet.verticalmode.DefaultVerticalModeFormInteractor
 import com.stripe.android.paymentsheet.verticalmode.PaymentMethodIncentiveInteractor
@@ -29,7 +28,6 @@ internal class EmbeddedFormInteractorFactory @Inject constructor(
     @ViewModelScope private val viewModelScope: CoroutineScope,
     private val formActivityStateHelper: FormActivityStateHelper,
     private val eventReporter: EventReporter,
-    private val initializationMode: PaymentElementLoader.InitializationMode,
 ) {
     fun create(): DefaultVerticalModeFormInteractor {
         val formHelper = embeddedFormHelperFactory.create(
@@ -49,7 +47,6 @@ internal class EmbeddedFormInteractorFactory @Inject constructor(
             hostedSurface = HOSTED_SURFACE_PAYMENT_ELEMENT,
             setSelection = embeddedSelectionHolder::set,
             hasSavedPaymentMethods = hasSavedPaymentMethods,
-            initializationMode = initializationMode,
             onAnalyticsEvent = eventReporter::onUsBankAccountFormEvent,
             onMandateTextChanged = { mandateText, _ ->
                 formActivityStateHelper.updateMandate(mandateText)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArguments.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArguments.kt
@@ -10,11 +10,9 @@ import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.paymentsheet.PaymentSheetViewModel
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.model.PaymentMethodIncentive
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.verticalmode.BankFormInteractor
 import com.stripe.android.paymentsheet.verticalmode.PaymentMethodIncentiveInteractor
@@ -88,12 +86,6 @@ internal class USBankAccountFormArguments(
                 hasCustomerConfiguration = paymentMethodMetadata.customerMetadata != null,
             )
             val instantDebits = selectedPaymentMethodCode == PaymentMethod.Type.Link.code
-            val initializationMode = (viewModel as? PaymentSheetViewModel)
-                ?.args
-                ?.initializationMode
-            val onBehalfOf = (initializationMode as? PaymentElementLoader.InitializationMode.DeferredIntent)
-                ?.intentConfiguration
-                ?.onBehalfOf
             val stripeIntent = paymentMethodMetadata.stripeIntent
             return USBankAccountFormArguments(
                 showCheckbox = isSaveForFutureUseValueChangeable &&
@@ -102,7 +94,7 @@ internal class USBankAccountFormArguments(
                 hostedSurface = hostedSurface,
                 instantDebits = instantDebits,
                 linkMode = paymentMethodMetadata.linkMode,
-                onBehalfOf = onBehalfOf,
+                onBehalfOf = paymentMethodMetadata.onBehalfOf,
                 isCompleteFlow = viewModel.isCompleteFlow,
                 isPaymentFlow = stripeIntent is PaymentIntent,
                 stripeIntentId = stripeIntent.id,
@@ -138,7 +130,6 @@ internal class USBankAccountFormArguments(
             hostedSurface: String,
             setSelection: (PaymentSelection?) -> Unit,
             hasSavedPaymentMethods: Boolean,
-            initializationMode: PaymentElementLoader.InitializationMode,
             onMandateTextChanged: (mandate: ResolvableString?, showAbove: Boolean) -> Unit,
             onAnalyticsEvent: (USBankAccountFormViewModel.AnalyticsEvent) -> Unit,
             onUpdatePrimaryButtonUIState: ((PrimaryButton.UIState?) -> (PrimaryButton.UIState?)) -> Unit,
@@ -158,16 +149,13 @@ internal class USBankAccountFormArguments(
                     paymentMethodMetadata.paymentMethodIncentive
                 )
             )
-            val onBehalfOf = (initializationMode as? PaymentElementLoader.InitializationMode.DeferredIntent)
-                ?.intentConfiguration
-                ?.onBehalfOf
 
             return USBankAccountFormArguments(
                 showCheckbox = isSaveForFutureUseValueChangeable && instantDebits.not(),
                 hostedSurface = hostedSurface,
                 instantDebits = instantDebits,
                 linkMode = paymentMethodMetadata.linkMode,
-                onBehalfOf = onBehalfOf,
+                onBehalfOf = paymentMethodMetadata.onBehalfOf,
                 isCompleteFlow = false,
                 isPaymentFlow = paymentMethodMetadata.stripeIntent is PaymentIntent,
                 stripeIntentId = paymentMethodMetadata.stripeIntent.id,

--- a/paymentsheet/src/test/java/com/stripe/android/common/analytics/experiment/LogLinkGlobalHoldbackExposureTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/analytics/experiment/LogLinkGlobalHoldbackExposureTest.kt
@@ -466,6 +466,8 @@ class LogLinkGlobalHoldbackExposureTest {
             passiveCaptcha = null,
             merchantLogoUrl = null,
             elementsSessionConfigId = null,
+            accountId = "acct_1SGP1sPvdtoA7EjP",
+            merchantId = "acct_1SGP1sPvdtoA7EjP",
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetFixtures.kt
@@ -90,6 +90,8 @@ internal object CustomerSheetFixtures {
             passiveCaptcha = null,
             merchantLogoUrl = null,
             elementsSessionConfigId = null,
+            accountId = "acct_1SGP1sPvdtoA7EjP",
+            merchantId = "acct_1SGP1sPvdtoA7EjP",
         )
 
         return CustomerSheetSession(

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/FakeCustomerSessionElementsSessionManager.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/FakeCustomerSessionElementsSessionManager.kt
@@ -61,6 +61,8 @@ internal class FakeCustomerSessionElementsSessionManager(
                 passiveCaptcha = null,
                 merchantLogoUrl = null,
                 elementsSessionConfigId = null,
+                accountId = "acct_1SGP1sPvdtoA7EjP",
+                merchantId = "acct_1SGP1sPvdtoA7EjP",
             ),
             customer = customer,
             ephemeralKey = CachedCustomerEphemeralKey(

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -722,6 +722,8 @@ internal class DefaultCustomerSheetLoaderTest {
             passiveCaptcha = null,
             merchantLogoUrl = null,
             elementsSessionConfigId = null,
+            accountId = "acct_1SGP1sPvdtoA7EjP",
+            merchantId = "acct_1SGP1sPvdtoA7EjP",
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/CustomerMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/CustomerMetadataTest.kt
@@ -252,6 +252,8 @@ internal class CustomerMetadataTest {
             passiveCaptcha = null,
             merchantLogoUrl = null,
             elementsSessionConfigId = null,
+            accountId = "acct_1SGP1sPvdtoA7EjP",
+            merchantId = "acct_1SGP1sPvdtoA7EjP",
         )
 
         return CustomerSheetSession(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
@@ -58,6 +58,7 @@ internal object PaymentMethodMetadataFactory {
         clientAttributionMetadata: ClientAttributionMetadata? = null,
         attestOnIntentConfirmation: Boolean = false,
         appearance: PaymentSheet.Appearance = PaymentSheet.Appearance(),
+        onBehalfOf: String? = null,
     ): PaymentMethodMetadata {
         return PaymentMethodMetadata(
             stripeIntent = stripeIntent,
@@ -102,6 +103,7 @@ internal object PaymentMethodMetadataFactory {
             clientAttributionMetadata ?: PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
             attestOnIntentConfirmation = attestOnIntentConfirmation,
             appearance = appearance,
+            onBehalfOf = onBehalfOf,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -1176,6 +1176,7 @@ internal class PaymentMethodMetadataTest {
             clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
             attestOnIntentConfirmation = false,
             appearance = configuration.appearance,
+            onBehalfOf = null,
         )
 
         assertThat(metadata).isEqualTo(expectedMetadata)
@@ -1261,6 +1262,7 @@ internal class PaymentMethodMetadataTest {
             ),
             attestOnIntentConfirmation = false,
             appearance = configuration.appearance,
+            onBehalfOf = null,
         )
         assertThat(metadata).isEqualTo(expectedMetadata)
     }
@@ -1384,6 +1386,8 @@ internal class PaymentMethodMetadataTest {
             merchantLogoUrl = null,
             passiveCaptcha = passiveCaptchaParams,
             elementsSessionConfigId = null,
+            accountId = "acct_1SGP1sPvdtoA7EjP",
+            merchantId = "acct_1SGP1sPvdtoA7EjP",
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityScreenShotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityScreenShotTest.kt
@@ -114,12 +114,10 @@ internal class FormActivityScreenShotTest {
             selectedPaymentMethodCode = "",
         )
         val eventReporter = FakeEventReporter()
-        val initializationMode = EmbeddedConfirmationStateFixtures.defaultState().initializationMode
         val interactor = EmbeddedFormInteractorFactory(
             paymentMethodMetadata = paymentMethodMetadata,
             paymentMethodCode = "card",
             hasSavedPaymentMethods = false,
-            initializationMode = initializationMode,
             embeddedSelectionHolder = selectionHolder,
             embeddedFormHelperFactory = formHelperFactory,
             viewModelScope = TestScope(UnconfinedTestDispatcher()),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultVerticalModeFormInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultVerticalModeFormInteractorTest.kt
@@ -258,12 +258,10 @@ internal class DefaultVerticalModeFormInteractorTest {
             selectedPaymentMethodCode = "",
         )
         val eventReporter = FakeEventReporter()
-        val initializationMode = EmbeddedConfirmationStateFixtures.defaultState().initializationMode
         val setAsDefaultInteractor = EmbeddedFormInteractorFactory(
             paymentMethodMetadata = paymentMethodMetadata,
             paymentMethodCode = "card",
             hasSavedPaymentMethods = hasSavedPaymentMethods,
-            initializationMode = initializationMode,
             embeddedSelectionHolder = selectionHolder,
             embeddedFormHelperFactory = formHelperFactory,
             viewModelScope = TestScope(UnconfinedTestDispatcher()),
@@ -309,12 +307,10 @@ internal class DefaultVerticalModeFormInteractorTest {
             selectedPaymentMethodCode = selectedPaymentMethodCode,
         )
         val eventReporter = FakeEventReporter()
-        val initializationMode = EmbeddedConfirmationStateFixtures.defaultState().initializationMode
         val setAsDefaultInteractor = EmbeddedFormInteractorFactory(
             paymentMethodMetadata = paymentMethodMetadata,
             paymentMethodCode = selectedPaymentMethodCode,
             hasSavedPaymentMethods = false,
-            initializationMode = initializationMode,
             embeddedSelectionHolder = selectionHolder,
             embeddedFormHelperFactory = formHelperFactory,
             viewModelScope = TestScope(UnconfinedTestDispatcher()),

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeElementsSessionRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeElementsSessionRepository.kt
@@ -73,6 +73,8 @@ internal class FakeElementsSessionRepository(
                     passiveCaptcha = passiveCaptchaParams,
                     merchantLogoUrl = null,
                     elementsSessionConfigId = DEFAULT_ELEMENTS_SESSION_CONFIG_ID,
+                    accountId = "acct_1SGP1sPvdtoA7EjP",
+                    merchantId = "acct_1SGP1sPvdtoA7EjP",
                 )
             )
         }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
I'm trying to avoid using `PaymentElementLoader.InitializationMode` after configuration. We have the data (including for intent first), so we should just use it!
