### PR TITLE
Fix PollingActivity launched with no arguments.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingActivity.kt
@@ -44,6 +44,12 @@ internal class PollingActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        // Check if required args are present, finish gracefully if not
+        if (!hasRequiredArgs()) {
+            finish()
+            return
+        }
+
         WindowCompat.setDecorFitsSystemWindows(window, false)
 
         setContent {
@@ -101,6 +107,10 @@ internal class PollingActivity : AppCompatActivity() {
             Intent().putExtras(result.toBundle())
         )
         finish()
+    }
+
+    private fun hasRequiredArgs(): Boolean {
+        return PollingContract.Args.fromIntent(intent) != null
     }
 
     override fun finish() {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingActivityTest.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.paymentdatacollection.polling
 
+import android.content.Intent
 import android.os.Build
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
@@ -9,6 +10,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.SavedStateHandle
+import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onIdle
 import androidx.test.espresso.Espresso.onView
@@ -217,6 +219,19 @@ internal class PollingActivityTest {
             scenario.recreate()
 
             assertQrCodeWebViewIsNotDisplayed()
+        }
+    }
+
+    @Test
+    fun `activity finishes gracefully when required args are missing`() {
+        ActivityScenario.launchActivityForResult<PollingActivity>(
+            Intent(
+                ApplicationProvider.getApplicationContext(),
+                PollingActivity::class.java
+            )
+        ).use { scenario ->
+            // Activity should finish gracefully without crashing
+            assertThat(scenario.state).isEqualTo(Lifecycle.State.DESTROYED)
         }
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Gracefully finishes PollingActivity if the required args aren't supplied. Note, this wasn't possible to happen in production, but ensures penetration testers don't trigger this error.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
#11765

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

