### PR TITLE
Refactor CheckoutSessionType to sealed CheckoutSession hierarchy

### DIFF
--- a/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
@@ -442,7 +442,7 @@ abstract class AbsFakeStripeRepository : StripeRepository {
     }
 
     override suspend fun initCheckoutSession(
-        params: ElementsSessionParams.CheckoutSessionType,
+        params: ElementsSessionParams.CheckoutSession.Initial,
         options: ApiRequest.Options,
     ): Result<CheckoutSessionResponse> {
         TODO("Not yet implemented")

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -1549,7 +1549,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
     }
 
     override suspend fun initCheckoutSession(
-        params: ElementsSessionParams.CheckoutSessionType,
+        params: ElementsSessionParams.CheckoutSession.Initial,
         options: ApiRequest.Options,
     ): Result<CheckoutSessionResponse> {
         return fetchStripeModelResult(
@@ -1589,7 +1589,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
                 ),
             ),
             jsonParser = CheckoutSessionResponseJsonParser(
-                elementsSessionParams = ElementsSessionParams.CheckoutSessionType(
+                elementsSessionParams = ElementsSessionParams.CheckoutSession.Initial(
                     clientSecret = "", // Not needed for confirm parsing
                 ),
                 isLiveMode = options.apiKeyIsLiveMode,

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -417,7 +417,7 @@ interface StripeRepository {
      */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     suspend fun initCheckoutSession(
-        params: ElementsSessionParams.CheckoutSessionType,
+        params: ElementsSessionParams.CheckoutSession.Initial,
         options: ApiRequest.Options,
     ): Result<CheckoutSessionResponse>
 

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/CheckoutSessionResponseJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/CheckoutSessionResponseJsonParserTest.kt
@@ -15,7 +15,7 @@ class CheckoutSessionResponseJsonParserTest {
 
     @Test
     fun `parse checkout session response`() {
-        val params = ElementsSessionParams.CheckoutSessionType(
+        val params = ElementsSessionParams.CheckoutSession.Initial(
             clientSecret = "cs_test_123_secret_abc",
         )
         val result = CheckoutSessionResponseJsonParser(
@@ -67,7 +67,7 @@ class CheckoutSessionResponseJsonParserTest {
             }
             """.trimIndent()
         )
-        val params = ElementsSessionParams.CheckoutSessionType(clientSecret = "cs_test_secret")
+        val params = ElementsSessionParams.CheckoutSession.Initial(clientSecret = "cs_test_secret")
         val result = CheckoutSessionResponseJsonParser(params, isLiveMode = false).parse(json)
 
         assertThat(result).isNull()
@@ -84,7 +84,7 @@ class CheckoutSessionResponseJsonParserTest {
             }
             """.trimIndent()
         )
-        val params = ElementsSessionParams.CheckoutSessionType(clientSecret = "cs_test_secret")
+        val params = ElementsSessionParams.CheckoutSession.Initial(clientSecret = "cs_test_secret")
         val result = CheckoutSessionResponseJsonParser(params, isLiveMode = false).parse(json)
 
         assertThat(result).isNull()
@@ -101,7 +101,7 @@ class CheckoutSessionResponseJsonParserTest {
             }
             """.trimIndent()
         )
-        val params = ElementsSessionParams.CheckoutSessionType(clientSecret = "cs_test_secret")
+        val params = ElementsSessionParams.CheckoutSession.Initial(clientSecret = "cs_test_secret")
         val result = CheckoutSessionResponseJsonParser(params, isLiveMode = false).parse(json)
 
         assertThat(result).isNull()
@@ -118,7 +118,7 @@ class CheckoutSessionResponseJsonParserTest {
             }
             """.trimIndent()
         )
-        val params = ElementsSessionParams.CheckoutSessionType(clientSecret = "cs_test_secret")
+        val params = ElementsSessionParams.CheckoutSession.Initial(clientSecret = "cs_test_secret")
         val result = CheckoutSessionResponseJsonParser(params, isLiveMode = false).parse(json)
 
         assertThat(result).isNotNull()
@@ -140,7 +140,7 @@ class CheckoutSessionResponseJsonParserTest {
             }
             """.trimIndent()
         )
-        val params = ElementsSessionParams.CheckoutSessionType(clientSecret = "cs_test_secret")
+        val params = ElementsSessionParams.CheckoutSession.Initial(clientSecret = "cs_test_secret")
         val result = CheckoutSessionResponseJsonParser(params, isLiveMode = false).parse(json)
 
         // Response is parsed successfully but elements_session is null due to invalid JSON
@@ -151,7 +151,7 @@ class CheckoutSessionResponseJsonParserTest {
 
     @Test
     fun `parse confirm response with succeeded payment intent`() {
-        val params = ElementsSessionParams.CheckoutSessionType(clientSecret = "cs_test_secret")
+        val params = ElementsSessionParams.CheckoutSession.Initial(clientSecret = "cs_test_secret")
         val result = CheckoutSessionResponseJsonParser(params, isLiveMode = false)
             .parse(CheckoutSessionFixtures.CHECKOUT_SESSION_CONFIRM_SUCCEEDED_JSON)
 
@@ -173,7 +173,7 @@ class CheckoutSessionResponseJsonParserTest {
 
     @Test
     fun `parse confirm response with requires_action payment intent`() {
-        val params = ElementsSessionParams.CheckoutSessionType(clientSecret = "cs_test_secret")
+        val params = ElementsSessionParams.CheckoutSession.Initial(clientSecret = "cs_test_secret")
         val result = CheckoutSessionResponseJsonParser(params, isLiveMode = false)
             .parse(CheckoutSessionFixtures.CHECKOUT_SESSION_CONFIRM_REQUIRES_ACTION_JSON)
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
@@ -78,7 +78,7 @@ internal class RealElementsSessionRepository @Inject constructor(
         )
 
         val elementsSession =
-            if (params is ElementsSessionParams.CheckoutSessionType) {
+            if (params is ElementsSessionParams.CheckoutSession.Initial) {
                 // CheckoutSession uses a different API endpoint that returns ElementsSession embedded
                 stripeRepository.initCheckoutSession(
                     params = params,
@@ -125,7 +125,7 @@ internal class RealElementsSessionRepository @Inject constructor(
             is ElementsSessionParams.DeferredIntentType -> {
                 Result.success(params.toStripeIntent(requestOptions))
             }
-            is ElementsSessionParams.CheckoutSessionType -> {
+            is ElementsSessionParams.CheckoutSession -> {
                 // CheckoutSession is handled earlier in get() and should never reach fallback
                 error("CheckoutSession does not support fallback")
             }
@@ -240,7 +240,7 @@ internal fun PaymentElementLoader.InitializationMode.toElementsSessionParams(
         }
 
         is PaymentElementLoader.InitializationMode.CheckoutSession -> {
-            ElementsSessionParams.CheckoutSessionType(
+            ElementsSessionParams.CheckoutSession.Initial(
                 clientSecret = clientSecret,
                 customPaymentMethods = customPaymentMethodIds,
                 externalPaymentMethods = externalPaymentMethods,


### PR DESCRIPTION
Introduces DeferredIntentCapable interface and refactors CheckoutSessionType into CheckoutSession.Initial (for API calls) and CheckoutSession.WithIntent (for parsing with deferred intent params). This provides better type safety and clearer modeling of the checkout session lifecycle.


Committed-By-Agent: claude

# Summary
<!-- Simple summary of what was changed. -->

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
