### PR TITLE
Move `Alipay` to `UiDefinitionFactory.Simple`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AlipayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AlipayDefinition.kt
@@ -7,7 +7,6 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
-import com.stripe.android.ui.core.elements.SharedDataSpec
 
 internal object AlipayDefinition : PaymentMethodDefinition {
     override val type: PaymentMethod.Type = PaymentMethod.Type.Alipay
@@ -25,13 +24,11 @@ internal object AlipayDefinition : PaymentMethodDefinition {
     override fun uiDefinitionFactory(): UiDefinitionFactory = AlipayUiDefinitionFactory
 }
 
-private object AlipayUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDataSpec {
-    override fun createSupportedPaymentMethod(
-        metadata: PaymentMethodMetadata,
-        sharedDataSpec: SharedDataSpec,
-    ) = SupportedPaymentMethod(
-        paymentMethodDefinition = AlipayDefinition,
-        sharedDataSpec = sharedDataSpec,
+private object AlipayUiDefinitionFactory : UiDefinitionFactory.Simple() {
+    override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
+        code = PaymentMethod.Type.Alipay.code,
+        lightThemeIconUrl = null,
+        darkThemeIconUrl = null,
         displayNameResource = R.string.stripe_paymentsheet_payment_method_alipay,
         iconResource = R.drawable.stripe_ic_paymentsheet_pm_alipay,
         iconResourceNight = null,

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AlipayDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AlipayDefinitionTest.kt
@@ -1,0 +1,71 @@
+package com.stripe.android.lpmfoundations.paymentmethod.definitions
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.lpmfoundations.paymentmethod.formElements
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.testing.PaymentIntentFactory
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AlipayDefinitionTest {
+    @Test
+    fun `createFormElements returns no elements`() {
+        val formElements = AlipayDefinition.formElements(
+            metadata = PaymentMethodMetadataFactory.create(
+                stripeIntent = PaymentIntentFactory.create(
+                    paymentMethodTypes = listOf("alipay")
+                )
+            )
+        )
+
+        assertThat(formElements).isEmpty()
+    }
+
+    @Test
+    fun `createFormElements returns requested contact information fields`() {
+        val formElements = AlipayDefinition.formElements(
+            metadata = PaymentMethodMetadataFactory.create(
+                stripeIntent = PaymentIntentFactory.create(
+                    paymentMethodTypes = listOf("alipay")
+                ),
+                billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                    phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                    email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                    address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never,
+                )
+            )
+        )
+
+        assertThat(formElements).hasSize(2)
+
+        checkPhoneField(formElements, 0)
+        checkEmailField(formElements, 1)
+    }
+
+    @Test
+    fun `createFormElements returns all billing details fields`() {
+        val formElements = AlipayDefinition.formElements(
+            metadata = PaymentMethodMetadataFactory.create(
+                stripeIntent = PaymentIntentFactory.create(
+                    paymentMethodTypes = listOf("alipay")
+                ),
+                billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                    phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                    email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                    name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                    address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
+                )
+            )
+        )
+
+        assertThat(formElements).hasSize(4)
+
+        checkNameField(formElements, 0)
+        checkPhoneField(formElements, 1)
+        checkEmailField(formElements, 2)
+        checkBillingField(formElements, 3)
+    }
+}


### PR DESCRIPTION
# Summary
Move Alipay to simple LPM definition based on [LUXE spec](https://stripe.sourcegraphcloud.com/stripe-internal/pay-server/-/blob/lib/lpm_ui_platform/private/specs/alipay.json)

# Motivation
Remove LUXE usage from Alipay

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified