### PR TITLE
Add paymentsheet card funding api

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -519,6 +519,7 @@ public final class com/stripe/android/paymentelement/EmbeddedPaymentElement$Conf
 public final class com/stripe/android/paymentelement/EmbeddedPaymentElement$Configuration$Builder {
 	public static final field $stable I
 	public fun <init> (Ljava/lang/String;)V
+	public final fun allowedCardFundingTypes (Lcom/stripe/android/paymentsheet/PaymentSheet$CardFundingAcceptance;)Lcom/stripe/android/paymentelement/EmbeddedPaymentElement$Configuration$Builder;
 	public final fun allowsDelayedPaymentMethods (Z)Lcom/stripe/android/paymentelement/EmbeddedPaymentElement$Configuration$Builder;
 	public final fun allowsPaymentMethodsRequiringShippingAddress (Z)Lcom/stripe/android/paymentelement/EmbeddedPaymentElement$Configuration$Builder;
 	public final fun allowsRemovalOfLastSavedPaymentMethod (Z)Lcom/stripe/android/paymentelement/EmbeddedPaymentElement$Configuration$Builder;
@@ -1136,6 +1137,31 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$CardBrandAccepta
 	public final fun disallowed (Ljava/util/List;)Lcom/stripe/android/paymentsheet/PaymentSheet$CardBrandAcceptance;
 }
 
