### PR TITLE
Include full PaymentMethod in LinkPaymentDetails.Saved

### DIFF
--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -22,6 +22,7 @@
     <ID>LargeClass:DefaultConfirmationHandlerTest.kt$DefaultConfirmationHandlerTest</ID>
     <ID>LargeClass:DefaultEventReporterTest.kt$DefaultEventReporterTest</ID>
     <ID>LargeClass:DefaultFlowControllerTest.kt$DefaultFlowControllerTest</ID>
+    <ID>LargeClass:DefaultLinkConfirmationHandlerTest.kt$DefaultLinkConfirmationHandlerTest</ID>
     <ID>LargeClass:DefaultPaymentElementLoaderTest.kt$DefaultPaymentElementLoaderTest</ID>
     <ID>LargeClass:ElementsSessionRepositoryTest.kt$ElementsSessionRepositoryTest</ID>
     <ID>LargeClass:InputAddressViewModelTest.kt$InputAddressViewModelTest</ID>
@@ -54,7 +55,9 @@
     <ID>LongMethod:InputAddressViewModelTest.kt$InputAddressViewModelTest$@OptIn(AddressElementSameAsBillingPreview::class) @Test fun `'Shipping same as billing' should work as expected with both billing &amp; shipping`()</ID>
     <ID>LongMethod:InputAddressViewModelTest.kt$InputAddressViewModelTest$@OptIn(AddressElementSameAsBillingPreview::class) @Test fun `'Shipping same as billing' should work as expected with same billing &amp; shipping &amp; empty values`()</ID>
     <ID>LongMethod:InputAddressViewModelTest.kt$InputAddressViewModelTest$@OptIn(AddressElementSameAsBillingPreview::class) @Test fun `'Shipping same as billing' should work as expected with same billing &amp; shipping`()</ID>
+    <ID>LongMethod:LinkInlineSignupConfirmationDefinitionTest.kt$LinkInlineSignupConfirmationDefinitionTest$@Test fun `'action' should return 'Launch' after successful sign-in &amp; attach`()</ID>
     <ID>LongMethod:LinkInlineSignupConfirmationDefinitionTest.kt$LinkInlineSignupConfirmationDefinitionTest$private fun testSuccessfulSignupWithNewCard( saveOption: LinkInlineSignupConfirmationOption.PaymentMethodSaveOption, expectedSetupForFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage?, expectedShouldSave: Boolean, )</ID>
+    <ID>LongMethod:LinkInlineSignupConfirmationDefinitionTest.kt$LinkInlineSignupConfirmationDefinitionTest$private fun testSuccessfulSignupWithSavedLinkCard( saveOption: LinkInlineSignupConfirmationOption.PaymentMethodSaveOption, expectedSetupForFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage, verifyBillingDetails: Boolean = false, includePaymentMethod: Boolean = false, )</ID>
     <ID>LongMethod:LinkInlineSignupFields.kt$@Composable internal fun LinkInlineSignupFields( sectionError: Int?, emailController: TextFieldController, phoneNumberController: PhoneNumberController, nameController: TextFieldController, signUpState: SignUpState, enabled: Boolean, isShowingPhoneFirst: Boolean, requiresNameCollection: Boolean, allowsDefaultOptIn: Boolean, errorMessage: String?, didShowAllFields: Boolean, onShowingAllFields: () -> Unit, modifier: Modifier = Modifier, emailFocusRequester: FocusRequester = remember { FocusRequester() }, phoneFocusRequester: FocusRequester = remember { FocusRequester() }, nameFocusRequester: FocusRequester = remember { FocusRequester() }, )</ID>
     <ID>LongMethod:PaymentDetails.kt$@Preview(showBackground = true) @Composable private fun PaymentDetailsListItemPreview()</ID>
     <ID>LongMethod:PaymentMethodVerticalLayoutInteractor.kt$DefaultPaymentMethodVerticalLayoutInteractor.Companion$fun create( viewModel: BaseSheetViewModel, paymentMethodMetadata: PaymentMethodMetadata, customerStateHolder: CustomerStateHolder, bankFormInteractor: BankFormInteractor, ): PaymentMethodVerticalLayoutInteractor</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkPaymentDetails.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkPaymentDetails.kt
@@ -2,6 +2,7 @@ package com.stripe.android.link
 
 import android.os.Parcelable
 import com.stripe.android.model.ConsumerPaymentDetails
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.ui.core.forms.convertToFormValuesMap
 import kotlinx.parcelize.Parcelize
@@ -25,7 +26,8 @@ internal sealed class LinkPaymentDetails(
     @Parcelize
     class Saved(
         override val paymentDetails: ConsumerPaymentDetails.Passthrough,
-        override val paymentMethodCreateParams: PaymentMethodCreateParams
+        override val paymentMethodCreateParams: PaymentMethodCreateParams,
+        val paymentMethod: PaymentMethod,
     ) : LinkPaymentDetails(paymentDetails, paymentMethodCreateParams)
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
@@ -18,7 +18,6 @@ import com.stripe.android.model.PaymentMethod.Type.USBankAccount
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.model.SetupIntent
-import com.stripe.android.model.wallets.Wallet
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.link.LinkPassthroughConfirmationOption
@@ -198,17 +197,7 @@ internal class DefaultLinkConfirmationHandler @Inject constructor(
     ): ConfirmationHandler.Args {
         return ConfirmationHandler.Args(
             confirmationOption = PaymentMethodConfirmationOption.Saved(
-                paymentMethod = PaymentMethod.Builder()
-                    .setId(paymentDetails.paymentDetails.paymentMethodId)
-                    .setCode(paymentDetails.paymentMethodCreateParams.typeCode)
-                    .setCard(
-                        PaymentMethod.Card(
-                            last4 = paymentDetails.paymentDetails.last4,
-                            wallet = Wallet.LinkWallet(paymentDetails.paymentDetails.last4),
-                        )
-                    )
-                    .setType(PaymentMethod.Type.Card)
-                    .build(),
+                paymentMethod = paymentDetails.paymentMethod,
                 optionsParams = PaymentMethodOptionsParams.Card(
                     setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession,
                     cvc = cvc?.takeIf {

--- a/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
@@ -321,6 +321,7 @@ internal class LinkApiRepository @Inject constructor(
                     extraParams = extraConfirmationParams(paymentMethodCreateParams.toParamMap()),
                     clientAttributionMetadata = clientAttributionMetadata,
                 ),
+                paymentMethod = paymentMethod,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinition.kt
@@ -10,11 +10,8 @@ import com.stripe.android.link.analytics.LinkAnalyticsHelper
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.model.ConfirmPaymentIntentParams
-import com.stripe.android.model.PaymentMethod
-import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.PaymentMethodOptionsParams
-import com.stripe.android.model.wallets.Wallet
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
@@ -139,30 +136,17 @@ internal class LinkInlineSignupConfirmationDefinition(
             is LinkPaymentDetails.Saved -> {
                 linkStore.markLinkAsUsed()
 
-                linkPaymentDetails.toSavedOption(createParams, saveOption)
+                linkPaymentDetails.toSavedOption(saveOption)
             }
             null -> linkInlineSignupConfirmationOption.toNewOption()
         }
     }
 
     private fun LinkPaymentDetails.Saved.toSavedOption(
-        createParams: PaymentMethodCreateParams,
         saveOption: LinkInlineSignupConfirmationOption.PaymentMethodSaveOption,
     ): PaymentMethodConfirmationOption.Saved {
-        val last4 = paymentDetails.last4
-
         return PaymentMethodConfirmationOption.Saved(
-            paymentMethod = PaymentMethod.Builder()
-                .setId(paymentDetails.paymentMethodId)
-                .setCode(createParams.typeCode)
-                .setCard(
-                    PaymentMethod.Card(
-                        last4 = last4,
-                        wallet = Wallet.LinkWallet(last4),
-                    )
-                )
-                .setType(PaymentMethod.Type.Card)
-                .build(),
+            paymentMethod = paymentMethod,
             optionsParams = PaymentMethodOptionsParams.Card(
                 setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession.takeIf {
                     saveOption.shouldSave()

--- a/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
@@ -30,8 +30,10 @@ import com.stripe.android.model.PaymentIntentCreationFlow
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.model.PaymentMethodSelectionFlow
 import com.stripe.android.model.SharePaymentDetails
+import com.stripe.android.model.wallets.Wallet
 import com.stripe.android.networking.RequestSurface
 import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -174,6 +176,32 @@ internal object TestFactory {
     val LINK_SAVED_PAYMENT_DETAILS = LinkPaymentDetails.Saved(
         paymentDetails = CONSUMER_PAYMENT_DETAILS_PASSTHROUGH,
         paymentMethodCreateParams = PAYMENT_METHOD_CREATE_PARAMS,
+        paymentMethod = PaymentMethod.Builder()
+            .setId(CONSUMER_PAYMENT_DETAILS_PASSTHROUGH.paymentMethodId)
+            .setType(PaymentMethod.Type.Card)
+            .setCard(
+                PaymentMethod.Card(
+                    last4 = CONSUMER_PAYMENT_DETAILS_PASSTHROUGH.last4,
+                    wallet = Wallet.LinkWallet(CONSUMER_PAYMENT_DETAILS_PASSTHROUGH.last4),
+                )
+            )
+            .build(),
+    )
+
+    val LINK_SAVED_PAYMENT_DETAILS_WITH_BILLING = LinkPaymentDetails.Saved(
+        paymentDetails = CONSUMER_PAYMENT_DETAILS_PASSTHROUGH,
+        paymentMethodCreateParams = PAYMENT_METHOD_CREATE_PARAMS,
+        paymentMethod = PaymentMethod.Builder()
+            .setId(CONSUMER_PAYMENT_DETAILS_PASSTHROUGH.paymentMethodId)
+            .setType(PaymentMethod.Type.Card)
+            .setCard(
+                PaymentMethod.Card(
+                    last4 = CONSUMER_PAYMENT_DETAILS_PASSTHROUGH.last4,
+                    wallet = Wallet.LinkWallet(CONSUMER_PAYMENT_DETAILS_PASSTHROUGH.last4),
+                )
+            )
+            .setBillingDetails(PaymentMethodCreateParamsFixtures.BILLING_DETAILS)
+            .build(),
     )
 
     val LINK_ACCOUNT = LinkAccount(CONSUMER_SESSION)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
@@ -164,6 +164,15 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
         )
 
     @Test
+    fun `'action' should include billing details in saved option when PaymentMethod is provided`() =
+        testSuccessfulSignupWithSavedLinkCard(
+            saveOption = LinkInlineSignupConfirmationOption.PaymentMethodSaveOption.NoRequest,
+            expectedSetupForFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.Blank,
+            verifyBillingDetails = true,
+            includePaymentMethod = true,
+        )
+
+    @Test
     fun `'action' should skip & return 'Launch' if input is sign in`() = test(
         initialAccountStatus = AccountStatus.Verified(true, null),
     ) {
@@ -228,6 +237,16 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
                     paymentMethodId = "pm_1",
                 ),
                 paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                paymentMethod = PaymentMethod.Builder()
+                    .setId("pm_1")
+                    .setType(PaymentMethod.Type.Card)
+                    .setCard(
+                        PaymentMethod.Card(
+                            last4 = "4242",
+                            wallet = Wallet.LinkWallet("4242"),
+                        )
+                    )
+                    .build(),
             )
         ),
         signInResult = Result.success(true),
@@ -474,10 +493,28 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
     private fun testSuccessfulSignupWithSavedLinkCard(
         saveOption: LinkInlineSignupConfirmationOption.PaymentMethodSaveOption,
         expectedSetupForFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage,
+        verifyBillingDetails: Boolean = false,
+        includePaymentMethod: Boolean = false,
     ) {
         val confirmationOption = createLinkInlineSignupConfirmationOption(
             saveOption = saveOption,
         )
+
+        val paymentMethod = PaymentMethod.Builder()
+            .setId("pm_1")
+            .setType(PaymentMethod.Type.Card)
+            .setCard(
+                PaymentMethod.Card(
+                    last4 = "4242",
+                    wallet = Wallet.LinkWallet("4242"),
+                )
+            )
+            .apply {
+                if (includePaymentMethod) {
+                    setBillingDetails(PaymentMethodCreateParamsFixtures.BILLING_DETAILS)
+                }
+            }
+            .build()
 
         actionTest(
             attachNewCardToAccountResult = Result.success(
@@ -488,6 +525,7 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
                         paymentMethodId = "pm_1",
                     ),
                     paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                    paymentMethod = paymentMethod,
                 )
             ),
             signInResult = Result.success(true),
@@ -514,12 +552,18 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
 
             assertThat(savedConfirmationOption.originatedFromWallet).isTrue()
 
-            val paymentMethod = savedConfirmationOption.paymentMethod
+            val resultPaymentMethod = savedConfirmationOption.paymentMethod
 
-            assertThat(paymentMethod.id).isEqualTo("pm_1")
-            assertThat(paymentMethod.type).isEqualTo(PaymentMethod.Type.Card)
-            assertThat(paymentMethod.card?.last4).isEqualTo("4242")
-            assertThat(paymentMethod.card?.wallet).isEqualTo(Wallet.LinkWallet(dynamicLast4 = "4242"))
+            assertThat(resultPaymentMethod.id).isEqualTo("pm_1")
+            assertThat(resultPaymentMethod.type).isEqualTo(PaymentMethod.Type.Card)
+            assertThat(resultPaymentMethod.card?.last4).isEqualTo("4242")
+            assertThat(resultPaymentMethod.card?.wallet).isEqualTo(Wallet.LinkWallet(dynamicLast4 = "4242"))
+
+            if (verifyBillingDetails) {
+                assertThat(resultPaymentMethod.billingDetails).isEqualTo(
+                    PaymentMethodCreateParamsFixtures.BILLING_DETAILS
+                )
+            }
 
             assertThat(launchAction.receivesResultInProcess).isTrue()
             assertThat(launchAction.deferredIntentConfirmationType).isNull()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
@@ -12,6 +12,7 @@ import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.CvcCheck
 import com.stripe.android.model.LinkMode
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.wallets.Wallet
 import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
@@ -35,6 +36,16 @@ internal object LinkTestUtils {
             )
         ),
         paymentMethodCreateParams = mock(),
+        paymentMethod = PaymentMethod.Builder()
+            .setId("pm_123")
+            .setType(PaymentMethod.Type.Card)
+            .setCard(
+                PaymentMethod.Card(
+                    last4 = "4242",
+                    wallet = Wallet.LinkWallet("4242"),
+                )
+            )
+            .build(),
     )
 
     val LINK_NEW_PAYMENT_DETAILS = LinkPaymentDetails.New(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This ensures billing details are preserved when using saved Link payment methods rather than reconstructing a partial PaymentMethod object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Committed-By-Agent: claude

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

[RUN_LINK_MOBILE-54](https://jira.corp.stripe.com/browse/RUN_LINK_MOBILE-54)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
