### PR TITLE
[Identity] Change Identity consumer proguard rules to fix over optimization 

### DIFF
--- a/identity/consumer-rules.txt
+++ b/identity/consumer-rules.txt
@@ -1,0 +1,2 @@
+# Consumer Proguard/R8 rules for Stripe ML core (default / LiteRT)
+-keep class org.tensorflow.lite.** { *; }


### PR DESCRIPTION
This fixes a problem with consumers of Identity using AGP 8.13+ where the scanning of identity documents does not work at all due to R8 becoming more aggressive and optimizing out TFLite in this version.

## Testing 

1. Use the `theme1Release` to build and run the identity example, using the latest AGP 
2. Verify that live scanning is working in the identity example application.