### PR TITLE
Add `PaymentMethodMetadata` to `uiDefinitionFactory` function in `PaymentMethodDefinition`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodDefinition.kt
@@ -20,7 +20,9 @@ internal interface PaymentMethodDefinition {
      */
     fun requirementsToBeUsedAsNewPaymentMethod(hasIntentToSetup: Boolean): Set<AddPaymentMethodRequirement>
 
-    fun uiDefinitionFactory(): UiDefinitionFactory
+    fun uiDefinitionFactory(
+        metadata: PaymentMethodMetadata
+    ): UiDefinitionFactory
 }
 
 internal fun PaymentMethodDefinition.isSupported(metadata: PaymentMethodMetadata): Boolean {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -162,7 +162,7 @@ internal data class PaymentMethodMetadata(
                 ?.createSupportedPaymentMethod(metadata = this)
         } else {
             val definition = supportedPaymentMethodDefinitions().firstOrNull { it.type.code == code } ?: return null
-            definition.uiDefinitionFactory().supportedPaymentMethod(this, definition, sharedDataSpecs)
+            definition.uiDefinitionFactory(this).supportedPaymentMethod(this, definition, sharedDataSpecs)
         }
     }
 
@@ -248,7 +248,8 @@ internal data class PaymentMethodMetadata(
             stripeIntent.isLiveMode &&
                 stripeIntent.unactivatedPaymentMethods.contains(it.type.code)
         }.filter { paymentMethodDefinition ->
-            paymentMethodDefinition.uiDefinitionFactory().canBeDisplayedInUi(paymentMethodDefinition, sharedDataSpecs)
+            paymentMethodDefinition.uiDefinitionFactory(this)
+                .canBeDisplayedInUi(paymentMethodDefinition, sharedDataSpecs)
         }
     }
 
@@ -281,7 +282,7 @@ internal data class PaymentMethodMetadata(
         } else {
             val definition = supportedPaymentMethodDefinitions().firstOrNull { it.type.code == code } ?: return null
 
-            definition.uiDefinitionFactory().formHeaderInformation(
+            definition.uiDefinitionFactory(this).formHeaderInformation(
                 metadata = this,
                 definition = definition,
                 sharedDataSpecs = sharedDataSpecs,
@@ -307,7 +308,7 @@ internal data class PaymentMethodMetadata(
         } else {
             val definition = supportedPaymentMethodDefinitions().firstOrNull { it.type.code == code } ?: return null
 
-            definition.uiDefinitionFactory().formElements(
+            definition.uiDefinitionFactory(this).formElements(
                 metadata = this,
                 definition = definition,
                 sharedDataSpecs = sharedDataSpecs,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AffirmDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AffirmDefinition.kt
@@ -26,7 +26,9 @@ internal object AffirmDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
-    override fun uiDefinitionFactory(): UiDefinitionFactory = AffirmUiDefinitionFactory
+    override fun uiDefinitionFactory(
+        metadata: PaymentMethodMetadata
+    ): UiDefinitionFactory = AffirmUiDefinitionFactory
 }
 
 private object AffirmUiDefinitionFactory : UiDefinitionFactory.Simple() {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AfterpayClearpayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AfterpayClearpayDefinition.kt
@@ -26,7 +26,9 @@ internal object AfterpayClearpayDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
-    override fun uiDefinitionFactory(): UiDefinitionFactory = AfterpayClearpayUiDefinitionFactory
+    override fun uiDefinitionFactory(
+        metadata: PaymentMethodMetadata
+    ): UiDefinitionFactory = AfterpayClearpayUiDefinitionFactory
 }
 
 private object AfterpayClearpayUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDataSpec {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AlipayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AlipayDefinition.kt
@@ -21,7 +21,9 @@ internal object AlipayDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
-    override fun uiDefinitionFactory(): UiDefinitionFactory = AlipayUiDefinitionFactory
+    override fun uiDefinitionFactory(
+        metadata: PaymentMethodMetadata
+    ): UiDefinitionFactory = AlipayUiDefinitionFactory
 }
 
 private object AlipayUiDefinitionFactory : UiDefinitionFactory.Simple() {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AlmaDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AlmaDefinition.kt
@@ -21,7 +21,9 @@ internal object AlmaDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
-    override fun uiDefinitionFactory(): UiDefinitionFactory = AlmaUiDefinitionFactory
+    override fun uiDefinitionFactory(
+        metadata: PaymentMethodMetadata
+    ): UiDefinitionFactory = AlmaUiDefinitionFactory
 }
 
 private object AlmaUiDefinitionFactory : UiDefinitionFactory.Simple() {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AmazonPayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AmazonPayDefinition.kt
@@ -24,7 +24,9 @@ internal object AmazonPayDefinition : PaymentMethodDefinition {
         return metadata.hasIntentToSetup(type.code) && metadata.mandateAllowed(type)
     }
 
-    override fun uiDefinitionFactory(): UiDefinitionFactory = AmazonPayUiDefinitionFactory
+    override fun uiDefinitionFactory(
+        metadata: PaymentMethodMetadata
+    ): UiDefinitionFactory = AmazonPayUiDefinitionFactory
 }
 
 private object AmazonPayUiDefinitionFactory : UiDefinitionFactory.Simple() {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AuBecsDebitDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AuBecsDebitDefinition.kt
@@ -22,7 +22,9 @@ internal object AuBecsDebitDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = true
 
-    override fun uiDefinitionFactory(): UiDefinitionFactory = AuBecsDebitUiDefinitionFactory
+    override fun uiDefinitionFactory(
+        metadata: PaymentMethodMetadata
+    ): UiDefinitionFactory = AuBecsDebitUiDefinitionFactory
 }
 
 private object AuBecsDebitUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDataSpec {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BacsDebitDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BacsDebitDefinition.kt
@@ -28,7 +28,9 @@ internal object BacsDebitDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = true
 
-    override fun uiDefinitionFactory(): UiDefinitionFactory = BacsDebitUiDefinitionFactory
+    override fun uiDefinitionFactory(
+        metadata: PaymentMethodMetadata
+    ): UiDefinitionFactory = BacsDebitUiDefinitionFactory
 }
 
 private object BacsDebitUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDataSpec {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BancontactDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BancontactDefinition.kt
@@ -26,7 +26,9 @@ internal object BancontactDefinition : PaymentMethodDefinition {
         return metadata.hasIntentToSetup(type.code) && metadata.mandateAllowed(type)
     }
 
-    override fun uiDefinitionFactory(): UiDefinitionFactory = BancontactUiDefinitionFactory
+    override fun uiDefinitionFactory(
+        metadata: PaymentMethodMetadata
+    ): UiDefinitionFactory = BancontactUiDefinitionFactory
 }
 
 private object BancontactUiDefinitionFactory : UiDefinitionFactory.Simple() {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BillieDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BillieDefinition.kt
@@ -21,7 +21,9 @@ internal object BillieDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
-    override fun uiDefinitionFactory(): UiDefinitionFactory = BillieUiDefinitionFactory
+    override fun uiDefinitionFactory(
+        metadata: PaymentMethodMetadata
+    ): UiDefinitionFactory = BillieUiDefinitionFactory
 }
 
 private object BillieUiDefinitionFactory : UiDefinitionFactory.Simple() {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BlikDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BlikDefinition.kt
@@ -24,7 +24,9 @@ internal object BlikDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
-    override fun uiDefinitionFactory(): UiDefinitionFactory = BlikUiDefinitionFactory
+    override fun uiDefinitionFactory(
+        metadata: PaymentMethodMetadata
+    ): UiDefinitionFactory = BlikUiDefinitionFactory
 }
 
 private object BlikUiDefinitionFactory : UiDefinitionFactory.Simple() {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BoletoDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BoletoDefinition.kt
@@ -31,7 +31,9 @@ internal object BoletoDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
-    override fun uiDefinitionFactory(): UiDefinitionFactory = BoletoUiDefinitionFactory
+    override fun uiDefinitionFactory(
+        metadata: PaymentMethodMetadata
+    ): UiDefinitionFactory = BoletoUiDefinitionFactory
 }
 
 private object BoletoUiDefinitionFactory : UiDefinitionFactory.Simple() {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -53,7 +53,9 @@ internal object CardDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
-    override fun uiDefinitionFactory(): UiDefinitionFactory = CardUiDefinitionFactory
+    override fun uiDefinitionFactory(
+        metadata: PaymentMethodMetadata
+    ): UiDefinitionFactory = CardUiDefinitionFactory
 }
 
 private object CardUiDefinitionFactory : UiDefinitionFactory.Custom {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CashAppPayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CashAppPayDefinition.kt
@@ -24,7 +24,9 @@ internal object CashAppPayDefinition : PaymentMethodDefinition {
         return metadata.hasIntentToSetup(type.code) && metadata.mandateAllowed(type)
     }
 
-    override fun uiDefinitionFactory(): UiDefinitionFactory = CashAppPayUiDefinitionFactory
+    override fun uiDefinitionFactory(
+        metadata: PaymentMethodMetadata
+    ): UiDefinitionFactory = CashAppPayUiDefinitionFactory
 }
 
 private object CashAppPayUiDefinitionFactory : UiDefinitionFactory.Simple() {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CryptoDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CryptoDefinition.kt
@@ -21,7 +21,9 @@ internal object CryptoDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
-    override fun uiDefinitionFactory(): UiDefinitionFactory = CryptoUiDefinitionFactory
+    override fun uiDefinitionFactory(
+        metadata: PaymentMethodMetadata
+    ): UiDefinitionFactory = CryptoUiDefinitionFactory
 }
 
 private object CryptoUiDefinitionFactory : UiDefinitionFactory.Simple() {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/EpsDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/EpsDefinition.kt
@@ -30,7 +30,9 @@ internal object EpsDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
-    override fun uiDefinitionFactory(): UiDefinitionFactory = EpsUiDefinitionFactory
+    override fun uiDefinitionFactory(
+        metadata: PaymentMethodMetadata
+    ): UiDefinitionFactory = EpsUiDefinitionFactory
 }
 
 private object EpsUiDefinitionFactory : UiDefinitionFactory.Simple() {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/FpxDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/FpxDefinition.kt
@@ -29,7 +29,9 @@ internal object FpxDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
-    override fun uiDefinitionFactory(): UiDefinitionFactory = FpxUiDefinitionFactory
+    override fun uiDefinitionFactory(
+        metadata: PaymentMethodMetadata
+    ): UiDefinitionFactory = FpxUiDefinitionFactory
 }
 
 private object FpxUiDefinitionFactory : UiDefinitionFactory.Simple() {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/GrabPayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/GrabPayDefinition.kt
@@ -21,7 +21,9 @@ internal object GrabPayDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
-    override fun uiDefinitionFactory(): UiDefinitionFactory = GrabPayUiDefinitionFactory
+    override fun uiDefinitionFactory(
+        metadata: PaymentMethodMetadata
+    ): UiDefinitionFactory = GrabPayUiDefinitionFactory
 }
 
 private object GrabPayUiDefinitionFactory : UiDefinitionFactory.Simple() {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/IdealDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/IdealDefinition.kt
@@ -25,7 +25,9 @@ internal object IdealDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = metadata.hasIntentToSetup(type.code)
 
-    override fun uiDefinitionFactory(): UiDefinitionFactory = IdealUiDefinitionFactory
+    override fun uiDefinitionFactory(
+        metadata: PaymentMethodMetadata
+    ): UiDefinitionFactory = IdealUiDefinitionFactory
 }
 
 private object IdealUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDataSpec {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/InstantDebitsDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/InstantDebitsDefinition.kt
@@ -25,7 +25,9 @@ internal object InstantDebitsDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = true
 
-    override fun uiDefinitionFactory(): UiDefinitionFactory = InstantDebitsUiDefinitionFactory
+    override fun uiDefinitionFactory(
+        metadata: PaymentMethodMetadata
+    ): UiDefinitionFactory = InstantDebitsUiDefinitionFactory
 }
 
 private object InstantDebitsUiDefinitionFactory : UiDefinitionFactory.Custom {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KlarnaDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KlarnaDefinition.kt
@@ -36,7 +36,7 @@ internal object KlarnaDefinition : PaymentMethodDefinition {
         return metadata.hasIntentToSetup(type.code) && metadata.mandateAllowed(type)
     }
 
-    override fun uiDefinitionFactory(): UiDefinitionFactory {
+    override fun uiDefinitionFactory(metadata: PaymentMethodMetadata): UiDefinitionFactory {
         return if (FeatureFlags.enableKlarnaFormRemoval.isEnabled) {
             KlarnaRemovedFormUiDefinitionFactory
         } else {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KonbiniDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KonbiniDefinition.kt
@@ -32,7 +32,9 @@ internal object KonbiniDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
-    override fun uiDefinitionFactory(): UiDefinitionFactory = KonbiniUiDefinitionFactory
+    override fun uiDefinitionFactory(
+        metadata: PaymentMethodMetadata
+    ): UiDefinitionFactory = KonbiniUiDefinitionFactory
 }
 
 private object KonbiniUiDefinitionFactory : UiDefinitionFactory.Simple() {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/LinkCardBrandDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/LinkCardBrandDefinition.kt
@@ -25,7 +25,9 @@ internal object LinkCardBrandDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = true
 
-    override fun uiDefinitionFactory(): UiDefinitionFactory = LinkCardBrandDefinitionFactory
+    override fun uiDefinitionFactory(
+        metadata: PaymentMethodMetadata
+    ): UiDefinitionFactory = LinkCardBrandDefinitionFactory
 }
 
 private object LinkCardBrandDefinitionFactory : UiDefinitionFactory.Custom {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/MobilePayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/MobilePayDefinition.kt
@@ -21,7 +21,9 @@ internal object MobilePayDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
-    override fun uiDefinitionFactory(): UiDefinitionFactory = MobilePayUiDefinitionFactory
+    override fun uiDefinitionFactory(
+        metadata: PaymentMethodMetadata
+    ): UiDefinitionFactory = MobilePayUiDefinitionFactory
 }
 
 private object MobilePayUiDefinitionFactory : UiDefinitionFactory.Simple() {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/MultibancoDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/MultibancoDefinition.kt
@@ -24,7 +24,9 @@ internal object MultibancoDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
-    override fun uiDefinitionFactory(): UiDefinitionFactory = MultibancoUiDefinitionFactory
+    override fun uiDefinitionFactory(
+        metadata: PaymentMethodMetadata
+    ): UiDefinitionFactory = MultibancoUiDefinitionFactory
 }
 
 private object MultibancoUiDefinitionFactory : UiDefinitionFactory.Simple() {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/OxxoDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/OxxoDefinition.kt
@@ -23,7 +23,9 @@ internal object OxxoDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
-    override fun uiDefinitionFactory(): UiDefinitionFactory = OxxoUiDefinitionFactory
+    override fun uiDefinitionFactory(
+        metadata: PaymentMethodMetadata
+    ): UiDefinitionFactory = OxxoUiDefinitionFactory
 }
 
 private object OxxoUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDataSpec {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/P24Definition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/P24Definition.kt
@@ -30,7 +30,9 @@ internal object P24Definition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
-    override fun uiDefinitionFactory(): UiDefinitionFactory = P24UiDefinitionFactory
+    override fun uiDefinitionFactory(
+        metadata: PaymentMethodMetadata
+    ): UiDefinitionFactory = P24UiDefinitionFactory
 }
 
 private object P24UiDefinitionFactory : UiDefinitionFactory.Simple() {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/PayNowDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/PayNowDefinition.kt
@@ -20,7 +20,9 @@ internal object PayNowDefinition : PaymentMethodDefinition {
         return setOf(AddPaymentMethodRequirement.UnsupportedForSetup)
     }
 
-    override fun uiDefinitionFactory(): UiDefinitionFactory = PayNowUiDefinitionFactory
+    override fun uiDefinitionFactory(
+        metadata: PaymentMethodMetadata
+    ): UiDefinitionFactory = PayNowUiDefinitionFactory
 }
 
 private object PayNowUiDefinitionFactory : UiDefinitionFactory.Simple() {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/PayPalDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/PayPalDefinition.kt
@@ -23,7 +23,9 @@ internal object PayPalDefinition : PaymentMethodDefinition {
         return metadata.hasIntentToSetup(type.code) && metadata.mandateAllowed(type)
     }
 
-    override fun uiDefinitionFactory(): UiDefinitionFactory = PayPalUiDefinitionFactory
+    override fun uiDefinitionFactory(
+        metadata: PaymentMethodMetadata
+    ): UiDefinitionFactory = PayPalUiDefinitionFactory
 }
 
 private object PayPalUiDefinitionFactory : UiDefinitionFactory.Simple() {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/PayPayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/PayPayDefinition.kt
@@ -20,7 +20,9 @@ internal object PayPayDefinition : PaymentMethodDefinition {
         return setOf(AddPaymentMethodRequirement.UnsupportedForSetup)
     }
 
-    override fun uiDefinitionFactory(): UiDefinitionFactory = PayPayUiDefinitionFactory
+    override fun uiDefinitionFactory(
+        metadata: PaymentMethodMetadata
+    ): UiDefinitionFactory = PayPayUiDefinitionFactory
 }
 
 private object PayPayUiDefinitionFactory : UiDefinitionFactory.Simple() {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/PromptPayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/PromptPayDefinition.kt
@@ -23,7 +23,9 @@ internal object PromptPayDefinition : PaymentMethodDefinition {
         return setOf(AddPaymentMethodRequirement.UnsupportedForSetup)
     }
 
-    override fun uiDefinitionFactory(): UiDefinitionFactory = PromptPayUiDefinitionFactory
+    override fun uiDefinitionFactory(
+        metadata: PaymentMethodMetadata
+    ): UiDefinitionFactory = PromptPayUiDefinitionFactory
 }
 
 private object PromptPayUiDefinitionFactory : UiDefinitionFactory.Simple() {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/RevolutPayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/RevolutPayDefinition.kt
@@ -23,7 +23,9 @@ internal object RevolutPayDefinition : PaymentMethodDefinition {
         return metadata.hasIntentToSetup(type.code) && metadata.mandateAllowed(type)
     }
 
-    override fun uiDefinitionFactory(): UiDefinitionFactory = RevolutPayUiDefinitionFactory
+    override fun uiDefinitionFactory(
+        metadata: PaymentMethodMetadata
+    ): UiDefinitionFactory = RevolutPayUiDefinitionFactory
 }
 
 private object RevolutPayUiDefinitionFactory : UiDefinitionFactory.Simple() {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SatispayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SatispayDefinition.kt
@@ -23,7 +23,9 @@ internal object SatispayDefinition : PaymentMethodDefinition {
         return metadata.hasIntentToSetup(type.code) && metadata.mandateAllowed(type)
     }
 
-    override fun uiDefinitionFactory(): UiDefinitionFactory = SatispayUiDefinitionFactory
+    override fun uiDefinitionFactory(
+        metadata: PaymentMethodMetadata
+    ): UiDefinitionFactory = SatispayUiDefinitionFactory
 }
 
 private object SatispayUiDefinitionFactory : UiDefinitionFactory.Simple() {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SepaDebitDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SepaDebitDefinition.kt
@@ -27,7 +27,9 @@ internal object SepaDebitDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = true
 
-    override fun uiDefinitionFactory(): UiDefinitionFactory = SepaDebitUiDefinitionFactory
+    override fun uiDefinitionFactory(
+        metadata: PaymentMethodMetadata
+    ): UiDefinitionFactory = SepaDebitUiDefinitionFactory
 }
 
 private object SepaDebitUiDefinitionFactory : UiDefinitionFactory.RequiresSharedDataSpec {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SunbitDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SunbitDefinition.kt
@@ -21,7 +21,9 @@ internal object SunbitDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
-    override fun uiDefinitionFactory(): UiDefinitionFactory = SunbitUiDefinitionFactory
+    override fun uiDefinitionFactory(
+        metadata: PaymentMethodMetadata
+    ): UiDefinitionFactory = SunbitUiDefinitionFactory
 }
 
 private object SunbitUiDefinitionFactory : UiDefinitionFactory.Simple() {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SwishDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SwishDefinition.kt
@@ -21,7 +21,9 @@ internal object SwishDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
-    override fun uiDefinitionFactory(): UiDefinitionFactory = SwishUiDefinitionFactory
+    override fun uiDefinitionFactory(
+        metadata: PaymentMethodMetadata
+    ): UiDefinitionFactory = SwishUiDefinitionFactory
 }
 
 private object SwishUiDefinitionFactory : UiDefinitionFactory.Simple() {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/TwintDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/TwintDefinition.kt
@@ -21,7 +21,9 @@ internal object TwintDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
-    override fun uiDefinitionFactory(): UiDefinitionFactory = TwintUiDefinitionFactory
+    override fun uiDefinitionFactory(
+        metadata: PaymentMethodMetadata
+    ): UiDefinitionFactory = TwintUiDefinitionFactory
 }
 
 private object TwintUiDefinitionFactory : UiDefinitionFactory.Simple() {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/UpiDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/UpiDefinition.kt
@@ -25,7 +25,9 @@ internal object UpiDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
-    override fun uiDefinitionFactory(): UiDefinitionFactory = UpiUiDefinitionFactory
+    override fun uiDefinitionFactory(
+        metadata: PaymentMethodMetadata
+    ): UiDefinitionFactory = UpiUiDefinitionFactory
 }
 
 private object UpiUiDefinitionFactory : UiDefinitionFactory.Simple() {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/UsBankAccountDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/UsBankAccountDefinition.kt
@@ -27,7 +27,9 @@ internal object UsBankAccountDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = true
 
-    override fun uiDefinitionFactory(): UiDefinitionFactory = UsBankAccountUiDefinitionFactory
+    override fun uiDefinitionFactory(
+        metadata: PaymentMethodMetadata
+    ): UiDefinitionFactory = UsBankAccountUiDefinitionFactory
 }
 
 private object UsBankAccountUiDefinitionFactory : UiDefinitionFactory.Custom {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/WeChatPayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/WeChatPayDefinition.kt
@@ -21,7 +21,9 @@ internal object WeChatPayDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
-    override fun uiDefinitionFactory(): UiDefinitionFactory = WeChatPayUiDefinitionFactory
+    override fun uiDefinitionFactory(
+        metadata: PaymentMethodMetadata
+    ): UiDefinitionFactory = WeChatPayUiDefinitionFactory
 }
 
 private object WeChatPayUiDefinitionFactory : UiDefinitionFactory.Simple() {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/ZipDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/ZipDefinition.kt
@@ -21,7 +21,9 @@ internal object ZipDefinition : PaymentMethodDefinition {
 
     override fun requiresMandate(metadata: PaymentMethodMetadata): Boolean = false
 
-    override fun uiDefinitionFactory(): UiDefinitionFactory = ZipUiDefinitionFactory
+    override fun uiDefinitionFactory(
+        metadata: PaymentMethodMetadata
+    ): UiDefinitionFactory = ZipUiDefinitionFactory
 }
 
 private object ZipUiDefinitionFactory : UiDefinitionFactory.Simple() {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodLayoutUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodLayoutUITest.kt
@@ -86,12 +86,13 @@ internal class PaymentMethodLayoutUITest(
 
     @Test
     fun clickingOnNewPaymentMethod_callsOnClick() {
+        val metadata = PaymentMethodMetadataFactory.create()
         var onClickCalled = false
         runScenario(
             initialState = createState(
                 displayablePaymentMethods = listOf(
-                    CardDefinition.uiDefinitionFactory().supportedPaymentMethod(
-                        metadata = PaymentMethodMetadataFactory.create(),
+                    CardDefinition.uiDefinitionFactory(metadata).supportedPaymentMethod(
+                        metadata = metadata,
                         definition = CardDefinition,
                         sharedDataSpecs = emptyList()
                     )!!

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUITest.kt
@@ -176,11 +176,13 @@ internal class VerticalModeFormUITest {
     }
 
     private fun createCardState(customerHasSavedPaymentMethods: Boolean): VerticalModeFormInteractor.State {
-        val headerInformation =
-            (CardDefinition.uiDefinitionFactory() as UiDefinitionFactory.Custom).createFormHeaderInformation(
-                customerHasSavedPaymentMethods = customerHasSavedPaymentMethods,
-                incentive = null,
-            )
+        val customUiDefinitionFactory = CardDefinition.uiDefinitionFactory(
+            metadata = PaymentMethodMetadataFactory.create()
+        ) as UiDefinitionFactory.Custom
+        val headerInformation = customUiDefinitionFactory.createFormHeaderInformation(
+            customerHasSavedPaymentMethods = customerHasSavedPaymentMethods,
+            incentive = null,
+        )
         return VerticalModeFormInteractor.State(
             selectedPaymentMethodCode = PaymentMethod.Type.Card.code,
             isProcessing = false,


### PR DESCRIPTION
# Summary
Add `PaymentMethodMetadata` to `uiDefinitionFactory` function in `PaymentMethodDefinition`

# Motivation
Want to support separate `UiDefinitionFactory` implementations for `CardDefinition` for Tap to Add.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified