### PR TITLE
Move `isAccepted` with PM into interface & use `CardBrandFilter` interface in `PaymentMethodFilter`

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/CardBrandFilter.kt
+++ b/payments-core/src/main/java/com/stripe/android/CardBrandFilter.kt
@@ -3,17 +3,23 @@ package com.stripe.android
 import android.os.Parcelable
 import androidx.annotation.RestrictTo
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.PaymentMethod
 import kotlinx.parcelize.Parcelize
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 interface CardBrandFilter : Parcelable {
     fun isAccepted(cardBrand: CardBrand): Boolean
+    fun isAccepted(paymentMethod: PaymentMethod): Boolean
 }
 
 @Parcelize
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 object DefaultCardBrandFilter : CardBrandFilter {
     override fun isAccepted(cardBrand: CardBrand): Boolean {
+        return true
+    }
+
+    override fun isAccepted(paymentMethod: PaymentMethod): Boolean {
         return true
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/GooglePayJsonFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/GooglePayJsonFactoryTest.kt
@@ -6,6 +6,7 @@ import com.stripe.android.core.model.StripeJsonUtils
 import com.stripe.android.core.version.StripeSdkVersion
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.CardFunding
+import com.stripe.android.model.PaymentMethod
 import kotlinx.parcelize.Parcelize
 import org.json.JSONObject
 import org.junit.runner.RunWith
@@ -398,6 +399,10 @@ class GooglePayJsonFactoryTest {
                 return cardBrand == CardBrand.Visa || cardBrand == CardBrand.MasterCard
             }
 
+            override fun isAccepted(paymentMethod: PaymentMethod): Boolean {
+                throw IllegalStateException("Should not be called!")
+            }
+
             override fun describeContents(): Int {
                 throw IllegalStateException("describeContents should not be called.")
             }
@@ -435,6 +440,10 @@ class GooglePayJsonFactoryTest {
                 return false
             }
 
+            override fun isAccepted(paymentMethod: PaymentMethod): Boolean {
+                throw IllegalStateException("Should not be called!")
+            }
+
             override fun describeContents(): Int {
                 throw IllegalStateException("describeContents should not be called.")
             }
@@ -470,6 +479,10 @@ class GooglePayJsonFactoryTest {
         val customCardBrandFilter = object : CardBrandFilter {
             override fun isAccepted(cardBrand: CardBrand): Boolean {
                 return true
+            }
+
+            override fun isAccepted(paymentMethod: PaymentMethod): Boolean {
+                throw IllegalStateException("Should not be called!")
             }
 
             override fun describeContents(): Int {
@@ -532,6 +545,10 @@ class GooglePayJsonFactoryTest {
                 return true
             }
 
+            override fun isAccepted(paymentMethod: PaymentMethod): Boolean {
+                throw IllegalStateException("Should not be called!")
+            }
+
             override fun describeContents(): Int {
                 throw IllegalStateException("describeContents should not be called.")
             }
@@ -570,6 +587,10 @@ class GooglePayJsonFactoryTest {
                 return cardBrand != CardBrand.JCB
             }
 
+            override fun isAccepted(paymentMethod: PaymentMethod): Boolean {
+                throw IllegalStateException("Should not be called!")
+            }
+
             override fun describeContents(): Int {
                 throw IllegalStateException("describeContents should not be called.")
             }
@@ -606,6 +627,10 @@ class GooglePayJsonFactoryTest {
         val customCardBrandFilter = object : CardBrandFilter {
             override fun isAccepted(cardBrand: CardBrand): Boolean {
                 return cardBrand == CardBrand.Visa || cardBrand == CardBrand.MasterCard
+            }
+
+            override fun isAccepted(paymentMethod: PaymentMethod): Boolean {
+                throw IllegalStateException("Should not be called!")
             }
 
             override fun describeContents(): Int {

--- a/payments-core/src/test/java/com/stripe/android/cards/CardAccountRangeServiceTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/cards/CardAccountRangeServiceTest.kt
@@ -22,6 +22,7 @@ import com.stripe.android.model.AccountRange
 import com.stripe.android.model.BinRange
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.CardFunding
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.networking.RequestSurface
 import com.stripe.android.networking.StripeApiRepository
@@ -421,6 +422,10 @@ private class FakeCardBrandFilter(
 ) : CardBrandFilter {
     override fun isAccepted(cardBrand: CardBrand): Boolean {
         return !disallowedBrands.contains(cardBrand)
+    }
+
+    override fun isAccepted(paymentMethod: PaymentMethod): Boolean {
+        throw IllegalStateException("Should not be called!")
     }
 }
 

--- a/payments-ui-core/src/test/java/com/stripe/android/utils/FakeCardBrandFilter.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/utils/FakeCardBrandFilter.kt
@@ -2,6 +2,7 @@ package com.stripe.android.utils
 
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.PaymentMethod
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -10,5 +11,9 @@ class FakeCardBrandFilter(
 ) : CardBrandFilter {
     override fun isAccepted(cardBrand: CardBrand): Boolean {
         return !disallowedBrands.contains(cardBrand)
+    }
+
+    override fun isAccepted(paymentMethod: PaymentMethod): Boolean {
+        throw NotImplementedError()
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentSheetCardBrandFilter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentSheetCardBrandFilter.kt
@@ -29,7 +29,7 @@ internal data class PaymentSheetCardBrandFilter(
         }
     }
 
-    fun isAccepted(paymentMethod: PaymentMethod): Boolean {
+    override fun isAccepted(paymentMethod: PaymentMethod): Boolean {
         val brand = paymentMethod.card?.displayBrand?.let { displayBrand ->
             val cardBrand = CardBrand.fromCode(displayBrand)
             if (cardBrand == CardBrand.Unknown) null else cardBrand

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentMethodFilter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentMethodFilter.kt
@@ -1,10 +1,10 @@
 package com.stripe.android.paymentsheet.state
 
+import com.stripe.android.CardBrandFilter
 import com.stripe.android.CardFundingFilter
 import com.stripe.android.common.validation.isSupportedWithBillingConfig
 import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.IS_PAYMENT_METHOD_SET_AS_DEFAULT_ENABLED_DEFAULT_VALUE
-import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilter
 import com.stripe.android.model.CardFunding
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -23,7 +23,7 @@ internal interface PaymentMethodFilter {
         val billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration,
         val customerMetadata: CustomerMetadata?,
         val remoteDefaultPaymentMethodId: String?,
-        val cardBrandFilter: PaymentSheetCardBrandFilter,
+        val cardBrandFilter: CardBrandFilter,
         val cardFundingFilter: CardFundingFilter,
         val localSavedSelection: Deferred<SavedSelection>,
     )

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/RejectCardBrands.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/RejectCardBrands.kt
@@ -2,6 +2,7 @@ package com.stripe.android.link.ui.wallet
 
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.PaymentMethod
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -12,5 +13,9 @@ class RejectCardBrands(
 
     override fun isAccepted(cardBrand: CardBrand): Boolean {
         return cardBrand !in cardBrands
+    }
+
+    override fun isAccepted(paymentMethod: PaymentMethod): Boolean {
+        throw IllegalStateException("Should not be called!")
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinitionTest.kt
@@ -15,6 +15,7 @@ import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLaun
 import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.wallets.Wallet
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
@@ -609,6 +610,10 @@ class GooglePayConfirmationDefinitionTest {
     @Parcelize
     private object FakeCardBrandFilter : CardBrandFilter {
         override fun isAccepted(cardBrand: CardBrand): Boolean {
+            return false
+        }
+
+        override fun isAccepted(paymentMethod: PaymentMethod): Boolean {
             return false
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/UpdatePaymentMethodUITest.kt
@@ -20,6 +20,7 @@ import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodFixtures.toDisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
@@ -183,6 +184,10 @@ class UpdatePaymentMethodUITest {
         val cardBrandFilter = object : CardBrandFilter {
             override fun isAccepted(cardBrand: CardBrand): Boolean {
                 return cardBrand in listOf(CardBrand.CartesBancaires)
+            }
+
+            override fun isAccepted(paymentMethod: PaymentMethod): Boolean {
+                throw NotImplementedError()
             }
 
             override fun describeContents(): Int {


### PR DESCRIPTION
# Summary
Move `isAccepted` with PM into interface & use `CardBrandFilter` interface in `PaymentMethodFilter`

# Motivation
Makes it easier to refresh payment methods using `PaymentMethodMetadata`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified