### PR TITLE
Move `Affirm` to `UiDefinitionFactory.Simple`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AffirmDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AffirmDefinition.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.lpmfoundations.paymentmethod.definitions
 
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.lpmfoundations.luxe.FormElementsBuilder
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
@@ -32,8 +33,7 @@ internal object AffirmDefinition : PaymentMethodDefinition {
 private object AffirmUiDefinitionFactory : UiDefinitionFactory.Simple {
     override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
         code = PaymentMethod.Type.Affirm.code,
-        lightThemeIconUrl = "https://js.stripe.com/v3/fingerprinted/img/payment-methods/icon-pm-affirm@3x-d2" +
-            "623d995950761883fca048ce6e0550.png",
+        lightThemeIconUrl = null,
         darkThemeIconUrl = null,
         displayNameResource = UiCoreR.string.stripe_paymentsheet_payment_method_affirm,
         iconResource = UiCoreR.drawable.stripe_ic_paymentsheet_pm_affirm,
@@ -45,6 +45,8 @@ private object AffirmUiDefinitionFactory : UiDefinitionFactory.Simple {
         metadata: PaymentMethodMetadata,
         arguments: UiDefinitionFactory.Arguments
     ): List<FormElement> {
-        return listOf(AffirmHeaderElement(identifier = IdentifierSpec.Generic("affirm_header")))
+        return FormElementsBuilder(arguments)
+            .header(AffirmHeaderElement(identifier = IdentifierSpec.Generic("affirm_header")))
+            .build()
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AffirmDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AffirmDefinitionTest.kt
@@ -1,0 +1,84 @@
+package com.stripe.android.lpmfoundations.paymentmethod.definitions
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.isInstanceOf
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.lpmfoundations.paymentmethod.formElements
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.testing.PaymentIntentFactory
+import com.stripe.android.ui.core.elements.AffirmHeaderElement
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AffirmDefinitionTest {
+    @Test
+    fun `createFormElements returns just header in its elements`() {
+        val formElements = AffirmDefinition.formElements(
+            metadata = PaymentMethodMetadataFactory.create(
+                stripeIntent = PaymentIntentFactory.create(
+                    paymentMethodTypes = listOf("affirm")
+                ),
+                billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                    address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never,
+                )
+            )
+        )
+
+        assertThat(formElements).hasSize(1)
+        assertThat(formElements[0].identifier.v1).isEqualTo("affirm_header")
+        assertThat(formElements[0]).isInstanceOf<AffirmHeaderElement>()
+    }
+
+    @Test
+    fun `createFormElements returns header & requested contact information fields`() {
+        val formElements = AffirmDefinition.formElements(
+            metadata = PaymentMethodMetadataFactory.create(
+                stripeIntent = PaymentIntentFactory.create(
+                    paymentMethodTypes = listOf("affirm")
+                ),
+                billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                    phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                    email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                    address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never,
+                )
+            )
+        )
+
+        assertThat(formElements).hasSize(3)
+
+        assertThat(formElements[0].identifier.v1).isEqualTo("affirm_header")
+        assertThat(formElements[0]).isInstanceOf<AffirmHeaderElement>()
+
+        checkPhoneField(formElements, 1)
+        checkEmailField(formElements, 2)
+    }
+
+    @Test
+    fun `createFormElements returns header & all billing details fields`() {
+        val formElements = AffirmDefinition.formElements(
+            metadata = PaymentMethodMetadataFactory.create(
+                stripeIntent = PaymentIntentFactory.create(
+                    paymentMethodTypes = listOf("affirm")
+                ),
+                billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                    phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                    email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                    name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                    address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
+                )
+            )
+        )
+
+        assertThat(formElements).hasSize(5)
+
+        assertThat(formElements[0].identifier.v1).isEqualTo("affirm_header")
+        assertThat(formElements[0]).isInstanceOf<AffirmHeaderElement>()
+
+        checkNameField(formElements, 1)
+        checkPhoneField(formElements, 2)
+        checkEmailField(formElements, 3)
+        checkBillingField(formElements, 4)
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/UiDefinitionTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/UiDefinitionTestHelper.kt
@@ -1,7 +1,9 @@
 package com.stripe.android.lpmfoundations.paymentmethod.definitions
 
 import androidx.compose.runtime.Composable
+import com.google.common.truth.Truth.assertThat
 import com.stripe.android.common.taptoadd.TapToAddHelper
+import com.stripe.android.isInstanceOf
 import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
@@ -10,7 +12,13 @@ import com.stripe.android.lpmfoundations.paymentmethod.formElements
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.ui.core.FormUI
+import com.stripe.android.uicore.elements.AddressElement
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
+import com.stripe.android.uicore.elements.EmailElement
+import com.stripe.android.uicore.elements.FormElement
+import com.stripe.android.uicore.elements.PhoneNumberElement
+import com.stripe.android.uicore.elements.SectionElement
+import com.stripe.android.uicore.elements.SimpleTextElement
 
 @Composable
 internal fun PaymentMethodDefinition.CreateFormUi(
@@ -40,4 +48,52 @@ internal fun PaymentMethodDefinition.CreateFormUi(
         elements = formElements,
         lastTextFieldIdentifier = null,
     )
+}
+
+internal fun checkNameField(
+    formElements: List<FormElement>,
+    position: Int,
+) {
+    val nameSection = checkSectionField(formElements, "billing_details[name]_section", position)
+    assertThat(nameSection.fields).hasSize(1)
+    assertThat(nameSection.fields[0]).isInstanceOf<SimpleTextElement>()
+}
+
+internal fun checkPhoneField(
+    formElements: List<FormElement>,
+    position: Int,
+) {
+    val phoneSection = checkSectionField(formElements, "billing_details[phone]_section", position)
+    assertThat(phoneSection.fields).hasSize(1)
+    assertThat(phoneSection.fields[0]).isInstanceOf<PhoneNumberElement>()
+}
+
+internal fun checkEmailField(
+    formElements: List<FormElement>,
+    position: Int,
+) {
+    val emailSection = checkSectionField(formElements, "billing_details[email]_section", position)
+    assertThat(emailSection.fields).hasSize(1)
+    assertThat(emailSection.fields[0]).isInstanceOf<EmailElement>()
+}
+
+internal fun checkBillingField(
+    formElements: List<FormElement>,
+    position: Int,
+) {
+    val billingSection = checkSectionField(formElements, "billing_details[address]_section", position)
+    assertThat(billingSection.fields).hasSize(1)
+    assertThat(billingSection.fields[0]).isInstanceOf<AddressElement>()
+}
+
+private fun checkSectionField(
+    formElements: List<FormElement>,
+    sectionName: String,
+    position: Int,
+): SectionElement {
+    assertThat(formElements[position].identifier.v1)
+        .isEqualTo(sectionName)
+    assertThat(formElements[position]).isInstanceOf<SectionElement>()
+
+    return formElements[position] as SectionElement
 }


### PR DESCRIPTION
# Summary
Move `Affirm` to `UiDefinitionFactory.Simple` and follow current definition of LUXE spec [here](https://stripe.sourcegraphcloud.com/stripe-internal/pay-server/-/blob/lib/lpm_ui_platform/private/specs/affirm.json).

# Motivation
Remove `LUXE` definition for Affirm.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified