### PR TITLE
Use temporary remote host for intent confirmation challenge

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/challenge/confirmation/IntentConfirmationChallengeActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/challenge/confirmation/IntentConfirmationChallengeActivity.kt
@@ -73,7 +73,7 @@ internal class IntentConfirmationChallengeActivity : AppCompatActivity() {
     companion object {
         internal const val EXTRA_ARGS = "intent_confirmation_challenge_args"
         internal const val RESULT_COMPLETE = 4639
-        internal const val HOST_URL = "http://10.0.2.2:3004"
+        internal const val HOST_URL = "https://mobile-active-challenge-764603794666.us-central1.run.app"
 
         internal fun createIntent(
             context: Context,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Use temporary remote host for intent confirmation challenge

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
This will allow us to test without having to start the frontend locally. We will swap this out with `mobile-confirmation-challenge.stripe.com` when it's ready.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
