### PR TITLE
Use collected payment method from `Tap to Add` as a selection

### DIFF
--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -24,6 +24,7 @@
     <ID>LargeClass:DefaultFlowControllerTest.kt$DefaultFlowControllerTest</ID>
     <ID>LargeClass:DefaultPaymentElementLoaderTest.kt$DefaultPaymentElementLoaderTest</ID>
     <ID>LargeClass:ElementsSessionRepositoryTest.kt$ElementsSessionRepositoryTest</ID>
+    <ID>LargeClass:FormHelperTest.kt$FormHelperTest</ID>
     <ID>LargeClass:InputAddressViewModelTest.kt$InputAddressViewModelTest</ID>
     <ID>LargeClass:PaymentMethodMetadataTest.kt$PaymentMethodMetadataTest</ID>
     <ID>LargeClass:PaymentOptionsViewModelTest.kt$PaymentOptionsViewModelTest</ID>
@@ -59,7 +60,6 @@
     <ID>LongMethod:LinkInlineSignupConfirmationDefinitionTest.kt$LinkInlineSignupConfirmationDefinitionTest$@Test fun `'action' should return 'Launch' after successful sign-in &amp; attach`()</ID>
     <ID>LongMethod:LinkInlineSignupConfirmationDefinitionTest.kt$LinkInlineSignupConfirmationDefinitionTest$private fun testSuccessfulSignupWithNewCard( saveOption: LinkInlineSignupConfirmationOption.PaymentMethodSaveOption, expectedSetupForFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage?, expectedShouldSave: Boolean, )</ID>
     <ID>LongMethod:LinkInlineSignupConfirmationDefinitionTest.kt$LinkInlineSignupConfirmationDefinitionTest$private fun testSuccessfulSignupWithSavedLinkCard( saveOption: LinkInlineSignupConfirmationOption.PaymentMethodSaveOption, expectedSetupForFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage, verifyBillingDetails: Boolean = false, includePaymentMethod: Boolean = false, )</ID>
-    <ID>LongMethod:LinkInlineSignupFields.kt$@Composable internal fun LinkInlineSignupFields( sectionError: Int?, emailController: TextFieldController, phoneNumberController: PhoneNumberController, nameController: TextFieldController, signUpState: SignUpState, enabled: Boolean, isShowingPhoneFirst: Boolean, requiresNameCollection: Boolean, allowsDefaultOptIn: Boolean, errorMessage: String?, didShowAllFields: Boolean, onShowingAllFields: () -> Unit, modifier: Modifier = Modifier, emailFocusRequester: FocusRequester = remember { FocusRequester() }, phoneFocusRequester: FocusRequester = remember { FocusRequester() }, nameFocusRequester: FocusRequester = remember { FocusRequester() }, )</ID>
     <ID>LongMethod:PaymentDetails.kt$@Preview(showBackground = true) @Composable private fun PaymentDetailsListItemPreview()</ID>
     <ID>LongMethod:PaymentMethodVerticalLayoutInteractor.kt$DefaultPaymentMethodVerticalLayoutInteractor.Companion$fun create( viewModel: BaseSheetViewModel, paymentMethodMetadata: PaymentMethodMetadata, customerStateHolder: CustomerStateHolder, bankFormInteractor: BankFormInteractor, ): PaymentMethodVerticalLayoutInteractor</ID>
     <ID>LongMethod:PaymentSheetConfigurationKtx.kt$@OptIn(AppearanceAPIAdditionsPreview::class) internal fun PaymentSheet.Appearance.parseAppearance()</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddFormWrapperElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddFormWrapperElement.kt
@@ -17,6 +17,8 @@ import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.uicore.utils.collectAsState
 import com.stripe.android.uicore.utils.combineAsStateFlow
+import com.stripe.android.uicore.utils.flatMapLatestAsStateFlow
+import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.flow.StateFlow
 
 internal class TapToAddFormWrapperElement(
@@ -61,12 +63,18 @@ internal class TapToAddFormWrapperElement(
     }
 
     override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> {
-        return combineAsStateFlow(
-            elements.map {
-                it.getFormFieldValueFlow()
+        return tapToAddHelper.collectedPaymentMethod.flatMapLatestAsStateFlow { collectedPaymentMethod ->
+            if (collectedPaymentMethod != null) {
+                stateFlowOf(emptyList())
+            } else {
+                combineAsStateFlow(
+                    elements.map {
+                        it.getFormFieldValueFlow()
+                    }
+                ) {
+                    it.flatten()
+                }
             }
-        ) {
-            it.flatten()
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultFormHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultFormHelper.kt
@@ -26,6 +26,7 @@ import com.stripe.android.ui.core.elements.AutomaticallyLaunchedCardScanFormData
 import com.stripe.android.ui.core.elements.FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.FormElement
+import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -135,10 +136,12 @@ internal class DefaultFormHelper(
     private val paymentSelection: Flow<PaymentSelection?> = combine(
         lastFormValues,
         linkInlineHandler.linkInlineState,
-    ) { formValues, inlineSignupViewState ->
+        tapToAddHelper?.collectedPaymentMethod ?: stateFlowOf(null)
+    ) { formValues, inlineSignupViewState, collectedPaymentMethod ->
         formValues.first?.transformToPaymentSelection(
             paymentMethod = supportedPaymentMethodForCode(formValues.second),
             paymentMethodMetadata = paymentMethodMetadata,
+            collectedPaymentMethod = collectedPaymentMethod?.paymentMethod,
             inlineSignupViewState = inlineSignupViewState,
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -107,6 +107,7 @@ internal fun FormFieldValues.transformToExtraParams(
 internal fun FormFieldValues.transformToPaymentSelection(
     paymentMethod: SupportedPaymentMethod,
     paymentMethodMetadata: PaymentMethodMetadata,
+    collectedPaymentMethod: PaymentMethod? = null,
     inlineSignupViewState: InlineSignupViewState? = null,
 ): PaymentSelection? {
     val setupFutureUsage = userRequestedReuse.getSetupFutureUseValue(
@@ -122,6 +123,10 @@ internal fun FormFieldValues.transformToPaymentSelection(
             inlineSignupViewState.userInput == null
         ) {
             return null
+        }
+
+        if (collectedPaymentMethod != null) {
+            return PaymentSelection.Saved(collectedPaymentMethod)
         }
 
         PaymentSelection.New.Card(

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/FakeTapToAddHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/FakeTapToAddHelper.kt
@@ -25,8 +25,8 @@ internal class FakeTapToAddHelper private constructor(
         suspend fun test(
             block: suspend Scenario.() -> Unit,
         ) {
-            val helper = FakeTapToAddHelper()
             val collectedPaymentMethod = MutableStateFlow<DisplayableSavedPaymentMethod?>(null)
+            val helper = FakeTapToAddHelper(collectedPaymentMethod)
 
             block(
                 Scenario(

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddFormWrapperElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddFormWrapperElementTest.kt
@@ -3,11 +3,14 @@ package com.stripe.android.common.taptoadd
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.SimpleTextElement
 import com.stripe.android.uicore.elements.SimpleTextFieldConfig
 import com.stripe.android.uicore.elements.SimpleTextFieldController
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -26,7 +29,7 @@ class TapToAddFormWrapperElementTest {
     }
 
     @Test
-    fun `getFormFieldValueFlow combines all elements`() = runTest {
+    fun `getFormFieldValueFlow combines all elements when collectedPaymentMethod is null`() = runTest {
         val element = TapToAddFormWrapperElement(
             elements = listOf(
                 SectionElement.wrap(
@@ -58,6 +61,42 @@ class TapToAddFormWrapperElementTest {
             val identifiers = formFieldValues.map { it.first }
             assertThat(identifiers).contains(IdentifierSpec.Generic("card_number"))
             assertThat(identifiers).contains(IdentifierSpec.Generic("phone"))
+        }
+    }
+
+    @Test
+    fun `getFormFieldValueFlow returns empty list when collectedPaymentMethod is not null`() = runTest {
+        val collectedPaymentMethod = MutableStateFlow(
+            DisplayableSavedPaymentMethod.create(
+                displayName = "Visa •••• 4242".resolvableString,
+                paymentMethod = PaymentMethod(
+                    id = "pm_123",
+                    created = null,
+                    liveMode = false,
+                    type = PaymentMethod.Type.Card,
+                    code = PaymentMethod.Type.Card.code,
+                ),
+            )
+        )
+
+        val element = TapToAddFormWrapperElement(
+            elements = listOf(
+                SectionElement.wrap(
+                    sectionFieldElements = listOf(
+                        SimpleTextElement(
+                            identifier = IdentifierSpec.Generic("card_number"),
+                            controller = SimpleTextFieldController(
+                                textFieldConfig = SimpleTextFieldConfig(label = "Card".resolvableString),
+                            ),
+                        ),
+                    ),
+                )
+            ),
+            tapToAddHelper = FakeTapToAddHelper.noOp(collectedPaymentMethod = collectedPaymentMethod),
+        )
+
+        element.getFormFieldValueFlow().test {
+            assertThat(awaitItem()).isEmpty()
         }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodTest.kt
@@ -612,6 +612,29 @@ internal class AddPaymentMethodTest {
     }
 
     @Test
+    fun `transformToPaymentSelection returns Saved selection when collectedPaymentMethod is provided for card`() {
+        val collectedPaymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
+        val formFieldValues = FormFieldValues(
+            fieldValuePairs = mapOf(
+                IdentifierSpec.CardBrand to FormFieldEntry("visa", true),
+            ),
+            userRequestedReuse = PaymentSelection.CustomerRequestedSave.RequestNoReuse,
+        )
+
+        val paymentSelection = formFieldValues.transformToPaymentSelection(
+            paymentMethod = requireNotNull(metadata.supportedPaymentMethodForCode("card")),
+            paymentMethodMetadata = metadata,
+            collectedPaymentMethod = collectedPaymentMethod,
+        )
+
+        assertThat(paymentSelection).isInstanceOf<PaymentSelection.Saved>()
+
+        val savedSelection = paymentSelection as PaymentSelection.Saved
+
+        assertThat(savedSelection.paymentMethod).isEqualTo(collectedPaymentMethod)
+    }
+
+    @Test
     fun `transformToExtraParams returns correct params for SepaDebit with setAsDefault`() {
         val formFieldValues = FormFieldValues(
             fieldValuePairs = mapOf(


### PR DESCRIPTION
# Summary
Use collected payment method from the Tap to Add as a payment selection

# Motivation
Allows users to pay with collected payment method directly in the card form.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Video
https://github.com/user-attachments/assets/efc903c0-d2e0-432f-a0ac-af241a6e8fa2