### PR TITLE
Get gradle managed device logs for better debugging.

### DIFF
--- a/scripts/copy_test_results_to_tmp.sh
+++ b/scripts/copy_test_results_to_tmp.sh
@@ -18,6 +18,7 @@ touch "/tmp/test_results/.keep"
 copy_test_results ".*/build/reports/tests/testDebugUnitTest$"
 copy_test_results ".*/build/reports/androidTests/connected$"
 copy_test_results ".*/build/reports/androidTests/managedDevice$"
+copy_test_results ".*/build/outputs/androidTest-results/managedDevice$"
 
 # If screenshots were requested, and it's a failure.
 if [ "$INCLUDE_SCREENSHOT_ON_FAILURE" == "true" ] && [ "$BITRISE_BUILD_STATUS" == 1 ]; then


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
We weren't getting the logcat logs from gradle managed devices, making test failures hard to figure out. This should help!