+public abstract class com/stripe/android/paymentsheet/PaymentSheet$CardFundingAcceptance : android/os/Parcelable {
+	public static final field $stable I
+	public static final field Companion Lcom/stripe/android/paymentsheet/PaymentSheet$CardFundingAcceptance$Companion;
+	public static final fun all ()Lcom/stripe/android/paymentsheet/PaymentSheet$CardFundingAcceptance;
+	public static final fun allowed (Ljava/util/List;)Lcom/stripe/android/paymentsheet/PaymentSheet$CardFundingAcceptance;
+}
+
+public final class com/stripe/android/paymentsheet/PaymentSheet$CardFundingAcceptance$CardFundingType : java/lang/Enum, android/os/Parcelable {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Credit Lcom/stripe/android/paymentsheet/PaymentSheet$CardFundingAcceptance$CardFundingType;
+	public static final field Debit Lcom/stripe/android/paymentsheet/PaymentSheet$CardFundingAcceptance$CardFundingType;
+	public static final field Prepaid Lcom/stripe/android/paymentsheet/PaymentSheet$CardFundingAcceptance$CardFundingType;
+	public static final field Unknown Lcom/stripe/android/paymentsheet/PaymentSheet$CardFundingAcceptance$CardFundingType;
+	public final fun describeContents ()I
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentSheet$CardFundingAcceptance$CardFundingType;
+	public static fun values ()[Lcom/stripe/android/paymentsheet/PaymentSheet$CardFundingAcceptance$CardFundingType;
+	public final fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/paymentsheet/PaymentSheet$CardFundingAcceptance$Companion {
+	public final fun all ()Lcom/stripe/android/paymentsheet/PaymentSheet$CardFundingAcceptance;
+	public final fun allowed (Ljava/util/List;)Lcom/stripe/android/paymentsheet/PaymentSheet$CardFundingAcceptance;
+}
+
 public final class com/stripe/android/paymentsheet/PaymentSheet$Colors : android/os/Parcelable {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
@@ -1217,6 +1243,7 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$Configuration : 
 public final class com/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder {
 	public static final field $stable I
 	public fun <init> (Ljava/lang/String;)V
+	public final fun allowedCardFundingTypes (Lcom/stripe/android/paymentsheet/PaymentSheet$CardFundingAcceptance;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun allowsDelayedPaymentMethods (Z)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun allowsPaymentMethodsRequiringShippingAddress (Z)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun allowsRemovalOfLastSavedPaymentMethod (Z)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;

--- a/paymentsheet/src/main/java/com/stripe/android/common/configuration/ConfigurationDefaults.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/configuration/ConfigurationDefaults.kt
@@ -25,6 +25,7 @@ internal object ConfigurationDefaults {
     val externalPaymentMethods: List<String> = emptyList()
     val paymentMethodLayout: PaymentMethodLayout = PaymentMethodLayout.Automatic
     val cardBrandAcceptance: PaymentSheet.CardBrandAcceptance = PaymentSheet.CardBrandAcceptance.All
+    val cardFundingAcceptance: PaymentSheet.CardFundingAcceptance = PaymentSheet.CardFundingAcceptance.all()
     val customPaymentMethods: List<PaymentSheet.CustomPaymentMethod> = emptyList()
     val walletButtons: PaymentSheet.WalletButtonsConfiguration = PaymentSheet.WalletButtonsConfiguration()
     val shopPayConfiguration: PaymentSheet.ShopPayConfiguration? = null

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
@@ -32,6 +32,7 @@ import com.stripe.android.paymentelement.embedded.content.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.embedded.content.EmbeddedPaymentElementViewModel
 import com.stripe.android.paymentelement.embedded.content.EmbeddedStateHelper
 import com.stripe.android.paymentelement.embedded.content.PaymentOptionDisplayDataHolder
+import com.stripe.android.paymentsheet.CardFundingFilteringPrivatePreview
 import com.stripe.android.paymentsheet.CreateIntentCallback
 import com.stripe.android.paymentsheet.ExternalPaymentMethodConfirmHandler
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -258,6 +259,7 @@ class EmbeddedPaymentElement @Inject internal constructor(
         internal val paymentMethodOrder: List<String>,
         internal val externalPaymentMethods: List<String>,
         internal val cardBrandAcceptance: PaymentSheet.CardBrandAcceptance,
+        internal val cardFundingAcceptance: PaymentSheet.CardFundingAcceptance,
         internal val customPaymentMethods: List<PaymentSheet.CustomPaymentMethod>,
         internal val embeddedViewDisplaysMandateText: Boolean,
         internal val link: PaymentSheet.LinkConfiguration,
@@ -291,6 +293,8 @@ class EmbeddedPaymentElement @Inject internal constructor(
             private var externalPaymentMethods: List<String> = ConfigurationDefaults.externalPaymentMethods
             private var cardBrandAcceptance: PaymentSheet.CardBrandAcceptance =
                 ConfigurationDefaults.cardBrandAcceptance
+            private var cardFundingAcceptance: PaymentSheet.CardFundingAcceptance =
+                ConfigurationDefaults.cardFundingAcceptance
             private var embeddedViewDisplaysMandateText: Boolean = ConfigurationDefaults.embeddedViewDisplaysMandateText
             private var customPaymentMethods: List<PaymentSheet.CustomPaymentMethod> =
                 ConfigurationDefaults.customPaymentMethods
@@ -457,6 +461,24 @@ class EmbeddedPaymentElement @Inject internal constructor(
             }
 
             /**
+             * By default, the embedded payment element will accept cards of all funding types
+             * (credit, debit, prepaid, unknown).
+             * You can specify which card funding types to allow.
+             *
+             * **Note**: This is only a client-side solution.
+             * **Note**: Card funding filtering is not currently supported in Link.
+             *
+             * @param allowedCardFundingTypes The card funding acceptance configuration.
+             * Defaults to [PaymentSheet.CardFundingAcceptance.all].
+             */
+            @CardFundingFilteringPrivatePreview
+            fun allowedCardFundingTypes(
+                allowedCardFundingTypes: PaymentSheet.CardFundingAcceptance
+            ): Builder = apply {
+                this.cardFundingAcceptance = allowedCardFundingTypes
+            }
+
+            /**
              * Configuration related to custom payment methods.
              *
              * If set, Embedded Payment Element will display the defined list of custom payment methods in the UI.
@@ -536,6 +558,7 @@ class EmbeddedPaymentElement @Inject internal constructor(
                 paymentMethodOrder = paymentMethodOrder,
                 externalPaymentMethods = externalPaymentMethods,
                 cardBrandAcceptance = cardBrandAcceptance,
+                cardFundingAcceptance = cardFundingAcceptance,
                 customPaymentMethods = customPaymentMethods,
                 embeddedViewDisplaysMandateText = embeddedViewDisplaysMandateText,
                 link = link,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/CardFundingFilteringPrivatePreview.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/CardFundingFilteringPrivatePreview.kt
@@ -1,0 +1,24 @@
+package com.stripe.android.paymentsheet
+
+import androidx.annotation.RestrictTo
+
+/**
+ * Marks card funding filtering API as being in private preview.
+ * This feature allows filtering which card funding types (credit, debit, prepaid) are accepted.
+ *
+ * Note: This is a client-side solution. Card funding filtering is not currently supported in Link.
+ * The backend performs the final validation.
+ */
+@RequiresOptIn(
+    message = "This card funding filtering API is in private preview and may change without notice.",
+    level = RequiresOptIn.Level.WARNING
+)
+@Retention(AnnotationRetention.BINARY)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.TYPEALIAS
+)
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+annotation class CardFundingFilteringPrivatePreview


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add paymentsheet card funding api. This is a standardized fund filtering api that will allow merchants to limit card funding types to a subset of credit, debit and prepaid cards.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://docs.google.com/document/d/19cVJ7dkA7dOxu5KIwOzLNfxXmCWmXFtUBwBf9_cpDDg/edit?tab=t.0#heading=h.gfhoas24rlu1

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
