### PR TITLE
Add analytics for card funding in mpe configuration

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
@@ -31,7 +31,7 @@ internal data class CommonConfiguration(
     val paymentMethodOrder: List<String>,
     val externalPaymentMethods: List<String>,
     val cardBrandAcceptance: PaymentSheet.CardBrandAcceptance,
-    private val allowedCardFundingTypes: List<PaymentSheet.CardFundingType>,
+    internal val allowedCardFundingTypes: List<PaymentSheet.CardFundingType>,
     val customPaymentMethods: List<PaymentSheet.CustomPaymentMethod>,
     val shopPayConfiguration: PaymentSheet.ShopPayConfiguration?,
     val googlePlacesApiKey: String?,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/DefaultAnalyticsMetadataFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/DefaultAnalyticsMetadataFactory.kt
@@ -177,6 +177,7 @@ internal class DefaultAnalyticsMetadataFactory @Inject constructor(
         put("billing_details_collection_configuration", Nested(billingDetailsCollectionConfiguration.analyticsMap()))
 
         put("appearance", Nested(appearance.analyticsMap()))
+        put("card_funding_acceptance", SimpleBoolean(allowedCardFundingTypes.toAnalyticsValue()))
     }
 
     private fun PaymentSheet.BillingDetailsCollectionConfiguration.analyticsMap() =
@@ -314,6 +315,10 @@ private fun CommonConfiguration.getExternalPaymentMethodsAnalyticsValue(): List<
 
 private fun PaymentSheet.CardBrandAcceptance.toAnalyticsValue(): Boolean {
     return this !is PaymentSheet.CardBrandAcceptance.All
+}
+
+private fun List<PaymentSheet.CardFundingType>.toAnalyticsValue(): Boolean {
+    return this.toSet() != PaymentSheet.CardFundingType.entries.toSet()
 }
 
 private fun PaymentSheet.PaymentMethodLayout.toAnalyticsValue(): String {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add analytics for card funding in mpe configuration

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

To track how many merchants adopt card funding by specifying funding types in their configuration.

https://docs.google.com/document/d/1eihnXys1Cx3WpSwb5xnj24ysi8_oak2aDR1Zr8eOgrI/edit?tab=t.0#heading=h.e0xfe5cqe659

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
