### PR TITLE
PaymentMethod.id is no longer nullable!

### DIFF
--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampInteractor.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampInteractor.kt
@@ -408,7 +408,7 @@ internal class OnrampInteractor @Inject constructor(
                         // Create a crypto payment token
                         cryptoApiRepository.createPaymentToken(
                             cryptoCustomerId = cryptoCustomerId,
-                            paymentMethod = result.paymentMethod.id!!,
+                            paymentMethod = result.paymentMethod.id,
                         )
                     }
                     is LinkController.CreatePaymentMethodResult.Failed -> {

--- a/example/src/main/java/com/stripe/example/activity/CreateCardPaymentMethodActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/CreateCardPaymentMethodActivity.kt
@@ -164,7 +164,7 @@ class CreateCardPaymentMethodActivity : AppCompatActivity() {
         }
 
         override fun getItemId(position: Int): Long {
-            return requireNotNull(paymentMethods[position].id).hashCode().toLong()
+            return paymentMethods[position].id.hashCode().toLong()
         }
 
         class PaymentMethodViewHolder internal constructor(

--- a/payments-core/src/main/java/com/stripe/android/ConfirmStripeIntentParamsFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/ConfirmStripeIntentParamsFactory.kt
@@ -57,7 +57,7 @@ sealed class ConfirmStripeIntentParamsFactory<out T : ConfirmStripeIntentParams>
         clientAttributionMetadata: ClientAttributionMetadata?
     ): T {
         return create(
-            paymentMethodId = paymentMethod.id.orEmpty(),
+            paymentMethodId = paymentMethod.id,
             paymentMethodType = requireNotNull(paymentMethod.type),
             optionsParams = optionsParams,
             extraParams = extraParams,

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -1940,7 +1940,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
         return paymentMethodResult.mapCatching { paymentMethod ->
             ConfirmPaymentIntentParams.createForDashboard(
                 clientSecret = clientSecret,
-                paymentMethodId = paymentMethod.id!!,
+                paymentMethodId = paymentMethod.id,
                 paymentMethodOptions = paymentMethodOptions,
             )
         }
@@ -1962,7 +1962,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
         return paymentMethodResult.mapCatching { paymentMethod ->
             ConfirmSetupIntentParams.createForDashboard(
                 clientSecret = clientSecret,
-                paymentMethodId = paymentMethod.id!!,
+                paymentMethodId = paymentMethod.id,
                 paymentMethodOptions = paymentMethodOptions,
             )
         }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundViewModel.kt
@@ -518,7 +518,7 @@ internal class PaymentSheetPlaygroundViewModel(
         )
         return createAndConfirmIntent(
             confirmationParams = ConfirmationParams.PaymentMethod(
-                id = paymentMethod.id!!,
+                id = paymentMethod.id,
                 shouldSavePaymentMethod = shouldSavePaymentMethod,
             ),
             playgroundState = playgroundState,

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/network/SharedPaymentTokenPlaygroundRequester.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/network/SharedPaymentTokenPlaygroundRequester.kt
@@ -95,9 +95,7 @@ internal class SharedPaymentTokenPlaygroundRequester(
 
         val request = SharedPaymentTokenCreateIntentRequest(
             customerId = customerId,
-            paymentMethod = paymentMethod.id ?: throw IllegalStateException(
-                "No payment method ID was found when creating SPT!"
-            ),
+            paymentMethod = paymentMethod.id,
             shipping = null,
         )
 

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/paymentsheet/server_side_confirm/complete_flow/ServerSideConfirmationCompleteFlowViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/paymentsheet/server_side_confirm/complete_flow/ServerSideConfirmationCompleteFlowViewModel.kt
@@ -38,7 +38,6 @@ import kotlinx.coroutines.flow.updateAndGet
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
-import kotlin.Result
 import kotlin.time.Duration.Companion.milliseconds
 import com.github.kittinunf.result.Result as ApiResult
 
@@ -72,7 +71,7 @@ internal class ServerSideConfirmationCompleteFlowViewModel(
         shouldSavePaymentMethod: Boolean,
     ): CreateIntentResult = withContext(Dispatchers.IO) {
         val request = state.value.cartState.toCreateIntentRequest(
-            paymentMethodId = paymentMethod.id!!,
+            paymentMethodId = paymentMethod.id,
             shouldSavePaymentMethod = shouldSavePaymentMethod,
             returnUrl = "stripesdk://payment_return_url/com.stripe.android.paymentsheet.example",
         )

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/paymentsheet/server_side_confirm/custom_flow/ServerSideConfirmationCustomFlowViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/paymentsheet/server_side_confirm/custom_flow/ServerSideConfirmationCustomFlowViewModel.kt
@@ -40,7 +40,6 @@ import kotlinx.coroutines.flow.updateAndGet
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
-import kotlin.Result
 import kotlin.time.Duration.Companion.milliseconds
 import com.github.kittinunf.result.Result as ApiResult
 
@@ -94,7 +93,7 @@ internal class ServerSideConfirmationCustomFlowViewModel(
         shouldSavePaymentMethod: Boolean,
     ): CreateIntentResult = withContext(Dispatchers.IO) {
         val request = state.value.cartState.toCreateIntentRequest(
-            paymentMethodId = paymentMethod.id!!,
+            paymentMethodId = paymentMethod.id,
             shouldSavePaymentMethod = shouldSavePaymentMethod,
             returnUrl = "stripesdk://payment_return_url/com.stripe.android.paymentsheet.example",
         )

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/PaymentSheetLayoutType.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/PaymentSheetLayoutType.kt
@@ -139,12 +139,12 @@ internal sealed class PaymentSheetLayoutType(val paymentMethodLayout: PaymentShe
             val managePage = ManagePage(composeTestRule)
 
             verticalModePage.assertHasSavedPaymentMethods()
-            verticalModePage.assertHasSelectedSavedPaymentMethod(paymentMethod.id!!)
+            verticalModePage.assertHasSelectedSavedPaymentMethod(paymentMethod.id)
             verticalModePage.assertPrimaryButton(isEnabled())
 
             verticalModePage.clickViewMore()
             managePage.waitUntilVisible()
-            verticalModePage.assertHasSelectedSavedPaymentMethod(paymentMethod.id!!)
+            verticalModePage.assertHasSelectedSavedPaymentMethod(paymentMethod.id)
 
             Espresso.pressBack()
         }
@@ -210,7 +210,7 @@ internal sealed class PaymentSheetLayoutType(val paymentMethodLayout: PaymentShe
             managePage.waitUntilVisible()
 
             managePage.clickEdit()
-            managePage.clickEdit(paymentMethod.id!!)
+            managePage.clickEdit(paymentMethod.id)
 
             editPage.waitUntilVisible()
         }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapter.kt
@@ -193,7 +193,7 @@ interface CustomerAdapter {
             internal fun PaymentSelection.toPaymentOption(): PaymentOption? {
                 return when (this) {
                     is PaymentSelection.GooglePay -> GooglePay
-                    is PaymentSelection.Saved -> StripeId(paymentMethod.id!!)
+                    is PaymentSelection.Saved -> StripeId(paymentMethod.id)
                     else -> null
                 }
             }

--- a/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
@@ -306,7 +306,7 @@ internal class LinkApiRepository @Inject constructor(
         ).onFailure {
             errorReporter.report(ErrorReporter.ExpectedErrorEvent.LINK_SHARE_CARD_FAILURE, StripeException.create(it))
         }.map { paymentMethod ->
-            val paymentMethodId = requireNotNull(paymentMethod.id)
+            val paymentMethodId = paymentMethod.id
             LinkPaymentDetails.Saved(
                 paymentDetails = ConsumerPaymentDetails.Passthrough(
                     id = id,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/SharedPaymentTokenConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/SharedPaymentTokenConfirmationInterceptor.kt
@@ -2,7 +2,6 @@ package com.stripe.android.paymentelement.confirmation.intent
 
 import com.stripe.android.SharedPaymentTokenSessionPreview
 import com.stripe.android.common.exception.stripeErrorMessage
-import com.stripe.android.core.exception.GenericStripeException
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.link.utils.errorMessage
@@ -77,13 +76,7 @@ internal class SharedPaymentTokenConfirmationInterceptor @AssistedInject constru
     ): ConfirmationDefinition.Action<Args> {
         runCatching {
             stripeRepository.createSavedPaymentMethodRadarSession(
-                paymentMethodId = paymentMethod.id
-                    ?: throw GenericStripeException(
-                        cause = IllegalStateException(
-                            "No payment method ID was found for provided 'PaymentMethod' object!"
-                        ),
-                        analyticsValue = "noPaymentMethodId"
-                    ),
+                paymentMethodId = paymentMethod.id,
                 requestOptions = requestOptions,
             ).getOrThrow()
         }.onFailure {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/SavedSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/SavedSelection.kt
@@ -25,7 +25,7 @@ internal fun PaymentSelection.toSavedSelection(): SavedSelection? {
         is PaymentSelection.GooglePay -> SavedSelection.GooglePay
         is PaymentSelection.Link -> SavedSelection.Link
         is PaymentSelection.Saved -> SavedSelection.PaymentMethod(
-            id = paymentMethod.id.orEmpty(),
+            id = paymentMethod.id,
             isLinkOrigin = paymentMethod.isLinkPaymentMethod || paymentMethod.isLinkPassthroughMode,
         )
         else -> null

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
@@ -665,7 +665,7 @@ class CustomerAdapterTest {
             }
         }
         val savedPaymentOption = CustomerAdapter.PaymentOption.StripeId(
-            PaymentMethodFixtures.CARD_PAYMENT_METHOD.id!!
+            PaymentMethodFixtures.CARD_PAYMENT_METHOD.id
         )
         val savedSelection = savedPaymentOption.toPaymentSelection(paymentMethodProvider)
         assertThat(savedSelection)

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/FakeCustomerAdapter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/FakeCustomerAdapter.kt
@@ -32,12 +32,12 @@ internal class FakeCustomerAdapter(
 
     override suspend fun attachPaymentMethod(paymentMethodId: String): CustomerAdapter.Result<PaymentMethod> {
         return onAttachPaymentMethod?.invoke(paymentMethodId)
-            ?: CustomerAdapter.Result.success(paymentMethods.getOrNull()?.find { it.id!! == paymentMethodId }!!)
+            ?: CustomerAdapter.Result.success(paymentMethods.getOrNull()?.find { it.id == paymentMethodId }!!)
     }
 
     override suspend fun detachPaymentMethod(paymentMethodId: String): CustomerAdapter.Result<PaymentMethod> {
         return onDetachPaymentMethod?.invoke(paymentMethodId)
-            ?: CustomerAdapter.Result.success(paymentMethods.getOrNull()?.find { it.id!! == paymentMethodId }!!)
+            ?: CustomerAdapter.Result.success(paymentMethods.getOrNull()?.find { it.id == paymentMethodId }!!)
     }
 
     override suspend fun updatePaymentMethod(
@@ -47,7 +47,7 @@ internal class FakeCustomerAdapter(
         return onUpdatePaymentMethod?.invoke(paymentMethodId, params)
             ?: CustomerAdapter.Result.success(
                 paymentMethods.getOrNull()?.find {
-                    it.id!! == paymentMethodId
+                    it.id == paymentMethodId
                 }!!
             )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/FakeCustomerSheetPaymentMethodDataSource.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/FakeCustomerSheetPaymentMethodDataSource.kt
@@ -50,7 +50,7 @@ internal class FakeCustomerSheetPaymentMethodDataSource(
                 onSuccess = { it },
                 onFailure = { _, _ -> listOf() }
             ).find { method ->
-                method.id!! == id
+                method.id == id
             }!!
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -92,7 +92,7 @@ internal class DefaultCustomerSheetLoaderTest {
     fun `load with configuration should return expected result`() = runTest {
         val loader = createCustomerSheetLoader(
             savedSelection = SavedSelection.PaymentMethod(
-                id = PaymentMethodFixtures.CARD_PAYMENT_METHOD.id!!
+                id = PaymentMethodFixtures.CARD_PAYMENT_METHOD.id
             ),
             paymentMethods = listOf(
                 PaymentMethodFixtures.CARD_PAYMENT_METHOD,
@@ -203,7 +203,7 @@ internal class DefaultCustomerSheetLoaderTest {
         val loader = createCustomerSheetLoader(
             paymentMethods = expectedPaymentMethods,
             // Setting a saved selection here so we can validate that it is not used.
-            savedSelection = SavedSelection.PaymentMethod(expectedPaymentMethods[1].id!!),
+            savedSelection = SavedSelection.PaymentMethod(expectedPaymentMethods[1].id),
             isPaymentMethodSyncDefaultEnabled = true,
             defaultPaymentMethodId = defaultPaymentMethod.id,
         )
@@ -226,7 +226,7 @@ internal class DefaultCustomerSheetLoaderTest {
         val loader = createCustomerSheetLoader(
             paymentMethods = expectedPaymentMethods,
             // Setting a saved selection here so we can validate that it is not used.
-            savedSelection = SavedSelection.PaymentMethod(expectedPaymentMethods[1].id!!),
+            savedSelection = SavedSelection.PaymentMethod(expectedPaymentMethods[1].id),
             isPaymentMethodSyncDefaultEnabled = true,
             defaultPaymentMethodId = null,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
@@ -5,7 +5,6 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.model.CountryCode
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.link.FakeConsumersApiService
-import com.stripe.android.link.LinkPaymentDetails
 import com.stripe.android.link.TestFactory
 import com.stripe.android.link.model.PaymentDetailsFixtures
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
@@ -599,7 +598,7 @@ class LinkApiRepositoryTest {
         )
 
         assertThat(result.isSuccess).isTrue()
-        val savedLinkPaymentDetails = result.getOrThrow() as LinkPaymentDetails.Saved
+        val savedLinkPaymentDetails = result.getOrThrow()
 
         verify(stripeRepository).sharePaymentDetails(
             consumerSessionClientSecret = consumerSessionSecret,
@@ -616,7 +615,7 @@ class LinkApiRepositoryTest {
                 ConsumerPaymentDetails.Passthrough(
                     id = paymentDetailsId,
                     last4 = cardPaymentMethodCreateParams.cardLast4().orEmpty(),
-                    paymentMethodId = PaymentMethodFixtures.CARD_PAYMENT_METHOD.id!!,
+                    paymentMethodId = PaymentMethodFixtures.CARD_PAYMENT_METHOD.id,
                     billingEmailAddress = "jenny.rosen@example.com",
                     billingAddress = ConsumerPaymentDetails.BillingAddress(
                         name = "Jenny Rosen",
@@ -632,7 +631,7 @@ class LinkApiRepositoryTest {
         assertThat(savedLinkPaymentDetails.paymentMethodCreateParams)
             .isEqualTo(
                 PaymentMethodCreateParams.createLink(
-                    PaymentMethodFixtures.CARD_PAYMENT_METHOD.id!!,
+                    PaymentMethodFixtures.CARD_PAYMENT_METHOD.id,
                     consumerSessionSecret,
                     PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
                     extraParams = mapOf("card" to mapOf("cvc" to "123")),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -801,7 +801,7 @@ internal class PaymentOptionsViewModelTest {
         val cards = PaymentMethodFactory.cards(3)
         val paymentMethodToRemove = cards.first()
 
-        whenever(customerRepository.detachPaymentMethod(any(), eq(paymentMethodToRemove.id!!), eq(false))).thenReturn(
+        whenever(customerRepository.detachPaymentMethod(any(), eq(paymentMethodToRemove.id), eq(false))).thenReturn(
             Result.success(paymentMethodToRemove)
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
@@ -150,7 +150,7 @@ class SavedPaymentMethodMutatorTest {
         var calledDetach = false
         val customerRepository = FakeCustomerRepository(
             onDetachPaymentMethod = { paymentMethodId ->
-                assertThat(paymentMethodId).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_METHOD.id!!)
+                assertThat(paymentMethodId).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_METHOD.id)
                 calledDetach = true
                 Result.failure(IllegalStateException())
             }
@@ -346,7 +346,7 @@ class SavedPaymentMethodMutatorTest {
         val calledDetach = Turbine<Boolean>()
         val customerRepository = FakeCustomerRepository(
             onDetachPaymentMethod = { paymentMethodId ->
-                assertThat(paymentMethodId).isEqualTo(displayableSavedPaymentMethod.paymentMethod.id!!)
+                assertThat(paymentMethodId).isEqualTo(displayableSavedPaymentMethod.paymentMethod.id)
                 calledDetach.add(true)
                 Result.success(displayableSavedPaymentMethod.paymentMethod)
             }
@@ -380,7 +380,7 @@ class SavedPaymentMethodMutatorTest {
         val calledDetach = Turbine<Boolean>()
         val customerRepository = FakeCustomerRepository(
             onDetachPaymentMethod = { paymentMethodId ->
-                assertThat(paymentMethodId).isEqualTo(displayableSavedPaymentMethod.paymentMethod.id!!)
+                assertThat(paymentMethodId).isEqualTo(displayableSavedPaymentMethod.paymentMethod.id)
                 calledDetach.add(true)
                 Result.success(displayableSavedPaymentMethod.paymentMethod)
             }
@@ -412,7 +412,7 @@ class SavedPaymentMethodMutatorTest {
         val calledDetach = Turbine<Boolean>()
         val customerRepository = FakeCustomerRepository(
             onDetachPaymentMethod = { paymentMethodId ->
-                assertThat(paymentMethodId).isEqualTo(displayableSavedPaymentMethod.paymentMethod.id!!)
+                assertThat(paymentMethodId).isEqualTo(displayableSavedPaymentMethod.paymentMethod.id)
                 calledDetach.add(true)
                 Result.failure(IllegalStateException("Test failure."))
             }
@@ -882,7 +882,7 @@ class SavedPaymentMethodMutatorTest {
 
             assertThat(repository.detachRequests.awaitItem()).isEqualTo(
                 FakeCustomerRepository.DetachRequest(
-                    paymentMethodId = paymentMethod.id!!,
+                    paymentMethodId = paymentMethod.id,
                     customerInfo = CustomerRepository.CustomerInfo(
                         id = "cus_123",
                         ephemeralKeySecret = "ek_123",

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenManageSavedPaymentMethodsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreenManageSavedPaymentMethodsTest.kt
@@ -78,7 +78,7 @@ internal class PaymentSheetScreenManageSavedPaymentMethodsTest {
         return ManageScreenInteractor.State(
             paymentMethods = paymentMethods.map { paymentMethod ->
                 DisplayableSavedPaymentMethod.create(
-                    displayName = paymentMethod.id?.resolvableString ?: "unknown".resolvableString,
+                    displayName = paymentMethod.id.resolvableString,
                     paymentMethod = paymentMethod
                 )
             },

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerRepositoryTest.kt
@@ -437,7 +437,7 @@ internal class CustomerRepositoryTest {
 
             repository.detachPaymentMethod(
                 customerInfo = FAKE_CUSTOMER_INFO,
-                paymentMethodId = paymentMethodToRemove.id!!,
+                paymentMethodId = paymentMethodToRemove.id,
                 canRemoveDuplicates = true,
             )
 
@@ -462,7 +462,7 @@ internal class CustomerRepositoryTest {
 
             repository.detachPaymentMethod(
                 customerInfo = FAKE_CUSTOMER_INFO,
-                paymentMethodId = usBankAccount.id!!,
+                paymentMethodId = usBankAccount.id,
                 canRemoveDuplicates = true,
             )
 
@@ -486,7 +486,7 @@ internal class CustomerRepositoryTest {
 
             repository.detachPaymentMethod(
                 customerInfo = FAKE_CUSTOMER_INFO,
-                paymentMethodId = paymentMethodToRemove.id!!,
+                paymentMethodId = paymentMethodToRemove.id,
                 canRemoveDuplicates = false,
             )
 
@@ -515,7 +515,7 @@ internal class CustomerRepositoryTest {
 
             val result = repository.detachPaymentMethod(
                 customerInfo = FAKE_CUSTOMER_INFO,
-                paymentMethodId = paymentMethods.first().id!!,
+                paymentMethodId = paymentMethods.first().id,
                 canRemoveDuplicates = true,
             )
 

--- a/stripe-test-e2e/src/test/java/com/stripe/android/test/e2e/EndToEndTest.kt
+++ b/stripe-test-e2e/src/test/java/com/stripe/android/test/e2e/EndToEndTest.kt
@@ -579,7 +579,7 @@ internal class EndToEndTest {
         )
 
         val attachResult = stripe.attachPaymentMethod(
-            paymentMethodId = paymentMethod.id!!,
+            paymentMethodId = paymentMethod.id,
             customerId = createEphemeralKeyResponse.customerId,
             ephemeralKeySecret = createEphemeralKeyResponse.ephemeralKeySecret,
         )
@@ -593,7 +593,7 @@ internal class EndToEndTest {
         )
 
         val updatedPaymentMethod = stripe.updatePaymentMethod(
-            paymentMethodId = paymentMethod.id!!,
+            paymentMethodId = paymentMethod.id,
             paymentMethodUpdateParams = updateParams,
             ephemeralKeySecret = createEphemeralKeyResponse.ephemeralKeySecret,
         )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
We recently released a change that made the payment method id not nullable. This is a cleanup for a bunch of random warnings due to that change.

This is all internal implementation details, no behavior change, or public API changes are included in this PR.
