### PR TITLE
Reduce crypto on ramp flakes.

### DIFF
--- a/crypto-onramp-example/src/androidTest/java/com/stripe/android/crypto/onramp/example/OnrampFlowTest.kt
+++ b/crypto-onramp-example/src/androidTest/java/com/stripe/android/crypto/onramp/example/OnrampFlowTest.kt
@@ -112,6 +112,12 @@ class OnrampFlowTest {
 
     @OptIn(ExperimentalTestApi::class)
     private fun waitForTag(tag: String, timeoutMs: Long = defaultTimeout.inWholeMilliseconds) {
+        composeRule.waitUntil(timeoutMs) {
+            composeRule.onAllNodes(hasTestTag(tag))
+                // We need to call fetchSemanticsNodes with atLeastOneRootRequired = false to ensure the activity is
+                // launched, which prevents flakes.
+                .fetchSemanticsNodes(atLeastOneRootRequired = false).size == 1
+        }
         composeRule.waitUntilExactlyOneExists(
             hasTestTag(tag),
             timeoutMillis = timeoutMs


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Improve flakes in crypto on ramp. Sometimes we'd attempt compose assertions before the activity was launched. This should fix that crash!

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/MOBILESDK-4278
