### PR TITLE
Update light/dark builders for Colors in PaymentSheet

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -1428,6 +1428,7 @@ class PaymentSheet internal constructor(
                                 this.unselectedColor = color
                             }
 
+                            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
                             fun build(): Colors {
                                 return Colors(
                                     separatorColor = separatorColor,
@@ -1436,6 +1437,7 @@ class PaymentSheet internal constructor(
                                 )
                             }
 
+                            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
                             companion object {
 
                                 /**
@@ -1611,6 +1613,7 @@ class PaymentSheet internal constructor(
                                 )
                             }
 
+                            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
                             companion object {
 
                                 /**
@@ -1866,13 +1869,20 @@ class PaymentSheet internal constructor(
                                 )
                             }
 
+                            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
                             companion object {
+                                /**
+                                 * Creates a [Builder] prepopulated with default light mode values.
+                                 */
                                 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
                                 fun light(): Builder = Builder(
                                     separatorColor = StripeThemeDefaults.disclosureColorsLight.separatorColor.toArgb(),
                                     disclosureColor = StripeThemeDefaults.disclosureColorsLight.disclosureColor.toArgb()
                                 )
 
+                                /**
+                                 * Creates a [Builder] prepopulated with default dark mode values.
+                                 */
                                 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
                                 fun dark(): Builder = Builder(
                                     separatorColor = StripeThemeDefaults.disclosureColorsDark.separatorColor.toArgb(),
@@ -2428,7 +2438,11 @@ class PaymentSheet internal constructor(
                 )
             }
 
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
             companion object {
+                /**
+                 * Creates a [Builder] prepopulated with default light mode values.
+                 */
                 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
                 fun light(): Builder = Builder(
                     primary = StripeThemeDefaults.colorsLight.materialColors.primary.toArgb(),
@@ -2444,6 +2458,9 @@ class PaymentSheet internal constructor(
                     error = StripeThemeDefaults.colorsLight.materialColors.error.toArgb()
                 )
 
+                /**
+                 * Creates a [Builder] prepopulated with default dark mode values.
+                 */
                 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
                 fun dark(): Builder = Builder(
                     primary = StripeThemeDefaults.colorsDark.materialColors.primary.toArgb(),
@@ -2964,6 +2981,7 @@ class PaymentSheet internal constructor(
                 )
             }
 
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
             companion object {
 
                 /**


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Per discussion, making the constructor private, and exposing a factory method to create the builder, so something like `Builder.light().build()` would create the default light theme.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://docs.google.com/document/d/1C3Kqe7edhcBeQxS5QvcoEZ-wEBNolOXTjzVMCoRuBRY/edit?disco=AAABwGrkIMg

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
