### PR TITLE
Fix placeholder handling in Lokalise script

### DIFF
--- a/scripts/lokalise/lokalise_client.rb
+++ b/scripts/lokalise/lokalise_client.rb
@@ -30,6 +30,12 @@ class LokaliseClient
 
         set_request_x_api_token(request)
 
+        translation = key_object[:lokalise_value]
+
+        # Wrap placeholders in [] so that Lokalise creates the correct iOS strings
+        # Example: "Hi %s" becomes "Hi [%s]".
+        translation = translation.gsub(/%\d+$[sd]|%[sd]/) { |m| "[#{m}]" }
+
         request_body = {
             "keys": [
                 {
@@ -46,7 +52,7 @@ class LokaliseClient
                     "translations": [
                         {
                             "language_iso": "en",
-                            "translation": key_object[:lokalise_value],
+                            "translation": translation,
                             "is_reviewed": true,
                             "is_unverified": false,
                             "is_archived": false,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request updates the Lokalise script to fix an issue where new strings with placeholders such as `%s` would be sent to Lokalise and synced to iOS with an invalid placeholder string (using the same `%s` instead of `%@`).

This has rarely been an issue, since (1) iOS work is typically ahead of Android work and (2) we rarely add strings with placeholders. However, it happened for `stripe_link_verification_message_short`, which is now displayed incorrectly in some locales.

Going by [this note](https://developers.lokalise.com/reference/api-plurals-and-placeholders#placeholder-format-descriptions) on the Lokalise site, which suggests to send `[%s]` instead of `%s`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

[RUN_LINK_MOBILE-52](https://jira.corp.stripe.com/browse/RUN_LINK_MOBILE-52)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
