### PR TITLE
Replace `DeferredIntentConfirmationType` with launcher arguments in `toResult` function in `ConfirmationDefinition`

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/challenge/passive/PassiveChallengeActivityContract.kt
+++ b/payments-core/src/main/java/com/stripe/android/challenge/passive/PassiveChallengeActivityContract.kt
@@ -2,10 +2,12 @@ package com.stripe.android.challenge.passive
 
 import android.content.Context
 import android.content.Intent
+import android.os.Parcelable
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.annotation.RestrictTo
 import androidx.core.os.BundleCompat
 import com.stripe.android.model.PassiveCaptchaParams
+import kotlinx.parcelize.Parcelize
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class PassiveChallengeActivityContract :
@@ -26,11 +28,12 @@ class PassiveChallengeActivityContract :
     }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @Parcelize
     data class Args(
         val passiveCaptchaParams: PassiveCaptchaParams,
         val publishableKey: String,
         val productUsage: Set<String>
-    )
+    ) : Parcelable
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     companion object {

--- a/paymentsheet/src/main/java/com/stripe/android/attestation/AttestationActivityContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/attestation/AttestationActivityContract.kt
@@ -2,8 +2,10 @@ package com.stripe.android.attestation
 
 import android.content.Context
 import android.content.Intent
+import android.os.Parcelable
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.core.os.BundleCompat
+import kotlinx.parcelize.Parcelize
 
 internal class AttestationActivityContract :
     ActivityResultContract<AttestationActivityContract.Args, AttestationActivityResult>() {
@@ -26,10 +28,11 @@ internal class AttestationActivityContract :
             ?: AttestationActivityResult.Failed(IllegalStateException("No result received from AttestationActivity"))
     }
 
+    @Parcelize
     internal data class Args(
         val publishableKey: String,
         val productUsage: Set<String>
-    )
+    ) : Parcelable
 
     companion object {
         const val EXTRA_RESULT = "com.stripe.android.attestation.AttestationActivityContract.extra_result"

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationDefinition.kt
@@ -13,7 +13,7 @@ import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfi
 internal interface ConfirmationDefinition<
     TConfirmationOption : ConfirmationHandler.Option,
     TLauncher,
-    TLauncherArgs,
+    TLauncherArgs : Parcelable,
     TLauncherResult : Parcelable
     > {
     /**
@@ -105,13 +105,13 @@ internal interface ConfirmationDefinition<
      *
      * @param confirmationOption the expected [ConfirmationHandler.Option] type used during confirmation
      * @param confirmationArgs a set of general confirmation parameters using during confirmation
-     * @param deferredIntentConfirmationType DO NOT USE OUTSIDE OF INTENT CONFIRMATION
+     * @param launcherArgs set of arguments used to launch the confirmation process.
      * @param result the launcher result received after the confirmation flow was closed.
      */
     fun toResult(
         confirmationOption: TConfirmationOption,
         confirmationArgs: ConfirmationHandler.Args,
-        deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+        launcherArgs: TLauncherArgs,
         result: TLauncherResult,
     ): Result
 
@@ -142,7 +142,7 @@ internal interface ConfirmationDefinition<
             /**
              * DO NOT USE OUTSIDE OF INTENT CONFIRMATION
              */
-            val deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+            val deferredIntentConfirmationType: DeferredIntentConfirmationType? = null,
             /**
              * Indicates if the full payment flow was completed by the handler. Can be used to decide if internal
              * product state needs to be reset. Useful for confirmation flows that are handed off to merchants to
@@ -252,10 +252,6 @@ internal interface ConfirmationDefinition<
              * covers the merchant's application (ie. the Google Pay or Bacs Mandate sheets).
              */
             val receivesResultInProcess: Boolean,
-            /**
-             * DO NOT USE OUTSIDE OF INTENT CONFIRMATION
-             */
-            val deferredIntentConfirmationType: DeferredIntentConfirmationType?,
         ) : Action<TLauncherArgs>
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediator.kt
@@ -15,7 +15,7 @@ import kotlinx.parcelize.Parcelize
 internal class ConfirmationMediator<
     TConfirmationOption : ConfirmationHandler.Option,
     TLauncher,
-    TLauncherArgs,
+    TLauncherArgs : Parcelable,
     TLauncherResult : Parcelable
     >(
     private val savedStateHandle: SavedStateHandle,
@@ -25,7 +25,7 @@ internal class ConfirmationMediator<
     private var launcher: TLauncher? = null
 
     private val parametersKey = definition.key + PARAMETERS_POSTFIX_KEY
-    private var persistedParameters: Parameters<TConfirmationOption>?
+    private var persistedParameters: Parameters<TConfirmationOption, TLauncherArgs>?
         get() = savedStateHandle[parametersKey]
         set(value) {
             savedStateHandle[parametersKey] = value
@@ -54,7 +54,7 @@ internal class ConfirmationMediator<
                 definition.toResult(
                     confirmationOption = params.confirmationOption,
                     confirmationArgs = params.confirmationArgs,
-                    deferredIntentConfirmationType = params.deferredIntentConfirmationType,
+                    launcherArgs = params.launcherArgs,
                     result = result
                 )
             } ?: run {
@@ -107,7 +107,7 @@ internal class ConfirmationMediator<
                             persistedParameters = Parameters(
                                 confirmationOption = confirmationOption,
                                 confirmationArgs = arguments,
-                                deferredIntentConfirmationType = action.deferredIntentConfirmationType,
+                                launcherArgs = action.launcherArguments,
                             )
 
                             definition.launch(
@@ -168,10 +168,10 @@ internal class ConfirmationMediator<
     }
 
     @Parcelize
-    internal data class Parameters<TConfirmationOption : ConfirmationHandler.Option>(
+    internal data class Parameters<TConfirmationOption : ConfirmationHandler.Option, TLauncherArgs : Parcelable>(
         val confirmationOption: TConfirmationOption,
         val confirmationArgs: ConfirmationHandler.Args,
-        val deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+        val launcherArgs: TLauncherArgs,
     ) : Parcelable
 
     companion object {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/EmptyConfirmationLauncherArgs.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/EmptyConfirmationLauncherArgs.kt
@@ -1,0 +1,7 @@
+package com.stripe.android.paymentelement.confirmation
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+internal object EmptyConfirmationLauncherArgs : Parcelable

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/attestation/AttestationConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/attestation/AttestationConfirmationDefinition.kt
@@ -15,7 +15,6 @@ import com.stripe.android.model.RadarOptions
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
-import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.attestation.IntegrityRequestManager
@@ -75,7 +74,7 @@ internal class AttestationConfirmationDefinition @Inject constructor(
     override fun toResult(
         confirmationOption: PaymentMethodConfirmationOption.New,
         confirmationArgs: ConfirmationHandler.Args,
-        deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+        launcherArgs: AttestationActivityContract.Args,
         result: AttestationActivityResult
     ): ConfirmationDefinition.Result {
         return when (result) {
@@ -121,7 +120,6 @@ internal class AttestationConfirmationDefinition @Inject constructor(
                     productUsage = productUsage
                 ),
                 receivesResultInProcess = false,
-                deferredIntentConfirmationType = null,
             )
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationDefinition.kt
@@ -4,7 +4,6 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
-import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateConfirmationContract
 import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateConfirmationLauncher
@@ -35,7 +34,6 @@ internal class BacsConfirmationDefinition @Inject constructor(
             ConfirmationDefinition.Action.Launch(
                 launcherArguments = data,
                 receivesResultInProcess = true,
-                deferredIntentConfirmationType = null,
             )
         } ?: run {
             ConfirmationDefinition.Action.Fail(
@@ -75,7 +73,7 @@ internal class BacsConfirmationDefinition @Inject constructor(
     override fun toResult(
         confirmationOption: BacsConfirmationOption,
         confirmationArgs: ConfirmationHandler.Args,
-        deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+        launcherArgs: BacsMandateData,
         result: BacsMandateConfirmationResult,
     ): ConfirmationDefinition.Result {
         return when (result) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinition.kt
@@ -13,7 +13,6 @@ import com.stripe.android.model.RadarOptions
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
-import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import javax.inject.Inject
@@ -57,7 +56,7 @@ internal class PassiveChallengeConfirmationDefinition @Inject constructor(
     override fun toResult(
         confirmationOption: PaymentMethodConfirmationOption.New,
         confirmationArgs: ConfirmationHandler.Args,
-        deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+        launcherArgs: PassiveChallengeActivityContract.Args,
         result: PassiveChallengeActivityResult
     ): ConfirmationDefinition.Result {
         return when (result) {
@@ -106,7 +105,6 @@ internal class PassiveChallengeConfirmationDefinition @Inject constructor(
                     productUsage = productUsage
                 ),
                 receivesResultInProcess = false,
-                deferredIntentConfirmationType = null,
             )
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/cpms/CustomPaymentMethodConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/cpms/CustomPaymentMethodConfirmationDefinition.kt
@@ -7,7 +7,7 @@ import com.stripe.android.paymentelement.ConfirmCustomPaymentMethodCallback
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
-import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
+import com.stripe.android.paymentelement.confirmation.EmptyConfirmationLauncherArgs
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import javax.inject.Inject
 import javax.inject.Provider
@@ -19,7 +19,7 @@ internal class CustomPaymentMethodConfirmationDefinition @Inject constructor(
 ) : ConfirmationDefinition<
     CustomPaymentMethodConfirmationOption,
     ActivityResultLauncher<CustomPaymentMethodInput>,
-    Unit,
+    EmptyConfirmationLauncherArgs,
     InternalCustomPaymentMethodResult
     > {
     override val key: String = "CustomPaymentMethod"
@@ -33,7 +33,7 @@ internal class CustomPaymentMethodConfirmationDefinition @Inject constructor(
     override suspend fun action(
         confirmationOption: CustomPaymentMethodConfirmationOption,
         confirmationArgs: ConfirmationHandler.Args,
-    ): ConfirmationDefinition.Action<Unit> {
+    ): ConfirmationDefinition.Action<EmptyConfirmationLauncherArgs> {
         val customPaymentMethodId = confirmationOption.customPaymentMethodType.id
         val confirmCustomPaymentMethodCallback = confirmCustomPaymentMethodCallbackProvider.get()
 
@@ -55,9 +55,8 @@ internal class CustomPaymentMethodConfirmationDefinition @Inject constructor(
             )
         } else {
             ConfirmationDefinition.Action.Launch(
-                launcherArguments = Unit,
+                launcherArguments = EmptyConfirmationLauncherArgs,
                 receivesResultInProcess = false,
-                deferredIntentConfirmationType = null,
             )
         }
     }
@@ -74,7 +73,7 @@ internal class CustomPaymentMethodConfirmationDefinition @Inject constructor(
 
     override fun launch(
         launcher: ActivityResultLauncher<CustomPaymentMethodInput>,
-        arguments: Unit,
+        arguments: EmptyConfirmationLauncherArgs,
         confirmationOption: CustomPaymentMethodConfirmationOption,
         confirmationArgs: ConfirmationHandler.Args,
     ) {
@@ -97,13 +96,12 @@ internal class CustomPaymentMethodConfirmationDefinition @Inject constructor(
     override fun toResult(
         confirmationOption: CustomPaymentMethodConfirmationOption,
         confirmationArgs: ConfirmationHandler.Args,
-        deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+        launcherArgs: EmptyConfirmationLauncherArgs,
         result: InternalCustomPaymentMethodResult
     ): ConfirmationDefinition.Result {
         return when (result) {
             is InternalCustomPaymentMethodResult.Completed -> ConfirmationDefinition.Result.Succeeded(
                 intent = confirmationArgs.intent,
-                deferredIntentConfirmationType = null,
             )
             is InternalCustomPaymentMethodResult.Failed -> ConfirmationDefinition.Result.Failed(
                 cause = result.throwable,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationDefinition.kt
@@ -4,8 +4,8 @@ import androidx.activity.result.ActivityResultCaller
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.EmptyConfirmationLauncherArgs
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
-import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
 import com.stripe.android.paymentsheet.cvcrecollection.CvcRecollectionHandler
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcRecollectionContract
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcRecollectionLauncher
@@ -19,7 +19,7 @@ internal class CvcRecollectionConfirmationDefinition @Inject constructor(
 ) : ConfirmationDefinition<
     PaymentMethodConfirmationOption.Saved,
     CvcRecollectionLauncher,
-    Unit,
+    EmptyConfirmationLauncherArgs,
     CvcRecollectionResult,
     > {
     override val key: String = "CvcRecollection"
@@ -42,11 +42,10 @@ internal class CvcRecollectionConfirmationDefinition @Inject constructor(
     override suspend fun action(
         confirmationOption: PaymentMethodConfirmationOption.Saved,
         confirmationArgs: ConfirmationHandler.Args
-    ): ConfirmationDefinition.Action<Unit> {
+    ): ConfirmationDefinition.Action<EmptyConfirmationLauncherArgs> {
         return ConfirmationDefinition.Action.Launch(
-            launcherArguments = Unit,
+            launcherArguments = EmptyConfirmationLauncherArgs,
             receivesResultInProcess = true,
-            deferredIntentConfirmationType = null,
         )
     }
 
@@ -64,7 +63,7 @@ internal class CvcRecollectionConfirmationDefinition @Inject constructor(
 
     override fun launch(
         launcher: CvcRecollectionLauncher,
-        arguments: Unit,
+        arguments: EmptyConfirmationLauncherArgs,
         confirmationOption: PaymentMethodConfirmationOption.Saved,
         confirmationArgs: ConfirmationHandler.Args
     ) {
@@ -80,7 +79,7 @@ internal class CvcRecollectionConfirmationDefinition @Inject constructor(
     override fun toResult(
         confirmationOption: PaymentMethodConfirmationOption.Saved,
         confirmationArgs: ConfirmationHandler.Args,
-        deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+        launcherArgs: EmptyConfirmationLauncherArgs,
         result: CvcRecollectionResult
     ): ConfirmationDefinition.Result {
         return when (result) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationDefinition.kt
@@ -6,7 +6,7 @@ import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
-import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
+import com.stripe.android.paymentelement.confirmation.EmptyConfirmationLauncherArgs
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.paymentsheet.ExternalPaymentMethodConfirmHandler
@@ -22,7 +22,7 @@ internal class ExternalPaymentMethodConfirmationDefinition @Inject constructor(
 ) : ConfirmationDefinition<
     ExternalPaymentMethodConfirmationOption,
     ActivityResultLauncher<ExternalPaymentMethodInput>,
-    Unit,
+    EmptyConfirmationLauncherArgs,
     PaymentResult
     > {
     override val key: String = "ExternalPaymentMethod"
@@ -36,7 +36,7 @@ internal class ExternalPaymentMethodConfirmationDefinition @Inject constructor(
     override suspend fun action(
         confirmationOption: ExternalPaymentMethodConfirmationOption,
         confirmationArgs: ConfirmationHandler.Args,
-    ): ConfirmationDefinition.Action<Unit> {
+    ): ConfirmationDefinition.Action<EmptyConfirmationLauncherArgs> {
         val externalPaymentMethodType = confirmationOption.type
         val externalPaymentMethodConfirmHandler = externalPaymentMethodConfirmHandlerProvider.get()
 
@@ -58,9 +58,8 @@ internal class ExternalPaymentMethodConfirmationDefinition @Inject constructor(
             )
         } else {
             ConfirmationDefinition.Action.Launch(
-                launcherArguments = Unit,
+                launcherArguments = EmptyConfirmationLauncherArgs,
                 receivesResultInProcess = false,
-                deferredIntentConfirmationType = null,
             )
         }
     }
@@ -77,7 +76,7 @@ internal class ExternalPaymentMethodConfirmationDefinition @Inject constructor(
 
     override fun launch(
         launcher: ActivityResultLauncher<ExternalPaymentMethodInput>,
-        arguments: Unit,
+        arguments: EmptyConfirmationLauncherArgs,
         confirmationOption: ExternalPaymentMethodConfirmationOption,
         confirmationArgs: ConfirmationHandler.Args,
     ) {
@@ -98,13 +97,12 @@ internal class ExternalPaymentMethodConfirmationDefinition @Inject constructor(
     override fun toResult(
         confirmationOption: ExternalPaymentMethodConfirmationOption,
         confirmationArgs: ConfirmationHandler.Args,
-        deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+        launcherArgs: EmptyConfirmationLauncherArgs,
         result: PaymentResult
     ): ConfirmationDefinition.Result {
         return when (result) {
             is PaymentResult.Completed -> ConfirmationDefinition.Result.Succeeded(
                 intent = confirmationArgs.intent,
-                deferredIntentConfirmationType = null,
             )
             is PaymentResult.Failed -> ConfirmationDefinition.Result.Failed(
                 cause = result.throwable,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinition.kt
@@ -13,8 +13,8 @@ import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.EmptyConfirmationLauncherArgs
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
-import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
 import kotlinx.coroutines.CoroutineScope
@@ -28,7 +28,7 @@ internal class GooglePayConfirmationDefinition @Inject constructor(
 ) : ConfirmationDefinition<
     GooglePayConfirmationOption,
     ActivityResultLauncher<GooglePayPaymentMethodLauncherContractV2.Args>,
-    Unit,
+    EmptyConfirmationLauncherArgs,
     GooglePayPaymentMethodLauncher.Result,
     > {
     override val key: String = "GooglePay"
@@ -40,7 +40,7 @@ internal class GooglePayConfirmationDefinition @Inject constructor(
     override suspend fun action(
         confirmationOption: GooglePayConfirmationOption,
         confirmationArgs: ConfirmationHandler.Args,
-    ): ConfirmationDefinition.Action<Unit> {
+    ): ConfirmationDefinition.Action<EmptyConfirmationLauncherArgs> {
         if (
             confirmationOption.config.merchantCurrencyCode == null &&
             confirmationArgs.intent !is PaymentIntent
@@ -58,9 +58,8 @@ internal class GooglePayConfirmationDefinition @Inject constructor(
         }
 
         return ConfirmationDefinition.Action.Launch(
-            launcherArguments = Unit,
+            launcherArguments = EmptyConfirmationLauncherArgs,
             receivesResultInProcess = true,
-            deferredIntentConfirmationType = null,
         )
     }
 
@@ -76,7 +75,7 @@ internal class GooglePayConfirmationDefinition @Inject constructor(
 
     override fun launch(
         launcher: ActivityResultLauncher<GooglePayPaymentMethodLauncherContractV2.Args>,
-        arguments: Unit,
+        arguments: EmptyConfirmationLauncherArgs,
         confirmationOption: GooglePayConfirmationOption,
         confirmationArgs: ConfirmationHandler.Args,
     ) {
@@ -106,7 +105,7 @@ internal class GooglePayConfirmationDefinition @Inject constructor(
     override fun toResult(
         confirmationOption: GooglePayConfirmationOption,
         confirmationArgs: ConfirmationHandler.Args,
-        deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+        launcherArgs: EmptyConfirmationLauncherArgs,
         result: GooglePayPaymentMethodLauncher.Result,
     ): ConfirmationDefinition.Result {
         return when (result) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
@@ -107,9 +107,8 @@ internal class CheckoutSessionConfirmationInterceptor @AssistedInject constructo
                     }
                     paymentIntent.requiresAction() -> {
                         ConfirmationDefinition.Action.Launch(
-                            launcherArguments = Args.NextAction(paymentIntent),
+                            launcherArguments = Args.NextAction(paymentIntent, DeferredIntentConfirmationType.Server),
                             receivesResultInProcess = false,
-                            deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
                         )
                     }
                     else -> {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/ConfirmationTokenConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/ConfirmationTokenConfirmationInterceptor.kt
@@ -176,9 +176,11 @@ internal class ConfirmationTokenConfirmationInterceptor @AssistedInject construc
                 )
             } else if (intent.requiresAction()) {
                 ConfirmationDefinition.Action.Launch<Args>(
-                    launcherArguments = Args.NextAction(intent),
+                    launcherArguments = Args.NextAction(
+                        intent = intent,
+                        deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
+                    ),
                     receivesResultInProcess = false,
-                    deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
                 )
             } else {
                 confirmActionHelper.createConfirmAction(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/DeferredIntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/DeferredIntentConfirmationInterceptor.kt
@@ -233,9 +233,11 @@ internal class DeferredIntentConfirmationInterceptor @AssistedInject constructor
         return runCatching<ConfirmationDefinition.Action<Args>> {
             DeferredIntentValidator.validatePaymentMethod(intent, paymentMethod)
             ConfirmationDefinition.Action.Launch(
-                launcherArguments = Args.NextAction(intent),
+                launcherArguments = Args.NextAction(
+                    intent = intent,
+                    deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
+                ),
                 receivesResultInProcess = false,
-                deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
             )
         }.getOrElse {
             ConfirmationDefinition.Action.Fail(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationDefinition.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentelement.confirmation.intent
 
+import android.os.Parcelable
 import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
 import com.stripe.android.common.exception.stripeErrorMessage
@@ -14,6 +15,7 @@ import com.stripe.android.payments.paymentlauncher.InternalPaymentResult
 import com.stripe.android.payments.paymentlauncher.PaymentLauncher
 import com.stripe.android.payments.paymentlauncher.PaymentLauncherContract
 import com.stripe.android.paymentsheet.addresselement.toConfirmPaymentIntentShipping
+import kotlinx.parcelize.Parcelize
 
 internal class IntentConfirmationDefinition(
     private val intentConfirmationInterceptorFactory: IntentConfirmationInterceptor.Factory,
@@ -95,13 +97,13 @@ internal class IntentConfirmationDefinition(
     override fun toResult(
         confirmationOption: PaymentMethodConfirmationOption,
         confirmationArgs: ConfirmationHandler.Args,
-        deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+        launcherArgs: Args,
         result: InternalPaymentResult
     ): ConfirmationDefinition.Result {
         return when (result) {
             is InternalPaymentResult.Completed -> ConfirmationDefinition.Result.Succeeded(
                 intent = result.intent,
-                deferredIntentConfirmationType = deferredIntentConfirmationType,
+                deferredIntentConfirmationType = launcherArgs.deferredIntentConfirmationType,
             )
             is InternalPaymentResult.Failed -> ConfirmationDefinition.Result.Failed(
                 cause = result.throwable,
@@ -128,11 +130,19 @@ internal class IntentConfirmationDefinition(
         }
     }
 
-    sealed interface Args {
+    sealed interface Args : Parcelable {
+        val deferredIntentConfirmationType: DeferredIntentConfirmationType?
+
+        @Parcelize
         data class NextAction(
             val intent: StripeIntent,
+            override val deferredIntentConfirmationType: DeferredIntentConfirmationType?,
         ) : Args
 
-        data class Confirm(val confirmNextParams: ConfirmStripeIntentParams) : Args
+        @Parcelize
+        data class Confirm(
+            val confirmNextParams: ConfirmStripeIntentParams,
+            override val deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+        ) : Args
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinition.kt
@@ -9,15 +9,20 @@ import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.link.account.LinkStore
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.EmptyConfirmationLauncherArgs
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
-import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
 import javax.inject.Inject
 
 internal class LinkConfirmationDefinition @Inject constructor(
     private val linkPaymentLauncher: LinkPaymentLauncher,
     private val linkStore: LinkStore,
     private val linkAccountHolder: LinkAccountHolder,
-) : ConfirmationDefinition<LinkConfirmationOption, LinkPaymentLauncher, Unit, LinkActivityResult> {
+) : ConfirmationDefinition<
+    LinkConfirmationOption,
+    LinkPaymentLauncher,
+    EmptyConfirmationLauncherArgs,
+    LinkActivityResult
+    > {
     override val key: String = "Link"
 
     override fun option(confirmationOption: ConfirmationHandler.Option): LinkConfirmationOption? {
@@ -40,17 +45,16 @@ internal class LinkConfirmationDefinition @Inject constructor(
     override suspend fun action(
         confirmationOption: LinkConfirmationOption,
         confirmationArgs: ConfirmationHandler.Args,
-    ): ConfirmationDefinition.Action<Unit> {
+    ): ConfirmationDefinition.Action<EmptyConfirmationLauncherArgs> {
         return ConfirmationDefinition.Action.Launch(
-            launcherArguments = Unit,
+            launcherArguments = EmptyConfirmationLauncherArgs,
             receivesResultInProcess = false,
-            deferredIntentConfirmationType = null,
         )
     }
 
     override fun launch(
         launcher: LinkPaymentLauncher,
-        arguments: Unit,
+        arguments: EmptyConfirmationLauncherArgs,
         confirmationOption: LinkConfirmationOption,
         confirmationArgs: ConfirmationHandler.Args,
     ) {
@@ -66,7 +70,7 @@ internal class LinkConfirmationDefinition @Inject constructor(
     override fun toResult(
         confirmationOption: LinkConfirmationOption,
         confirmationArgs: ConfirmationHandler.Args,
-        deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+        launcherArgs: EmptyConfirmationLauncherArgs,
         result: LinkActivityResult
     ): ConfirmationDefinition.Result {
         if (
@@ -105,7 +109,6 @@ internal class LinkConfirmationDefinition @Inject constructor(
                 result.linkAccountUpdate.updateLinkAccount()
                 ConfirmationDefinition.Result.Succeeded(
                     intent = confirmationArgs.intent,
-                    deferredIntentConfirmationType = deferredIntentConfirmationType,
                 )
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkPassthroughConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/link/LinkPassthroughConfirmationDefinition.kt
@@ -9,7 +9,6 @@ import com.stripe.android.model.parsers.PaymentMethodJsonParser
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
-import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
 import com.stripe.android.paymentsheet.R
 import kotlinx.parcelize.Parcelize
 import org.json.JSONObject
@@ -38,7 +37,6 @@ internal class LinkPassthroughConfirmationDefinition @Inject constructor(
                 ConfirmationDefinition.Action.Launch(
                     launcherArguments = LauncherArguments(nextConfirmationOption),
                     receivesResultInProcess = true,
-                    deferredIntentConfirmationType = null,
                 )
             },
             onFailure = { error ->
@@ -70,7 +68,7 @@ internal class LinkPassthroughConfirmationDefinition @Inject constructor(
     override fun toResult(
         confirmationOption: LinkPassthroughConfirmationOption,
         confirmationArgs: ConfirmationHandler.Args,
-        deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+        launcherArgs: LauncherArguments,
         result: Result,
     ): ConfirmationDefinition.Result {
         return ConfirmationDefinition.Result.NextStep(
@@ -104,9 +102,10 @@ internal class LinkPassthroughConfirmationDefinition @Inject constructor(
         val nextConfirmationOption: PaymentMethodConfirmationOption,
     ) : Parcelable
 
+    @Parcelize
     data class LauncherArguments(
         val nextConfirmationOption: PaymentMethodConfirmationOption,
-    )
+    ) : Parcelable
 
     class Launcher(
         val onResult: (Result) -> Unit,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinition.kt
@@ -15,7 +15,6 @@ import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
-import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
 import kotlinx.coroutines.flow.first
 import kotlinx.parcelize.Parcelize
 
@@ -44,7 +43,6 @@ internal class LinkInlineSignupConfirmationDefinition(
         return ConfirmationDefinition.Action.Launch(
             launcherArguments = LauncherArguments(nextConfirmationOption),
             receivesResultInProcess = true,
-            deferredIntentConfirmationType = null,
         )
     }
 
@@ -67,7 +65,7 @@ internal class LinkInlineSignupConfirmationDefinition(
     override fun toResult(
         confirmationOption: LinkInlineSignupConfirmationOption,
         confirmationArgs: ConfirmationHandler.Args,
-        deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+        launcherArgs: LauncherArguments,
         result: Result,
     ): ConfirmationDefinition.Result {
         return ConfirmationDefinition.Result.NextStep(
@@ -193,9 +191,10 @@ internal class LinkInlineSignupConfirmationDefinition(
         val nextConfirmationOption: PaymentMethodConfirmationOption,
     ) : Parcelable
 
+    @Parcelize
     data class LauncherArguments(
         val nextConfirmationOption: PaymentMethodConfirmationOption,
-    )
+    ) : Parcelable
 
     class Launcher(
         val onResult: (Result) -> Unit,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/shoppay/ShopPayConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/shoppay/ShopPayConfirmationDefinition.kt
@@ -5,7 +5,7 @@ import androidx.activity.result.ActivityResultLauncher
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
-import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
+import com.stripe.android.paymentelement.confirmation.EmptyConfirmationLauncherArgs
 import com.stripe.android.shoppay.ShopPayActivityContract
 import com.stripe.android.shoppay.ShopPayActivityResult
 import javax.inject.Inject
@@ -15,7 +15,7 @@ internal class ShopPayConfirmationDefinition @Inject constructor(
 ) : ConfirmationDefinition<
     ShopPayConfirmationOption,
     ActivityResultLauncher<ShopPayActivityContract.Args>,
-    Unit,
+    EmptyConfirmationLauncherArgs,
     ShopPayActivityResult
     > {
     override val key = "ShopPay"
@@ -27,7 +27,7 @@ internal class ShopPayConfirmationDefinition @Inject constructor(
     override fun toResult(
         confirmationOption: ShopPayConfirmationOption,
         confirmationArgs: ConfirmationHandler.Args,
-        deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+        launcherArgs: EmptyConfirmationLauncherArgs,
         result: ShopPayActivityResult
     ): ConfirmationDefinition.Result {
         return when (result) {
@@ -39,7 +39,6 @@ internal class ShopPayConfirmationDefinition @Inject constructor(
             is ShopPayActivityResult.Completed -> {
                 ConfirmationDefinition.Result.Succeeded(
                     intent = confirmationArgs.intent,
-                    deferredIntentConfirmationType = deferredIntentConfirmationType,
                     // Shop Pay is handed off for `preparePaymentMethod` purposes
                     completedFullPaymentFlow = false,
                 )
@@ -66,7 +65,7 @@ internal class ShopPayConfirmationDefinition @Inject constructor(
 
     override fun launch(
         launcher: ActivityResultLauncher<ShopPayActivityContract.Args>,
-        arguments: Unit,
+        arguments: EmptyConfirmationLauncherArgs,
         confirmationOption: ShopPayConfirmationOption,
         confirmationArgs: ConfirmationHandler.Args
     ) {
@@ -84,11 +83,10 @@ internal class ShopPayConfirmationDefinition @Inject constructor(
     override suspend fun action(
         confirmationOption: ShopPayConfirmationOption,
         confirmationArgs: ConfirmationHandler.Args
-    ): ConfirmationDefinition.Action<Unit> {
+    ): ConfirmationDefinition.Action<EmptyConfirmationLauncherArgs> {
         return ConfirmationDefinition.Action.Launch(
-            launcherArguments = Unit,
+            launcherArguments = EmptyConfirmationLauncherArgs,
             receivesResultInProcess = false,
-            deferredIntentConfirmationType = null,
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/utils/ConfirmActionHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/utils/ConfirmActionHelper.kt
@@ -33,9 +33,11 @@ internal class ConfirmActionHelper(private val isLiveMode: Boolean) {
 
         val confirmParams = factory.confirmParamsCreation()
         return ConfirmationDefinition.Action.Launch(
-            launcherArguments = Args.Confirm(confirmParams),
+            launcherArguments = Args.Confirm(
+                confirmNextParams = confirmParams,
+                deferredIntentConfirmationType = DeferredIntentConfirmationType.Client.takeIf { isDeferred }
+            ),
             receivesResultInProcess = false,
-            deferredIntentConfirmationType = DeferredIntentConfirmationType.Client.takeIf { isDeferred },
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateData.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/bacs/BacsMandateData.kt
@@ -1,14 +1,17 @@
 package com.stripe.android.paymentsheet.paymentdatacollection.bacs
 
+import android.os.Parcelable
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentelement.confirmation.bacs.BacsConfirmationOption
+import kotlinx.parcelize.Parcelize
 
+@Parcelize
 internal data class BacsMandateData(
     val name: String,
     val email: String,
     val accountNumber: String,
     val sortCode: String
-) {
+) : Parcelable {
     companion object {
         fun fromConfirmationOption(
             confirmationOption: BacsConfirmationOption,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationTestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationTestUtils.kt
@@ -17,7 +17,7 @@ import java.util.concurrent.TimeUnit
 internal fun <
     TConfirmationOption : ConfirmationHandler.Option,
     TLauncher,
-    TLauncherArgs,
+    TLauncherArgs : Parcelable,
     TLauncherResult : Parcelable
     > runLaunchTest(
     definition: ConfirmationDefinition<TConfirmationOption, TLauncher, TLauncherArgs, TLauncherResult>,
@@ -47,11 +47,10 @@ internal fun <
         launchAction.launch()
 
         val savedParameters = savedStateHandle
-            .get<Parameters<TConfirmationOption>>("${definition.key}Parameters")
+            .get<Parameters<TConfirmationOption, TLauncherArgs>>("${definition.key}Parameters")
 
         assertThat(savedParameters?.confirmationOption).isEqualTo(confirmationOption)
         assertThat(savedParameters?.confirmationArgs).isEqualTo(parameters)
-        assertThat(savedParameters?.deferredIntentConfirmationType).isNull()
 
         assertThat(awaitRegisterCall()).isNotNull()
         assertThat(awaitLaunchCall()).isNotNull()
@@ -61,12 +60,13 @@ internal fun <
 internal fun <
     TConfirmationOption : ConfirmationHandler.Option,
     TLauncher,
-    TLauncherArgs,
+    TLauncherArgs : Parcelable,
     TLauncherResult : Parcelable
     > runResultTest(
     definition: ConfirmationDefinition<TConfirmationOption, TLauncher, TLauncherArgs, TLauncherResult>,
     confirmationOption: ConfirmationHandler.Option,
     parameters: ConfirmationHandler.Args,
+    launcherArgs: TLauncherArgs,
     launcherResult: TLauncherResult,
     definitionResult: ConfirmationDefinition.Result,
 ) = runTest {
@@ -78,7 +78,7 @@ internal fun <
             Parameters(
                 confirmationOption = confirmationOption,
                 confirmationArgs = parameters,
-                deferredIntentConfirmationType = null,
+                launcherArgs = launcherArgs,
             )
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandlerTest.kt
@@ -64,12 +64,10 @@ class DefaultConfirmationHandlerTest {
         someDefinitionAction = ConfirmationDefinition.Action.Launch(
             launcherArguments = SomeConfirmationDefinition.LauncherArgs,
             receivesResultInProcess = true,
-            deferredIntentConfirmationType = null,
         ),
         someOtherDefinitionAction = ConfirmationDefinition.Action.Launch(
             launcherArguments = SomeOtherConfirmationDefinition.LauncherArgs,
             receivesResultInProcess = true,
-            deferredIntentConfirmationType = null,
         ),
     ) {
         val activityResultCaller = mock<ActivityResultCaller>()
@@ -391,7 +389,6 @@ class DefaultConfirmationHandlerTest {
         someDefinitionAction = ConfirmationDefinition.Action.Launch(
             launcherArguments = SomeConfirmationDefinition.LauncherArgs,
             receivesResultInProcess = true,
-            deferredIntentConfirmationType = null,
         ),
         someDefinitionResult = ConfirmationDefinition.Result.NextStep(
             confirmationOption = SomeOtherConfirmationDefinition.Option,
@@ -400,11 +397,9 @@ class DefaultConfirmationHandlerTest {
         someOtherDefinitionAction = ConfirmationDefinition.Action.Launch(
             launcherArguments = SomeOtherConfirmationDefinition.LauncherArgs,
             receivesResultInProcess = true,
-            deferredIntentConfirmationType = null,
         ),
         someOtherDefinitionResult = ConfirmationDefinition.Result.Succeeded(
             intent = PAYMENT_INTENT,
-            deferredIntentConfirmationType = null,
         ),
     ) {
         confirmationHandler.state.test {
@@ -446,7 +441,6 @@ class DefaultConfirmationHandlerTest {
             savedStateHandle = createPrepopulatedSavedStateHandle(receivesResultInProcess = true),
             someDefinitionResult = ConfirmationDefinition.Result.Succeeded(
                 intent = PAYMENT_INTENT,
-                deferredIntentConfirmationType = null,
             ),
             dispatcher = dispatcher,
         ) {
@@ -509,7 +503,6 @@ class DefaultConfirmationHandlerTest {
             savedStateHandle = createPrepopulatedSavedStateHandle(receivesResultInProcess = false),
             someDefinitionResult = ConfirmationDefinition.Result.Succeeded(
                 intent = PAYMENT_INTENT,
-                deferredIntentConfirmationType = null,
             ),
             dispatcher = dispatcher,
         ) {
@@ -547,11 +540,9 @@ class DefaultConfirmationHandlerTest {
             someOtherDefinitionAction = ConfirmationDefinition.Action.Launch(
                 launcherArguments = SomeOtherConfirmationDefinition.LauncherArgs,
                 receivesResultInProcess = false,
-                deferredIntentConfirmationType = null,
             ),
             someOtherDefinitionResult = ConfirmationDefinition.Result.Succeeded(
                 intent = UPDATED_PAYMENT_INTENT,
-                deferredIntentConfirmationType = null,
             ),
             dispatcher = dispatcher,
         ) {
@@ -599,11 +590,9 @@ class DefaultConfirmationHandlerTest {
             someDefinitionAction = ConfirmationDefinition.Action.Launch(
                 launcherArguments = SomeConfirmationDefinition.LauncherArgs,
                 receivesResultInProcess = true,
-                deferredIntentConfirmationType = null,
             ),
             someDefinitionResult = ConfirmationDefinition.Result.Succeeded(
                 intent = PAYMENT_INTENT,
-                deferredIntentConfirmationType = null,
             ),
             dispatcher = dispatcher,
         ) {
@@ -663,7 +652,6 @@ class DefaultConfirmationHandlerTest {
         someDefinitionAction = ConfirmationDefinition.Action.Launch(
             launcherArguments = SomeConfirmationDefinition.LauncherArgs,
             receivesResultInProcess = true,
-            deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
         ),
         someDefinitionResult = result,
     ) {
@@ -690,7 +678,6 @@ class DefaultConfirmationHandlerTest {
         someDefinitionAction = ConfirmationDefinition.Action.Launch(
             launcherArguments = SomeConfirmationDefinition.LauncherArgs,
             receivesResultInProcess = receivesResultInProcess,
-            deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
         ),
     ) {
         confirmationHandler.state.test {
@@ -712,12 +699,16 @@ class DefaultConfirmationHandlerTest {
             assertThat(resultData?.confirmationOption).isEqualTo(SomeConfirmationDefinition.Option)
             assertThat(resultData?.receivesResultInProcess).isEqualTo(receivesResultInProcess)
 
-            val parameters = savedStateHandle.get<ConfirmationMediator.Parameters<SomeConfirmationDefinition.Option>>(
+            val parameters = savedStateHandle.get<
+                ConfirmationMediator.Parameters<
+                    SomeConfirmationDefinition.Option,
+                    SomeConfirmationDefinition.LauncherArgs
+                    >
+                >(
                 SOME_DEFINITION_PERSISTED_KEY
             )
 
             assertThat(parameters?.confirmationArgs).isEqualTo(CONFIRMATION_PARAMETERS)
-            assertThat(parameters?.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Client)
         }
     }
 
@@ -859,7 +850,7 @@ class DefaultConfirmationHandlerTest {
             ConfirmationMediator.Parameters(
                 confirmationOption = SomeConfirmationDefinition.Option,
                 confirmationArgs = CONFIRMATION_PARAMETERS,
-                deferredIntentConfirmationType = null,
+                launcherArgs = SomeConfirmationDefinition.LauncherArgs,
             )
         )
     }
@@ -1077,7 +1068,8 @@ class DefaultConfirmationHandlerTest {
 
         object Launcher
 
-        data object LauncherArgs
+        @Parcelize
+        data object LauncherArgs : Parcelable
 
         @Parcelize
         data object LauncherResult : Parcelable
@@ -1114,7 +1106,8 @@ class DefaultConfirmationHandlerTest {
 
         object Launcher
 
-        data object LauncherArgs
+        @Parcelize
+        data object LauncherArgs : Parcelable
 
         @Parcelize
         data object LauncherResult : Parcelable

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/FakeConfirmationDefinition.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/FakeConfirmationDefinition.kt
@@ -3,13 +3,12 @@ package com.stripe.android.paymentelement.confirmation
 import android.os.Parcelable
 import androidx.activity.result.ActivityResultCaller
 import com.stripe.android.core.strings.resolvableString
-import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
 import com.stripe.android.paymentsheet.R
 
 internal abstract class FakeConfirmationDefinition<
     TConfirmationOption : ConfirmationHandler.Option,
     TLauncher,
-    TLauncherArgs,
+    TLauncherArgs : Parcelable,
     TLauncherResult : Parcelable,
     >(
     private val launcher: TLauncher,
@@ -53,7 +52,7 @@ internal abstract class FakeConfirmationDefinition<
     override fun toResult(
         confirmationOption: TConfirmationOption,
         confirmationArgs: ConfirmationHandler.Args,
-        deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+        launcherArgs: TLauncherArgs,
         result: TLauncherResult
     ): ConfirmationDefinition.Result {
         return this.result

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationDefinitionTest.kt
@@ -204,10 +204,10 @@ class IntentConfirmationDefinitionTest {
 
         assertThat(launchAction.launcherArguments).isEqualTo(
             IntentConfirmationDefinition.Args.NextAction(
-                intent = paymentIntent
+                intent = paymentIntent,
+                deferredIntentConfirmationType = DeferredIntentConfirmationType.Server
             )
         )
-        assertThat(launchAction.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Server)
     }
 
     @Test
@@ -234,9 +234,9 @@ class IntentConfirmationDefinitionTest {
         assertThat(launchAction.launcherArguments).isEqualTo(
             IntentConfirmationDefinition.Args.Confirm(
                 confirmNextParams = confirmParams,
+                deferredIntentConfirmationType = null,
             )
         )
-        assertThat(launchAction.deferredIntentConfirmationType).isNull()
     }
 
     @Test
@@ -254,7 +254,10 @@ class IntentConfirmationDefinitionTest {
 
         definition.launch(
             launcher = launcher,
-            arguments = IntentConfirmationDefinition.Args.Confirm(confirmParams),
+            arguments = IntentConfirmationDefinition.Args.Confirm(
+                confirmNextParams = confirmParams,
+                deferredIntentConfirmationType = null,
+            ),
             confirmationArgs = CONFIRMATION_PARAMETERS_WITH_SI,
             confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
         )
@@ -276,7 +279,8 @@ class IntentConfirmationDefinitionTest {
         definition.launch(
             launcher = launcher,
             arguments = IntentConfirmationDefinition.Args.NextAction(
-                intent = setupIntent
+                intent = setupIntent,
+                deferredIntentConfirmationType = null,
             ),
             confirmationArgs = CONFIRMATION_PARAMETERS_WITH_SI,
             confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
@@ -302,7 +306,10 @@ class IntentConfirmationDefinitionTest {
 
         definition.launch(
             launcher = launcher,
-            arguments = IntentConfirmationDefinition.Args.Confirm(confirmParams),
+            arguments = IntentConfirmationDefinition.Args.Confirm(
+                confirmNextParams = confirmParams,
+                deferredIntentConfirmationType = null,
+            ),
             confirmationArgs = CONFIRMATION_PARAMETERS_WITH_SI,
             confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
         )
@@ -324,7 +331,8 @@ class IntentConfirmationDefinitionTest {
         definition.launch(
             launcher = launcher,
             arguments = IntentConfirmationDefinition.Args.NextAction(
-                intent = paymentIntent
+                intent = paymentIntent,
+                deferredIntentConfirmationType = null,
             ),
             confirmationArgs = CONFIRMATION_PARAMETERS,
             confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
@@ -348,7 +356,8 @@ class IntentConfirmationDefinitionTest {
         definition.launch(
             launcher = launcher,
             arguments = IntentConfirmationDefinition.Args.NextAction(
-                intent = paymentIntent
+                intent = paymentIntent,
+                deferredIntentConfirmationType = null,
             ),
             confirmationArgs = CONFIRMATION_PARAMETERS,
             confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
@@ -372,7 +381,8 @@ class IntentConfirmationDefinitionTest {
         definition.launch(
             launcher = launcher,
             arguments = IntentConfirmationDefinition.Args.NextAction(
-                intent = setupIntent
+                intent = setupIntent,
+                deferredIntentConfirmationType = null,
             ),
             confirmationArgs = CONFIRMATION_PARAMETERS_WITH_SI,
             confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
@@ -394,7 +404,10 @@ class IntentConfirmationDefinitionTest {
         val result = definition.toResult(
             confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS,
-            deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
+            launcherArgs = IntentConfirmationDefinition.Args.NextAction(
+                intent = PaymentIntentFixtures.PI_SUCCEEDED,
+                deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
+            ),
             result = InternalPaymentResult.Completed(PaymentIntentFixtures.PI_SUCCEEDED),
         )
 
@@ -418,7 +431,10 @@ class IntentConfirmationDefinitionTest {
         val result = definition.toResult(
             confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS,
-            deferredIntentConfirmationType = null,
+            launcherArgs = IntentConfirmationDefinition.Args.NextAction(
+                intent = PaymentIntentFixtures.PI_SUCCEEDED,
+                deferredIntentConfirmationType = null,
+            ),
             result = InternalPaymentResult.Failed(exception),
         )
 
@@ -440,7 +456,10 @@ class IntentConfirmationDefinitionTest {
         val result = definition.toResult(
             confirmationOption = SAVED_PAYMENT_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS,
-            deferredIntentConfirmationType = null,
+            launcherArgs = IntentConfirmationDefinition.Args.NextAction(
+                intent = PaymentIntentFixtures.PI_SUCCEEDED,
+                deferredIntentConfirmationType = null,
+            ),
             result = InternalPaymentResult.Canceled,
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationFlowTest.kt
@@ -151,7 +151,8 @@ internal class IntentConfirmationFlowTest {
         val setupIntentParams = confirmArguments.confirmNextParams.asSetup()
 
         assertThat(setupIntentParams.clientSecret).isEqualTo("seti_123_secret_123")
-        assertThat(launchAction.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Client)
+        assertThat(confirmArguments.deferredIntentConfirmationType)
+            .isEqualTo(DeferredIntentConfirmationType.Client)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/RecordingConfirmationDefinition.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/RecordingConfirmationDefinition.kt
@@ -5,12 +5,11 @@ import androidx.activity.result.ActivityResultCaller
 import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
-import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
 
 internal class RecordingConfirmationDefinition<
     TConfirmationOption : ConfirmationHandler.Option,
     TLauncher,
-    TLauncherArgs,
+    TLauncherArgs : Parcelable,
     TLauncherResult : Parcelable,
     > private constructor(
     private val definition: ConfirmationDefinition<TConfirmationOption, TLauncher, TLauncherArgs, TLauncherResult>
@@ -22,7 +21,7 @@ internal class RecordingConfirmationDefinition<
     > {
     private val optionCalls = Turbine<OptionCall>()
     private val canConfirmCalls = Turbine<CanConfirmCall>()
-    private val toResultCalls = Turbine<ToResultCall<TConfirmationOption, TLauncherResult>>()
+    private val toResultCalls = Turbine<ToResultCall<TConfirmationOption, TLauncherArgs, TLauncherResult>>()
     private val createLauncherCalls = Turbine<CreateLauncherCall<TLauncherResult>>()
     private val unregisterCalls = Turbine<UnregisterCall<TLauncher>>()
     private val launchCalls = Turbine<LaunchCall<TConfirmationOption, TLauncher, TLauncherArgs>>()
@@ -49,13 +48,13 @@ internal class RecordingConfirmationDefinition<
     override fun toResult(
         confirmationOption: TConfirmationOption,
         confirmationArgs: ConfirmationHandler.Args,
-        deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+        launcherArgs: TLauncherArgs,
         result: TLauncherResult
     ): ConfirmationDefinition.Result {
         toResultCalls.add(
             ToResultCall(
                 confirmationOption = confirmationOption,
-                deferredIntentConfirmationType = deferredIntentConfirmationType,
+                launcherArgs = launcherArgs,
                 confirmationArgs = confirmationArgs,
                 result = result
             )
@@ -64,7 +63,7 @@ internal class RecordingConfirmationDefinition<
         return definition.toResult(
             confirmationOption = confirmationOption,
             confirmationArgs = confirmationArgs,
-            deferredIntentConfirmationType = deferredIntentConfirmationType,
+            launcherArgs = launcherArgs,
             result = result
         )
     }
@@ -117,10 +116,10 @@ internal class RecordingConfirmationDefinition<
         val confirmationArgs: ConfirmationHandler.Args,
     )
 
-    class ToResultCall<TConfirmationOption : ConfirmationHandler.Option, TLauncherResult>(
+    class ToResultCall<TConfirmationOption : ConfirmationHandler.Option, TLauncherArgs : Parcelable, TLauncherResult>(
         val confirmationOption: TConfirmationOption,
         val confirmationArgs: ConfirmationHandler.Args,
-        val deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+        val launcherArgs: TLauncherArgs,
         val result: TLauncherResult,
     )
 
@@ -152,13 +151,13 @@ internal class RecordingConfirmationDefinition<
     class Scenario<
         TConfirmationOption : ConfirmationHandler.Option,
         TLauncher,
-        TLauncherArgs,
+        TLauncherArgs : Parcelable,
         TLauncherResult : Parcelable,
         >(
         val definition: ConfirmationDefinition<TConfirmationOption, TLauncher, TLauncherArgs, TLauncherResult>,
         val optionCalls: ReceiveTurbine<OptionCall>,
         val canConfirmCalls: ReceiveTurbine<CanConfirmCall>,
-        val toResultCalls: ReceiveTurbine<ToResultCall<TConfirmationOption, TLauncherResult>>,
+        val toResultCalls: ReceiveTurbine<ToResultCall<TConfirmationOption, TLauncherArgs, TLauncherResult>>,
         val createLauncherCalls: ReceiveTurbine<CreateLauncherCall<TLauncherResult>>,
         val unregisterCalls: ReceiveTurbine<UnregisterCall<TLauncher>>,
         val launchCalls: ReceiveTurbine<LaunchCall<TConfirmationOption, TLauncher, TLauncherArgs>>,
@@ -170,7 +169,7 @@ internal class RecordingConfirmationDefinition<
         suspend fun <
             TConfirmationOption : ConfirmationHandler.Option,
             TLauncher,
-            TLauncherArgs,
+            TLauncherArgs : Parcelable,
             TLauncherResult : Parcelable,
             > test(
             definition: ConfirmationDefinition<TConfirmationOption, TLauncher, TLauncherArgs, TLauncherResult>,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/attestation/AttestationConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/attestation/AttestationConfirmationDefinitionTest.kt
@@ -146,7 +146,6 @@ internal class AttestationConfirmationDefinitionTest {
         assertThat(launchAction.launcherArguments.publishableKey).isEqualTo(launcherArgs.publishableKey)
         assertThat(launchAction.launcherArguments.productUsage).isEqualTo(launcherArgs.productUsage)
         assertThat(launchAction.receivesResultInProcess).isFalse()
-        assertThat(launchAction.deferredIntentConfirmationType).isNull()
     }
 
     @Test
@@ -219,7 +218,7 @@ internal class AttestationConfirmationDefinitionTest {
         val result = definition.toResult(
             confirmationOption = PAYMENT_METHOD_CONFIRMATION_OPTION_NEW,
             confirmationArgs = CONFIRMATION_PARAMETERS,
-            deferredIntentConfirmationType = null,
+            launcherArgs = launcherArgs,
             result = AttestationActivityResult.Success(testToken),
         )
 
@@ -251,7 +250,7 @@ internal class AttestationConfirmationDefinitionTest {
         val result = definition.toResult(
             confirmationOption = PAYMENT_METHOD_CONFIRMATION_OPTION_NEW,
             confirmationArgs = CONFIRMATION_PARAMETERS,
-            deferredIntentConfirmationType = null,
+            launcherArgs = launcherArgs,
             result = AttestationActivityResult.Failed(exception),
         )
 
@@ -283,7 +282,7 @@ internal class AttestationConfirmationDefinitionTest {
                 )
             ),
             confirmationArgs = CONFIRMATION_PARAMETERS,
-            deferredIntentConfirmationType = null,
+            launcherArgs = launcherArgs,
             result = AttestationActivityResult.Success(testToken),
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationDefinitionTest.kt
@@ -95,7 +95,7 @@ class BacsConfirmationDefinitionTest {
         val result = definition.toResult(
             confirmationOption = createBacsConfirmationOption(),
             confirmationArgs = CONFIRMATION_PARAMETERS,
-            deferredIntentConfirmationType = null,
+            launcherArgs = createBacsMandateData(),
             result = BacsMandateConfirmationResult.Confirmed,
         )
 
@@ -124,7 +124,7 @@ class BacsConfirmationDefinitionTest {
             val result = definition.toResult(
                 confirmationOption = createBacsConfirmationOption(),
                 confirmationArgs = CONFIRMATION_PARAMETERS,
-                deferredIntentConfirmationType = null,
+                launcherArgs = createBacsMandateData(),
                 result = BacsMandateConfirmationResult.Cancelled,
             )
 
@@ -143,7 +143,7 @@ class BacsConfirmationDefinitionTest {
             val result = definition.toResult(
                 confirmationOption = createBacsConfirmationOption(),
                 confirmationArgs = CONFIRMATION_PARAMETERS,
-                deferredIntentConfirmationType = null,
+                launcherArgs = createBacsMandateData(),
                 result = BacsMandateConfirmationResult.ModifyDetails,
             )
 
@@ -221,7 +221,6 @@ class BacsConfirmationDefinitionTest {
         assertThat(mandateData.sortCode).isEqualTo("108800")
         assertThat(mandateData.accountNumber).isEqualTo("00012345")
 
-        assertThat(launchAction.deferredIntentConfirmationType).isNull()
         assertThat(launchAction.receivesResultInProcess).isTrue()
     }
 
@@ -290,6 +289,13 @@ class BacsConfirmationDefinitionTest {
             optionsParams = null,
         )
     }
+
+    private fun createBacsMandateData() = BacsMandateData(
+        name = "John Doe",
+        email = "johndoe@email.com",
+        accountNumber = "00012345",
+        sortCode = "108800",
+    )
 
     private fun ConfirmationHandler.Option.asNewPaymentMethodOption(): PaymentMethodConfirmationOption.New {
         return this as PaymentMethodConfirmationOption.New

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationFlowTest.kt
@@ -8,6 +8,7 @@ import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationO
 import com.stripe.android.paymentelement.confirmation.runLaunchTest
 import com.stripe.android.paymentelement.confirmation.runResultTest
 import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateConfirmationResult
+import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateData
 import com.stripe.android.paymentsheet.paymentdatacollection.bacs.DefaultBacsMandateConfirmationLauncherFactory
 import org.junit.Test
 
@@ -29,6 +30,12 @@ class BacsConfirmationFlowTest {
         ),
         launcherResult = BacsMandateConfirmationResult.Confirmed,
         parameters = CONFIRMATION_PARAMETERS,
+        launcherArgs = BacsMandateData(
+            name = "John",
+            email = "email@email.com",
+            sortCode = "000000",
+            accountNumber = "0001234"
+        ),
         definitionResult = ConfirmationDefinition.Result.NextStep(
             confirmationOption = PaymentMethodConfirmationOption.New(
                 createParams = BACS_CONFIRMATION_OPTION.createParams,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinitionTest.kt
@@ -152,7 +152,6 @@ internal class PassiveChallengeConfirmationDefinitionTest {
         assertThat(launchAction.launcherArguments.passiveCaptchaParams)
             .isEqualTo(CONFIRMATION_PARAMETERS.paymentMethodMetadata.passiveCaptchaParams)
         assertThat(launchAction.receivesResultInProcess).isFalse()
-        assertThat(launchAction.deferredIntentConfirmationType).isNull()
     }
 
     @Test
@@ -251,7 +250,7 @@ internal class PassiveChallengeConfirmationDefinitionTest {
         val result = definition.toResult(
             confirmationOption = PAYMENT_METHOD_CONFIRMATION_OPTION_NEW,
             confirmationArgs = CONFIRMATION_PARAMETERS,
-            deferredIntentConfirmationType = null,
+            launcherArgs = launcherArgs,
             result = PassiveChallengeActivityResult.Success(testToken),
         )
 
@@ -281,7 +280,7 @@ internal class PassiveChallengeConfirmationDefinitionTest {
         val result = definition.toResult(
             confirmationOption = PAYMENT_METHOD_CONFIRMATION_OPTION_NEW,
             confirmationArgs = CONFIRMATION_PARAMETERS,
-            deferredIntentConfirmationType = null,
+            launcherArgs = launcherArgs,
             result = PassiveChallengeActivityResult.Failed(exception),
         )
 
@@ -354,7 +353,7 @@ internal class PassiveChallengeConfirmationDefinitionTest {
         val result = definition.toResult(
             confirmationOption = PAYMENT_METHOD_CONFIRMATION_OPTION_NEW,
             confirmationArgs = CONFIRMATION_PARAMETERS,
-            deferredIntentConfirmationType = null,
+            launcherArgs = launcherArgs,
             result = PassiveChallengeActivityResult.Success(testToken),
         )
 
@@ -377,7 +376,7 @@ internal class PassiveChallengeConfirmationDefinitionTest {
         val result = definition.toResult(
             confirmationOption = PAYMENT_METHOD_CONFIRMATION_OPTION_NEW,
             confirmationArgs = CONFIRMATION_PARAMETERS,
-            deferredIntentConfirmationType = null,
+            launcherArgs = launcherArgs,
             result = PassiveChallengeActivityResult.Failed(RuntimeException("Failed")),
         )
 
@@ -410,7 +409,7 @@ internal class PassiveChallengeConfirmationDefinitionTest {
                 )
             ),
             confirmationArgs = CONFIRMATION_PARAMETERS,
-            deferredIntentConfirmationType = null,
+            launcherArgs = launcherArgs,
             result = PassiveChallengeActivityResult.Success(testToken),
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationFlowTest.kt
@@ -1,7 +1,9 @@
 package com.stripe.android.paymentelement.confirmation.challenge
 
+import com.stripe.android.challenge.passive.PassiveChallengeActivityContract
 import com.stripe.android.challenge.passive.PassiveChallengeActivityResult
 import com.stripe.android.challenge.passive.warmer.PassiveChallengeWarmer
+import com.stripe.android.model.PassiveCaptchaParams
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.paymentelement.confirmation.CONFIRMATION_PARAMETERS
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
@@ -27,6 +29,7 @@ internal class PassiveChallengeConfirmationFlowTest {
         definition = confirmationDefinition(),
         launcherResult = PassiveChallengeActivityResult.Success("test_token"),
         parameters = CONFIRMATION_PARAMETERS,
+        launcherArgs = LAUNCHER_ARGS,
         definitionResult = ConfirmationDefinition.Result.NextStep(
             confirmationOption = PaymentMethodConfirmationOption.New(
                 createParams = NEW_CONFIRMATION_OPTION.createParams.copy(
@@ -49,6 +52,7 @@ internal class PassiveChallengeConfirmationFlowTest {
         definition = confirmationDefinition(),
         launcherResult = PassiveChallengeActivityResult.Failed(RuntimeException("Challenge failed")),
         parameters = CONFIRMATION_PARAMETERS,
+        launcherArgs = LAUNCHER_ARGS,
         definitionResult = ConfirmationDefinition.Result.NextStep(
             confirmationOption = PaymentMethodConfirmationOption.New(
                 createParams = NEW_CONFIRMATION_OPTION.createParams,
@@ -67,6 +71,15 @@ internal class PassiveChallengeConfirmationFlowTest {
             optionsParams = null,
             extraParams = null,
             shouldSave = false,
+        )
+
+        val LAUNCHER_ARGS = PassiveChallengeActivityContract.Args(
+            passiveCaptchaParams = PassiveCaptchaParams(
+                siteKey = "site_key",
+                rqData = null
+            ),
+            publishableKey = "pk_123",
+            productUsage = setOf("PaymentSheet")
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cpms/CustomPaymentMethodConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cpms/CustomPaymentMethodConfirmationDefinitionTest.kt
@@ -9,6 +9,7 @@ import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentelement.ConfirmCustomPaymentMethodCallback
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.EmptyConfirmationLauncherArgs
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationOption
 import com.stripe.android.paymentelement.confirmation.asCallbackFor
 import com.stripe.android.paymentelement.confirmation.asCanceled
@@ -116,8 +117,7 @@ class CustomPaymentMethodConfirmationDefinitionTest {
 
         val launchAction = action.asLaunch()
 
-        assertThat(launchAction.launcherArguments).isEqualTo(Unit)
-        assertThat(launchAction.deferredIntentConfirmationType).isNull()
+        assertThat(launchAction.launcherArguments).isEqualTo(EmptyConfirmationLauncherArgs)
     }
 
     @Test
@@ -128,7 +128,7 @@ class CustomPaymentMethodConfirmationDefinitionTest {
 
         definition.launch(
             launcher = launcher,
-            arguments = Unit,
+            arguments = EmptyConfirmationLauncherArgs,
             confirmationOption = option,
             confirmationArgs = CONFIRMATION_PARAMETERS,
         )
@@ -153,7 +153,7 @@ class CustomPaymentMethodConfirmationDefinitionTest {
         val result = definition.toResult(
             confirmationOption = option,
             confirmationArgs = CONFIRMATION_PARAMETERS,
-            deferredIntentConfirmationType = null,
+            launcherArgs = EmptyConfirmationLauncherArgs,
             result = InternalCustomPaymentMethodResult.Completed,
         )
 
@@ -173,7 +173,7 @@ class CustomPaymentMethodConfirmationDefinitionTest {
         val result = definition.toResult(
             confirmationOption = option,
             confirmationArgs = CONFIRMATION_PARAMETERS,
-            deferredIntentConfirmationType = null,
+            launcherArgs = EmptyConfirmationLauncherArgs,
             result = InternalCustomPaymentMethodResult.Failed(exception),
         )
 
@@ -193,7 +193,7 @@ class CustomPaymentMethodConfirmationDefinitionTest {
         val result = definition.toResult(
             confirmationOption = option,
             confirmationArgs = CONFIRMATION_PARAMETERS,
-            deferredIntentConfirmationType = null,
+            launcherArgs = EmptyConfirmationLauncherArgs,
             result = InternalCustomPaymentMethodResult.Canceled,
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationDefinitionTest.kt
@@ -7,6 +7,7 @@ import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.EmptyConfirmationLauncherArgs
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationOption
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.asCallbackFor
@@ -138,13 +139,12 @@ class CvcRecollectionConfirmationDefinitionTest {
             confirmationArgs = CONFIRMATION_PARAMETERS,
         )
 
-        assertThat(action).isInstanceOf<ConfirmationDefinition.Action.Launch<Unit>>()
+        assertThat(action).isInstanceOf<ConfirmationDefinition.Action.Launch<EmptyConfirmationLauncherArgs>>()
 
         val launchAction = action.asLaunch()
 
-        assertThat(launchAction.launcherArguments).isEqualTo(Unit)
+        assertThat(launchAction.launcherArguments).isEqualTo(EmptyConfirmationLauncherArgs)
         assertThat(launchAction.receivesResultInProcess).isTrue()
-        assertThat(launchAction.deferredIntentConfirmationType).isNull()
     }
 
     @Test
@@ -153,7 +153,7 @@ class CvcRecollectionConfirmationDefinitionTest {
 
         definition.launch(
             launcher = launcherScenario.launcher,
-            arguments = Unit,
+            arguments = EmptyConfirmationLauncherArgs,
             confirmationOption = option,
             confirmationArgs = CONFIRMATION_PARAMETERS,
         )
@@ -173,7 +173,7 @@ class CvcRecollectionConfirmationDefinitionTest {
         val result = definition.toResult(
             confirmationOption = option,
             confirmationArgs = CONFIRMATION_PARAMETERS,
-            deferredIntentConfirmationType = null,
+            launcherArgs = EmptyConfirmationLauncherArgs,
             result = CvcRecollectionResult.Confirmed(
                 cvc = "444",
             ),
@@ -207,7 +207,7 @@ class CvcRecollectionConfirmationDefinitionTest {
         val result = definition.toResult(
             confirmationOption = option,
             confirmationArgs = CONFIRMATION_PARAMETERS,
-            deferredIntentConfirmationType = null,
+            launcherArgs = EmptyConfirmationLauncherArgs,
             result = CvcRecollectionResult.Confirmed(
                 cvc = "555",
             ),
@@ -238,7 +238,7 @@ class CvcRecollectionConfirmationDefinitionTest {
         val result = definition.toResult(
             confirmationOption = option,
             confirmationArgs = CONFIRMATION_PARAMETERS,
-            deferredIntentConfirmationType = null,
+            launcherArgs = EmptyConfirmationLauncherArgs,
             result = CvcRecollectionResult.Cancelled,
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationDefinitionTest.kt
@@ -10,6 +10,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentelement.confirmation.CONFIRMATION_PARAMETERS
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.EmptyConfirmationLauncherArgs
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationOption
 import com.stripe.android.paymentelement.confirmation.PAYMENT_INTENT
 import com.stripe.android.paymentelement.confirmation.asCallbackFor
@@ -93,7 +94,7 @@ class ExternalPaymentMethodConfirmationDefinitionTest {
         val result = definition.toResult(
             confirmationOption = EPM_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS,
-            deferredIntentConfirmationType = null,
+            launcherArgs = EmptyConfirmationLauncherArgs,
             result = PaymentResult.Completed,
         )
 
@@ -114,7 +115,7 @@ class ExternalPaymentMethodConfirmationDefinitionTest {
         val result = definition.toResult(
             confirmationOption = EPM_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS,
-            deferredIntentConfirmationType = null,
+            launcherArgs = EmptyConfirmationLauncherArgs,
             result = PaymentResult.Failed(exception),
         )
 
@@ -134,7 +135,7 @@ class ExternalPaymentMethodConfirmationDefinitionTest {
         val result = definition.toResult(
             confirmationOption = EPM_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS,
-            deferredIntentConfirmationType = null,
+            launcherArgs = EmptyConfirmationLauncherArgs,
             result = PaymentResult.Canceled,
         )
 
@@ -193,12 +194,11 @@ class ExternalPaymentMethodConfirmationDefinitionTest {
             confirmationArgs = CONFIRMATION_PARAMETERS,
         )
 
-        assertThat(action).isInstanceOf<ConfirmationDefinition.Action.Launch<Unit>>()
+        assertThat(action).isInstanceOf<ConfirmationDefinition.Action.Launch<EmptyConfirmationLauncherArgs>>()
 
         val launchAction = action.asLaunch()
 
-        assertThat(launchAction.launcherArguments).isEqualTo(Unit)
-        assertThat(launchAction.deferredIntentConfirmationType).isNull()
+        assertThat(launchAction.launcherArguments).isEqualTo(EmptyConfirmationLauncherArgs)
     }
 
     @Test
@@ -213,7 +213,7 @@ class ExternalPaymentMethodConfirmationDefinitionTest {
         definition.launch(
             confirmationOption = EPM_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS,
-            arguments = Unit,
+            arguments = EmptyConfirmationLauncherArgs,
             launcher = launcher,
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationFlowTest.kt
@@ -4,6 +4,7 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentelement.confirmation.CONFIRMATION_PARAMETERS
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
+import com.stripe.android.paymentelement.confirmation.EmptyConfirmationLauncherArgs
 import com.stripe.android.paymentelement.confirmation.PAYMENT_INTENT
 import com.stripe.android.paymentelement.confirmation.runLaunchTest
 import com.stripe.android.paymentelement.confirmation.runResultTest
@@ -42,9 +43,9 @@ class ExternalPaymentMethodConfirmationFlowTest {
             errorReporter = FakeErrorReporter()
         ),
         launcherResult = PaymentResult.Completed,
+        launcherArgs = EmptyConfirmationLauncherArgs,
         definitionResult = ConfirmationDefinition.Result.Succeeded(
             intent = PAYMENT_INTENT,
-            deferredIntentConfirmationType = null,
         )
     )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinitionTest.kt
@@ -20,6 +20,7 @@ import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.wallets.Wallet
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.EmptyConfirmationLauncherArgs
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationOption
 import com.stripe.android.paymentelement.confirmation.PAYMENT_INTENT
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
@@ -110,7 +111,7 @@ class GooglePayConfirmationDefinitionTest {
         val result = definition.toResult(
             confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS,
-            deferredIntentConfirmationType = null,
+            launcherArgs = EmptyConfirmationLauncherArgs,
             result = GooglePayPaymentMethodLauncher.Result.Completed(
                 paymentMethod = paymentMethod,
             ),
@@ -139,7 +140,7 @@ class GooglePayConfirmationDefinitionTest {
         val result = definition.toResult(
             confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS,
-            deferredIntentConfirmationType = null,
+            launcherArgs = EmptyConfirmationLauncherArgs,
             result = GooglePayPaymentMethodLauncher.Result.Failed(
                 errorCode = 400,
                 error = exception
@@ -163,7 +164,7 @@ class GooglePayConfirmationDefinitionTest {
         val result = definition.toResult(
             confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS,
-            deferredIntentConfirmationType = null,
+            launcherArgs = EmptyConfirmationLauncherArgs,
             result = GooglePayPaymentMethodLauncher.Result.Failed(
                 errorCode = GooglePayPaymentMethodLauncher.NETWORK_ERROR,
                 error = exception
@@ -189,7 +190,7 @@ class GooglePayConfirmationDefinitionTest {
         val result = definition.toResult(
             confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS,
-            deferredIntentConfirmationType = null,
+            launcherArgs = EmptyConfirmationLauncherArgs,
             result = GooglePayPaymentMethodLauncher.Result.Canceled,
         )
 
@@ -271,7 +272,7 @@ class GooglePayConfirmationDefinitionTest {
             definition.launch(
                 confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION,
                 confirmationArgs = CONFIRMATION_PARAMETERS,
-                arguments = Unit,
+                arguments = EmptyConfirmationLauncherArgs,
                 launcher = launcher,
             )
 
@@ -366,7 +367,7 @@ class GooglePayConfirmationDefinitionTest {
                         sellerBusinessName = "My business, Inc.",
                     ),
                 ),
-                arguments = Unit,
+                arguments = EmptyConfirmationLauncherArgs,
                 launcher = launcher,
             )
 
@@ -396,7 +397,7 @@ class GooglePayConfirmationDefinitionTest {
                         stripeIntent = PAYMENT_INTENT.copy(currency = "CAD")
                     ),
                 ),
-                arguments = Unit,
+                arguments = EmptyConfirmationLauncherArgs,
                 launcher = launcher,
             )
 
@@ -433,7 +434,7 @@ class GooglePayConfirmationDefinitionTest {
                         stripeIntent = PAYMENT_INTENT.copy(currency = "CAD")
                     ),
                 ),
-                arguments = Unit,
+                arguments = EmptyConfirmationLauncherArgs,
                 launcher = launcher,
             )
 
@@ -471,7 +472,7 @@ class GooglePayConfirmationDefinitionTest {
                         stripeIntent = SetupIntentFactory.create(),
                     ),
                 ),
-                arguments = Unit,
+                arguments = EmptyConfirmationLauncherArgs,
                 launcher = launcher,
             )
 
@@ -535,7 +536,7 @@ class GooglePayConfirmationDefinitionTest {
             definition.launch(
                 confirmationOption = confirmationOption,
                 confirmationArgs = CONFIRMATION_PARAMETERS,
-                arguments = Unit,
+                arguments = EmptyConfirmationLauncherArgs,
                 launcher = launcher,
             )
 
@@ -587,13 +588,12 @@ class GooglePayConfirmationDefinitionTest {
     ) {
         val action = scenario.action
 
-        assertThat(action).isInstanceOf<ConfirmationDefinition.Action.Launch<Unit>>()
+        assertThat(action).isInstanceOf<ConfirmationDefinition.Action.Launch<EmptyConfirmationLauncherArgs>>()
 
         val launchAction = action.asLaunch()
 
         assertThat(launchAction.receivesResultInProcess).isTrue()
-        assertThat(launchAction.deferredIntentConfirmationType).isNull()
-        assertThat(launchAction.launcherArguments).isEqualTo(Unit)
+        assertThat(launchAction.launcherArguments).isEqualTo(EmptyConfirmationLauncherArgs)
     }
 
     private fun createGooglePayConfirmationDefinition(
@@ -619,7 +619,7 @@ class GooglePayConfirmationDefinitionTest {
     }
 
     private class ActionScenario(
-        val action: ConfirmationDefinition.Action<Unit>,
+        val action: ConfirmationDefinition.Action<EmptyConfirmationLauncherArgs>,
         val userFacingLogger: FakeUserFacingLogger,
     )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationFlowTest.kt
@@ -10,6 +10,7 @@ import com.stripe.android.paymentelement.confirmation.CONFIRMATION_PARAMETERS
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationMediator
 import com.stripe.android.paymentelement.confirmation.ConfirmationMediator.Parameters
+import com.stripe.android.paymentelement.confirmation.EmptyConfirmationLauncherArgs
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.asLaunch
 import com.stripe.android.paymentelement.confirmation.runResultTest
@@ -61,11 +62,10 @@ class GooglePayConfirmationFlowTest {
                 assertThat(createGooglePayPaymentMethodLauncherCalls.awaitItem()).isNotNull()
 
                 val parameters = savedStateHandle
-                    .get<Parameters<GooglePayConfirmationOption>>("GooglePayParameters")
+                    .get<Parameters<GooglePayConfirmationOption, EmptyConfirmationLauncherArgs>>("GooglePayParameters")
 
                 assertThat(parameters?.confirmationOption).isEqualTo(GOOGLE_PAY_CONFIRMATION_OPTION)
                 assertThat(parameters?.confirmationArgs).isEqualTo(CONFIRMATION_PARAMETERS)
-                assertThat(parameters?.deferredIntentConfirmationType).isNull()
 
                 verify(googlePayPaymentMethodLauncher, times(1)).present(
                     currencyCode = "usd",
@@ -88,6 +88,7 @@ class GooglePayConfirmationFlowTest {
             userFacingLogger = null,
         ),
         launcherResult = GooglePayPaymentMethodLauncher.Result.Completed(PAYMENT_METHOD),
+        launcherArgs = EmptyConfirmationLauncherArgs,
         definitionResult = ConfirmationDefinition.Result.NextStep(
             confirmationOption = PaymentMethodConfirmationOption.Saved(
                 paymentMethod = PAYMENT_METHOD,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
@@ -115,7 +115,8 @@ class CheckoutSessionConfirmationInterceptorTest {
 
         val launchAction = result as ConfirmationDefinition.Action.Launch
         assertThat(launchAction.launcherArguments).isInstanceOf<IntentConfirmationDefinition.Args.NextAction>()
-        assertThat(launchAction.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Server)
+        assertThat(launchAction.launcherArguments.deferredIntentConfirmationType)
+            .isEqualTo(DeferredIntentConfirmationType.Server)
         assertThat(launchAction.receivesResultInProcess).isFalse()
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/ConfirmationTokenConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/ConfirmationTokenConfirmationInterceptorTest.kt
@@ -312,8 +312,8 @@ class ConfirmationTokenConfirmationInterceptorTest {
                 ConfirmationDefinition.Action.Launch<IntentConfirmationDefinition.Args>(
                     launcherArguments = IntentConfirmationDefinition.Args.NextAction(
                         intent = PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2,
+                        deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
                     ),
-                    deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
                     receivesResultInProcess = false,
                 )
             )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/DeferredIntentConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/DeferredIntentConfirmationInterceptorTest.kt
@@ -272,9 +272,9 @@ class DeferredIntentConfirmationInterceptorTest {
                         intent = PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2.copy(
                             paymentMethodId = PaymentMethodFixtures.CARD_PAYMENT_METHOD.id,
                             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
-                        )
+                        ),
+                        deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
                     ),
-                    deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
                     receivesResultInProcess = false,
                 )
             )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinitionTest.kt
@@ -15,6 +15,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFact
 import com.stripe.android.paymentelement.confirmation.CONFIRMATION_PARAMETERS
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.EmptyConfirmationLauncherArgs
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationOption
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.asCanceled
@@ -98,13 +99,12 @@ internal class LinkConfirmationDefinitionTest {
             confirmationArgs = CONFIRMATION_PARAMETERS,
         )
 
-        assertThat(action).isInstanceOf<ConfirmationDefinition.Action.Launch<Unit>>()
+        assertThat(action).isInstanceOf<ConfirmationDefinition.Action.Launch<EmptyConfirmationLauncherArgs>>()
 
         val launchAction = action.asLaunch()
 
-        assertThat(launchAction.launcherArguments).isEqualTo(Unit)
+        assertThat(launchAction.launcherArguments).isEqualTo(EmptyConfirmationLauncherArgs)
         assertThat(launchAction.receivesResultInProcess).isFalse()
-        assertThat(launchAction.deferredIntentConfirmationType).isNull()
     }
 
     @Test
@@ -115,7 +115,7 @@ internal class LinkConfirmationDefinitionTest {
             confirmationOption = LINK_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS,
             launcher = launcherScenario.launcher,
-            arguments = Unit,
+            arguments = EmptyConfirmationLauncherArgs,
         )
 
         val presentCall = launcherScenario.presentCalls.awaitItem()
@@ -137,7 +137,7 @@ internal class LinkConfirmationDefinitionTest {
             confirmationOption = LINK_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS,
             launcher = launcherScenario.launcher,
-            arguments = Unit,
+            arguments = EmptyConfirmationLauncherArgs,
         )
 
         val presentCall = launcherScenario.presentCalls.awaitItem()
@@ -155,7 +155,7 @@ internal class LinkConfirmationDefinitionTest {
             ),
             confirmationArgs = CONFIRMATION_PARAMETERS,
             launcher = launcherScenario.launcher,
-            arguments = Unit,
+            arguments = EmptyConfirmationLauncherArgs,
         )
 
         val presentCall = launcherScenario.presentCalls.awaitItem()
@@ -192,7 +192,7 @@ internal class LinkConfirmationDefinitionTest {
         val result = definition.toResult(
             confirmationOption = LINK_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS,
-            deferredIntentConfirmationType = null,
+            launcherArgs = EmptyConfirmationLauncherArgs,
             result = LinkActivityResult.PaymentMethodObtained(paymentMethod),
         )
 
@@ -219,7 +219,7 @@ internal class LinkConfirmationDefinitionTest {
         val result = definition.toResult(
             confirmationOption = LINK_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS,
-            deferredIntentConfirmationType = null,
+            launcherArgs = EmptyConfirmationLauncherArgs,
             result = LinkActivityResult.Completed(
                 linkAccountUpdate = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT)
             ),
@@ -228,7 +228,6 @@ internal class LinkConfirmationDefinitionTest {
         assertThat(result).isEqualTo(
             ConfirmationDefinition.Result.Succeeded(
                 intent = CONFIRMATION_PARAMETERS.intent,
-                deferredIntentConfirmationType = null,
             )
         )
         assertThat(storeScenario.markAsUsedCalls.awaitItem()).isNotNull()
@@ -248,7 +247,7 @@ internal class LinkConfirmationDefinitionTest {
         val result = definition.toResult(
             confirmationOption = LINK_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS,
-            deferredIntentConfirmationType = null,
+            launcherArgs = EmptyConfirmationLauncherArgs,
             result = LinkActivityResult.Failed(
                 error = exception,
                 linkAccountUpdate = LinkAccountUpdate.Value(null)
@@ -280,7 +279,7 @@ internal class LinkConfirmationDefinitionTest {
         val result = definition.toResult(
             confirmationOption = LINK_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS,
-            deferredIntentConfirmationType = null,
+            launcherArgs = EmptyConfirmationLauncherArgs,
             result = LinkActivityResult.Canceled(
                 reason = LinkActivityResult.Canceled.Reason.LoggedOut,
                 linkAccountUpdate = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT)
@@ -309,7 +308,7 @@ internal class LinkConfirmationDefinitionTest {
         val result = definition.toResult(
             confirmationOption = LINK_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS,
-            deferredIntentConfirmationType = null,
+            launcherArgs = EmptyConfirmationLauncherArgs,
             result = LinkActivityResult.Canceled(
                 reason = LinkActivityResult.Canceled.Reason.BackPressed,
                 linkAccountUpdate = LinkAccountUpdate.None
@@ -373,7 +372,7 @@ internal class LinkConfirmationDefinitionTest {
                 paymentMethodMetadata = paymentMethodMetadata,
             ),
             launcher = launcherScenario.launcher,
-            arguments = Unit,
+            arguments = EmptyConfirmationLauncherArgs,
         )
 
         return launcherScenario.presentCalls.awaitItem()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationFlowTest.kt
@@ -11,6 +11,7 @@ import com.stripe.android.paymentelement.confirmation.CONFIRMATION_PARAMETERS
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationMediator
 import com.stripe.android.paymentelement.confirmation.ConfirmationMediator.Parameters
+import com.stripe.android.paymentelement.confirmation.EmptyConfirmationLauncherArgs
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.asLaunch
 import com.stripe.android.testing.DummyActivityResultCaller
@@ -61,11 +62,11 @@ class LinkConfirmationFlowTest {
 
         assertThat(presentCall.configuration).isEqualTo(LINK_CONFIRMATION_OPTION.configuration)
 
-        val parameters = savedStateHandle.get<Parameters<LinkConfirmationOption>>("LinkParameters")
+        val parameters = savedStateHandle
+            .get<Parameters<LinkConfirmationOption, EmptyConfirmationLauncherArgs>>("LinkParameters")
 
         assertThat(parameters?.confirmationOption).isEqualTo(LINK_CONFIRMATION_OPTION)
         assertThat(parameters?.confirmationArgs).isEqualTo(CONFIRMATION_PARAMETERS)
-        assertThat(parameters?.deferredIntentConfirmationType).isNull()
     }
 
     @Test
@@ -78,7 +79,7 @@ class LinkConfirmationFlowTest {
                 Parameters(
                     confirmationOption = LINK_CONFIRMATION_OPTION,
                     confirmationArgs = CONFIRMATION_PARAMETERS,
-                    deferredIntentConfirmationType = null,
+                    launcherArgs = EmptyConfirmationLauncherArgs,
                 )
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
@@ -303,7 +303,6 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
         assertThat(paymentMethod.card?.wallet).isEqualTo(Wallet.LinkWallet(dynamicLast4 = "4242"))
 
         assertThat(launchAction.receivesResultInProcess).isTrue()
-        assertThat(launchAction.deferredIntentConfirmationType).isNull()
 
         assertThat(storeScenario.markAsUsedCalls.awaitItem()).isNotNull()
     }
@@ -348,7 +347,9 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
         val result = definition.toResult(
             confirmationOption = createLinkInlineSignupConfirmationOption(),
             confirmationArgs = CONFIRMATION_PARAMETERS,
-            deferredIntentConfirmationType = null,
+            launcherArgs = LinkInlineSignupConfirmationDefinition.LauncherArguments(
+                nextConfirmationOption = nextOption,
+            ),
             result = LinkInlineSignupConfirmationDefinition.Result(
                 nextConfirmationOption = nextOption,
             ),
@@ -482,7 +483,6 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
                 assertThat(newConfirmationOption.shouldSave).isEqualTo(expectedShouldSave)
 
                 assertThat(launchAction.receivesResultInProcess).isTrue()
-                assertThat(launchAction.deferredIntentConfirmationType).isNull()
 
                 assertThat(storeScenario.markAsUsedCalls.awaitItem()).isNotNull()
             }
@@ -565,7 +565,6 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
             }
 
             assertThat(launchAction.receivesResultInProcess).isTrue()
-            assertThat(launchAction.deferredIntentConfirmationType).isNull()
 
             assertThat(storeScenario.markAsUsedCalls.awaitItem()).isNotNull()
         }
@@ -613,7 +612,6 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
         assertThat(nextNewConfirmationOption.optionsParams).isEqualTo(confirmationOption.optionsParams)
 
         assertThat(launchAction.receivesResultInProcess).isTrue()
-        assertThat(launchAction.deferredIntentConfirmationType).isNull()
     }
 
     private fun test(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/shoppay/ShopPayConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/shoppay/ShopPayConfirmationDefinitionTest.kt
@@ -8,6 +8,7 @@ import com.stripe.android.isInstanceOf
 import com.stripe.android.paymentelement.confirmation.CONFIRMATION_PARAMETERS
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.EmptyConfirmationLauncherArgs
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationOption
 import com.stripe.android.paymentelement.confirmation.asCallbackFor
 import com.stripe.android.paymentelement.confirmation.asCanceled
@@ -80,13 +81,12 @@ internal class ShopPayConfirmationDefinitionTest {
             confirmationArgs = CONFIRMATION_PARAMETERS,
         )
 
-        assertThat(action).isInstanceOf<ConfirmationDefinition.Action.Launch<Unit>>()
+        assertThat(action).isInstanceOf<ConfirmationDefinition.Action.Launch<EmptyConfirmationLauncherArgs>>()
 
         val launchAction = action.asLaunch()
 
-        assertThat(launchAction.launcherArguments).isEqualTo(Unit)
+        assertThat(launchAction.launcherArguments).isEqualTo(EmptyConfirmationLauncherArgs)
         assertThat(launchAction.receivesResultInProcess).isFalse()
-        assertThat(launchAction.deferredIntentConfirmationType).isNull()
     }
 
     @Test
@@ -99,7 +99,7 @@ internal class ShopPayConfirmationDefinitionTest {
             confirmationOption = SHOP_PAY_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS,
             launcher = launcher,
-            arguments = Unit,
+            arguments = EmptyConfirmationLauncherArgs,
         )
 
         val launchCall = launcher.calls.awaitItem()
@@ -125,7 +125,7 @@ internal class ShopPayConfirmationDefinitionTest {
                 ),
             ),
             launcher = launcher,
-            arguments = Unit,
+            arguments = EmptyConfirmationLauncherArgs,
         )
 
         val launchCall = launcher.calls.awaitItem()
@@ -140,7 +140,7 @@ internal class ShopPayConfirmationDefinitionTest {
         val result = definition.toResult(
             confirmationOption = SHOP_PAY_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS,
-            deferredIntentConfirmationType = null,
+            launcherArgs = EmptyConfirmationLauncherArgs,
             result = ShopPayActivityResult.Completed,
         )
 
@@ -161,7 +161,7 @@ internal class ShopPayConfirmationDefinitionTest {
         val result = definition.toResult(
             confirmationOption = SHOP_PAY_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS,
-            deferredIntentConfirmationType = null,
+            launcherArgs = EmptyConfirmationLauncherArgs,
             result = ShopPayActivityResult.Failed(exception),
         )
 
@@ -181,7 +181,7 @@ internal class ShopPayConfirmationDefinitionTest {
         val result = definition.toResult(
             confirmationOption = SHOP_PAY_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS,
-            deferredIntentConfirmationType = null,
+            launcherArgs = EmptyConfirmationLauncherArgs,
             result = ShopPayActivityResult.Canceled,
         )
 
@@ -200,7 +200,7 @@ internal class ShopPayConfirmationDefinitionTest {
         val result = definition.toResult(
             confirmationOption = SHOP_PAY_CONFIRMATION_OPTION,
             confirmationArgs = CONFIRMATION_PARAMETERS,
-            deferredIntentConfirmationType = null,
+            launcherArgs = EmptyConfirmationLauncherArgs,
             result = ShopPayActivityResult.Failed(exception),
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeIntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeIntentConfirmationInterceptor.kt
@@ -31,9 +31,11 @@ internal class FakeIntentConfirmationInterceptor : IntentConfirmationInterceptor
     ) {
         val nextStep: ConfirmationDefinition.Action<IntentConfirmationDefinition.Args> =
             ConfirmationDefinition.Action.Launch(
-                launcherArguments = IntentConfirmationDefinition.Args.Confirm(confirmParams),
+                launcherArguments = IntentConfirmationDefinition.Args.Confirm(
+                    confirmNextParams = confirmParams,
+                    deferredIntentConfirmationType = DeferredIntentConfirmationType.Client.takeIf { isDeferred },
+                ),
                 receivesResultInProcess = false,
-                deferredIntentConfirmationType = DeferredIntentConfirmationType.Client.takeIf { isDeferred },
             )
         channel.trySend(nextStep)
     }
@@ -59,9 +61,11 @@ internal class FakeIntentConfirmationInterceptor : IntentConfirmationInterceptor
     fun enqueueNextActionStep(intent: StripeIntent) {
         channel.trySend(
             ConfirmationDefinition.Action.Launch(
-                launcherArguments = IntentConfirmationDefinition.Args.NextAction(intent),
+                launcherArguments = IntentConfirmationDefinition.Args.NextAction(
+                    intent = intent,
+                    deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
+                ),
                 receivesResultInProcess = false,
-                deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
             )
         )
     }


### PR DESCRIPTION
# Summary
Replace `DeferredIntentConfirmationType` with launcher arguments in `toResult` function in `ConfirmationDefinition`

# Motivation
`DeferredIntentConfirmationType` is an intent confirmation specific attribute that has been lingering in the confirmation architecture and had no place to live. Placing it in launcher arguments and passing them through to `toResult` allows the consumers to determine any result metadata required while not using the launcher as a passthrough.

This PR is part of a larger refactor to move it into a generic `Metadata` class that individual consumers can use to retrieve to receive confirmation metadata that belong to various confirmation steps.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified