### PR TITLE
Bring back the cardParams API on card form UIs

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -6591,6 +6591,7 @@ public final class com/stripe/android/view/CardFormView : android/widget/LinearL
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
 	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getBrand ()Lcom/stripe/android/model/CardBrand;
+	public final fun getCardParams ()Lcom/stripe/android/model/CardParams;
 	public final fun getOnBehalfOf ()Ljava/lang/String;
 	public final fun getPaymentMethodCreateParams ()Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public final fun setCardValidCallback (Lcom/stripe/android/view/CardValidCallback;)V
@@ -6625,6 +6626,7 @@ public final class com/stripe/android/view/CardInputWidget : android/widget/Line
 	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun clear ()V
 	public final fun getBrand ()Lcom/stripe/android/model/CardBrand;
+	public fun getCardParams ()Lcom/stripe/android/model/CardParams;
 	public final fun getOnBehalfOf ()Ljava/lang/String;
 	public fun getPaymentMethodCard ()Lcom/stripe/android/model/PaymentMethodCreateParams$Card;
 	public fun getPaymentMethodCreateParams ()Lcom/stripe/android/model/PaymentMethodCreateParams;
@@ -6661,6 +6663,7 @@ public final class com/stripe/android/view/CardMultilineWidget : android/widget/
 	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun clear ()V
 	public final synthetic fun getBrand ()Lcom/stripe/android/model/CardBrand;
+	public fun getCardParams ()Lcom/stripe/android/model/CardParams;
 	public final fun getOnBehalfOf ()Ljava/lang/String;
 	public final fun getPaymentMethodBillingDetails ()Lcom/stripe/android/model/PaymentMethod$BillingDetails;
 	public final fun getPaymentMethodBillingDetailsBuilder ()Lcom/stripe/android/model/PaymentMethod$BillingDetails$Builder;

--- a/payments-core/src/main/java/com/stripe/android/view/CardWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardWidget.kt
@@ -2,9 +2,16 @@ package com.stripe.android.view
 
 import android.text.TextWatcher
 import androidx.annotation.IntRange
+import com.stripe.android.model.CardParams
 import com.stripe.android.model.PaymentMethodCreateParams
 
 internal interface CardWidget {
+    /**
+     * A [CardParams] representing the card details and postal code if all fields are valid;
+     * otherwise `null`
+     */
+    @Deprecated("Use paymentMethodCreateParams instead")
+    val cardParams: CardParams?
 
     /**
      * A [PaymentMethodCreateParams.Card] representing the card details if all fields are valid;

--- a/payments-core/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
@@ -33,6 +33,7 @@ import com.stripe.android.cards.DefaultCardAccountRangeStore
 import com.stripe.android.model.Address
 import com.stripe.android.model.BinFixtures
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.CardParams
 import com.stripe.android.model.Networks
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
@@ -106,6 +107,20 @@ internal class CardInputWidgetTest {
             expiryDateEditText.append("50")
             cvcEditText.append(CVC_VALUE_COMMON)
 
+            assertThat(cardParams)
+                .isEqualTo(
+                    CardParams(
+                        brand = CardBrand.Visa,
+                        loggingTokens = ATTRIBUTION,
+                        number = VISA_NO_SPACES,
+                        expMonth = 12,
+                        expYear = 2050,
+                        cvc = CVC_VALUE_COMMON,
+                        address = Address.Builder()
+                            .build()
+                    )
+                )
+
             assertThat(paymentMethodCreateParams)
                 .isEqualTo(
                     PaymentMethodCreateParams.create(
@@ -131,6 +146,9 @@ internal class CardInputWidgetTest {
             cvcEditText.append(CVC_VALUE_COMMON)
             setPreferredNetworks(listOf(CardBrand.CartesBancaires))
 
+            assertThat(cardParams?.networks)
+                .isEqualTo(Networks(CardBrand.CartesBancaires.code))
+
             assertThat(paymentMethodCreateParams?.card?.networks?.preferred)
                 .isEqualTo(CardBrand.CartesBancaires.code)
         }
@@ -145,6 +163,21 @@ internal class CardInputWidgetTest {
             expiryDateEditText.append("50")
             cvcEditText.append(CVC_VALUE_COMMON)
             postalCodeEditText.setText(POSTAL_CODE_VALUE)
+
+            assertThat(cardParams)
+                .isEqualTo(
+                    CardParams(
+                        brand = CardBrand.Visa,
+                        loggingTokens = ATTRIBUTION,
+                        number = VISA_NO_SPACES,
+                        expMonth = 12,
+                        expYear = 2050,
+                        cvc = CVC_VALUE_COMMON,
+                        address = Address.Builder()
+                            .setPostalCode(POSTAL_CODE_VALUE)
+                            .build()
+                    )
+                )
 
             assertThat(paymentMethodCreateParams)
                 .isEqualTo(
@@ -174,6 +207,20 @@ internal class CardInputWidgetTest {
         expiryDateEditText.append("50")
         cvcEditText.append(CVC_VALUE_AMEX)
 
+        assertThat(cardParams)
+            .isEqualTo(
+                CardParams(
+                    brand = CardBrand.AmericanExpress,
+                    loggingTokens = ATTRIBUTION,
+                    number = AMEX_NO_SPACES,
+                    expMonth = 12,
+                    expYear = 2050,
+                    cvc = CVC_VALUE_AMEX,
+                    address = Address.Builder()
+                        .build()
+                )
+            )
+
         assertThat(paymentMethodCreateParams)
             .isEqualTo(
                 PaymentMethodCreateParams.create(
@@ -197,6 +244,21 @@ internal class CardInputWidgetTest {
         expiryDateEditText.append("50")
         cvcEditText.append(CVC_VALUE_AMEX)
         postalCodeEditText.setText(POSTAL_CODE_VALUE)
+
+        assertThat(cardParams)
+            .isEqualTo(
+                CardParams(
+                    brand = CardBrand.AmericanExpress,
+                    loggingTokens = ATTRIBUTION,
+                    number = AMEX_NO_SPACES,
+                    expMonth = 12,
+                    expYear = 2050,
+                    cvc = CVC_VALUE_AMEX,
+                    address = Address.Builder()
+                        .setPostalCode(POSTAL_CODE_VALUE)
+                        .build()
+                )
+            )
 
         assertThat(paymentMethodCreateParams)
             .isEqualTo(
@@ -229,6 +291,20 @@ internal class CardInputWidgetTest {
             expiryDateEditText.append("50")
             cvcEditText.append(CVC_VALUE_COMMON)
 
+            assertThat(cardParams)
+                .isEqualTo(
+                    CardParams(
+                        brand = CardBrand.DinersClub,
+                        loggingTokens = ATTRIBUTION,
+                        number = DINERS_CLUB_14_NO_SPACES,
+                        expMonth = 12,
+                        expYear = 2050,
+                        cvc = CVC_VALUE_COMMON,
+                        address = Address.Builder()
+                            .build()
+                    )
+                )
+
             assertThat(paymentMethodCard)
                 .isEqualTo(
                     PaymentMethodCreateParams.Card(
@@ -251,6 +327,21 @@ internal class CardInputWidgetTest {
             expiryDateEditText.append("50")
             cvcEditText.append(CVC_VALUE_COMMON)
             postalCodeEditText.setText(POSTAL_CODE_VALUE)
+
+            assertThat(cardParams)
+                .isEqualTo(
+                    CardParams(
+                        brand = CardBrand.DinersClub,
+                        loggingTokens = ATTRIBUTION,
+                        number = DINERS_CLUB_14_NO_SPACES,
+                        expMonth = 12,
+                        expYear = 2050,
+                        cvc = CVC_VALUE_COMMON,
+                        address = Address.Builder()
+                            .setPostalCode(POSTAL_CODE_VALUE)
+                            .build()
+                    )
+                )
 
             assertThat(paymentMethodCard)
                 .isEqualTo(
@@ -275,6 +366,9 @@ internal class CardInputWidgetTest {
         cvcEditText.append(CVC_VALUE_COMMON)
         postalCodeEditText.append("")
 
+        assertThat(cardParams)
+            .isNull()
+
         assertThat(paymentMethodCard)
             .isNull()
     }
@@ -286,6 +380,9 @@ internal class CardInputWidgetTest {
         expiryDateEditText.append("12")
         expiryDateEditText.append("50")
         cvcEditText.append(CVC_VALUE_COMMON)
+
+        assertThat(cardParams)
+            .isNull()
 
         assertThat(paymentMethodCard)
             .isNull()
@@ -310,6 +407,9 @@ internal class CardInputWidgetTest {
         expiryDateEditText.append("50")
         cvcEditText.append("12")
 
+        assertThat(cardParams)
+            .isNull()
+
         assertThat(paymentMethodCard)
             .isNull()
     }
@@ -324,6 +424,21 @@ internal class CardInputWidgetTest {
         cvcEditText.append(CVC_VALUE_COMMON)
         postalCodeEditText.setText("")
 
+        assertThat(cardParams)
+            .isEqualTo(
+                CardParams(
+                    brand = CardBrand.Visa,
+                    loggingTokens = ATTRIBUTION,
+                    number = VISA_NO_SPACES,
+                    expMonth = 12,
+                    expYear = 2050,
+                    cvc = CVC_VALUE_COMMON,
+                    address = Address()
+                )
+            )
+        assertThat(paymentMethodCard)
+            .isNotNull()
+
         assertThat(paymentMethodCreateParams?.billingDetails?.address?.postalCode)
             .isEqualTo("")
     }
@@ -336,6 +451,21 @@ internal class CardInputWidgetTest {
         expiryDateEditText.append("12")
         expiryDateEditText.append("50")
         cvcEditText.append(CVC_VALUE_COMMON)
+
+        assertThat(cardParams)
+            .isEqualTo(
+                CardParams(
+                    brand = CardBrand.AmericanExpress,
+                    loggingTokens = ATTRIBUTION,
+                    number = AMEX_NO_SPACES,
+                    expMonth = 12,
+                    expYear = 2050,
+                    cvc = CVC_VALUE_COMMON,
+                    address = Address()
+                )
+            )
+        assertThat(paymentMethodCard)
+            .isNotNull()
 
         assertThat(paymentMethodCreateParams?.billingDetails)
             .isNull()
@@ -351,6 +481,23 @@ internal class CardInputWidgetTest {
         cvcEditText.append(CVC_VALUE_COMMON)
         postalCodeEditText.setText(POSTAL_CODE_VALUE)
 
+        assertThat(cardParams)
+            .isEqualTo(
+                CardParams(
+                    brand = CardBrand.AmericanExpress,
+                    loggingTokens = ATTRIBUTION,
+                    number = AMEX_NO_SPACES,
+                    expMonth = 12,
+                    expYear = 2050,
+                    cvc = CVC_VALUE_COMMON,
+                    address = Address.Builder()
+                        .setPostalCode(POSTAL_CODE_VALUE)
+                        .build()
+                )
+            )
+        assertThat(paymentMethodCard)
+            .isNotNull()
+
         assertThat(paymentMethodCreateParams?.billingDetails?.address?.postalCode)
             .isEqualTo(POSTAL_CODE_VALUE)
     }
@@ -362,6 +509,8 @@ internal class CardInputWidgetTest {
         expiryDateEditText.append("50")
         cvcEditText.append("12")
 
+        assertThat(cardParams)
+            .isNull()
         assertThat(paymentMethodCard)
             .isNull()
     }
@@ -401,6 +550,8 @@ internal class CardInputWidgetTest {
         expiryDateEditText.append("50")
         cvcEditText.append("12")
 
+        assertThat(cardParams)
+            .isNull()
         assertThat(paymentMethodCard)
             .isNull()
     }
@@ -973,6 +1124,20 @@ internal class CardInputWidgetTest {
             setExpiryDate(12, 2079)
             setCvcCode(CVC_VALUE_AMEX)
 
+            assertThat(cardParams)
+                .isEqualTo(
+                    CardParams(
+                        brand = CardBrand.AmericanExpress,
+                        loggingTokens = ATTRIBUTION,
+                        number = AMEX_NO_SPACES,
+                        expMonth = 12,
+                        expYear = 2079,
+                        cvc = CVC_VALUE_AMEX,
+                        address = Address.Builder()
+                            .build()
+                    )
+                )
+
             assertThat(paymentMethodCard)
                 .isEqualTo(
                     PaymentMethodCreateParams.Card(
@@ -994,6 +1159,21 @@ internal class CardInputWidgetTest {
             setExpiryDate(12, 2079)
             setCvcCode(CVC_VALUE_AMEX)
             setPostalCode(POSTAL_CODE_VALUE)
+
+            assertThat(cardParams)
+                .isEqualTo(
+                    CardParams(
+                        brand = CardBrand.AmericanExpress,
+                        loggingTokens = ATTRIBUTION,
+                        number = AMEX_NO_SPACES,
+                        expMonth = 12,
+                        expYear = 2079,
+                        cvc = CVC_VALUE_AMEX,
+                        address = Address.Builder()
+                            .setPostalCode(POSTAL_CODE_VALUE)
+                            .build()
+                    )
+                )
 
             assertThat(paymentMethodCard)
                 .isEqualTo(
@@ -1333,6 +1513,7 @@ internal class CardInputWidgetTest {
 
         // invalid zipcode
         postalCodeEditText.setText(CVC_VALUE_AMEX)
+        assertThat(cardParams)
         assertThat(paymentMethodCreateParams)
             .isNull()
     }
@@ -1351,6 +1532,20 @@ internal class CardInputWidgetTest {
         // valid zipcode
         postalCodeEditText.setText(POSTAL_CODE_VALUE)
 
+        assertThat(cardParams)
+            .isEqualTo(
+                CardParams(
+                    brand = CardBrand.Visa,
+                    loggingTokens = ATTRIBUTION,
+                    number = VISA_NO_SPACES,
+                    expMonth = 12,
+                    expYear = 2050,
+                    cvc = CVC_VALUE_COMMON,
+                    address = Address.Builder()
+                        .setPostalCode(POSTAL_CODE_VALUE)
+                        .build()
+                )
+            )
         assertThat(paymentMethodCreateParams?.billingDetails?.address?.postalCode)
             .isEqualTo(POSTAL_CODE_VALUE)
     }

--- a/payments-core/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
@@ -35,6 +35,8 @@ import com.stripe.android.cards.DefaultCardAccountRangeStore
 import com.stripe.android.model.Address
 import com.stripe.android.model.BinFixtures
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.CardParams
+import com.stripe.android.model.Networks
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.testharness.ViewTestUtils
@@ -146,6 +148,58 @@ internal class CardMultilineWidgetTest {
     }
 
     @Test
+    fun getCard_whenInputIsValidVisaWithZip_returnsCardObjectWithLoggingToken() = runCardMultilineWidgetTest {
+        fullGroup.cardNumberEditText.setText(VISA_WITH_SPACES)
+        fullGroup.expiryDateEditText.append("12")
+        fullGroup.expiryDateEditText.append("50")
+        fullGroup.cvcEditText.append(CVC_VALUE_COMMON)
+        fullGroup.postalCodeEditText.append(POSTAL_CODE_VALUE)
+
+        assertThat(cardMultilineWidget.cardParams)
+            .isEqualTo(
+                CardParams(
+                    brand = CardBrand.Visa,
+                    loggingTokens = ATTRIBUTION,
+                    number = VISA_NO_SPACES,
+                    expMonth = 12,
+                    expYear = 2050,
+                    cvc = CVC_VALUE_COMMON,
+                    address = Address.Builder()
+                        .setPostalCode(POSTAL_CODE_VALUE)
+                        .build()
+                )
+            )
+    }
+
+    @Test
+    fun getCard_whenInputHasPrefNewtworks_returnsCardObjectWithNetworks() = runCardMultilineWidgetTest {
+        cardMultilineWidget.cardNumberEditText.setText(CO_BRAND_CARTES_MASTERCARD_WITH_SPACES)
+        cardMultilineWidget.expiryDateEditText.append("12")
+        cardMultilineWidget.expiryDateEditText.append("50")
+        cardMultilineWidget.cvcEditText.append(CVC_VALUE_COMMON)
+        cardMultilineWidget.postalCodeEditText.append(POSTAL_CODE_VALUE)
+        cardMultilineWidget.setPreferredNetworks(listOf(CardBrand.CartesBancaires))
+
+        assertThat(cardMultilineWidget.cardParams)
+            .isEqualTo(
+                CardParams(
+                    brand = CardBrand.Unknown,
+                    loggingTokens = ATTRIBUTION,
+                    number = CO_BRAND_CARTES_MASTERCARD_NO_SPACES,
+                    expMonth = 12,
+                    expYear = 2050,
+                    cvc = CVC_VALUE_COMMON,
+                    address = Address.Builder()
+                        .setPostalCode(POSTAL_CODE_VALUE)
+                        .build(),
+                    networks = Networks(
+                        preferred = CardBrand.CartesBancaires.code
+                    )
+                )
+            )
+    }
+
+    @Test
     fun getPaymentMethodParams_whenInputIsValidAmexAndNoZipRequiredAnd4DigitCvc_returnsFullCardAndExpectedLogging() =
         runCardMultilineWidgetTest {
             noZipGroup.cardNumberEditText.setText(AMEX_WITH_SPACES)
@@ -163,6 +217,96 @@ internal class CardMultilineWidgetTest {
                             expiryYear = 2050,
                             attribution = ATTRIBUTION
                         )
+                    )
+                )
+        }
+
+    @Test
+    fun getCard_whenInputIsValidVisaButInputHasNoZip_returnsValidCard() = runCardMultilineWidgetTest {
+        fullGroup.cardNumberEditText.setText(VISA_WITH_SPACES)
+        fullGroup.expiryDateEditText.append("12")
+        fullGroup.expiryDateEditText.append("50")
+        fullGroup.cvcEditText.append(CVC_VALUE_COMMON)
+
+        assertThat(cardMultilineWidget.cardParams)
+            .isEqualTo(
+                CardParams(
+                    brand = CardBrand.Visa,
+                    loggingTokens = ATTRIBUTION,
+                    number = VISA_NO_SPACES,
+                    expMonth = 12,
+                    expYear = 2050,
+                    cvc = CVC_VALUE_COMMON,
+                    address = Address.Builder()
+                        .build()
+                )
+            )
+    }
+
+    @Test
+    fun getCard_whenInputIsValidVisaAndNoZipRequired_returnsFullCardAndExpectedLogging() = runCardMultilineWidgetTest {
+        noZipGroup.cardNumberEditText.setText(VISA_WITH_SPACES)
+        noZipGroup.expiryDateEditText.append("12")
+        noZipGroup.expiryDateEditText.append("50")
+        noZipGroup.cvcEditText.append(CVC_VALUE_COMMON)
+
+        assertThat(noZipCardMultilineWidget.cardParams)
+            .isEqualTo(
+                CardParams(
+                    brand = CardBrand.Visa,
+                    loggingTokens = ATTRIBUTION,
+                    number = VISA_NO_SPACES,
+                    expMonth = 12,
+                    expYear = 2050,
+                    cvc = CVC_VALUE_COMMON,
+                    address = Address.Builder()
+                        .build()
+                )
+            )
+    }
+
+    @Test
+    fun getCard_whenInputIsValidAmexAndNoZipRequiredAnd4DigitCvc_returnsFullCardAndExpectedLogging() =
+        runCardMultilineWidgetTest {
+            noZipGroup.cardNumberEditText.setText(AMEX_WITH_SPACES)
+            noZipGroup.expiryDateEditText.append("12")
+            noZipGroup.expiryDateEditText.append("50")
+            noZipGroup.cvcEditText.append("1234")
+
+            assertThat(noZipCardMultilineWidget.cardParams)
+                .isEqualTo(
+                    CardParams(
+                        brand = CardBrand.AmericanExpress,
+                        loggingTokens = ATTRIBUTION,
+                        number = AMEX_NO_SPACES,
+                        expMonth = 12,
+                        expYear = 2050,
+                        cvc = CVC_VALUE_AMEX,
+                        address = Address.Builder()
+                            .build()
+                    )
+                )
+        }
+
+    @Test
+    fun getCard_whenInputIsValidAmexAndNoZipRequiredAnd3DigitCvc_returnsFullCardAndExpectedLogging() =
+        runCardMultilineWidgetTest {
+            noZipGroup.cardNumberEditText.setText(AMEX_WITH_SPACES)
+            noZipGroup.expiryDateEditText.append("12")
+            noZipGroup.expiryDateEditText.append("50")
+            noZipGroup.cvcEditText.append(CVC_VALUE_COMMON)
+
+            assertThat(noZipCardMultilineWidget.cardParams)
+                .isEqualTo(
+                    CardParams(
+                        brand = CardBrand.AmericanExpress,
+                        loggingTokens = ATTRIBUTION,
+                        number = AMEX_NO_SPACES,
+                        expMonth = 12,
+                        expYear = 2050,
+                        cvc = CVC_VALUE_COMMON,
+                        address = Address.Builder()
+                            .build()
                     )
                 )
         }
@@ -691,6 +835,54 @@ internal class CardMultilineWidgetTest {
     }
 
     @Test
+    fun setCardNumber_whenHasSpaces_canCreateValidCard() = runCardMultilineWidgetTest {
+        cardMultilineWidget.setCardNumber(VISA_NO_SPACES)
+        fullGroup.expiryDateEditText.append("12")
+        fullGroup.expiryDateEditText.append("50")
+        fullGroup.cvcEditText.append(CVC_VALUE_COMMON)
+        fullGroup.postalCodeEditText.append(POSTAL_CODE_VALUE)
+
+        assertThat(cardMultilineWidget.cardParams)
+            .isEqualTo(
+                CardParams(
+                    brand = CardBrand.Visa,
+                    loggingTokens = ATTRIBUTION,
+                    number = VISA_NO_SPACES,
+                    expMonth = 12,
+                    expYear = 2050,
+                    cvc = CVC_VALUE_COMMON,
+                    address = Address.Builder()
+                        .setPostalCode(POSTAL_CODE_VALUE)
+                        .build()
+                )
+            )
+    }
+
+    @Test
+    fun setCardNumber_whenHasNoSpaces_canCreateValidCard() = runCardMultilineWidgetTest {
+        cardMultilineWidget.setCardNumber(VISA_WITH_SPACES)
+        fullGroup.expiryDateEditText.append("12")
+        fullGroup.expiryDateEditText.append("50")
+        fullGroup.cvcEditText.append(CVC_VALUE_COMMON)
+        fullGroup.postalCodeEditText.append(POSTAL_CODE_VALUE)
+
+        assertThat(cardMultilineWidget.cardParams)
+            .isEqualTo(
+                CardParams(
+                    brand = CardBrand.Visa,
+                    loggingTokens = ATTRIBUTION,
+                    number = VISA_NO_SPACES,
+                    expMonth = 12,
+                    expYear = 2050,
+                    cvc = CVC_VALUE_COMMON,
+                    address = Address.Builder()
+                        .setPostalCode(POSTAL_CODE_VALUE)
+                        .build()
+                )
+            )
+    }
+
+    @Test
     fun validateCardNumber_whenValid_doesNotShowError() = runCardMultilineWidgetTest {
         cardMultilineWidget.setCardNumber(VISA_WITH_SPACES)
 
@@ -721,6 +913,87 @@ internal class CardMultilineWidgetTest {
     fun onFinishInflate_shouldSetPostalCodeInputLayoutHint() = runCardMultilineWidgetTest {
         assertThat(cardMultilineWidget.postalInputLayout.hint)
             .isEqualTo("Postal code")
+    }
+
+    @Test
+    fun usZipCodeRequired_whenFalse_shouldSetPostalCodeHint() = runCardMultilineWidgetTest {
+        cardMultilineWidget.usZipCodeRequired = false
+        cardMultilineWidget.setCardInputListener(fullCardListener)
+        assertThat(cardMultilineWidget.postalInputLayout.hint)
+            .isEqualTo("Postal code")
+
+        cardMultilineWidget.setCardNumber(VISA_WITH_SPACES)
+        fullGroup.expiryDateEditText.append("12")
+        fullGroup.expiryDateEditText.append("50")
+        fullGroup.cvcEditText.append(CVC_VALUE_COMMON)
+
+        assertThat(cardMultilineWidget.cardParams)
+            .isEqualTo(
+                CardParams(
+                    brand = CardBrand.Visa,
+                    loggingTokens = ATTRIBUTION,
+                    number = VISA_NO_SPACES,
+                    expMonth = 12,
+                    expYear = 2050,
+                    cvc = CVC_VALUE_COMMON,
+                    address = Address.Builder()
+                        .build()
+                )
+            )
+
+        verify(fullCardListener, never()).onPostalCodeComplete()
+    }
+
+    @Test
+    fun usZipCodeRequired_whenTrue_withInvalidZipCode_shouldReturnNullCard() = runCardMultilineWidgetTest {
+        cardMultilineWidget.usZipCodeRequired = true
+        cardMultilineWidget.setCardInputListener(fullCardListener)
+        assertThat(cardMultilineWidget.postalInputLayout.hint)
+            .isEqualTo("ZIP Code")
+
+        cardMultilineWidget.setCardNumber(VISA_WITH_SPACES)
+        fullGroup.expiryDateEditText.append("12")
+        fullGroup.expiryDateEditText.append("50")
+        fullGroup.cvcEditText.append(CVC_VALUE_COMMON)
+
+        // invalid zipcode
+        fullGroup.postalCodeEditText.setText("1234")
+        assertThat(cardMultilineWidget.cardParams)
+            .isNull()
+
+        verify(fullCardListener, never()).onPostalCodeComplete()
+    }
+
+    @Test
+    fun usZipCodeRequired_whenTrue_withValidZipCode_shouldReturnNotNullCard() = runCardMultilineWidgetTest {
+        cardMultilineWidget.usZipCodeRequired = true
+        cardMultilineWidget.setCardInputListener(fullCardListener)
+        assertThat(cardMultilineWidget.postalInputLayout.hint)
+            .isEqualTo("ZIP Code")
+
+        cardMultilineWidget.setCardNumber(VISA_WITH_SPACES)
+        fullGroup.expiryDateEditText.append("12")
+        fullGroup.expiryDateEditText.append("50")
+        fullGroup.cvcEditText.append(CVC_VALUE_COMMON)
+
+        // valid zipcode
+        fullGroup.postalCodeEditText.setText(POSTAL_CODE_VALUE)
+        assertThat(cardMultilineWidget.cardParams)
+            .isEqualTo(
+                CardParams(
+                    brand = CardBrand.Visa,
+                    loggingTokens = ATTRIBUTION,
+                    number = VISA_NO_SPACES,
+                    expMonth = 12,
+                    expYear = 2050,
+                    cvc = CVC_VALUE_COMMON,
+                    address = Address.Builder()
+                        .setPostalCode(POSTAL_CODE_VALUE)
+                        .build()
+                )
+            )
+
+        verify(fullCardListener).onPostalCodeComplete()
     }
 
     @Test


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Bring back cardParams in CardFormView, CardInputWidget, CardMultilineWidget and tests from #10440

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://stripe.slack.com/archives/C01CY476ESJ/p1763589990395209?thread_ts=1762880860.951899&cid=C01CY476ESJ

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
