### PR TITLE
Add Reset to defaults button to PaymentSheet Playground

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
@@ -297,6 +297,8 @@ internal class PaymentSheetPlaygroundActivity :
                     QrCodeButton(playgroundSettings = localPlaygroundSettings)
 
                     ClearLinkDataButton()
+
+                    ResetToDefaultsButton()
                 },
                 bottomBarContent = {
                     ReloadButton(playgroundSettings = localPlaygroundSettings)
@@ -428,6 +430,18 @@ internal class PaymentSheetPlaygroundActivity :
             modifier = Modifier.fillMaxWidth(),
         ) {
             Text("Clear Link customer")
+        }
+    }
+
+    @Composable
+    private fun ResetToDefaultsButton() {
+        Button(
+            onClick = {
+                viewModel.resetToDefaults()
+            },
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text("Reset to defaults")
         }
     }
 

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundViewModel.kt
@@ -1,8 +1,10 @@
 package com.stripe.android.paymentsheet.example.playground
 
 import android.app.Application
+import android.content.Context
 import android.net.Uri
 import android.util.Log
+import androidx.core.content.edit
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
@@ -33,6 +35,7 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetResult
 import com.stripe.android.paymentsheet.addresselement.AddressLauncherResult
 import com.stripe.android.paymentsheet.example.Settings
+import com.stripe.android.paymentsheet.example.playground.activity.AppearanceStore
 import com.stripe.android.paymentsheet.example.playground.model.ConfirmIntentRequestParams
 import com.stripe.android.paymentsheet.example.playground.model.ConfirmIntentResponse
 import com.stripe.android.paymentsheet.example.playground.model.CreateSetupIntentRequest
@@ -763,6 +766,36 @@ internal class PaymentSheetPlaygroundViewModel(
                     }
                 }
             )
+        }
+    }
+
+    fun resetToDefaults() {
+        viewModelScope.launch {
+            // Reset appearance
+            AppearanceStore.reset()
+
+            // Clear SharedPreferences
+            withContext(Dispatchers.IO) {
+                val sharedPreferences = getApplication<Application>().getSharedPreferences(
+                    "PlaygroundSettings",
+                    Context.MODE_PRIVATE
+                )
+                sharedPreferences.edit {
+                    clear()
+                }
+            }
+
+            // Create and apply default settings
+            val defaultSettings = PlaygroundSettings.createFromDefaults()
+            playgroundSettingsFlow.value = defaultSettings
+
+            // Clear states
+            setPlaygroundState(null)
+            flowControllerState.value = null
+            customerSheetState.value = null
+
+            // Auto-reload
+            prepare(defaultSettings)
         }
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Adds a new "Reset to defaults" button at the bottom of the PlaymentSheetPlaygroundActivity that allows users to quickly reset all playground settings and appearance to their default values.

Changes:
- Add resetToDefaults() method to PaymentSheetPlaygroundViewModel that resets settings, appearance, clears SharedPreferences, and triggers auto-reload
- Add ResetToDefaultsButton composable to PaymentSheetPlaygroundActivity
- Button placed after "Clear Link customer" button in the scrollable content section

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Committed-By-Agent: claude


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
The iOS team has this and likes it! 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screen recording

[Screen_recording_20251218_160039.webm](https://github.com/user-attachments/assets/5557676e-9075-475d-b4d3-c727b57c2eaa)
