### PR TITLE
Fix PassiveChallengeActivity launched with no arguments.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/challenge/passive/PassiveChallengeActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/challenge/passive/PassiveChallengeActivity.kt
@@ -23,6 +23,12 @@ internal class PassiveChallengeActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        // Check if required args are present, finish gracefully if not
+        if (!hasRequiredArgs()) {
+            finish()
+            return
+        }
+
         lifecycleScope.launch {
             viewModel.result.collect { result ->
                 dismissWithResult(result)
@@ -40,6 +46,10 @@ internal class PassiveChallengeActivity : AppCompatActivity() {
         )
         setResult(RESULT_COMPLETE, Intent().putExtras(bundle))
         finish()
+    }
+
+    private fun hasRequiredArgs(): Boolean {
+        return intent?.extras?.containsKey(EXTRA_ARGS) == true
     }
 
     companion object {

--- a/payments-core/src/test/java/com/stripe/android/challenge/passive/PassiveChallengeActivityTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/challenge/passive/PassiveChallengeActivityTest.kt
@@ -3,9 +3,11 @@ package com.stripe.android.challenge.passive
 import android.content.Context
 import android.content.Intent
 import androidx.core.os.BundleCompat
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.hcaptcha.FakeHCaptchaService
@@ -99,6 +101,21 @@ internal class PassiveChallengeActivityTest {
         val retrievedArgs = PassiveChallengeActivity.getArgs(savedStateHandle)
 
         assertThat(retrievedArgs).isNull()
+    }
+
+    @Test
+    fun `activity finishes gracefully when required args are missing`() = runTest {
+        ActivityScenario.launchActivityForResult<PassiveChallengeActivity>(
+            Intent(
+                ApplicationProvider.getApplicationContext(),
+                PassiveChallengeActivity::class.java
+            )
+        ).use { scenario ->
+            advanceUntilIdle()
+
+            // Activity should finish gracefully without crashing
+            assertThat(scenario.state).isEqualTo(Lifecycle.State.DESTROYED)
+        }
     }
 
     private fun launchActivityForResult(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Gracefully finishes PassiveChallengeActivity if the required args aren't supplied. Note, this wasn't possible to happen in production, but ensures penetration testers don't trigger this error.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fix it week

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

