### PR TITLE
Fix system/navigation bar padding for PaymentAuthWebViewActivity

### DIFF
--- a/payments-core/res/layout/stripe_payment_auth_web_view_activity.xml
+++ b/payments-core/res/layout/stripe_payment_auth_web_view_activity.xml
@@ -22,6 +22,7 @@
     </FrameLayout>
 
     <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/app_bar"
         android:fitsSystemWindows="true"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/payments-core/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.kt
@@ -56,7 +56,8 @@ class PaymentAuthWebViewActivity : AppCompatActivity() {
         WindowCompat.setDecorFitsSystemWindows(window, false)
         ViewCompat.setOnApplyWindowInsetsListener(viewBinding.root) { view, insets ->
             val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-            view.updatePaddingRelative(systemBars.bottom)
+            viewBinding.appBar.updatePaddingRelative(top = systemBars.top)
+            view.updatePaddingRelative(bottom = systemBars.bottom)
             WindowInsetsCompat.CONSUMED
         }
 
@@ -76,6 +77,7 @@ class PaymentAuthWebViewActivity : AppCompatActivity() {
         setContentView(viewBinding.root)
 
         setSupportActionBar(viewBinding.toolbar)
+
         customizeToolbar()
 
         onBackPressedDispatcher.addCallback {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
- Change system bar padding to be applied to the app bar
- Add system bar padding to root view bottom

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
- Applying padding to app bar sets system bar to same color as app bar
- Root view bottom padding fixes button overlap if user has navigation bar enabled

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
## API 34
<img width="1080" height="2400" alt="api34" src="https://github.com/user-attachments/assets/2df5b567-d87e-4312-bbee-f608c6489222" />

## API 35
<img width="1080" height="2400" alt="api35" src="https://github.com/user-attachments/assets/1c57eda7-d9fe-4fb0-bbff-09e8cd567599" />

## API 36
<img width="1080" height="2424" alt="api36" src="https://github.com/user-attachments/assets/08b08be0-c8da-4a9a-9b91-69a26e451c96" />

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
