### PR TITLE
Add workflow to monitor UnexpectedErrorEvent changes

### DIFF
--- a/.github/workflows/notify_error_event_change.yml
+++ b/.github/workflows/notify_error_event_change.yml
@@ -45,7 +45,7 @@ jobs:
 
             This PR modifies the `UnexpectedErrorEvent` enum in `ErrorReporter.kt`.
 
-            **Action Required:** Please ensure you have added the new error event to the `https://git.corp.stripe.com/stripe-internal/zoolander/blob/master/src/resources/com/stripe/dscore/analyticseventlogger/server/rpcserver/client_config.yaml` file in the `pay-server` repository.
+            **Action Required:** Please ensure you have added the new error event to the `https://git.corp.stripe.com/stripe-internal/zoolander/blob/master/src/resources/com/stripe/dscore/analyticseventlogger/server/rpcserver/client_config.yaml` file.
 
             Once you have verified that the error event has been added to `client_config.yaml`, please add the label `added-to-client-config` to this PR to acknowledge this requirement.
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add GitHub Action that triggers when UnexpectedErrorEvent enum is modified in ErrorReporter.kt. Requires the 'added-to-client-config' label to ensure new error events are added to client_config.yaml in pay-server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Committed-By-Agent: claude

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
We now need to manually add new unexpected error events to our AEL allowlist in order for those events to trigger our unexpected errors alert. This adds a new github workflow which reminds us to do that. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

This [PR](https://github.com/stripe/stripe-android/pull/12198) adds a new unexpected error event and requires adding a label to merge.

This [PR](https://github.com/stripe/stripe-android/pull/12199) adds a new expected error event and doesn't require adding a label to merge.
