### PR TITLE
Move `CustomerSheet` setup intent operations into an intent interceptor

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelComponent.kt
@@ -8,7 +8,6 @@ import com.stripe.android.customersheet.CustomerSheetViewModel
 import com.stripe.android.googlepaylauncher.injection.GooglePayLauncherModule
 import com.stripe.android.networking.PaymentElementRequestSurfaceModule
 import com.stripe.android.paymentelement.confirmation.injection.CustomerSheetConfirmationModule
-import com.stripe.android.paymentelement.confirmation.injection.DefaultConfirmationModule
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import dagger.BindsInstance
@@ -18,7 +17,6 @@ import javax.inject.Named
 @CustomerSheetViewModelScope
 @Component(
     modules = [
-        DefaultConfirmationModule::class,
         CustomerSheetConfirmationModule::class,
         CustomerSheetViewModelModule::class,
         StripeRepositoryModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CustomerSheetConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CustomerSheetConfirmationInterceptor.kt
@@ -1,0 +1,78 @@
+package com.stripe.android.paymentelement.confirmation.intent
+
+import com.stripe.android.common.exception.stripeErrorMessage
+import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
+import com.stripe.android.model.ClientAttributionMetadata
+import com.stripe.android.model.ConfirmPaymentIntentParams
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import javax.inject.Inject
+
+internal class CustomerSheetConfirmationInterceptor @AssistedInject constructor(
+    @Assisted private val clientAttributionMetadata: ClientAttributionMetadata,
+    private val setupIntentInterceptorFactory: CustomerSheetSetupIntentInterceptor.Factory,
+) : IntentConfirmationInterceptor {
+    override suspend fun intercept(
+        intent: StripeIntent,
+        confirmationOption: PaymentMethodConfirmationOption.New,
+        shippingValues: ConfirmPaymentIntentParams.Shipping?
+    ): ConfirmationDefinition.Action<IntentConfirmationDefinition.Args> {
+        val error = IllegalStateException(
+            "Cannot use CustomerSheetConfirmationInterceptor with new payment methods!"
+        )
+
+        return ConfirmationDefinition.Action.Fail(
+            errorType = ConfirmationHandler.Result.Failed.ErrorType.Internal,
+            cause = error,
+            message = error.stripeErrorMessage()
+        )
+    }
+
+    override suspend fun intercept(
+        intent: StripeIntent,
+        confirmationOption: PaymentMethodConfirmationOption.Saved,
+        shippingValues: ConfirmPaymentIntentParams.Shipping?
+    ): ConfirmationDefinition.Action<IntentConfirmationDefinition.Args> {
+        val setupIntentInterceptor = setupIntentInterceptorFactory.create(clientAttributionMetadata)
+
+        return setupIntentInterceptor.intercept(
+            intent = intent,
+            confirmationOption = confirmationOption,
+            shippingValues = null,
+        )
+    }
+
+    @AssistedFactory
+    interface Factory {
+        fun create(
+            clientAttributionMetadata: ClientAttributionMetadata
+        ): CustomerSheetConfirmationInterceptor
+    }
+}
+
+internal class CustomerSheetIntentConfirmationInterceptorFactory @Inject constructor(
+    private val customerSheetConfirmationInterceptor: CustomerSheetConfirmationInterceptor.Factory
+) : IntentConfirmationInterceptor.Factory {
+    override suspend fun create(
+        integrationMetadata: IntegrationMetadata,
+        customerId: String?,
+        ephemeralKeySecret: String?,
+        clientAttributionMetadata: ClientAttributionMetadata
+    ): IntentConfirmationInterceptor {
+        return when (integrationMetadata) {
+            is IntegrationMetadata.CustomerSheet -> {
+                customerSheetConfirmationInterceptor.create(clientAttributionMetadata)
+            }
+            else -> {
+                throw IllegalStateException(
+                    "${integrationMetadata::class.java.name} is not supported by Customer Sheet!"
+                )
+            }
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CustomerSheetIntentConfirmationModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CustomerSheetIntentConfirmationModule.kt
@@ -6,7 +6,12 @@ import dagger.Module
 @Module(includes = [IntentConfirmationModule::class])
 internal interface CustomerSheetIntentConfirmationModule {
     @Binds
+    fun bindsSetupIntentInterceptorFactory(
+        defaultCustomerSheetSetupIntentInterceptorFactory: DefaultCustomerSheetSetupIntentInterceptorFactory
+    ): CustomerSheetSetupIntentInterceptor.Factory
+
+    @Binds
     fun bindsIntentConfirmationInterceptorFactory(
-        defaultConfirmationInterceptorFactory: DefaultIntentConfirmationInterceptorFactory
+        customerSheetConfirmationInterceptorFactory: CustomerSheetIntentConfirmationInterceptorFactory
     ): IntentConfirmationInterceptor.Factory
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CustomerSheetSetupIntentInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CustomerSheetSetupIntentInterceptor.kt
@@ -1,0 +1,96 @@
+package com.stripe.android.paymentelement.confirmation.intent
+
+import com.stripe.android.common.coroutines.Single
+import com.stripe.android.common.exception.stripeErrorMessage
+import com.stripe.android.core.Logger
+import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.customersheet.data.CustomerSheetIntentDataSource
+import com.stripe.android.customersheet.data.fold
+import com.stripe.android.customersheet.util.CustomerSheetHacks
+import com.stripe.android.model.ClientAttributionMetadata
+import com.stripe.android.model.ConfirmPaymentIntentParams
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
+import javax.inject.Inject
+
+internal class CustomerSheetSetupIntentInterceptor(
+    private val intentDataSourceProvider: Single<CustomerSheetIntentDataSource>,
+    private val intentFirstConfirmationInterceptorFactory: IntentFirstConfirmationInterceptor.Factory,
+    private val logger: Logger,
+    private val clientAttributionMetadata: ClientAttributionMetadata,
+) : IntentConfirmationInterceptor {
+    override suspend fun intercept(
+        intent: StripeIntent,
+        confirmationOption: PaymentMethodConfirmationOption.Saved,
+        shippingValues: ConfirmPaymentIntentParams.Shipping?
+    ): ConfirmationDefinition.Action<IntentConfirmationDefinition.Args> {
+        return intentDataSourceProvider.await()
+            .retrieveSetupIntentClientSecret()
+            .fold(
+                onSuccess = { clientSecret ->
+                    intentFirstConfirmationInterceptorFactory
+                        .create(clientSecret, clientAttributionMetadata)
+                        .intercept(
+                            intent = intent,
+                            confirmationOption = PaymentMethodConfirmationOption.Saved(
+                                paymentMethod = confirmationOption.paymentMethod,
+                                optionsParams = null,
+                            ),
+                            shippingValues = null,
+                        )
+                },
+                onFailure = { cause, displayMessage ->
+                    logger.error(
+                        msg = "Failed to attach payment method to SetupIntent: ${confirmationOption.paymentMethod}",
+                        t = cause,
+                    )
+
+                    ConfirmationDefinition.Action.Fail(
+                        cause = cause,
+                        message = displayMessage?.resolvableString ?: cause.stripeErrorMessage(),
+                        errorType = ConfirmationHandler.Result.Failed.ErrorType.Payment,
+                    )
+                }
+            )
+    }
+
+    override suspend fun intercept(
+        intent: StripeIntent,
+        confirmationOption: PaymentMethodConfirmationOption.New,
+        shippingValues: ConfirmPaymentIntentParams.Shipping?
+    ): ConfirmationDefinition.Action<IntentConfirmationDefinition.Args> {
+        val error = IllegalStateException(
+            "Cannot use CustomerSheetSetupIntentInterceptor with new payment methods!"
+        )
+
+        return ConfirmationDefinition.Action.Fail(
+            errorType = ConfirmationHandler.Result.Failed.ErrorType.Internal,
+            cause = error,
+            message = error.stripeErrorMessage()
+        )
+    }
+
+    interface Factory {
+        fun create(
+            clientAttributionMetadata: ClientAttributionMetadata
+        ): IntentConfirmationInterceptor
+    }
+}
+
+internal class DefaultCustomerSheetSetupIntentInterceptorFactory @Inject constructor(
+    private val intentFirstConfirmationInterceptorFactory: IntentFirstConfirmationInterceptor.Factory,
+    private val logger: Logger,
+) : CustomerSheetSetupIntentInterceptor.Factory {
+    override fun create(
+        clientAttributionMetadata: ClientAttributionMetadata
+    ): CustomerSheetSetupIntentInterceptor {
+        return CustomerSheetSetupIntentInterceptor(
+            intentDataSourceProvider = CustomerSheetHacks.intentDataSource,
+            intentFirstConfirmationInterceptorFactory = intentFirstConfirmationInterceptorFactory,
+            logger = logger,
+            clientAttributionMetadata = clientAttributionMetadata,
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -113,7 +113,7 @@ internal object CustomerSheetTestHelper {
             permissions = customerPermissions,
         ),
         errorReporter: ErrorReporter = FakeErrorReporter(),
-        confirmationHandlerFactory: ConfirmationHandler.Factory? = null,
+        confirmationHandler: ConfirmationHandler? = null,
     ): CustomerSheetViewModel {
         val savedStateHandle = SavedStateHandle()
         return CustomerSheetViewModel(
@@ -130,41 +130,43 @@ internal object CustomerSheetTestHelper {
             isLiveModeProvider = { isLiveMode },
             logger = Logger.noop(),
             productUsage = emptySet(),
-            confirmationHandlerFactory = confirmationHandlerFactory ?: createTestConfirmationHandlerFactory(
-                paymentElementCallbackIdentifier = "CustomerSheetTestIdentifier",
-                intentConfirmationInterceptorFactory = intentConfirmationInterceptorFactory,
-                paymentConfiguration = paymentConfiguration,
-                bacsMandateConfirmationLauncherFactory = {
-                    FakeBacsMandateConfirmationLauncher()
-                },
-                stripePaymentLauncherAssistedFactory = object : StripePaymentLauncherAssistedFactory {
-                    override fun create(
-                        publishableKey: () -> String,
-                        stripeAccountId: () -> String?,
-                        statusBarColor: Int?,
-                        includePaymentSheetNextHandlers: Boolean,
-                        hostActivityLauncher: ActivityResultLauncher<PaymentLauncherContract.Args>
-                    ): StripePaymentLauncher {
-                        return mock()
-                    }
-                },
-                googlePayPaymentMethodLauncherFactory = object : GooglePayPaymentMethodLauncherFactory {
-                    override fun create(
-                        lifecycleScope: CoroutineScope,
-                        config: GooglePayPaymentMethodLauncher.Config,
-                        readyCallback: GooglePayPaymentMethodLauncher.ReadyCallback,
-                        activityResultLauncher: ActivityResultLauncher<GooglePayPaymentMethodLauncherContractV2.Args>,
-                        skipReadyCheck: Boolean,
-                        cardBrandFilter: CardBrandFilter
-                    ): GooglePayPaymentMethodLauncher = mock()
-                },
-                statusBarColor = null,
-                savedStateHandle = savedStateHandle,
-                errorReporter = FakeErrorReporter(),
-                linkLauncher = RecordingLinkPaymentLauncher.noOp(),
-                linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
-                cvcRecollectionLauncherFactory = RecordingCvcRecollectionLauncherFactory.noOp()
-            ),
+            confirmationHandlerFactory = confirmationHandler?.let { ConfirmationHandler.Factory { _ -> it } }
+                ?: createTestConfirmationHandlerFactory(
+                    paymentElementCallbackIdentifier = "CustomerSheetTestIdentifier",
+                    intentConfirmationInterceptorFactory = intentConfirmationInterceptorFactory,
+                    paymentConfiguration = paymentConfiguration,
+                    bacsMandateConfirmationLauncherFactory = {
+                        FakeBacsMandateConfirmationLauncher()
+                    },
+                    stripePaymentLauncherAssistedFactory = object : StripePaymentLauncherAssistedFactory {
+                        override fun create(
+                            publishableKey: () -> String,
+                            stripeAccountId: () -> String?,
+                            statusBarColor: Int?,
+                            includePaymentSheetNextHandlers: Boolean,
+                            hostActivityLauncher: ActivityResultLauncher<PaymentLauncherContract.Args>
+                        ): StripePaymentLauncher {
+                            return mock()
+                        }
+                    },
+                    googlePayPaymentMethodLauncherFactory = object : GooglePayPaymentMethodLauncherFactory {
+                        override fun create(
+                            lifecycleScope: CoroutineScope,
+                            config: GooglePayPaymentMethodLauncher.Config,
+                            readyCallback: GooglePayPaymentMethodLauncher.ReadyCallback,
+                            activityResultLauncher:
+                            ActivityResultLauncher<GooglePayPaymentMethodLauncherContractV2.Args>,
+                            skipReadyCheck: Boolean,
+                            cardBrandFilter: CardBrandFilter
+                        ): GooglePayPaymentMethodLauncher = mock()
+                    },
+                    statusBarColor = null,
+                    savedStateHandle = savedStateHandle,
+                    errorReporter = FakeErrorReporter(),
+                    linkLauncher = RecordingLinkPaymentLauncher.noOp(),
+                    linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
+                    cvcRecollectionLauncherFactory = RecordingCvcRecollectionLauncherFactory.noOp()
+                ),
             eventReporter = eventReporter,
             customerSheetLoader = customerSheetLoader,
             errorReporter = errorReporter,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CustomerSheetSetupIntentInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CustomerSheetSetupIntentInterceptorTest.kt
@@ -1,0 +1,178 @@
+package com.stripe.android.paymentelement.confirmation.intent
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.Logger
+import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.customersheet.data.CustomerSheetDataResult
+import com.stripe.android.customersheet.data.CustomerSheetIntentDataSource
+import com.stripe.android.customersheet.data.FakeCustomerSheetIntentDataSource
+import com.stripe.android.isInstanceOf
+import com.stripe.android.model.ClientAttributionMetadata
+import com.stripe.android.model.PaymentIntentCreationFlow
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.model.PaymentMethodSelectionFlow
+import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
+import com.stripe.android.testing.FakeLogger
+import com.stripe.android.testing.SetupIntentFactory
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class CustomerSheetSetupIntentInterceptorTest {
+
+    private val clientAttributionMetadata = ClientAttributionMetadata(
+        elementsSessionConfigId = "test_session_id",
+        paymentIntentCreationFlow = PaymentIntentCreationFlow.Standard,
+        paymentMethodSelectionFlow = PaymentMethodSelectionFlow.MerchantSpecified,
+    )
+
+    private val requestOptions = ApiRequest.Options(
+        apiKey = "pk_test_123",
+    )
+
+    @Test
+    fun `Rejects new payment method confirmation`() = runTest {
+        val interceptor = createInterceptor()
+
+        val result = interceptor.intercept(
+            intent = SetupIntentFactory.create(),
+            confirmationOption = PaymentMethodConfirmationOption.New(
+                createParams = com.stripe.android.model.PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                optionsParams = null,
+                extraParams = null,
+                shouldSave = false,
+            ),
+            shippingValues = null,
+        )
+
+        assertThat(result).isInstanceOf<ConfirmationDefinition.Action.Fail<IntentConfirmationDefinition.Args>>()
+
+        val failAction = result as ConfirmationDefinition.Action.Fail
+
+        assertThat(failAction.errorType).isEqualTo(ConfirmationHandler.Result.Failed.ErrorType.Internal)
+        assertThat(failAction.cause).isInstanceOf<IllegalStateException>()
+        assertThat(failAction.cause.message)
+            .isEqualTo("Cannot use CustomerSheetSetupIntentInterceptor with new payment methods!")
+    }
+
+    @Test
+    fun `Successfully creates and confirms setup intent`() = runTest {
+        val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
+        val setupIntentClientSecret = "seti_1234_secret_5678"
+        val setupIntent = SetupIntentFactory.create(clientSecret = setupIntentClientSecret)
+
+        val interceptor = createInterceptor(
+            intentDataSource = FakeCustomerSheetIntentDataSource(
+                canCreateSetupIntents = true,
+                onRetrieveSetupIntentClientSecret = {
+                    CustomerSheetDataResult.success(setupIntentClientSecret)
+                }
+            ),
+        )
+
+        val result = interceptor.intercept(
+            intent = setupIntent,
+            confirmationOption = PaymentMethodConfirmationOption.Saved(
+                paymentMethod = paymentMethod,
+                optionsParams = null,
+            ),
+            shippingValues = null,
+        )
+
+        assertThat(result).isInstanceOf<ConfirmationDefinition.Action.Launch<*>>()
+    }
+
+    @Test
+    fun `Fails when setup intent creation fails`() = runTest {
+        val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
+        val errorCause = Exception("Failed to create setup intent")
+        val errorMessage = "Unable to create setup intent"
+
+        val interceptor = createInterceptor(
+            intentDataSource = FakeCustomerSheetIntentDataSource(
+                canCreateSetupIntents = true,
+                onRetrieveSetupIntentClientSecret = {
+                    CustomerSheetDataResult.failure(
+                        displayMessage = errorMessage,
+                        cause = errorCause,
+                    )
+                }
+            ),
+        )
+
+        val result = interceptor.intercept(
+            intent = SetupIntentFactory.create(),
+            confirmationOption = PaymentMethodConfirmationOption.Saved(
+                paymentMethod = paymentMethod,
+                optionsParams = null,
+            ),
+            shippingValues = null,
+        )
+
+        assertThat(result).isInstanceOf<ConfirmationDefinition.Action.Fail<IntentConfirmationDefinition.Args>>()
+
+        val failAction = result as ConfirmationDefinition.Action.Fail
+
+        assertThat(failAction.message).isEqualTo(errorMessage.resolvableString)
+        assertThat(failAction.errorType).isEqualTo(ConfirmationHandler.Result.Failed.ErrorType.Payment)
+    }
+
+    @Test
+    fun `Logs error when setup intent creation fails`() = runTest {
+        val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
+        val errorCause = Exception("Failed to create setup intent")
+
+        val logger = FakeLogger()
+
+        val interceptor = createInterceptor(
+            intentDataSource = FakeCustomerSheetIntentDataSource(
+                canCreateSetupIntents = true,
+                onRetrieveSetupIntentClientSecret = {
+                    CustomerSheetDataResult.failure(
+                        displayMessage = "Error",
+                        cause = errorCause,
+                    )
+                }
+            ),
+            logger = logger,
+        )
+
+        interceptor.intercept(
+            intent = SetupIntentFactory.create(),
+            confirmationOption = PaymentMethodConfirmationOption.Saved(
+                paymentMethod = paymentMethod,
+                optionsParams = null,
+            ),
+            shippingValues = null,
+        )
+
+        assertThat(logger.errorLogs).hasSize(1)
+        assertThat(logger.errorLogs[0].first).contains("Failed to attach payment method to SetupIntent")
+    }
+
+    private fun createInterceptor(
+        intentDataSource: CustomerSheetIntentDataSource = FakeCustomerSheetIntentDataSource(),
+        logger: Logger = FakeLogger(),
+    ): CustomerSheetSetupIntentInterceptor {
+        return CustomerSheetSetupIntentInterceptor(
+            intentDataSourceProvider = { intentDataSource },
+            intentFirstConfirmationInterceptorFactory = FakeIntentFirstConfirmationInterceptorFactory(requestOptions),
+            logger = logger,
+            clientAttributionMetadata = clientAttributionMetadata,
+        )
+    }
+
+    private class FakeIntentFirstConfirmationInterceptorFactory(
+        private val requestOptions: ApiRequest.Options,
+    ) : IntentFirstConfirmationInterceptor.Factory {
+        override fun create(
+            clientSecret: String,
+            clientAttributionMetadata: ClientAttributionMetadata
+        ) = IntentFirstConfirmationInterceptor(clientSecret, clientAttributionMetadata, requestOptions)
+    }
+}


### PR DESCRIPTION
# Summary
Move `CustomerSheet` setup intent operations into an intent interceptor

# Motivation
Secludes customer sheet confirmation logic from the view model.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified