### PR TITLE
Move payment method creation into `CustomerSheetConfirmationInterceptor`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CustomerSheetConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CustomerSheetConfirmationInterceptor.kt
@@ -1,11 +1,17 @@
 package com.stripe.android.paymentelement.confirmation.intent
 
 import com.stripe.android.common.exception.stripeErrorMessage
+import com.stripe.android.core.Logger
+import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.customersheet.util.isUnverifiedUSBankAccount
 import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.ConfirmPaymentIntentParams
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.networking.StripeRepository
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
@@ -17,28 +23,15 @@ import javax.inject.Inject
 internal class CustomerSheetConfirmationInterceptor @AssistedInject constructor(
     @Assisted private val clientAttributionMetadata: ClientAttributionMetadata,
     @Assisted private val integrationMetadata: IntegrationMetadata.CustomerSheet,
+    private val stripeRepository: StripeRepository,
+    private val requestOptions: ApiRequest.Options,
     private val setupIntentInterceptorFactory: CustomerSheetSetupIntentInterceptor.Factory,
     private val attachPaymentMethodInterceptorFactory: CustomerSheetAttachPaymentMethodInterceptor.Factory,
+    private val logger: Logger,
 ) : IntentConfirmationInterceptor {
     override suspend fun intercept(
         intent: StripeIntent,
         confirmationOption: PaymentMethodConfirmationOption.New,
-        shippingValues: ConfirmPaymentIntentParams.Shipping?
-    ): ConfirmationDefinition.Action<IntentConfirmationDefinition.Args> {
-        val error = IllegalStateException(
-            "Cannot use CustomerSheetConfirmationInterceptor with new payment methods!"
-        )
-
-        return ConfirmationDefinition.Action.Fail(
-            errorType = ConfirmationHandler.Result.Failed.ErrorType.Internal,
-            cause = error,
-            message = error.stripeErrorMessage()
-        )
-    }
-
-    override suspend fun intercept(
-        intent: StripeIntent,
-        confirmationOption: PaymentMethodConfirmationOption.Saved,
         shippingValues: ConfirmPaymentIntentParams.Shipping?
     ): ConfirmationDefinition.Action<IntentConfirmationDefinition.Args> {
         if (intent !is SetupIntent) {
@@ -51,25 +44,79 @@ internal class CustomerSheetConfirmationInterceptor @AssistedInject constructor(
             )
         }
 
-        return when (integrationMetadata.attachmentStyle) {
-            IntegrationMetadata.CustomerSheet.AttachmentStyle.SetupIntent -> {
-                val setupIntentInterceptor = setupIntentInterceptorFactory.create(clientAttributionMetadata)
+        return runCatching {
+            val paymentMethod = createPaymentMethod(confirmationOption.createParams)
 
-                setupIntentInterceptor.intercept(
-                    intent = intent,
-                    confirmationOption = confirmationOption,
-                    shippingValues = null,
+            if (paymentMethod.isUnverifiedUSBankAccount()) {
+                return ConfirmationDefinition.Action.Complete(
+                    intent = intent.copy(paymentMethod = paymentMethod),
+                    deferredIntentConfirmationType = null,
+                    completedFullPaymentFlow = true,
                 )
             }
-            IntegrationMetadata.CustomerSheet.AttachmentStyle.CreateAttach -> {
-                val attachPaymentMethodInterceptor = attachPaymentMethodInterceptorFactory.create()
 
-                attachPaymentMethodInterceptor.intercept(
-                    intent = intent,
-                    paymentMethod = confirmationOption.paymentMethod,
+            return when (integrationMetadata.attachmentStyle) {
+                IntegrationMetadata.CustomerSheet.AttachmentStyle.SetupIntent -> {
+                    val setupIntentInterceptor = setupIntentInterceptorFactory.create(clientAttributionMetadata)
+
+                    setupIntentInterceptor.intercept(
+                        intent = intent,
+                        confirmationOption = PaymentMethodConfirmationOption.Saved(
+                            paymentMethod = paymentMethod,
+                            optionsParams = null,
+                        ),
+                        shippingValues = null,
+                    )
+                }
+                IntegrationMetadata.CustomerSheet.AttachmentStyle.CreateAttach -> {
+                    val attachPaymentMethodInterceptor = attachPaymentMethodInterceptorFactory.create()
+
+                    attachPaymentMethodInterceptor.intercept(
+                        intent = intent,
+                        paymentMethod = paymentMethod,
+                    )
+                }
+            }
+        }.fold(
+            onSuccess = { it },
+            onFailure = { cause ->
+                ConfirmationDefinition.Action.Fail(
+                    cause = cause,
+                    message = cause.stripeErrorMessage(),
+                    errorType = ConfirmationHandler.Result.Failed.ErrorType.Payment,
                 )
             }
-        }
+        )
+    }
+
+    override suspend fun intercept(
+        intent: StripeIntent,
+        confirmationOption: PaymentMethodConfirmationOption.Saved,
+        shippingValues: ConfirmPaymentIntentParams.Shipping?
+    ): ConfirmationDefinition.Action<IntentConfirmationDefinition.Args> {
+        val error = IllegalStateException(
+            "Cannot use CustomerSheetConfirmationInterceptor with saved payment methods!"
+        )
+
+        return ConfirmationDefinition.Action.Fail(
+            errorType = ConfirmationHandler.Result.Failed.ErrorType.Internal,
+            cause = error,
+            message = error.stripeErrorMessage()
+        )
+    }
+
+    private suspend fun createPaymentMethod(
+        paymentMethodCreateParams: PaymentMethodCreateParams,
+    ): PaymentMethod {
+        return stripeRepository.createPaymentMethod(
+            paymentMethodCreateParams = paymentMethodCreateParams,
+            options = requestOptions,
+        ).onFailure { throwable ->
+            logger.error(
+                msg = "Failed to create payment method for ${paymentMethodCreateParams.typeCode}",
+                t = throwable,
+            )
+        }.getOrThrow()
     }
 
     @AssistedFactory

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -14,7 +14,6 @@ import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.customersheet.CustomerSheetIntegration
 import com.stripe.android.customersheet.CustomerSheetLoader
 import com.stripe.android.customersheet.CustomerSheetViewModel
-import com.stripe.android.customersheet.FakeStripeRepository
 import com.stripe.android.customersheet.analytics.CustomerSheetEventReporter
 import com.stripe.android.customersheet.data.CustomerSheetDataResult
 import com.stripe.android.customersheet.data.CustomerSheetPaymentMethodDataSource
@@ -30,7 +29,6 @@ import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures.CARD_PAYMENT_METHOD
-import com.stripe.android.networking.StripeRepository
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.createTestConfirmationHandlerFactory
 import com.stripe.android.paymentelement.confirmation.intent.IntentConfirmationInterceptor
@@ -74,7 +72,6 @@ internal object CustomerSheetTestHelper {
             LpmRepositoryTestHelpers.usBankAccount,
         ),
         savedPaymentSelection: PaymentSelection? = null,
-        stripeRepository: StripeRepository = FakeStripeRepository(),
         paymentConfiguration: PaymentConfiguration = PaymentConfiguration(
             publishableKey = "pk_test_123",
             stripeAccountId = null,
@@ -120,10 +117,8 @@ internal object CustomerSheetTestHelper {
             application = application,
             workContext = workContext,
             originalPaymentSelection = savedPaymentSelection,
-            paymentConfigurationProvider = { paymentConfiguration },
             paymentMethodDataSourceProvider = CompletableSingle(paymentMethodDataSource),
             savedSelectionDataSourceProvider = CompletableSingle(savedSelectionDataSource),
-            stripeRepository = stripeRepository,
             configuration = configuration,
             integrationType = integrationType,
             isLiveModeProvider = { isLiveMode },


### PR DESCRIPTION
# Summary
Move confirmation logic from `CustomerSheetViewModel` to `CustomerSheetConfirmationInterceptor`

# Motivation
Secluding confirmation logic away from the view model.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified