### PR TITLE
Create LoadingEventReporter.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedCommonModule.kt
@@ -29,6 +29,7 @@ import com.stripe.android.paymentsheet.BuildConfig
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.analytics.DefaultEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.analytics.LoadingEventReporter
 import com.stripe.android.paymentsheet.repositories.CustomerApiRepository
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.uicore.utils.mapAsStateFlow
@@ -54,6 +55,10 @@ internal interface EmbeddedCommonModule {
     @Binds
     @Singleton
     fun bindsEventReporter(eventReporter: DefaultEventReporter): EventReporter
+
+    @Binds
+    @Singleton
+    fun bindsLoadingReporter(eventReporter: DefaultEventReporter): LoadingEventReporter
 
     @Binds
     fun bindsErrorReporter(errorReporter: RealErrorReporter): ErrorReporter

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -49,7 +49,7 @@ internal class DefaultEventReporter @Inject internal constructor(
     private val analyticEventCallbackProvider: Provider<AnalyticEventCallback?>,
     @IOContext private val workContext: CoroutineContext,
     private val logger: UserFacingLogger,
-) : EventReporter {
+) : EventReporter, LoadingEventReporter {
 
     private var isDeferred: Boolean = false
     private var isSpt: Boolean = false
@@ -333,9 +333,7 @@ internal class DefaultEventReporter @Inject internal constructor(
         paymentSelection: PaymentSelection,
     ) {
         if (paymentSelection.isSaved) {
-            paymentSelection.code()?.let {
-                fireAnalyticEvent(AnalyticEvent.SelectedSavedPaymentMethod(it))
-            }
+            fireAnalyticEvent(AnalyticEvent.SelectedSavedPaymentMethod(paymentSelection.code()))
         }
         fireEvent(
             PaymentSheetEvent.SelectPaymentOption(
@@ -611,7 +609,7 @@ internal class DefaultEventReporter @Inject internal constructor(
         val isLinkVisible = walletsState?.link(WalletLocation.HEADER) != null &&
             walletsState.buttonsEnabled
 
-        val visiblePaymentMethodsWithWallets = buildList<String> {
+        val visiblePaymentMethodsWithWallets = buildList {
             if (isGooglePayVisible) add("google_pay")
             if (isLinkVisible) add("link")
             addAll(visiblePaymentMethods)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
@@ -19,20 +19,7 @@ import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.paymentsheet.state.WalletsState
 import com.stripe.android.ui.core.cardscan.CardScanEventsReporter
 
-@Suppress("TooManyFunctions")
-internal interface EventReporter : CardScanEventsReporter {
-
-    /**
-     * PaymentSheet has been instantiated or FlowController has finished its configuration.
-     */
-    fun onInit(
-        commonConfiguration: CommonConfiguration,
-        appearance: PaymentSheet.Appearance,
-        primaryButtonColor: Boolean?,
-        configurationSpecificPayload: PaymentSheetEvent.ConfigurationSpecificPayload,
-        isDeferred: Boolean,
-    )
-
+internal interface LoadingEventReporter {
     /**
      * PaymentSheet or FlowController have started loading.
      */
@@ -71,6 +58,26 @@ internal interface EventReporter : CardScanEventsReporter {
      * PaymentSheet or FlowController have failed to load from the Elements session endpoint.
      */
     fun onElementsSessionLoadFailed(error: Throwable)
+
+    /**
+     * The client was unable to parse the response from LUXE.
+     */
+    fun onLpmSpecFailure(errorMessage: String?)
+}
+
+@Suppress("TooManyFunctions")
+internal interface EventReporter : CardScanEventsReporter {
+
+    /**
+     * PaymentSheet has been instantiated or FlowController has finished its configuration.
+     */
+    fun onInit(
+        commonConfiguration: CommonConfiguration,
+        appearance: PaymentSheet.Appearance,
+        primaryButtonColor: Boolean?,
+        configurationSpecificPayload: PaymentSheetEvent.ConfigurationSpecificPayload,
+        isDeferred: Boolean,
+    )
 
     /**
      * PaymentSheet has been dismissed by pressing the close button.
@@ -157,11 +164,6 @@ internal interface EventReporter : CardScanEventsReporter {
         paymentSelection: PaymentSelection,
         error: PaymentSheetConfirmationError,
     )
-
-    /**
-     * The client was unable to parse the response from LUXE.
-     */
-    fun onLpmSpecFailure(errorMessage: String?)
 
     /**
      * The user has auto-filled a text field.

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
@@ -34,6 +34,7 @@ import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.analytics.DefaultEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.analytics.LoadingEventReporter
 import com.stripe.android.paymentsheet.flowcontroller.DefaultPaymentSelectionUpdater
 import com.stripe.android.paymentsheet.flowcontroller.PaymentSelectionUpdater
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcRecollectionInteractor
@@ -74,6 +75,10 @@ internal abstract class PaymentSheetCommonModule {
     @Singleton
     @Binds
     abstract fun bindsEventReporter(eventReporter: DefaultEventReporter): EventReporter
+
+    @Binds
+    @Singleton
+    abstract fun bindsLoadingReporter(eventReporter: DefaultEventReporter): LoadingEventReporter
 
     @Binds
     abstract fun bindsCustomerRepository(repository: CustomerApiRepository): CustomerRepository

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -33,7 +33,7 @@ import com.stripe.android.payments.financialconnections.GetFinancialConnectionsA
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheet.IntentConfiguration
 import com.stripe.android.paymentsheet.PrefsRepository
-import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.analytics.LoadingEventReporter
 import com.stripe.android.paymentsheet.cvcrecollection.CvcRecollectionHandler
 import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -146,7 +146,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
     private val customerRepository: CustomerRepository,
     private val lpmRepository: LpmRepository,
     private val logger: Logger,
-    private val eventReporter: EventReporter,
+    private val eventReporter: LoadingEventReporter,
     private val errorReporter: ErrorReporter,
     @IOContext private val workContext: CoroutineContext,
     private val createLinkState: CreateLinkState,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -1541,8 +1541,8 @@ class DefaultEventReporterTest {
     private fun createEventReporter(
         mode: EventReporter.Mode,
         duration: Duration = 1.seconds,
-        configure: EventReporter.() -> Unit = {},
-    ): EventReporter {
+        configure: DefaultEventReporter.() -> Unit = {},
+    ): DefaultEventReporter {
         val reporter = DefaultEventReporter(
             context = ApplicationProvider.getApplicationContext(),
             mode = mode,
@@ -1566,8 +1566,8 @@ class DefaultEventReporterTest {
     private fun createEventReporter(
         mode: EventReporter.Mode,
         durationProvider: DurationProvider,
-        configure: EventReporter.() -> Unit = {},
-    ): EventReporter {
+        configure: DefaultEventReporter.() -> Unit = {},
+    ): DefaultEventReporter {
         val reporter = DefaultEventReporter(
             context = ApplicationProvider.getApplicationContext(),
             mode = mode,
@@ -1587,7 +1587,7 @@ class DefaultEventReporterTest {
         return reporter
     }
 
-    private fun EventReporter.simulateInit() {
+    private fun DefaultEventReporter.simulateInit() {
         onInit(
             commonConfiguration = configuration.asCommonConfiguration(),
             appearance = configuration.appearance,
@@ -1597,7 +1597,7 @@ class DefaultEventReporterTest {
         )
     }
 
-    private fun EventReporter.simulateSuccessfulSetup(
+    private fun DefaultEventReporter.simulateSuccessfulSetup(
         paymentSelection: PaymentSelection = PaymentSelection.GooglePay,
         linkEnabled: Boolean = true,
         linkMode: LinkMode? = LinkMode.LinkPaymentMethod,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeEventReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeEventReporter.kt
@@ -6,17 +6,11 @@ import com.stripe.android.common.analytics.experiment.LoggableExperiment
 import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.core.networking.AnalyticsEvent
 import com.stripe.android.model.CardBrand
-import com.stripe.android.model.LinkDisabledReason
-import com.stripe.android.model.LinkMode
-import com.stripe.android.model.LinkSignupDisabledReason
 import com.stripe.android.model.PaymentMethodCode
-import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
-import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormViewModel
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.paymentsheet.state.WalletsState
 
 @Suppress("EmptyFunctionBlock")
@@ -103,36 +97,6 @@ internal class FakeEventReporter : EventReporter {
     ) {
     }
 
-    override fun onLoadStarted(initializedViaCompose: Boolean) {
-    }
-
-    override fun onLoadSucceeded(
-        paymentSelection: PaymentSelection?,
-        linkEnabled: Boolean,
-        linkMode: LinkMode?,
-        linkDisabledReasons: List<LinkDisabledReason>?,
-        linkSignupDisabledReasons: List<LinkSignupDisabledReason>?,
-        googlePaySupported: Boolean,
-        linkDisplay: PaymentSheet.LinkConfiguration.Display,
-        currency: String?,
-        initializationMode: PaymentElementLoader.InitializationMode,
-        financialConnectionsAvailability: FinancialConnectionsAvailability?,
-        orderedLpms: List<String>,
-        requireCvcRecollection: Boolean,
-        hasDefaultPaymentMethod: Boolean?,
-        setAsDefaultEnabled: Boolean?,
-        paymentMethodOptionsSetupFutureUsage: Boolean,
-        setupFutureUsage: StripeIntent.Usage?,
-        openCardScanAutomatically: Boolean,
-    ) {
-    }
-
-    override fun onLoadFailed(error: Throwable) {
-    }
-
-    override fun onElementsSessionLoadFailed(error: Throwable) {
-    }
-
     override fun onDismiss() {
     }
 
@@ -202,9 +166,6 @@ internal class FakeEventReporter : EventReporter {
                 error = error,
             )
         )
-    }
-
-    override fun onLpmSpecFailure(errorMessage: String?) {
     }
 
     override fun onAutofill(type: String) {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -51,8 +51,8 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.PaymentSheetFixtures.MERCHANT_DISPLAY_NAME
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
-import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.FakeLogLinkHoldbackExperiment
+import com.stripe.android.paymentsheet.analytics.LoadingEventReporter
 import com.stripe.android.paymentsheet.cvcrecollection.CvcRecollectionHandlerImpl
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
@@ -94,7 +94,7 @@ import kotlin.test.assertFailsWith
 internal class DefaultPaymentElementLoaderTest {
 
     private val testDispatcher = UnconfinedTestDispatcher()
-    private val eventReporter = mock<EventReporter>()
+    private val eventReporter = mock<LoadingEventReporter>()
 
     private val customerRepository = FakeCustomerRepository(PAYMENT_METHODS)
     private val lpmRepository = LpmRepository()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This is a start of my plan to isolate loading and post loading events.

The current problem is we need state post loading, so we store it in DefaultEventReporter. Storing that state there means we lose it when we create a new instance (ie, EmbeddedPaymentElement and FormActivity have 2 different instances of DefaultEventReporter).

While this doesn't fix that problem, it's the first step of many to get us to a place where we can fix the state issues.

This PR has no behavior changes, and is just a very simple first step of isolating _some_ of what will end up in the loading event reporter long term.
