### PR TITLE
Fix ChallengeActivity launched with no arguments.

### DIFF
--- a/3ds2sdk/src/main/kotlin/com/stripe/android/stripe3ds2/views/ChallengeActivity.kt
+++ b/3ds2sdk/src/main/kotlin/com/stripe/android/stripe3ds2/views/ChallengeActivity.kt
@@ -7,6 +7,7 @@ import android.view.WindowManager
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
 import androidx.fragment.app.commit
 import com.stripe.android.stripe3ds2.databinding.StripeChallengeActivityBinding
@@ -98,6 +99,13 @@ class ChallengeActivity : AppCompatActivity() {
     private val analyticsDelegate = AnalyticsProvider.instance.serviceImpl()
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        // Check if required args are present, finish gracefully if not
+        if (!hasRequiredArgs()) {
+            super.onCreate(savedInstanceState)
+            finish()
+            return
+        }
+
         supportFragmentManager.fragmentFactory = ChallengeFragmentFactory(
             uiCustomization = viewArgs.uiCustomization,
             analyticsDelegate = analyticsDelegate,
@@ -267,6 +275,12 @@ class ChallengeActivity : AppCompatActivity() {
             }
         }
         progressDialog = null
+    }
+
+    private fun hasRequiredArgs(): Boolean {
+        return intent.extras?.let { extras ->
+            BundleCompat.getParcelable(extras, "extra_args", ChallengeViewArgs::class.java) != null
+        } ?: false
     }
 
     private companion object {

--- a/3ds2sdk/src/test/kotlin/com/stripe/android/stripe3ds2/views/ChallengeActivityTest.kt
+++ b/3ds2sdk/src/test/kotlin/com/stripe/android/stripe3ds2/views/ChallengeActivityTest.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.stripe3ds2.views
 
+import android.content.Intent
 import android.graphics.Bitmap
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.core.view.children
@@ -150,6 +151,19 @@ class ChallengeActivityTest {
 
             assertThat(actionBar.title)
                 .isEqualTo("Secure Checkout")
+        }
+    }
+
+    @Test
+    fun `activity finishes gracefully when required args are missing`() {
+        ActivityScenario.launchActivityForResult<ChallengeActivity>(
+            Intent(
+                ApplicationProvider.getApplicationContext(),
+                ChallengeActivity::class.java
+            )
+        ).use { scenario ->
+            // Activity should finish gracefully without crashing
+            assertThat(scenario.state).isEqualTo(Lifecycle.State.DESTROYED)
         }
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Gracefully finishes ChallengeActivity if the required args aren't supplied. Note, this wasn't possible to happen in production, but ensures penetration testers don't trigger this error.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
#11765

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

