### PR TITLE
Use integration metadata in ConfirmationHandler.

### DIFF
--- a/payments-core-testing/src/main/java/com/stripe/android/testing/PaymentIntentFactory.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/PaymentIntentFactory.kt
@@ -9,6 +9,7 @@ object PaymentIntentFactory {
 
     fun create(
         id: String? = "pi_12345",
+        clientSecret: String? = "secret",
         paymentMethod: PaymentMethod? = createCardPaymentMethod(),
         paymentMethodTypes: List<String> = listOf("card"),
         setupFutureUsage: StripeIntent.Usage? = null,
@@ -18,14 +19,15 @@ object PaymentIntentFactory {
         linkFundingSources: List<String> = emptyList(),
         countryCode: String? = null,
         amount: Long = 1000L,
+        currency: String? = "usd",
     ): PaymentIntent = PaymentIntent(
         created = 500L,
         amount = amount,
-        clientSecret = "secret",
+        clientSecret = clientSecret,
         paymentMethod = paymentMethod,
         isLiveMode = false,
         id = id,
-        currency = "usd",
+        currency = currency,
         countryCode = countryCode,
         paymentMethodTypes = paymentMethodTypes,
         status = status,

--- a/payments-core-testing/src/main/java/com/stripe/android/testing/SetupIntentFactory.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/SetupIntentFactory.kt
@@ -6,6 +6,11 @@ import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
 
 object SetupIntentFactory {
+    fun createDeferredIntent(): SetupIntent = create(
+        clientSecret = null,
+        id = null,
+    )
+
     fun create(
         paymentMethod: PaymentMethod? = createCardPaymentMethod(),
         paymentMethodTypes: List<String> = listOf("card"),
@@ -15,12 +20,14 @@ object SetupIntentFactory {
         countryCode: String? = null,
         cancellationReason: SetupIntent.CancellationReason? = null,
         usage: StripeIntent.Usage? = null,
+        clientSecret: String? = "secret",
+        id: String? = "pi_12345",
     ): SetupIntent = SetupIntent(
         created = 500L,
-        clientSecret = "secret",
+        clientSecret = clientSecret,
         paymentMethod = paymentMethod,
         isLiveMode = false,
-        id = "pi_12345",
+        id = id,
         countryCode = countryCode,
         paymentMethodTypes = paymentMethodTypes,
         status = status,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -39,6 +39,7 @@ import com.stripe.android.customersheet.util.CustomerSheetHacks
 import com.stripe.android.customersheet.util.isUnverifiedUSBankAccount
 import com.stripe.android.customersheet.util.sortPaymentMethods
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
+import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilter
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
@@ -68,7 +69,6 @@ import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.model.toSavedSelection
 import com.stripe.android.paymentsheet.parseAppearance
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormArguments
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.paymentsheet.ui.DefaultUpdatePaymentMethodInteractor
 import com.stripe.android.paymentsheet.ui.PaymentMethodRemovalDelayMillis
 import com.stripe.android.paymentsheet.ui.PrimaryButton
@@ -1050,10 +1050,9 @@ internal class CustomerSheetViewModel(
                     paymentMethod = paymentMethod,
                     optionsParams = null,
                 ),
-                initializationMode = PaymentElementLoader.InitializationMode.SetupIntent(
-                    clientSecret = clientSecret
+                paymentMethodMetadata = metadata.copy(
+                    integrationMetadata = IntegrationMetadata.IntentFirst(clientSecret = clientSecret)
                 ),
-                paymentMethodMetadata = metadata,
             )
         )
 

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkConfiguration.kt
@@ -9,7 +9,6 @@ import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -31,7 +30,6 @@ internal data class LinkConfiguration(
     val useAttestationEndpointsForLink: Boolean,
     val suppress2faModal: Boolean,
     val disableRuxInFlowController: Boolean,
-    val initializationMode: PaymentElementLoader.InitializationMode,
     val elementsSessionId: String,
     val linkMode: LinkMode?,
     val allowDefaultOptIn: Boolean,

--- a/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
@@ -173,7 +173,6 @@ internal class DefaultLinkConfirmationHandler @Inject constructor(
 
         return ConfirmationHandler.Args(
             confirmationOption = confirmationOption,
-            initializationMode = configuration.initializationMode,
             paymentMethodMetadata = paymentMethodMetadata,
         )
     }
@@ -216,7 +215,6 @@ internal class DefaultLinkConfirmationHandler @Inject constructor(
                     }
                 ),
             ),
-            initializationMode = configuration.initializationMode,
             paymentMethodMetadata = paymentMethodMetadata,
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/IntegrationMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/IntegrationMetadata.kt
@@ -1,20 +1,29 @@
 package com.stripe.android.lpmfoundations.paymentmethod
 
 import android.os.Parcelable
+import com.stripe.android.paymentsheet.PaymentSheet.IntentConfiguration
 import kotlinx.parcelize.Parcelize
 
 internal sealed class IntegrationMetadata : Parcelable {
     @Parcelize
-    object IntentFirst : IntegrationMetadata()
+    data class IntentFirst(
+        val clientSecret: String,
+    ) : IntegrationMetadata()
 
     @Parcelize
-    object DeferredIntentWithPaymentMethod : IntegrationMetadata()
+    data class DeferredIntentWithPaymentMethod(
+        val intentConfiguration: IntentConfiguration,
+    ) : IntegrationMetadata()
 
     @Parcelize
-    object DeferredIntentWithSharedPaymentToken : IntegrationMetadata()
+    data class DeferredIntentWithSharedPaymentToken(
+        val intentConfiguration: IntentConfiguration,
+    ) : IntegrationMetadata()
 
     @Parcelize
-    object DeferredIntentWithConfirmationToken : IntegrationMetadata()
+    data class DeferredIntentWithConfirmationToken(
+        val intentConfiguration: IntentConfiguration,
+    ) : IntegrationMetadata()
 
     // CustomerSheet doesn't really fit the bill of any of the other integrations, so making it's own, even though it's
     // not ideal.

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandler.kt
@@ -8,7 +8,6 @@ import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.parcelize.IgnoredOnParcel
@@ -71,11 +70,6 @@ internal interface ConfirmationHandler {
          * The confirmation option used to in order to potentially confirm the intent
          */
         val confirmationOption: Option,
-
-        /**
-         * The mode that a Payment Element product was initialized with
-         */
-        val initializationMode: PaymentElementLoader.InitializationMode,
 
         /**
          * The immutable data created during configuration.

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationDefinition.kt
@@ -38,7 +38,7 @@ internal class IntentConfirmationDefinition(
         val interceptor: IntentConfirmationInterceptor
         try {
             interceptor = intentConfirmationInterceptorFactory.create(
-                initializationMode = confirmationArgs.initializationMode,
+                integrationMetadata = confirmationArgs.paymentMethodMetadata.integrationMetadata,
                 customerId = paymentMethodMetadata.customerMetadata?.id,
                 ephemeralKeySecret = paymentMethodMetadata.customerMetadata?.ephemeralKeySecret,
                 clientAttributionMetadata = paymentMethodMetadata.clientAttributionMetadata,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
@@ -122,7 +122,6 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
             paymentMethodMetadata = paymentMethodMetadata,
             hasSavedPaymentMethods = hasSavedPaymentMethods,
             configuration = embeddedConfirmationState.configuration,
-            initializationMode = embeddedConfirmationState.initializationMode,
             paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
             statusBarColor = statusBarColor,
             paymentSelection = currentSelection,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfigurationCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfigurationCoordinator.kt
@@ -42,7 +42,6 @@ internal class DefaultEmbeddedConfigurationCoordinator @Inject constructor(
                 onSuccess = { state ->
                     handleLoadedState(
                         state = state,
-                        intentConfiguration = intentConfiguration,
                         configuration = configuration,
                     )
                     ConfigureResult.Succeeded()
@@ -56,7 +55,6 @@ internal class DefaultEmbeddedConfigurationCoordinator @Inject constructor(
 
     private fun handleLoadedState(
         state: PaymentElementLoader.State,
-        intentConfiguration: PaymentSheet.IntentConfiguration,
         configuration: EmbeddedPaymentElement.Configuration,
     ) {
         val newPaymentSelection = selectionChooser.choose(
@@ -71,9 +69,6 @@ internal class DefaultEmbeddedConfigurationCoordinator @Inject constructor(
             confirmationState = EmbeddedConfirmationStateHolder.State(
                 paymentMethodMetadata = state.paymentMethodMetadata,
                 selection = newPaymentSelection,
-                initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
-                    intentConfiguration
-                ),
                 configuration = configuration,
             ),
             customer = state.customer,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationHelper.kt
@@ -59,7 +59,6 @@ internal class DefaultEmbeddedConfirmationHelper @Inject constructor(
 
         return ConfirmationHandler.Args(
             confirmationOption = confirmationOption,
-            initializationMode = confirmationState.initializationMode,
             paymentMethodMetadata = confirmationState.paymentMethodMetadata,
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationStateHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationStateHolder.kt
@@ -7,7 +7,6 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -42,7 +41,6 @@ internal class EmbeddedConfirmationStateHolder @Inject constructor(
     data class State(
         val paymentMethodMetadata: PaymentMethodMetadata,
         val selection: PaymentSelection?,
-        val initializationMode: PaymentElementLoader.InitializationMode,
         val configuration: EmbeddedPaymentElement.Configuration,
     ) : Parcelable
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModelComponent.kt
@@ -170,13 +170,6 @@ internal interface EmbeddedPaymentElementViewModelModule {
         }
 
         @Provides
-        fun providesInitializationMode(
-            stateHolder: EmbeddedConfirmationStateHolder
-        ): PaymentElementLoader.InitializationMode? {
-            return stateHolder.state?.initializationMode
-        }
-
-        @Provides
         @Named(IS_LIVE_MODE)
         fun providesIsLiveMode(
             paymentConfiguration: Provider<PaymentConfiguration>

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityConfirmationHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityConfirmationHelper.kt
@@ -11,7 +11,6 @@ import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.toConfirmationOption
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentsheet.analytics.EventReporter
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -23,7 +22,6 @@ internal interface FormActivityConfirmationHelper {
 
 @FormActivityScope
 internal class DefaultFormActivityConfirmationHelper @Inject constructor(
-    private val initializationMode: PaymentElementLoader.InitializationMode,
     private val paymentMethodMetadata: PaymentMethodMetadata,
     private val confirmationHandler: ConfirmationHandler,
     private val configuration: EmbeddedPaymentElement.Configuration,
@@ -83,7 +81,6 @@ internal class DefaultFormActivityConfirmationHelper @Inject constructor(
         ) ?: return null
         return ConfirmationHandler.Args(
             confirmationOption = confirmationOption,
-            initializationMode = initializationMode,
             paymentMethodMetadata = paymentMethodMetadata,
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityViewModel.kt
@@ -29,7 +29,6 @@ internal class FormActivityViewModel @Inject constructor(
                 selectedPaymentMethodCode = args.selectedPaymentMethodCode,
                 hasSavedPaymentMethods = args.hasSavedPaymentMethods,
                 configuration = args.configuration,
-                initializationMode = args.initializationMode,
                 statusBarColor = args.statusBarColor,
                 application = extras.requireApplication(),
                 paymentElementCallbackIdentifier = args.paymentElementCallbackIdentifier,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityViewModelComponent.kt
@@ -24,7 +24,6 @@ import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.PrefsRepository
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.paymentsheet.verticalmode.DefaultVerticalModeFormInteractor
 import dagger.Binds
 import dagger.BindsInstance
@@ -62,7 +61,6 @@ internal interface FormActivityViewModelComponent {
             @Named(STATUS_BAR_COLOR)
             statusBarColor: Int?,
             @BindsInstance configuration: EmbeddedPaymentElement.Configuration,
-            @BindsInstance initializationMode: PaymentElementLoader.InitializationMode,
             @BindsInstance
             @PaymentElementCallbackIdentifier
             paymentElementCallbackIdentifier: String,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormContract.kt
@@ -8,7 +8,6 @@ import androidx.core.os.BundleCompat
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.view.ActivityStarter
 import kotlinx.parcelize.Parcelize
 
@@ -58,7 +57,6 @@ internal object FormContract : ActivityResultContract<FormContract.Args, FormRes
         val paymentMethodMetadata: PaymentMethodMetadata,
         val hasSavedPaymentMethods: Boolean,
         val configuration: EmbeddedPaymentElement.Configuration,
-        val initializationMode: PaymentElementLoader.InitializationMode,
         val paymentElementCallbackIdentifier: String,
         val statusBarColor: Int?,
         val paymentSelection: PaymentSelection?,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -513,7 +513,6 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                 confirmationHandler.start(
                     arguments = ConfirmationHandler.Args(
                         confirmationOption = option,
-                        initializationMode = args.initializationMode,
                         paymentMethodMetadata = paymentMethodMetadata,
                     ),
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -113,9 +113,6 @@ internal class DefaultFlowController @Inject internal constructor(
      */
     lateinit var flowControllerComponent: FlowControllerComponent
 
-    private val initializationMode: PaymentElementLoader.InitializationMode?
-        get() = viewModel.previousConfigureRequest?.initializationMode
-
     override var shippingDetails: AddressDetails?
         get() = viewModel.state?.config?.shippingDetails
         set(value) {
@@ -481,8 +478,6 @@ internal class DefaultFlowController @Inject internal constructor(
             return
         }
 
-        val initializationMode = requireNotNull(initializationMode)
-
         when (val paymentSelection = viewModel.paymentSelection) {
             is Link,
             is PaymentSelection.New.LinkInline,
@@ -494,12 +489,10 @@ internal class DefaultFlowController @Inject internal constructor(
             null -> confirmPaymentSelection(
                 paymentSelection = paymentSelection,
                 state = state.paymentSheetState,
-                initializationMode = initializationMode,
             )
             is PaymentSelection.Saved -> confirmSavedPaymentMethod(
                 paymentSelection = paymentSelection,
                 state = state.paymentSheetState,
-                initializationMode = initializationMode,
             )
         }
     }
@@ -507,7 +500,6 @@ internal class DefaultFlowController @Inject internal constructor(
     private fun confirmSavedPaymentMethod(
         paymentSelection: PaymentSelection.Saved,
         state: PaymentSheetState.Full,
-        initializationMode: PaymentElementLoader.InitializationMode,
     ) {
         if (paymentSelection.paymentMethod.type == PaymentMethod.Type.SepaDebit &&
             viewModel.paymentSelection?.hasAcknowledgedSepaMandate == false
@@ -521,7 +513,7 @@ internal class DefaultFlowController @Inject internal constructor(
                 )
             )
         } else {
-            confirmPaymentSelection(paymentSelection, state, initializationMode)
+            confirmPaymentSelection(paymentSelection, state)
         }
     }
 
@@ -529,7 +521,6 @@ internal class DefaultFlowController @Inject internal constructor(
     fun confirmPaymentSelection(
         paymentSelection: PaymentSelection?,
         state: PaymentSheetState.Full,
-        initializationMode: PaymentElementLoader.InitializationMode,
     ) {
         viewModelScope.launch {
             val confirmationOption = paymentSelection?.toConfirmationOption(
@@ -541,7 +532,6 @@ internal class DefaultFlowController @Inject internal constructor(
                 confirmationHandler.start(
                     arguments = ConfirmationHandler.Args(
                         confirmationOption = option,
-                        initializationMode = initializationMode,
                         paymentMethodMetadata = state.paymentMethodMetadata,
                     )
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CreateLinkState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CreateLinkState.kt
@@ -242,7 +242,6 @@ internal class DefaultCreateLinkState @Inject constructor(
             linkSignUpOptInFeatureEnabled = elementsSession.linkSignUpOptInFeatureEnabled,
             linkSignUpOptInInitialValue = elementsSession.linkSignUpOptInInitialValue,
             elementsSessionId = elementsSession.elementsSessionId,
-            initializationMode = initializationMode,
             linkMode = elementsSession.linkSettings?.linkMode,
             billingDetailsCollectionConfiguration = configuration.billingDetailsCollectionConfiguration,
             defaultBillingDetails = configuration.defaultBillingDetails,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -96,7 +96,7 @@ internal interface PaymentElementLoader {
             }
 
             override fun integrationMetadata(paymentElementCallbacks: PaymentElementCallbacks?): IntegrationMetadata {
-                return IntegrationMetadata.IntentFirst
+                return IntegrationMetadata.IntentFirst(clientSecret)
             }
         }
 
@@ -110,7 +110,7 @@ internal interface PaymentElementLoader {
             }
 
             override fun integrationMetadata(paymentElementCallbacks: PaymentElementCallbacks?): IntegrationMetadata {
-                return IntegrationMetadata.IntentFirst
+                return IntegrationMetadata.IntentFirst(clientSecret)
             }
         }
 
@@ -133,13 +133,13 @@ internal interface PaymentElementLoader {
             override fun integrationMetadata(paymentElementCallbacks: PaymentElementCallbacks?): IntegrationMetadata {
                 return when {
                     paymentElementCallbacks?.preparePaymentMethodHandler != null -> {
-                        IntegrationMetadata.DeferredIntentWithSharedPaymentToken
+                        IntegrationMetadata.DeferredIntentWithSharedPaymentToken(intentConfiguration)
                     }
                     paymentElementCallbacks?.createIntentWithConfirmationTokenCallback != null -> {
-                        IntegrationMetadata.DeferredIntentWithConfirmationToken
+                        IntegrationMetadata.DeferredIntentWithConfirmationToken(intentConfiguration)
                     }
                     paymentElementCallbacks?.createIntentCallback != null -> {
-                        IntegrationMetadata.DeferredIntentWithPaymentMethod
+                        IntegrationMetadata.DeferredIntentWithPaymentMethod(intentConfiguration)
                     }
                     else -> throw IllegalStateException("No callback for deferred intent.")
                 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
@@ -35,7 +35,6 @@ import com.stripe.android.paymentsheet.configType
 import com.stripe.android.paymentsheet.flowcontroller.FlowControllerViewModel
 import com.stripe.android.paymentsheet.model.GooglePayButtonType
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.paymentsheet.ui.WalletButtonsInteractor.ViewAction.OnButtonPressed
 import com.stripe.android.paymentsheet.ui.WalletButtonsInteractor.ViewAction.OnHidden
 import com.stripe.android.paymentsheet.ui.WalletButtonsInteractor.ViewAction.OnResendCode
@@ -318,7 +317,6 @@ internal class DefaultWalletButtonsInteractor constructor(
 
         return ConfirmationHandler.Args(
             confirmationOption = confirmationOption,
-            initializationMode = arguments.initializationMode,
             paymentMethodMetadata = arguments.paymentMethodMetadata,
         )
     }
@@ -328,7 +326,6 @@ internal class DefaultWalletButtonsInteractor constructor(
         val paymentMethodMetadata: PaymentMethodMetadata,
         val configuration: CommonConfiguration,
         val appearance: PaymentSheet.Appearance,
-        val initializationMode: PaymentElementLoader.InitializationMode,
         val paymentSelection: PaymentSelection?,
     )
 
@@ -352,7 +349,6 @@ internal class DefaultWalletButtonsInteractor constructor(
                             configuration = flowControllerState.paymentSheetState.config,
                             paymentMethodMetadata = flowControllerState.paymentSheetState.paymentMethodMetadata,
                             appearance = configureRequest.configuration.appearance,
-                            initializationMode = configureRequest.initializationMode,
                             paymentSelection = flowControllerViewModel.paymentSelection
                         )
                     } else {
@@ -395,7 +391,6 @@ internal class DefaultWalletButtonsInteractor constructor(
                             configuration = state.configuration.asCommonConfiguration(),
                             paymentMethodMetadata = state.paymentMethodMetadata,
                             appearance = state.configuration.appearance,
-                            initializationMode = state.initializationMode,
                             paymentSelection = state.selection
                         )
                     }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -28,6 +28,7 @@ import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContra
 import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLauncherFactory
 import com.stripe.android.lpmfoundations.luxe.LpmRepositoryTestHelpers
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
+import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures.CARD_PAYMENT_METHOD
@@ -42,7 +43,6 @@ import com.stripe.android.payments.paymentlauncher.StripePaymentLauncherAssisted
 import com.stripe.android.paymentsheet.cvcrecollection.RecordingCvcRecollectionLauncherFactory
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.bacs.FakeBacsMandateConfirmationLauncher
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.DummyActivityResultCaller
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
@@ -88,7 +88,7 @@ internal object CustomerSheetTestHelper {
         intentConfirmationInterceptorFactory: IntentConfirmationInterceptor.Factory =
             object : IntentConfirmationInterceptor.Factory {
                 override suspend fun create(
-                    initializationMode: PaymentElementLoader.InitializationMode,
+                    integrationMetadata: IntegrationMetadata,
                     customerId: String?,
                     ephemeralKeySecret: String?,
                     clientAttributionMetadata: ClientAttributionMetadata,

--- a/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
@@ -35,7 +35,6 @@ import com.stripe.android.model.SharePaymentDetails
 import com.stripe.android.networking.RequestSurface
 import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.ui.core.Amount
@@ -237,7 +236,6 @@ internal object TestFactory {
         defaultBillingDetails = null,
         useAttestationEndpointsForLink = false,
         suppress2faModal = false,
-        initializationMode = PaymentSheetFixtures.INITIALIZATION_MODE_PAYMENT_INTENT,
         elementsSessionId = "session_1234",
         linkMode = LinkMode.LinkPaymentMethod,
         allowDefaultOptIn = false,

--- a/paymentsheet/src/test/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandlerTest.kt
@@ -628,7 +628,6 @@ internal class DefaultLinkConfirmationHandlerTest {
         )
         assertThat(paymentMethodMetadata.passiveCaptchaParams).isEqualTo(passiveCaptchaParams)
         assertThat(paymentMethodMetadata.shippingDetails).isEqualTo(configuration.shippingDetails)
-        assertThat(initializationMode).isEqualTo(configuration.initializationMode)
     }
 
     private fun ConfirmationHandler.Args.assertSavedConfirmationArgs(
@@ -645,7 +644,6 @@ internal class DefaultLinkConfirmationHandlerTest {
         val optionsCard = option.optionsParams as? PaymentMethodOptionsParams.Card
         assertThat(optionsCard?.cvc).isEqualTo(cvc)
         assertThat(paymentMethodMetadata.shippingDetails).isEqualTo(configuration.shippingDetails)
-        assertThat(initializationMode).isEqualTo(configuration.initializationMode)
     }
 
     private suspend fun createHandler(

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenStateTest.kt
@@ -8,7 +8,6 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentB
 import com.stripe.android.model.LinkMode
 import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.PaymentIntentFactory
 import org.junit.Test
 
@@ -96,7 +95,6 @@ class SignUpScreenStateTest {
             financialConnectionsAvailability = FinancialConnectionsAvailability.Full,
             useAttestationEndpointsForLink = true,
             suppress2faModal = false,
-            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent("pi_123_secret_456"),
             elementsSessionId = "elements_session_id_123",
             linkMode = LinkMode.Passthrough,
             allowDefaultOptIn = false,

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
@@ -6,8 +6,10 @@ import com.stripe.android.common.model.SHOP_PAY_CONFIGURATION
 import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.LinkMode
 import com.stripe.android.model.PassiveCaptchaParams
+import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -59,7 +61,7 @@ internal object PaymentMethodMetadataFactory {
         attestOnIntentConfirmation: Boolean = false,
         appearance: PaymentSheet.Appearance = PaymentSheet.Appearance(),
         onBehalfOf: String? = null,
-        integrationMetadata: IntegrationMetadata = IntegrationMetadata.IntentFirst,
+        integrationMetadata: IntegrationMetadata = stripeIntent.integrationMetadata(),
     ): PaymentMethodMetadata {
         return PaymentMethodMetadata(
             stripeIntent = stripeIntent,
@@ -113,5 +115,30 @@ internal object PaymentMethodMetadataFactory {
         val inputStream = PaymentMethodMetadataFactory::class.java.classLoader!!.getResourceAsStream("lpms.json")
         val specsString = inputStream.bufferedReader().use { it.readText() }
         return LpmSerializer.deserializeList(specsString).getOrThrow()
+    }
+
+    private fun StripeIntent.integrationMetadata(): IntegrationMetadata {
+        clientSecret?.let { return IntegrationMetadata.IntentFirst(it) }
+        return when (this) {
+            is PaymentIntent -> {
+                IntegrationMetadata.DeferredIntentWithPaymentMethod(
+                    intentConfiguration = PaymentSheet.IntentConfiguration(
+                        mode = PaymentSheet.IntentConfiguration.Mode.Payment(
+                            amount = amount ?: 5000,
+                            currency = currency ?: "usd"
+                        )
+                    )
+                )
+            }
+            is SetupIntent -> {
+                IntegrationMetadata.DeferredIntentWithPaymentMethod(
+                    intentConfiguration = PaymentSheet.IntentConfiguration(
+                        mode = PaymentSheet.IntentConfiguration.Mode.Setup(
+                            currency = "usd"
+                        )
+                    )
+                )
+            }
+        }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -1179,7 +1179,7 @@ internal class PaymentMethodMetadataTest {
             attestOnIntentConfirmation = false,
             appearance = configuration.appearance,
             onBehalfOf = null,
-            integrationMetadata = IntegrationMetadata.IntentFirst,
+            integrationMetadata = IntegrationMetadata.IntentFirst("cs_123"),
         )
 
         assertThat(metadata).isEqualTo(expectedMetadata)
@@ -2174,7 +2174,6 @@ internal class PaymentMethodMetadataTest {
             passthroughModeEnabled = false,
             useAttestationEndpointsForLink = false,
             suppress2faModal = false,
-            initializationMode = PaymentSheetFixtures.INITIALIZATION_MODE_PAYMENT_INTENT,
             elementsSessionId = "session_1234",
             linkMode = LinkMode.LinkPaymentMethod,
             allowDefaultOptIn = false,

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElementTest.kt
@@ -32,7 +32,6 @@ import com.stripe.android.model.LinkMode
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.createComposeCleanupRule
 import com.stripe.android.utils.FakeLinkComponent
@@ -149,9 +148,6 @@ class LinkFormElementTest {
             flags = mapOf(),
             useAttestationEndpointsForLink = false,
             suppress2faModal = false,
-            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
-                clientSecret = "pi_123_secret_123",
-            ),
             elementsSessionId = "session_1234",
             linkMode = LinkMode.LinkPaymentMethod,
             allowDefaultOptIn = false,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
@@ -35,7 +35,6 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.utils.BankFormScreenStateFactory
@@ -608,9 +607,6 @@ class ConfirmationHandlerOptionKtxTest {
             flags = mapOf(),
             useAttestationEndpointsForLink = false,
             suppress2faModal = false,
-            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
-                clientSecret = "pi_123_secret_123",
-            ),
             elementsSessionId = "session_1234",
             linkMode = LinkMode.LinkPaymentMethod,
             allowDefaultOptIn = false,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediatorTest.kt
@@ -10,7 +10,6 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFact
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
 import com.stripe.android.paymentsheet.R
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import kotlinx.coroutines.test.runTest
 import kotlinx.parcelize.Parcelize
 import org.junit.Test
@@ -648,11 +647,8 @@ class ConfirmationMediatorTest {
         private val INTENT = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD
 
         private val CONFIRMATION_PARAMETERS = ConfirmationHandler.Args(
-            paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
             confirmationOption = FakeConfirmationOption(),
-            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
-                clientSecret = "pi_123_secret_123",
-            ),
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationTestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationTestUtils.kt
@@ -8,7 +8,6 @@ import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.paymentelement.confirmation.ConfirmationMediator.Parameters
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.DummyActivityResultCaller
 import com.stripe.android.testing.PaymentIntentFactory
 import kotlinx.coroutines.test.runTest
@@ -193,15 +192,12 @@ internal fun ConfirmationHandler.Result?.assertCanceled(): ConfirmationHandler.R
     return this as ConfirmationHandler.Result.Canceled
 }
 
-internal val PAYMENT_INTENT = PaymentIntentFactory.create()
+internal val PAYMENT_INTENT = PaymentIntentFactory.create(clientSecret = "pi_123_secret_123")
 
 internal val CONFIRMATION_PARAMETERS = ConfirmationHandler.Args(
+    confirmationOption = FakeConfirmationOption(),
     paymentMethodMetadata = PaymentMethodMetadataFactory.create(
         stripeIntent = PAYMENT_INTENT,
         passiveCaptchaParams = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
     ),
-    initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
-        clientSecret = "pi_123_secret_123",
-    ),
-    confirmationOption = FakeConfirmationOption(),
 )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationUtils.kt
@@ -13,6 +13,7 @@ import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.link.analytics.FakeLinkAnalyticsHelper
 import com.stripe.android.link.analytics.FakeLinkEventsReporter
 import com.stripe.android.link.analytics.LinkEventsReporter
+import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
 import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.networking.StripeRepository
@@ -40,7 +41,6 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.cvcrecollection.CvcRecollectionHandlerImpl
 import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateConfirmationLauncherFactory
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcRecollectionLauncherFactory
-import com.stripe.android.paymentsheet.state.PaymentElementLoader.InitializationMode
 import com.stripe.android.paymentsheet.utils.FakeUserFacingLogger
 import com.stripe.android.testing.AbsFakeStripeRepository
 import com.stripe.android.testing.FakeErrorReporter
@@ -50,7 +50,7 @@ import javax.inject.Provider
 
 @OptIn(SharedPaymentTokenSessionPreview::class)
 internal suspend fun createIntentConfirmationInterceptor(
-    initializationMode: InitializationMode,
+    integrationMetadata: IntegrationMetadata,
     customerId: String? = null,
     ephemeralKeySecret: String? = null,
     stripeRepository: StripeRepository = object : AbsFakeStripeRepository() {},
@@ -139,7 +139,7 @@ internal suspend fun createIntentConfirmationInterceptor(
             }
         },
     ).create(
-        initializationMode = initializationMode,
+        integrationMetadata = integrationMetadata,
         customerId = customerId,
         ephemeralKeySecret = ephemeralKeySecret,
         clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationDefinitionTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentelement.confirmation
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.ConfirmPaymentIntentParams
@@ -22,7 +23,6 @@ import com.stripe.android.payments.paymentlauncher.PaymentLauncherContract
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.addresselement.toConfirmPaymentIntentShipping
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.FakePaymentLauncher
 import com.stripe.android.utils.FakeIntentConfirmationInterceptor
 import kotlinx.coroutines.test.runTest
@@ -466,7 +466,7 @@ class IntentConfirmationDefinitionTest {
         intentConfirmationInterceptorFactory: IntentConfirmationInterceptor.Factory =
             object : IntentConfirmationInterceptor.Factory {
                 override suspend fun create(
-                    initializationMode: PaymentElementLoader.InitializationMode,
+                    integrationMetadata: IntegrationMetadata,
                     customerId: String?,
                     ephemeralKeySecret: String?,
                     clientAttributionMetadata: ClientAttributionMetadata,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/attestation/AttestationConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/attestation/AttestationConfirmationActivityTest.kt
@@ -28,7 +28,6 @@ import com.stripe.android.paymentelement.confirmation.paymentElementConfirmation
 import com.stripe.android.payments.paymentlauncher.InternalPaymentResult
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.createTestActivityRule
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.testing.RadarOptionsFactory
@@ -236,10 +235,11 @@ internal class AttestationConfirmationActivityTest {
     }
 
     private companion object {
-        private val PAYMENT_INTENT = PaymentIntentFactory.create().copy(
+        private val PAYMENT_INTENT = PaymentIntentFactory.create(
             id = "pm_1",
             amount = 5000,
             currency = "USD",
+            clientSecret = "pi_123_secret_123",
         )
 
         private val NEW_CONFIRMATION_OPTION = PaymentMethodConfirmationOption.New(
@@ -258,9 +258,6 @@ internal class AttestationConfirmationActivityTest {
 
         private val CONFIRMATION_ARGUMENTS_NEW = ConfirmationHandler.Args(
             confirmationOption = NEW_CONFIRMATION_OPTION,
-            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
-                clientSecret = "pi_123_secret_123"
-            ),
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                 shippingDetails = AddressDetails(),
                 stripeIntent = PAYMENT_INTENT,
@@ -269,9 +266,6 @@ internal class AttestationConfirmationActivityTest {
 
         private val CONFIRMATION_ARGUMENTS_SAVED = ConfirmationHandler.Args(
             confirmationOption = SAVED_CONFIRMATION_OPTION,
-            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
-                clientSecret = "pi_123_secret_123"
-            ),
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                 shippingDetails = AddressDetails(),
                 stripeIntent = PAYMENT_INTENT,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationActivityTest.kt
@@ -29,7 +29,6 @@ import com.stripe.android.payments.paymentlauncher.InternalPaymentResult
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.createTestActivityRule
 import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateConfirmationResult
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.view.ActivityStarter
@@ -174,7 +173,8 @@ internal class BacsConfirmationActivityTest {
             currency = "CAD",
             paymentMethodOptionsJsonString = """
                 {"card": {"require_cvc_recollection": true}}
-            """.trimIndent()
+            """.trimIndent(),
+            clientSecret = "pi_123_secret_123",
         )
 
         val PAYMENT_METHOD = PaymentMethodFactory.bacs()
@@ -195,9 +195,6 @@ internal class BacsConfirmationActivityTest {
 
         val CONFIRMATION_ARGUMENTS = ConfirmationHandler.Args(
             confirmationOption = CONFIRMATION_OPTION,
-            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
-                clientSecret = "pi_123_secret_123"
-            ),
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                 stripeIntent = PAYMENT_INTENT,
                 shippingDetails = AddressDetails(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationActivityTest.kt
@@ -29,7 +29,6 @@ import com.stripe.android.paymentelement.confirmation.paymentElementConfirmation
 import com.stripe.android.payments.paymentlauncher.InternalPaymentResult
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.createTestActivityRule
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.testing.RadarOptionsFactory
@@ -216,7 +215,7 @@ internal class PassiveChallengeConfirmationActivityTest {
     }
 
     private companion object {
-        val PAYMENT_INTENT = PaymentIntentFactory.create()
+        val PAYMENT_INTENT = PaymentIntentFactory.create(clientSecret = "pi_123_secret_123")
 
         val PAYMENT_METHOD = PaymentMethodFactory.card()
 
@@ -236,9 +235,6 @@ internal class PassiveChallengeConfirmationActivityTest {
 
         val CONFIRMATION_ARGUMENTS = ConfirmationHandler.Args(
             confirmationOption = CONFIRMATION_OPTION,
-            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
-                clientSecret = "pi_123_secret_123"
-            ),
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                 stripeIntent = PAYMENT_INTENT,
                 shippingDetails = AddressDetails(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cpms/CustomPaymentMethodConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cpms/CustomPaymentMethodConfirmationActivityTest.kt
@@ -31,7 +31,6 @@ import com.stripe.android.paymentelement.confirmation.paymentElementConfirmation
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.createTestActivityRule
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.utils.PaymentElementCallbackTestRule
 import org.junit.Before
@@ -168,9 +167,6 @@ internal class CustomPaymentMethodConfirmationActivityTest {
 
         val CONFIRMATION_ARGUMENTS = ConfirmationHandler.Args(
             confirmationOption = CONFIRMATION_OPTION,
-            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
-                clientSecret = "pi_123_secret_123"
-            ),
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                 stripeIntent = PAYMENT_INTENT,
                 shippingDetails = AddressDetails(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cpms/CustomPaymentMethodConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cpms/CustomPaymentMethodConfirmationDefinitionTest.kt
@@ -20,7 +20,6 @@ import com.stripe.android.paymentelement.confirmation.asSucceeded
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.DummyActivityResultCaller
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.PaymentIntentFactory
@@ -245,12 +244,9 @@ class CustomPaymentMethodConfirmationDefinitionTest {
 
     companion object {
         private val CONFIRMATION_PARAMETERS = ConfirmationHandler.Args(
+            confirmationOption = FakeConfirmationOption(),
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                 stripeIntent = PaymentIntentFactory.create(),
-            ),
-            confirmationOption = FakeConfirmationOption(),
-            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
-                clientSecret = "pi_123_secret_123",
             ),
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationActivityTest.kt
@@ -27,7 +27,6 @@ import com.stripe.android.payments.paymentlauncher.InternalPaymentResult
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.createTestActivityRule
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcRecollectionResult
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.view.ActivityStarter
@@ -160,7 +159,8 @@ internal class CvcRecollectionConfirmationActivityTest {
             currency = "CAD",
             paymentMethodOptionsJsonString = """
                 {"card": {"require_cvc_recollection": true}}
-            """.trimIndent()
+            """.trimIndent(),
+            clientSecret = "pi_123_secret_123",
         )
 
         val PAYMENT_INTENT_WITHOUT_CVC_RECOLLECTION = PaymentIntentFactory.create().copy(
@@ -178,9 +178,6 @@ internal class CvcRecollectionConfirmationActivityTest {
 
         val CONFIRMATION_ARGUMENTS = ConfirmationHandler.Args(
             confirmationOption = CONFIRMATION_OPTION,
-            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
-                clientSecret = "pi_123_secret_123"
-            ),
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                 stripeIntent = PAYMENT_INTENT,
                 shippingDetails = AddressDetails(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationActivityTest.kt
@@ -31,7 +31,6 @@ import com.stripe.android.paymentelement.confirmation.paymentElementConfirmation
 import com.stripe.android.paymentsheet.ExternalPaymentMethodResult
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.createTestActivityRule
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.utils.PaymentElementCallbackTestRule
 import org.junit.Before
@@ -192,9 +191,6 @@ internal class ExternalPaymentMethodConfirmationActivityTest {
 
         val CONFIRMATION_ARGUMENTS = ConfirmationHandler.Args(
             confirmationOption = CONFIRMATION_OPTION,
-            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
-                clientSecret = "pi_123_secret_123"
-            ),
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                 stripeIntent = PAYMENT_INTENT,
                 shippingDetails = AddressDetails(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationActivityTest.kt
@@ -33,7 +33,6 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.createTestActivityRule
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.PaymentMethodFactory
 import org.junit.Rule
@@ -258,9 +257,9 @@ internal class GooglePayConfirmationActivityTest {
         val PAYMENT_INTENT = PaymentIntentFactory.create(
             paymentMethodOptionsJsonString = """
                 {"card": {"require_cvc_recollection": true}}
-            """.trimIndent()
-        ).copy(
+            """.trimIndent(),
             id = "pm_1",
+            clientSecret = "pi_123_secret_123",
             amount = 5000,
             currency = "CAD",
         )
@@ -281,9 +280,6 @@ internal class GooglePayConfirmationActivityTest {
 
         val CONFIRMATION_ARGUMENTS = ConfirmationHandler.Args(
             confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION,
-            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
-                clientSecret = "pi_123_secret_123"
-            ),
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                 stripeIntent = PAYMENT_INTENT,
                 shippingDetails = AddressDetails(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/ConfirmationInterceptorTestUtil.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/ConfirmationInterceptorTestUtil.kt
@@ -4,6 +4,7 @@ import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.SharedPaymentTokenSessionPreview
 import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.model.AndroidVerificationObject
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
@@ -26,7 +27,6 @@ import com.stripe.android.paymentelement.confirmation.intent.IntentConfirmationD
 import com.stripe.android.paymentelement.confirmation.intent.IntentConfirmationInterceptor
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.CreateIntentCallback
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.AbsFakeStripeRepository
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.PaymentIntentFactory
@@ -49,12 +49,12 @@ internal data class InterceptorTestScenario(
 
 @OptIn(SharedPaymentTokenSessionPreview::class)
 internal fun runInterceptorScenario(
-    initializationMode: PaymentElementLoader.InitializationMode,
+    integrationMetadata: IntegrationMetadata,
     scenario: InterceptorTestScenario = InterceptorTestScenario(),
     test: suspend (interceptor: IntentConfirmationInterceptor) -> Unit
 ) = runTest {
     val interceptor = createIntentConfirmationInterceptor(
-        initializationMode = initializationMode,
+        integrationMetadata = integrationMetadata,
         ephemeralKeySecret = scenario.ephemeralKeySecret,
         stripeRepository = scenario.stripeRepository,
         publishableKeyProvider = scenario.publishableKeyProvider,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/DeferredIntentConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/DeferredIntentConfirmationInterceptorTest.kt
@@ -8,6 +8,7 @@ import com.stripe.android.core.exception.InvalidRequestException
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.isInstanceOf
+import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.model.AndroidVerificationObject
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.PaymentIntentFixtures
@@ -30,7 +31,6 @@ import com.stripe.android.paymentsheet.CreateIntentCallback
 import com.stripe.android.paymentsheet.CreateIntentResult
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
-import com.stripe.android.paymentsheet.state.PaymentElementLoader.InitializationMode
 import com.stripe.android.testing.AbsFakeStripeRepository
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.RadarOptionsFactory
@@ -48,6 +48,15 @@ import javax.inject.Provider
 @RunWith(RobolectricTestRunner::class)
 @OptIn(SharedPaymentTokenSessionPreview::class)
 class DeferredIntentConfirmationInterceptorTest {
+    private val defaultIntegrationMetadata = IntegrationMetadata.DeferredIntentWithPaymentMethod(
+        intentConfiguration = PaymentSheet.IntentConfiguration(
+            mode = PaymentSheet.IntentConfiguration.Mode.Payment(
+                amount = 1099L,
+                currency = "usd",
+            ),
+        ),
+    )
+
     @Test
     fun `Fails if creating payment method did not succeed`() = runTest {
         val invalidRequestException = InvalidRequestException(
@@ -61,7 +70,7 @@ class DeferredIntentConfirmationInterceptorTest {
         )
 
         val interceptor = createIntentConfirmationInterceptor(
-            initializationMode = DEFAULT_DEFERRED_INTENT,
+            integrationMetadata = defaultIntegrationMetadata,
             stripeRepository = object : AbsFakeStripeRepository() {
                 override suspend fun createPaymentMethod(
                     paymentMethodCreateParams: PaymentMethodCreateParams,
@@ -99,7 +108,7 @@ class DeferredIntentConfirmationInterceptorTest {
         )
 
         val interceptor = createIntentConfirmationInterceptor(
-            initializationMode = DEFAULT_DEFERRED_INTENT,
+            integrationMetadata = defaultIntegrationMetadata,
             stripeRepository = object : AbsFakeStripeRepository() {
                 override suspend fun retrieveStripeIntent(
                     clientSecret: String,
@@ -127,7 +136,7 @@ class DeferredIntentConfirmationInterceptorTest {
 
     @Test
     fun `Fails if callback returns failure with custom error message`() = runInterceptorScenario(
-        initializationMode = DEFAULT_DEFERRED_INTENT,
+        integrationMetadata = defaultIntegrationMetadata,
         scenario = InterceptorTestScenario(
             stripeRepository = mock(),
             intentCreationCallbackProvider = {
@@ -152,7 +161,7 @@ class DeferredIntentConfirmationInterceptorTest {
     @Test
     fun `Fails if callback returns failure without custom error message`() = runTest {
         val interceptor = createIntentConfirmationInterceptor(
-            initializationMode = DEFAULT_DEFERRED_INTENT,
+            integrationMetadata = defaultIntegrationMetadata,
             stripeRepository = mock(),
             intentCreationCallbackProvider = {
                 failingCreateIntentCallback()
@@ -172,7 +181,7 @@ class DeferredIntentConfirmationInterceptorTest {
 
     @Test
     fun `Returns confirm as next step after creating an unconfirmed intent`() = runInterceptorScenario(
-        initializationMode = DEFAULT_DEFERRED_INTENT,
+        integrationMetadata = defaultIntegrationMetadata,
         scenario = InterceptorTestScenario(
             stripeRepository = object : AbsFakeStripeRepository() {
                 override suspend fun retrieveStripeIntent(
@@ -200,7 +209,7 @@ class DeferredIntentConfirmationInterceptorTest {
 
     @Test
     fun `Returns complete as next step after creating and confirming a succeeded intent`() = runInterceptorScenario(
-        initializationMode = DEFAULT_DEFERRED_INTENT,
+        integrationMetadata = defaultIntegrationMetadata,
         scenario = InterceptorTestScenario(
             stripeRepository = object : AbsFakeStripeRepository() {
                 override suspend fun retrieveStripeIntent(
@@ -233,7 +242,7 @@ class DeferredIntentConfirmationInterceptorTest {
     @Test
     fun `Returns handleNextAction as next step after creating and confirming a non-succeeded intent`() =
         runInterceptorScenario(
-            initializationMode = DEFAULT_DEFERRED_INTENT,
+            integrationMetadata = defaultIntegrationMetadata,
             scenario = InterceptorTestScenario(
                 stripeRepository = object : AbsFakeStripeRepository() {
                     override suspend fun retrieveStripeIntent(
@@ -280,7 +289,7 @@ class DeferredIntentConfirmationInterceptorTest {
         val observedValues = mutableListOf<Boolean>()
 
         val interceptor = createIntentConfirmationInterceptor(
-            initializationMode = DEFAULT_DEFERRED_INTENT,
+            integrationMetadata = defaultIntegrationMetadata,
             stripeRepository = object : AbsFakeStripeRepository() {
                 override suspend fun retrieveStripeIntent(
                     clientSecret: String,
@@ -322,7 +331,7 @@ class DeferredIntentConfirmationInterceptorTest {
         val stripeRepository = mock<StripeRepository>()
 
         val interceptor = createIntentConfirmationInterceptor(
-            initializationMode = DEFAULT_DEFERRED_INTENT,
+            integrationMetadata = defaultIntegrationMetadata,
             stripeRepository = stripeRepository,
             intentCreationCallbackProvider = {
                 CreateIntentCallback { _, _ ->
@@ -350,7 +359,7 @@ class DeferredIntentConfirmationInterceptorTest {
     fun `If requires next action with an attached payment method different then the created one, throw error`() =
         runTest {
             val interceptor = createIntentConfirmationInterceptor(
-                initializationMode = DEFAULT_DEFERRED_INTENT,
+                integrationMetadata = defaultIntegrationMetadata,
                 stripeRepository = stripeRepositoryReturning(
                     onCreatePaymentMethodId = "pm_1234",
                     onRetrievePaymentMethodId = "pm_5678"
@@ -379,7 +388,7 @@ class DeferredIntentConfirmationInterceptorTest {
         val hCaptchaToken = "test_hcaptcha_token"
 
         val interceptor = createIntentConfirmationInterceptor(
-            initializationMode = DEFAULT_DEFERRED_INTENT,
+            integrationMetadata = defaultIntegrationMetadata,
             stripeRepository = object : AbsFakeStripeRepository() {
                 override suspend fun retrieveStripeIntent(
                     clientSecret: String,
@@ -428,7 +437,7 @@ class DeferredIntentConfirmationInterceptorTest {
         val hCaptchaToken = "test_hcaptcha_token"
 
         val interceptor = createIntentConfirmationInterceptor(
-            initializationMode = DEFAULT_DEFERRED_INTENT,
+            integrationMetadata = defaultIntegrationMetadata,
             stripeRepository = object : AbsFakeStripeRepository() {
                 override suspend fun retrieveStripeIntent(
                     clientSecret: String,
@@ -474,7 +483,7 @@ class DeferredIntentConfirmationInterceptorTest {
         val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
 
         val interceptor = createIntentConfirmationInterceptor(
-            initializationMode = DEFAULT_DEFERRED_INTENT,
+            integrationMetadata = defaultIntegrationMetadata,
             stripeRepository = object : AbsFakeStripeRepository() {
                 override suspend fun retrieveStripeIntent(
                     clientSecret: String,
@@ -521,7 +530,7 @@ class DeferredIntentConfirmationInterceptorTest {
         val attestationToken = "attestation_token_123"
 
         val interceptor = createIntentConfirmationInterceptor(
-            initializationMode = DEFAULT_DEFERRED_INTENT,
+            integrationMetadata = defaultIntegrationMetadata,
             stripeRepository = object : AbsFakeStripeRepository() {
                 override suspend fun retrieveStripeIntent(
                     clientSecret: String,
@@ -565,17 +574,6 @@ class DeferredIntentConfirmationInterceptorTest {
                     )
                 )
             )
-    }
-
-    companion object {
-        internal val DEFAULT_DEFERRED_INTENT = InitializationMode.DeferredIntent(
-            intentConfiguration = PaymentSheet.IntentConfiguration(
-                mode = PaymentSheet.IntentConfiguration.Mode.Payment(
-                    amount = 1099L,
-                    currency = "usd",
-                ),
-            ),
-        )
     }
 }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/FakeIntentConfirmationInterceptorFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/FakeIntentConfirmationInterceptorFactory.kt
@@ -1,8 +1,8 @@
 package com.stripe.android.paymentelement.confirmation.interceptor
 
+import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.paymentelement.confirmation.intent.IntentConfirmationInterceptor
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.utils.FakeIntentConfirmationInterceptor
 
 internal open class FakeIntentConfirmationInterceptorFactory(
@@ -10,7 +10,7 @@ internal open class FakeIntentConfirmationInterceptorFactory(
 ) : IntentConfirmationInterceptor.Factory {
     lateinit var interceptor: FakeIntentConfirmationInterceptor
     override suspend fun create(
-        initializationMode: PaymentElementLoader.InitializationMode,
+        integrationMetadata: IntegrationMetadata,
         customerId: String?,
         ephemeralKeySecret: String?,
         clientAttributionMetadata: ClientAttributionMetadata,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/HCaptchaConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/HCaptchaConfirmationInterceptorTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentelement.confirmation.interceptor
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.SharedPaymentTokenSessionPreview
 import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.PaymentIntentFixtures
@@ -14,7 +15,6 @@ import com.stripe.android.paymentelement.confirmation.createIntentConfirmationIn
 import com.stripe.android.paymentsheet.CreateIntentCallback
 import com.stripe.android.paymentsheet.CreateIntentResult
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.paymentsheet.state.PaymentElementLoader.InitializationMode
 import com.stripe.android.testing.AbsFakeStripeRepository
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.SetupIntentFactory
@@ -61,7 +61,7 @@ class HCaptchaConfirmationInterceptorTest {
     ): ConfirmSetupIntentParams? {
         val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
         val interceptor = createIntentConfirmationInterceptor(
-            initializationMode = InitializationMode.DeferredIntent(
+            integrationMetadata = IntegrationMetadata.DeferredIntentWithPaymentMethod(
                 intentConfiguration = PaymentSheet.IntentConfiguration(
                     mode = PaymentSheet.IntentConfiguration.Mode.Setup(
                         currency = "usd",
@@ -104,7 +104,7 @@ class HCaptchaConfirmationInterceptorTest {
     ): ConfirmPaymentIntentParams? {
         val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
         val interceptor = createIntentConfirmationInterceptor(
-            initializationMode = InitializationMode.DeferredIntent(
+            integrationMetadata = IntegrationMetadata.DeferredIntentWithPaymentMethod(
                 intentConfiguration = PaymentSheet.IntentConfiguration(
                     mode = PaymentSheet.IntentConfiguration.Mode.Payment(
                         amount = 1099L,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/IntentFirstConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/IntentFirstConfirmationInterceptorTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentelement.confirmation.interceptor
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.SharedPaymentTokenSessionPreview
+import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.model.AndroidVerificationObject
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
@@ -10,7 +11,6 @@ import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.createIntentConfirmationInterceptor
-import com.stripe.android.paymentsheet.state.PaymentElementLoader.InitializationMode
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.RadarOptionsFactory
 import com.stripe.android.testing.SetupIntentFactory
@@ -24,7 +24,7 @@ class IntentFirstConfirmationInterceptorTest {
     @Test
     fun `Returns confirm as next step if invoked with client secret for existing payment method`() =
         runInterceptorScenario(
-            initializationMode = InitializationMode.PaymentIntent("pi_1234_secret_4321"),
+            integrationMetadata = IntegrationMetadata.IntentFirst("pi_1234_secret_4321"),
         ) { interceptor ->
 
             val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
@@ -47,7 +47,7 @@ class IntentFirstConfirmationInterceptorTest {
     @Test
     fun `Returns confirm as next step if invoked with client secret for new payment method`() =
         runInterceptorScenario(
-            initializationMode = InitializationMode.PaymentIntent("pi_1234_secret_4321"),
+            integrationMetadata = IntegrationMetadata.IntentFirst("pi_1234_secret_4321"),
         ) { interceptor ->
 
             val createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD
@@ -70,7 +70,7 @@ class IntentFirstConfirmationInterceptorTest {
     @Test
     fun `Returns confirm params with 'setup_future_usage' set to 'off_session' when requires save on confirmation`() =
         runInterceptorScenario(
-            initializationMode = InitializationMode.PaymentIntent("pi_1234_secret_4321"),
+            integrationMetadata = IntegrationMetadata.IntentFirst("pi_1234_secret_4321"),
         ) { interceptor ->
             val nextStep = interceptor.intercept(
                 intent = PaymentIntentFactory.create(),
@@ -122,7 +122,7 @@ class IntentFirstConfirmationInterceptorTest {
     @Test
     fun `hCaptchaToken is not set for new payment method confirmation option`() =
         runInterceptorScenario(
-            initializationMode = InitializationMode.PaymentIntent("pi_1234_secret_4321"),
+            integrationMetadata = IntegrationMetadata.IntentFirst("pi_1234_secret_4321"),
         ) { interceptor ->
             val nextStep = interceptor.intercept(
                 confirmationOption = PaymentMethodConfirmationOption.New(
@@ -159,7 +159,7 @@ class IntentFirstConfirmationInterceptorTest {
     @Test
     fun `Returns confirm params with androidVerificationToken set to null for Saved pm with no attestation token`() =
         runInterceptorScenario(
-            initializationMode = InitializationMode.PaymentIntent("pi_1234_secret_4321"),
+            integrationMetadata = IntegrationMetadata.IntentFirst("pi_1234_secret_4321"),
         ) { interceptor ->
             val hCaptchaToken = "test-hcaptcha-token"
             val nextStep = interceptor.intercept(
@@ -190,7 +190,7 @@ class IntentFirstConfirmationInterceptorTest {
         hCaptchaToken: String?
     ): ConfirmPaymentIntentParams? {
         val interceptor = createIntentConfirmationInterceptor(
-            initializationMode = InitializationMode.PaymentIntent("pi_1234_secret_4321"),
+            integrationMetadata = IntegrationMetadata.IntentFirst("pi_1234_secret_4321"),
         )
 
         val nextStep = interceptor.intercept(
@@ -211,7 +211,7 @@ class IntentFirstConfirmationInterceptorTest {
         hCaptchaToken: String?
     ): ConfirmSetupIntentParams? {
         val interceptor = createIntentConfirmationInterceptor(
-            initializationMode = InitializationMode.SetupIntent("seti_1234_secret_4321"),
+            integrationMetadata = IntegrationMetadata.IntentFirst("seti_1234_secret_4321"),
         )
 
         val nextStep = interceptor.intercept(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/PaymentMethodOptionsSetupFutureUsageConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/PaymentMethodOptionsSetupFutureUsageConfirmationInterceptorTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentelement.confirmation.interceptor
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.SharedPaymentTokenSessionPreview
 import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
@@ -16,7 +17,6 @@ import com.stripe.android.paymentelement.confirmation.createIntentConfirmationIn
 import com.stripe.android.paymentsheet.CreateIntentCallback
 import com.stripe.android.paymentsheet.CreateIntentResult
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.paymentsheet.state.PaymentElementLoader.InitializationMode
 import com.stripe.android.testing.AbsFakeStripeRepository
 import com.stripe.android.testing.PaymentIntentFactory
 import kotlinx.coroutines.test.runTest
@@ -32,7 +32,7 @@ class PaymentMethodOptionsSetupFutureUsageConfirmationInterceptorTest {
         var observedValue = false
 
         val interceptor = createIntentConfirmationInterceptor(
-            initializationMode = InitializationMode.DeferredIntent(
+            integrationMetadata = IntegrationMetadata.DeferredIntentWithPaymentMethod(
                 intentConfiguration = PaymentSheet.IntentConfiguration(
                     mode = PaymentSheet.IntentConfiguration.Mode.Payment(
                         amount = 1099L,
@@ -73,7 +73,7 @@ class PaymentMethodOptionsSetupFutureUsageConfirmationInterceptorTest {
         var observedValue = false
 
         val interceptor = createIntentConfirmationInterceptor(
-            initializationMode = InitializationMode.DeferredIntent(
+            integrationMetadata = IntegrationMetadata.DeferredIntentWithPaymentMethod(
                 intentConfiguration = PaymentSheet.IntentConfiguration(
                     mode = PaymentSheet.IntentConfiguration.Mode.Payment(
                         amount = 1099L,
@@ -111,7 +111,7 @@ class PaymentMethodOptionsSetupFutureUsageConfirmationInterceptorTest {
     @Test
     fun `Returns confirm params with pmo 'setup_future_usage' set to 'off_session' when set on configuration`() =
         runInterceptorScenario(
-            initializationMode = InitializationMode.DeferredIntent(
+            integrationMetadata = IntegrationMetadata.DeferredIntentWithPaymentMethod(
                 PaymentSheet.IntentConfiguration(
                     mode = PaymentSheet.IntentConfiguration.Mode.Payment(
                         currency = "usd",
@@ -176,7 +176,7 @@ class PaymentMethodOptionsSetupFutureUsageConfirmationInterceptorTest {
     @Test
     fun `Returns confirm params with top level 'setup_future_usage' set to 'off_session' when set on configuration`() =
         runInterceptorScenario(
-            initializationMode = InitializationMode.DeferredIntent(
+            integrationMetadata = IntegrationMetadata.DeferredIntentWithPaymentMethod(
                 PaymentSheet.IntentConfiguration(
                     mode = PaymentSheet.IntentConfiguration.Mode.Payment(
                         currency = "usd",

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/SharedPaymentTokenConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/SharedPaymentTokenConfirmationInterceptorTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentelement.confirmation.interceptor
 import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.SharedPaymentTokenSessionPreview
+import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.model.Address
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.PaymentMethod
@@ -16,7 +17,6 @@ import com.stripe.android.paymentelement.confirmation.intent.IntentConfirmationD
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
-import com.stripe.android.paymentsheet.state.PaymentElementLoader.InitializationMode
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.PaymentIntentFactory
 import kotlinx.coroutines.CompletableDeferred
@@ -39,7 +39,7 @@ class SharedPaymentTokenConfirmationInterceptorTest {
             val providedShippingAddress = SHIPPING_ADDRESS
 
             val interceptor = createIntentConfirmationInterceptor(
-                initializationMode = DEFAULT_SPT_INTENT,
+                integrationMetadata = DEFAULT_INTEGRATION_METADATA,
                 stripeRepository = stripeRepositoryReturning(
                     onCreatePaymentMethodId = "pm_1234",
                     onRetrievePaymentMethodId = "pm_5678",
@@ -95,7 +95,7 @@ class SharedPaymentTokenConfirmationInterceptorTest {
             val createSavedPaymentMethodRadarSessionCalls = Turbine<CreateSavedPaymentMethodRadarSessionCall>()
 
             val interceptor = createIntentConfirmationInterceptor(
-                initializationMode = DEFAULT_SPT_INTENT,
+                integrationMetadata = DEFAULT_INTEGRATION_METADATA,
                 stripeRepository = stripeRepositoryReturning(
                     onCreatePaymentMethodId = "pm_1234",
                     onRetrievePaymentMethodId = "pm_5678",
@@ -143,7 +143,7 @@ class SharedPaymentTokenConfirmationInterceptorTest {
             val eventReporter = FakeErrorReporter()
 
             val interceptor = createIntentConfirmationInterceptor(
-                initializationMode = DEFAULT_SPT_INTENT,
+                integrationMetadata = DEFAULT_INTEGRATION_METADATA,
                 stripeRepository = stripeRepositoryReturning(
                     onCreatePaymentMethodId = "pm_1234",
                     onRetrievePaymentMethodId = "pm_5678",
@@ -221,7 +221,7 @@ class SharedPaymentTokenConfirmationInterceptorTest {
     }
 
     private companion object {
-        val DEFAULT_SPT_INTENT = InitializationMode.DeferredIntent(
+        val DEFAULT_INTEGRATION_METADATA = IntegrationMetadata.DeferredIntentWithSharedPaymentToken(
             intentConfiguration = PaymentSheet.IntentConfiguration(
                 sharedPaymentTokenSessionWithMode = PaymentSheet.IntentConfiguration.Mode.Payment(
                     amount = 1099L,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationActivityTest.kt
@@ -103,7 +103,6 @@ internal class LinkConfirmationActivityTest(private val nativeLinkEnabled: Boole
                 ConfirmationHandler.Args(
                     confirmationOption = LINK_CONFIRMATION_OPTION,
                     paymentMethodMetadata = paymentMethodMetadata,
-                    initializationMode = CONFIRMATION_PARAMETERS.initializationMode,
                 )
             )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
@@ -42,7 +42,6 @@ import com.stripe.android.paymentelement.confirmation.asNextStep
 import com.stripe.android.paymentelement.confirmation.asSaved
 import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.DummyActivityResultCaller
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.PaymentMethodFactory
@@ -693,9 +692,6 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
                 financialConnectionsAvailability = FinancialConnectionsAvailability.Full,
                 useAttestationEndpointsForLink = false,
                 suppress2faModal = false,
-                initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
-                    clientSecret = "pi_123_secret_123",
-                ),
                 elementsSessionId = "session_1234",
                 linkMode = LinkMode.LinkPaymentMethod,
                 allowDefaultOptIn = false,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/BaseLpmNetworkTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/BaseLpmNetworkTest.kt
@@ -65,7 +65,7 @@ internal open class BaseLpmNetworkTest(
                 this,
                 LpmAssertionParams(
                     intent = data.intent,
-                    initializationMode = data.initializationMode,
+                    integrationMetadata = data.integrationMetadata,
                     createParams = createParams,
                     optionsParams = optionsParams,
                     extraParams = extraParams,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/foundations/CreateIntentFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/foundations/CreateIntentFactory.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentelement.confirmation.lpms.foundations
 
+import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
@@ -8,7 +9,6 @@ import com.stripe.android.paymentelement.confirmation.lpms.foundations.network.M
 import com.stripe.android.paymentelement.confirmation.lpms.foundations.network.StripeNetworkTestClient
 import com.stripe.android.paymentsheet.CreateIntentResult
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.SetupIntentFactory
 
@@ -31,7 +31,7 @@ internal class CreateIntentFactory(
             createWithSetupFutureUsage = createWithSetupFutureUsage,
         ).mapCatching { clientSecret ->
             CreateIntentData(
-                initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
+                integrationMetadata = IntegrationMetadata.IntentFirst(
                     clientSecret = clientSecret,
                 ),
                 intent = testClient.retrievePaymentIntent(clientSecret).getOrThrow(),
@@ -73,7 +73,7 @@ internal class CreateIntentFactory(
 
         return Result.success(
             CreateIntentData(
-                initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
+                integrationMetadata = IntegrationMetadata.DeferredIntentWithPaymentMethod(
                     intentConfiguration = PaymentSheet.IntentConfiguration(
                         mode = PaymentSheet.IntentConfiguration.Mode.Payment(
                             amount = amount.toLong(),
@@ -84,8 +84,7 @@ internal class CreateIntentFactory(
                         )
                     )
                 ),
-                // This intent is never used in the deferred mode so it's safe to make a mocked one here
-                intent = PaymentIntentFactory.create(),
+                intent = PaymentIntentFactory.create(id = null, clientSecret = null),
             )
         )
     }
@@ -98,7 +97,7 @@ internal class CreateIntentFactory(
             paymentMethodType = paymentMethodType,
         ).mapCatching { clientSecret ->
             CreateIntentData(
-                initializationMode = PaymentElementLoader.InitializationMode.SetupIntent(
+                integrationMetadata = IntegrationMetadata.IntentFirst(
                     clientSecret = clientSecret,
                 ),
                 intent = testClient.retrieveSetupIntent(clientSecret).getOrThrow(),
@@ -134,7 +133,7 @@ internal class CreateIntentFactory(
 
         return Result.success(
             CreateIntentData(
-                initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
+                integrationMetadata = IntegrationMetadata.DeferredIntentWithPaymentMethod(
                     intentConfiguration = PaymentSheet.IntentConfiguration(
                         mode = PaymentSheet.IntentConfiguration.Mode.Setup(
                             setupFutureUse = PaymentSheet.IntentConfiguration.SetupFutureUse.OffSession,
@@ -147,7 +146,7 @@ internal class CreateIntentFactory(
     }
 
     data class CreateIntentData(
-        val initializationMode: PaymentElementLoader.InitializationMode,
+        val integrationMetadata: IntegrationMetadata,
         val intent: StripeIntent,
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/foundations/LpmAssertionParams.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/foundations/LpmAssertionParams.kt
@@ -1,11 +1,11 @@
 package com.stripe.android.paymentelement.confirmation.lpms.foundations
 
+import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 
 internal data class LpmAssertionParams(
     val intent: StripeIntent,
@@ -14,5 +14,5 @@ internal data class LpmAssertionParams(
     val extraParams: PaymentMethodExtraParams? = null,
     val shippingDetails: AddressDetails? = null,
     val customerRequestedSave: Boolean = false,
-    val initializationMode: PaymentElementLoader.InitializationMode,
+    val integrationMetadata: IntegrationMetadata,
 )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/foundations/LpmTestAssertions.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/foundations/LpmTestAssertions.kt
@@ -47,8 +47,8 @@ internal suspend fun assertIntentConfirmed(
                 paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                     stripeIntent = params.intent,
                     shippingDetails = params.shippingDetails,
+                    integrationMetadata = params.integrationMetadata,
                 ),
-                initializationMode = params.initializationMode,
             )
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/shoppay/ShopPayConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/shoppay/ShopPayConfirmationDefinitionTest.kt
@@ -14,8 +14,6 @@ import com.stripe.android.paymentelement.confirmation.asCanceled
 import com.stripe.android.paymentelement.confirmation.asFailed
 import com.stripe.android.paymentelement.confirmation.asLaunch
 import com.stripe.android.paymentelement.confirmation.asSucceeded
-import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.shoppay.ShopPayActivityContract
 import com.stripe.android.shoppay.ShopPayActivityResult
 import com.stripe.android.testing.DummyActivityResultCaller
@@ -122,19 +120,6 @@ internal class ShopPayConfirmationDefinitionTest {
         definition.launch(
             confirmationOption = SHOP_PAY_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS.copy(
-                initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
-                    intentConfiguration = PaymentSheet.IntentConfiguration(
-                        sharedPaymentTokenSessionWithMode = PaymentSheet.IntentConfiguration.Mode.Payment(
-                            amount = 5000,
-                            currency = "CAD",
-                        ),
-                        sellerDetails = PaymentSheet.IntentConfiguration.SellerDetails(
-                            businessName = "My business, Inc.",
-                            networkId = "network_123",
-                            externalId = "external_123"
-                        )
-                    )
-                ),
                 paymentMethodMetadata = CONFIRMATION_PARAMETERS.paymentMethodMetadata.copy(
                     sellerBusinessName = "My business, Inc.",
                 ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfirmationHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfirmationHelperTest.kt
@@ -18,7 +18,6 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.state.LinkState
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.paymentsheet.utils.LinkTestUtils
 import com.stripe.android.testing.CoroutineTestRule
 import kotlinx.coroutines.CoroutineScope
@@ -125,14 +124,6 @@ internal class DefaultEmbeddedConfirmationHelperTest {
         return EmbeddedConfirmationStateHolder.State(
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
             selection = PaymentSelection.GooglePay,
-            initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
-                PaymentSheet.IntentConfiguration(
-                    mode = PaymentSheet.IntentConfiguration.Mode.Payment(
-                        amount = 5000,
-                        currency = "USD",
-                    ),
-                ),
-            ),
             configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc")
                 .googlePay(
                     PaymentSheet.GooglePayConfiguration(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
@@ -43,7 +43,6 @@ internal class DefaultEmbeddedSheetLauncherTest {
             paymentMethodMetadata = paymentMethodMetadata,
             hasSavedPaymentMethods = false,
             configuration = state.configuration,
-            initializationMode = state.initializationMode,
             paymentElementCallbackIdentifier = "EmbeddedFormTestIdentifier",
             statusBarColor = null,
             paymentSelection = null,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedStateHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedStateHelperTest.kt
@@ -20,7 +20,6 @@ import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.parseAppearance
 import com.stripe.android.paymentsheet.state.CustomerState
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.StripeThemeDefaults
 import com.stripe.android.uicore.utils.stateFlowOf
@@ -251,14 +250,6 @@ internal class DefaultEmbeddedStateHelperTest {
                 confirmationState = EmbeddedConfirmationStateHolder.State(
                     paymentMethodMetadata = paymentMethodMetadata,
                     selection = selection,
-                    initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
-                        intentConfiguration = PaymentSheet.IntentConfiguration(
-                            mode = PaymentSheet.IntentConfiguration.Mode.Payment(
-                                amount = 5050,
-                                currency = "USD"
-                            )
-                        ),
-                    ),
                     configuration = configuration,
                 ),
                 customer = customer,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationStarterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationStarterTest.kt
@@ -10,7 +10,6 @@ import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationOption
 import com.stripe.android.paymentelement.confirmation.assertCanceled
 import com.stripe.android.paymentelement.confirmation.assertSucceeded
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.DummyActivityResultCaller
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.PaymentMethodFactory
@@ -41,14 +40,11 @@ class EmbeddedConfirmationStarterTest {
     @Test
     fun `on confirm, should call 'start' on confirmation handler`() = test {
         val arguments = ConfirmationHandler.Args(
+            confirmationOption = FakeConfirmationOption(),
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                 stripeIntent = PaymentIntentFactory.create(
                     paymentMethod = PaymentMethodFactory.card(random = true),
                 )
-            ),
-            confirmationOption = FakeConfirmationOption(),
-            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
-                clientSecret = "pi_123_secret_123",
             ),
         )
 
@@ -58,7 +54,6 @@ class EmbeddedConfirmationStarterTest {
 
         assertThat(startCall.confirmationOption).isEqualTo(arguments.confirmationOption)
         assertThat(startCall.intent).isEqualTo(arguments.intent)
-        assertThat(startCall.initializationMode).isEqualTo(arguments.initializationMode)
         assertThat(startCall.paymentMethodMetadata).isEqualTo(arguments.paymentMethodMetadata)
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationStateFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationStateFixtures.kt
@@ -4,8 +4,6 @@ package com.stripe.android.paymentelement.embedded.content
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
-import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 
 internal object EmbeddedConfirmationStateFixtures {
     fun defaultState(
@@ -13,11 +11,6 @@ internal object EmbeddedConfirmationStateFixtures {
     ): EmbeddedConfirmationStateHolder.State = EmbeddedConfirmationStateHolder.State(
         paymentMethodMetadata = paymentMethodMetadata,
         selection = null,
-        initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
-            intentConfiguration = PaymentSheet.IntentConfiguration(
-                mode = PaymentSheet.IntentConfiguration.Mode.Payment(amount = 5000, currency = "USD"),
-            )
-        ),
         configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.")
             .formSheetAction(EmbeddedPaymentElement.FormSheetAction.Confirm)
             .build()
@@ -27,11 +20,6 @@ internal object EmbeddedConfirmationStateFixtures {
         EmbeddedConfirmationStateHolder.State(
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
             selection = null,
-            initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
-                intentConfiguration = PaymentSheet.IntentConfiguration(
-                    mode = PaymentSheet.IntentConfiguration.Mode.Payment(amount = 5000, currency = "USD"),
-                )
-            ),
             configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.")
                 .formSheetAction(EmbeddedPaymentElement.FormSheetAction.Confirm)
                 .opensCardScannerAutomatically(true)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/DefaultFormActivityConfirmationHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/DefaultFormActivityConfirmationHelperTest.kt
@@ -13,9 +13,7 @@ import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.CoroutineTestRule
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
@@ -110,11 +108,6 @@ class DefaultFormActivityConfirmationHelperTest {
         val eventReporter = FakeEventReporter()
         val testLifecycleOwner = TestLifecycleOwner(coroutineDispatcher = Dispatchers.Unconfined)
         val confirmationHelper = DefaultFormActivityConfirmationHelper(
-            initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
-                intentConfiguration = PaymentSheet.IntentConfiguration(
-                    mode = PaymentSheet.IntentConfiguration.Mode.Payment(5050, "USD")
-                )
-            ),
             paymentMethodMetadata = paymentMethodMetadata,
             confirmationHandler = confirmationHandler,
             configuration = configuration,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityConfirmationHandlerTest.kt
@@ -84,7 +84,6 @@ internal class FormActivityConfirmationHandlerTest {
         val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
 
         val confirmationHelper = DefaultFormActivityConfirmationHelper(
-            initializationMode = embeddedState.initializationMode,
             paymentMethodMetadata = paymentMethodMetadata,
             confirmationHandler = confirmationHandler,
             configuration = embeddedState.configuration,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityTest.kt
@@ -19,8 +19,6 @@ import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.embedded.manage.ManageActivity
-import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.paymentsheet.ui.PRIMARY_BUTTON_TEST_TAG
 import com.stripe.android.testing.PaymentConfigurationTestRule
 import com.stripe.paymentelementtestpages.FormPage
@@ -83,12 +81,6 @@ internal class FormActivityTest {
         hasSavedPaymentMethods: Boolean = false,
         configuration: EmbeddedPaymentElement.Configuration =
             EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
-        intentConfiguration: PaymentSheet.IntentConfiguration = PaymentSheet.IntentConfiguration(
-            mode = PaymentSheet.IntentConfiguration.Mode.Payment(
-                amount = 5000,
-                currency = "USD",
-            ),
-        ),
         block: () -> Unit,
     ) {
         ActivityScenario.launchActivityForResult<FormActivity>(
@@ -99,7 +91,6 @@ internal class FormActivityTest {
                     paymentMethodMetadata = paymentMethodMetadata,
                     hasSavedPaymentMethods = hasSavedPaymentMethods,
                     configuration = configuration,
-                    initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(intentConfiguration),
                     statusBarColor = null,
                     paymentElementCallbackIdentifier = "EmbeddedFormTestIdentifier",
                     paymentSelection = null,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -47,6 +47,7 @@ import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.TestFactory
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.ui.LinkButtonTestTag
+import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.PaymentIntent
@@ -1259,7 +1260,7 @@ internal class PaymentSheetActivityTest {
                     intentConfirmationInterceptorFactory =
                     object : IntentConfirmationInterceptor.Factory {
                         override suspend fun create(
-                            initializationMode: PaymentElementLoader.InitializationMode,
+                            integrationMetadata: IntegrationMetadata,
                             customerId: String?,
                             ephemeralKeySecret: String?,
                             clientAttributionMetadata: ClientAttributionMetadata,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -3050,7 +3050,6 @@ internal class PaymentSheetViewModelTest {
 
         val arguments = startTurbine.awaitItem()
 
-        assertThat(arguments.initializationMode).isEqualTo(initializationMode)
         assertThat(arguments.confirmationOption).isEqualTo(
             PaymentMethodConfirmationOption.Saved(
                 paymentMethod = CARD_PAYMENT_METHOD,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -32,6 +32,7 @@ import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.link.gate.FakeLinkGate
 import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.link.ui.inline.LinkSignupMode
+import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilter
 import com.stripe.android.model.CardBrand
@@ -868,7 +869,6 @@ internal class DefaultFlowControllerTest {
                 validationError = null,
                 paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
             ),
-            initializationMode = INITIALIZATION_MODE,
         )
 
         verifyPaymentSelection(
@@ -900,7 +900,6 @@ internal class DefaultFlowControllerTest {
                 validationError = null,
                 paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
             ),
-            initializationMode = INITIALIZATION_MODE,
         )
 
         verifyPaymentSelection(
@@ -938,7 +937,6 @@ internal class DefaultFlowControllerTest {
                     validationError = null,
                     paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
                 ),
-                initializationMode = INITIALIZATION_MODE,
             )
 
             verifyPaymentSelection(
@@ -962,7 +960,6 @@ internal class DefaultFlowControllerTest {
         flowController.confirmPaymentSelection(
             paymentSelection = null,
             state = PAYMENT_SHEET_STATE_FULL,
-            initializationMode = INITIALIZATION_MODE,
         )
 
         assertThat(errorReporter.getLoggedErrors()).isEmpty()
@@ -984,7 +981,6 @@ internal class DefaultFlowControllerTest {
         flowController.confirmPaymentSelection(
             paymentSelection = PaymentSelection.Link(),
             state = PAYMENT_SHEET_STATE_FULL,
-            initializationMode = INITIALIZATION_MODE,
         )
 
         assertThat(errorReporter.getLoggedErrors()).contains(
@@ -1609,11 +1605,10 @@ internal class DefaultFlowControllerTest {
             )
         )
         val flowController = createAndConfigureFlowControllerForDeferred(
-            intentConfiguration = PaymentSheet.IntentConfiguration(
-                mode = PaymentSheet.IntentConfiguration.Mode.Payment(
-                    amount = 12345,
-                    currency = "usd"
-                )
+            intentConfiguration = intentConfiguration,
+            paymentIntent = PaymentIntentFixtures.PI_SUCCEEDED.copy(
+                amount = 12345,
+                currency = "usd"
             )
         )
 
@@ -1636,8 +1631,8 @@ internal class DefaultFlowControllerTest {
                 optionsParams = null,
             )
         )
-        assertThat(arguments.initializationMode)
-            .isEqualTo(PaymentElementLoader.InitializationMode.DeferredIntent(intentConfiguration))
+        assertThat(arguments.paymentMethodMetadata.integrationMetadata)
+            .isEqualTo(IntegrationMetadata.DeferredIntentWithPaymentMethod(intentConfiguration))
     }
 
     @Test
@@ -2481,10 +2476,6 @@ internal class DefaultFlowControllerTest {
             paymentSelection = null,
             validationError = null,
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
-        )
-
-        private val INITIALIZATION_MODE = PaymentElementLoader.InitializationMode.PaymentIntent(
-            clientSecret = "pi_123"
         )
 
         private const val ENABLE_LOGGING = false

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -187,7 +187,8 @@ internal class DefaultPaymentElementLoaderTest {
                         elementsSessionConfigId = DEFAULT_ELEMENTS_SESSION_CONFIG_ID,
                         paymentIntentCreationFlow = PaymentIntentCreationFlow.Standard,
                         paymentMethodSelectionFlow = PaymentMethodSelectionFlow.MerchantSpecified,
-                    )
+                    ),
+                    integrationMetadata = IntegrationMetadata.IntentFirst("pi_1234_secret_1234"),
                 ),
             )
         )
@@ -1561,30 +1562,31 @@ internal class DefaultPaymentElementLoaderTest {
     fun `integrationMetadata returns intent first for payment intent`() = runTest {
         val paymentIntent = PaymentElementLoader.InitializationMode.PaymentIntent("secret")
         assertThat(paymentIntent.integrationMetadata(null))
-            .isEqualTo(IntegrationMetadata.IntentFirst)
+            .isEqualTo(IntegrationMetadata.IntentFirst("secret"))
         assertThat(paymentIntent.integrationMetadata(PaymentElementCallbacks.Builder().build()))
-            .isEqualTo(IntegrationMetadata.IntentFirst)
+            .isEqualTo(IntegrationMetadata.IntentFirst("secret"))
     }
 
     @Test
     fun `integrationMetadata returns intent first for setup intent`() = runTest {
         val setupIntent = PaymentElementLoader.InitializationMode.SetupIntent("secret")
         assertThat(setupIntent.integrationMetadata(null))
-            .isEqualTo(IntegrationMetadata.IntentFirst)
+            .isEqualTo(IntegrationMetadata.IntentFirst("secret"))
         assertThat(setupIntent.integrationMetadata(PaymentElementCallbacks.Builder().build()))
-            .isEqualTo(IntegrationMetadata.IntentFirst)
+            .isEqualTo(IntegrationMetadata.IntentFirst("secret"))
     }
 
     @Test
     @OptIn(SharedPaymentTokenSessionPreview::class)
     fun `integrationMetadata returns spt`() = runTest {
-        val initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
-            intentConfiguration = PaymentSheet.IntentConfiguration(
-                mode = PaymentSheet.IntentConfiguration.Mode.Payment(
-                    amount = 1234,
-                    currency = "cad",
-                ),
+        val intentConfiguration = PaymentSheet.IntentConfiguration(
+            mode = PaymentSheet.IntentConfiguration.Mode.Payment(
+                amount = 1234,
+                currency = "cad",
             ),
+        )
+        val initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
+            intentConfiguration = intentConfiguration
         )
         assertThat(
             initializationMode.integrationMetadata(
@@ -1593,18 +1595,19 @@ internal class DefaultPaymentElementLoaderTest {
                         error("Should not be called.")
                     }.build()
             )
-        ).isEqualTo(IntegrationMetadata.DeferredIntentWithSharedPaymentToken)
+        ).isEqualTo(IntegrationMetadata.DeferredIntentWithSharedPaymentToken(intentConfiguration))
     }
 
     @Test
     fun `integrationMetadata returns confirmation token`() = runTest {
-        val initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
-            intentConfiguration = PaymentSheet.IntentConfiguration(
-                mode = PaymentSheet.IntentConfiguration.Mode.Payment(
-                    amount = 1234,
-                    currency = "cad",
-                ),
+        val intentConfiguration = PaymentSheet.IntentConfiguration(
+            mode = PaymentSheet.IntentConfiguration.Mode.Payment(
+                amount = 1234,
+                currency = "cad",
             ),
+        )
+        val initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
+            intentConfiguration = intentConfiguration
         )
         assertThat(
             initializationMode.integrationMetadata(
@@ -1613,18 +1616,19 @@ internal class DefaultPaymentElementLoaderTest {
                         error("Should not be called.")
                     }.build()
             )
-        ).isEqualTo(IntegrationMetadata.DeferredIntentWithConfirmationToken)
+        ).isEqualTo(IntegrationMetadata.DeferredIntentWithConfirmationToken(intentConfiguration))
     }
 
     @Test
     fun `integrationMetadata returns payment method`() = runTest {
-        val initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
-            intentConfiguration = PaymentSheet.IntentConfiguration(
-                mode = PaymentSheet.IntentConfiguration.Mode.Payment(
-                    amount = 1234,
-                    currency = "cad",
-                ),
+        val intentConfiguration = PaymentSheet.IntentConfiguration(
+            mode = PaymentSheet.IntentConfiguration.Mode.Payment(
+                amount = 1234,
+                currency = "cad",
             ),
+        )
+        val initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
+            intentConfiguration = intentConfiguration
         )
         assertThat(
             initializationMode.integrationMetadata(
@@ -1633,7 +1637,7 @@ internal class DefaultPaymentElementLoaderTest {
                         error("Should not be called.")
                     }.build()
             )
-        ).isEqualTo(IntegrationMetadata.DeferredIntentWithPaymentMethod)
+        ).isEqualTo(IntegrationMetadata.DeferredIntentWithPaymentMethod(intentConfiguration))
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultWalletButtonsInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultWalletButtonsInteractorTest.kt
@@ -36,7 +36,6 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheet.ButtonThemes.LinkButtonTheme
 import com.stripe.android.paymentsheet.model.GooglePayButtonType
 import com.stripe.android.paymentsheet.state.LinkState
-import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.uicore.utils.stateFlowOf
@@ -1052,8 +1051,6 @@ class DefaultWalletButtonsInteractorTest {
             > = emptyMap(),
         billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration =
             PaymentSheet.BillingDetailsCollectionConfiguration(),
-        initializationMode: PaymentElementLoader.InitializationMode =
-            PaymentElementLoader.InitializationMode.SetupIntent(clientSecret = "seti_123_secret_123"),
         attestOnIntentConfirmation: Boolean = false
     ): DefaultWalletButtonsInteractor.Arguments {
         return DefaultWalletButtonsInteractor.Arguments(
@@ -1075,7 +1072,6 @@ class DefaultWalletButtonsInteractorTest {
                 ),
             ),
             appearance = appearance,
-            initializationMode = initializationMode,
             paymentSelection = null,
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
@@ -14,7 +14,6 @@ import com.stripe.android.model.LinkMode
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 
@@ -86,7 +85,6 @@ internal object LinkTestUtils {
             shippingDetails = null,
             useAttestationEndpointsForLink = false,
             suppress2faModal = false,
-            initializationMode = PaymentSheetFixtures.INITIALIZATION_MODE_PAYMENT_INTENT,
             elementsSessionId = "session_1234",
             linkMode = LinkMode.LinkPaymentMethod,
             allowDefaultOptIn = false,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This change updates our confirmation code to use IntegrationMetadata. No intended behavior changes, a pure refactor.

This simplifies many integration points to no longer need to hold onto PaymentElementLoader.InitializationMode!

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Streamlines integrations and callbacks from validation happening during loading to execution happening during confirmation.