### PR TITLE
Update `CardDefinition` to show tap capabilities when supported

### DIFF
--- a/payments-ui-core/res/drawable/stripe_ic_paymentsheet_pm_card_with_tap.xml
+++ b/payments-ui-core/res/drawable/stripe_ic_paymentsheet_pm_card_with_tap.xml
@@ -1,0 +1,37 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="16dp"
+    android:viewportWidth="24"
+    android:viewportHeight="16">
+  <path
+      android:strokeWidth="1"
+      android:pathData="M2,0.5L22,0.5A1.5,1.5 0,0 1,23.5 2L23.5,14A1.5,1.5 0,0 1,22 15.5L2,15.5A1.5,1.5 0,0 1,0.5 14L0.5,2A1.5,1.5 0,0 1,2 0.5z"
+      android:strokeColor="#ffffff"/>
+  <path
+      android:pathData="M17.025,9.702L17.042,9.726C17.362,10.179 17.356,10.787 17.025,11.232"
+      android:strokeWidth="0.607251"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M18.177,9.23L18.34,9.536C18.394,9.637 18.436,9.743 18.465,9.853L18.482,9.914C18.503,9.99 18.517,10.068 18.526,10.147L18.542,10.298C18.556,10.428 18.553,10.56 18.534,10.69L18.506,10.874C18.483,11.024 18.438,11.169 18.372,11.305L18.186,11.689"
+      android:strokeWidth="0.607251"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M19.312,8.711L19.569,9.217C19.616,9.309 19.653,9.405 19.68,9.504L19.735,9.704C19.758,9.788 19.774,9.874 19.782,9.961L19.816,10.317C19.827,10.431 19.825,10.545 19.81,10.658L19.77,10.969L19.727,11.191C19.708,11.291 19.678,11.389 19.639,11.483L19.522,11.768L19.312,12.156"
+      android:strokeWidth="0.607251"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M20.446,8.01L20.806,8.718C20.871,8.847 20.923,8.981 20.961,9.12L21.038,9.4C21.07,9.518 21.092,9.638 21.104,9.76L21.151,10.259C21.167,10.417 21.164,10.577 21.143,10.735L21.086,11.171L21.027,11.481C21,11.622 20.959,11.759 20.904,11.891L20.74,12.29L20.446,12.833"
+      android:strokeWidth="0.607283"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M0,3h24v3h-24z"
+      android:fillColor="#ffffff"/>
+</vector>

--- a/payments-ui-core/res/values/strings.xml
+++ b/payments-ui-core/res/values/strings.xml
@@ -28,6 +28,8 @@
   <string name="stripe_blik_code">BLIK code</string>
   <!-- Label for Boleto Payment method Tax ID -->
   <string name="stripe_boleto_tax_id_label">CPF/CNPJ</string>
+  <!-- Klarna pay later copy -->
+  <string name="stripe_card_with_tap_or_enter_manually">Tap or enter manually</string>
   <!-- Shown in a dropdown picker next to a card brand that is not accepted by a merchant. E.g. \"Visa (not accepted)\" -->
   <string name="stripe_card_brand_not_accepted">(not accepted)</string>
   <!-- Shown in a dropdown picker next to a card brand that is not accepted by a merchant. E.g. "Visa (not accepted)" -->

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -55,7 +55,13 @@ internal object CardDefinition : PaymentMethodDefinition {
 
     override fun uiDefinitionFactory(
         metadata: PaymentMethodMetadata
-    ): UiDefinitionFactory = CardUiDefinitionFactory
+    ): UiDefinitionFactory {
+        return if (metadata.isTapToAddSupported) {
+            CardWithTapUiDefinitionFactory
+        } else {
+            CardUiDefinitionFactory
+        }
+    }
 }
 
 private object CardUiDefinitionFactory : UiDefinitionFactory.Custom {
@@ -189,6 +195,25 @@ private object CardUiDefinitionFactory : UiDefinitionFactory.Custom {
                 )
             )
         }
+    }
+}
+
+private object CardWithTapUiDefinitionFactory : UiDefinitionFactory.Custom {
+    override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
+        paymentMethodDefinition = CardDefinition,
+        displayNameResource = PaymentsUiCoreR.string.stripe_paymentsheet_payment_method_card,
+        iconResource = PaymentsUiCoreR.drawable.stripe_ic_paymentsheet_pm_card_with_tap,
+        iconResourceNight = null,
+        outlinedIconResource = PaymentsUiCoreR.drawable.stripe_ic_paymentsheet_pm_card_with_tap,
+        subtitle = PaymentsUiCoreR.string.stripe_card_with_tap_or_enter_manually.resolvableString,
+        iconRequiresTinting = true,
+    )
+
+    override fun createFormElements(
+        metadata: PaymentMethodMetadata,
+        arguments: UiDefinitionFactory.Arguments
+    ): List<FormElement> {
+        return emptyList()
     }
 }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinitionTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.lpmfoundations.paymentmethod.definitions
 import androidx.lifecycle.SavedStateHandle
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.model.CountryUtils
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.isInstanceOf
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.TestFactory
@@ -38,6 +39,7 @@ import com.stripe.android.utils.FakeLinkConfigurationCoordinator
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import com.stripe.android.ui.core.R as PaymentsUiCoreR
 
 @RunWith(RobolectricTestRunner::class)
 class CardDefinitionTest {
@@ -623,6 +625,47 @@ class CardDefinitionTest {
         assertThat(
             (formElements[0].controller as CardDetailsSectionController).shouldAutomaticallyLaunchCardScan()
         ).isFalse()
+    }
+
+    @Test
+    fun `createSupportedPaymentMethod returns expected supported PM when tap to add is not supported`() {
+        val metadata = PaymentMethodMetadataFactory.create(isTapToAddSupported = false)
+        val nullablePaymentMethod = CardDefinition.uiDefinitionFactory(metadata).supportedPaymentMethod(
+            metadata = metadata,
+            definition = CardDefinition,
+            sharedDataSpecs = emptyList()
+        )
+
+        assertThat(nullablePaymentMethod).isNotNull()
+
+        val supportedPaymentMethod = requireNotNull(nullablePaymentMethod)
+
+        assertThat(supportedPaymentMethod.iconResource)
+            .isEqualTo(PaymentsUiCoreR.drawable.stripe_ic_paymentsheet_pm_card)
+        assertThat(supportedPaymentMethod.outlinedIconResource)
+            .isEqualTo(PaymentsUiCoreR.drawable.stripe_ic_paymentsheet_pm_card_outlined)
+        assertThat(supportedPaymentMethod.subtitle).isNull()
+    }
+
+    @Test
+    fun `createSupportedPaymentMethod returns tap to add icon when tap to add is supported`() {
+        val metadata = PaymentMethodMetadataFactory.create(isTapToAddSupported = true)
+        val nullablePaymentMethod = CardDefinition.uiDefinitionFactory(metadata).supportedPaymentMethod(
+            metadata = metadata,
+            definition = CardDefinition,
+            sharedDataSpecs = emptyList()
+        )
+
+        assertThat(nullablePaymentMethod).isNotNull()
+
+        val supportedPaymentMethod = requireNotNull(nullablePaymentMethod)
+
+        assertThat(supportedPaymentMethod.iconResource)
+            .isEqualTo(PaymentsUiCoreR.drawable.stripe_ic_paymentsheet_pm_card_with_tap)
+        assertThat(supportedPaymentMethod.outlinedIconResource)
+            .isEqualTo(PaymentsUiCoreR.drawable.stripe_ic_paymentsheet_pm_card_with_tap)
+        assertThat(supportedPaymentMethod.subtitle)
+            .isEqualTo(PaymentsUiCoreR.string.stripe_card_with_tap_or_enter_manually.resolvableString)
     }
 
     private fun createLinkConfiguration(): LinkConfiguration {


### PR DESCRIPTION
# Summary
Update `CardDefinition` to show tap capabilities when supported

# Motivation
Support changes for Tap to Add from [Figma](https://www.figma.com/design/3O3xuCH1HqiBCv5SK6AJZG/Tap-to-Add---Tap-to-Verify?node-id=793-193&p=f&t=mLAmudsuAyFotIL7-0).

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified