### PR TITLE
Only retry in CI.

### DIFF
--- a/payments-core-testing/build.gradle
+++ b/payments-core-testing/build.gradle
@@ -1,5 +1,11 @@
 apply from: configs.androidLibrary
 
+android {
+    defaultConfig {
+        buildConfigField "boolean", "IS_RUNNING_IN_CI", "$gradle.ext.isCi"
+    }
+}
+
 dependencies {
     implementation project(":payments-core")
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
We've had quite a few flakey tests, and I think part of that is because we're retrying when developing tests, which can one be confusing to see breakpoints hit multiple times, but also can lead to flakey tests in CI.

By only running tests once locally, but allowing retries to happen in CI, we'll end up having better tests.