### PR TITLE
Add retries to crypto onramp flow test.

### DIFF
--- a/crypto-onramp-example/build.gradle
+++ b/crypto-onramp-example/build.gradle
@@ -42,6 +42,7 @@ dependencies {
 
     androidTestImplementation project(':payments-core-testing')
     androidTestImplementation testLibs.androidx.junit
+    androidTestImplementation testLibs.androidx.junitKtx
     androidTestImplementation testLibs.androidx.testRunner
     androidTestImplementation testLibs.androidx.uiAutomator
     androidTestImplementation testLibs.androidx.archCore

--- a/payments-core-testing/src/main/java/com/stripe/android/testing/ShampooRule.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/ShampooRule.kt
@@ -16,6 +16,7 @@ class ShampooRule(private val iterations: Int) : TestRule {
             override fun evaluate() {
                 repeat(iterations) { iteration ->
                     try {
+                        println("Executing iteration: $iteration")
                         base.evaluate()
                     } catch (@Suppress("TooGenericExceptionCaught") e: Throwable) {
                         println("Failed on iteration: $iteration")


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
These tests continue to be flakey. Trying retries before we disable them.