### PR TITLE
Remove `IntentConfirmationInterceptor` interface from `CustomerSheetSetupIntentInterceptor`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CustomerSheetConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CustomerSheetConfirmationInterceptor.kt
@@ -61,11 +61,7 @@ internal class CustomerSheetConfirmationInterceptor @AssistedInject constructor(
 
                     setupIntentInterceptor.intercept(
                         intent = intent,
-                        confirmationOption = PaymentMethodConfirmationOption.Saved(
-                            paymentMethod = paymentMethod,
-                            optionsParams = null,
-                        ),
-                        shippingValues = null,
+                        paymentMethod = paymentMethod,
                     )
                 }
                 IntegrationMetadata.CustomerSheet.AttachmentStyle.CreateAttach -> {


### PR DESCRIPTION
# Summary
Remove `IntentConfirmationInterceptor` interface from `CustomerSheetSetupIntentInterceptor`

# Motivation
Not needed for this interceptor

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified