### PR TITLE
Always accept CardFunding.Unknown in PaymentSheetCardFundingFilter

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentSheetCardFundingFilter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentSheetCardFundingFilter.kt
@@ -14,6 +14,7 @@ internal data class PaymentSheetCardFundingFilter(
     private val allowedCardFundingTypes: List<PaymentSheet.CardFundingType>
 ) : CardFundingFilter {
     override fun isAccepted(cardFunding: CardFunding): Boolean {
+        if (cardFunding == CardFunding.Unknown) return true
         return allowedCardFundingTypes.any { it.cardFunding == cardFunding }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletUiStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletUiStateTest.kt
@@ -308,7 +308,7 @@ class WalletUiStateTest {
         assertThat(state.isItemAvailable(creditCard)).isTrue()
         assertThat(state.isItemAvailable(debitCard)).isFalse()
         assertThat(state.isItemAvailable(prepaidCard)).isFalse()
-        assertThat(state.isItemAvailable(unknownCard)).isFalse()
+        assertThat(state.isItemAvailable(unknownCard)).isTrue()
         assertThat(state.isItemAvailable(bankAccount)).isTrue()
         assertThat(state.isItemAvailable(passthrough)).isTrue()
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetCardFundingFilterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetCardFundingFilterTest.kt
@@ -25,7 +25,7 @@ internal class PaymentSheetCardFundingFilterTest {
     }
 
     @Test
-    fun `filter with only debit accepted should return true for debit and false for others`() {
+    fun `filter with only debit accepted should return true for debit and unknown`() {
         val filter = PaymentSheetCardFundingFilter(
             listOf(PaymentSheet.CardFundingType.Debit)
         )
@@ -33,11 +33,11 @@ internal class PaymentSheetCardFundingFilterTest {
         assertThat(filter.isAccepted(CardFunding.Debit)).isTrue()
         assertThat(filter.isAccepted(CardFunding.Credit)).isFalse()
         assertThat(filter.isAccepted(CardFunding.Prepaid)).isFalse()
-        assertThat(filter.isAccepted(CardFunding.Unknown)).isFalse()
+        assertThat(filter.isAccepted(CardFunding.Unknown)).isTrue()
     }
 
     @Test
-    fun `filter with only credit accepted should return true for credit and false for others`() {
+    fun `filter with only credit accepted should return true for credit and unknown`() {
         val filter = PaymentSheetCardFundingFilter(
             listOf(PaymentSheet.CardFundingType.Credit)
         )
@@ -45,11 +45,11 @@ internal class PaymentSheetCardFundingFilterTest {
         assertThat(filter.isAccepted(CardFunding.Credit)).isTrue()
         assertThat(filter.isAccepted(CardFunding.Debit)).isFalse()
         assertThat(filter.isAccepted(CardFunding.Prepaid)).isFalse()
-        assertThat(filter.isAccepted(CardFunding.Unknown)).isFalse()
+        assertThat(filter.isAccepted(CardFunding.Unknown)).isTrue()
     }
 
     @Test
-    fun `filter with only prepaid accepted should return true for prepaid and false for others`() {
+    fun `filter with only prepaid accepted should return true for prepaid and unknown`() {
         val filter = PaymentSheetCardFundingFilter(
             listOf(PaymentSheet.CardFundingType.Prepaid)
         )
@@ -57,11 +57,11 @@ internal class PaymentSheetCardFundingFilterTest {
         assertThat(filter.isAccepted(CardFunding.Prepaid)).isTrue()
         assertThat(filter.isAccepted(CardFunding.Debit)).isFalse()
         assertThat(filter.isAccepted(CardFunding.Credit)).isFalse()
-        assertThat(filter.isAccepted(CardFunding.Unknown)).isFalse()
+        assertThat(filter.isAccepted(CardFunding.Unknown)).isTrue()
     }
 
     @Test
-    fun `filter with only unknown accepted should return true for unknown and false for others`() {
+    fun `filter with only unknown in list should return true for unknown and false for others`() {
         val filter = PaymentSheetCardFundingFilter(
             listOf(PaymentSheet.CardFundingType.Unknown)
         )
@@ -73,12 +73,13 @@ internal class PaymentSheetCardFundingFilterTest {
     }
 
     @Test
-    fun `filter with no accepted types should reject all funding types`() {
+    fun `filter with no accepted types should reject all funding types except unknown`() {
         val filter = PaymentSheetCardFundingFilter(emptyList())
 
-        for (funding in CardFunding.entries) {
-            assertThat(filter.isAccepted(funding)).isFalse()
-        }
+        assertThat(filter.isAccepted(CardFunding.Credit)).isFalse()
+        assertThat(filter.isAccepted(CardFunding.Debit)).isFalse()
+        assertThat(filter.isAccepted(CardFunding.Prepaid)).isFalse()
+        assertThat(filter.isAccepted(CardFunding.Unknown)).isTrue()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentMethodFilterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentMethodFilterTest.kt
@@ -114,7 +114,7 @@ class DefaultPaymentMethodFilterTest {
             ),
         )
 
-        val expectedElements = listOf(paymentMethodsData.credit, paymentMethodsData.bank)
+        val expectedElements = listOf(paymentMethodsData.credit, paymentMethodsData.noFunding, paymentMethodsData.bank)
         assertThat(observedElements).containsExactlyElementsIn(expectedElements).inOrder()
     }
 
@@ -130,7 +130,7 @@ class DefaultPaymentMethodFilterTest {
             ),
         )
 
-        val expectedElements = listOf(paymentMethodsData.debit, paymentMethodsData.bank)
+        val expectedElements = listOf(paymentMethodsData.debit, paymentMethodsData.noFunding, paymentMethodsData.bank)
         assertThat(observedElements).containsExactlyElementsIn(expectedElements).inOrder()
     }
 
@@ -146,7 +146,7 @@ class DefaultPaymentMethodFilterTest {
             ),
         )
 
-        val expectedElements = listOf(paymentMethodsData.prepaid, paymentMethodsData.bank)
+        val expectedElements = listOf(paymentMethodsData.prepaid, paymentMethodsData.noFunding, paymentMethodsData.bank)
         assertThat(observedElements).containsExactlyElementsIn(expectedElements).inOrder()
     }
 
@@ -165,7 +165,12 @@ class DefaultPaymentMethodFilterTest {
             ),
         )
 
-        val expectedElements = listOf(paymentMethodsData.credit, paymentMethodsData.debit, paymentMethodsData.bank)
+        val expectedElements = listOf(
+            paymentMethodsData.credit,
+            paymentMethodsData.debit,
+            paymentMethodsData.noFunding,
+            paymentMethodsData.bank
+        )
         assertThat(observedElements).containsExactlyElementsIn(expectedElements).inOrder()
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Cards with unknown funding type should always be accepted to avoid incorrectly rejecting valid cards when the funding type cannot be determined.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Bug bash feedback

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
