### PR TITLE
Add openscardscannerautomatically to customersheet init events

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/analytics/CustomerSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/analytics/CustomerSheetEvent.kt
@@ -38,6 +38,7 @@ internal sealed class CustomerSheetEvent : AnalyticsEvent {
                         ),
                     FIELD_PREFERRED_NETWORKS to configuration.preferredNetworks.toAnalyticsValue(),
                     FIELD_CARD_BRAND_ACCEPTANCE to configuration.cardBrandAcceptance.toAnalyticsValue(),
+                    FIELD_OPEN_CARD_SCAN_AUTOMATICALLY_ENABLED to configuration.opensCardScannerAutomatically
                 )
                 return mapOf(
                     FIELD_CUSTOMER_SHEET_CONFIGURATION to configurationMap,
@@ -415,6 +416,7 @@ internal sealed class CustomerSheetEvent : AnalyticsEvent {
         const val FIELD_ERROR_MESSAGE = "error_message"
         const val FIELD_PAYMENT_METHOD_TYPE = "payment_method_type"
         const val FIELD_SYNC_DEFAULT_ENABLED = "sync_default_enabled"
+        const val FIELD_OPEN_CARD_SCAN_AUTOMATICALLY_ENABLED = "open_card_scan_automatically_enabled"
         const val FIELD_SELECTED_LPM = "selected_lpm"
         const val FIELD_CARD_BRAND_ACCEPTANCE = "card_brand_acceptance"
         const val FIELD_CUSTOMER_ACCESS_PROVIDER = "customer_access_provider"

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetFixtures.kt
@@ -64,6 +64,7 @@ internal object CustomerSheetFixtures {
         .allowsRemovalOfLastSavedPaymentMethod(false)
         .paymentMethodOrder(listOf("klarna", "afterpay", "card"))
         .googlePayEnabled(googlePayEnabled = true)
+        .opensCardScannerAutomatically(true)
         .build()
 
     fun createCustomerSheetSession(

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/analytics/CustomerSheetEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/analytics/CustomerSheetEventTest.kt
@@ -47,6 +47,7 @@ class CustomerSheetEventTest {
             ),
             "preferred_networks" to null,
             "card_brand_acceptance" to false,
+            "open_card_scan_automatically_enabled" to false,
         )
 
         assertThat(event.additionalParams)
@@ -93,6 +94,7 @@ class CustomerSheetEventTest {
             ),
             "preferred_networks" to null,
             "card_brand_acceptance" to false,
+            "open_card_scan_automatically_enabled" to false
         )
 
         assertThat(event.additionalParams)
@@ -138,6 +140,7 @@ class CustomerSheetEventTest {
             "billing_details_collection_configuration" to expectedBillingDetailsCollection,
             "preferred_networks" to "cartes_bancaires, visa",
             "card_brand_acceptance" to false,
+            "open_card_scan_automatically_enabled" to true,
         )
 
         val event = CustomerSheetEvent.Init(


### PR DESCRIPTION
# Summary
Add openscardscannerautomatically to customersheet init event

# Motivation
Missing this data

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [ ] Manually verified
