### PR TITLE
Don't block on google pay analytics.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -326,7 +326,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
             elementsSession = elementsSession,
             state = state,
             isReloadingAfterProcessDeath = metadata.isReloadingAfterProcessDeath,
-            isGooglePaySupported = isGooglePaySupportedOnDevice.await(),
+            isGooglePaySupported = isGooglePaySupportedOnDevice.completeResultOrNull() ?: false,
             linkDisplay = configuration.link.display,
             initializationMode = initializationMode,
             customerInfo = customerInfo,
@@ -911,4 +911,10 @@ private fun StripeIntent.paymentMethodOptionsSetupFutureUsageMap(): Boolean {
 private fun StripeIntent.setupFutureUsage(): StripeIntent.Usage? = when (this) {
     is SetupIntent -> usage
     is PaymentIntent -> setupFutureUsage
+}
+
+private suspend fun <T> Deferred<T>.completeResultOrNull(): T? = if (isCompleted) {
+    await()
+} else {
+    null
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This ensures we don't block load when waiting purely on the google pay status for analytics purposes.