### PR TITLE
Make deferred integrations a sealed class of `IntegrationMetadata`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/IntegrationMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/IntegrationMetadata.kt
@@ -10,20 +10,24 @@ internal sealed class IntegrationMetadata : Parcelable {
         val clientSecret: String,
     ) : IntegrationMetadata()
 
-    @Parcelize
-    data class DeferredIntentWithPaymentMethod(
-        val intentConfiguration: IntentConfiguration,
-    ) : IntegrationMetadata()
+    sealed class DeferredIntent : IntegrationMetadata() {
+        abstract val intentConfiguration: IntentConfiguration
 
-    @Parcelize
-    data class DeferredIntentWithSharedPaymentToken(
-        val intentConfiguration: IntentConfiguration,
-    ) : IntegrationMetadata()
+        @Parcelize
+        data class WithPaymentMethod(
+            override val intentConfiguration: IntentConfiguration,
+        ) : DeferredIntent()
 
-    @Parcelize
-    data class DeferredIntentWithConfirmationToken(
-        val intentConfiguration: IntentConfiguration,
-    ) : IntegrationMetadata()
+        @Parcelize
+        data class WithSharedPaymentToken(
+            override val intentConfiguration: IntentConfiguration,
+        ) : DeferredIntent()
+
+        @Parcelize
+        data class WithConfirmationToken(
+            override val intentConfiguration: IntentConfiguration,
+        ) : DeferredIntent()
+    }
 
     // CustomerSheet doesn't really fit the bill of any of the other integrations, so making it's own, even though it's
     // not ideal.

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptor.kt
@@ -65,7 +65,7 @@ internal class DefaultIntentConfirmationInterceptorFactory @Inject constructor(
                 // CryptoOnRamp doesn't call confirm.
                 throw IllegalStateException("No intent confirmation interceptor for CryptoOnramp.")
             }
-            is IntegrationMetadata.DeferredIntentWithConfirmationToken -> {
+            is IntegrationMetadata.DeferredIntent.WithConfirmationToken -> {
                 confirmationTokenConfirmationInterceptorFactory.create(
                     intentConfiguration = integrationMetadata.intentConfiguration,
                     createIntentCallback = deferredIntentCallbackRetriever.waitForConfirmationTokenCallback(),
@@ -74,14 +74,14 @@ internal class DefaultIntentConfirmationInterceptorFactory @Inject constructor(
                     clientAttributionMetadata = clientAttributionMetadata,
                 )
             }
-            is IntegrationMetadata.DeferredIntentWithPaymentMethod -> {
+            is IntegrationMetadata.DeferredIntent.WithPaymentMethod -> {
                 deferredIntentConfirmationInterceptorFactory.create(
                     intentConfiguration = integrationMetadata.intentConfiguration,
                     createIntentCallback = deferredIntentCallbackRetriever.waitForPaymentMethodCallback(),
                     clientAttributionMetadata = clientAttributionMetadata,
                 )
             }
-            is IntegrationMetadata.DeferredIntentWithSharedPaymentToken -> {
+            is IntegrationMetadata.DeferredIntent.WithSharedPaymentToken -> {
                 sharedPaymentTokenConfirmationInterceptorFactory.create(
                     intentConfiguration = integrationMetadata.intentConfiguration,
                     handler = deferredIntentCallbackRetriever.waitForSharedPaymentTokenCallback(),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/DefaultAnalyticsMetadataFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/DefaultAnalyticsMetadataFactory.kt
@@ -257,18 +257,18 @@ private fun IntegrationMetadata.isDeferred(): Boolean = when (this) {
     is IntegrationMetadata.IntentFirst -> false
     IntegrationMetadata.CryptoOnramp -> true
     is IntegrationMetadata.CustomerSheet -> true
-    is IntegrationMetadata.DeferredIntentWithConfirmationToken -> true
-    is IntegrationMetadata.DeferredIntentWithPaymentMethod -> true
-    is IntegrationMetadata.DeferredIntentWithSharedPaymentToken -> true
+    is IntegrationMetadata.DeferredIntent.WithConfirmationToken -> true
+    is IntegrationMetadata.DeferredIntent.WithPaymentMethod -> true
+    is IntegrationMetadata.DeferredIntent.WithSharedPaymentToken -> true
     is IntegrationMetadata.CheckoutSession -> false
 }
 
 private fun IntegrationMetadata.isSpt(): Boolean {
-    return this is IntegrationMetadata.DeferredIntentWithSharedPaymentToken
+    return this is IntegrationMetadata.DeferredIntent.WithSharedPaymentToken
 }
 
 private fun IntegrationMetadata.isConfirmationTokens(): Boolean {
-    return this is IntegrationMetadata.DeferredIntentWithConfirmationToken
+    return this is IntegrationMetadata.DeferredIntent.WithConfirmationToken
 }
 
 private fun StripeIntent.paymentMethodOptionsSetupFutureUsageMap(): Boolean {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -154,13 +154,13 @@ internal interface PaymentElementLoader {
             override fun integrationMetadata(paymentElementCallbacks: PaymentElementCallbacks?): IntegrationMetadata {
                 return when {
                     paymentElementCallbacks?.preparePaymentMethodHandler != null -> {
-                        IntegrationMetadata.DeferredIntentWithSharedPaymentToken(intentConfiguration)
+                        IntegrationMetadata.DeferredIntent.WithSharedPaymentToken(intentConfiguration)
                     }
                     paymentElementCallbacks?.createIntentWithConfirmationTokenCallback != null -> {
-                        IntegrationMetadata.DeferredIntentWithConfirmationToken(intentConfiguration)
+                        IntegrationMetadata.DeferredIntent.WithConfirmationToken(intentConfiguration)
                     }
                     paymentElementCallbacks?.createIntentCallback != null -> {
-                        IntegrationMetadata.DeferredIntentWithPaymentMethod(intentConfiguration)
+                        IntegrationMetadata.DeferredIntent.WithPaymentMethod(intentConfiguration)
                     }
                     else -> throw IllegalStateException("No callback for deferred intent.")
                 }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
@@ -128,7 +128,7 @@ internal object PaymentMethodMetadataFactory {
         clientSecret?.let { return IntegrationMetadata.IntentFirst(it) }
         return when (this) {
             is PaymentIntent -> {
-                IntegrationMetadata.DeferredIntentWithPaymentMethod(
+                IntegrationMetadata.DeferredIntent.WithPaymentMethod(
                     intentConfiguration = PaymentSheet.IntentConfiguration(
                         mode = PaymentSheet.IntentConfiguration.Mode.Payment(
                             amount = amount ?: 5000,
@@ -138,7 +138,7 @@ internal object PaymentMethodMetadataFactory {
                 )
             }
             is SetupIntent -> {
-                IntegrationMetadata.DeferredIntentWithPaymentMethod(
+                IntegrationMetadata.DeferredIntent.WithPaymentMethod(
                     intentConfiguration = PaymentSheet.IntentConfiguration(
                         mode = PaymentSheet.IntentConfiguration.Mode.Setup(
                             currency = "usd"

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationFlowTest.kt
@@ -110,7 +110,7 @@ internal class IntentConfirmationFlowTest {
             confirmationOption = CONFIRMATION_OPTION,
             confirmationArgs = DEFERRED_CONFIRMATION_PARAMETERS.copy(
                 paymentMethodMetadata = DEFERRED_CONFIRMATION_PARAMETERS.paymentMethodMetadata.copy(
-                    integrationMetadata = IntegrationMetadata.DeferredIntentWithSharedPaymentToken(
+                    integrationMetadata = IntegrationMetadata.DeferredIntent.WithSharedPaymentToken(
                         intentConfiguration = PaymentSheet.IntentConfiguration(
                             sharedPaymentTokenSessionWithMode = PaymentSheet.IntentConfiguration.Mode.Setup(
                                 currency = "USD",

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/ConfirmationTokenConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/ConfirmationTokenConfirmationInterceptorTest.kt
@@ -63,7 +63,7 @@ class ConfirmationTokenConfirmationInterceptorTest {
         confirmationTokenParser.parse(ConfirmationTokenFixtures.CONFIRMATION_TOKEN_JSON)!!
     }
 
-    internal val defaultIntegrationMetadata = IntegrationMetadata.DeferredIntentWithConfirmationToken(
+    internal val defaultIntegrationMetadata = IntegrationMetadata.DeferredIntent.WithConfirmationToken(
         intentConfiguration = PaymentSheet.IntentConfiguration(
             mode = PaymentSheet.IntentConfiguration.Mode.Payment(
                 amount = 1099L,
@@ -832,7 +832,7 @@ class ConfirmationTokenConfirmationInterceptorTest {
 
         val interceptor = createIntentConfirmationInterceptor(
             ephemeralKeySecret = "ek_test_123",
-            integrationMetadata = IntegrationMetadata.DeferredIntentWithConfirmationToken(
+            integrationMetadata = IntegrationMetadata.DeferredIntent.WithConfirmationToken(
                 intentConfiguration = PaymentSheet.IntentConfiguration(
                     mode = PaymentSheet.IntentConfiguration.Mode.Payment(
                         amount = 1099L,
@@ -887,7 +887,7 @@ class ConfirmationTokenConfirmationInterceptorTest {
 
         val interceptor = createIntentConfirmationInterceptor(
             ephemeralKeySecret = "ek_test_123",
-            integrationMetadata = IntegrationMetadata.DeferredIntentWithConfirmationToken(
+            integrationMetadata = IntegrationMetadata.DeferredIntent.WithConfirmationToken(
                 intentConfiguration = PaymentSheet.IntentConfiguration(
                     mode = PaymentSheet.IntentConfiguration.Mode.Payment(
                         amount = 1099L,
@@ -943,7 +943,7 @@ class ConfirmationTokenConfirmationInterceptorTest {
         val interceptor = createIntentConfirmationInterceptor(
             ephemeralKeySecret = "ek_test_123",
             publishableKeyProvider = { "pk_test_123" },
-            integrationMetadata = IntegrationMetadata.DeferredIntentWithConfirmationToken(
+            integrationMetadata = IntegrationMetadata.DeferredIntent.WithConfirmationToken(
                 intentConfiguration = PaymentSheet.IntentConfiguration(
                     mode = PaymentSheet.IntentConfiguration.Mode.Payment(
                         amount = 1099L,
@@ -1231,7 +1231,7 @@ class ConfirmationTokenConfirmationInterceptorTest {
         runConfirmationTokenInterceptorScenario(
             observedParams = observedParams,
             isLiveMode = false,
-            integrationMetadata = IntegrationMetadata.DeferredIntentWithConfirmationToken(
+            integrationMetadata = IntegrationMetadata.DeferredIntent.WithConfirmationToken(
                 intentConfiguration = PaymentSheet.IntentConfiguration(mode = paymentMode)
             ),
         ) { interceptor ->
@@ -1301,7 +1301,7 @@ class ConfirmationTokenConfirmationInterceptorTest {
     ) {
         val observedParams = Turbine<ConfirmationTokenParams>()
 
-        val integrationMetadata = IntegrationMetadata.DeferredIntentWithConfirmationToken(
+        val integrationMetadata = IntegrationMetadata.DeferredIntent.WithConfirmationToken(
             intentConfiguration = PaymentSheet.IntentConfiguration(
                 mode = PaymentSheet.IntentConfiguration.Mode.Payment(
                     amount = 1099L,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/DefaultIntentConfirmationInterceptorFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/DefaultIntentConfirmationInterceptorFactoryTest.kt
@@ -27,7 +27,7 @@ internal class DefaultIntentConfirmationInterceptorFactoryTest {
     @Test
     fun `create() with sharedPaymentToken returns SharedPaymentTokenConfirmationInterceptor`() =
         runScenario(
-            integrationMetadata = IntegrationMetadata.DeferredIntentWithSharedPaymentToken(
+            integrationMetadata = IntegrationMetadata.DeferredIntent.WithSharedPaymentToken(
                 intentConfiguration = PaymentSheet.IntentConfiguration(
                     sharedPaymentTokenSessionWithMode = PaymentSheet.IntentConfiguration.Mode.Payment(
                         amount = 1099L,
@@ -48,7 +48,7 @@ internal class DefaultIntentConfirmationInterceptorFactoryTest {
     @Test
     fun `create() with DeferredIntent returns DeferredIntentConfirmationInterceptor`() =
         runScenario(
-            integrationMetadata = IntegrationMetadata.DeferredIntentWithPaymentMethod(
+            integrationMetadata = IntegrationMetadata.DeferredIntent.WithPaymentMethod(
                 intentConfiguration = PaymentSheet.IntentConfiguration(
                     mode = PaymentSheet.IntentConfiguration.Mode.Payment(
                         amount = 1099L,
@@ -68,7 +68,7 @@ internal class DefaultIntentConfirmationInterceptorFactoryTest {
     @Test
     fun `create() with DeferredIntent returns ConfirmationTokenConfirmationInterceptor`() =
         runScenario(
-            integrationMetadata = IntegrationMetadata.DeferredIntentWithConfirmationToken(
+            integrationMetadata = IntegrationMetadata.DeferredIntent.WithConfirmationToken(
                 intentConfiguration = PaymentSheet.IntentConfiguration(
                     mode = PaymentSheet.IntentConfiguration.Mode.Payment(
                         amount = 1099L,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/DeferredIntentConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/DeferredIntentConfirmationInterceptorTest.kt
@@ -48,7 +48,7 @@ import javax.inject.Provider
 @RunWith(RobolectricTestRunner::class)
 @OptIn(SharedPaymentTokenSessionPreview::class)
 class DeferredIntentConfirmationInterceptorTest {
-    private val defaultIntegrationMetadata = IntegrationMetadata.DeferredIntentWithPaymentMethod(
+    private val defaultIntegrationMetadata = IntegrationMetadata.DeferredIntent.WithPaymentMethod(
         intentConfiguration = PaymentSheet.IntentConfiguration(
             mode = PaymentSheet.IntentConfiguration.Mode.Payment(
                 amount = 1099L,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/HCaptchaConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/HCaptchaConfirmationInterceptorTest.kt
@@ -61,7 +61,7 @@ class HCaptchaConfirmationInterceptorTest {
     ): ConfirmSetupIntentParams? {
         val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
         val interceptor = createIntentConfirmationInterceptor(
-            integrationMetadata = IntegrationMetadata.DeferredIntentWithPaymentMethod(
+            integrationMetadata = IntegrationMetadata.DeferredIntent.WithPaymentMethod(
                 intentConfiguration = PaymentSheet.IntentConfiguration(
                     mode = PaymentSheet.IntentConfiguration.Mode.Setup(
                         currency = "usd",
@@ -104,7 +104,7 @@ class HCaptchaConfirmationInterceptorTest {
     ): ConfirmPaymentIntentParams? {
         val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
         val interceptor = createIntentConfirmationInterceptor(
-            integrationMetadata = IntegrationMetadata.DeferredIntentWithPaymentMethod(
+            integrationMetadata = IntegrationMetadata.DeferredIntent.WithPaymentMethod(
                 intentConfiguration = PaymentSheet.IntentConfiguration(
                     mode = PaymentSheet.IntentConfiguration.Mode.Payment(
                         amount = 1099L,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/PaymentMethodOptionsSetupFutureUsageConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/PaymentMethodOptionsSetupFutureUsageConfirmationInterceptorTest.kt
@@ -32,7 +32,7 @@ class PaymentMethodOptionsSetupFutureUsageConfirmationInterceptorTest {
         var observedValue = false
 
         val interceptor = createIntentConfirmationInterceptor(
-            integrationMetadata = IntegrationMetadata.DeferredIntentWithPaymentMethod(
+            integrationMetadata = IntegrationMetadata.DeferredIntent.WithPaymentMethod(
                 intentConfiguration = PaymentSheet.IntentConfiguration(
                     mode = PaymentSheet.IntentConfiguration.Mode.Payment(
                         amount = 1099L,
@@ -73,7 +73,7 @@ class PaymentMethodOptionsSetupFutureUsageConfirmationInterceptorTest {
         var observedValue = false
 
         val interceptor = createIntentConfirmationInterceptor(
-            integrationMetadata = IntegrationMetadata.DeferredIntentWithPaymentMethod(
+            integrationMetadata = IntegrationMetadata.DeferredIntent.WithPaymentMethod(
                 intentConfiguration = PaymentSheet.IntentConfiguration(
                     mode = PaymentSheet.IntentConfiguration.Mode.Payment(
                         amount = 1099L,
@@ -111,7 +111,7 @@ class PaymentMethodOptionsSetupFutureUsageConfirmationInterceptorTest {
     @Test
     fun `Returns confirm params with pmo 'setup_future_usage' set to 'off_session' when set on configuration`() =
         runInterceptorScenario(
-            integrationMetadata = IntegrationMetadata.DeferredIntentWithPaymentMethod(
+            integrationMetadata = IntegrationMetadata.DeferredIntent.WithPaymentMethod(
                 PaymentSheet.IntentConfiguration(
                     mode = PaymentSheet.IntentConfiguration.Mode.Payment(
                         currency = "usd",
@@ -176,7 +176,7 @@ class PaymentMethodOptionsSetupFutureUsageConfirmationInterceptorTest {
     @Test
     fun `Returns confirm params with top level 'setup_future_usage' set to 'off_session' when set on configuration`() =
         runInterceptorScenario(
-            integrationMetadata = IntegrationMetadata.DeferredIntentWithPaymentMethod(
+            integrationMetadata = IntegrationMetadata.DeferredIntent.WithPaymentMethod(
                 PaymentSheet.IntentConfiguration(
                     mode = PaymentSheet.IntentConfiguration.Mode.Payment(
                         currency = "usd",

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/SharedPaymentTokenConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/SharedPaymentTokenConfirmationInterceptorTest.kt
@@ -218,7 +218,7 @@ class SharedPaymentTokenConfirmationInterceptorTest {
     }
 
     private companion object {
-        val DEFAULT_INTEGRATION_METADATA = IntegrationMetadata.DeferredIntentWithSharedPaymentToken(
+        val DEFAULT_INTEGRATION_METADATA = IntegrationMetadata.DeferredIntent.WithSharedPaymentToken(
             intentConfiguration = PaymentSheet.IntentConfiguration(
                 sharedPaymentTokenSessionWithMode = PaymentSheet.IntentConfiguration.Mode.Payment(
                     amount = 1099L,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/foundations/CreateIntentFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/foundations/CreateIntentFactory.kt
@@ -73,7 +73,7 @@ internal class CreateIntentFactory(
 
         return Result.success(
             CreateIntentData(
-                integrationMetadata = IntegrationMetadata.DeferredIntentWithPaymentMethod(
+                integrationMetadata = IntegrationMetadata.DeferredIntent.WithPaymentMethod(
                     intentConfiguration = PaymentSheet.IntentConfiguration(
                         mode = PaymentSheet.IntentConfiguration.Mode.Payment(
                             amount = amount.toLong(),
@@ -133,7 +133,7 @@ internal class CreateIntentFactory(
 
         return Result.success(
             CreateIntentData(
-                integrationMetadata = IntegrationMetadata.DeferredIntentWithPaymentMethod(
+                integrationMetadata = IntegrationMetadata.DeferredIntent.WithPaymentMethod(
                     intentConfiguration = PaymentSheet.IntentConfiguration(
                         mode = PaymentSheet.IntentConfiguration.Mode.Setup(
                             setupFutureUse = PaymentSheet.IntentConfiguration.SetupFutureUse.OffSession,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -1632,7 +1632,7 @@ internal class DefaultFlowControllerTest {
             )
         )
         assertThat(arguments.paymentMethodMetadata.integrationMetadata)
-            .isEqualTo(IntegrationMetadata.DeferredIntentWithPaymentMethod(intentConfiguration))
+            .isEqualTo(IntegrationMetadata.DeferredIntent.WithPaymentMethod(intentConfiguration))
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultAnalyticsMetadataFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultAnalyticsMetadataFactoryTest.kt
@@ -126,7 +126,7 @@ class DefaultAnalyticsMetadataFactoryTest {
         )
         val resultMap = createAnalyticsMetadata(
             initializationMode = InitializationMode.DeferredIntent(intentConfiguration),
-            integrationMetadata = IntegrationMetadata.DeferredIntentWithPaymentMethod(intentConfiguration),
+            integrationMetadata = IntegrationMetadata.DeferredIntent.WithPaymentMethod(intentConfiguration),
             elementsSession = createElementsSession(stripeIntent = intent)
         )
 
@@ -152,7 +152,7 @@ class DefaultAnalyticsMetadataFactoryTest {
         )
         val resultMap = createAnalyticsMetadata(
             initializationMode = InitializationMode.DeferredIntent(intentConfiguration),
-            integrationMetadata = IntegrationMetadata.DeferredIntentWithConfirmationToken(intentConfiguration),
+            integrationMetadata = IntegrationMetadata.DeferredIntent.WithConfirmationToken(intentConfiguration),
             elementsSession = createElementsSession(stripeIntent = intent)
         )
 
@@ -187,7 +187,7 @@ class DefaultAnalyticsMetadataFactoryTest {
         )
         val resultMap = createAnalyticsMetadata(
             initializationMode = InitializationMode.DeferredIntent(intentConfiguration),
-            integrationMetadata = IntegrationMetadata.DeferredIntentWithSharedPaymentToken(intentConfiguration),
+            integrationMetadata = IntegrationMetadata.DeferredIntent.WithSharedPaymentToken(intentConfiguration),
             elementsSession = createElementsSession(stripeIntent = intent)
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -1710,7 +1710,7 @@ internal class DefaultPaymentElementLoaderTest {
                         error("Should not be called.")
                     }.build()
             )
-        ).isEqualTo(IntegrationMetadata.DeferredIntentWithSharedPaymentToken(intentConfiguration))
+        ).isEqualTo(IntegrationMetadata.DeferredIntent.WithSharedPaymentToken(intentConfiguration))
     }
 
     @Test
@@ -1731,7 +1731,7 @@ internal class DefaultPaymentElementLoaderTest {
                         error("Should not be called.")
                     }.build()
             )
-        ).isEqualTo(IntegrationMetadata.DeferredIntentWithConfirmationToken(intentConfiguration))
+        ).isEqualTo(IntegrationMetadata.DeferredIntent.WithConfirmationToken(intentConfiguration))
     }
 
     @Test
@@ -1752,7 +1752,7 @@ internal class DefaultPaymentElementLoaderTest {
                         error("Should not be called.")
                     }.build()
             )
-        ).isEqualTo(IntegrationMetadata.DeferredIntentWithPaymentMethod(intentConfiguration))
+        ).isEqualTo(IntegrationMetadata.DeferredIntent.WithPaymentMethod(intentConfiguration))
     }
 
     @Test
@@ -4113,7 +4113,7 @@ internal class DefaultPaymentElementLoaderTest {
         assertThat(createCall.isGooglePaySupported).isFalse()
         assertThat(createCall.customerMetadata).isNull()
         assertThat(createCall.integrationMetadata).isEqualTo(
-            IntegrationMetadata.DeferredIntentWithConfirmationToken(initializationMode.intentConfiguration)
+            IntegrationMetadata.DeferredIntent.WithConfirmationToken(initializationMode.intentConfiguration)
         )
         assertThat(createCall.elementsSession).isNotNull()
         assertThat(createCall.linkStateResult).isNotNull()


### PR DESCRIPTION
# Summary
Make deferred integrations a sealed class of `IntegrationMetadata`

# Motivation
Assists with refreshing payment methods integration

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified