### PR TITLE
Add a build config flag that launches directly to the playground.

### DIFF
--- a/paymentsheet-example/build.gradle
+++ b/paymentsheet-example/build.gradle
@@ -24,6 +24,10 @@ def getSentryDsn() {
     }
 }
 
+def directlyToPlayground() {
+    return project.hasProperty("DIRECTLY_TO_PLAYGROUND") && project.DIRECTLY_TO_PLAYGROUND.contains("true")
+}
+
 emerge {
     // Api token is implicitly set to the EMERGE_API_TOKEN env variable
 
@@ -54,6 +58,7 @@ android {
 
         buildConfigField "boolean", "IS_RUNNING_IN_CI", "$gradle.ext.isCi"
         buildConfigField "boolean", "IS_BROWSERSTACK_BUILD", "$gradle.ext.isBrowserstackBuild"
+        buildConfigField "boolean", "DIRECTLY_TO_PLAYGROUND", "${directlyToPlayground()}"
 
         manifestPlaceholders = [
                 BACKEND_URL: getBackendUrl(),

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/MainActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/MainActivity.kt
@@ -118,6 +118,10 @@ class MainActivity : AppCompatActivity() {
                 MainScreen(items = items)
             }
         }
+
+        if (BuildConfig.DIRECTLY_TO_PLAYGROUND) {
+            startActivity(Intent(this, PaymentSheetPlaygroundActivity::class.java))
+        }
     }
 }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Adds a configuration to allow stripe developers to always launch directly into the playground, saving developers time.

Add to your `~/.gradle/gradle.properties`:
```
DIRECTLY_TO_PLAYGROUND=true
```

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-4274

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

