### PR TITLE
Fix account name issue in IBP tests

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -1608,7 +1608,7 @@ internal class PlaygroundTestDriver(
         clickButton("Agree and continue")
         clickButtonWithTag("existing_email-button")
         clickButton("Use test code")
-        clickButton("Checking")
+        clickButton("Success")
         clickButton("Connect account")
         clickButtonWithTag("done_button")
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes issues with IBP tests now that the account name is `Success` and not `Checking`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

CI.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
