### PR TITLE
Use PaymentMethodMetadata in analytics.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
@@ -98,6 +98,9 @@ internal class LinkControllerInteractor @Inject constructor(
         MutableSharedFlow<LinkController.AuthorizeResult>(extraBufferCapacity = 1)
     val authorizeResultFlow = _authorizeResultFlow.asSharedFlow()
 
+    val paymentMethodMetadata: PaymentMethodMetadata?
+        get() = _state.value.paymentMethodMetadata
+
     fun state(context: Context): StateFlow<LinkController.State> {
         return combineAsStateFlow(_internalLinkAccount, _state) { account, state ->
             LinkController.State(

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerModule.kt
@@ -11,6 +11,8 @@ import com.stripe.android.core.injection.IS_LIVE_MODE
 import com.stripe.android.googlepaylauncher.injection.GooglePayLauncherModule
 import com.stripe.android.link.DefaultLinkConfigurationLoader
 import com.stripe.android.link.LinkConfigurationLoader
+import com.stripe.android.link.LinkControllerInteractor
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentelement.confirmation.injection.ExtendedPaymentElementConfirmationModule
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
@@ -53,6 +55,12 @@ internal interface LinkControllerModule {
         @Provides
         @Singleton
         fun provideAppContext(application: Application): Context = application.applicationContext
+
+        @Provides
+        @Singleton
+        fun providePaymentMethodMetadata(interactor: LinkControllerInteractor): PaymentMethodMetadata? {
+            return interactor.paymentMethodMetadata
+        }
 
         // TODO
         @Provides

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationDefinition.kt
@@ -112,7 +112,6 @@ internal interface ConfirmationDefinition<
         confirmationOption: TConfirmationOption,
         confirmationArgs: ConfirmationHandler.Args,
         deferredIntentConfirmationType: DeferredIntentConfirmationType?,
-        isConfirmationToken: Boolean,
         result: TLauncherResult,
     ): Result
 
@@ -144,11 +143,6 @@ internal interface ConfirmationDefinition<
              * DO NOT USE OUTSIDE OF INTENT CONFIRMATION
              */
             val deferredIntentConfirmationType: DeferredIntentConfirmationType?,
-            /**
-             * Indicates if the result was from a confirmation token flow
-             * DO NOT USE OUTSIDE OF INTENT CONFIRMATION
-             */
-            val isConfirmationToken: Boolean,
             /**
              * Indicates if the full payment flow was completed by the handler. Can be used to decide if internal
              * product state needs to be reset. Useful for confirmation flows that are handed off to merchants to
@@ -213,10 +207,6 @@ internal interface ConfirmationDefinition<
              */
             val deferredIntentConfirmationType: DeferredIntentConfirmationType?,
             /**
-             * DO NOT USE OUTSIDE OF INTENT CONFIRMATION
-             */
-            val isConfirmationToken: Boolean,
-            /**
              * Indicates if the full payment flow was completed by the handler. Can be used to decide if internal
              * product state needs to be reset. Useful for confirmation flows that are handed off to merchants to
              * complete and require no action by Stripe flows afterwards.
@@ -266,10 +256,6 @@ internal interface ConfirmationDefinition<
              * DO NOT USE OUTSIDE OF INTENT CONFIRMATION
              */
             val deferredIntentConfirmationType: DeferredIntentConfirmationType?,
-            /**
-             * DO NOT USE OUTSIDE OF INTENT CONFIRMATION
-             */
-            val isConfirmationToken: Boolean,
         ) : Action<TLauncherArgs>
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandler.kt
@@ -154,7 +154,6 @@ internal interface ConfirmationHandler {
         data class Succeeded(
             val intent: StripeIntent,
             val deferredIntentConfirmationType: DeferredIntentConfirmationType?,
-            val isConfirmationToken: Boolean,
             val completedFullPaymentFlow: Boolean = true,
         ) : Result {
             override fun log(logger: Logger) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediator.kt
@@ -55,7 +55,6 @@ internal class ConfirmationMediator<
                     confirmationOption = params.confirmationOption,
                     confirmationArgs = params.confirmationArgs,
                     deferredIntentConfirmationType = params.deferredIntentConfirmationType,
-                    isConfirmationToken = params.isConfirmationToken,
                     result = result
                 )
             } ?: run {
@@ -109,7 +108,6 @@ internal class ConfirmationMediator<
                                 confirmationOption = confirmationOption,
                                 confirmationArgs = arguments,
                                 deferredIntentConfirmationType = action.deferredIntentConfirmationType,
-                                isConfirmationToken = action.isConfirmationToken,
                             )
 
                             definition.launch(
@@ -137,7 +135,6 @@ internal class ConfirmationMediator<
                 Action.Complete(
                     intent = action.intent,
                     deferredIntentConfirmationType = action.deferredIntentConfirmationType,
-                    isConfirmationToken = action.isConfirmationToken,
                     completedFullPaymentFlow = action.completedFullPaymentFlow,
                 )
             }
@@ -166,7 +163,6 @@ internal class ConfirmationMediator<
         data class Complete(
             val intent: StripeIntent,
             val deferredIntentConfirmationType: DeferredIntentConfirmationType? = null,
-            val isConfirmationToken: Boolean,
             val completedFullPaymentFlow: Boolean,
         ) : Action
     }
@@ -176,7 +172,6 @@ internal class ConfirmationMediator<
         val confirmationOption: TConfirmationOption,
         val confirmationArgs: ConfirmationHandler.Args,
         val deferredIntentConfirmationType: DeferredIntentConfirmationType?,
-        val isConfirmationToken: Boolean,
     ) : Parcelable
 
     companion object {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandler.kt
@@ -200,7 +200,6 @@ internal class DefaultConfirmationHandler(
                         intent = action.intent,
                         deferredIntentConfirmationType = action.deferredIntentConfirmationType,
                         completedFullPaymentFlow = action.completedFullPaymentFlow,
-                        isConfirmationToken = action.isConfirmationToken,
                     )
                 )
             }
@@ -226,7 +225,6 @@ internal class DefaultConfirmationHandler(
                 intent = result.intent,
                 deferredIntentConfirmationType = result.deferredIntentConfirmationType,
                 completedFullPaymentFlow = result.completedFullPaymentFlow,
-                isConfirmationToken = result.isConfirmationToken,
             )
             is ConfirmationDefinition.Result.Failed -> ConfirmationHandler.Result.Failed(
                 cause = result.cause,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/attestation/AttestationConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/attestation/AttestationConfirmationDefinition.kt
@@ -76,7 +76,6 @@ internal class AttestationConfirmationDefinition @Inject constructor(
         confirmationOption: PaymentMethodConfirmationOption,
         confirmationArgs: ConfirmationHandler.Args,
         deferredIntentConfirmationType: DeferredIntentConfirmationType?,
-        isConfirmationToken: Boolean,
         result: AttestationActivityResult
     ): ConfirmationDefinition.Result {
         return when (result) {
@@ -125,7 +124,6 @@ internal class AttestationConfirmationDefinition @Inject constructor(
                 ),
                 receivesResultInProcess = false,
                 deferredIntentConfirmationType = null,
-                isConfirmationToken = false,
             )
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationDefinition.kt
@@ -34,9 +34,8 @@ internal class BacsConfirmationDefinition @Inject constructor(
         return BacsMandateData.fromConfirmationOption(confirmationOption)?.let { data ->
             ConfirmationDefinition.Action.Launch(
                 launcherArguments = data,
-                deferredIntentConfirmationType = null,
-                isConfirmationToken = false,
                 receivesResultInProcess = true,
+                deferredIntentConfirmationType = null,
             )
         } ?: run {
             ConfirmationDefinition.Action.Fail(
@@ -77,7 +76,6 @@ internal class BacsConfirmationDefinition @Inject constructor(
         confirmationOption: BacsConfirmationOption,
         confirmationArgs: ConfirmationHandler.Args,
         deferredIntentConfirmationType: DeferredIntentConfirmationType?,
-        isConfirmationToken: Boolean,
         result: BacsMandateConfirmationResult,
     ): ConfirmationDefinition.Result {
         return when (result) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinition.kt
@@ -57,7 +57,6 @@ internal class PassiveChallengeConfirmationDefinition @Inject constructor(
         confirmationOption: PaymentMethodConfirmationOption,
         confirmationArgs: ConfirmationHandler.Args,
         deferredIntentConfirmationType: DeferredIntentConfirmationType?,
-        isConfirmationToken: Boolean,
         result: PassiveChallengeActivityResult
     ): ConfirmationDefinition.Result {
         return when (result) {
@@ -107,7 +106,6 @@ internal class PassiveChallengeConfirmationDefinition @Inject constructor(
                 ),
                 receivesResultInProcess = false,
                 deferredIntentConfirmationType = null,
-                isConfirmationToken = false,
             )
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/cpms/CustomPaymentMethodConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/cpms/CustomPaymentMethodConfirmationDefinition.kt
@@ -58,9 +58,8 @@ internal class CustomPaymentMethodConfirmationDefinition @Inject constructor(
         } else {
             ConfirmationDefinition.Action.Launch(
                 launcherArguments = Unit,
-                deferredIntentConfirmationType = null,
-                isConfirmationToken = false,
                 receivesResultInProcess = false,
+                deferredIntentConfirmationType = null,
             )
         }
     }
@@ -101,14 +100,12 @@ internal class CustomPaymentMethodConfirmationDefinition @Inject constructor(
         confirmationOption: CustomPaymentMethodConfirmationOption,
         confirmationArgs: ConfirmationHandler.Args,
         deferredIntentConfirmationType: DeferredIntentConfirmationType?,
-        isConfirmationToken: Boolean,
         result: InternalCustomPaymentMethodResult
     ): ConfirmationDefinition.Result {
         return when (result) {
             is InternalCustomPaymentMethodResult.Completed -> ConfirmationDefinition.Result.Succeeded(
                 intent = confirmationArgs.intent,
                 deferredIntentConfirmationType = null,
-                isConfirmationToken = false,
             )
             is InternalCustomPaymentMethodResult.Failed -> ConfirmationDefinition.Result.Failed(
                 cause = result.throwable,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationDefinition.kt
@@ -47,7 +47,6 @@ internal class CvcRecollectionConfirmationDefinition @Inject constructor(
             launcherArguments = Unit,
             receivesResultInProcess = true,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
         )
     }
 
@@ -82,7 +81,6 @@ internal class CvcRecollectionConfirmationDefinition @Inject constructor(
         confirmationOption: PaymentMethodConfirmationOption.Saved,
         confirmationArgs: ConfirmationHandler.Args,
         deferredIntentConfirmationType: DeferredIntentConfirmationType?,
-        isConfirmationToken: Boolean,
         result: CvcRecollectionResult
     ): ConfirmationDefinition.Result {
         return when (result) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationDefinition.kt
@@ -59,9 +59,8 @@ internal class ExternalPaymentMethodConfirmationDefinition @Inject constructor(
         } else {
             ConfirmationDefinition.Action.Launch(
                 launcherArguments = Unit,
-                deferredIntentConfirmationType = null,
-                isConfirmationToken = false,
                 receivesResultInProcess = false,
+                deferredIntentConfirmationType = null,
             )
         }
     }
@@ -100,14 +99,12 @@ internal class ExternalPaymentMethodConfirmationDefinition @Inject constructor(
         confirmationOption: ExternalPaymentMethodConfirmationOption,
         confirmationArgs: ConfirmationHandler.Args,
         deferredIntentConfirmationType: DeferredIntentConfirmationType?,
-        isConfirmationToken: Boolean,
         result: PaymentResult
     ): ConfirmationDefinition.Result {
         return when (result) {
             is PaymentResult.Completed -> ConfirmationDefinition.Result.Succeeded(
                 intent = confirmationArgs.intent,
                 deferredIntentConfirmationType = null,
-                isConfirmationToken = false,
             )
             is PaymentResult.Failed -> ConfirmationDefinition.Result.Failed(
                 cause = result.throwable,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinition.kt
@@ -61,7 +61,6 @@ internal class GooglePayConfirmationDefinition @Inject constructor(
             launcherArguments = Unit,
             receivesResultInProcess = true,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
         )
     }
 
@@ -107,7 +106,6 @@ internal class GooglePayConfirmationDefinition @Inject constructor(
         confirmationOption: GooglePayConfirmationOption,
         confirmationArgs: ConfirmationHandler.Args,
         deferredIntentConfirmationType: DeferredIntentConfirmationType?,
-        isConfirmationToken: Boolean,
         result: GooglePayPaymentMethodLauncher.Result,
     ): ConfirmationDefinition.Result {
         return when (result) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/ConfirmationTokenConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/ConfirmationTokenConfirmationInterceptor.kt
@@ -133,7 +133,6 @@ internal class ConfirmationTokenConfirmationInterceptor @AssistedInject construc
                     ConfirmationDefinition.Action.Complete(
                         intent = intent,
                         deferredIntentConfirmationType = DeferredIntentConfirmationType.None,
-                        isConfirmationToken = true,
                         completedFullPaymentFlow = true,
                     )
                 } else {
@@ -172,15 +171,13 @@ internal class ConfirmationTokenConfirmationInterceptor @AssistedInject construc
                 ConfirmationDefinition.Action.Complete(
                     intent = intent,
                     deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
-                    isConfirmationToken = true,
                     completedFullPaymentFlow = true,
                 )
             } else if (intent.requiresAction()) {
                 ConfirmationDefinition.Action.Launch<Args>(
                     launcherArguments = Args.NextAction(intent),
-                    deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
-                    isConfirmationToken = true,
                     receivesResultInProcess = false,
+                    deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
                 )
             } else {
                 confirmActionHelper.createConfirmAction(
@@ -188,7 +185,6 @@ internal class ConfirmationTokenConfirmationInterceptor @AssistedInject construc
                     intent,
                     shippingValues,
                     isDeferred = true,
-                    isConfirmationToken = true,
                 ) {
                     create(
                         confirmationTokenId = confirmationTokenId,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/DeferredIntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/DeferredIntentConfirmationInterceptor.kt
@@ -151,7 +151,6 @@ internal class DeferredIntentConfirmationInterceptor @AssistedInject constructor
                     ConfirmationDefinition.Action.Complete(
                         intent = intent,
                         deferredIntentConfirmationType = DeferredIntentConfirmationType.None,
-                        isConfirmationToken = false,
                         completedFullPaymentFlow = true,
                     )
                 } else {
@@ -223,7 +222,6 @@ internal class DeferredIntentConfirmationInterceptor @AssistedInject constructor
         return ConfirmationDefinition.Action.Complete(
             intent = intent,
             deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
-            isConfirmationToken = false,
             completedFullPaymentFlow = true,
         )
     }
@@ -236,9 +234,8 @@ internal class DeferredIntentConfirmationInterceptor @AssistedInject constructor
             DeferredIntentValidator.validatePaymentMethod(intent, paymentMethod)
             ConfirmationDefinition.Action.Launch(
                 launcherArguments = Args.NextAction(intent),
-                deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
-                isConfirmationToken = false,
                 receivesResultInProcess = false,
+                deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
             )
         }.getOrElse {
             ConfirmationDefinition.Action.Fail(
@@ -265,7 +262,6 @@ internal class DeferredIntentConfirmationInterceptor @AssistedInject constructor
             intent,
             shippingValues,
             isDeferred = true,
-            isConfirmationToken = false,
         ) {
             create(
                 paymentMethod = paymentMethod,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationDefinition.kt
@@ -96,14 +96,12 @@ internal class IntentConfirmationDefinition(
         confirmationOption: PaymentMethodConfirmationOption,
         confirmationArgs: ConfirmationHandler.Args,
         deferredIntentConfirmationType: DeferredIntentConfirmationType?,
-        isConfirmationToken: Boolean,
         result: InternalPaymentResult
     ): ConfirmationDefinition.Result {
         return when (result) {
             is InternalPaymentResult.Completed -> ConfirmationDefinition.Result.Succeeded(
                 intent = result.intent,
                 deferredIntentConfirmationType = deferredIntentConfirmationType,
-                isConfirmationToken = isConfirmationToken,
             )
             is InternalPaymentResult.Failed -> ConfirmationDefinition.Result.Failed(
                 cause = result.throwable,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentFirstConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentFirstConfirmationInterceptor.kt
@@ -31,7 +31,6 @@ internal class IntentFirstConfirmationInterceptor @AssistedInject constructor(
             intent = intent,
             shippingValues = shippingValues,
             isDeferred = false,
-            isConfirmationToken = false,
         ) {
             create(
                 confirmationOption.createParams,
@@ -52,7 +51,6 @@ internal class IntentFirstConfirmationInterceptor @AssistedInject constructor(
             intent = intent,
             shippingValues = shippingValues,
             isDeferred = false,
-            isConfirmationToken = false,
         ) {
             create(
                 paymentMethod = confirmationOption.paymentMethod,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/SharedPaymentTokenConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/SharedPaymentTokenConfirmationInterceptor.kt
@@ -95,7 +95,6 @@ internal class SharedPaymentTokenConfirmationInterceptor @AssistedInject constru
             ConfirmationDefinition.Action.Complete(
                 intent = intent,
                 deferredIntentConfirmationType = DeferredIntentConfirmationType.None,
-                isConfirmationToken = false,
                 completedFullPaymentFlow = false,
             )
         } catch (@Suppress("TooGenericExceptionCaught") exception: Exception) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinition.kt
@@ -45,7 +45,6 @@ internal class LinkConfirmationDefinition @Inject constructor(
             launcherArguments = Unit,
             receivesResultInProcess = false,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
         )
     }
 
@@ -68,7 +67,6 @@ internal class LinkConfirmationDefinition @Inject constructor(
         confirmationOption: LinkConfirmationOption,
         confirmationArgs: ConfirmationHandler.Args,
         deferredIntentConfirmationType: DeferredIntentConfirmationType?,
-        isConfirmationToken: Boolean,
         result: LinkActivityResult
     ): ConfirmationDefinition.Result {
         if (
@@ -108,7 +106,6 @@ internal class LinkConfirmationDefinition @Inject constructor(
                 ConfirmationDefinition.Result.Succeeded(
                     intent = confirmationArgs.intent,
                     deferredIntentConfirmationType = deferredIntentConfirmationType,
-                    isConfirmationToken = isConfirmationToken,
                 )
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkPassthroughConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkPassthroughConfirmationDefinition.kt
@@ -39,7 +39,6 @@ internal class LinkPassthroughConfirmationDefinition @Inject constructor(
                     launcherArguments = LauncherArguments(nextConfirmationOption),
                     receivesResultInProcess = true,
                     deferredIntentConfirmationType = null,
-                    isConfirmationToken = false,
                 )
             },
             onFailure = { error ->
@@ -72,7 +71,6 @@ internal class LinkPassthroughConfirmationDefinition @Inject constructor(
         confirmationOption: LinkPassthroughConfirmationOption,
         confirmationArgs: ConfirmationHandler.Args,
         deferredIntentConfirmationType: DeferredIntentConfirmationType?,
-        isConfirmationToken: Boolean,
         result: Result,
     ): ConfirmationDefinition.Result {
         return ConfirmationDefinition.Result.NextStep(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinition.kt
@@ -45,7 +45,6 @@ internal class LinkInlineSignupConfirmationDefinition(
             launcherArguments = LauncherArguments(nextConfirmationOption),
             receivesResultInProcess = true,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
         )
     }
 
@@ -69,7 +68,6 @@ internal class LinkInlineSignupConfirmationDefinition(
         confirmationOption: LinkInlineSignupConfirmationOption,
         confirmationArgs: ConfirmationHandler.Args,
         deferredIntentConfirmationType: DeferredIntentConfirmationType?,
-        isConfirmationToken: Boolean,
         result: Result,
     ): ConfirmationDefinition.Result {
         return ConfirmationDefinition.Result.NextStep(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/shoppay/ShopPayConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/shoppay/ShopPayConfirmationDefinition.kt
@@ -28,7 +28,6 @@ internal class ShopPayConfirmationDefinition @Inject constructor(
         confirmationOption: ShopPayConfirmationOption,
         confirmationArgs: ConfirmationHandler.Args,
         deferredIntentConfirmationType: DeferredIntentConfirmationType?,
-        isConfirmationToken: Boolean,
         result: ShopPayActivityResult
     ): ConfirmationDefinition.Result {
         return when (result) {
@@ -41,7 +40,6 @@ internal class ShopPayConfirmationDefinition @Inject constructor(
                 ConfirmationDefinition.Result.Succeeded(
                     intent = confirmationArgs.intent,
                     deferredIntentConfirmationType = deferredIntentConfirmationType,
-                    isConfirmationToken = isConfirmationToken,
                     // Shop Pay is handed off for `preparePaymentMethod` purposes
                     completedFullPaymentFlow = false,
                 )
@@ -74,6 +72,7 @@ internal class ShopPayConfirmationDefinition @Inject constructor(
     ) {
         launcher.launch(
             ShopPayActivityContract.Args(
+                paymentMethodMetadata = confirmationArgs.paymentMethodMetadata,
                 shopPayConfiguration = confirmationOption.shopPayConfiguration,
                 customerSessionClientSecret = confirmationOption.customerSessionClientSecret,
                 businessName = confirmationArgs.paymentMethodMetadata.sellerBusinessName
@@ -90,7 +89,6 @@ internal class ShopPayConfirmationDefinition @Inject constructor(
             launcherArguments = Unit,
             receivesResultInProcess = false,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/utils/ConfirmActionHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/utils/ConfirmActionHelper.kt
@@ -18,7 +18,6 @@ internal class ConfirmActionHelper(private val isLiveMode: Boolean) {
         intent: StripeIntent,
         shippingValues: ConfirmPaymentIntentParams.Shipping?,
         isDeferred: Boolean,
-        isConfirmationToken: Boolean,
         confirmParamsCreation:
         ConfirmStripeIntentParamsFactory<ConfirmStripeIntentParams>.() -> ConfirmStripeIntentParams
     ): ConfirmationDefinition.Action<Args> {
@@ -35,9 +34,8 @@ internal class ConfirmActionHelper(private val isLiveMode: Boolean) {
         val confirmParams = factory.confirmParamsCreation()
         return ConfirmationDefinition.Action.Launch(
             launcherArguments = Args.Confirm(confirmParams),
-            deferredIntentConfirmationType = DeferredIntentConfirmationType.Client.takeIf { isDeferred },
-            isConfirmationToken = isConfirmationToken,
             receivesResultInProcess = false,
+            deferredIntentConfirmationType = DeferredIntentConfirmationType.Client.takeIf { isDeferred },
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModelComponent.kt
@@ -170,6 +170,13 @@ internal interface EmbeddedPaymentElementViewModelModule {
         }
 
         @Provides
+        fun providePaymentMethodMetadataValue(
+            confirmationStateHolder: EmbeddedConfirmationStateHolder,
+        ): PaymentMethodMetadata? {
+            return confirmationStateHolder.state?.paymentMethodMetadata
+        }
+
+        @Provides
         @Named(IS_LIVE_MODE)
         fun providesIsLiveMode(
             paymentConfiguration: Provider<PaymentConfiguration>

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -71,8 +71,10 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Named
+import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
+@Singleton
 internal class PaymentSheetViewModel @Inject internal constructor(
     // Properties provided through PaymentSheetViewModelComponent.Builder
     internal val args: PaymentSheetContract.Args,
@@ -264,7 +266,6 @@ internal class PaymentSheetViewModel @Inject internal constructor(
             // PaymentSheet and return a `Completed` result to the caller.
             handlePaymentCompleted(
                 deferredIntentConfirmationType = pendingResult.deferredIntentConfirmationType,
-                isConfirmationToken = pendingResult.isConfirmationToken,
                 finishImmediately = true,
             )
         } else if (state.validationError != null) {
@@ -562,14 +563,12 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     private fun handlePaymentCompleted(
         deferredIntentConfirmationType: DeferredIntentConfirmationType?,
         finishImmediately: Boolean,
-        isConfirmationToken: Boolean
     ) {
         val currentSelection = inProgressSelection
         currentSelection?.let { paymentSelection ->
             eventReporter.onPaymentSuccess(
                 paymentSelection = paymentSelection,
                 deferredIntentConfirmationType = deferredIntentConfirmationType,
-                isConfirmationToken = isConfirmationToken,
             )
         }
 
@@ -593,7 +592,6 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         when (result) {
             is ConfirmationHandler.Result.Succeeded -> handlePaymentCompleted(
                 deferredIntentConfirmationType = result.deferredIntentConfirmationType,
-                isConfirmationToken = result.isConfirmationToken,
                 finishImmediately = false,
             )
             is ConfirmationHandler.Result.Failed -> processConfirmationFailure(result)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
@@ -154,7 +154,6 @@ internal interface EventReporter : CardScanEventsReporter {
     fun onPaymentSuccess(
         paymentSelection: PaymentSelection,
         deferredIntentConfirmationType: DeferredIntentConfirmationType?,
-        isConfirmationToken: Boolean,
     )
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -601,7 +601,6 @@ internal class DefaultFlowController @Inject internal constructor(
                     eventReporter.onPaymentSuccess(
                         paymentSelection = paymentSelection,
                         deferredIntentConfirmationType = result.deferredIntentConfirmationType,
-                        isConfirmationToken = result.isConfirmationToken,
                     )
                 }
 
@@ -711,7 +710,6 @@ internal class DefaultFlowController @Inject internal constructor(
                     eventReporter.onPaymentSuccess(
                         paymentSelection = paymentSelection,
                         deferredIntentConfirmationType = deferredIntentConfirmationType,
-                        isConfirmationToken = false,
                     )
                 }
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerModule.kt
@@ -10,6 +10,7 @@ import com.stripe.android.link.LinkActivityContract
 import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.account.LinkStore
 import com.stripe.android.link.injection.LinkAnalyticsComponent
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.paymentelement.confirmation.ALLOWS_MANUAL_CONFIRMATION
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
@@ -127,6 +128,11 @@ internal object FlowControllerModule {
     @Named(IS_LIVE_MODE)
     fun provideIsLiveMode(paymentConfiguration: Provider<PaymentConfiguration>): () -> Boolean {
         return { paymentConfiguration.get().isLiveMode() }
+    }
+
+    @Provides
+    fun providePaymentMethodMetadata(viewModel: FlowControllerViewModel): PaymentMethodMetadata? {
+        return viewModel.state?.paymentSheetState?.paymentMethodMetadata
     }
 
     @Module

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.injection
 
 import android.app.Application
 import android.content.Context
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.paymentsheet.PaymentOptionContract
@@ -28,4 +29,9 @@ internal class PaymentOptionsViewModelModule {
     @Provides
     @Named(PRODUCT_USAGE)
     fun provideProductUsage(args: PaymentOptionContract.Args): Set<String> = args.productUsage
+
+    @Provides
+    fun providePaymentMethodMetadata(args: PaymentOptionContract.Args): PaymentMethodMetadata {
+        return args.state.paymentMethodMetadata
+    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherModule.kt
@@ -4,8 +4,10 @@ import android.app.Application
 import android.content.Context
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.injection.IS_LIVE_MODE
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentelement.confirmation.ALLOWS_MANUAL_CONFIRMATION
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
+import com.stripe.android.paymentsheet.PaymentSheetViewModel
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.cvcrecollection.CvcRecollectionHandler
 import com.stripe.android.paymentsheet.cvcrecollection.CvcRecollectionHandlerImpl
@@ -47,5 +49,10 @@ internal abstract class PaymentSheetLauncherModule {
         fun isLiveMode(
             paymentConfiguration: Provider<PaymentConfiguration>
         ): () -> Boolean = { paymentConfiguration.get().isLiveMode() }
+
+        @Provides
+        fun providePaymentMethodMetadata(viewModel: PaymentSheetViewModel): PaymentMethodMetadata? {
+            return viewModel.paymentMethodMetadata.value
+        }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/utils/ConfirmationReportingUtils.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/utils/ConfirmationReportingUtils.kt
@@ -28,7 +28,6 @@ internal fun EventReporter.reportPaymentResult(
             is ConfirmationHandler.Result.Succeeded -> onPaymentSuccess(
                 paymentSelection = selection,
                 deferredIntentConfirmationType = result.deferredIntentConfirmationType,
-                isConfirmationToken = result.isConfirmationToken,
             )
             is ConfirmationHandler.Result.Failed -> {
                 result.toConfirmationError()?.let { confirmationError ->

--- a/paymentsheet/src/main/java/com/stripe/android/shoppay/ShopPayActivityContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/shoppay/ShopPayActivityContract.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.core.os.BundleCompat
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.paymentsheet.PaymentSheet
 import javax.inject.Inject
@@ -19,6 +20,7 @@ internal class ShopPayActivityContract @Inject constructor(
         return ShopPayActivity.createIntent(
             context,
             ShopPayArgs(
+                paymentMethodMetadata = input.paymentMethodMetadata,
                 shopPayConfiguration = input.shopPayConfiguration,
                 publishableKey = configuration.publishableKey,
                 stripeAccountId = configuration.stripeAccountId,
@@ -37,6 +39,7 @@ internal class ShopPayActivityContract @Inject constructor(
     }
 
     data class Args(
+        val paymentMethodMetadata: PaymentMethodMetadata,
         val shopPayConfiguration: PaymentSheet.ShopPayConfiguration,
         val customerSessionClientSecret: String,
         val businessName: String

--- a/paymentsheet/src/main/java/com/stripe/android/shoppay/ShopPayArgs.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/shoppay/ShopPayArgs.kt
@@ -1,11 +1,13 @@
 package com.stripe.android.shoppay
 
 import android.os.Parcelable
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentsheet.PaymentSheet
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
 internal data class ShopPayArgs(
+    val paymentMethodMetadata: PaymentMethodMetadata,
     val shopPayConfiguration: PaymentSheet.ShopPayConfiguration,
     val publishableKey: String,
     val stripeAccountId: String?,

--- a/paymentsheet/src/main/java/com/stripe/android/shoppay/di/ShopPayModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/shoppay/di/ShopPayModule.kt
@@ -12,6 +12,7 @@ import com.stripe.android.core.utils.DefaultDurationProvider
 import com.stripe.android.core.utils.DurationProvider
 import com.stripe.android.core.utils.RealUserFacingLogger
 import com.stripe.android.core.utils.UserFacingLogger
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.networking.PaymentElementRequestSurfaceModule
 import com.stripe.android.paymentelement.AnalyticEventCallback
@@ -92,6 +93,11 @@ internal interface ShopPayModule {
     ): AnalyticsRequestFactory
 
     companion object {
+        @Provides
+        fun providePaymentMethodMetadata(args: ShopPayArgs): PaymentMethodMetadata {
+            return args.paymentMethodMetadata
+        }
+
         @OptIn(ShopPayPreview::class)
         @Provides
         fun provideShopPayHandlers(

--- a/paymentsheet/src/test/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandlerTest.kt
@@ -61,7 +61,6 @@ internal class DefaultLinkConfirmationHandlerTest {
             item = ConfirmationHandler.Result.Succeeded(
                 intent = configuration.stripeIntent,
                 deferredIntentConfirmationType = null,
-                isConfirmationToken = false,
             )
         )
 
@@ -103,7 +102,6 @@ internal class DefaultLinkConfirmationHandlerTest {
             item = ConfirmationHandler.Result.Succeeded(
                 intent = configuration.stripeIntent,
                 deferredIntentConfirmationType = null,
-                isConfirmationToken = false,
             )
         )
 
@@ -219,7 +217,6 @@ internal class DefaultLinkConfirmationHandlerTest {
             item = ConfirmationHandler.Result.Succeeded(
                 intent = configuration.stripeIntent,
                 deferredIntentConfirmationType = null,
-                isConfirmationToken = false,
             )
         )
 
@@ -259,7 +256,6 @@ internal class DefaultLinkConfirmationHandlerTest {
             item = ConfirmationHandler.Result.Succeeded(
                 intent = configuration.stripeIntent,
                 deferredIntentConfirmationType = null,
-                isConfirmationToken = false,
             )
         )
 
@@ -292,7 +288,6 @@ internal class DefaultLinkConfirmationHandlerTest {
             item = ConfirmationHandler.Result.Succeeded(
                 intent = configuration.stripeIntent,
                 deferredIntentConfirmationType = null,
-                isConfirmationToken = false,
             )
         )
 
@@ -325,7 +320,6 @@ internal class DefaultLinkConfirmationHandlerTest {
             item = ConfirmationHandler.Result.Succeeded(
                 intent = configuration.stripeIntent,
                 deferredIntentConfirmationType = null,
-                isConfirmationToken = false,
             )
         )
 
@@ -358,7 +352,6 @@ internal class DefaultLinkConfirmationHandlerTest {
                 item = ConfirmationHandler.Result.Succeeded(
                     intent = configuration.stripeIntent,
                     deferredIntentConfirmationType = null,
-                    isConfirmationToken = false,
                 )
             )
 
@@ -395,7 +388,6 @@ internal class DefaultLinkConfirmationHandlerTest {
             item = ConfirmationHandler.Result.Succeeded(
                 intent = configuration.stripeIntent,
                 deferredIntentConfirmationType = null,
-                isConfirmationToken = false,
             )
         )
 
@@ -438,7 +430,6 @@ internal class DefaultLinkConfirmationHandlerTest {
                 item = ConfirmationHandler.Result.Succeeded(
                     intent = configuration.stripeIntent,
                     deferredIntentConfirmationType = null,
-                    isConfirmationToken = false,
                 )
             )
 
@@ -475,7 +466,6 @@ internal class DefaultLinkConfirmationHandlerTest {
                 item = ConfirmationHandler.Result.Succeeded(
                     intent = configuration.stripeIntent,
                     deferredIntentConfirmationType = null,
-                    isConfirmationToken = false,
                 )
             )
 
@@ -512,7 +502,6 @@ internal class DefaultLinkConfirmationHandlerTest {
                 item = ConfirmationHandler.Result.Succeeded(
                     intent = configuration.stripeIntent,
                     deferredIntentConfirmationType = null,
-                    isConfirmationToken = false,
                 )
             )
 
@@ -574,7 +563,6 @@ internal class DefaultLinkConfirmationHandlerTest {
                 item = ConfirmationHandler.Result.Succeeded(
                     intent = configuration.stripeIntent,
                     deferredIntentConfirmationType = null,
-                    isConfirmationToken = false,
                 )
             )
 
@@ -617,7 +605,6 @@ internal class DefaultLinkConfirmationHandlerTest {
                 item = ConfirmationHandler.Result.Succeeded(
                     intent = configuration.stripeIntent,
                     deferredIntentConfirmationType = null,
-                    isConfirmationToken = false,
                 )
             )
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
@@ -63,6 +63,7 @@ internal object PaymentMethodMetadataFactory {
         appearance: PaymentSheet.Appearance = PaymentSheet.Appearance(),
         onBehalfOf: String? = null,
         integrationMetadata: IntegrationMetadata = stripeIntent.integrationMetadata(),
+        sellerBusinessName: String? = null,
     ): PaymentMethodMetadata {
         return PaymentMethodMetadata(
             stripeIntent = stripeIntent,
@@ -74,7 +75,7 @@ internal object PaymentMethodMetadataFactory {
             paymentMethodOrder = paymentMethodOrder,
             cbcEligibility = cbcEligibility,
             merchantName = PaymentSheetFixtures.MERCHANT_DISPLAY_NAME,
-            sellerBusinessName = null,
+            sellerBusinessName = sellerBusinessName,
             defaultBillingDetails = defaultBillingDetails,
             shippingDetails = shippingDetails,
             customerMetadata = if (hasCustomerConfiguration) {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediatorTest.kt
@@ -158,7 +158,6 @@ class ConfirmationMediatorTest {
         action = ConfirmationDefinition.Action.Complete(
             intent = INTENT,
             deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
-            isConfirmationToken = false,
             completedFullPaymentFlow = true,
         ),
     ) {
@@ -183,7 +182,6 @@ class ConfirmationMediatorTest {
 
         assertThat(completeAction.intent).isEqualTo(INTENT)
         assertThat(completeAction.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Client)
-        assertThat(completeAction.isConfirmationToken).isEqualTo(false)
         assertThat(completeAction.completedFullPaymentFlow).isTrue()
     }
 
@@ -192,7 +190,6 @@ class ConfirmationMediatorTest {
         action = ConfirmationDefinition.Action.Complete(
             intent = INTENT,
             deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
-            isConfirmationToken = false,
             completedFullPaymentFlow = false,
         ),
     ) {
@@ -217,7 +214,6 @@ class ConfirmationMediatorTest {
 
         assertThat(completeAction.intent).isEqualTo(INTENT)
         assertThat(completeAction.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Client)
-        assertThat(completeAction.isConfirmationToken).isEqualTo(false)
         assertThat(completeAction.completedFullPaymentFlow).isFalse()
     }
 
@@ -259,7 +255,6 @@ class ConfirmationMediatorTest {
         action = ConfirmationDefinition.Action.Launch(
             launcherArguments = TestConfirmationDefinition.LauncherArgs,
             deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
-            isConfirmationToken = false,
             receivesResultInProcess = false,
         ),
     ) {
@@ -310,7 +305,6 @@ class ConfirmationMediatorTest {
         assertThat(parameters?.confirmationOption).isEqualTo(TestConfirmationDefinition.Option)
         assertThat(parameters?.confirmationArgs).isEqualTo(CONFIRMATION_PARAMETERS)
         assertThat(parameters?.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Client)
-        assertThat(parameters?.isConfirmationToken).isEqualTo(false)
     }
 
     @Test
@@ -319,7 +313,6 @@ class ConfirmationMediatorTest {
             action = ConfirmationDefinition.Action.Launch(
                 launcherArguments = TestConfirmationDefinition.LauncherArgs,
                 deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
-                isConfirmationToken = false,
                 receivesResultInProcess = true,
             ),
         ) {
@@ -357,7 +350,6 @@ class ConfirmationMediatorTest {
         action = ConfirmationDefinition.Action.Launch(
             launcherArguments = TestConfirmationDefinition.LauncherArgs,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
             receivesResultInProcess = false,
         ),
     ) {
@@ -393,7 +385,6 @@ class ConfirmationMediatorTest {
         action = ConfirmationDefinition.Action.Launch(
             launcherArguments = TestConfirmationDefinition.LauncherArgs,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
             receivesResultInProcess = false,
         ),
     ) {
@@ -438,13 +429,11 @@ class ConfirmationMediatorTest {
         action = ConfirmationDefinition.Action.Launch(
             launcherArguments = TestConfirmationDefinition.LauncherArgs,
             deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
-            isConfirmationToken = false,
             receivesResultInProcess = false,
         ),
         result = ConfirmationDefinition.Result.Succeeded(
             intent = INTENT,
             deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
-            isConfirmationToken = false,
         ),
     ) {
         val waitForResultLatch = CountDownLatch(1)
@@ -512,7 +501,6 @@ class ConfirmationMediatorTest {
 
         assertThat(successResult.intent).isEqualTo(INTENT)
         assertThat(successResult.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Client)
-        assertThat(successResult.isConfirmationToken).isEqualTo(false)
 
         // The params should be cleared to avoid keeping the PAN around in memory longer than necessary.
         assertThat(savedStateHandle.get<Any>(mediator.key + ConfirmationMediator.PARAMETERS_POSTFIX_KEY)).isNull()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationTestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationTestUtils.kt
@@ -79,7 +79,6 @@ internal fun <
                 confirmationOption = confirmationOption,
                 confirmationArgs = parameters,
                 deferredIntentConfirmationType = null,
-                isConfirmationToken = false,
             )
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandlerTest.kt
@@ -65,13 +65,11 @@ class DefaultConfirmationHandlerTest {
             launcherArguments = SomeConfirmationDefinition.LauncherArgs,
             receivesResultInProcess = true,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
         ),
         someOtherDefinitionAction = ConfirmationDefinition.Action.Launch(
             launcherArguments = SomeOtherConfirmationDefinition.LauncherArgs,
             receivesResultInProcess = true,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
         ),
     ) {
         val activityResultCaller = mock<ActivityResultCaller>()
@@ -227,7 +225,6 @@ class DefaultConfirmationHandlerTest {
         someDefinitionAction = ConfirmationDefinition.Action.Complete(
             intent = UPDATED_PAYMENT_INTENT,
             deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
-            isConfirmationToken = false,
             completedFullPaymentFlow = true,
         ),
     ) {
@@ -245,7 +242,6 @@ class DefaultConfirmationHandlerTest {
             assertThat(successResult.intent).isEqualTo(UPDATED_PAYMENT_INTENT)
             assertThat(successResult.deferredIntentConfirmationType)
                 .isEqualTo(DeferredIntentConfirmationType.Client)
-            assertThat(successResult.isConfirmationToken).isFalse()
             assertThat(successResult.completedFullPaymentFlow).isTrue()
 
             confirmationHandler.assertAwaitResultCallReceivesSameResult(completeState)
@@ -259,7 +255,6 @@ class DefaultConfirmationHandlerTest {
         someDefinitionAction = ConfirmationDefinition.Action.Complete(
             intent = UPDATED_PAYMENT_INTENT,
             deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
-            isConfirmationToken = false,
             completedFullPaymentFlow = false,
         ),
     ) {
@@ -277,7 +272,6 @@ class DefaultConfirmationHandlerTest {
             assertThat(successResult.intent).isEqualTo(UPDATED_PAYMENT_INTENT)
             assertThat(successResult.deferredIntentConfirmationType)
                 .isEqualTo(DeferredIntentConfirmationType.Client)
-            assertThat(successResult.isConfirmationToken).isFalse()
             assertThat(successResult.completedFullPaymentFlow).isFalse()
 
             confirmationHandler.assertAwaitResultCallReceivesSameResult(completeState)
@@ -299,7 +293,6 @@ class DefaultConfirmationHandlerTest {
         result = ConfirmationDefinition.Result.Succeeded(
             intent = UPDATED_PAYMENT_INTENT,
             deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
-            isConfirmationToken = false,
             completedFullPaymentFlow = true,
         ),
     ) { completeState ->
@@ -307,7 +300,6 @@ class DefaultConfirmationHandlerTest {
 
         assertThat(successResult.intent).isEqualTo(UPDATED_PAYMENT_INTENT)
         assertThat(successResult.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Server)
-        assertThat(successResult.isConfirmationToken).isFalse()
         assertThat(successResult.completedFullPaymentFlow).isTrue()
 
         assertThat(confirmationSaverTurbine.awaitItem()).isNotNull()
@@ -319,7 +311,6 @@ class DefaultConfirmationHandlerTest {
             result = ConfirmationDefinition.Result.Succeeded(
                 intent = UPDATED_PAYMENT_INTENT,
                 deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
-                isConfirmationToken = false,
                 completedFullPaymentFlow = false,
             ),
         ) { completeState ->
@@ -327,7 +318,6 @@ class DefaultConfirmationHandlerTest {
 
             assertThat(successResult.intent).isEqualTo(UPDATED_PAYMENT_INTENT)
             assertThat(successResult.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Server)
-            assertThat(successResult.isConfirmationToken).isFalse()
             assertThat(successResult.completedFullPaymentFlow).isFalse()
 
             assertThat(confirmationSaverTurbine.awaitItem()).isNotNull()
@@ -402,7 +392,6 @@ class DefaultConfirmationHandlerTest {
             launcherArguments = SomeConfirmationDefinition.LauncherArgs,
             receivesResultInProcess = true,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
         ),
         someDefinitionResult = ConfirmationDefinition.Result.NextStep(
             confirmationOption = SomeOtherConfirmationDefinition.Option,
@@ -412,12 +401,10 @@ class DefaultConfirmationHandlerTest {
             launcherArguments = SomeOtherConfirmationDefinition.LauncherArgs,
             receivesResultInProcess = true,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
         ),
         someOtherDefinitionResult = ConfirmationDefinition.Result.Succeeded(
             intent = PAYMENT_INTENT,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
         ),
     ) {
         confirmationHandler.state.test {
@@ -442,7 +429,6 @@ class DefaultConfirmationHandlerTest {
 
             assertThat(successResult.intent).isEqualTo(PAYMENT_INTENT)
             assertThat(successResult.deferredIntentConfirmationType).isNull()
-            assertThat(successResult.isConfirmationToken).isFalse()
 
             confirmationHandler.assertAwaitResultCallReceivesSameResult(completeState)
 
@@ -461,7 +447,6 @@ class DefaultConfirmationHandlerTest {
             someDefinitionResult = ConfirmationDefinition.Result.Succeeded(
                 intent = PAYMENT_INTENT,
                 deferredIntentConfirmationType = null,
-                isConfirmationToken = false,
             ),
             dispatcher = dispatcher,
         ) {
@@ -480,7 +465,6 @@ class DefaultConfirmationHandlerTest {
 
                 assertThat(successResult.intent).isEqualTo(PAYMENT_INTENT)
                 assertThat(successResult.deferredIntentConfirmationType).isNull()
-                assertThat(successResult.isConfirmationToken).isFalse()
 
                 confirmationHandler.assertAwaitResultCallReceivesSameResult(completeState)
             }
@@ -526,7 +510,6 @@ class DefaultConfirmationHandlerTest {
             someDefinitionResult = ConfirmationDefinition.Result.Succeeded(
                 intent = PAYMENT_INTENT,
                 deferredIntentConfirmationType = null,
-                isConfirmationToken = false,
             ),
             dispatcher = dispatcher,
         ) {
@@ -545,7 +528,6 @@ class DefaultConfirmationHandlerTest {
 
                 assertThat(successResult.intent).isEqualTo(PAYMENT_INTENT)
                 assertThat(successResult.deferredIntentConfirmationType).isNull()
-                assertThat(successResult.isConfirmationToken).isFalse()
 
                 confirmationHandler.assertAwaitResultCallReceivesSameResult(completeState)
             }
@@ -566,12 +548,10 @@ class DefaultConfirmationHandlerTest {
                 launcherArguments = SomeOtherConfirmationDefinition.LauncherArgs,
                 receivesResultInProcess = false,
                 deferredIntentConfirmationType = null,
-                isConfirmationToken = false,
             ),
             someOtherDefinitionResult = ConfirmationDefinition.Result.Succeeded(
                 intent = UPDATED_PAYMENT_INTENT,
                 deferredIntentConfirmationType = null,
-                isConfirmationToken = false,
             ),
             dispatcher = dispatcher,
         ) {
@@ -596,7 +576,6 @@ class DefaultConfirmationHandlerTest {
 
                 assertThat(successResult.intent).isEqualTo(UPDATED_PAYMENT_INTENT)
                 assertThat(successResult.deferredIntentConfirmationType).isNull()
-                assertThat(successResult.isConfirmationToken).isFalse()
 
                 confirmationHandler.assertAwaitResultCallReceivesSameResult(completeState)
             }
@@ -621,12 +600,10 @@ class DefaultConfirmationHandlerTest {
                 launcherArguments = SomeConfirmationDefinition.LauncherArgs,
                 receivesResultInProcess = true,
                 deferredIntentConfirmationType = null,
-                isConfirmationToken = false,
             ),
             someDefinitionResult = ConfirmationDefinition.Result.Succeeded(
                 intent = PAYMENT_INTENT,
                 deferredIntentConfirmationType = null,
-                isConfirmationToken = false,
             ),
             dispatcher = dispatcher,
         ) {
@@ -637,7 +614,6 @@ class DefaultConfirmationHandlerTest {
 
                 assertThat(result.intent).isEqualTo(PAYMENT_INTENT)
                 assertThat(result.deferredIntentConfirmationType).isNull()
-                assertThat(result.isConfirmationToken).isFalse()
             }
 
             dispatcher.scheduler.advanceUntilIdle()
@@ -688,7 +664,6 @@ class DefaultConfirmationHandlerTest {
             launcherArguments = SomeConfirmationDefinition.LauncherArgs,
             receivesResultInProcess = true,
             deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
-            isConfirmationToken = false,
         ),
         someDefinitionResult = result,
     ) {
@@ -716,7 +691,6 @@ class DefaultConfirmationHandlerTest {
             launcherArguments = SomeConfirmationDefinition.LauncherArgs,
             receivesResultInProcess = receivesResultInProcess,
             deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
-            isConfirmationToken = false,
         ),
     ) {
         confirmationHandler.state.test {
@@ -744,7 +718,6 @@ class DefaultConfirmationHandlerTest {
 
             assertThat(parameters?.confirmationArgs).isEqualTo(CONFIRMATION_PARAMETERS)
             assertThat(parameters?.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Client)
-            assertThat(parameters?.isConfirmationToken).isEqualTo(false)
         }
     }
 
@@ -887,7 +860,6 @@ class DefaultConfirmationHandlerTest {
                 confirmationOption = SomeConfirmationDefinition.Option,
                 confirmationArgs = CONFIRMATION_PARAMETERS,
                 deferredIntentConfirmationType = null,
-                isConfirmationToken = false,
             )
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/FakeConfirmationDefinition.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/FakeConfirmationDefinition.kt
@@ -54,7 +54,6 @@ internal abstract class FakeConfirmationDefinition<
         confirmationOption: TConfirmationOption,
         confirmationArgs: ConfirmationHandler.Args,
         deferredIntentConfirmationType: DeferredIntentConfirmationType?,
-        isConfirmationToken: Boolean,
         result: TLauncherResult
     ): ConfirmationDefinition.Result {
         return this.result

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationDefinitionTest.kt
@@ -131,7 +131,6 @@ class IntentConfirmationDefinitionTest {
 
         assertThat(completeAction.intent).isEqualTo(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
         assertThat(completeAction.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Server)
-        assertThat(completeAction.isConfirmationToken).isEqualTo(false)
     }
 
     @Test
@@ -156,7 +155,6 @@ class IntentConfirmationDefinitionTest {
 
             assertThat(completeAction.intent).isEqualTo(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
             assertThat(completeAction.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Server)
-            assertThat(completeAction.isConfirmationToken).isEqualTo(false)
             assertThat(completeAction.completedFullPaymentFlow).isFalse()
         }
 
@@ -210,7 +208,6 @@ class IntentConfirmationDefinitionTest {
             )
         )
         assertThat(launchAction.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Server)
-        assertThat(launchAction.isConfirmationToken).isEqualTo(false)
     }
 
     @Test
@@ -240,7 +237,6 @@ class IntentConfirmationDefinitionTest {
             )
         )
         assertThat(launchAction.deferredIntentConfirmationType).isNull()
-        assertThat(launchAction.isConfirmationToken).isFalse()
     }
 
     @Test
@@ -399,7 +395,6 @@ class IntentConfirmationDefinitionTest {
             confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
-            isConfirmationToken = false,
             result = InternalPaymentResult.Completed(PaymentIntentFixtures.PI_SUCCEEDED),
         )
 
@@ -407,7 +402,6 @@ class IntentConfirmationDefinitionTest {
 
         assertThat(succeededResult.intent).isEqualTo(PaymentIntentFixtures.PI_SUCCEEDED)
         assertThat(succeededResult.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Client)
-        assertThat(succeededResult.isConfirmationToken).isEqualTo(false)
         assertThat(succeededResult.completedFullPaymentFlow).isTrue()
     }
 
@@ -425,7 +419,6 @@ class IntentConfirmationDefinitionTest {
             confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
             result = InternalPaymentResult.Failed(exception),
         )
 
@@ -448,7 +441,6 @@ class IntentConfirmationDefinitionTest {
             confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
             result = InternalPaymentResult.Canceled,
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/RecordingConfirmationDefinition.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/RecordingConfirmationDefinition.kt
@@ -50,7 +50,6 @@ internal class RecordingConfirmationDefinition<
         confirmationOption: TConfirmationOption,
         confirmationArgs: ConfirmationHandler.Args,
         deferredIntentConfirmationType: DeferredIntentConfirmationType?,
-        isConfirmationToken: Boolean,
         result: TLauncherResult
     ): ConfirmationDefinition.Result {
         toResultCalls.add(
@@ -66,7 +65,6 @@ internal class RecordingConfirmationDefinition<
             confirmationOption = confirmationOption,
             confirmationArgs = confirmationArgs,
             deferredIntentConfirmationType = deferredIntentConfirmationType,
-            isConfirmationToken = isConfirmationToken,
             result = result
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/attestation/AttestationConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/attestation/AttestationConfirmationDefinitionTest.kt
@@ -240,7 +240,6 @@ internal class AttestationConfirmationDefinitionTest {
             confirmationOption = PAYMENT_METHOD_CONFIRMATION_OPTION_NEW,
             confirmationArgs = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
             result = AttestationActivityResult.Success(testToken),
         )
 
@@ -272,7 +271,6 @@ internal class AttestationConfirmationDefinitionTest {
             confirmationOption = PAYMENT_METHOD_CONFIRMATION_OPTION_SAVED,
             confirmationArgs = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
             result = AttestationActivityResult.Success(testToken),
         )
 
@@ -297,7 +295,6 @@ internal class AttestationConfirmationDefinitionTest {
             confirmationOption = PAYMENT_METHOD_CONFIRMATION_OPTION_NEW,
             confirmationArgs = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
             result = AttestationActivityResult.Failed(exception),
         )
 
@@ -319,7 +316,6 @@ internal class AttestationConfirmationDefinitionTest {
             confirmationOption = PAYMENT_METHOD_CONFIRMATION_OPTION_SAVED,
             confirmationArgs = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
             result = AttestationActivityResult.Failed(exception),
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationDefinitionTest.kt
@@ -96,7 +96,6 @@ class BacsConfirmationDefinitionTest {
             confirmationOption = createBacsConfirmationOption(),
             confirmationArgs = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
             result = BacsMandateConfirmationResult.Confirmed,
         )
 
@@ -126,7 +125,6 @@ class BacsConfirmationDefinitionTest {
                 confirmationOption = createBacsConfirmationOption(),
                 confirmationArgs = CONFIRMATION_PARAMETERS,
                 deferredIntentConfirmationType = null,
-                isConfirmationToken = false,
                 result = BacsMandateConfirmationResult.Cancelled,
             )
 
@@ -146,7 +144,6 @@ class BacsConfirmationDefinitionTest {
                 confirmationOption = createBacsConfirmationOption(),
                 confirmationArgs = CONFIRMATION_PARAMETERS,
                 deferredIntentConfirmationType = null,
-                isConfirmationToken = false,
                 result = BacsMandateConfirmationResult.ModifyDetails,
             )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinitionTest.kt
@@ -278,7 +278,6 @@ internal class PassiveChallengeConfirmationDefinitionTest {
             confirmationOption = PAYMENT_METHOD_CONFIRMATION_OPTION_NEW,
             confirmationArgs = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
             result = PassiveChallengeActivityResult.Success(testToken),
         )
 
@@ -309,7 +308,6 @@ internal class PassiveChallengeConfirmationDefinitionTest {
             confirmationOption = PAYMENT_METHOD_CONFIRMATION_OPTION_SAVED,
             confirmationArgs = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
             result = PassiveChallengeActivityResult.Success(testToken),
         )
 
@@ -335,7 +333,6 @@ internal class PassiveChallengeConfirmationDefinitionTest {
             confirmationOption = PAYMENT_METHOD_CONFIRMATION_OPTION_NEW,
             confirmationArgs = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
             result = PassiveChallengeActivityResult.Failed(exception),
         )
 
@@ -358,7 +355,6 @@ internal class PassiveChallengeConfirmationDefinitionTest {
             confirmationOption = PAYMENT_METHOD_CONFIRMATION_OPTION_SAVED,
             confirmationArgs = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
             result = PassiveChallengeActivityResult.Failed(exception),
         )
 
@@ -479,7 +475,6 @@ internal class PassiveChallengeConfirmationDefinitionTest {
             confirmationOption = PAYMENT_METHOD_CONFIRMATION_OPTION_NEW,
             confirmationArgs = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
             result = PassiveChallengeActivityResult.Success(testToken),
         )
 
@@ -503,7 +498,6 @@ internal class PassiveChallengeConfirmationDefinitionTest {
             confirmationOption = PAYMENT_METHOD_CONFIRMATION_OPTION_NEW,
             confirmationArgs = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
             result = PassiveChallengeActivityResult.Failed(RuntimeException("Failed")),
         )
 
@@ -537,7 +531,6 @@ internal class PassiveChallengeConfirmationDefinitionTest {
             ),
             confirmationArgs = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
             result = PassiveChallengeActivityResult.Success(testToken),
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cpms/CustomPaymentMethodConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cpms/CustomPaymentMethodConfirmationDefinitionTest.kt
@@ -156,7 +156,6 @@ class CustomPaymentMethodConfirmationDefinitionTest {
             confirmationOption = option,
             confirmationArgs = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
             result = InternalCustomPaymentMethodResult.Completed,
         )
 
@@ -165,7 +164,6 @@ class CustomPaymentMethodConfirmationDefinitionTest {
         val succeededResult = result.asSucceeded()
         assertThat(succeededResult.intent).isEqualTo(CONFIRMATION_PARAMETERS.intent)
         assertThat(succeededResult.deferredIntentConfirmationType).isNull()
-        assertThat(succeededResult.isConfirmationToken).isFalse()
         assertThat(succeededResult.completedFullPaymentFlow).isTrue()
     }
 
@@ -178,7 +176,6 @@ class CustomPaymentMethodConfirmationDefinitionTest {
             confirmationOption = option,
             confirmationArgs = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
             result = InternalCustomPaymentMethodResult.Failed(exception),
         )
 
@@ -199,7 +196,6 @@ class CustomPaymentMethodConfirmationDefinitionTest {
             confirmationOption = option,
             confirmationArgs = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
             result = InternalCustomPaymentMethodResult.Canceled,
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationDefinitionTest.kt
@@ -174,7 +174,6 @@ class CvcRecollectionConfirmationDefinitionTest {
             confirmationOption = option,
             confirmationArgs = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
             result = CvcRecollectionResult.Confirmed(
                 cvc = "444",
             ),
@@ -209,7 +208,6 @@ class CvcRecollectionConfirmationDefinitionTest {
             confirmationOption = option,
             confirmationArgs = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
             result = CvcRecollectionResult.Confirmed(
                 cvc = "555",
             ),
@@ -241,7 +239,6 @@ class CvcRecollectionConfirmationDefinitionTest {
             confirmationOption = option,
             confirmationArgs = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
             result = CvcRecollectionResult.Cancelled,
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationDefinitionTest.kt
@@ -94,7 +94,6 @@ class ExternalPaymentMethodConfirmationDefinitionTest {
             confirmationOption = EPM_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
             result = PaymentResult.Completed,
         )
 
@@ -116,7 +115,6 @@ class ExternalPaymentMethodConfirmationDefinitionTest {
             confirmationOption = EPM_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
             result = PaymentResult.Failed(exception),
         )
 
@@ -137,7 +135,6 @@ class ExternalPaymentMethodConfirmationDefinitionTest {
             confirmationOption = EPM_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
             result = PaymentResult.Canceled,
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationFlowTest.kt
@@ -45,7 +45,6 @@ class ExternalPaymentMethodConfirmationFlowTest {
         definitionResult = ConfirmationDefinition.Result.Succeeded(
             intent = PAYMENT_INTENT,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
         )
     )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinitionTest.kt
@@ -109,7 +109,6 @@ class GooglePayConfirmationDefinitionTest {
             confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
             result = GooglePayPaymentMethodLauncher.Result.Completed(
                 paymentMethod = paymentMethod,
             ),
@@ -139,7 +138,6 @@ class GooglePayConfirmationDefinitionTest {
             confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
             result = GooglePayPaymentMethodLauncher.Result.Failed(
                 errorCode = 400,
                 error = exception
@@ -164,7 +162,6 @@ class GooglePayConfirmationDefinitionTest {
             confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
             result = GooglePayPaymentMethodLauncher.Result.Failed(
                 errorCode = GooglePayPaymentMethodLauncher.NETWORK_ERROR,
                 error = exception
@@ -191,7 +188,6 @@ class GooglePayConfirmationDefinitionTest {
             confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
             result = GooglePayPaymentMethodLauncher.Result.Canceled,
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/ConfirmationTokenConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/ConfirmationTokenConfirmationInterceptorTest.kt
@@ -271,7 +271,6 @@ class ConfirmationTokenConfirmationInterceptorTest {
             ConfirmationDefinition.Action.Complete<IntentConfirmationDefinition.Args>(
                 intent = PaymentIntentFixtures.PI_SUCCEEDED,
                 deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
-                isConfirmationToken = true,
                 completedFullPaymentFlow = true,
             )
         )
@@ -315,7 +314,6 @@ class ConfirmationTokenConfirmationInterceptorTest {
                         intent = PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2,
                     ),
                     deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
-                    isConfirmationToken = true,
                     receivesResultInProcess = false,
                 )
             )
@@ -347,7 +345,6 @@ class ConfirmationTokenConfirmationInterceptorTest {
             ConfirmationDefinition.Action.Complete<IntentConfirmationDefinition.Args>(
                 intent = intent,
                 deferredIntentConfirmationType = DeferredIntentConfirmationType.None,
-                isConfirmationToken = true,
                 completedFullPaymentFlow = true,
             )
         )
@@ -502,7 +499,6 @@ class ConfirmationTokenConfirmationInterceptorTest {
                 ConfirmationDefinition.Action.Complete<IntentConfirmationDefinition.Args>(
                     intent = PaymentIntentFixtures.PI_SUCCEEDED,
                     deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
-                    isConfirmationToken = true,
                     completedFullPaymentFlow = true,
                 )
             )
@@ -544,7 +540,6 @@ class ConfirmationTokenConfirmationInterceptorTest {
                 ConfirmationDefinition.Action.Complete<IntentConfirmationDefinition.Args>(
                     intent = PaymentIntentFixtures.PI_SUCCEEDED,
                     deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
-                    isConfirmationToken = true,
                     completedFullPaymentFlow = true,
                 )
             )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/DeferredIntentConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/DeferredIntentConfirmationInterceptorTest.kt
@@ -233,7 +233,6 @@ class DeferredIntentConfirmationInterceptorTest {
             ConfirmationDefinition.Action.Complete<IntentConfirmationDefinition.Args>(
                 intent = PaymentIntentFixtures.PI_SUCCEEDED,
                 deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
-                isConfirmationToken = false,
                 completedFullPaymentFlow = true,
             )
         )
@@ -276,7 +275,6 @@ class DeferredIntentConfirmationInterceptorTest {
                         )
                     ),
                     deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
-                    isConfirmationToken = false,
                     receivesResultInProcess = false,
                 )
             )
@@ -348,7 +346,6 @@ class DeferredIntentConfirmationInterceptorTest {
             ConfirmationDefinition.Action.Complete<IntentConfirmationDefinition.Args>(
                 intent = intent,
                 deferredIntentConfirmationType = DeferredIntentConfirmationType.None,
-                isConfirmationToken = false,
                 completedFullPaymentFlow = true,
             )
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/SharedPaymentTokenConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/SharedPaymentTokenConfirmationInterceptorTest.kt
@@ -68,7 +68,6 @@ class SharedPaymentTokenConfirmationInterceptorTest {
                 ConfirmationDefinition.Action.Complete<IntentConfirmationDefinition.Args>(
                     intent = intent,
                     deferredIntentConfirmationType = DeferredIntentConfirmationType.None,
-                    isConfirmationToken = false,
                     completedFullPaymentFlow = false,
                 )
             )
@@ -116,7 +115,6 @@ class SharedPaymentTokenConfirmationInterceptorTest {
                 ConfirmationDefinition.Action.Complete<IntentConfirmationDefinition.Args>(
                     intent = intent,
                     deferredIntentConfirmationType = DeferredIntentConfirmationType.None,
-                    isConfirmationToken = false,
                     completedFullPaymentFlow = false,
                 )
             )
@@ -166,7 +164,6 @@ class SharedPaymentTokenConfirmationInterceptorTest {
                 ConfirmationDefinition.Action.Complete<IntentConfirmationDefinition.Args>(
                     intent = intent,
                     deferredIntentConfirmationType = DeferredIntentConfirmationType.None,
-                    isConfirmationToken = false,
                     completedFullPaymentFlow = false,
                 )
             )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinitionTest.kt
@@ -193,7 +193,6 @@ internal class LinkConfirmationDefinitionTest {
             confirmationOption = LINK_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
             result = LinkActivityResult.PaymentMethodObtained(paymentMethod),
         )
 
@@ -221,7 +220,6 @@ internal class LinkConfirmationDefinitionTest {
             confirmationOption = LINK_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
             result = LinkActivityResult.Completed(
                 linkAccountUpdate = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT)
             ),
@@ -231,7 +229,6 @@ internal class LinkConfirmationDefinitionTest {
             ConfirmationDefinition.Result.Succeeded(
                 intent = CONFIRMATION_PARAMETERS.intent,
                 deferredIntentConfirmationType = null,
-                isConfirmationToken = false,
             )
         )
         assertThat(storeScenario.markAsUsedCalls.awaitItem()).isNotNull()
@@ -252,7 +249,6 @@ internal class LinkConfirmationDefinitionTest {
             confirmationOption = LINK_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
             result = LinkActivityResult.Failed(
                 error = exception,
                 linkAccountUpdate = LinkAccountUpdate.Value(null)
@@ -285,7 +281,6 @@ internal class LinkConfirmationDefinitionTest {
             confirmationOption = LINK_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
             result = LinkActivityResult.Canceled(
                 reason = LinkActivityResult.Canceled.Reason.LoggedOut,
                 linkAccountUpdate = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT)
@@ -315,7 +310,6 @@ internal class LinkConfirmationDefinitionTest {
             confirmationOption = LINK_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
             result = LinkActivityResult.Canceled(
                 reason = LinkActivityResult.Canceled.Reason.BackPressed,
                 linkAccountUpdate = LinkAccountUpdate.None

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationFlowTest.kt
@@ -77,9 +77,8 @@ class LinkConfirmationFlowTest {
                 "LinkParameters",
                 Parameters(
                     confirmationOption = LINK_CONFIRMATION_OPTION,
-                    deferredIntentConfirmationType = null,
-                    isConfirmationToken = false,
                     confirmationArgs = CONFIRMATION_PARAMETERS,
+                    deferredIntentConfirmationType = null,
                 )
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
@@ -348,7 +348,6 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
             confirmationOption = createLinkInlineSignupConfirmationOption(),
             confirmationArgs = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
             result = LinkInlineSignupConfirmationDefinition.Result(
                 nextConfirmationOption = nextOption,
             ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/shoppay/ShopPayConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/shoppay/ShopPayConfirmationDefinitionTest.kt
@@ -141,7 +141,6 @@ internal class ShopPayConfirmationDefinitionTest {
             confirmationOption = SHOP_PAY_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
             result = ShopPayActivityResult.Completed,
         )
 
@@ -151,7 +150,6 @@ internal class ShopPayConfirmationDefinitionTest {
 
         assertThat(succeededResult.intent).isEqualTo(CONFIRMATION_PARAMETERS.intent)
         assertThat(succeededResult.deferredIntentConfirmationType).isNull()
-        assertThat(succeededResult.isConfirmationToken).isFalse()
         assertThat(succeededResult.completedFullPaymentFlow).isFalse()
     }
 
@@ -164,7 +162,6 @@ internal class ShopPayConfirmationDefinitionTest {
             confirmationOption = SHOP_PAY_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
             result = ShopPayActivityResult.Failed(exception),
         )
 
@@ -185,7 +182,6 @@ internal class ShopPayConfirmationDefinitionTest {
             confirmationOption = SHOP_PAY_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
             result = ShopPayActivityResult.Canceled,
         )
 
@@ -205,7 +201,6 @@ internal class ShopPayConfirmationDefinitionTest {
             confirmationOption = SHOP_PAY_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
             result = ShopPayActivityResult.Failed(exception),
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfirmationHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfirmationHelperTest.kt
@@ -56,7 +56,6 @@ internal class DefaultEmbeddedConfirmationHelperTest {
             ConfirmationHandler.Result.Succeeded(
                 intent = PaymentIntentFixtures.PI_SUCCEEDED,
                 deferredIntentConfirmationType = null,
-                isConfirmationToken = false,
             )
         )
         assertThat(callbackHelper.stateHelper.stateTurbine.awaitItem()).isNull()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationStarterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationStarterTest.kt
@@ -89,7 +89,6 @@ class EmbeddedConfirmationStarterTest {
                 result = ConfirmationHandler.Result.Succeeded(
                     intent = intent,
                     deferredIntentConfirmationType = null,
-                    isConfirmationToken = false,
                 ),
             ),
         ) {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/ConfirmationStateHelpers.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/ConfirmationStateHelpers.kt
@@ -21,7 +21,6 @@ internal fun confirmationStateComplete(succeeded: Boolean): ConfirmationHandler.
         ConfirmationHandler.Result.Succeeded(
             PaymentIntentFixtures.PI_SUCCEEDED,
             null,
-            false,
         )
     } else {
         ConfirmationHandler.Result.Failed(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityConfirmationHandlerTest.kt
@@ -51,7 +51,6 @@ internal class FormActivityConfirmationHandlerTest {
             ConfirmationHandler.Result.Succeeded(
                 intent = PaymentIntentFixtures.PI_SUCCEEDED,
                 deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
-                isConfirmationToken = false,
             )
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -787,7 +787,6 @@ internal class PaymentSheetActivityTest {
                 result = ConfirmationHandler.Result.Succeeded(
                     intent = PAYMENT_INTENT,
                     deferredIntentConfirmationType = null,
-                    isConfirmationToken = false,
                 )
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -869,7 +869,6 @@ internal class PaymentSheetViewModelTest {
                 ConfirmationHandler.Result.Succeeded(
                     intent = PAYMENT_INTENT,
                     deferredIntentConfirmationType = null,
-                    isConfirmationToken = false,
                 )
             )
 
@@ -981,7 +980,6 @@ internal class PaymentSheetViewModelTest {
                 ConfirmationHandler.Result.Succeeded(
                     intent = PAYMENT_INTENT,
                     deferredIntentConfirmationType = null,
-                    isConfirmationToken = false,
                 )
             )
 
@@ -1017,7 +1015,6 @@ internal class PaymentSheetViewModelTest {
                 result = ConfirmationHandler.Result.Succeeded(
                     intent = PAYMENT_INTENT,
                     deferredIntentConfirmationType = null,
-                    isConfirmationToken = false,
                 )
             )
 
@@ -1037,7 +1034,6 @@ internal class PaymentSheetViewModelTest {
                 .onPaymentSuccess(
                     paymentSelection = selection,
                     deferredIntentConfirmationType = null,
-                    isConfirmationToken = false,
                 )
 
             resultTurbine.cancel()
@@ -2030,7 +2026,6 @@ internal class PaymentSheetViewModelTest {
                 ConfirmationHandler.Result.Succeeded(
                     intent = PAYMENT_INTENT,
                     deferredIntentConfirmationType = null,
-                    isConfirmationToken = false,
                 )
             )
 
@@ -2167,14 +2162,12 @@ internal class PaymentSheetViewModelTest {
             result = ConfirmationHandler.Result.Succeeded(
                 intent = PAYMENT_INTENT,
                 deferredIntentConfirmationType = null,
-                isConfirmationToken = false,
             )
         )
 
         verify(eventReporter).onPaymentSuccess(
             paymentSelection = eq(savedSelection),
             deferredIntentConfirmationType = isNull(),
-            isConfirmationToken = eq(false),
         )
     }
 
@@ -2203,14 +2196,12 @@ internal class PaymentSheetViewModelTest {
                 ConfirmationHandler.Result.Succeeded(
                     intent = PAYMENT_INTENT,
                     deferredIntentConfirmationType = DeferredIntentConfirmationType.None,
-                    isConfirmationToken = false,
                 )
             )
 
             verify(eventReporter).onPaymentSuccess(
                 paymentSelection = eq(savedSelection),
                 deferredIntentConfirmationType = eq(DeferredIntentConfirmationType.None),
-                isConfirmationToken = eq(false),
             )
         }
 
@@ -2239,14 +2230,12 @@ internal class PaymentSheetViewModelTest {
                 ConfirmationHandler.Result.Succeeded(
                     intent = PAYMENT_INTENT,
                     deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
-                    isConfirmationToken = false,
                 )
             )
 
             verify(eventReporter).onPaymentSuccess(
                 paymentSelection = eq(savedSelection),
                 deferredIntentConfirmationType = eq(DeferredIntentConfirmationType.Client),
-                isConfirmationToken = eq(false),
             )
         }
 
@@ -2275,14 +2264,12 @@ internal class PaymentSheetViewModelTest {
                 ConfirmationHandler.Result.Succeeded(
                     intent = PAYMENT_INTENT,
                     deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
-                    isConfirmationToken = false,
                 )
             )
 
             verify(eventReporter).onPaymentSuccess(
                 paymentSelection = eq(savedSelection),
                 deferredIntentConfirmationType = eq(DeferredIntentConfirmationType.Server),
-                isConfirmationToken = eq(false),
             )
         }
 
@@ -2600,7 +2587,6 @@ internal class PaymentSheetViewModelTest {
             ConfirmationHandler.Result.Succeeded(
                 intent = PaymentIntentFixtures.PI_SUCCEEDED,
                 deferredIntentConfirmationType = null,
-                isConfirmationToken = false,
             )
         )
 
@@ -2681,7 +2667,6 @@ internal class PaymentSheetViewModelTest {
             ConfirmationHandler.Result.Succeeded(
                 intent = PaymentIntentFixtures.PI_SUCCEEDED,
                 deferredIntentConfirmationType = null,
-                isConfirmationToken = false,
             )
         )
 
@@ -2757,7 +2742,6 @@ internal class PaymentSheetViewModelTest {
             ConfirmationHandler.Result.Succeeded(
                 intent = PaymentIntentFixtures.PI_SUCCEEDED,
                 deferredIntentConfirmationType = null,
-                isConfirmationToken = false,
             )
         )
 
@@ -3342,7 +3326,6 @@ internal class PaymentSheetViewModelTest {
                 ConfirmationHandler.Result.Succeeded(
                     intent = stripeIntent,
                     deferredIntentConfirmationType = null,
-                    isConfirmationToken = false,
                 )
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -17,6 +17,9 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.core.utils.DurationProvider
 import com.stripe.android.core.utils.UserFacingLogger
 import com.stripe.android.link.ui.LinkButtonState
+import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.WalletType
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ElementsSession.ExperimentAssignment.LINK_GLOBAL_HOLD_BACK
@@ -285,7 +288,6 @@ class DefaultEventReporterTest {
         completeEventReporter.onPaymentSuccess(
             paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
         )
 
         verify(analyticsRequestExecutor).executeAsync(
@@ -316,7 +318,6 @@ class DefaultEventReporterTest {
                     walletType = PaymentSelection.Saved.WalletType.GooglePay,
                 ),
                 deferredIntentConfirmationType = null,
-                isConfirmationToken = false,
             )
 
             analyticEventCallbackRule.assertMatchesExpectedEvent(AnalyticEvent.PresentedSheet())
@@ -347,7 +348,6 @@ class DefaultEventReporterTest {
                     walletType = PaymentSelection.Saved.WalletType.Link,
                 ),
                 deferredIntentConfirmationType = null,
-                isConfirmationToken = false,
             )
 
             verify(analyticsRequestExecutor).executeAsync(
@@ -362,7 +362,16 @@ class DefaultEventReporterTest {
     fun `onPaymentSuccess() with confirmation token should include isConfirmationToken in analytics`() =
         runTest(testDispatcher) {
             // Log initial event so that duration is tracked
-            val completeEventReporter = createEventReporter(EventReporter.Mode.Complete) {
+            val completeEventReporter = createEventReporter(
+                mode = EventReporter.Mode.Complete,
+                paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                    integrationMetadata = IntegrationMetadata.DeferredIntentWithConfirmationToken(
+                        intentConfiguration = PaymentSheet.IntentConfiguration(
+                            mode = PaymentSheet.IntentConfiguration.Mode.Setup()
+                        )
+                    )
+                )
+            ) {
                 simulateSuccessfulSetup()
                 onShowExistingPaymentOptions()
             }
@@ -371,7 +380,6 @@ class DefaultEventReporterTest {
             completeEventReporter.onPaymentSuccess(
                 paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
                 deferredIntentConfirmationType = null,
-                isConfirmationToken = true,
             )
 
             verify(analyticsRequestExecutor).executeAsync(
@@ -823,6 +831,7 @@ class DefaultEventReporterTest {
             analyticEventCallbackProvider = analyticEventCallbackRule,
             workContext = testDispatcher,
             logger = fakeUserFacingLogger,
+            paymentMethodMetadataProvider = { null },
         )
     }
 
@@ -1074,7 +1083,6 @@ class DefaultEventReporterTest {
         completeEventReporter.onPaymentSuccess(
             paymentSelection = selection,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
         )
 
         val argumentCaptor = argumentCaptor<AnalyticsRequest>()
@@ -1094,7 +1102,6 @@ class DefaultEventReporterTest {
         completeEventReporter.onPaymentSuccess(
             paymentSelection = selection,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
         )
 
         val argumentCaptor = argumentCaptor<AnalyticsRequest>()
@@ -1114,7 +1121,6 @@ class DefaultEventReporterTest {
         completeEventReporter.onPaymentSuccess(
             paymentSelection = selection,
             deferredIntentConfirmationType = null,
-            isConfirmationToken = false,
         )
 
         val argumentCaptor = argumentCaptor<AnalyticsRequest>()
@@ -1280,8 +1286,20 @@ class DefaultEventReporterTest {
         expectedIsSptValue: Boolean,
     ) {
         analyticEventCallbackRule.setCallback(null)
+        val paymentMethodMetadata = if (expectedIsSptValue) {
+            PaymentMethodMetadataFactory.create(
+                integrationMetadata = IntegrationMetadata.DeferredIntentWithSharedPaymentToken(
+                    intentConfiguration = intentConfiguration
+                )
+            )
+        } else {
+            null
+        }
 
-        val completeEventReporter = createEventReporter(EventReporter.Mode.Complete) {
+        val completeEventReporter = createEventReporter(
+            mode = EventReporter.Mode.Complete,
+            paymentMethodMetadata = paymentMethodMetadata,
+        ) {
             simulateSuccessfulSetup(
                 initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
                     intentConfiguration = intentConfiguration,
@@ -1541,6 +1559,7 @@ class DefaultEventReporterTest {
     private fun createEventReporter(
         mode: EventReporter.Mode,
         duration: Duration = 1.seconds,
+        paymentMethodMetadata: PaymentMethodMetadata? = null,
         configure: DefaultEventReporter.() -> Unit = {},
     ): DefaultEventReporter {
         val reporter = DefaultEventReporter(
@@ -1553,6 +1572,7 @@ class DefaultEventReporterTest {
             analyticEventCallbackProvider = analyticEventCallbackRule,
             workContext = testDispatcher,
             logger = fakeUserFacingLogger,
+            paymentMethodMetadataProvider = { paymentMethodMetadata },
         )
 
         reporter.configure()
@@ -1578,6 +1598,7 @@ class DefaultEventReporterTest {
             analyticEventCallbackProvider = analyticEventCallbackRule,
             workContext = testDispatcher,
             logger = fakeUserFacingLogger,
+            paymentMethodMetadataProvider = { null },
         )
 
         reporter.configure()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeEventReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeEventReporter.kt
@@ -144,14 +144,12 @@ internal class FakeEventReporter : EventReporter {
 
     override fun onPaymentSuccess(
         paymentSelection: PaymentSelection,
-        deferredIntentConfirmationType: DeferredIntentConfirmationType?,
-        isConfirmationToken: Boolean
+        deferredIntentConfirmationType: DeferredIntentConfirmationType?
     ) {
         _paymentSuccessCalls.add(
             PaymentSuccessCall(
                 paymentSelection = paymentSelection,
                 deferredIntentConfirmationType = deferredIntentConfirmationType,
-                isConfirmationToken = isConfirmationToken,
             )
         )
     }
@@ -277,7 +275,6 @@ internal class FakeEventReporter : EventReporter {
     data class PaymentSuccessCall(
         val paymentSelection: PaymentSelection,
         val deferredIntentConfirmationType: DeferredIntentConfirmationType?,
-        val isConfirmationToken: Boolean,
     )
 
     data class UpdatePaymentMethodSucceededCall(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -191,7 +191,6 @@ internal class DefaultFlowControllerTest {
             .onPaymentSuccess(
                 paymentSelection = isA<PaymentSelection.New>(),
                 deferredIntentConfirmationType = isNull(),
-                isConfirmationToken = eq(false),
             )
     }
 
@@ -234,7 +233,6 @@ internal class DefaultFlowControllerTest {
                 intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
                 deferredIntentConfirmationType = null,
                 completedFullPaymentFlow = false,
-                isConfirmationToken = false,
             )
         )
 
@@ -1660,7 +1658,6 @@ internal class DefaultFlowControllerTest {
             ConfirmationHandler.Result.Succeeded(
                 intent = PaymentIntentFixtures.PI_SUCCEEDED,
                 deferredIntentConfirmationType = null,
-                isConfirmationToken = false,
             )
         )
 
@@ -1847,14 +1844,12 @@ internal class DefaultFlowControllerTest {
             ConfirmationHandler.Result.Succeeded(
                 intent = PaymentIntentFixtures.PI_SUCCEEDED,
                 deferredIntentConfirmationType = null,
-                isConfirmationToken = false,
             )
         )
 
         verify(eventReporter).onPaymentSuccess(
             paymentSelection = eq(savedSelection),
             deferredIntentConfirmationType = isNull(),
-            isConfirmationToken = eq(false),
         )
     }
 
@@ -1879,14 +1874,12 @@ internal class DefaultFlowControllerTest {
                 ConfirmationHandler.Result.Succeeded(
                     intent = PaymentIntentFixtures.PI_SUCCEEDED,
                     deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
-                    isConfirmationToken = false,
                 )
             )
 
             verify(eventReporter).onPaymentSuccess(
                 paymentSelection = eq(savedSelection),
                 deferredIntentConfirmationType = eq(DeferredIntentConfirmationType.Client),
-                isConfirmationToken = eq(false),
             )
         }
 
@@ -1911,14 +1904,12 @@ internal class DefaultFlowControllerTest {
                 ConfirmationHandler.Result.Succeeded(
                     intent = PaymentIntentFixtures.PI_SUCCEEDED,
                     deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
-                    isConfirmationToken = false,
                 )
             )
 
             verify(eventReporter).onPaymentSuccess(
                 paymentSelection = eq(savedSelection),
                 deferredIntentConfirmationType = eq(DeferredIntentConfirmationType.Server),
-                isConfirmationToken = eq(false),
             )
         }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/ConfirmationReportingUtilsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/ConfirmationReportingUtilsTest.kt
@@ -78,7 +78,6 @@ class ConfirmationReportingUtilsTest {
         val result = ConfirmationHandler.Result.Succeeded(
             intent = PaymentIntentFixtures.PI_SUCCEEDED,
             deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
-            isConfirmationToken = false,
         )
 
         eventReporter.reportPaymentResult(result, PaymentSelection.GooglePay)
@@ -86,7 +85,6 @@ class ConfirmationReportingUtilsTest {
         val event = eventReporter.paymentSuccessCalls.awaitItem()
         assertThat(event.paymentSelection).isEqualTo(PaymentSelection.GooglePay)
         assertThat(event.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Client)
-        assertThat(event.isConfirmationToken).isEqualTo(false)
         eventReporter.validate()
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/shoppay/ShopPayActivityContractTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/shoppay/ShopPayActivityContractTest.kt
@@ -7,6 +7,7 @@ import androidx.core.os.bundleOf
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.paymentsheet.PaymentSheet
 import org.junit.Before
 import org.junit.Test
@@ -33,6 +34,10 @@ internal class ShopPayActivityContractTest {
     fun `intent is created correctly`() {
         val shopPayConfiguration: PaymentSheet.ShopPayConfiguration = mock()
         val args = ShopPayActivityContract.Args(
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                sellerBusinessName = "Example Inc.",
+                shopPayConfiguration = shopPayConfiguration,
+            ),
             shopPayConfiguration = shopPayConfiguration,
             customerSessionClientSecret = "customer_secret",
             businessName = "Example Inc."

--- a/paymentsheet/src/test/java/com/stripe/android/shoppay/ShopPayTestFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/shoppay/ShopPayTestFactory.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.shoppay
 
 import com.stripe.android.common.model.SHOP_PAY_CONFIGURATION
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.shoppay.bridge.ECEBillingDetails
 import com.stripe.android.shoppay.bridge.ECEDeliveryEstimate
 import com.stripe.android.shoppay.bridge.ECEFullAddress
@@ -81,6 +82,10 @@ internal object ShopPayTestFactory {
     )
 
     val SHOP_PAY_ARGS = ShopPayArgs(
+        paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            sellerBusinessName = "Test Business",
+            shopPayConfiguration = SHOP_PAY_CONFIGURATION,
+        ),
         publishableKey = "pk_1234",
         shopPayConfiguration = SHOP_PAY_CONFIGURATION,
         customerSessionClientSecret = "css_test_123",

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeIntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeIntentConfirmationInterceptor.kt
@@ -32,9 +32,8 @@ internal class FakeIntentConfirmationInterceptor : IntentConfirmationInterceptor
         val nextStep: ConfirmationDefinition.Action<IntentConfirmationDefinition.Args> =
             ConfirmationDefinition.Action.Launch(
                 launcherArguments = IntentConfirmationDefinition.Args.Confirm(confirmParams),
-                deferredIntentConfirmationType = DeferredIntentConfirmationType.Client.takeIf { isDeferred },
-                isConfirmationToken = false,
                 receivesResultInProcess = false,
+                deferredIntentConfirmationType = DeferredIntentConfirmationType.Client.takeIf { isDeferred },
             )
         channel.trySend(nextStep)
     }
@@ -52,7 +51,6 @@ internal class FakeIntentConfirmationInterceptor : IntentConfirmationInterceptor
                 } else {
                     DeferredIntentConfirmationType.Server
                 },
-                isConfirmationToken = false,
                 completedFullPaymentFlow = completedFullPaymentFlow,
             )
         )
@@ -62,9 +60,8 @@ internal class FakeIntentConfirmationInterceptor : IntentConfirmationInterceptor
         channel.trySend(
             ConfirmationDefinition.Action.Launch(
                 launcherArguments = IntentConfirmationDefinition.Args.NextAction(intent),
-                deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
-                isConfirmationToken = false,
                 receivesResultInProcess = false,
+                deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
             )
         )
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This GREATLY simplifies how we need to pass isConfirmationToken (and fixes a long standing issues with isDeferred).

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
We previously had a bug in analytics where we would always send isDeferred=false in most of our analytics if we were in FlowController or Embedded's FormActivity.
