### PR TITLE
Fix CvcRecollectionActivity launched with no arguments.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/CvcRecollectionActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/CvcRecollectionActivity.kt
@@ -31,6 +31,12 @@ internal class CvcRecollectionActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        // Check if required args are present, finish gracefully if not
+        if (!hasRequiredArgs()) {
+            finish()
+            return
+        }
+
         args.appearance.parseAppearance()
         setContent {
             StripeTheme {
@@ -63,6 +69,10 @@ internal class CvcRecollectionActivity : AppCompatActivity() {
                 }
             }
         }
+    }
+
+    private fun hasRequiredArgs(): Boolean {
+        return CvcRecollectionContract.Args.fromIntent(intent) != null
     }
 
     override fun finish() {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/CvcRecollectionActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/CvcRecollectionActivityTest.kt
@@ -1,0 +1,27 @@
+package com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection
+
+import android.content.Intent
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class CvcRecollectionActivityTest {
+
+    @Test
+    fun `activity finishes gracefully when required args are missing`() {
+        ActivityScenario.launchActivityForResult<CvcRecollectionActivity>(
+            Intent(
+                ApplicationProvider.getApplicationContext(),
+                CvcRecollectionActivity::class.java
+            )
+        ).use { scenario ->
+            // Activity should finish gracefully without crashing
+            assertThat(scenario.state).isEqualTo(Lifecycle.State.DESTROYED)
+        }
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Gracefully finishes CvcRecollectionActivity if the required args aren't supplied. Note, this wasn't possible to happen in production, but ensures penetration testers don't trigger this error.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
#11765

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified
