### PR TITLE
Fix transitive dependencies check.

### DIFF
--- a/identity-example/dependencies/theme1-dependencies.txt
+++ b/identity-example/dependencies/theme1-dependencies.txt
@@ -1,4 +1,4 @@
-+--- androidx.databinding:viewbinding:8.8.2
++--- androidx.databinding:viewbinding:8.13.1
 |    \--- androidx.annotation:annotation:1.0.0 -> 1.9.1
 |         \--- androidx.annotation:annotation-jvm:1.9.1
 |              \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.24 -> 2.1.10
@@ -6,7 +6,7 @@
 |                   \--- org.jetbrains.kotlin:kotlin-stdlib-common:2.1.10 (c)
 +--- org.jetbrains.kotlin:kotlin-stdlib:2.1.10 (*)
 +--- project :identity
-|    +--- androidx.databinding:viewbinding:8.8.2 (*)
+|    +--- androidx.databinding:viewbinding:8.13.1 (*)
 |    +--- org.jetbrains.kotlin:kotlin-stdlib:2.1.10 (*)
 |    +--- project :camera-core
 |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:2.1.10 (*)

--- a/identity-example/dependencies/theme2-dependencies.txt
+++ b/identity-example/dependencies/theme2-dependencies.txt
@@ -1,4 +1,4 @@
-+--- androidx.databinding:viewbinding:8.8.2
++--- androidx.databinding:viewbinding:8.13.1
 |    \--- androidx.annotation:annotation:1.0.0 -> 1.9.1
 |         \--- androidx.annotation:annotation-jvm:1.9.1
 |              \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.24 -> 2.1.10
@@ -6,7 +6,7 @@
 |                   \--- org.jetbrains.kotlin:kotlin-stdlib-common:2.1.10 (c)
 +--- org.jetbrains.kotlin:kotlin-stdlib:2.1.10 (*)
 +--- project :identity
-|    +--- androidx.databinding:viewbinding:8.8.2 (*)
+|    +--- androidx.databinding:viewbinding:8.13.1 (*)
 |    +--- org.jetbrains.kotlin:kotlin-stdlib:2.1.10 (*)
 |    +--- project :camera-core
 |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:2.1.10 (*)

--- a/scripts/dependencies/check_transitive_dependencies.rb
+++ b/scripts/dependencies/check_transitive_dependencies.rb
@@ -2,7 +2,7 @@
 
 require 'open3'
 
-diff_command = 'git status --porcelain */dependencies/dependencies.txt'
+diff_command = 'git status --porcelain */dependencies/*dependencies.txt'
 stdout, _, _ = Open3.capture3(diff_command)
 
 if stdout.empty?


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
A recent change made it so the dependencies files might have other prefixes, so updating the CI check and fixing the master breakages.

#12068
