### PR TITLE
support cards with more than one funding type in pan field

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsTextFieldConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsTextFieldConfig.kt
@@ -22,7 +22,7 @@ interface CardDetailsTextFieldConfig {
     fun determineVisualTransformation(number: String, panLength: Int): VisualTransformation
     fun determineState(
         brand: CardBrand,
-        funding: CardFunding?,
+        fundingTypes: List<CardFunding>,
         number: String,
         numberAllowedDigits: Int
     ): TextFieldState

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberConfig.kt
@@ -42,7 +42,7 @@ internal class CardNumberConfig(
 
     override fun determineState(
         brand: CardBrand,
-        funding: CardFunding?,
+        fundingTypes: List<CardFunding>,
         number: String,
         numberAllowedDigits: Int
     ): TextFieldState {
@@ -63,7 +63,7 @@ internal class CardNumberConfig(
         }
 
         val isDigitLimit = brand.getMaxLengthForCardNumber(number) != -1
-        val fundingErrorMessageId = getFundingErrorMessage(funding, number)
+        val fundingErrorMessageId = getFundingErrorMessage(fundingTypes, number)
 
         return when {
             isDigitLimit && number.length < numberAllowedDigits -> {
@@ -127,11 +127,13 @@ internal class CardNumberConfig(
     }
 
     private fun getFundingErrorMessage(
-        funding: CardFunding?,
+        fundingTypes: List<CardFunding>,
         number: String,
     ): Int? {
-        val cardFundingAccepted = funding?.let(cardFundingFilter::isAccepted)
-        val hasError = number.length >= digitsRequiredToFetchFunding && cardFundingAccepted == false
+        val anyFundingAccepted = fundingTypes.any { cardFundingFilter.isAccepted(it) }
+        val hasError = number.length >= digitsRequiredToFetchFunding &&
+            fundingTypes.isNotEmpty() &&
+            !anyFundingAccepted
         return cardFundingFilter.allowedFundingTypesDisplayMessage()?.takeIf { hasError }
     }
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
@@ -215,7 +215,7 @@ internal class DefaultCardNumberController(
     ) { brand, fieldValue, accountRanges ->
         textFieldState(
             brand = brand,
-            funding = accountRanges.ranges.firstOrNull()?.funding,
+            fundingTypes = accountRanges.ranges.map { it.funding },
             number = fieldValue
         )
     }.stateIn(
@@ -392,12 +392,12 @@ internal class DefaultCardNumberController(
 
     private fun textFieldState(
         brand: CardBrand = impliedCardBrand.value,
-        funding: CardFunding? = null,
+        fundingTypes: List<CardFunding> = emptyList(),
         number: String = _fieldValue.value
     ): TextFieldState {
         return cardTextFieldConfig.determineState(
             brand,
-            funding,
+            fundingTypes,
             number,
             numberAllowedDigits = accountRangeService.accountRange?.panLength
                 ?: brand.getMaxLengthForCardNumber(number)

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcConfig.kt
@@ -25,7 +25,7 @@ class CvcConfig : CvcTextFieldConfig {
 
     override fun determineState(
         brand: CardBrand,
-        funding: CardFunding?,
+        fundingTypes: List<CardFunding>,
         number: String,
         numberAllowedDigits: Int
     ): TextFieldState {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcController.kt
@@ -70,7 +70,7 @@ class CvcController constructor(
     private val _fieldState = combineAsStateFlow(cardBrandFlow, _fieldValue) { brand, fieldValue ->
         cvcTextFieldConfig.determineState(
             brand = brand,
-            funding = null,
+            fundingTypes = emptyList(),
             number = fieldValue,
             numberAllowedDigits = brand.maxCvcLength
         )

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsControllerTest.kt
@@ -287,7 +287,7 @@ class CardDetailsControllerTest {
     ) : CardNumberTextFieldConfig by defaultCardNumberTextFieldConfig {
         override fun determineState(
             brand: CardBrand,
-            funding: CardFunding?,
+            fundingTypes: List<CardFunding>,
             number: String,
             numberAllowedDigits: Int
         ): TextFieldState {
@@ -301,7 +301,7 @@ class CardDetailsControllerTest {
     ) : CvcTextFieldConfig by defaultCvcTextFieldConfig {
         override fun determineState(
             brand: CardBrand,
-            funding: CardFunding?,
+            fundingTypes: List<CardFunding>,
             number: String,
             numberAllowedDigits: Int
         ): TextFieldState {

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberConfigTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberConfigTest.kt
@@ -98,7 +98,7 @@ class CardNumberConfigTest {
             assertThat(
                 cardNumberConfig.determineState(
                     brand = CardBrand.Visa,
-                    funding = null,
+                    fundingTypes = emptyList(),
                     number = "",
                     numberAllowedDigits = CardBrand.Visa.getMaxLengthForCardNumber("")
                 )
@@ -116,7 +116,7 @@ class CardNumberConfigTest {
             )
             val state = cardNumberConfig.determineState(
                 brand = CardBrand.Unknown,
-                funding = null,
+                fundingTypes = emptyList(),
                 number = "0",
                 numberAllowedDigits = CardBrand.Unknown.getMaxLengthForCardNumber("0")
             )
@@ -137,7 +137,7 @@ class CardNumberConfigTest {
             )
             val state = cardNumberConfig.determineState(
                 brand = CardBrand.Visa,
-                funding = null,
+                fundingTypes = emptyList(),
                 number = "12",
                 numberAllowedDigits = CardBrand.Visa.getMaxLengthForCardNumber("12")
             )
@@ -158,7 +158,7 @@ class CardNumberConfigTest {
             )
             val state = cardNumberConfig.determineState(
                 brand = CardBrand.Visa,
-                funding = null,
+                fundingTypes = emptyList(),
                 number = "1234567890123456789",
                 numberAllowedDigits = CardBrand.Visa.getMaxLengthForCardNumber("1234567890123456789")
             )
@@ -179,7 +179,7 @@ class CardNumberConfigTest {
             )
             val state = cardNumberConfig.determineState(
                 brand = CardBrand.Visa,
-                funding = null,
+                fundingTypes = emptyList(),
                 number = "4242424242424243",
                 numberAllowedDigits = CardBrand.Visa.getMaxLengthForCardNumber("4242424242424243")
             )
@@ -200,7 +200,7 @@ class CardNumberConfigTest {
             )
             val state = cardNumberConfig.determineState(
                 brand = CardBrand.Visa,
-                funding = null,
+                fundingTypes = emptyList(),
                 number = "4242424242424242",
                 numberAllowedDigits = CardBrand.Visa.getMaxLengthForCardNumber("4242424242424242")
             )
@@ -219,7 +219,7 @@ class CardNumberConfigTest {
 
         val state = cardNumberConfig.determineState(
             brand = CardBrand.Visa,
-            funding = null,
+            fundingTypes = emptyList(),
             number = "4242424242424242",
             numberAllowedDigits = CardBrand.Visa.getMaxLengthForCardNumber("4242424242424242")
         )
@@ -237,7 +237,7 @@ class CardNumberConfigTest {
 
         val state = cardNumberConfig.determineState(
             brand = CardBrand.MasterCard,
-            funding = null,
+            fundingTypes = emptyList(),
             number = "5555555555554444",
             numberAllowedDigits = CardBrand.MasterCard.getMaxLengthForCardNumber("5555555555554444")
         )
@@ -257,7 +257,7 @@ class CardNumberConfigTest {
 
         val state = cardNumberConfig.determineState(
             brand = CardBrand.MasterCard,
-            funding = null,
+            fundingTypes = emptyList(),
             number = "55555555", // Length is 8
             numberAllowedDigits = CardBrand.MasterCard.getMaxLengthForCardNumber("55555555")
         )
@@ -276,7 +276,7 @@ class CardNumberConfigTest {
 
         val state = cardNumberConfig.determineState(
             brand = CardBrand.MasterCard,
-            funding = null,
+            fundingTypes = emptyList(),
             number = "5555555555554444", // Length is greater than 8
             numberAllowedDigits = CardBrand.MasterCard.getMaxLengthForCardNumber("5555555555554444")
         )
@@ -297,7 +297,7 @@ class CardNumberConfigTest {
 
         val state = cardNumberConfig.determineState(
             brand = CardBrand.Visa,
-            funding = null,
+            fundingTypes = emptyList(),
             number = "4242424242424242",
             numberAllowedDigits = CardBrand.Visa.getMaxLengthForCardNumber("4242424242424242")
         )
@@ -320,7 +320,7 @@ class CardNumberConfigTest {
         // 5 digits, with debit funding (which is disallowed)
         val state = cardNumberConfig.determineState(
             brand = CardBrand.Visa,
-            funding = CardFunding.Debit,
+            fundingTypes = listOf(CardFunding.Debit),
             number = "42424",
             numberAllowedDigits = CardBrand.Visa.getMaxLengthForCardNumber("42424")
         )
@@ -346,7 +346,7 @@ class CardNumberConfigTest {
         // 10 digits (incomplete), with debit funding (which is disallowed)
         val state = cardNumberConfig.determineState(
             brand = CardBrand.Visa,
-            funding = CardFunding.Debit,
+            fundingTypes = listOf(CardFunding.Debit),
             number = "4242424242",
             numberAllowedDigits = CardBrand.Visa.getMaxLengthForCardNumber("4242424242")
         )
@@ -373,7 +373,7 @@ class CardNumberConfigTest {
         // Complete valid card with debit funding (which is disallowed)
         val state = cardNumberConfig.determineState(
             brand = CardBrand.Visa,
-            funding = CardFunding.Debit,
+            fundingTypes = listOf(CardFunding.Debit),
             number = "4242424242424242",
             numberAllowedDigits = CardBrand.Visa.getMaxLengthForCardNumber("4242424242424242")
         )
@@ -399,7 +399,7 @@ class CardNumberConfigTest {
         // Complete valid card with credit funding (which is allowed)
         val state = cardNumberConfig.determineState(
             brand = CardBrand.Visa,
-            funding = CardFunding.Credit,
+            fundingTypes = listOf(CardFunding.Credit),
             number = "4242424242424242",
             numberAllowedDigits = CardBrand.Visa.getMaxLengthForCardNumber("4242424242424242")
         )
@@ -410,7 +410,7 @@ class CardNumberConfigTest {
     }
 
     @Test
-    fun `determineState returns valid when funding is null`() {
+    fun `determineState returns valid when funding list is empty`() {
         val cardFundingFilter = FakeCardFundingFilter(
             disallowedFundingTypes = setOf(CardFunding.Debit),
             messageResId = StripeR.string.stripe_card_funding_only_credit
@@ -421,15 +421,40 @@ class CardNumberConfigTest {
             cardFundingFilter
         )
 
-        // Complete valid card with null funding (funding not yet determined)
+        // Complete valid card with empty funding list (funding not yet determined)
         val state = cardNumberConfig.determineState(
             brand = CardBrand.Visa,
-            funding = null,
+            fundingTypes = emptyList(),
             number = "4242424242424242",
             numberAllowedDigits = CardBrand.Visa.getMaxLengthForCardNumber("4242424242424242")
         )
 
         // Should show valid state without warning
+        assertThat(state).isInstanceOf<TextFieldStateConstants.Valid.Full>()
+        assertThat(state.getValidationMessage()).isNull()
+    }
+
+    @Test
+    fun `determineState returns valid without warning when any funding type is accepted`() {
+        val cardFundingFilter = FakeCardFundingFilter(
+            disallowedFundingTypes = setOf(CardFunding.Debit),
+            messageResId = StripeR.string.stripe_card_funding_only_credit
+        )
+        val cardNumberConfig = CardNumberConfig(
+            false,
+            DefaultCardBrandFilter,
+            cardFundingFilter
+        )
+
+        // Complete valid card with both debit (disallowed) and credit (allowed) funding
+        val state = cardNumberConfig.determineState(
+            brand = CardBrand.Visa,
+            fundingTypes = listOf(CardFunding.Debit, CardFunding.Credit),
+            number = "4242424242424242",
+            numberAllowedDigits = CardBrand.Visa.getMaxLengthForCardNumber("4242424242424242")
+        )
+
+        // Should show valid state without warning because credit is accepted
         assertThat(state).isInstanceOf<TextFieldStateConstants.Valid.Full>()
         assertThat(state.getValidationMessage()).isNull()
     }
@@ -449,7 +474,7 @@ class CardNumberConfigTest {
         // Complete valid card with debit funding (which is disallowed but has no message)
         val state = cardNumberConfig.determineState(
             brand = CardBrand.Visa,
-            funding = CardFunding.Debit,
+            fundingTypes = listOf(CardFunding.Debit),
             number = "4242424242424242",
             numberAllowedDigits = CardBrand.Visa.getMaxLengthForCardNumber("4242424242424242")
         )

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CvcConfigTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CvcConfigTest.kt
@@ -21,7 +21,7 @@ class CvcConfigTest {
         Truth.assertThat(
             cvcConfig.determineState(
                 brand = CardBrand.Visa,
-                funding = null,
+                fundingTypes = emptyList(),
                 number = "",
                 numberAllowedDigits = CardBrand.Visa.maxCvcLength
             )
@@ -33,7 +33,7 @@ class CvcConfigTest {
     fun `card brand is invalid`() {
         val state = cvcConfig.determineState(
             brand = CardBrand.Unknown,
-            funding = null,
+            fundingTypes = emptyList(),
             number = "0",
             numberAllowedDigits = CardBrand.Unknown.maxCvcLength
         )
@@ -45,7 +45,7 @@ class CvcConfigTest {
     fun `incomplete number is in incomplete state`() {
         val state = cvcConfig.determineState(
             brand = CardBrand.Visa,
-            funding = null,
+            fundingTypes = emptyList(),
             number = "12",
             numberAllowedDigits = CardBrand.Visa.maxCvcLength
         )
@@ -60,7 +60,7 @@ class CvcConfigTest {
     fun `cvc is too long`() {
         val state = cvcConfig.determineState(
             brand = CardBrand.Visa,
-            funding = null,
+            fundingTypes = emptyList(),
             number = "1234567890123456789",
             numberAllowedDigits = CardBrand.Visa.maxCvcLength
         )
@@ -75,7 +75,7 @@ class CvcConfigTest {
     fun `cvc is valid`() {
         var state = cvcConfig.determineState(
             brand = CardBrand.Visa,
-            funding = null,
+            fundingTypes = emptyList(),
             number = "123",
             numberAllowedDigits = CardBrand.Visa.maxCvcLength
         )
@@ -84,7 +84,7 @@ class CvcConfigTest {
 
         state = cvcConfig.determineState(
             brand = CardBrand.AmericanExpress,
-            funding = null,
+            fundingTypes = emptyList(),
             number = "1234",
             numberAllowedDigits = CardBrand.AmericanExpress.maxCvcLength
         )
@@ -96,7 +96,7 @@ class CvcConfigTest {
     fun `cvc is valid for lengths 3 and 4 for amex`() {
         var state = cvcConfig.determineState(
             brand = CardBrand.AmericanExpress,
-            funding = null,
+            fundingTypes = emptyList(),
             number = "123",
             numberAllowedDigits = CardBrand.AmericanExpress.maxCvcLength
         )
@@ -105,7 +105,7 @@ class CvcConfigTest {
 
         state = cvcConfig.determineState(
             brand = CardBrand.AmericanExpress,
-            funding = null,
+            fundingTypes = emptyList(),
             number = "1234",
             numberAllowedDigits = CardBrand.AmericanExpress.maxCvcLength
         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/CvcState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/cvcrecollection/CvcState.kt
@@ -15,7 +15,7 @@ internal data class CvcState(
 
     val isValid: Boolean = cvcTextFieldConfig.determineState(
         brand = cardBrand,
-        funding = null,
+        fundingTypes = emptyList(),
         number = cvc,
         numberAllowedDigits = cardBrand.maxCvcLength
     ).isValid()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Some cards are dual funded and can have multiple possible funding types, to handle this we block the card if **all** of the funding types are blocked.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://stripe.slack.com/archives/C0A0CDA2EGY/p1768581283235529?thread_ts=1768580119.771969&cid=C0A0CDA2EGY

**No test cards have dual funding types sadly**

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
