### PR TITLE
Add back PayPay SFU Support

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
@@ -186,7 +186,6 @@ constructor(
         internal val requiresMandateForPaymentIntent: Boolean,
         private val hasDelayedSettlement: Boolean,
         internal val afterRedirectAction: AfterRedirectAction = AfterRedirectAction.None,
-        internal val supportsSetupFutureUsage: Boolean = true,
     ) : Parcelable {
         Link(
             "link",
@@ -536,7 +535,6 @@ constructor(
             requiresMandate = false,
             hasDelayedSettlement = false,
             requiresMandateForPaymentIntent = false,
-            supportsSetupFutureUsage = false,
             afterRedirectAction = AfterRedirectAction.Poll(pollingDuration = REDUCED_POLLING_DURATION),
         ),
         PromptPay(

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -3299,11 +3299,9 @@ internal class StripeApiRepositoryTest {
     fun `elements session accepts PMO SFU params`() = runTest {
         val pmMap = mutableMapOf<String, Map<String, String>>()
         PaymentMethod.Type.entries.forEach {
-            if (it.supportsSetupFutureUsage) {
-                pmMap[it.code] = mapOf(
-                    "setup_future_usage" to "off_session"
-                )
-            }
+            pmMap[it.code] = mapOf(
+                "setup_future_usage" to "off_session"
+            )
         }
 
         val session = stripeApiRepository.retrieveElementsSession(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Remove `supportsSetupFutureUsage` from `PaymentMethod.Type`
Add comment linking to runbook to `elements session accepts PMO SFU params`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
