### PR TITLE
Upgrade min SDK version to 24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## XX.XX.XX - 20XX-XX-XX
 
+* [CHANGED][12036](https://github.com/stripe/stripe-android/pull/12095) Upgrade minimum SDK version from 21 to 24
+
 ### PaymentSheet
 * [CHANGED][12036](https://github.com/stripe/stripe-android/pull/12036) Updates the google places SDK from 3.5.0 to 5.0.0.
 

--- a/build-configuration/android-application.gradle
+++ b/build-configuration/android-application.gradle
@@ -20,7 +20,7 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 24
         targetSdkVersion rootProject.ext.compileSdkVersion
         versionName VERSION_NAME
     }

--- a/build-configuration/android-library.gradle
+++ b/build-configuration/android-library.gradle
@@ -34,7 +34,7 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 24
         targetSdkVersion rootProject.ext.compileSdkVersion
         consumerProguardFiles "consumer-rules.txt"
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/PlacesClientProxy.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/PlacesClientProxy.kt
@@ -2,7 +2,6 @@ package com.stripe.android.ui.core.elements.autocomplete
 
 import android.content.Context
 import android.graphics.Typeface
-import android.os.Build
 import android.text.style.StyleSpan
 import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
@@ -51,7 +50,7 @@ interface PlacesClientProxy {
             initializer: () -> Unit = { Places.initialize(context, googlePlacesApiKey) },
             errorReporter: ErrorReporter
         ): PlacesClientProxy {
-            return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && isPlacesAvailable()) {
+            return if (isPlacesAvailable()) {
                 override ?: run {
                     initializer()
                     DefaultPlacesClientProxy(

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/autocomplete/PlacesClientProxyTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/autocomplete/PlacesClientProxyTest.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.ui.core.elements.autocomplete
 
-import android.os.Build
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.tasks.Task
 import com.google.android.gms.tasks.Tasks
@@ -37,7 +36,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
 class PlacesClientProxyTest {
@@ -61,25 +59,6 @@ class PlacesClientProxyTest {
         )
 
         assertThat(client).isInstanceOf<DefaultPlacesClientProxy>()
-    }
-
-    @Test
-    @Config(sdk = [Build.VERSION_CODES.M])
-    fun `create returns unsupported client when run on old devices`() {
-        val client = PlacesClientProxy.create(
-            context = mock(),
-            googlePlacesApiKey = "abc123",
-            isPlacesAvailable = object : IsPlacesAvailable {
-                override fun invoke(): Boolean {
-                    throw IllegalStateException("Shouldn't be called.")
-                }
-            },
-            clientFactory = { mock() },
-            initializer = { /* no-op */ },
-            errorReporter = FakeErrorReporter(),
-        )
-
-        assertThat(client).isInstanceOf<UnsupportedPlacesClientProxy>()
     }
 
     @Test


### PR DESCRIPTION
# Summary
Upgrade min SDK version to 24

# Motivation
Google is moving various libraries that we depend and don't depend to have a minimum SDK version of 23. Upgrading to have a minimum of 24 loses us around [1.4% of overall Android device support](https://composables.com/android-distribution-chart).

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified