### PR TITLE
Throw NotImplementedError for CashAppWithSetupFutureUsage in PaymentSheetConfirmationTokenTest

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetConfirmationTokenTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetConfirmationTokenTest.kt
@@ -199,7 +199,9 @@ internal class PaymentSheetConfirmationTokenTest {
                         page.fillCvcRecollection("123")
                     }
                     PaymentMethodType.CashAppWithSetupFutureUsage -> {
-                        // We do not test this payment method with returning customer
+                        throw NotImplementedError(
+                            "We do not test this payment method with returning customer"
+                        )
                     }
                 }
             }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://github.com/stripe/stripe-android/pull/11823#discussion_r2528959649

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
