### PR TITLE
Remove chooser when launching browser.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/StripeBrowserLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/StripeBrowserLauncherViewModel.kt
@@ -26,7 +26,6 @@ internal class StripeBrowserLauncherViewModel(
     private val analyticsRequestExecutor: AnalyticsRequestExecutor,
     private val paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory,
     private val browserCapabilities: BrowserCapabilities,
-    private val intentChooserTitle: String,
     private val resolveErrorMessage: String,
     private val savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
@@ -53,7 +52,7 @@ internal class StripeBrowserLauncherViewModel(
             }
         }
 
-        return Intent.createChooser(intent, intentChooserTitle)
+        return intent
     }
 
     private fun createCustomTabsIntent(
@@ -137,7 +136,6 @@ internal class StripeBrowserLauncherViewModel(
                     publishableKey = config.publishableKey,
                 ),
                 browserCapabilities = browserCapabilitiesSupplier.get(),
-                intentChooserTitle = application.getString(R.string.stripe_verify_your_payment),
                 resolveErrorMessage = application.getString(R.string.stripe_failure_reason_authentication),
                 savedStateHandle = savedStateHandle,
             ) as T

--- a/payments-core/src/test/java/com/stripe/android/payments/StripeBrowserLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/StripeBrowserLauncherViewModelTest.kt
@@ -36,11 +36,8 @@ class StripeBrowserLauncherViewModelTest {
         val viewModel = createViewModel()
         val launchIntent = viewModel.createLaunchIntent(ARGS)
 
-        val browserIntent = requireNotNull(launchIntent.getParcelableExtra<Intent>(Intent.EXTRA_INTENT))
-
-        assertThat(browserIntent.action).isEqualTo(Intent.ACTION_VIEW)
-        assertThat(browserIntent.data).isEqualTo(Uri.parse("https://bank.com"))
-        assertThat(launchIntent.getStringExtra(Intent.EXTRA_TITLE)).isEqualTo("Verify your payment")
+        assertThat(launchIntent.action).isEqualTo(Intent.ACTION_VIEW)
+        assertThat(launchIntent.data).isEqualTo(Uri.parse("https://bank.com"))
     }
 
     @Test
@@ -103,7 +100,6 @@ class StripeBrowserLauncherViewModelTest {
             analyticsRequestExecutor = analyticsRequestExecutor,
             paymentAnalyticsRequestFactory = analyticsRequestFactory,
             browserCapabilities = browserCapabilities,
-            intentChooserTitle = "Verify your payment",
             resolveErrorMessage = "Unable to resolve things",
             savedStateHandle = savedStateHandle,
         )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
While testing paypay it was discovered that a chooser would show even with only a single browser installed if you had a work profile.

The [original context](https://github.com/stripe/stripe-android/pull/3665) of using a chooser was to show a title, but it doesn't actually show a title.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Better UX for launching LPM redirects from PaymentSheet with a work profile configured.
