### PR TITLE
Clarify card scanning signing key requirement in MIGRATING.md

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -83,6 +83,9 @@ APIs that are no longer publicly exposed. If you need access to any of these int
 - The card scanning feature in our UI surfaces has been migrated to [Google Pay Card Recognition](https://developers.google.com/pay/payment-card-recognition/debit-credit-card-recognition), which requires your application to have production access to the Google Pay API. 
   - If you have enabled Google Pay, the card scanning feature is available in our UI surfaces automatically on eligible devices. To learn more about eligible devices, see the [Google Pay API constraints](https://developers.google.com/pay/payment-card-recognition/debit-credit-card-recognition)
   - If you previously used the card scanning feature but have not enabled Google Pay, you can continue using our card scanning feature by [requesting production access](https://developers.google.com/pay/api/android/guides/test-and-deploy/request-prod-access) to the Google Pay API using the [Google Pay & Wallet Console](https://pay.google.com/business/console?utm_source=devsite&utm_medium=devsite&utm_campaign=devsite)
+  - **Important:** The card scanning feature will only appear in builds signed with the same signing key registered in the [Google Pay & Wallet Console](https://pay.google.com/business/console). Test or debug builds using different signing keys (e.g., builds distributed via Firebase App Tester) will not show the "Scan card" option. To test card scanning in pre-release builds, you must either:
+    * Sign your test builds with your production signing key, or
+    * Add your test signing key fingerprint to the Google Pay & Wallet Console
 - If you integrate with the `stripecardscan` module directly, you can [migrate to Google Payment Card Recognition API](stripecardscan/MIGRATION_GUIDE.md).
 
 ### 4. Other Breaking Changes


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add important note about card scanning requiring builds to be signed with the same signing key registered in Google Pay & Wallet Console. 

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://github.com/stripe/stripe-android/issues/11980#issuecomment-3543080066

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
