### PR TITLE
Add `PaymentMethodMetadata` to `createSupportedPaymentMethod`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -152,9 +152,11 @@ internal data class PaymentMethodMetadata(
         code: String,
     ): SupportedPaymentMethod? {
         return if (isExternalPaymentMethod(code)) {
-            getUiDefinitionFactoryForExternalPaymentMethod(code)?.createSupportedPaymentMethod()
+            getUiDefinitionFactoryForExternalPaymentMethod(code)
+                ?.createSupportedPaymentMethod(metadata = this)
         } else if (isCustomPaymentMethod(code)) {
-            getUiDefinitionFactoryForCustomPaymentMethod(code)?.createSupportedPaymentMethod()
+            getUiDefinitionFactoryForCustomPaymentMethod(code)
+                ?.createSupportedPaymentMethod(metadata = this)
         } else {
             val definition = supportedPaymentMethodDefinitions().firstOrNull { it.type.code == code } ?: return null
             definition.uiDefinitionFactory().supportedPaymentMethod(this, definition, sharedDataSpecs)
@@ -263,11 +265,13 @@ internal data class PaymentMethodMetadata(
     ): FormHeaderInformation? {
         return if (isExternalPaymentMethod(code)) {
             getUiDefinitionFactoryForExternalPaymentMethod(code)?.createFormHeaderInformation(
+                metadata = this,
                 customerHasSavedPaymentMethods = customerHasSavedPaymentMethods,
                 incentive = null,
             )
         } else if (isCustomPaymentMethod(code)) {
             getUiDefinitionFactoryForCustomPaymentMethod(code)?.createFormHeaderInformation(
+                metadata = this,
                 customerHasSavedPaymentMethods = customerHasSavedPaymentMethods,
                 incentive = null,
             )

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionFactory.kt
@@ -155,13 +155,16 @@ internal sealed interface UiDefinitionFactory {
     }
 
     abstract class Simple : UiDefinitionFactory {
-        abstract fun createSupportedPaymentMethod(): SupportedPaymentMethod
+        abstract fun createSupportedPaymentMethod(
+            metadata: PaymentMethodMetadata,
+        ): SupportedPaymentMethod
 
         open fun createFormHeaderInformation(
+            metadata: PaymentMethodMetadata,
             customerHasSavedPaymentMethods: Boolean,
             incentive: PaymentMethodIncentive?,
         ): FormHeaderInformation {
-            return createSupportedPaymentMethod().asFormHeaderInformation(incentive)
+            return createSupportedPaymentMethod(metadata).asFormHeaderInformation(incentive)
         }
 
         fun createFormElements(metadata: PaymentMethodMetadata, arguments: Arguments): List<FormElement> {
@@ -213,7 +216,7 @@ internal sealed interface UiDefinitionFactory {
         sharedDataSpecs: List<SharedDataSpec>,
     ): SupportedPaymentMethod? = when (this) {
         is Simple -> {
-            createSupportedPaymentMethod()
+            createSupportedPaymentMethod(metadata)
         }
 
         is Custom -> {
@@ -238,6 +241,7 @@ internal sealed interface UiDefinitionFactory {
     ): FormHeaderInformation? = when (this) {
         is Simple -> {
             createFormHeaderInformation(
+                metadata = metadata,
                 customerHasSavedPaymentMethods = customerHasSavedPaymentMethods,
                 incentive = metadata.paymentMethodIncentive,
             )

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AffirmDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AffirmDefinition.kt
@@ -30,7 +30,7 @@ internal object AffirmDefinition : PaymentMethodDefinition {
 }
 
 private object AffirmUiDefinitionFactory : UiDefinitionFactory.Simple() {
-    override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
+    override fun createSupportedPaymentMethod(metadata: PaymentMethodMetadata) = SupportedPaymentMethod(
         code = PaymentMethod.Type.Affirm.code,
         lightThemeIconUrl = null,
         darkThemeIconUrl = null,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AlipayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AlipayDefinition.kt
@@ -25,7 +25,7 @@ internal object AlipayDefinition : PaymentMethodDefinition {
 }
 
 private object AlipayUiDefinitionFactory : UiDefinitionFactory.Simple() {
-    override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
+    override fun createSupportedPaymentMethod(metadata: PaymentMethodMetadata) = SupportedPaymentMethod(
         paymentMethodDefinition = AlipayDefinition,
         displayNameResource = R.string.stripe_paymentsheet_payment_method_alipay,
         iconResource = R.drawable.stripe_ic_paymentsheet_pm_alipay,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AlmaDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AlmaDefinition.kt
@@ -25,7 +25,7 @@ internal object AlmaDefinition : PaymentMethodDefinition {
 }
 
 private object AlmaUiDefinitionFactory : UiDefinitionFactory.Simple() {
-    override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
+    override fun createSupportedPaymentMethod(metadata: PaymentMethodMetadata) = SupportedPaymentMethod(
         paymentMethodDefinition = AlmaDefinition,
         displayNameResource = R.string.stripe_paymentsheet_payment_method_alma,
         iconResource = R.drawable.stripe_ic_paymentsheet_pm_alma_day,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AmazonPayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AmazonPayDefinition.kt
@@ -28,7 +28,7 @@ internal object AmazonPayDefinition : PaymentMethodDefinition {
 }
 
 private object AmazonPayUiDefinitionFactory : UiDefinitionFactory.Simple() {
-    override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
+    override fun createSupportedPaymentMethod(metadata: PaymentMethodMetadata) = SupportedPaymentMethod(
         code = PaymentMethod.Type.AmazonPay.code,
         lightThemeIconUrl = null,
         darkThemeIconUrl = null,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BancontactDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BancontactDefinition.kt
@@ -30,7 +30,7 @@ internal object BancontactDefinition : PaymentMethodDefinition {
 }
 
 private object BancontactUiDefinitionFactory : UiDefinitionFactory.Simple() {
-    override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
+    override fun createSupportedPaymentMethod(metadata: PaymentMethodMetadata) = SupportedPaymentMethod(
         paymentMethodDefinition = BancontactDefinition,
         displayNameResource = R.string.stripe_paymentsheet_payment_method_bancontact,
         iconResource = R.drawable.stripe_ic_paymentsheet_pm_bancontact,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BillieDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BillieDefinition.kt
@@ -25,7 +25,7 @@ internal object BillieDefinition : PaymentMethodDefinition {
 }
 
 private object BillieUiDefinitionFactory : UiDefinitionFactory.Simple() {
-    override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
+    override fun createSupportedPaymentMethod(metadata: PaymentMethodMetadata) = SupportedPaymentMethod(
         paymentMethodDefinition = BillieDefinition,
         displayNameResource = R.string.stripe_paymentsheet_payment_method_billie,
         iconResource = R.drawable.stripe_ic_paymentsheet_pm_billie_day,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BlikDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BlikDefinition.kt
@@ -28,7 +28,7 @@ internal object BlikDefinition : PaymentMethodDefinition {
 }
 
 private object BlikUiDefinitionFactory : UiDefinitionFactory.Simple() {
-    override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
+    override fun createSupportedPaymentMethod(metadata: PaymentMethodMetadata) = SupportedPaymentMethod(
         paymentMethodDefinition = BlikDefinition,
         displayNameResource = R.string.stripe_paymentsheet_payment_method_blik,
         iconResource = R.drawable.stripe_ic_paymentsheet_pm_blik,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BoletoDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BoletoDefinition.kt
@@ -35,7 +35,7 @@ internal object BoletoDefinition : PaymentMethodDefinition {
 }
 
 private object BoletoUiDefinitionFactory : UiDefinitionFactory.Simple() {
-    override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
+    override fun createSupportedPaymentMethod(metadata: PaymentMethodMetadata) = SupportedPaymentMethod(
         paymentMethodDefinition = BoletoDefinition,
         displayNameResource = R.string.stripe_paymentsheet_payment_method_boleto,
         iconResource = R.drawable.stripe_ic_paymentsheet_pm_boleto,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CashAppPayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CashAppPayDefinition.kt
@@ -28,7 +28,7 @@ internal object CashAppPayDefinition : PaymentMethodDefinition {
 }
 
 private object CashAppPayUiDefinitionFactory : UiDefinitionFactory.Simple() {
-    override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
+    override fun createSupportedPaymentMethod(metadata: PaymentMethodMetadata) = SupportedPaymentMethod(
         paymentMethodDefinition = CashAppPayDefinition,
         displayNameResource = R.string.stripe_paymentsheet_payment_method_cashapp,
         iconResource = R.drawable.stripe_ic_paymentsheet_pm_cash_app_pay,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CryptoDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CryptoDefinition.kt
@@ -25,7 +25,7 @@ internal object CryptoDefinition : PaymentMethodDefinition {
 }
 
 private object CryptoUiDefinitionFactory : UiDefinitionFactory.Simple() {
-    override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
+    override fun createSupportedPaymentMethod(metadata: PaymentMethodMetadata) = SupportedPaymentMethod(
         paymentMethodDefinition = CryptoDefinition,
         displayNameResource = R.string.stripe_paymentsheet_payment_method_crypto,
         iconResource = R.drawable.stripe_ic_paymentsheet_pm_crypto_day,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CustomPaymentMethodUiDefinitionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CustomPaymentMethodUiDefinitionFactory.kt
@@ -12,7 +12,7 @@ import com.stripe.android.uicore.elements.IdentifierSpec
 internal class CustomPaymentMethodUiDefinitionFactory(
     private val displayableCustomPaymentMethod: DisplayableCustomPaymentMethod
 ) : UiDefinitionFactory.Simple() {
-    override fun createSupportedPaymentMethod(): SupportedPaymentMethod {
+    override fun createSupportedPaymentMethod(metadata: PaymentMethodMetadata): SupportedPaymentMethod {
         return SupportedPaymentMethod(
             code = displayableCustomPaymentMethod.id,
             displayName = displayableCustomPaymentMethod.displayName.resolvableString,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/EpsDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/EpsDefinition.kt
@@ -36,7 +36,7 @@ internal object EpsDefinition : PaymentMethodDefinition {
 private object EpsUiDefinitionFactory : UiDefinitionFactory.Simple() {
     private val epsIdentifier = IdentifierSpec.Generic("eps[bank]")
 
-    override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
+    override fun createSupportedPaymentMethod(metadata: PaymentMethodMetadata) = SupportedPaymentMethod(
         paymentMethodDefinition = EpsDefinition,
         displayNameResource = R.string.stripe_paymentsheet_payment_method_eps,
         iconResource = R.drawable.stripe_ic_paymentsheet_pm_eps,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/ExternalPaymentMethodUiDefinitionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/ExternalPaymentMethodUiDefinitionFactory.kt
@@ -2,13 +2,14 @@ package com.stripe.android.lpmfoundations.paymentmethod.definitions
 
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.ui.core.elements.ExternalPaymentMethodSpec
 
 internal class ExternalPaymentMethodUiDefinitionFactory(
     private val externalPaymentMethodSpec: ExternalPaymentMethodSpec
 ) : UiDefinitionFactory.Simple() {
-    override fun createSupportedPaymentMethod(): SupportedPaymentMethod {
+    override fun createSupportedPaymentMethod(metadata: PaymentMethodMetadata): SupportedPaymentMethod {
         return SupportedPaymentMethod(
             code = externalPaymentMethodSpec.type,
             displayName = externalPaymentMethodSpec.label.resolvableString,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/FpxDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/FpxDefinition.kt
@@ -35,7 +35,7 @@ internal object FpxDefinition : PaymentMethodDefinition {
 private object FpxUiDefinitionFactory : UiDefinitionFactory.Simple() {
     private val fpsIdentifier = IdentifierSpec.Generic("fpx[bank]")
 
-    override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
+    override fun createSupportedPaymentMethod(metadata: PaymentMethodMetadata) = SupportedPaymentMethod(
         paymentMethodDefinition = FpxDefinition,
         displayNameResource = R.string.stripe_paymentsheet_payment_method_fpx,
         iconResource = R.drawable.stripe_ic_paymentsheet_pm_fpx,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/GrabPayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/GrabPayDefinition.kt
@@ -25,7 +25,7 @@ internal object GrabPayDefinition : PaymentMethodDefinition {
 }
 
 private object GrabPayUiDefinitionFactory : UiDefinitionFactory.Simple() {
-    override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
+    override fun createSupportedPaymentMethod(metadata: PaymentMethodMetadata) = SupportedPaymentMethod(
         paymentMethodDefinition = GrabPayDefinition,
         displayNameResource = R.string.stripe_paymentsheet_payment_method_grabpay,
         iconResource = R.drawable.stripe_ic_paymentsheet_pm_grabpay,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KlarnaDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KlarnaDefinition.kt
@@ -46,7 +46,7 @@ internal object KlarnaDefinition : PaymentMethodDefinition {
 }
 
 private object KlarnaUiDefinitionFactory : UiDefinitionFactory.Simple() {
-    override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
+    override fun createSupportedPaymentMethod(metadata: PaymentMethodMetadata) = SupportedPaymentMethod(
         paymentMethodDefinition = KlarnaDefinition,
         displayNameResource = R.string.stripe_paymentsheet_payment_method_klarna,
         iconResource = R.drawable.stripe_ic_paymentsheet_pm_klarna,
@@ -115,7 +115,7 @@ private object KlarnaUiDefinitionFactory : UiDefinitionFactory.Simple() {
 }
 
 private object KlarnaRemovedFormUiDefinitionFactory : UiDefinitionFactory.Simple() {
-    override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
+    override fun createSupportedPaymentMethod(metadata: PaymentMethodMetadata) = SupportedPaymentMethod(
         paymentMethodDefinition = KlarnaDefinition,
         displayNameResource = R.string.stripe_paymentsheet_payment_method_klarna,
         iconResource = R.drawable.stripe_ic_paymentsheet_pm_klarna,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KonbiniDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KonbiniDefinition.kt
@@ -36,7 +36,7 @@ internal object KonbiniDefinition : PaymentMethodDefinition {
 }
 
 private object KonbiniUiDefinitionFactory : UiDefinitionFactory.Simple() {
-    override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
+    override fun createSupportedPaymentMethod(metadata: PaymentMethodMetadata) = SupportedPaymentMethod(
         paymentMethodDefinition = KonbiniDefinition,
         displayNameResource = R.string.stripe_paymentsheet_payment_method_konbini,
         iconResource = R.drawable.stripe_ic_paymentsheet_pm_konbini,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/MobilePayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/MobilePayDefinition.kt
@@ -25,7 +25,7 @@ internal object MobilePayDefinition : PaymentMethodDefinition {
 }
 
 private object MobilePayUiDefinitionFactory : UiDefinitionFactory.Simple() {
-    override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
+    override fun createSupportedPaymentMethod(metadata: PaymentMethodMetadata) = SupportedPaymentMethod(
         paymentMethodDefinition = MobilePayDefinition,
         displayNameResource = R.string.stripe_paymentsheet_payment_method_mobile_pay,
         iconResource = R.drawable.stripe_ic_paymentsheet_pm_mobile_pay_day,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/MultibancoDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/MultibancoDefinition.kt
@@ -28,7 +28,7 @@ internal object MultibancoDefinition : PaymentMethodDefinition {
 }
 
 private object MultibancoUiDefinitionFactory : UiDefinitionFactory.Simple() {
-    override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
+    override fun createSupportedPaymentMethod(metadata: PaymentMethodMetadata) = SupportedPaymentMethod(
         paymentMethodDefinition = MultibancoDefinition,
         displayNameResource = R.string.stripe_paymentsheet_payment_method_multibanco,
         iconResource = R.drawable.stripe_ic_paymentsheet_pm_multibanco_day,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/P24Definition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/P24Definition.kt
@@ -36,7 +36,7 @@ internal object P24Definition : PaymentMethodDefinition {
 private object P24UiDefinitionFactory : UiDefinitionFactory.Simple() {
     private val p24BankIdentifier = IdentifierSpec.Generic("p24[bank]")
 
-    override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
+    override fun createSupportedPaymentMethod(metadata: PaymentMethodMetadata) = SupportedPaymentMethod(
         paymentMethodDefinition = P24Definition,
         displayNameResource = R.string.stripe_paymentsheet_payment_method_p24,
         iconResource = R.drawable.stripe_ic_paymentsheet_pm_p24,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/PayNowDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/PayNowDefinition.kt
@@ -24,7 +24,7 @@ internal object PayNowDefinition : PaymentMethodDefinition {
 }
 
 private object PayNowUiDefinitionFactory : UiDefinitionFactory.Simple() {
-    override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
+    override fun createSupportedPaymentMethod(metadata: PaymentMethodMetadata) = SupportedPaymentMethod(
         paymentMethodDefinition = PayNowDefinition,
         displayNameResource = R.string.stripe_paymentsheet_payment_method_paynow,
         iconResource = R.drawable.stripe_ic_paymentsheet_pm_paynow_day,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/PayPalDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/PayPalDefinition.kt
@@ -27,7 +27,7 @@ internal object PayPalDefinition : PaymentMethodDefinition {
 }
 
 private object PayPalUiDefinitionFactory : UiDefinitionFactory.Simple() {
-    override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
+    override fun createSupportedPaymentMethod(metadata: PaymentMethodMetadata) = SupportedPaymentMethod(
         paymentMethodDefinition = PayPalDefinition,
         displayNameResource = R.string.stripe_paymentsheet_payment_method_paypal,
         iconResource = R.drawable.stripe_ic_paymentsheet_pm_paypal_day,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/PayPayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/PayPayDefinition.kt
@@ -24,7 +24,7 @@ internal object PayPayDefinition : PaymentMethodDefinition {
 }
 
 private object PayPayUiDefinitionFactory : UiDefinitionFactory.Simple() {
-    override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
+    override fun createSupportedPaymentMethod(metadata: PaymentMethodMetadata) = SupportedPaymentMethod(
         paymentMethodDefinition = PayPayDefinition,
         displayNameResource = R.string.stripe_paymentsheet_payment_method_paypay,
         iconResource = R.drawable.stripe_ic_paymentsheet_pm_paypay,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/RevolutPayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/RevolutPayDefinition.kt
@@ -27,7 +27,7 @@ internal object RevolutPayDefinition : PaymentMethodDefinition {
 }
 
 private object RevolutPayUiDefinitionFactory : UiDefinitionFactory.Simple() {
-    override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
+    override fun createSupportedPaymentMethod(metadata: PaymentMethodMetadata) = SupportedPaymentMethod(
         paymentMethodDefinition = RevolutPayDefinition,
         displayNameResource = R.string.stripe_paymentsheet_payment_method_revolut_pay,
         iconResource = R.drawable.stripe_ic_paymentsheet_pm_revolut_pay_day,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SatispayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SatispayDefinition.kt
@@ -27,7 +27,7 @@ internal object SatispayDefinition : PaymentMethodDefinition {
 }
 
 private object SatispayUiDefinitionFactory : UiDefinitionFactory.Simple() {
-    override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
+    override fun createSupportedPaymentMethod(metadata: PaymentMethodMetadata) = SupportedPaymentMethod(
         paymentMethodDefinition = SatispayDefinition,
         displayNameResource = R.string.stripe_paymentsheet_payment_method_satispay,
         iconResource = R.drawable.stripe_ic_paymentsheet_pm_satispay_day,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SunbitDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SunbitDefinition.kt
@@ -25,7 +25,7 @@ internal object SunbitDefinition : PaymentMethodDefinition {
 }
 
 private object SunbitUiDefinitionFactory : UiDefinitionFactory.Simple() {
-    override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
+    override fun createSupportedPaymentMethod(metadata: PaymentMethodMetadata) = SupportedPaymentMethod(
         paymentMethodDefinition = SunbitDefinition,
         displayNameResource = R.string.stripe_paymentsheet_payment_method_sunbit,
         iconResource = R.drawable.stripe_ic_paymentsheet_pm_sunbit_day,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SwishDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SwishDefinition.kt
@@ -25,7 +25,7 @@ internal object SwishDefinition : PaymentMethodDefinition {
 }
 
 private object SwishUiDefinitionFactory : UiDefinitionFactory.Simple() {
-    override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
+    override fun createSupportedPaymentMethod(metadata: PaymentMethodMetadata) = SupportedPaymentMethod(
         paymentMethodDefinition = SwishDefinition,
         displayNameResource = R.string.stripe_paymentsheet_payment_method_swish,
         iconResource = R.drawable.stripe_ic_paymentsheet_pm_swish,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/TwintDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/TwintDefinition.kt
@@ -25,7 +25,7 @@ internal object TwintDefinition : PaymentMethodDefinition {
 }
 
 private object TwintUiDefinitionFactory : UiDefinitionFactory.Simple() {
-    override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
+    override fun createSupportedPaymentMethod(metadata: PaymentMethodMetadata) = SupportedPaymentMethod(
         paymentMethodDefinition = TwintDefinition,
         displayNameResource = R.string.stripe_paymentsheet_payment_method_twint,
         iconResource = R.drawable.stripe_ic_paymentsheet_pm_twint,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/UpiDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/UpiDefinition.kt
@@ -29,7 +29,7 @@ internal object UpiDefinition : PaymentMethodDefinition {
 }
 
 private object UpiUiDefinitionFactory : UiDefinitionFactory.Simple() {
-    override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
+    override fun createSupportedPaymentMethod(metadata: PaymentMethodMetadata) = SupportedPaymentMethod(
         paymentMethodDefinition = UpiDefinition,
         displayNameResource = R.string.stripe_paymentsheet_payment_method_upi,
         iconResource = R.drawable.stripe_ic_paymentsheet_pm_upi,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/WeChatPayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/WeChatPayDefinition.kt
@@ -25,7 +25,7 @@ internal object WeChatPayDefinition : PaymentMethodDefinition {
 }
 
 private object WeChatPayUiDefinitionFactory : UiDefinitionFactory.Simple() {
-    override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
+    override fun createSupportedPaymentMethod(metadata: PaymentMethodMetadata) = SupportedPaymentMethod(
         paymentMethodDefinition = WeChatPayDefinition,
         displayNameResource = R.string.stripe_paymentsheet_payment_method_wechat,
         iconResource = R.drawable.stripe_ic_paymentsheet_pm_wechat_pay,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/ZipDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/ZipDefinition.kt
@@ -25,7 +25,7 @@ internal object ZipDefinition : PaymentMethodDefinition {
 }
 
 private object ZipUiDefinitionFactory : UiDefinitionFactory.Simple() {
-    override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
+    override fun createSupportedPaymentMethod(metadata: PaymentMethodMetadata) = SupportedPaymentMethod(
         paymentMethodDefinition = ZipDefinition,
         displayNameResource = R.string.stripe_paymentsheet_payment_method_zip,
         iconResource = R.drawable.stripe_ic_paymentsheet_pm_zip,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentMethodsUIScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentMethodsUIScreenshotTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.ui
 
 import androidx.compose.foundation.lazy.LazyListState
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.ExternalPaymentMethodUiDefinitionFactory
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.screenshottesting.FontSize
@@ -99,7 +100,7 @@ class PaymentMethodsUIScreenshotTest {
         val paymentMethods = listOf(
             ExternalPaymentMethodUiDefinitionFactory(
                 PaymentMethodFixtures.PAYPAL_EXTERNAL_PAYMENT_METHOD_SPEC
-            ).createSupportedPaymentMethod()
+            ).createSupportedPaymentMethod(PaymentMethodMetadataFactory.create())
         ).plus(paymentMethods)
         paparazziRule.snapshot {
             NewPaymentMethodTabLayoutUI(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/NewPaymentMethodVerticalLayoutUIScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/NewPaymentMethodVerticalLayoutUIScreenshotTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.verticalmode
 
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.ExternalPaymentMethodUiDefinitionFactory
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.screenshottesting.PaparazziRule
@@ -79,7 +80,7 @@ internal class NewPaymentMethodVerticalLayoutUIScreenshotTest {
         val paymentMethods = listOf(
             ExternalPaymentMethodUiDefinitionFactory(
                 PaymentMethodFixtures.PAYPAL_EXTERNAL_PAYMENT_METHOD_SPEC
-            ).createSupportedPaymentMethod().asDisplayablePaymentMethod(
+            ).createSupportedPaymentMethod(PaymentMethodMetadataFactory.create()).asDisplayablePaymentMethod(
                 customerSavedPaymentMethods = emptyList(),
                 incentive = null,
                 onClick = {},


### PR DESCRIPTION
# Summary
Add `PaymentMethodMetadata` to `createSupportedPaymentMethod`

# Motivation
Needed for `AfterpayClearpay` which uses metadata information to initialized its `SupportedPaymentMethod` instance.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified