### PR TITLE
[Playground] Reset the customer if keys for custom merchant are updated

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomPublishableKeyDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomPublishableKeyDefinition.kt
@@ -29,4 +29,12 @@ internal object CustomPublishableKeyDefinition :
             checkoutRequestBuilder.customPublishableKey(value)
         }
     }
+
+    override fun valueUpdated(value: String, playgroundSettings: PlaygroundSettings) {
+        // When this key is updated, that reflects that we are probably changing the merchant, so we need to reset
+        // the customer.
+        if (playgroundSettings[CustomerSettingsDefinition].value is CustomerType.Existing) {
+            playgroundSettings[CustomerSettingsDefinition] = CustomerType.NEW
+        }
+    }
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomSecretKeyDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomSecretKeyDefinition.kt
@@ -29,4 +29,12 @@ internal object CustomSecretKeyDefinition :
             checkoutRequestBuilder.customSecretKey(value)
         }
     }
+
+    override fun valueUpdated(value: String, playgroundSettings: PlaygroundSettings) {
+        // When this key is updated, that reflects that we are probably changing the merchant, so we need to reset
+        // the customer.
+        if (playgroundSettings[CustomerSettingsDefinition].value is CustomerType.Existing) {
+            playgroundSettings[CustomerSettingsDefinition] = CustomerType.NEW
+        }
+    }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Reset the customer if keys for custom merchant are updated

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
I was using the custom merchant to test scenarios for a few merchants. I forgot to reset the customer after switching keys to use a different merchant and got a 400 exception when trying to reload payment sheet. This change ensures that other people won't run into the same issue.