### PR TITLE
Preserve radar options when running passive challenge confirmation definition

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/attestation/AttestationConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/attestation/AttestationConfirmationDefinition.kt
@@ -139,16 +139,24 @@ internal class AttestationConfirmationDefinition @Inject constructor(
     }
 
     private fun PaymentMethodConfirmationOption.New.attachToken(token: String?): PaymentMethodConfirmationOption {
+        val radarOptions = if (token != null) {
+            createParams.radarOptions?.copy(
+                androidVerificationObject = AndroidVerificationObject(
+                    androidVerificationToken = token
+                )
+            ) ?: RadarOptions(
+                hCaptchaToken = null,
+                androidVerificationObject = AndroidVerificationObject(
+                    androidVerificationToken = token
+                )
+            )
+        } else {
+            createParams.radarOptions
+        }
+
         return copy(
             createParams = createParams.copy(
-                radarOptions = token?.let {
-                    RadarOptions(
-                        hCaptchaToken = null,
-                        androidVerificationObject = AndroidVerificationObject(
-                            androidVerificationToken = it
-                        )
-                    )
-                }
+                radarOptions = radarOptions
             ),
             attestationComplete = true
         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinition.kt
@@ -124,16 +124,21 @@ internal class PassiveChallengeConfirmationDefinition @Inject constructor(
     }
 
     private fun PaymentMethodConfirmationOption.New.attachToken(token: String?): PaymentMethodConfirmationOption {
+        val radarOptions = if (token != null) {
+            createParams.radarOptions?.copy(
+                hCaptchaToken = token
+            ) ?: RadarOptions(
+                hCaptchaToken = token,
+                androidVerificationObject = null
+            )
+        } else {
+            createParams.radarOptions
+        }
         return copy(
             createParams = createParams.copy(
-                radarOptions = token?.let {
-                    RadarOptions(
-                        hCaptchaToken = it,
-                        androidVerificationObject = null
-                    )
-                }
+                radarOptions = radarOptions
             ),
-            passiveChallengeComplete = true,
+            passiveChallengeComplete = true
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/attestation/AttestationConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/attestation/AttestationConfirmationDefinitionTest.kt
@@ -268,6 +268,38 @@ internal class AttestationConfirmationDefinitionTest {
     }
 
     @Test
+    fun `'toResult' should leave hCaptchaToken as is in RadarOptions for New option`() {
+        val definition = createAttestationConfirmationDefinition()
+        val testToken = "attestation_token"
+        val hCaptchaToken = "hcaptcha_token"
+
+        val result = definition.toResult(
+            confirmationOption = PAYMENT_METHOD_CONFIRMATION_OPTION_NEW.copy(
+                createParams = PAYMENT_METHOD_CONFIRMATION_OPTION_NEW.createParams.copy(
+                    radarOptions = RadarOptions(
+                        hCaptchaToken = hCaptchaToken,
+                        androidVerificationObject = null
+                    )
+                )
+            ),
+            confirmationArgs = CONFIRMATION_PARAMETERS,
+            deferredIntentConfirmationType = null,
+            result = AttestationActivityResult.Success(testToken),
+        )
+
+        val nextStepResult = result.asNextStep()
+        val option = nextStepResult.confirmationOption as PaymentMethodConfirmationOption.New
+
+        val expectedCreateParams = PAYMENT_METHOD_CONFIRMATION_OPTION_NEW.createParams.copy(
+            radarOptions = RadarOptions(
+                hCaptchaToken = hCaptchaToken,
+                androidVerificationObject = AndroidVerificationObject(testToken)
+            )
+        )
+        assertThat(option.createParams).isEqualTo(expectedCreateParams)
+    }
+
+    @Test
     fun `'canConfirm' should return false when New option already has a token`() {
         val definition = createAttestationConfirmationDefinition()
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinitionTest.kt
@@ -420,7 +420,7 @@ internal class PassiveChallengeConfirmationDefinitionTest {
         val expectedCreateParams = PAYMENT_METHOD_CONFIRMATION_OPTION_NEW.createParams.copy(
             radarOptions = RadarOptions(
                 hCaptchaToken = testToken,
-                androidVerificationObject = null
+                androidVerificationObject = AndroidVerificationObject(attestationToken)
             )
         )
         assertThat(option.createParams).isEqualTo(expectedCreateParams)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Preserve radar options when running passive challenge confirmation definition

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Radar options gets overwritten by `PassiveChallengeConfirmationDefinition`, this will make sure that the contents of radar options are preserved

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
