### PR TITLE
Remove earlyExitDueToIllegalState in BaseSheetActivity

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -36,13 +36,15 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionsActivity
 
     @OptIn(ExperimentalMaterialApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
-        val starterArgs = initializeStarterArgs()
         super.onCreate(savedInstanceState)
 
+        val starterArgs = this.starterArgs
         if (starterArgs == null) {
             finish()
             return
         }
+
+        starterArgs.configuration.appearance.parseAppearance()
 
         if (!applicationIsTaskOwner()) {
             viewModel.analyticsListener.cannotProperlyReturnFromLinkAndOtherLPMs()
@@ -78,12 +80,6 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionsActivity
                 }
             }
         }
-    }
-
-    private fun initializeStarterArgs(): PaymentOptionContract.Args? {
-        starterArgs?.configuration?.appearance?.parseAppearance()
-        earlyExitDueToIllegalState = starterArgs == null
-        return starterArgs
     }
 
     override fun setActivityResult(result: PaymentOptionsActivityResult) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
@@ -14,16 +14,10 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
     val linkHandler: LinkHandler
         get() = viewModel.linkHandler
 
-    protected var earlyExitDueToIllegalState: Boolean = false
-
     abstract fun setActivityResult(result: ResultType)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        if (earlyExitDueToIllegalState) {
-            return
-        }
 
         renderEdgeToEdge()
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isSelected
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onChildren
 import androidx.compose.ui.test.onNodeWithTag
@@ -137,7 +137,7 @@ internal class PaymentSheetActivityTest {
     val rule = InstantTaskExecutorRule()
 
     @get:Rule
-    val composeTestRule = createAndroidComposeRule<PaymentSheetActivity>()
+    val composeTestRule = createEmptyComposeRule()
 
     @get:Rule
     val composeCleanupRule = createComposeCleanupRule()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Remove `earlyExitDueToIllegalState` which does not correctly handle early exit in neither `PaymentSheetActivity` nor `PaymentOptionsActivity`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://github.com/stripe/stripe-android/pull/11895#discussion_r2500894106

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

