### PR TITLE
Add InitializationMode.CheckoutSession for checkout session support

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/ClientAttributionMetadataKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/ClientAttributionMetadataKtx.kt
@@ -11,6 +11,9 @@ internal fun ClientAttributionMetadata.Companion.create(
     automaticPaymentMethodsEnabled: Boolean,
 ): ClientAttributionMetadata {
     val paymentIntentCreationFlow = when (initializationMode) {
+        is PaymentElementLoader.InitializationMode.CheckoutSession -> {
+            TODO("CheckoutSession attribution not yet supported.")
+        }
         is PaymentElementLoader.InitializationMode.CryptoOnramp,
         is PaymentElementLoader.InitializationMode.DeferredIntent -> PaymentIntentCreationFlow.Deferred
         is PaymentElementLoader.InitializationMode.PaymentIntent,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/IntegrationMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/IntegrationMetadata.kt
@@ -39,4 +39,7 @@ internal sealed class IntegrationMetadata : Parcelable {
 
     @Parcelize
     object CryptoOnramp : IntegrationMetadata()
+
+    @Parcelize
+    data class CheckoutSession(val id: String) : IntegrationMetadata()
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptor.kt
@@ -93,6 +93,9 @@ internal class DefaultIntentConfirmationInterceptorFactory @Inject constructor(
                     clientAttributionMetadata = clientAttributionMetadata,
                 )
             }
+            is IntegrationMetadata.CheckoutSession -> {
+                TODO("CheckoutSession confirmation not yet supported.")
+            }
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
@@ -222,6 +222,10 @@ internal fun PaymentElementLoader.InitializationMode.toElementsSessionParams(
                 link = linkParams,
             )
         }
+
+        is PaymentElementLoader.InitializationMode.CheckoutSession -> {
+            TODO("CheckoutSession elements session not yet supported.")
+        }
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/DefaultAnalyticsMetadataFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/DefaultAnalyticsMetadataFactory.kt
@@ -242,6 +242,7 @@ internal class DefaultAnalyticsMetadataFactory @Inject constructor(
 private val PaymentElementLoader.InitializationMode.defaultAnalyticsValue: String
     get() = when (this) {
         is PaymentElementLoader.InitializationMode.CryptoOnramp -> "crypto_onramp"
+        is PaymentElementLoader.InitializationMode.CheckoutSession -> "checkout_session"
         is PaymentElementLoader.InitializationMode.DeferredIntent -> {
             when (this.intentConfiguration.mode) {
                 is PaymentSheet.IntentConfiguration.Mode.Payment -> "deferred_payment_intent"
@@ -259,6 +260,7 @@ private fun IntegrationMetadata.isDeferred(): Boolean = when (this) {
     is IntegrationMetadata.DeferredIntentWithConfirmationToken -> true
     is IntegrationMetadata.DeferredIntentWithPaymentMethod -> true
     is IntegrationMetadata.DeferredIntentWithSharedPaymentToken -> true
+    is IntegrationMetadata.CheckoutSession -> false
 }
 
 private fun IntegrationMetadata.isSpt(): Boolean {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -177,6 +177,23 @@ internal interface PaymentElementLoader {
                 return IntegrationMetadata.CryptoOnramp
             }
         }
+
+        @Parcelize
+        data class CheckoutSession(
+            val id: String,
+        ) : InitializationMode() {
+            override fun validate() {
+                if (!id.startsWith("cs_")) {
+                    throw IllegalArgumentException(
+                        "Must use a checkout session id."
+                    )
+                }
+            }
+
+            override fun integrationMetadata(paymentElementCallbacks: PaymentElementCallbacks?): IntegrationMetadata {
+                return IntegrationMetadata.CheckoutSession(id)
+            }
+        }
     }
 
     @Parcelize

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -1628,6 +1628,29 @@ internal class DefaultPaymentElementLoaderTest {
     }
 
     @Test
+    fun `Returns failure if configuring checkout session with invalid id prefix`() = runScenario {
+        assertFailsWith<IllegalArgumentException>("Must use a checkout session id.") {
+            PaymentElementLoader.InitializationMode.CheckoutSession(
+                id = "pi_test_123",
+            ).validate()
+        }
+    }
+
+    @Test
+    fun `CheckoutSession validate succeeds with valid id`() = runScenario {
+        PaymentElementLoader.InitializationMode.CheckoutSession(
+            id = "cs_test_123",
+        ).validate()
+    }
+
+    @Test
+    fun `integrationMetadata returns checkout session for checkout session mode`() = runScenario {
+        val checkoutSession = PaymentElementLoader.InitializationMode.CheckoutSession("cs_test_123")
+        assertThat(checkoutSession.integrationMetadata(null))
+            .isEqualTo(IntegrationMetadata.CheckoutSession("cs_test_123"))
+    }
+
+    @Test
     fun `integrationMetadata returns intent first for payment intent`() = runScenario {
         val paymentIntent = PaymentElementLoader.InitializationMode.PaymentIntent("secret")
         assertThat(paymentIntent.integrationMetadata(null))


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Adds `InitializationMode.CheckoutSession` to support the upcoming `presentWithCheckoutSession()` API

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
This PR adds the foundational initialization mode needed to support checkout sessions in PaymentSheet. Another PR is implementing the public API that depends on this mode.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
