### PR TITLE
Add `UiDefinition.Custom` & make implementing `UiDefinition.Simple` easier for no custom form LPMs

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AffirmDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AffirmDefinition.kt
@@ -9,7 +9,6 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.elements.AffirmHeaderElement
-import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.R as StripeR
 import com.stripe.android.ui.core.R as UiCoreR
@@ -30,7 +29,7 @@ internal object AffirmDefinition : PaymentMethodDefinition {
     override fun uiDefinitionFactory(): UiDefinitionFactory = AffirmUiDefinitionFactory
 }
 
-private object AffirmUiDefinitionFactory : UiDefinitionFactory.Simple {
+private object AffirmUiDefinitionFactory : UiDefinitionFactory.Simple() {
     override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
         code = PaymentMethod.Type.Affirm.code,
         lightThemeIconUrl = null,
@@ -41,12 +40,11 @@ private object AffirmUiDefinitionFactory : UiDefinitionFactory.Simple {
         subtitle = StripeR.string.stripe_affirm_buy_now_pay_later_plaintext.resolvableString
     )
 
-    override fun createFormElements(
+    override fun buildFormElements(
         metadata: PaymentMethodMetadata,
-        arguments: UiDefinitionFactory.Arguments
-    ): List<FormElement> {
-        return FormElementsBuilder(arguments)
-            .header(AffirmHeaderElement(identifier = IdentifierSpec.Generic("affirm_header")))
-            .build()
+        arguments: UiDefinitionFactory.Arguments,
+        builder: FormElementsBuilder,
+    ) {
+        builder.header(AffirmHeaderElement(identifier = IdentifierSpec.Generic("affirm_header")))
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BlikDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BlikDefinition.kt
@@ -9,7 +9,6 @@ import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.BlikElement
-import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.SectionElement
 
 internal object BlikDefinition : PaymentMethodDefinition {
@@ -28,7 +27,7 @@ internal object BlikDefinition : PaymentMethodDefinition {
     override fun uiDefinitionFactory(): UiDefinitionFactory = BlikUiDefinitionFactory
 }
 
-private object BlikUiDefinitionFactory : UiDefinitionFactory.Simple {
+private object BlikUiDefinitionFactory : UiDefinitionFactory.Simple() {
     override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
         paymentMethodDefinition = BlikDefinition,
         displayNameResource = R.string.stripe_paymentsheet_payment_method_blik,
@@ -36,10 +35,11 @@ private object BlikUiDefinitionFactory : UiDefinitionFactory.Simple {
         iconResourceNight = null
     )
 
-    override fun createFormElements(
+    override fun buildFormElements(
         metadata: PaymentMethodMetadata,
-        arguments: UiDefinitionFactory.Arguments
-    ): List<FormElement> {
-        return FormElementsBuilder(arguments).element(SectionElement.wrap(BlikElement())).build()
+        arguments: UiDefinitionFactory.Arguments,
+        builder: FormElementsBuilder,
+    ) {
+        builder.element(SectionElement.wrap(BlikElement()))
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BoletoDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BoletoDefinition.kt
@@ -12,7 +12,6 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
-import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.SimpleTextElement
@@ -35,7 +34,7 @@ internal object BoletoDefinition : PaymentMethodDefinition {
     override fun uiDefinitionFactory(): UiDefinitionFactory = BoletoUiDefinitionFactory
 }
 
-private object BoletoUiDefinitionFactory : UiDefinitionFactory.Simple {
+private object BoletoUiDefinitionFactory : UiDefinitionFactory.Simple() {
     override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
         paymentMethodDefinition = BoletoDefinition,
         displayNameResource = R.string.stripe_paymentsheet_payment_method_boleto,
@@ -43,10 +42,11 @@ private object BoletoUiDefinitionFactory : UiDefinitionFactory.Simple {
         iconResourceNight = null
     )
 
-    override fun createFormElements(
+    override fun buildFormElements(
         metadata: PaymentMethodMetadata,
-        arguments: UiDefinitionFactory.Arguments
-    ): List<FormElement> {
+        arguments: UiDefinitionFactory.Arguments,
+        builder: FormElementsBuilder
+    ) {
         val taxIdElementIdentifierSpec = IdentifierSpec.Generic("boleto[tax_id]")
         val taxIdElement = SimpleTextElement(
             taxIdElementIdentifierSpec,
@@ -59,11 +59,11 @@ private object BoletoUiDefinitionFactory : UiDefinitionFactory.Simple {
                 initialValue = arguments.initialValues[taxIdElementIdentifierSpec],
             )
         )
-        return FormElementsBuilder(arguments)
+
+        builder
             .requireContactInformationIfAllowed(ContactInformationCollectionMode.Name)
             .requireContactInformationIfAllowed(ContactInformationCollectionMode.Email)
             .element(SectionElement.wrap(taxIdElement))
             .requireBillingAddressIfAllowed(setOf("BR"))
-            .build()
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -57,7 +57,7 @@ internal object CardDefinition : PaymentMethodDefinition {
     override fun uiDefinitionFactory(): UiDefinitionFactory = CardUiDefinitionFactory
 }
 
-private object CardUiDefinitionFactory : UiDefinitionFactory.Simple {
+private object CardUiDefinitionFactory : UiDefinitionFactory.Custom {
     override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
         paymentMethodDefinition = CardDefinition,
         displayNameResource = PaymentsUiCoreR.string.stripe_paymentsheet_payment_method_card,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CustomPaymentMethodUiDefinitionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CustomPaymentMethodUiDefinitionFactory.kt
@@ -7,12 +7,11 @@ import com.stripe.android.lpmfoundations.paymentmethod.DisplayableCustomPaymentM
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.ui.core.elements.StaticTextElement
-import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
 
 internal class CustomPaymentMethodUiDefinitionFactory(
     private val displayableCustomPaymentMethod: DisplayableCustomPaymentMethod
-) : UiDefinitionFactory.Simple {
+) : UiDefinitionFactory.Simple() {
     override fun createSupportedPaymentMethod(): SupportedPaymentMethod {
         return SupportedPaymentMethod(
             code = displayableCustomPaymentMethod.id,
@@ -26,12 +25,11 @@ internal class CustomPaymentMethodUiDefinitionFactory(
         )
     }
 
-    override fun createFormElements(
+    override fun buildFormElements(
         metadata: PaymentMethodMetadata,
-        arguments: UiDefinitionFactory.Arguments
-    ): List<FormElement> {
-        val builder = FormElementsBuilder(arguments)
-
+        arguments: UiDefinitionFactory.Arguments,
+        builder: FormElementsBuilder,
+    ) {
         displayableCustomPaymentMethod.subtitle?.let { subtitle ->
             builder.header(
                 StaticTextElement(
@@ -45,7 +43,5 @@ internal class CustomPaymentMethodUiDefinitionFactory(
             builder.ignoreContactInformationRequirements()
             builder.ignoreBillingAddressRequirements()
         }
-
-        return builder.build()
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/ExternalPaymentMethodUiDefinitionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/ExternalPaymentMethodUiDefinitionFactory.kt
@@ -1,16 +1,13 @@
 package com.stripe.android.lpmfoundations.paymentmethod.definitions
 
 import com.stripe.android.core.strings.resolvableString
-import com.stripe.android.lpmfoundations.luxe.FormElementsBuilder
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
-import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.ui.core.elements.ExternalPaymentMethodSpec
-import com.stripe.android.uicore.elements.FormElement
 
 internal class ExternalPaymentMethodUiDefinitionFactory(
     private val externalPaymentMethodSpec: ExternalPaymentMethodSpec
-) : UiDefinitionFactory.Simple {
+) : UiDefinitionFactory.Simple() {
     override fun createSupportedPaymentMethod(): SupportedPaymentMethod {
         return SupportedPaymentMethod(
             code = externalPaymentMethodSpec.type,
@@ -21,12 +18,5 @@ internal class ExternalPaymentMethodUiDefinitionFactory(
             iconResourceNight = 0,
             iconRequiresTinting = false,
         )
-    }
-
-    override fun createFormElements(
-        metadata: PaymentMethodMetadata,
-        arguments: UiDefinitionFactory.Arguments
-    ): List<FormElement> {
-        return FormElementsBuilder(arguments).build()
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/InstantDebitsDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/InstantDebitsDefinition.kt
@@ -28,7 +28,7 @@ internal object InstantDebitsDefinition : PaymentMethodDefinition {
     override fun uiDefinitionFactory(): UiDefinitionFactory = InstantDebitsUiDefinitionFactory
 }
 
-private object InstantDebitsUiDefinitionFactory : UiDefinitionFactory.Simple {
+private object InstantDebitsUiDefinitionFactory : UiDefinitionFactory.Custom {
 
     override fun createSupportedPaymentMethod(): SupportedPaymentMethod {
         return SupportedPaymentMethod(

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KonbiniDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KonbiniDefinition.kt
@@ -12,7 +12,6 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
-import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.SimpleTextElement
@@ -36,7 +35,7 @@ internal object KonbiniDefinition : PaymentMethodDefinition {
     override fun uiDefinitionFactory(): UiDefinitionFactory = KonbiniUiDefinitionFactory
 }
 
-private object KonbiniUiDefinitionFactory : UiDefinitionFactory.Simple {
+private object KonbiniUiDefinitionFactory : UiDefinitionFactory.Simple() {
     override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
         paymentMethodDefinition = KonbiniDefinition,
         displayNameResource = R.string.stripe_paymentsheet_payment_method_konbini,
@@ -44,10 +43,11 @@ private object KonbiniUiDefinitionFactory : UiDefinitionFactory.Simple {
         iconResourceNight = null,
     )
 
-    override fun createFormElements(
+    override fun buildFormElements(
         metadata: PaymentMethodMetadata,
-        arguments: UiDefinitionFactory.Arguments
-    ): List<FormElement> {
+        arguments: UiDefinitionFactory.Arguments,
+        builder: FormElementsBuilder,
+    ) {
         val confirmationNumberElement = SimpleTextElement(
             identifier = IdentifierSpec.KonbiniConfirmationNumber,
             controller = SimpleTextFieldController(
@@ -60,10 +60,9 @@ private object KonbiniUiDefinitionFactory : UiDefinitionFactory.Simple {
                 initialValue = arguments.initialValues[IdentifierSpec.KonbiniConfirmationNumber],
             ),
         )
-        return FormElementsBuilder(arguments)
+        builder
             .requireContactInformationIfAllowed(ContactInformationCollectionMode.Name)
             .requireContactInformationIfAllowed(ContactInformationCollectionMode.Email)
             .element(SectionElement.wrap(confirmationNumberElement))
-            .build()
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/LinkCardBrandDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/LinkCardBrandDefinition.kt
@@ -28,7 +28,7 @@ internal object LinkCardBrandDefinition : PaymentMethodDefinition {
     override fun uiDefinitionFactory(): UiDefinitionFactory = LinkCardBrandDefinitionFactory
 }
 
-private object LinkCardBrandDefinitionFactory : UiDefinitionFactory.Simple {
+private object LinkCardBrandDefinitionFactory : UiDefinitionFactory.Custom {
 
     override fun createSupportedPaymentMethod(): SupportedPaymentMethod {
         return SupportedPaymentMethod(

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SwishDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SwishDefinition.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.lpmfoundations.paymentmethod.definitions
 
-import com.stripe.android.lpmfoundations.luxe.FormElementsBuilder
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
@@ -8,7 +7,6 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
-import com.stripe.android.uicore.elements.FormElement
 
 internal object SwishDefinition : PaymentMethodDefinition {
     override val type: PaymentMethod.Type = PaymentMethod.Type.Swish
@@ -26,18 +24,11 @@ internal object SwishDefinition : PaymentMethodDefinition {
     override fun uiDefinitionFactory(): UiDefinitionFactory = SwishUiDefinitionFactory
 }
 
-private object SwishUiDefinitionFactory : UiDefinitionFactory.Simple {
+private object SwishUiDefinitionFactory : UiDefinitionFactory.Simple() {
     override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
         paymentMethodDefinition = SwishDefinition,
         displayNameResource = R.string.stripe_paymentsheet_payment_method_swish,
         iconResource = R.drawable.stripe_ic_paymentsheet_pm_swish,
         iconResourceNight = null,
     )
-
-    override fun createFormElements(
-        metadata: PaymentMethodMetadata,
-        arguments: UiDefinitionFactory.Arguments
-    ): List<FormElement> {
-        return FormElementsBuilder(arguments).build()
-    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/UpiDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/UpiDefinition.kt
@@ -10,7 +10,6 @@ import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.UpiElement
-import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.SectionElement
 
 internal object UpiDefinition : PaymentMethodDefinition {
@@ -29,7 +28,7 @@ internal object UpiDefinition : PaymentMethodDefinition {
     override fun uiDefinitionFactory(): UiDefinitionFactory = UpiUiDefinitionFactory
 }
 
-private object UpiUiDefinitionFactory : UiDefinitionFactory.Simple {
+private object UpiUiDefinitionFactory : UiDefinitionFactory.Simple() {
     override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
         paymentMethodDefinition = UpiDefinition,
         displayNameResource = R.string.stripe_paymentsheet_payment_method_upi,
@@ -37,14 +36,16 @@ private object UpiUiDefinitionFactory : UiDefinitionFactory.Simple {
         iconResourceNight = null,
     )
 
-    override fun createFormElements(
+    override fun buildFormElements(
         metadata: PaymentMethodMetadata,
-        arguments: UiDefinitionFactory.Arguments
-    ): List<FormElement> {
+        arguments: UiDefinitionFactory.Arguments,
+        builder: FormElementsBuilder,
+    ) {
         val section = SectionElement.wrap(
             UpiElement(),
             label = resolvableString(R.string.stripe_paymentsheet_buy_using_upi_id)
         )
-        return FormElementsBuilder(arguments).element(section).build()
+
+        builder.element(section)
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/UsBankAccountDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/UsBankAccountDefinition.kt
@@ -30,7 +30,7 @@ internal object UsBankAccountDefinition : PaymentMethodDefinition {
     override fun uiDefinitionFactory(): UiDefinitionFactory = UsBankAccountUiDefinitionFactory
 }
 
-private object UsBankAccountUiDefinitionFactory : UiDefinitionFactory.Simple {
+private object UsBankAccountUiDefinitionFactory : UiDefinitionFactory.Custom {
     override fun createSupportedPaymentMethod(): SupportedPaymentMethod = SupportedPaymentMethod(
         code = UsBankAccountDefinition.type.code,
         displayNameResource = R.string.stripe_paymentsheet_payment_method_us_bank_account,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUITest.kt
@@ -177,7 +177,7 @@ internal class VerticalModeFormUITest {
 
     private fun createCardState(customerHasSavedPaymentMethods: Boolean): VerticalModeFormInteractor.State {
         val headerInformation =
-            (CardDefinition.uiDefinitionFactory() as UiDefinitionFactory.Simple).createFormHeaderInformation(
+            (CardDefinition.uiDefinitionFactory() as UiDefinitionFactory.Custom).createFormHeaderInformation(
                 customerHasSavedPaymentMethods = customerHasSavedPaymentMethods,
                 incentive = null,
             )


### PR DESCRIPTION
# Summary
Add `UiDefinition.Custom` & make implementing `UiDefinition.Simple` easier for no custom form LPMs

# Motivation
Suggestion from [Alipay PR](https://github.com/stripe/stripe-android/pull/12151#discussion_r2625332169). Makes implementing `Custom` definitions easy while making `Simple` definitions slightly easier.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified