### PR TITLE
Embedded visibility tracker

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedContentPage.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedContentPage.kt
@@ -29,6 +29,7 @@ internal class EmbeddedContentPage(
     }
 
     fun clickOnLpm(code: String) {
+        composeTestRule.waitForIdle()
         waitUntilVisible()
 
         composeTestRule.onNode(hasTestTag("${TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON}_$code"))

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementAnalyticsTest.kt
@@ -461,6 +461,9 @@ internal class EmbeddedPaymentElementAnalyticsTest {
         managePage.waitUntilGone(card1.id)
         managePage.clickDone()
 
+        validateAnalyticsRequest("mc_dismiss")
+        Espresso.pressBack()
+
         testContext.markTestSucceeded()
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
@@ -265,6 +265,7 @@ internal class DefaultEmbeddedContentHelper @Inject constructor(
             },
             invokeRowSelectionCallback = ::invokeRowSelectionCallback,
             displaysMandatesInFormScreen = isImmediateAction && embeddedViewDisplaysMandateText,
+            shouldTrackIndividualPaymentMethods = false,
             onInitiallyDisplayedPaymentMethodVisibilitySnapshot = { visiblePaymentMethods, hiddenPaymentMethods ->
                 eventReporter.onInitiallyDisplayedPaymentMethodVisibilitySnapshot(
                     visiblePaymentMethods = visiblePaymentMethods,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/LayoutCoordinateInitialVisibilityTracker.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/LayoutCoordinateInitialVisibilityTracker.kt
@@ -1,0 +1,96 @@
+package com.stripe.android.paymentsheet.verticalmode
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.positionInWindow
+import androidx.compose.ui.unit.IntSize
+
+internal abstract class LayoutCoordinateInitialVisibilityTracker(
+    var expectedItems: List<String>,
+    val visibilityThreshold: Int,
+){
+
+    protected data class CoordinateSnapshot(
+        val positionInWindow: Offset,
+        val size: IntSize,
+        val boundsInWindow: Rect
+    )
+
+    var hasDispatched = false
+        protected set
+
+    fun updateVisibility(itemCode: String, coordinates: LayoutCoordinates) {
+        if (itemCode !in expectedItems || expectedItems.isEmpty()) return
+        if (hasDispatched) return // Only dispatch once per tracker instance
+        /**
+         * Capture only the relevant fields from [LayoutCoordinates] when we know the coordinates are attached.
+         * Whether previous coordinates is/isn't attached or not is irrelevant, we only need to know
+         * the previous coordinate's boundsInWindow, positionInWindow, and size.
+         *
+         * When implemented, [LayoutCoordinates.isAttached] provides a getter to a var, so we cannot rely on being able
+         * to call `positionInWindow` and `boundsInWindow` of saved [LayoutCoordinates].
+         */
+        if (coordinates.isAttached) {
+            val coordinateSnapshot = CoordinateSnapshot(
+                positionInWindow = coordinates.positionInWindow(),
+                size = coordinates.size,
+                boundsInWindow = coordinates.boundsInWindow(),
+            )
+
+            val isVisible = calculateVisibility(
+                coordinates = coordinateSnapshot,
+                visibilityThresholdPercentage = visibilityThreshold,
+            )
+
+            updateVisibilityHelper(itemCode, coordinateSnapshot, isVisible)
+        } else {
+            return
+        }
+    }
+
+    fun updateExpectedItems(items: List<String>) {
+        if (this.expectedItems != items) {
+            // Reset to initial state with new items
+            this.expectedItems = items
+            reset()
+        }
+    }
+
+    abstract fun reset()
+
+    protected abstract fun updateVisibilityHelper(
+        itemCode: String,
+        coordinateSnapshot: CoordinateSnapshot,
+        isVisible: Boolean,
+    )
+
+    private fun calculateVisibility(
+        coordinates: CoordinateSnapshot,
+        visibilityThresholdPercentage: Int,
+    ): Boolean {
+        val bounds = coordinates.boundsInWindow
+
+        // Check if completely out of bounds (hidden)
+        @Suppress("ComplexCondition")
+        if (bounds.left == 0f && bounds.top == 0f && bounds.right == 0f && bounds.bottom == 0f) {
+            return false
+        }
+
+        // Calculate visibility percentage
+        val widthInBounds = bounds.width
+        val heightInBounds = bounds.height
+        val totalArea = coordinates.size.height * coordinates.size.width
+        val areaInBounds = widthInBounds * heightInBounds
+
+        // 100 refers to percentages
+        val percentVisible = if (totalArea > 0) {
+            ((areaInBounds / totalArea) * 100).toInt().coerceIn(0, 100)
+        } else {
+            0
+        }
+
+        return percentVisible >= visibilityThresholdPercentage
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/LayoutCoordinateInitialVisibilityTracker.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/LayoutCoordinateInitialVisibilityTracker.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.unit.IntSize
 internal abstract class LayoutCoordinateInitialVisibilityTracker(
     var expectedItems: List<String>,
     val visibilityThreshold: Int,
-){
+) {
 
     protected data class CoordinateSnapshot(
         val positionInWindow: Offset,
@@ -66,6 +66,7 @@ internal abstract class LayoutCoordinateInitialVisibilityTracker(
         isVisible: Boolean,
     )
 
+    @Suppress("MagicNumber")
     private fun calculateVisibility(
         coordinates: CoordinateSnapshot,
         visibilityThresholdPercentage: Int,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodEmbeddedLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodEmbeddedLayoutUI.kt
@@ -34,6 +34,7 @@ import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded
 import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded.RowStyle
 import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.verticalmode.PaymentMethodLayoutInitialVisibilityTracker.Companion.EMBEDDED_PAYMENT_METHOD_LAYOUT_NAME
 import com.stripe.android.ui.core.elements.Mandate
 import com.stripe.android.uicore.image.StripeImageLoader
 import com.stripe.android.uicore.strings.resolve
@@ -137,7 +138,12 @@ internal fun PaymentMethodEmbeddedLayoutUI(
     // Cancel tracking and any pending dispatches, when the paymentMethods used change
     DisposableEffect(paymentMethodCodes) { onDispose { cancelPaymentMethodVisibilityTracking.invoke() } }
 
-    Column(modifier = modifier, verticalArrangement = arrangement) {
+    Column(
+        modifier = modifier.onGloballyPositioned {
+            updatePaymentMethodVisibility(EMBEDDED_PAYMENT_METHOD_LAYOUT_NAME, it)
+        },
+        verticalArrangement = arrangement
+    ) {
         if (appearance.style.topSeparatorEnabled()) OptionalEmbeddedDivider(appearance.style)
 
         EmbeddedSavedPaymentMethodRowButton(
@@ -149,7 +155,6 @@ internal fun PaymentMethodEmbeddedLayoutUI(
             onViewMorePaymentMethods = onViewMorePaymentMethods,
             onManageOneSavedPaymentMethod = onManageOneSavedPaymentMethod,
             onSelectSavedPaymentMethod = onSelectSavedPaymentMethod,
-            updatePaymentMethodVisibility = updatePaymentMethodVisibility,
             appearance = appearance
         )
 
@@ -159,7 +164,6 @@ internal fun PaymentMethodEmbeddedLayoutUI(
             isEnabled = isEnabled,
             imageLoader = imageLoader,
             appearance = appearance,
-            updatePaymentMethodVisibility = updatePaymentMethodVisibility
         )
 
         if (appearance.style.bottomSeparatorEnabled()) OptionalEmbeddedDivider(appearance.style)
@@ -262,7 +266,6 @@ internal fun EmbeddedSavedPaymentMethodRowButton(
     onViewMorePaymentMethods: () -> Unit,
     onManageOneSavedPaymentMethod: (DisplayableSavedPaymentMethod) -> Unit,
     onSelectSavedPaymentMethod: (DisplayableSavedPaymentMethod) -> Unit,
-    updatePaymentMethodVisibility: (String, LayoutCoordinates) -> Unit = { _, _ -> },
     appearance: Embedded,
 ) {
     if (displayedSavedPaymentMethod != null) {
@@ -277,9 +280,6 @@ internal fun EmbeddedSavedPaymentMethodRowButton(
                     onViewMorePaymentMethods = onViewMorePaymentMethods,
                     onManageOneSavedPaymentMethod = { onManageOneSavedPaymentMethod(displayedSavedPaymentMethod) },
                 )
-            },
-            modifier = Modifier.onGloballyPositioned { coordinates ->
-                updatePaymentMethodVisibility("saved", coordinates)
             },
             onClick = { onSelectSavedPaymentMethod(displayedSavedPaymentMethod) },
             appearance = appearance
@@ -296,7 +296,6 @@ internal fun EmbeddedNewPaymentMethodRowButtonsLayoutUi(
     isEnabled: Boolean,
     imageLoader: StripeImageLoader,
     appearance: Embedded,
-    updatePaymentMethodVisibility: (String, LayoutCoordinates) -> Unit = { _, _ -> },
 ) {
     val selectedIndex = remember(selection, paymentMethods) {
         if (selection is PaymentMethodVerticalLayoutInteractor.Selection.New) {
@@ -327,9 +326,6 @@ internal fun EmbeddedNewPaymentMethodRowButtonsLayoutUi(
                         )
                     }
                 },
-                modifier = Modifier.onGloballyPositioned { coordinates ->
-                    updatePaymentMethodVisibility(item.code, coordinates)
-                },
             )
         } else {
             NewPaymentMethodRowButton(
@@ -338,9 +334,6 @@ internal fun EmbeddedNewPaymentMethodRowButtonsLayoutUi(
                 displayablePaymentMethod = item,
                 imageLoader = imageLoader,
                 appearance = appearance,
-                modifier = Modifier.onGloballyPositioned { coordinates ->
-                    updatePaymentMethodVisibility(item.code, coordinates)
-                },
             )
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodInitialVisibilityTracker.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodInitialVisibilityTracker.kt
@@ -23,7 +23,7 @@ internal class PaymentMethodInitialVisibilityTracker(
     expectedItems: List<String>,
     dispatcher: CoroutineContext = Dispatchers.Default,
     private val renderedLpmCallback: (List<String>, List<String>) -> Unit,
-): LayoutCoordinateInitialVisibilityTracker(
+) : LayoutCoordinateInitialVisibilityTracker(
     expectedItems = expectedItems,
     visibilityThreshold = DEFAULT_VISIBILITY_THRESHOLD_PERCENT
 ) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodInitialVisibilityTracker.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodInitialVisibilityTracker.kt
@@ -1,11 +1,5 @@
 package com.stripe.android.paymentsheet.verticalmode
 
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Rect
-import androidx.compose.ui.layout.LayoutCoordinates
-import androidx.compose.ui.layout.boundsInWindow
-import androidx.compose.ui.layout.positionInWindow
-import androidx.compose.ui.unit.IntSize
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -26,35 +20,20 @@ import kotlin.coroutines.CoroutineContext
  * Once stable, it dispatches a single analytics event.
  */
 internal class PaymentMethodInitialVisibilityTracker(
-    private var expectedItems: List<String> = emptyList(),
-    private val renderedLpmCallback: (List<String>, List<String>) -> Unit,
+    expectedItems: List<String>,
     dispatcher: CoroutineContext = Dispatchers.Default,
+    private val renderedLpmCallback: (List<String>, List<String>) -> Unit,
+): LayoutCoordinateInitialVisibilityTracker(
+    expectedItems = expectedItems,
+    visibilityThreshold = DEFAULT_VISIBILITY_THRESHOLD_PERCENT
 ) {
-    private data class CoordinateSnapshot(
-        val positionInWindow: Offset,
-        val size: IntSize,
-        val boundsInWindow: Rect
-    )
 
     private val visibilityMap = mutableMapOf<String, Boolean>()
     private val previousCoordinateSnapshots = mutableMapOf<String, CoordinateSnapshot>()
     private val coordinateStabilityMap = mutableMapOf<String, Boolean>()
-    private var hasDispatched = false
 
     private val coroutineScope = CoroutineScope(dispatcher)
     private var dispatchEventJob: Job? = null
-
-    fun updateExpectedItems(items: List<String>) {
-        if (this.expectedItems != items) {
-            // Reset to initial state with new items
-            this.expectedItems = items
-            reset()
-        }
-    }
-
-    fun getHasDispatched(): Boolean {
-        return this.hasDispatched
-    }
 
     /**
      * When this function is called from onGloballyPositioned
@@ -65,30 +44,11 @@ internal class PaymentMethodInitialVisibilityTracker(
      * when coordinates have moved
      * and when the composition is finalized and stable.
      */
-    fun updateVisibility(itemCode: String, coordinates: LayoutCoordinates) {
-        if (itemCode !in expectedItems || expectedItems.isEmpty()) return
-        if (hasDispatched) return // Only dispatch once per tracker instance
-
-        /**
-         * Capture only the relevant fields from [LayoutCoordinates] when we know the coordinates are attached.
-         * Whether previous coordinates is/isn't attached or not is irrelevant, we only need to know
-         * the previous coordinate's boundsInWindow, positionInWindow, and size.
-         *
-         * When implemented, [LayoutCoordinates.isAttached] provides a getter to a var, so we cannot rely on being able
-         * to call `positionInWindow` and `boundsInWindow` of saved [LayoutCoordinates].
-         */
-        val coordinateSnapshot: CoordinateSnapshot
-        if (coordinates.isAttached) {
-            coordinateSnapshot = CoordinateSnapshot(
-                positionInWindow = coordinates.positionInWindow(),
-                size = coordinates.size,
-                boundsInWindow = coordinates.boundsInWindow(),
-            )
-        } else {
-            return
-        }
-
-        val newVisibility = calculateVisibility(coordinateSnapshot)
+    override fun updateVisibilityHelper(
+        itemCode: String,
+        coordinateSnapshot: CoordinateSnapshot,
+        isVisible: Boolean,
+    ) {
         val previousCoordinatesForItem = previousCoordinateSnapshots[itemCode]
 
         // Check if coordinates are stable (haven't changed)
@@ -102,8 +62,8 @@ internal class PaymentMethodInitialVisibilityTracker(
 
         // Update our tracking
         this.previousCoordinateSnapshots[itemCode] = coordinateSnapshot
-        val wasVisibilityStable = visibilityMap[itemCode] == newVisibility
-        visibilityMap[itemCode] = newVisibility
+        val wasVisibilityStable = visibilityMap[itemCode] == isVisible
+        visibilityMap[itemCode] = isVisible
 
         if (coordinatesAreStable && wasVisibilityStable) {
             coordinateStabilityMap[itemCode] = true
@@ -114,32 +74,6 @@ internal class PaymentMethodInitialVisibilityTracker(
         }
 
         checkStabilityAndDispatch()
-    }
-
-    @Suppress("MagicNumber")
-    private fun calculateVisibility(coordinates: CoordinateSnapshot): Boolean {
-        val bounds = coordinates.boundsInWindow
-
-        // Check if completely out of bounds (hidden)
-        @Suppress("ComplexCondition")
-        if (bounds.left == 0f && bounds.top == 0f && bounds.right == 0f && bounds.bottom == 0f) {
-            return false
-        }
-
-        // Calculate visibility percentage
-        val widthInBounds = bounds.width
-        val heightInBounds = bounds.height
-        val totalArea = coordinates.size.height * coordinates.size.width
-        val areaInBounds = widthInBounds * heightInBounds
-
-        // 100 refers to percentages
-        val percentVisible = if (totalArea > 0) {
-            ((areaInBounds / totalArea) * 100).toInt().coerceIn(0, 100)
-        } else {
-            0
-        }
-
-        return percentVisible >= DEFAULT_VISIBILITY_THRESHOLD_PERCENT
     }
 
     private fun checkStability(): Boolean {
@@ -176,7 +110,7 @@ internal class PaymentMethodInitialVisibilityTracker(
         }
     }
 
-    fun reset() {
+    override fun reset() {
         coordinateStabilityMap.clear()
         previousCoordinateSnapshots.clear()
         visibilityMap.clear()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodLayoutInitialVisibilityTracker.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodLayoutInitialVisibilityTracker.kt
@@ -2,7 +2,7 @@ package com.stripe.android.paymentsheet.verticalmode
 
 internal class PaymentMethodLayoutInitialVisibilityTracker(
     private val callback: () -> Unit,
-): LayoutCoordinateInitialVisibilityTracker(
+) : LayoutCoordinateInitialVisibilityTracker(
     expectedItems = listOf(EMBEDDED_PAYMENT_METHOD_LAYOUT_NAME),
     visibilityThreshold = VISIBILITY_THRESHOLD_PERCENT_FOR_EMBEDDED_LAYOUT_TRACKING
 ) {
@@ -12,7 +12,7 @@ internal class PaymentMethodLayoutInitialVisibilityTracker(
         coordinateSnapshot: CoordinateSnapshot,
         isVisible: Boolean,
     ) {
-        if(isVisible) {
+        if (isVisible) {
             hasDispatched = true
             callback()
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodLayoutInitialVisibilityTracker.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodLayoutInitialVisibilityTracker.kt
@@ -1,0 +1,37 @@
+package com.stripe.android.paymentsheet.verticalmode
+
+internal class PaymentMethodLayoutInitialVisibilityTracker(
+    private val callback: () -> Unit,
+): LayoutCoordinateInitialVisibilityTracker(
+    expectedItems = listOf(EMBEDDED_PAYMENT_METHOD_LAYOUT_NAME),
+    visibilityThreshold = VISIBILITY_THRESHOLD_PERCENT_FOR_EMBEDDED_LAYOUT_TRACKING
+) {
+
+    override fun updateVisibilityHelper(
+        itemCode: String,
+        coordinateSnapshot: CoordinateSnapshot,
+        isVisible: Boolean,
+    ) {
+        if(isVisible) {
+            hasDispatched = true
+            callback()
+        }
+    }
+
+    override fun reset() {
+        hasDispatched = false
+    }
+
+    companion object {
+        const val EMBEDDED_PAYMENT_METHOD_LAYOUT_NAME = "embedded_payment_method_layout"
+
+        /**
+         * Arbitrary small non zero value to ensure that users see some of
+         * embedded payment method layout before dispatching event.
+         *
+         * It is assumed that users will scroll and see the entire
+         * embedded payment method layout before completing their purchase
+         */
+        const val VISIBILITY_THRESHOLD_PERCENT_FOR_EMBEDDED_LAYOUT_TRACKING = 25
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -544,7 +544,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
     )
 
     private fun updatePaymentMethodVisibility(itemCode: String, layoutCoordinates: LayoutCoordinates) {
-        if (visibilityTracker.getHasDispatched()) {
+        if (visibilityTracker.hasDispatched) {
             return
         }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakeLayoutCoordinatesFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakeLayoutCoordinatesFixtures.kt
@@ -31,7 +31,6 @@ internal object FakeLayoutCoordinatesFixtures {
     }
 
     fun getBoundsBasedOnPercentVisible(percentVisible: Float): Rect {
-        return Rect(0f, 0f, 100f,  percentVisible * 50f)
+        return Rect(0f, 0f, 100f, percentVisible * 50f)
     }
-
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakeLayoutCoordinatesFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakeLayoutCoordinatesFixtures.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.verticalmode
 
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.unit.IntSize
 
 internal object FakeLayoutCoordinatesFixtures {
@@ -21,4 +22,16 @@ internal object FakeLayoutCoordinatesFixtures {
         position = Offset(0f, 75f),
         bounds = Rect(0f, 75f, 100f, 100f),
     )
+
+    fun getCoordinatesBasedOnPercentVisible(percentVisible: Float): LayoutCoordinates {
+        return FakeLayoutCoordinates.create(
+            size = IntSize(100, 50),
+            bounds = getBoundsBasedOnPercentVisible(percentVisible)
+        )
+    }
+
+    fun getBoundsBasedOnPercentVisible(percentVisible: Float): Rect {
+        return Rect(0f, 0f, 100f,  percentVisible * 50f)
+    }
+
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodLayoutInitialVisibilityTrackerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodLayoutInitialVisibilityTrackerTest.kt
@@ -36,7 +36,6 @@ class PaymentMethodLayoutInitialVisibilityTrackerTest {
         verify(callback).invoke()
     }
 
-
     @Test
     fun `hidden item does not invoke callback`() = runTest {
         val tracker = getTracker()
@@ -90,7 +89,6 @@ class PaymentMethodLayoutInitialVisibilityTrackerTest {
             EMBEDDED_PAYMENT_METHOD_LAYOUT_NAME,
             FakeLayoutCoordinatesFixtures.getCoordinatesBasedOnPercentVisible(0.12F)
         )
-
 
         tracker.updateVisibility(
             EMBEDDED_PAYMENT_METHOD_LAYOUT_NAME,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodLayoutInitialVisibilityTrackerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodLayoutInitialVisibilityTrackerTest.kt
@@ -1,0 +1,125 @@
+package com.stripe.android.paymentsheet.verticalmode
+
+import com.stripe.android.paymentsheet.verticalmode.PaymentMethodLayoutInitialVisibilityTracker.Companion.EMBEDDED_PAYMENT_METHOD_LAYOUT_NAME
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.robolectric.RobolectricTestRunner
+
+@ExperimentalCoroutinesApi
+@RunWith(RobolectricTestRunner::class)
+class PaymentMethodLayoutInitialVisibilityTrackerTest {
+
+    private val callback: () -> Unit = mock()
+
+    @Test
+    fun `updateVisibility - ignores items not in expected list`() = runTest {
+        val tracker = getTracker()
+
+        val coordinates = FakeLayoutCoordinatesFixtures.FULLY_VISIBLE_COORDINATES
+
+        tracker.updateVisibility("unknown_method", coordinates)
+        verifyNoCallback(callback)
+    }
+
+    @Test
+    fun `visible item invokes callback`() = runTest {
+        val tracker = getTracker()
+
+        val coordinates = FakeLayoutCoordinatesFixtures.FULLY_VISIBLE_COORDINATES
+
+        tracker.updateVisibility(EMBEDDED_PAYMENT_METHOD_LAYOUT_NAME, coordinates)
+        verify(callback).invoke()
+    }
+
+
+    @Test
+    fun `hidden item does not invoke callback`() = runTest {
+        val tracker = getTracker()
+
+        val coordinates = FakeLayoutCoordinatesFixtures.FULLY_HIDDEN_COORDINATES
+
+        tracker.updateVisibility(EMBEDDED_PAYMENT_METHOD_LAYOUT_NAME, coordinates)
+        verifyNoCallback(callback)
+    }
+
+    @Test
+    fun `visibility calculation - partially visible above threshold invokes callback`() = runTest {
+        val tracker = getTracker()
+
+        tracker.updateVisibility(
+            itemCode = EMBEDDED_PAYMENT_METHOD_LAYOUT_NAME,
+            coordinates = FakeLayoutCoordinatesFixtures.getCoordinatesBasedOnPercentVisible(0.5F)
+        )
+
+        verify(callback).invoke()
+    }
+
+    @Test
+    fun `visibility calculation - partially visible below threshold does not invoke callback`() = runTest {
+        val tracker = getTracker()
+
+        tracker.updateVisibility(
+            itemCode = EMBEDDED_PAYMENT_METHOD_LAYOUT_NAME,
+            coordinates = FakeLayoutCoordinatesFixtures.getCoordinatesBasedOnPercentVisible(0.1F)
+        )
+
+        // Should not dispatch because item doesn't meet visibility threshold
+        verifyNoCallback(callback)
+    }
+
+    @Test
+    fun `visibility calculation - simulate scrolling invokes callback`() = runTest {
+        val tracker = getTracker()
+
+        tracker.updateVisibility(
+            EMBEDDED_PAYMENT_METHOD_LAYOUT_NAME,
+            FakeLayoutCoordinatesFixtures.getCoordinatesBasedOnPercentVisible(0F)
+        )
+
+        tracker.updateVisibility(
+            EMBEDDED_PAYMENT_METHOD_LAYOUT_NAME,
+            FakeLayoutCoordinatesFixtures.getCoordinatesBasedOnPercentVisible(0.06F)
+        )
+
+        tracker.updateVisibility(
+            EMBEDDED_PAYMENT_METHOD_LAYOUT_NAME,
+            FakeLayoutCoordinatesFixtures.getCoordinatesBasedOnPercentVisible(0.12F)
+        )
+
+
+        tracker.updateVisibility(
+            EMBEDDED_PAYMENT_METHOD_LAYOUT_NAME,
+            FakeLayoutCoordinatesFixtures.getCoordinatesBasedOnPercentVisible(0.18F)
+        )
+
+        tracker.updateVisibility(
+            EMBEDDED_PAYMENT_METHOD_LAYOUT_NAME,
+            FakeLayoutCoordinatesFixtures.getCoordinatesBasedOnPercentVisible(0.24F)
+        )
+
+        // Should not dispatch because item doesn't meet visibility threshold
+        verifyNoCallback(callback)
+
+        tracker.updateVisibility(
+            EMBEDDED_PAYMENT_METHOD_LAYOUT_NAME,
+            FakeLayoutCoordinatesFixtures.getCoordinatesBasedOnPercentVisible(0.3F)
+        )
+
+        verify(callback).invoke()
+    }
+
+    private fun getTracker(): PaymentMethodLayoutInitialVisibilityTracker {
+        return PaymentMethodLayoutInitialVisibilityTracker(
+            callback = callback
+        )
+    }
+
+    private fun verifyNoCallback(callback: () -> Unit) {
+        verify(callback, never()).invoke()
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodLayoutUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodLayoutUITest.kt
@@ -23,6 +23,7 @@ import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded
 import com.stripe.android.paymentsheet.ViewActionRecorder
+import com.stripe.android.paymentsheet.verticalmode.PaymentMethodLayoutInitialVisibilityTracker.Companion.EMBEDDED_PAYMENT_METHOD_LAYOUT_NAME
 import com.stripe.android.paymentsheet.verticalmode.PaymentMethodVerticalLayoutInteractor.SavedPaymentMethodAction
 import com.stripe.android.paymentsheet.verticalmode.PaymentMethodVerticalLayoutInteractor.Selection
 import com.stripe.android.testing.createComposeCleanupRule
@@ -38,7 +39,8 @@ internal class PaymentMethodLayoutUITest(
     private val paymentMethodsTag: String,
     private val allPaymentMethodsChildCount: Int,
     private val layoutUI:
-    @Composable ColumnScope.(interactor: FakePaymentMethodVerticalLayoutInteractor, modifier: Modifier) -> Unit
+    @Composable ColumnScope.(interactor: FakePaymentMethodVerticalLayoutInteractor, modifier: Modifier) -> Unit,
+    private val shouldTrackIndividualPaymentMethod: Boolean,
 ) {
     @get:Rule
     val composeRule = createComposeRule()
@@ -251,16 +253,24 @@ internal class PaymentMethodLayoutUITest(
             }
         }
 
-        initialState.displayedSavedPaymentMethod?.let {
-            viewActionRecorder.consume {
-                it is PaymentMethodVerticalLayoutInteractor.ViewAction.UpdatePaymentMethodVisibility &&
-                    it.itemCode == "saved"
+        if (shouldTrackIndividualPaymentMethod) {
+            initialState.displayedSavedPaymentMethod?.let {
+                viewActionRecorder.consume {
+                    it is PaymentMethodVerticalLayoutInteractor.ViewAction.UpdatePaymentMethodVisibility &&
+                        it.itemCode == "saved"
+                }
             }
-        }
-        initialState.displayablePaymentMethods.forEach { paymentMethod ->
+
+            initialState.displayablePaymentMethods.forEach { paymentMethod ->
+                viewActionRecorder.consume {
+                    it is PaymentMethodVerticalLayoutInteractor.ViewAction.UpdatePaymentMethodVisibility &&
+                        it.itemCode == paymentMethod.code
+                }
+            }
+        } else {
             viewActionRecorder.consume {
                 it is PaymentMethodVerticalLayoutInteractor.ViewAction.UpdatePaymentMethodVisibility &&
-                    it.itemCode == paymentMethod.code
+                    it.itemCode == EMBEDDED_PAYMENT_METHOD_LAYOUT_NAME
             }
         }
 
@@ -280,7 +290,8 @@ internal class PaymentMethodLayoutUITest(
                 allPaymentMethodsChildCount = 3,
                 layoutUI = { interactor, modifier ->
                     PaymentMethodVerticalLayoutUI(interactor, modifier)
-                }
+                },
+                shouldTrackIndividualPaymentMethod = true,
             ),
             parameters(
                 paymentMethodsTag = TEST_TAG_PAYMENT_METHOD_EMBEDDED_LAYOUT,
@@ -292,7 +303,8 @@ internal class PaymentMethodLayoutUITest(
                         modifier = modifier,
                         appearance = Embedded(Embedded.RowStyle.FloatingButton.default),
                     )
-                }
+                },
+                shouldTrackIndividualPaymentMethod = false,
             )
         )
 
@@ -302,8 +314,9 @@ internal class PaymentMethodLayoutUITest(
             layoutUI: @Composable ColumnScope.(
                 interactor: FakePaymentMethodVerticalLayoutInteractor,
                 modifier: Modifier
-            ) -> Unit
-        ) = arrayOf(paymentMethodsTag, allPaymentMethodsChildCount, layoutUI)
+            ) -> Unit,
+            shouldTrackIndividualPaymentMethod: Boolean,
+        ) = arrayOf(paymentMethodsTag, allPaymentMethodsChildCount, layoutUI, shouldTrackIndividualPaymentMethod)
 
         private fun createState(
             displayablePaymentMethods: List<DisplayablePaymentMethod> = emptyList(),


### PR DESCRIPTION
# Summary
Created a simplified embedded visibility tracker, if 25% of embedded payment method layout appears, dispatch all payment methods as visible.

# Motivation
Seeing low tracking rates on live mode for embedded, this will ensure higher tracking rates
Align embedded tracking behavior with web embedded elements
This tracking works better with embedded integrations: users scroll down to see list of payment methods

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [X] Manually verified

# Screenshots
N.A.

# Changelog
N.A.
