### PR TITLE
Fix IntentConfirmationChallengeActivity launched with no arguments.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/challenge/confirmation/IntentConfirmationChallengeActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/challenge/confirmation/IntentConfirmationChallengeActivity.kt
@@ -29,6 +29,12 @@ internal class IntentConfirmationChallengeActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        // Check if required args are present, finish gracefully if not
+        if (!hasRequiredArgs()) {
+            finish()
+            return
+        }
+
         listenForActivityResult()
 
         setContent {
@@ -68,6 +74,10 @@ internal class IntentConfirmationChallengeActivity : AppCompatActivity() {
         )
         setResult(RESULT_COMPLETE, Intent().putExtras(bundle))
         finish()
+    }
+
+    private fun hasRequiredArgs(): Boolean {
+        return intent?.extras?.containsKey(EXTRA_ARGS) == true
     }
 
     companion object {

--- a/payments-core/src/test/java/com/stripe/android/challenge/confirmation/IntentConfirmationChallengeActivityTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/challenge/confirmation/IntentConfirmationChallengeActivityTest.kt
@@ -7,9 +7,11 @@ import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.core.os.BundleCompat
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.isInstanceOf
@@ -74,6 +76,21 @@ internal class IntentConfirmationChallengeActivityTest {
         val retrievedArgs = IntentConfirmationChallengeActivity.getArgs(savedStateHandle)
 
         assertThat(retrievedArgs).isNull()
+    }
+
+    @Test
+    fun `activity finishes gracefully when required args are missing`() = runTest {
+        ActivityScenario.launchActivityForResult<IntentConfirmationChallengeActivity>(
+            Intent(
+                ApplicationProvider.getApplicationContext(),
+                IntentConfirmationChallengeActivity::class.java
+            )
+        ).use { scenario ->
+            advanceUntilIdle()
+
+            // Activity should finish gracefully without crashing
+            assertThat(scenario.state).isEqualTo(Lifecycle.State.DESTROYED)
+        }
     }
 
     @Test


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Gracefully finishes IntentConfirmationChallengeActivity if the required args aren't supplied. Note, this wasn't possible to happen in production, but ensures penetration testers don't trigger this error.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fixes #12051

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

