### PR TITLE
Move `Multibanco` to `UiDefinitionFactory.Simple`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/MultibancoDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/MultibancoDefinition.kt
@@ -1,5 +1,7 @@
 package com.stripe.android.lpmfoundations.paymentmethod.definitions
 
+import com.stripe.android.lpmfoundations.luxe.ContactInformationCollectionMode
+import com.stripe.android.lpmfoundations.luxe.FormElementsBuilder
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.AddPaymentMethodRequirement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
@@ -7,7 +9,6 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
-import com.stripe.android.ui.core.elements.SharedDataSpec
 
 internal object MultibancoDefinition : PaymentMethodDefinition {
     override val type: PaymentMethod.Type = PaymentMethod.Type.Multibanco
@@ -26,15 +27,19 @@ internal object MultibancoDefinition : PaymentMethodDefinition {
     override fun uiDefinitionFactory(): UiDefinitionFactory = MultibancoUiDefinitionFactory
 }
 
-private object MultibancoUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDataSpec {
-    override fun createSupportedPaymentMethod(
-        metadata: PaymentMethodMetadata,
-        sharedDataSpec: SharedDataSpec,
-    ) = SupportedPaymentMethod(
+private object MultibancoUiDefinitionFactory : UiDefinitionFactory.Simple() {
+    override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
         paymentMethodDefinition = MultibancoDefinition,
-        sharedDataSpec = sharedDataSpec,
         displayNameResource = R.string.stripe_paymentsheet_payment_method_multibanco,
         iconResource = R.drawable.stripe_ic_paymentsheet_pm_multibanco_day,
         iconResourceNight = R.drawable.stripe_ic_paymentsheet_pm_multibanco_night,
     )
+
+    override fun buildFormElements(
+        metadata: PaymentMethodMetadata,
+        arguments: UiDefinitionFactory.Arguments,
+        builder: FormElementsBuilder
+    ) {
+        builder.requireContactInformationIfAllowed(ContactInformationCollectionMode.Email)
+    }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/MultibancoDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/MultibancoDefinitionTest.kt
@@ -1,0 +1,74 @@
+package com.stripe.android.lpmfoundations.paymentmethod.definitions
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.lpmfoundations.paymentmethod.formElements
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.paymentsheet.PaymentSheet
+import org.junit.Test
+
+class MultibancoDefinitionTest {
+    private val multibancoMetadata = PaymentMethodMetadataFactory.create(
+        stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+            paymentMethodTypes = listOf("multibanco"),
+        )
+    )
+
+    @Test
+    fun `createFormElements returns email field by default`() {
+        val formElements = MultibancoDefinition.formElements(multibancoMetadata)
+
+        assertThat(formElements).hasSize(1)
+        checkEmailField(formElements, 0)
+    }
+
+    @Test
+    fun `createFormElements returns all billing details fields when configured`() {
+        val formElements = MultibancoDefinition.formElements(
+            metadata = multibancoMetadata.copy(
+                billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                    name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                    phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                    email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                    address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
+                )
+            )
+        )
+
+        assertThat(formElements).hasSize(4)
+        checkNameField(formElements, 0)
+        checkPhoneField(formElements, 1)
+        checkEmailField(formElements, 2)
+        checkBillingField(formElements, 3)
+    }
+
+    @Test
+    fun `createFormElements returns contact information fields when configured`() {
+        val formElements = MultibancoDefinition.formElements(
+            metadata = multibancoMetadata.copy(
+                billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                    phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                    email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                    address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never,
+                )
+            )
+        )
+
+        assertThat(formElements).hasSize(2)
+        checkPhoneField(formElements, 0)
+        checkEmailField(formElements, 1)
+    }
+
+    @Test
+    fun `createFormElements omits email when set to never`() {
+        val formElements = MultibancoDefinition.formElements(
+            metadata = multibancoMetadata.copy(
+                billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                    email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never,
+                )
+            )
+        )
+
+        assertThat(formElements).isEmpty()
+    }
+}


### PR DESCRIPTION
# Summary
Move `Multibanco` to `UiDefinitionFactory.Simple`

# Motivation
Removing LUXE specs in Android SDK. See [multibanco.json](https://stripe.sourcegraphcloud.com/stripe-internal/pay-server/-/blob/lib/lpm_ui_platform/private/specs/multibanco.json) for LUXE definition.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified