### PR TITLE
Add RetryRule to FullScreenComponentTest

### DIFF
--- a/connect/build.gradle
+++ b/connect/build.gradle
@@ -56,6 +56,7 @@ dependencies {
     testImplementation testLibs.robolectric
     testImplementation testLibs.truth
 
+    androidTestImplementation project(':payments-core-testing')
     androidTestImplementation testLibs.androidx.composeUi
     androidTestImplementation testLibs.androidx.coreKtx
     androidTestImplementation testLibs.androidx.junit

--- a/connect/src/androidTest/java/com/stripe/android/connect/FullScreenComponentTest.kt
+++ b/connect/src/androidTest/java/com/stripe/android/connect/FullScreenComponentTest.kt
@@ -28,25 +28,31 @@ import androidx.test.espresso.web.webdriver.Locator
 import androidx.test.ext.junit.rules.activityScenarioRule
 import com.stripe.android.connect.webview.serialization.AlertJs
 import com.stripe.android.connect.webview.serialization.ConnectJson
+import com.stripe.android.testing.RetryRule
 import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.equalTo
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 
 class FullScreenComponentTest {
     private val title = "Test title"
 
-    @get:Rule
-    val activityRule = activityScenarioRule<EmptyEmbeddedComponentActivity>(
+    private val activityRule = activityScenarioRule<EmptyEmbeddedComponentActivity>(
         EmptyEmbeddedComponentActivity.newIntent(
             context = ApplicationProvider.getApplicationContext(),
             title = title,
         )
     )
+
+    @get:Rule
+    val ruleChain: RuleChain = RuleChain
+        .outerRule(activityRule)
+        .around(RetryRule(3))
 
     private val rootView
         get() = isAssignableFrom(StripeComponentDialogFragmentView::class.java)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add RetryRule with 3 retry attempts to FullScreenComponentTest to reduce flakiness in CI environments. The RetryRule is applied using RuleChain to wrap the existing activityRule.

Changes:
- Add payments-core-testing dependency to connect module
- Update FullScreenComponentTest to use RuleChain with RetryRule(3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Committed-By-Agent: claude

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
A test in this test class flaked on one of my PRs. Adding retries may reduce flakes