### PR TITLE
Fix FinancialConnectionsSheetLiteActivity launched with no arguments.

### DIFF
--- a/financial-connections-lite/build.gradle
+++ b/financial-connections-lite/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     testImplementation testLibs.mockito.core
     testImplementation testLibs.mockito.inline
     testImplementation testLibs.mockito.kotlin
+    testImplementation testLibs.robolectric
     testImplementation testLibs.turbine
     testImplementation testLibs.truth
 

--- a/financial-connections-lite/src/main/java/com/stripe/android/financialconnections/lite/FinancialConnectionsSheetLiteActivity.kt
+++ b/financial-connections-lite/src/main/java/com/stripe/android/financialconnections/lite/FinancialConnectionsSheetLiteActivity.kt
@@ -48,6 +48,13 @@ internal class FinancialConnectionsSheetLiteActivity : ComponentActivity(R.layou
     @SuppressLint("SetJavaScriptEnabled")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        // Check if required args are present, finish gracefully if not
+        if (!hasRequiredArgs()) {
+            finish()
+            return
+        }
+
         setContentView(R.layout.stripe_activity_lite)
 
         webView = findViewById(R.id.webView)
@@ -168,6 +175,10 @@ internal class FinancialConnectionsSheetLiteActivity : ComponentActivity(R.layou
     private fun finishWithResult(result: FinancialConnectionsSheetActivityResult) {
         setResult(RESULT_OK, Intent().putExtras(result.toBundle()))
         finish()
+    }
+
+    private fun hasRequiredArgs(): Boolean {
+        return intent?.extras?.containsKey(EXTRA_ARGS) == true
     }
 
     companion object {

--- a/financial-connections-lite/src/test/java/com/stripe/android/financialconnections/lite/FinancialConnectionsSheetLiteActivityTest.kt
+++ b/financial-connections-lite/src/test/java/com/stripe/android/financialconnections/lite/FinancialConnectionsSheetLiteActivityTest.kt
@@ -1,0 +1,28 @@
+package com.stripe.android.financialconnections.lite
+
+import android.content.Intent
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class FinancialConnectionsSheetLiteActivityTest {
+
+    @Test
+    fun `activity finishes gracefully when required args are missing`() = runTest {
+        ActivityScenario.launchActivityForResult<FinancialConnectionsSheetLiteActivity>(
+            Intent(
+                ApplicationProvider.getApplicationContext(),
+                FinancialConnectionsSheetLiteActivity::class.java
+            )
+        ).use { scenario ->
+            // Activity should finish gracefully without crashing
+            assertThat(scenario.state).isEqualTo(Lifecycle.State.DESTROYED)
+        }
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Gracefully finishes FinancialConnectionsSheetLiteActivity if the required args aren't supplied. Note, this wasn't possible to happen in production, but ensures penetration testers don't trigger this error.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fixes #12050

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified
