### PR TITLE
Update MIGRATING.md with color override guidance

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -110,6 +110,44 @@ val type = paymentMethod.type
 val card = paymentMethod.card
 ```
 
+**Overriding a Subset of Colors**
+
+If you previously used `.copy()` to override a subset of colors while keeping other default values, use the new builder pattern with `.light()` or `.dark()` factory methods:
+
+```kotlin
+// before - using copy() to override specific colors
+return PaymentSheet.Appearance(
+    colorsLight = PaymentSheet.Colors.defaultLight.copy(
+        primary = yourBrandColor,
+        surface = yourBackgroundColor,
+        onSurface = yourTextColor,
+        error = yourErrorColor,
+    ),
+    ...
+)
+
+// after - using Builder.light() to start with defaults
+return PaymentSheet.Appearance.Builder()
+    .colorsLight(
+        PaymentSheet.Colors.Builder.light()
+            .primary(yourBrandColor)
+            .surface(yourBackgroundColor)
+            .onSurface(yourTextColor)
+            .error(yourErrorColor)
+            .build()
+    )
+    .build()
+```
+
+The same pattern applies to these classes:
+- `PaymentSheet.Colors`
+- `PaymentSheet.PrimaryButtonColors`
+- `PaymentSheet.Appearance.Embedded.RowStyle.FlatWithRadio.Colors`
+- `PaymentSheet.Appearance.Embedded.RowStyle.FlatWithCheckmark.Colors`
+- `PaymentSheet.Appearance.Embedded.RowStyle.FlatWithDisclosure.Colors`
+
+> Note: While `defaultLight` and `defaultDark` in the classes above still exist, we recommend using the builder pattern with `.light()` or `.dark()` for better forward compatibility.
+
 **PaymentMethod.id Non-Nullable**
 `PaymentMethod.id` is now non-nullable:
 ```kotlin


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add migration guidance for overriding a subset of colors when migrating from SDK versions < 22.0.0. Documents the new builder pattern using .light()/.dark() factory methods as replacement for .copy().

A follow-up PR is needed to deprecate `defaultLight` and `defaultDark`
# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
#12053

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
