### PR TITLE
Move `Fpx` to `UiDefinitionFactory.Simple`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/FpxDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/FpxDefinition.kt
@@ -1,5 +1,7 @@
 package com.stripe.android.lpmfoundations.paymentmethod.definitions
 
+import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.lpmfoundations.luxe.FormElementsBuilder
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
@@ -7,7 +9,12 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
-import com.stripe.android.ui.core.elements.SharedDataSpec
+import com.stripe.android.ui.core.elements.DropdownItemSpec
+import com.stripe.android.ui.core.elements.SimpleDropdownConfig
+import com.stripe.android.ui.core.elements.SimpleDropdownElement
+import com.stripe.android.uicore.elements.DropdownFieldController
+import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.SectionElement
 
 internal object FpxDefinition : PaymentMethodDefinition {
     override val type: PaymentMethod.Type = PaymentMethod.Type.Fpx
@@ -25,16 +32,57 @@ internal object FpxDefinition : PaymentMethodDefinition {
     override fun uiDefinitionFactory(): UiDefinitionFactory = FpxUiDefinitionFactory
 }
 
-private object FpxUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDataSpec {
-    override fun createSupportedPaymentMethod(
-        metadata: PaymentMethodMetadata,
-        sharedDataSpec: SharedDataSpec,
-    ) = SupportedPaymentMethod(
+private object FpxUiDefinitionFactory : UiDefinitionFactory.Simple() {
+    private val fpsIdentifier = IdentifierSpec.Generic("fpx[bank]")
+
+    override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
         paymentMethodDefinition = FpxDefinition,
-        sharedDataSpec = sharedDataSpec,
         displayNameResource = R.string.stripe_paymentsheet_payment_method_fpx,
         iconResource = R.drawable.stripe_ic_paymentsheet_pm_fpx,
         iconResourceNight = null,
         iconRequiresTinting = false,
+    )
+
+    override fun buildFormElements(
+        metadata: PaymentMethodMetadata,
+        arguments: UiDefinitionFactory.Arguments,
+        builder: FormElementsBuilder
+    ) {
+        builder
+            .element(
+                formElement = SectionElement.wrap(
+                    sectionFieldElement = SimpleDropdownElement(
+                        identifier = fpsIdentifier,
+                        controller = DropdownFieldController(
+                            config = SimpleDropdownConfig(
+                                label = R.string.stripe_fpx_bank.resolvableString,
+                                items = items,
+                            ),
+                            initialValue = arguments.initialValues[fpsIdentifier],
+                        ),
+                    ),
+                ),
+            )
+    }
+
+    private val items = listOf(
+        DropdownItemSpec(apiValue = "affin_bank", displayText = "Affin Bank"),
+        DropdownItemSpec(apiValue = "alliance_bank", displayText = "Alliance Bank"),
+        DropdownItemSpec(apiValue = "ambank", displayText = "AmBank"),
+        DropdownItemSpec(apiValue = "bank_islam", displayText = "Bank Islam"),
+        DropdownItemSpec(apiValue = "bank_muamalat", displayText = "Bank Muamalat"),
+        DropdownItemSpec(apiValue = "bank_rakyat", displayText = "Bank Rakyat"),
+        DropdownItemSpec(apiValue = "bsn", displayText = "BSN"),
+        DropdownItemSpec(apiValue = "cimb", displayText = "CIMB Clicks"),
+        DropdownItemSpec(apiValue = "hong_leong_bank", displayText = "Hong Leong Bank"),
+        DropdownItemSpec(apiValue = "hsbc", displayText = "HSBC BANK"),
+        DropdownItemSpec(apiValue = "kfh", displayText = "KFH"),
+        DropdownItemSpec(apiValue = "maybank2e", displayText = "Maybank2E"),
+        DropdownItemSpec(apiValue = "maybank2u", displayText = "Maybank2U"),
+        DropdownItemSpec(apiValue = "ocbc", displayText = "OCBC Bank"),
+        DropdownItemSpec(apiValue = "public_bank", displayText = "Public Bank"),
+        DropdownItemSpec(apiValue = "rhb", displayText = "RHB Bank"),
+        DropdownItemSpec(apiValue = "standard_chartered", displayText = "Standard Chartered"),
+        DropdownItemSpec(apiValue = "uob", displayText = "UOB Bank"),
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/FpxDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/FpxDefinitionTest.kt
@@ -1,0 +1,82 @@
+package com.stripe.android.lpmfoundations.paymentmethod.definitions
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.lpmfoundations.paymentmethod.formElements
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.testing.PaymentIntentFactory
+import com.stripe.android.ui.core.elements.SimpleDropdownElement
+import com.stripe.android.uicore.elements.FormElement
+import com.stripe.android.uicore.elements.SectionElement
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class FpxDefinitionTest {
+    private val fpxMetadata = PaymentMethodMetadataFactory.create(
+        stripeIntent = PaymentIntentFactory.create(
+            paymentMethodTypes = listOf("fpx"),
+        )
+    )
+
+    @Test
+    fun `createFormElements returns bank dropdown`() {
+        val formElements = FpxDefinition.formElements(fpxMetadata)
+
+        assertThat(formElements).hasSize(1)
+
+        checkFpxDropdownField(formElements, 0)
+    }
+
+    @Test
+    fun `createFormElements returns billing address collection fields`() {
+        val formElements = FpxDefinition.formElements(
+            metadata = fpxMetadata.copy(
+                billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                    name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                    phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                    email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                    address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
+                )
+            )
+        )
+
+        assertThat(formElements).hasSize(5)
+
+        checkNameField(formElements, 0)
+        checkPhoneField(formElements, 1)
+        checkEmailField(formElements, 2)
+        checkFpxDropdownField(formElements, 3)
+        checkBillingField(formElements, 4)
+    }
+
+    @Test
+    fun `createFormElements returns contact information fields`() {
+        val formElements = FpxDefinition.formElements(
+            metadata = fpxMetadata.copy(
+                billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                    phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                    email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                    address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never,
+                )
+            )
+        )
+
+        assertThat(formElements).hasSize(3)
+
+        checkPhoneField(formElements, 0)
+        checkEmailField(formElements, 1)
+        checkFpxDropdownField(formElements, 2)
+    }
+
+    private fun checkFpxDropdownField(
+        formElements: List<FormElement>,
+        position: Int,
+    ) {
+        val bankSection = formElements[position] as SectionElement
+        assertThat(bankSection.fields).hasSize(1)
+        val dropdownElement = bankSection.fields[0] as SimpleDropdownElement
+        assertThat(dropdownElement.identifier.v1).isEqualTo("fpx[bank]")
+    }
+}


### PR DESCRIPTION
# Summary
Move `Fpx` to `UiDefinitionFactory.Simple`

# Motivation
Remove its [LUXE spec](https://stripe.sourcegraphcloud.com/stripe-internal/pay-server/-/blob/lib/lpm_ui_platform/private/specs/fpx.json).

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
There's a bit of an experience change here that I thought was okay since it more closely matches our other LPMs.

| Before  | After |
| ------------- | ------------- |
| <img width="1280" height="2856" alt="Screenshot_20251219_132527" src="https://github.com/user-attachments/assets/a260d12a-ef74-48bc-8eae-cc11bd4caafb" /> | <img width="1280" height="2856" alt="Screenshot_20251219_132711" src="https://github.com/user-attachments/assets/5cf64d9a-92d9-4292-aa1b-80a3d3e3f1c6" /> |