### PR TITLE
Add structured Card fields to PaymentMethodPreview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### PaymentSheet
 * [Added][12011](https://github.com/stripe/stripe-android/pull/12011) Builder APIs for PaymentSheet appearance customization (Colors, Shapes, Typography, PrimaryButtonColors, and embedded row styles)
 
+### Payments
+* [Added][12014](https://github.com/stripe/stripe-android/pull/12014) `ConfirmationToken.PaymentMethodPreview` now includes structured `Card` field with detailed card information (brand, country, expiry, funding, last4, etc.)
+
 ## 22.2.0 - 2025-11-17
 
 ### Financial Connections

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -2134,6 +2134,7 @@ public final class com/stripe/android/model/ConfirmationToken$PaymentMethodPrevi
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final field allowRedisplay Lcom/stripe/android/model/PaymentMethod$AllowRedisplay;
 	public final field billingDetails Lcom/stripe/android/model/PaymentMethod$BillingDetails;
+	public final field card Lcom/stripe/android/model/PaymentMethod$Card;
 	public final field customerId Ljava/lang/String;
 	public final field type Lcom/stripe/android/model/PaymentMethod$Type;
 	public final fun describeContents ()I

--- a/payments-core/src/main/java/com/stripe/android/model/ConfirmationToken.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConfirmationToken.kt
@@ -96,6 +96,11 @@ class ConfirmationToken internal constructor(
         @JvmField val billingDetails: PaymentMethod.BillingDetails? = null,
 
         /**
+         *  If this is a `card` PaymentMethod, this hash contains details about the card.
+         */
+        @JvmField val card: PaymentMethod.Card? = null,
+
+        /**
          *  The ID of the Customer to which this PaymentMethod is saved.
          *  This will only be set when the PaymentMethod has been saved to a Customer.
          */

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/PaymentMethodPreviewJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/PaymentMethodPreviewJsonParser.kt
@@ -24,6 +24,9 @@ internal class PaymentMethodPreviewJsonParser : ModelJsonParser<ConfirmationToke
             billingDetails = json.optJSONObject(FIELD_BILLING_DETAILS)?.let {
                 PaymentMethodJsonParser.BillingDetails().parse(it)
             },
+            card = json.optJSONObject(FIELD_CARD)?.let {
+                PaymentMethodJsonParser.CardJsonParser().parse(it)
+            },
             customerId = StripeJsonUtils.optString(json, FIELD_CUSTOMER),
             type = type,
             allResponseFields = json.toString()
@@ -33,6 +36,7 @@ internal class PaymentMethodPreviewJsonParser : ModelJsonParser<ConfirmationToke
     private companion object {
         const val FIELD_ALLOW_REDISPLAY = "allow_redisplay"
         const val FIELD_BILLING_DETAILS = "billing_details"
+        const val FIELD_CARD = "card"
         const val FIELD_CUSTOMER = "customer"
         const val FIELD_TYPE = "type"
     }

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/PaymentMethodPreviewJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/PaymentMethodPreviewJsonParserTest.kt
@@ -108,4 +108,46 @@ class PaymentMethodPreviewJsonParserTest {
         val result = parser.parse(json)
         assertThat(result).isNull()
     }
+
+    @Test
+    fun parse_withCardFields_shouldParseCardCorrectly() {
+        val json = JSONObject(
+            """
+            {
+                "type": "card",
+                "card": {
+                    "brand": "visa",
+                    "country": "US",
+                    "exp_month": 12,
+                    "exp_year": 2025,
+                    "fingerprint": "abc123",
+                    "funding": "credit",
+                    "last4": "4242"
+                }
+            }
+            """.trimIndent()
+        )
+
+        val paymentMethodPreview = requireNotNull(parser.parse(json))
+
+        assertThat(paymentMethodPreview.type).isEqualTo(PaymentMethod.Type.Card)
+        val card = requireNotNull(paymentMethodPreview.card)
+        assertThat(card.brand.code).isEqualTo("visa")
+        assertThat(card.country).isEqualTo("US")
+        assertThat(card.expiryMonth).isEqualTo(12)
+        assertThat(card.expiryYear).isEqualTo(2025)
+        assertThat(card.fingerprint).isEqualTo("abc123")
+        assertThat(card.funding).isEqualTo("credit")
+        assertThat(card.last4).isEqualTo("4242")
+    }
+
+    @Test
+    fun parse_withCardType_butNoCardField_shouldReturnNull() {
+        val json = JSONObject("""{"type": "card"}""")
+
+        val paymentMethodPreview = requireNotNull(parser.parse(json))
+
+        assertThat(paymentMethodPreview.type).isEqualTo(PaymentMethod.Type.Card)
+        assertThat(paymentMethodPreview.card).isNull()
+    }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
[MOBILESDK-4217](https://jira.corp.stripe.com/browse/MOBILESDK-4217)
Adds structured `Card` field to `ConfirmationToken.PaymentMethodPreview` with detailed card information including brand, country, expiry, funding type, last4, and more.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
This enables merchants to provide soft warnings during payment input rather than hard errors after submission. A common use case is detecting credit vs debit cards early - merchants who only accept debit cards can now show a gentle "the card you entered might not be a debit card" message while the customer is still typing, rather than failing after they've completed the entire flow. This significantly reduces user dropoff at a common friction point. See the [slack thread](https://stripe.slack.com/archives/C01CY476ESJ/p1763043336288599?thread_ts=1762544836.074309&cid=C01CY476ESJ
) for more context.


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
* [Added] `ConfirmationToken.PaymentMethodPreview` now includes structured `Card` field with detailed card information (brand, country, expiry, funding, last4, etc.)