### PR TITLE
Change emulator for FC maestro tests

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -352,7 +352,7 @@ workflows:
     steps:
       - avd-manager@1:
           inputs:
-            - profile: "pixel_3a"
+            - profile: "pixel_6"
             - abi: "x86_64"
             - api_level: 33
             - tag: "google_apis"


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request [yet again](https://github.com/stripe/stripe-android/pull/12093) attempts to fix our testing flakiness by moving to a different (hopefully more stable) device.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
