### PR TITLE
Fix duration analytics sending units instead of numeric values

### DIFF
--- a/payment-method-messaging/src/main/java/com/stripe/android/paymentmethodmessaging/element/analytics/PaymentMethodMessagingEvent.kt
+++ b/payment-method-messaging/src/main/java/com/stripe/android/paymentmethodmessaging/element/analytics/PaymentMethodMessagingEvent.kt
@@ -6,6 +6,7 @@ import com.stripe.android.core.networking.AnalyticsEvent
 import com.stripe.android.paymentmethodmessaging.element.PaymentMethodMessagingElement
 import com.stripe.android.paymentmethodmessaging.element.PaymentMethodMessagingElementPreview
 import kotlin.time.Duration
+import kotlin.time.DurationUnit
 
 internal sealed class PaymentMethodMessagingEvent : AnalyticsEvent {
     abstract val additionalParams: Map<String, Any?>
@@ -37,7 +38,7 @@ internal sealed class PaymentMethodMessagingEvent : AnalyticsEvent {
         override val additionalParams: Map<String, Any?> = buildMap {
             put(FIELD_PAYMENT_METHODS, paymentMethods.joinToString(","))
             put(FIELD_CONTENT_TYPE, contentType.type)
-            put(FIELD_DURATION, duration)
+            put(FIELD_DURATION, duration?.toDouble(DurationUnit.SECONDS)?.toFloat())
         }
     }
 
@@ -47,7 +48,7 @@ internal sealed class PaymentMethodMessagingEvent : AnalyticsEvent {
     ) : PaymentMethodMessagingEvent() {
         override val eventName: String = PMME_LOAD_FAILED
         override val additionalParams: Map<String, Any?> = buildMap {
-            put(FIELD_DURATION, duration)
+            put(FIELD_DURATION, duration?.toDouble(DurationUnit.SECONDS)?.toFloat())
             put(FIELD_ERROR_MESSAGE, error.message)
         }
     }

--- a/payment-method-messaging/src/test/java/com/stripe/android/paymentmethodmessaging/element/analytics/DefaultPaymentMethodMessagingEventReporterTest.kt
+++ b/payment-method-messaging/src/test/java/com/stripe/android/paymentmethodmessaging/element/analytics/DefaultPaymentMethodMessagingEventReporterTest.kt
@@ -67,6 +67,7 @@ class DefaultPaymentMethodMessagingEventReporterTest {
         assertThat(request.params["event"]).isEqualTo(PMME_LOAD_SUCCEEDED)
         assertThat(request.params["payment_methods"]).isEqualTo("affirm,klarna")
         assertThat(request.params["content_type"]).isEqualTo("multi_partner")
+        assertThat(request.params["duration"]).isEqualTo(1.0f)
         validateDurationEndCall()
     }
 
@@ -76,6 +77,7 @@ class DefaultPaymentMethodMessagingEventReporterTest {
         val request = analyticsRequestExecutor.requestTurbine.awaitItem()
         assertThat(request.params["event"]).isEqualTo(PMME_LOAD_FAILED)
         assertThat(request.params["error_message"]).isEqualTo("something went wrong")
+        assertThat(request.params["duration"]).isEqualTo(1.0f)
         validateDurationEndCall()
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
- Fixes analytics pipeline failure caused by duration values being sent with unit suffixes (e.g., "254m", "5s") instead of plain numeric values
- Converts Duration objects to numeric seconds in PaymentMethodMessagingEvent before sending to analytics
- Adds test assertions to verify duration format

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Resolves go/jira/RUN_MOBILESDK-5053
The ocsmobile_sdk_analytics_1_staging pipeline was failing with Cannot cast '254m' to DOUBLE because `kotlin.time.Duration.toString()` produces human-readable strings like "254m" instead of numeric values.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
