### PR TITLE
Add a timeout to google pay isReady.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -101,6 +101,9 @@ interface ErrorReporter : FraudDetectionErrorReporter {
         GOOGLE_PAY_IS_READY_API_CALL(
             eventName = "elements.google_pay_repository.is_ready_request_api_call_failure"
         ),
+        GOOGLE_PAY_IS_READY_TIMEOUT(
+            eventName = "elements.google_pay_repository.is_ready_timeout"
+        ),
         CUSTOMER_SHEET_ELEMENTS_SESSION_LOAD_FAILURE(
             eventName = "elements.customer_sheet.elements_session.load_failure"
         ),


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This adds a 30 second timeout to the google pay isReady check.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
#ir-pluck-fraction

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified
