### PR TITLE
Introduce IntegrationMetadata, and add validation during configuration.

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -779,6 +779,46 @@ public final class com/stripe/android/lpmfoundations/paymentmethod/DisplayableCu
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/lpmfoundations/paymentmethod/IntegrationMetadata$CustomerSheet$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/lpmfoundations/paymentmethod/IntegrationMetadata$CustomerSheet;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/lpmfoundations/paymentmethod/IntegrationMetadata$CustomerSheet;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/lpmfoundations/paymentmethod/IntegrationMetadata$DeferredIntentWithConfirmationToken$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/lpmfoundations/paymentmethod/IntegrationMetadata$DeferredIntentWithConfirmationToken;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/lpmfoundations/paymentmethod/IntegrationMetadata$DeferredIntentWithConfirmationToken;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/lpmfoundations/paymentmethod/IntegrationMetadata$DeferredIntentWithPaymentMethod$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/lpmfoundations/paymentmethod/IntegrationMetadata$DeferredIntentWithPaymentMethod;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/lpmfoundations/paymentmethod/IntegrationMetadata$DeferredIntentWithPaymentMethod;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/lpmfoundations/paymentmethod/IntegrationMetadata$DeferredIntentWithSharedPaymentToken$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/lpmfoundations/paymentmethod/IntegrationMetadata$DeferredIntentWithSharedPaymentToken;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/lpmfoundations/paymentmethod/IntegrationMetadata$DeferredIntentWithSharedPaymentToken;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/lpmfoundations/paymentmethod/IntegrationMetadata$IntentFirst$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/lpmfoundations/paymentmethod/IntegrationMetadata$IntentFirst;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/lpmfoundations/paymentmethod/IntegrationMetadata$IntentFirst;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata;

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
@@ -258,6 +258,11 @@ internal class FlowControllerTest {
             networkRule = networkRule,
             integrationType = integrationType,
             callConfirmOnPaymentOptionCallback = false,
+            builder = {
+                createIntentCallback { _ ->
+                    error("Not expected to be called.")
+                }
+            },
             resultCallback = ::assertCompleted,
         ) { testContext ->
             networkRule.enqueue(
@@ -1281,6 +1286,11 @@ internal class FlowControllerTest {
     ) = runFlowControllerTest(
         networkRule = networkRule,
         integrationType = integrationType,
+        builder = {
+            createIntentCallback { _ ->
+                error("Not expected to be called.")
+            }
+        },
         resultCallback = ::assertCompleted,
     ) { testContext ->
         networkRule.enqueue(
@@ -1325,6 +1335,11 @@ internal class FlowControllerTest {
     ) = runFlowControllerTest(
         networkRule = networkRule,
         integrationType = integrationType,
+        builder = {
+            createIntentCallback { _ ->
+                error("Not expected to be called.")
+            }
+        },
         resultCallback = ::assertCompleted,
     ) { testContext ->
         val oboMerchantID = "acct_connected_1234"

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
@@ -823,6 +823,11 @@ internal class PaymentSheetTest {
     fun testTermsDisplayNeverHidesMandate() = runPaymentSheetTest(
         networkRule = networkRule,
         integrationType = integrationType,
+        builder = {
+            createIntentCallback { _ ->
+                error("Not expected to be called.")
+            }
+        },
         resultCallback = ::assertCompleted,
     ) { testContext ->
         networkRule.enqueue(
@@ -886,6 +891,11 @@ internal class PaymentSheetTest {
     fun testOBO_PassedToElementsSessionCall() = runPaymentSheetTest(
         networkRule = networkRule,
         integrationType = integrationType,
+        builder = {
+            createIntentCallback { _ ->
+                error("Not expected to be called.")
+            }
+        },
         resultCallback = ::assertCompleted,
     ) { testContext ->
         val oboMerchantID = "acct_connected_1234"

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/IntegrationMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/IntegrationMetadata.kt
@@ -1,0 +1,23 @@
+package com.stripe.android.lpmfoundations.paymentmethod
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+internal sealed class IntegrationMetadata : Parcelable {
+    @Parcelize
+    object IntentFirst : IntegrationMetadata()
+
+    @Parcelize
+    object DeferredIntentWithPaymentMethod : IntegrationMetadata()
+
+    @Parcelize
+    object DeferredIntentWithSharedPaymentToken : IntegrationMetadata()
+
+    @Parcelize
+    object DeferredIntentWithConfirmationToken : IntegrationMetadata()
+
+    // CustomerSheet doesn't really fit the bill of any of the other integrations, so making it's own, even though it's
+    // not ideal.
+    @Parcelize
+    object CustomerSheet : IntegrationMetadata()
+}

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -19,6 +19,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.paymentelement.callbacks.PaymentElementCallbacks
 import com.stripe.android.paymentelement.confirmation.utils.sellerBusinessName
 import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 import com.stripe.android.payments.financialconnections.GetFinancialConnectionsAvailability
@@ -81,6 +82,7 @@ internal data class PaymentMethodMetadata(
     val attestOnIntentConfirmation: Boolean,
     val appearance: PaymentSheet.Appearance,
     val onBehalfOf: String?,
+    val integrationMetadata: IntegrationMetadata,
 ) : Parcelable {
 
     @IgnoredOnParcel
@@ -324,6 +326,7 @@ internal data class PaymentMethodMetadata(
             customerMetadata: CustomerMetadata?,
             initializationMode: PaymentElementLoader.InitializationMode,
             clientAttributionMetadata: ClientAttributionMetadata,
+            paymentElementCallbacks: PaymentElementCallbacks?,
         ): PaymentMethodMetadata {
             val linkSettings = elementsSession.linkSettings
             return PaymentMethodMetadata(
@@ -371,6 +374,7 @@ internal data class PaymentMethodMetadata(
                 attestOnIntentConfirmation = elementsSession.enableAttestationOnIntentConfirmation,
                 appearance = configuration.appearance,
                 onBehalfOf = elementsSession.onBehalfOf,
+                integrationMetadata = initializationMode.integrationMetadata(paymentElementCallbacks),
             )
         }
 
@@ -433,6 +437,7 @@ internal data class PaymentMethodMetadata(
                 attestOnIntentConfirmation = elementsSession.enableAttestationOnIntentConfirmation,
                 appearance = configuration.appearance,
                 onBehalfOf = elementsSession.onBehalfOf,
+                integrationMetadata = IntegrationMetadata.CustomerSheet,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.state
 
 import android.os.Parcelable
+import com.stripe.android.SharedPaymentTokenSessionPreview
 import com.stripe.android.common.analytics.experiment.LogLinkHoldbackExperiment
 import com.stripe.android.common.coroutines.runCatching
 import com.stripe.android.common.model.CommonConfiguration
@@ -19,6 +20,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata.Permissions.Companion.createForPaymentSheetCustomerSession
 import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata.Permissions.Companion.createForPaymentSheetLegacyEphemeralKey
 import com.stripe.android.lpmfoundations.paymentmethod.IS_PAYMENT_METHOD_SET_AS_DEFAULT_ENABLED_DEFAULT_VALUE
+import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilter
 import com.stripe.android.lpmfoundations.paymentmethod.create
@@ -28,6 +30,9 @@ import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
+import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
+import com.stripe.android.paymentelement.callbacks.PaymentElementCallbacks
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.financialconnections.GetFinancialConnectionsAvailability
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -79,6 +84,7 @@ internal interface PaymentElementLoader {
 
     sealed class InitializationMode : Parcelable {
         abstract fun validate()
+        abstract fun integrationMetadata(paymentElementCallbacks: PaymentElementCallbacks?): IntegrationMetadata
 
         @Parcelize
         data class PaymentIntent(
@@ -87,6 +93,10 @@ internal interface PaymentElementLoader {
 
             override fun validate() {
                 PaymentIntentClientSecret(clientSecret).validate()
+            }
+
+            override fun integrationMetadata(paymentElementCallbacks: PaymentElementCallbacks?): IntegrationMetadata {
+                return IntegrationMetadata.IntentFirst
             }
         }
 
@@ -97,6 +107,10 @@ internal interface PaymentElementLoader {
 
             override fun validate() {
                 SetupIntentClientSecret(clientSecret).validate()
+            }
+
+            override fun integrationMetadata(paymentElementCallbacks: PaymentElementCallbacks?): IntegrationMetadata {
+                return IntegrationMetadata.IntentFirst
             }
         }
 
@@ -112,6 +126,22 @@ internal interface PaymentElementLoader {
                             "Payment IntentConfiguration requires a positive amount."
                         )
                     }
+                }
+            }
+
+            @OptIn(SharedPaymentTokenSessionPreview::class)
+            override fun integrationMetadata(paymentElementCallbacks: PaymentElementCallbacks?): IntegrationMetadata {
+                return when {
+                    paymentElementCallbacks?.preparePaymentMethodHandler != null -> {
+                        IntegrationMetadata.DeferredIntentWithSharedPaymentToken
+                    }
+                    paymentElementCallbacks?.createIntentWithConfirmationTokenCallback != null -> {
+                        IntegrationMetadata.DeferredIntentWithConfirmationToken
+                    }
+                    paymentElementCallbacks?.createIntentCallback != null -> {
+                        IntegrationMetadata.DeferredIntentWithPaymentMethod
+                    }
+                    else -> throw IllegalStateException("No callback for deferred intent.")
                 }
             }
         }
@@ -156,6 +186,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
     private val cvcRecollectionHandler: CvcRecollectionHandler,
     private val integrityRequestManager: IntegrityRequestManager,
     @Named(IS_LIVE_MODE) private val isLiveModeProvider: () -> Boolean,
+    @PaymentElementCallbackIdentifier private val paymentElementCallbackIdentifier: String,
 ) : PaymentElementLoader {
 
     @Suppress("LongMethod")
@@ -374,6 +405,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
             ),
             initializationMode = initializationMode,
             clientAttributionMetadata = clientAttributionMetadata,
+            paymentElementCallbacks = PaymentElementCallbackReferences[paymentElementCallbackIdentifier],
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
@@ -59,6 +59,7 @@ internal object PaymentMethodMetadataFactory {
         attestOnIntentConfirmation: Boolean = false,
         appearance: PaymentSheet.Appearance = PaymentSheet.Appearance(),
         onBehalfOf: String? = null,
+        integrationMetadata: IntegrationMetadata = IntegrationMetadata.IntentFirst,
     ): PaymentMethodMetadata {
         return PaymentMethodMetadata(
             stripeIntent = stripeIntent,
@@ -104,6 +105,7 @@ internal object PaymentMethodMetadataFactory {
             attestOnIntentConfirmation = attestOnIntentConfirmation,
             appearance = appearance,
             onBehalfOf = onBehalfOf,
+            integrationMetadata = integrationMetadata,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -25,6 +25,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.paymentelement.callbacks.PaymentElementCallbacks
 import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
@@ -1114,6 +1115,7 @@ internal class PaymentMethodMetadataTest {
             customerMetadata = DEFAULT_CUSTOMER_METADATA,
             initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent("cs_123"),
             clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
+            paymentElementCallbacks = PaymentElementCallbacks.Builder().build(),
         )
 
         val expectedMetadata = PaymentMethodMetadata(
@@ -1177,6 +1179,7 @@ internal class PaymentMethodMetadataTest {
             attestOnIntentConfirmation = false,
             appearance = configuration.appearance,
             onBehalfOf = null,
+            integrationMetadata = IntegrationMetadata.IntentFirst,
         )
 
         assertThat(metadata).isEqualTo(expectedMetadata)
@@ -1263,6 +1266,7 @@ internal class PaymentMethodMetadataTest {
             attestOnIntentConfirmation = false,
             appearance = configuration.appearance,
             onBehalfOf = null,
+            integrationMetadata = IntegrationMetadata.CustomerSheet,
         )
         assertThat(metadata).isEqualTo(expectedMetadata)
     }
@@ -1337,6 +1341,7 @@ internal class PaymentMethodMetadataTest {
             customerMetadata = DEFAULT_CUSTOMER_METADATA,
             initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent("cs_123"),
             clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
+            paymentElementCallbacks = PaymentElementCallbacks.Builder().build(),
         )
     }
 
@@ -2055,6 +2060,7 @@ internal class PaymentMethodMetadataTest {
             customerMetadata = DEFAULT_CUSTOMER_METADATA,
             initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent("cs_123"),
             clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
+            paymentElementCallbacks = PaymentElementCallbacks.Builder().build(),
         )
 
         assertThat(metadata.availableWallets)
@@ -2115,6 +2121,7 @@ internal class PaymentMethodMetadataTest {
             customerMetadata = null,
             initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent("cs_123"),
             clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
+            paymentElementCallbacks = PaymentElementCallbacks.Builder().build(),
         )
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
I'm planning to use this in analytics so we know everything we need from PaymentMethodMetadata without having to store state in DefaultEventReporter.
