### PR TITLE
disable(tests): disables tests using test institution names during name change. Active incident at #rider-prefix.

### DIFF
--- a/maestro/financial-connections/disabled/Testmode-PaymentIntent-TestInstitution.yaml
+++ b/maestro/financial-connections/disabled/Testmode-PaymentIntent-TestInstitution.yaml
@@ -1,3 +1,4 @@
+# TODO(alexzhu): Enable after institutions are renamed (ir-rider-prefix)
 appId: com.stripe.android.financialconnections.example
 tags:
   - all

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestConfirmationToken.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestConfirmationToken.kt
@@ -29,6 +29,7 @@ import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_OPTION_TEST_TAG
 import com.stripe.android.test.core.FieldPopulator
 import com.stripe.android.test.core.TestParameters
 import com.stripe.android.utils.ForceNativeBankFlowTestRule
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -95,6 +96,8 @@ internal class TestConfirmationToken : BasePlaygroundTest() {
         )
     }
 
+    // TODO(alexzhu): Enable after institutions are renamed (ir-rider-prefix)
+    @Ignore("Disabling test while institution name changes modifications are complete")
     @Test
     fun testBankAccountWithConfirmationTokenInCustomFlow_withCSC() {
         val testParameters = createConfirmationTokenParams("us_bank_account") { settings ->

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestEmbedded.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestEmbedded.kt
@@ -21,6 +21,7 @@ import com.stripe.android.paymentsheet.example.playground.settings.SupportedPaym
 import com.stripe.android.test.core.FieldPopulator
 import com.stripe.android.test.core.TestParameters
 import com.stripe.android.utils.ForceNativeBankFlowTestRule
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
@@ -85,6 +86,8 @@ internal class TestEmbedded : BasePlaygroundTest() {
         )
     }
 
+    // TODO(alexzhu): Enable after institutions are renamed (ir-rider-prefix)
+    @Ignore("Disabling test while institution name changes modifications are complete")
     @Test
     fun testUsBankAccount() {
         testDriver.confirmEmbeddedUsBankAccount(

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestUSBankAccount.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestUSBankAccount.kt
@@ -31,6 +31,7 @@ import com.stripe.android.test.core.TestParameters
 import com.stripe.android.test.core.ui.ComposeButton
 import com.stripe.android.test.core.ui.PaymentSelection
 import com.stripe.android.utils.ForceNativeBankFlowTestRule
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -50,6 +51,8 @@ internal class TestUSBankAccount : BasePlaygroundTest() {
         context = ApplicationProvider.getApplicationContext()
     )
 
+    // TODO(alexzhu): Enable after institutions are renamed (ir-rider-prefix)
+    @Ignore("Disabling test while institution name changes modifications are complete")
     @Test
     fun testUSBankAccountSuccess() {
         testDriver.confirmUSBankAccount(
@@ -68,6 +71,8 @@ internal class TestUSBankAccount : BasePlaygroundTest() {
      * Tests that save checkbox SFU (which is still present when customer session is enabled) does not override
      * PMO SFU.
      */
+    // TODO(alexzhu): Enable after institutions are renamed (ir-rider-prefix)
+    @Ignore("Disabling test while institution name changes modifications are complete")
     @Test
     fun testUSBankAccountSuccessWithPmoSfuAndCustomerSession() {
         testDriver.confirmUSBankAccount(
@@ -85,6 +90,8 @@ internal class TestUSBankAccount : BasePlaygroundTest() {
         )
     }
 
+    // TODO(alexzhu): Enable after institutions are renamed (ir-rider-prefix)
+    @Ignore("Disabling test while institution name changes modifications are complete")
     @OptIn(ExperimentalTestApi::class)
     @Test
     fun testUSBankAccountSuccessWithPmoSfu() {
@@ -117,6 +124,8 @@ internal class TestUSBankAccount : BasePlaygroundTest() {
         )
     }
 
+    // TODO(alexzhu): Enable after institutions are renamed (ir-rider-prefix)
+    @Ignore("Disabling test while institution name changes modifications are complete")
     @OptIn(ExperimentalTestApi::class)
     @Test
     fun testUSBankAccountSuccessWithPmoSfuDeferred() {
@@ -165,6 +174,8 @@ internal class TestUSBankAccount : BasePlaygroundTest() {
         )
     }
 
+    // TODO(alexzhu): Enable after institutions are renamed (ir-rider-prefix)
+    @Ignore("Disabling test while institution name changes modifications are complete")
     @Test
     fun testUSBankAccountSuccessWithIndecisiveUser() {
         // Select another LPM before coming back to the linked bank account
@@ -192,6 +203,8 @@ internal class TestUSBankAccount : BasePlaygroundTest() {
         )
     }
 
+    // TODO(alexzhu): Enable after institutions are renamed (ir-rider-prefix)
+    @Ignore("Disabling test while institution name changes modifications are complete")
     @Test
     fun testCardAfterConfirmingUSBankAccount() {
         // Link a bank account, but pay with a card instead
@@ -216,6 +229,8 @@ internal class TestUSBankAccount : BasePlaygroundTest() {
         )
     }
 
+    // TODO(alexzhu): Enable after institutions are renamed (ir-rider-prefix)
+    @Ignore("Disabling test while institution name changes modifications are complete")
     @Test
     fun testUSBankAccountCancelAllowsUserToContinue() {
         testDriver.confirmUSBankAccount(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Specifically targets disabling tests that use the `doUSBankAccountAuthorization` flow in `paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt`. "Test Institution" is referenced by [executeUsBankAccountFlow](https://stripe.sourcegraphcloud.com/stripe/stripe-android/-/blob/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt?L1573-1594).

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Updated hosted bank picker designs using icons caused institution names to be too difficult to read due to truncation. A recent change modifies testmode institutions to be more distinguishable even with truncation.

[Testmode institution changes runbook](https://docs.google.com/document/d/1hIxMJ9gyjEE4F_1dTkPNH16nVir9QMo3PlQweHfhUB8/edit?tab=t.1jmxkob0zslo)
[Testmode institution changes proposal](https://docs.google.com/document/d/1hIxMJ9gyjEE4F_1dTkPNH16nVir9QMo3PlQweHfhUB8/edit?tab=t.0)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

Disables tests. Active incident at [#rider-prefix](https://incident-reporting.corp.stripe.com/wf/incidents/rider-prefix).

# Screenshots

No visual changes.

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
No end-user effects.