### PR TITLE
Fix AttestationActivity launched with no arguments.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/attestation/AttestationActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/attestation/AttestationActivity.kt
@@ -22,6 +22,13 @@ internal class AttestationActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        // Check if required args are present, finish gracefully if not
+        if (!hasRequiredArgs()) {
+            finish()
+            return
+        }
+
         lifecycleScope.launch {
             viewModel.result.collect { result ->
                 dismissWithResult(result)
@@ -35,6 +42,10 @@ internal class AttestationActivity : AppCompatActivity() {
         )
         setResult(RESULT_COMPLETE, Intent().putExtras(bundle))
         finish()
+    }
+
+    private fun hasRequiredArgs(): Boolean {
+        return intent?.extras?.containsKey(EXTRA_ARGS) == true
     }
 
     companion object {

--- a/paymentsheet/src/test/java/com/stripe/android/attestation/AttestationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/attestation/AttestationActivityTest.kt
@@ -3,9 +3,11 @@ package com.stripe.android.attestation
 import android.content.Context
 import android.content.Intent
 import androidx.core.os.BundleCompat
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.attestation.analytics.AttestationAnalyticsEventsReporter
@@ -102,6 +104,21 @@ internal class AttestationActivityTest {
         val retrievedArgs = AttestationActivity.getArgs(savedStateHandle)
 
         assertThat(retrievedArgs).isNull()
+    }
+
+    @Test
+    fun `activity finishes gracefully when required args are missing`() = runTest {
+        ActivityScenario.launchActivityForResult<AttestationActivity>(
+            Intent(
+                ApplicationProvider.getApplicationContext(),
+                AttestationActivity::class.java
+            )
+        ).use { scenario ->
+            advanceUntilIdle()
+
+            // Activity should finish gracefully without crashing
+            assertThat(scenario.state).isEqualTo(Lifecycle.State.DESTROYED)
+        }
     }
 
     private fun launchActivityForResult(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Gracefully finishes AttestationActivity if the required args aren't supplied. Note, this wasn't possible to happen in production, but ensures penetration testers don't trigger this error.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fixes #12049

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

