### PR TITLE
Add dimensions to experiment exposure logging

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/analytics/experiment/CommonElementsDimensions.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/analytics/experiment/CommonElementsDimensions.kt
@@ -1,8 +1,6 @@
 package com.stripe.android.common.analytics.experiment
 
-import com.stripe.android.core.version.StripeSdkVersion
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
-import com.stripe.android.utils.filterNotNullValues
 import kotlin.collections.joinToString
 import kotlin.collections.plus
 

--- a/paymentsheet/src/main/java/com/stripe/android/common/analytics/experiment/LoggableExperiment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/analytics/experiment/LoggableExperiment.kt
@@ -19,11 +19,13 @@ internal sealed class LoggableExperiment(
         val experimentsData: ElementsSession.ExperimentsData,
         override val group: String,
         paymentMethodMetadata: PaymentMethodMetadata,
+        hasSavedPaymentMethod: Boolean,
     ) : LoggableExperiment(
         arbId = experimentsData.arbId,
         experiment = ExperimentAssignment.OCS_MOBILE_HORIZONTAL_MODE_ANDROID_AA,
         group = group,
-        dimensions = CommonElementsDimensions.getDimensions(paymentMethodMetadata),
+        dimensions = CommonElementsDimensions.getDimensions(paymentMethodMetadata) +
+            mapOf("has_saved_payment_method" to hasSavedPaymentMethod.toString()),
     )
 
     data class LinkHoldback(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -244,6 +244,7 @@ internal abstract class BaseSheetViewModel(
                     experimentsData = experimentsData,
                     group = variant,
                     paymentMethodMetadata = paymentMethodMetadata,
+                    hasSavedPaymentMethod = customerStateHolder.paymentMethods.value.isNotEmpty(),
                 )
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/common/analytics/experiment/CommonElementsDimensionsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/analytics/experiment/CommonElementsDimensionsTest.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.common.analytics.experiment
 
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.core.version.StripeSdkVersion
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.paymentsheet.state.LinkState


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add dimensions to our exposure log for the horizontal mode Android A/A experiment.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-4263

See the dimensions we need to log client-side [here](https://jira.corp.stripe.com/browse/MOBILESDK-4263). The only one currently missing is integration shape, I'll add that in a follow up.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified
