### PR TITLE
move opencardscanautomatically from load_succeeded to init event

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -127,7 +127,6 @@ internal class DefaultEventReporter @Inject internal constructor(
         setAsDefaultEnabled: Boolean?,
         paymentMethodOptionsSetupFutureUsage: Boolean,
         setupFutureUsage: StripeIntent.Usage?,
-        openCardScanAutomatically: Boolean,
     ) {
         this.currency = currency
         this.linkEnabled = linkEnabled
@@ -162,7 +161,6 @@ internal class DefaultEventReporter @Inject internal constructor(
                 setAsDefaultEnabled = setAsDefaultEnabled,
                 paymentMethodOptionsSetupFutureUsage = paymentMethodOptionsSetupFutureUsage,
                 setupFutureUsage = setupFutureUsage,
-                openCardScanAutomatically = openCardScanAutomatically,
             )
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
@@ -46,7 +46,6 @@ internal interface LoadingEventReporter {
         setAsDefaultEnabled: Boolean?,
         paymentMethodOptionsSetupFutureUsage: Boolean,
         setupFutureUsage: StripeIntent.Usage?,
-        openCardScanAutomatically: Boolean,
     )
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -106,7 +106,6 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         setAsDefaultEnabled: Boolean? = null,
         setupFutureUsage: StripeIntent.Usage? = null,
         paymentMethodOptionsSetupFutureUsage: Boolean,
-        openCardScanAutomatically: Boolean,
     ) : PaymentSheetEvent() {
         override val eventName: String = "mc_load_succeeded"
         override val additionalParams: Map<String, Any?> = buildMap {
@@ -124,7 +123,6 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
             setAsDefaultEnabled?.let {
                 put(FIELD_SET_AS_DEFAULT_ENABLED, it)
             }
-            put(FIELD_OPEN_CARD_SCAN_AUTOMATICALLY, openCardScanAutomatically)
             put(FIELD_LINK_DISPLAY, linkDisplay.analyticsValue)
             putIfNotEmpty(FIELD_LINK_DISABLED_REASONS, linkDisabledReasons?.map { it.value })
             putIfNotEmpty(FIELD_LINK_SIGNUP_DISABLED_REASONS, linkSignupDisabledReasons?.map { it.value })
@@ -232,6 +230,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
                     FIELD_EXTERNAL_PAYMENT_METHODS to configuration.getExternalPaymentMethodsAnalyticsValue(),
                     FIELD_CARD_BRAND_ACCEPTANCE to configuration.cardBrandAcceptance.toAnalyticsValue(),
                     FIELD_ANALYTIC_CALLBACK_SET to isAnalyticEventCallbackSet,
+                    FIELD_OPEN_CARD_SCAN_AUTOMATICALLY to configuration.opensCardScannerAutomatically,
                 ).plus(configurationSpecificPayload.payload)
                 return mapOf(
                     FIELD_MOBILE_PAYMENT_ELEMENT_CONFIGURATION to configurationMap,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -803,7 +803,6 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                 setupFutureUsage = elementsSession.stripeIntent.setupFutureUsage(),
                 paymentMethodOptionsSetupFutureUsage = elementsSession.stripeIntent
                     .paymentMethodOptionsSetupFutureUsageMap(),
-                openCardScanAutomatically = state.paymentMethodMetadata.openCardScanAutomatically
             )
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
@@ -88,7 +88,8 @@ internal object PaymentSheetFixtures {
             phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
             address = AddressCollectionMode.Full,
             attachDefaultsToPaymentMethod = true,
-        )
+        ),
+        opensCardScannerAutomatically = true,
     )
 
     const val DEFAULT_EPHEMERAL_KEY = "ek_123"

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -1637,7 +1637,6 @@ class DefaultEventReporterTest {
         linkDisplay: PaymentSheet.LinkConfiguration.Display = PaymentSheet.LinkConfiguration.Display.Automatic,
         paymentMethodOptionsSetupFutureUsage: Boolean = false,
         setupFutureUsage: StripeIntent.Usage? = null,
-        openCardScanAutomatically: Boolean = false,
     ) {
         simulateInit()
         onLoadStarted(initializedViaCompose = false)
@@ -1658,7 +1657,6 @@ class DefaultEventReporterTest {
             linkDisplay = linkDisplay,
             paymentMethodOptionsSetupFutureUsage = paymentMethodOptionsSetupFutureUsage,
             setupFutureUsage = setupFutureUsage,
-            openCardScanAutomatically = openCardScanAutomatically,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeLoadingEventReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeLoadingEventReporter.kt
@@ -61,7 +61,6 @@ internal class FakeLoadingEventReporter : LoadingEventReporter {
         setAsDefaultEnabled: Boolean?,
         paymentMethodOptionsSetupFutureUsage: Boolean,
         setupFutureUsage: StripeIntent.Usage?,
-        openCardScanAutomatically: Boolean
     ) {
         _loadSucceededTurbine.add(
             LoadSucceededCall(
@@ -81,7 +80,6 @@ internal class FakeLoadingEventReporter : LoadingEventReporter {
                 setAsDefaultEnabled = setAsDefaultEnabled,
                 paymentMethodOptionsSetupFutureUsage = paymentMethodOptionsSetupFutureUsage,
                 setupFutureUsage = setupFutureUsage,
-                openCardScanAutomatically = openCardScanAutomatically,
             )
         )
     }
@@ -131,7 +129,6 @@ internal class FakeLoadingEventReporter : LoadingEventReporter {
         val setAsDefaultEnabled: Boolean?,
         val paymentMethodOptionsSetupFutureUsage: Boolean,
         val setupFutureUsage: StripeIntent.Usage?,
-        val openCardScanAutomatically: Boolean,
     )
 
     class LoadFailedCall(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
@@ -479,7 +479,6 @@ class PaymentSheetEventTest {
                 "fc_sdk_availability" to "FULL",
                 "payment_method_options_setup_future_usage" to false,
                 "setup_future_usage" to null,
-                "open_card_scan_automatically" to false,
             )
         )
     }
@@ -646,18 +645,6 @@ class PaymentSheetEventTest {
         assertThat(event.params).containsEntry(
             "setup_future_usage",
             "off_session"
-        )
-    }
-
-    @Test
-    fun `LoadSucceeded with openCardScanAutomatically should return expected params`() {
-        val event = createLoadSucceededEvent(
-            openCardScanAutomatically = true
-        )
-
-        assertThat(event.params).containsEntry(
-            "open_card_scan_automatically",
-            true
         )
     }
 
@@ -1604,6 +1591,7 @@ class PaymentSheetEventTest {
                 "address" to "Full",
             ),
             paymentMethodLayout = "automatic",
+            openCardScannerAutomatically = true,
         )
         val config = PaymentSheetFixtures.CONFIG_WITH_EVERYTHING
         assertThat(
@@ -1972,7 +1960,6 @@ class PaymentSheetEventTest {
         linkDisplay: PaymentSheet.LinkConfiguration.Display = PaymentSheet.LinkConfiguration.Display.Automatic,
         paymentMethodOptionsSetupfutureUsage: Boolean = false,
         setupFutureUsage: StripeIntent.Usage? = null,
-        openCardScanAutomatically: Boolean = false,
     ): PaymentSheetEvent.LoadSucceeded {
         return PaymentSheetEvent.LoadSucceeded(
             isDeferred = isDeferred,
@@ -1992,7 +1979,6 @@ class PaymentSheetEventTest {
             financialConnectionsAvailability = financialConnectionsAvailability,
             paymentMethodOptionsSetupFutureUsage = paymentMethodOptionsSetupfutureUsage,
             setupFutureUsage = setupFutureUsage,
-            openCardScanAutomatically = openCardScanAutomatically
         )
     }
 
@@ -2014,6 +2000,7 @@ class PaymentSheetEventTest {
         paymentMethodLayout: String? = "horizontal",
         cardBrandAcceptance: Boolean = false,
         analyticCallbackSet: Boolean = false,
+        openCardScannerAutomatically: Boolean = false,
         extraParams: MutableMap<String, Any?>.() -> Unit = {},
     ): Map<String, Any?> {
         return mutableMapOf(
@@ -2033,6 +2020,7 @@ class PaymentSheetEventTest {
             "custom_payment_methods" to customPaymentMethods,
             "card_brand_acceptance" to cardBrandAcceptance,
             "analytic_callback_set" to analyticCallbackSet,
+            "open_card_scan_automatically" to openCardScannerAutomatically,
         ).apply {
             if (paymentMethodLayout != null) {
                 put("payment_method_layout", paymentMethodLayout)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -1708,7 +1708,6 @@ internal class DefaultPaymentElementLoaderTest {
         assertThat(loadSucceededCall.financialConnectionsAvailability).isEqualTo(FinancialConnectionsAvailability.Full)
         assertThat(loadSucceededCall.paymentMethodOptionsSetupFutureUsage).isFalse()
         assertThat(loadSucceededCall.setupFutureUsage).isNull()
-        assertThat(loadSucceededCall.openCardScanAutomatically).isFalse()
     }
 
     @Test
@@ -1779,7 +1778,6 @@ internal class DefaultPaymentElementLoaderTest {
         assertThat(loadSucceededCall.financialConnectionsAvailability).isEqualTo(FinancialConnectionsAvailability.Full)
         assertThat(loadSucceededCall.paymentMethodOptionsSetupFutureUsage).isFalse()
         assertThat(loadSucceededCall.setupFutureUsage).isNull()
-        assertThat(loadSucceededCall.openCardScanAutomatically).isFalse()
     }
 
     @Test
@@ -3437,7 +3435,6 @@ internal class DefaultPaymentElementLoaderTest {
         assertThat(loadSucceededCall.financialConnectionsAvailability).isEqualTo(FinancialConnectionsAvailability.Full)
         assertThat(loadSucceededCall.paymentMethodOptionsSetupFutureUsage).isFalse()
         assertThat(loadSucceededCall.setupFutureUsage).isNull()
-        assertThat(loadSucceededCall.openCardScanAutomatically).isFalse()
     }
 
     @Test
@@ -3475,7 +3472,6 @@ internal class DefaultPaymentElementLoaderTest {
         assertThat(loadSucceededCall.financialConnectionsAvailability).isEqualTo(FinancialConnectionsAvailability.Full)
         assertThat(loadSucceededCall.paymentMethodOptionsSetupFutureUsage).isFalse()
         assertThat(loadSucceededCall.setupFutureUsage).isNull()
-        assertThat(loadSucceededCall.openCardScanAutomatically).isFalse()
     }
 
     @Test
@@ -3991,30 +3987,6 @@ internal class DefaultPaymentElementLoaderTest {
         assertThat(loadSucceededCall.setupFutureUsage).isEqualTo(StripeIntent.Usage.OffSession)
     }
 
-    @Test
-    fun `Emits correct load event for openCardScanAutomatically'`() = runTest {
-        val loader = createPaymentElementLoader(
-            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD
-        )
-
-        loader.load(
-            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
-                clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
-            ),
-            paymentSheetConfiguration = PaymentSheet.Configuration(
-                merchantDisplayName = "Some Name",
-                opensCardScannerAutomatically = true,
-            ),
-            metadata = PaymentElementLoader.Metadata(
-                initializedViaCompose = false,
-            ),
-        ).getOrThrow()
-
-        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
-        val loadSucceededCall = eventReporter.loadSucceededTurbine.awaitItem()
-        assertThat(loadSucceededCall.openCardScanAutomatically).isTrue()
-    }
-
     private fun removeLastPaymentMethodTest(
         customer: PaymentSheet.CustomerConfiguration,
         shouldDisableMobilePaymentElement: Boolean = false,
@@ -4251,7 +4223,6 @@ internal class DefaultPaymentElementLoaderTest {
         assertThat(loadSucceededCall.financialConnectionsAvailability).isEqualTo(FinancialConnectionsAvailability.Full)
         assertThat(loadSucceededCall.paymentMethodOptionsSetupFutureUsage).isFalse()
         assertThat(loadSucceededCall.setupFutureUsage).isNull()
-        assertThat(loadSucceededCall.openCardScanAutomatically).isFalse()
     }
 
     private fun createLinkSettings(


### PR DESCRIPTION
# Summary
Moved opencardscanautomatically under mpe_config

# Motivation
Alignment with other config

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [X] Manually verified

