### PR TITLE
Make `providePaymentMethodName` a function of `PaymentMethodMetadata`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -3,6 +3,8 @@ package com.stripe.android.lpmfoundations.paymentmethod
 import android.os.Parcelable
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.common.model.CommonConfiguration
+import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.core.strings.orEmpty
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.lpmfoundations.FormHeaderInformation
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
@@ -157,6 +159,12 @@ internal data class PaymentMethodMetadata(
             val definition = supportedPaymentMethodDefinitions().firstOrNull { it.type.code == code } ?: return null
             definition.uiDefinitionFactory().supportedPaymentMethod(this, definition, sharedDataSpecs)
         }
+    }
+
+    fun displayNameForCode(
+        code: String?,
+    ): ResolvableString {
+        return code?.let { supportedPaymentMethodForCode(code) }?.displayName.orEmpty()
     }
 
     fun sortedSupportedPaymentMethods(): List<SupportedPaymentMethod> {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
@@ -241,7 +241,6 @@ internal class DefaultEmbeddedContentHelper @Inject constructor(
             },
             paymentMethods = customerStateHolder.paymentMethods,
             mostRecentlySelectedSavedPaymentMethod = customerStateHolder.mostRecentlySelectedSavedPaymentMethod,
-            providePaymentMethodName = savedPaymentMethodMutator.providePaymentMethodName,
             canRemove = customerStateHolder.canRemove,
             canUpdateFullPaymentMethodDetails = customerStateHolder.canUpdateFullPaymentMethodDetails,
             walletsState = walletsState,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedManageScreenInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedManageScreenInteractorFactory.kt
@@ -31,7 +31,6 @@ internal class DefaultEmbeddedManageScreenInteractorFactory @Inject constructor(
             editing = savedPaymentMethodMutator.editing,
             canEdit = savedPaymentMethodMutator.canEdit,
             toggleEdit = savedPaymentMethodMutator::toggleEditing,
-            providePaymentMethodName = savedPaymentMethodMutator.providePaymentMethodName,
             onSelectPaymentMethod = {
                 val savedPmSelection = PaymentSelection.Saved(it.paymentMethod)
                 selectionHolder.set(savedPmSelection)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentsheet
 
 import androidx.lifecycle.viewModelScope
-import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.orEmpty
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilter
@@ -69,12 +68,6 @@ internal class SavedPaymentMethodMutator(
         }
     }
 
-    val providePaymentMethodName: (code: String?) -> ResolvableString = { code ->
-        code?.let {
-            paymentMethodMetadataFlow.value?.supportedPaymentMethodForCode(code)
-        }?.displayName.orEmpty()
-    }
-
     private val paymentOptionsItemsMapper: PaymentOptionsItemsMapper by lazy {
         PaymentOptionsItemsMapper(
             customerMetadata = paymentMethodMetadataFlow.mapAsStateFlow { it?.customerMetadata },
@@ -82,7 +75,7 @@ internal class SavedPaymentMethodMutator(
             isGooglePayReady = paymentMethodMetadataFlow.mapAsStateFlow { it?.isGooglePayReady == true },
             isLinkEnabled = isLinkEnabled,
             isNotPaymentFlow = isNotPaymentFlow,
-            nameProvider = providePaymentMethodName,
+            nameProvider = { paymentMethodMetadataFlow.value?.displayNameForCode(it).orEmpty() },
             isCbcEligible = { paymentMethodMetadataFlow.value?.cbcEligibility is CardBrandChoiceEligibility.Eligible },
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/ManageScreenInteractor.kt
@@ -4,7 +4,6 @@ import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethod
-import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.R
@@ -101,7 +100,6 @@ internal class DefaultManageScreenInteractor(
     private val editing: StateFlow<Boolean>,
     private val canEdit: StateFlow<Boolean>,
     private val toggleEdit: () -> Unit,
-    private val providePaymentMethodName: (PaymentMethodCode?) -> ResolvableString,
     private val onSelectPaymentMethod: (DisplayableSavedPaymentMethod) -> Unit,
     private val onUpdatePaymentMethod: (DisplayableSavedPaymentMethod) -> Unit,
     private val navigateBack: (withDelay: Boolean) -> Unit,
@@ -117,7 +115,6 @@ internal class DefaultManageScreenInteractor(
         combineAsStateFlow(paymentMethods, defaultPaymentMethodId) { paymentMethods, defaultPaymentMethodId ->
             paymentMethods.map {
                 it.toDisplayableSavedPaymentMethod(
-                    providePaymentMethodName,
                     paymentMethodMetadata,
                     defaultPaymentMethodId
                 )
@@ -202,7 +199,6 @@ internal class DefaultManageScreenInteractor(
                 editing = savedPaymentMethodMutator.editing,
                 canEdit = savedPaymentMethodMutator.canEdit,
                 toggleEdit = savedPaymentMethodMutator::toggleEditing,
-                providePaymentMethodName = savedPaymentMethodMutator.providePaymentMethodName,
                 onSelectPaymentMethod = {
                     val savedPmSelection = PaymentSelection.Saved(it.paymentMethod)
                     viewModel.updateSelection(savedPmSelection)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -97,7 +97,6 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
     private val transitionToFormScreen: (selectedPaymentMethodCode: String) -> Unit,
     paymentMethods: StateFlow<List<PaymentMethod>>,
     private val mostRecentlySelectedSavedPaymentMethod: StateFlow<PaymentMethod?>,
-    private val providePaymentMethodName: (PaymentMethodCode?) -> ResolvableString,
     private val canRemove: StateFlow<Boolean>,
     private val walletsState: StateFlow<WalletsState?>,
     private val canUpdateFullPaymentMethodDetails: StateFlow<Boolean>,
@@ -158,7 +157,6 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
                 },
                 paymentMethods = customerStateHolder.paymentMethods,
                 mostRecentlySelectedSavedPaymentMethod = customerStateHolder.mostRecentlySelectedSavedPaymentMethod,
-                providePaymentMethodName = viewModel.savedPaymentMethodMutator.providePaymentMethodName,
                 canRemove = viewModel.customerStateHolder.canRemove,
                 onUpdatePaymentMethod = { viewModel.savedPaymentMethodMutator.updatePaymentMethod(it) },
                 updateSelection = { selection, isUserInput ->
@@ -421,8 +419,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
             mostRecentlySelectedSavedPaymentMethod = mostRecentlySelectedSavedPaymentMethod,
         )
         return paymentMethodToDisplay?.toDisplayableSavedPaymentMethod(
-            providePaymentMethodName,
-            paymentMethodMetadata,
+            paymentMethodMetadata = paymentMethodMetadata,
             defaultPaymentMethodId = null
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodsExtension.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodsExtension.kt
@@ -1,19 +1,17 @@
 package com.stripe.android.paymentsheet.verticalmode
 
-import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.core.strings.orEmpty
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethod
-import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 
 internal fun PaymentMethod.toDisplayableSavedPaymentMethod(
-    providePaymentMethodName: (PaymentMethodCode?) -> ResolvableString,
     paymentMethodMetadata: PaymentMethodMetadata?,
     defaultPaymentMethodId: String?
 ): DisplayableSavedPaymentMethod {
     return DisplayableSavedPaymentMethod.create(
-        displayName = providePaymentMethodName(type?.code),
+        displayName = paymentMethodMetadata?.displayNameForCode(type?.code).orEmpty(),
         paymentMethod = this,
         isCbcEligible = paymentMethodMetadata?.cbcEligibility is CardBrandChoiceEligibility.Eligible,
         shouldShowDefaultBadge = id == defaultPaymentMethodId

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -234,6 +234,40 @@ internal class PaymentMethodMetadataTest {
     }
 
     @Test
+    fun `displayNameForCode returns display name for supported payment method`() {
+        val metadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("klarna")
+            ),
+            sharedDataSpecs = listOf(SharedDataSpec("klarna")),
+        )
+        assertThat(metadata.displayNameForCode("klarna"))
+            .isEqualTo(R.string.stripe_paymentsheet_payment_method_klarna.resolvableString)
+    }
+
+    @Test
+    fun `displayNameForCode returns empty ResolvableString for unsupported payment method`() {
+        val metadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("card")
+            ),
+            sharedDataSpecs = listOf(SharedDataSpec("card")),
+        )
+        assertThat(metadata.displayNameForCode("klarna")).isEqualTo("".resolvableString)
+    }
+
+    @Test
+    fun `displayNameForCode returns empty ResolvableString for null code`() {
+        val metadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("card")
+            ),
+            sharedDataSpecs = listOf(SharedDataSpec("card")),
+        )
+        assertThat(metadata.displayNameForCode(null)).isEqualTo("".resolvableString)
+    }
+
+    @Test
     fun `sortedSupportedPaymentMethods returns list sorted by payment_method_types`() {
         val metadata = PaymentMethodMetadataFactory.create(
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodsExtensionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodsExtensionTest.kt
@@ -1,8 +1,5 @@
 package com.stripe.android.paymentsheet
 
-import com.stripe.android.core.strings.ResolvableString
-import com.stripe.android.core.strings.resolvableString
-import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentsheet.verticalmode.toDisplayableSavedPaymentMethod
 import com.stripe.android.testing.PaymentMethodFactory
 import org.junit.Test
@@ -40,16 +37,9 @@ class SavedPaymentMethodsExtensionTest {
     }
 
     private fun testSetup(paymentMethodId: String, defaultPaymentMethodId: String?): DisplayableSavedPaymentMethod {
-        val resolvableString = "acbde123".resolvableString
-
         val paymentMethod = PaymentMethodFactory.card(paymentMethodId)
 
-        val providePaymentMethodName: (PaymentMethodCode?) -> ResolvableString = { pmc ->
-            resolvableString
-        }
-
         return paymentMethod.toDisplayableSavedPaymentMethod(
-            providePaymentMethodName = providePaymentMethodName,
             paymentMethodMetadata = null,
             defaultPaymentMethodId = defaultPaymentMethodId
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultManageScreenInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultManageScreenInteractorTest.kt
@@ -354,7 +354,6 @@ class DefaultManageScreenInteractorTest {
             toggleEdit = {
                 toggleEditTurbine.add(Unit)
             },
-            providePaymentMethodName = { (it ?: "Missing name").resolvableString },
             onSelectPaymentMethod = {
                 onSelectPaymentMethodTurbine.add(it)
             },

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -1671,7 +1671,6 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
             },
             paymentMethods = paymentMethods,
             mostRecentlySelectedSavedPaymentMethod = mostRecentlySelectedSavedPaymentMethod,
-            providePaymentMethodName = { it!!.resolvableString },
             canRemove = canRemove,
             walletsState = walletsState,
             canUpdateFullPaymentMethodDetails = stateFlowOf(canUpdateFullPaymentMethodDetails),


### PR DESCRIPTION
# Summary
Make `providePaymentMethodName` a function of `PaymentMethodMetadata`.

# Motivation
Function lives in a more appropriate place. Helps reduce dependencies required by Tap to Add since we are displaying a saved PM row in the card form after tapping.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified