### PR TITLE
Replace `DeferredIntentConfirmationType` with new `ConfirmationMetadata`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationDefinition.kt
@@ -5,7 +5,6 @@ import androidx.activity.result.ActivityResultCaller
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.StripeIntent
-import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
 
 /**
  * Defines a confirmation flow that a user might use during confirmation.
@@ -140,9 +139,9 @@ internal interface ConfirmationDefinition<
              */
             val intent: StripeIntent,
             /**
-             * DO NOT USE OUTSIDE OF INTENT CONFIRMATION
+             * Metadata associated with final confirmation result
              */
-            val deferredIntentConfirmationType: DeferredIntentConfirmationType? = null,
+            val metadata: ConfirmationMetadata = MutableConfirmationMetadata(),
             /**
              * Indicates if the full payment flow was completed by the handler. Can be used to decide if internal
              * product state needs to be reset. Useful for confirmation flows that are handed off to merchants to
@@ -203,9 +202,9 @@ internal interface ConfirmationDefinition<
              */
             val intent: StripeIntent,
             /**
-             * DO NOT USE OUTSIDE OF INTENT CONFIRMATION
+             * Metadata associated with final confirmation result
              */
-            val deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+            val metadata: ConfirmationMetadata = MutableConfirmationMetadata(),
             /**
              * Indicates if the full payment flow was completed by the handler. Can be used to decide if internal
              * product state needs to be reset. Useful for confirmation flows that are handed off to merchants to

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandler.kt
@@ -7,7 +7,6 @@ import com.stripe.android.core.Logger
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.StripeIntent
-import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.parcelize.IgnoredOnParcel
@@ -153,7 +152,7 @@ internal interface ConfirmationHandler {
          */
         data class Succeeded(
             val intent: StripeIntent,
-            val deferredIntentConfirmationType: DeferredIntentConfirmationType?,
+            val metadata: ConfirmationMetadata = MutableConfirmationMetadata(),
             val completedFullPaymentFlow: Boolean = true,
         ) : Result {
             override fun log(logger: Logger) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediator.kt
@@ -8,7 +8,6 @@ import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.StripeIntent
-import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
 import com.stripe.android.paymentsheet.R
 import kotlinx.parcelize.Parcelize
 
@@ -134,7 +133,7 @@ internal class ConfirmationMediator<
             is ConfirmationDefinition.Action.Complete -> {
                 Action.Complete(
                     intent = action.intent,
-                    deferredIntentConfirmationType = action.deferredIntentConfirmationType,
+                    metadata = action.metadata,
                     completedFullPaymentFlow = action.completedFullPaymentFlow,
                 )
             }
@@ -162,7 +161,7 @@ internal class ConfirmationMediator<
 
         data class Complete(
             val intent: StripeIntent,
-            val deferredIntentConfirmationType: DeferredIntentConfirmationType? = null,
+            val metadata: ConfirmationMetadata,
             val completedFullPaymentFlow: Boolean,
         ) : Action
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/ConfirmationMetadata.kt
@@ -1,0 +1,31 @@
+package com.stripe.android.paymentelement.confirmation
+
+import java.util.Objects
+
+internal interface ConfirmationMetadata {
+    interface Key<V>
+
+    operator fun <V> get(key: Key<V>): V?
+}
+
+internal class MutableConfirmationMetadata : ConfirmationMetadata {
+    private val mappedMetadata = mutableMapOf<ConfirmationMetadata.Key<*>, Any?>()
+
+    override fun <V> get(key: ConfirmationMetadata.Key<V>): V? {
+        @Suppress("UNCHECKED_CAST")
+        return mappedMetadata[key] as V?
+    }
+
+    operator fun <V> set(key: ConfirmationMetadata.Key<V>, value: V) {
+        mappedMetadata[key] = value
+    }
+
+    override fun equals(other: Any?): Boolean {
+        return other is MutableConfirmationMetadata &&
+            other.mappedMetadata == mappedMetadata
+    }
+
+    override fun hashCode(): Int {
+        return Objects.hash(mappedMetadata)
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandler.kt
@@ -198,7 +198,7 @@ internal class DefaultConfirmationHandler(
                 onHandlerResult(
                     ConfirmationHandler.Result.Succeeded(
                         intent = action.intent,
-                        deferredIntentConfirmationType = action.deferredIntentConfirmationType,
+                        metadata = action.metadata,
                         completedFullPaymentFlow = action.completedFullPaymentFlow,
                     )
                 )
@@ -223,7 +223,7 @@ internal class DefaultConfirmationHandler(
             }
             is ConfirmationDefinition.Result.Succeeded -> ConfirmationHandler.Result.Succeeded(
                 intent = result.intent,
-                deferredIntentConfirmationType = result.deferredIntentConfirmationType,
+                metadata = result.metadata,
                 completedFullPaymentFlow = result.completedFullPaymentFlow,
             )
             is ConfirmationDefinition.Result.Failed -> ConfirmationHandler.Result.Failed(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
@@ -11,6 +11,7 @@ import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.MutableConfirmationMetadata
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.intent.IntentConfirmationDefinition.Args
 import com.stripe.android.payments.DefaultReturnUrl
@@ -101,7 +102,9 @@ internal class CheckoutSessionConfirmationInterceptor @AssistedInject constructo
                     paymentIntent.isConfirmed -> {
                         ConfirmationDefinition.Action.Complete(
                             intent = paymentIntent,
-                            deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
+                            metadata = MutableConfirmationMetadata().apply {
+                                set(DeferredIntentConfirmationTypeKey, DeferredIntentConfirmationType.Server)
+                            },
                             completedFullPaymentFlow = true,
                         )
                     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/ConfirmationTokenConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/ConfirmationTokenConfirmationInterceptor.kt
@@ -22,6 +22,7 @@ import com.stripe.android.networking.StripeRepository
 import com.stripe.android.paymentelement.CreateIntentWithConfirmationTokenCallback
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.MutableConfirmationMetadata
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.intent.IntentConfirmationDefinition.Args
 import com.stripe.android.paymentelement.confirmation.utils.ConfirmActionHelper
@@ -133,7 +134,9 @@ internal class ConfirmationTokenConfirmationInterceptor @AssistedInject construc
                 if (result.clientSecret == IntentConfirmationInterceptor.COMPLETE_WITHOUT_CONFIRMING_INTENT) {
                     ConfirmationDefinition.Action.Complete(
                         intent = intent,
-                        deferredIntentConfirmationType = DeferredIntentConfirmationType.None,
+                        metadata = MutableConfirmationMetadata().apply {
+                            set(DeferredIntentConfirmationTypeKey, DeferredIntentConfirmationType.None)
+                        },
                         completedFullPaymentFlow = true,
                     )
                 } else {
@@ -171,7 +174,9 @@ internal class ConfirmationTokenConfirmationInterceptor @AssistedInject construc
             if (intent.isConfirmed) {
                 ConfirmationDefinition.Action.Complete(
                     intent = intent,
-                    deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
+                    metadata = MutableConfirmationMetadata().apply {
+                        set(DeferredIntentConfirmationTypeKey, DeferredIntentConfirmationType.Server)
+                    },
                     completedFullPaymentFlow = true,
                 )
             } else if (intent.requiresAction()) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CustomerSheetAttachPaymentMethodInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CustomerSheetAttachPaymentMethodInterceptor.kt
@@ -37,7 +37,6 @@ internal class DefaultCustomerSheetAttachPaymentMethodInterceptor(
                 onSuccess = {
                     ConfirmationDefinition.Action.Complete(
                         intent = intent.copy(paymentMethod = paymentMethod),
-                        deferredIntentConfirmationType = null,
                         completedFullPaymentFlow = true,
                     )
                 },

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CustomerSheetConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CustomerSheetConfirmationInterceptor.kt
@@ -50,7 +50,6 @@ internal class CustomerSheetConfirmationInterceptor @AssistedInject constructor(
             if (paymentMethod.isUnverifiedUSBankAccount()) {
                 return ConfirmationDefinition.Action.Complete(
                     intent = intent.copy(paymentMethod = paymentMethod),
-                    deferredIntentConfirmationType = null,
                     completedFullPaymentFlow = true,
                 )
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/DeferredIntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/DeferredIntentConfirmationInterceptor.kt
@@ -15,6 +15,7 @@ import com.stripe.android.networking.StripeRepository
 import com.stripe.android.paymentelement.confirmation.ALLOWS_MANUAL_CONFIRMATION
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.MutableConfirmationMetadata
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.intent.IntentConfirmationDefinition.Args
 import com.stripe.android.paymentelement.confirmation.utils.ConfirmActionHelper
@@ -150,7 +151,9 @@ internal class DeferredIntentConfirmationInterceptor @AssistedInject constructor
                 if (result.clientSecret == IntentConfirmationInterceptor.COMPLETE_WITHOUT_CONFIRMING_INTENT) {
                     ConfirmationDefinition.Action.Complete(
                         intent = intent,
-                        deferredIntentConfirmationType = DeferredIntentConfirmationType.None,
+                        metadata = MutableConfirmationMetadata().apply {
+                            set(DeferredIntentConfirmationTypeKey, DeferredIntentConfirmationType.None)
+                        },
                         completedFullPaymentFlow = true,
                     )
                 } else {
@@ -221,7 +224,9 @@ internal class DeferredIntentConfirmationInterceptor @AssistedInject constructor
         failIfSetAsDefaultFeatureIsEnabled(confirmationOption)
         return ConfirmationDefinition.Action.Complete(
             intent = intent,
-            deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
+            metadata = MutableConfirmationMetadata().apply {
+                set(DeferredIntentConfirmationTypeKey, DeferredIntentConfirmationType.Server)
+            },
             completedFullPaymentFlow = true,
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/DeferredIntentConfirmationTypeKey.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/DeferredIntentConfirmationTypeKey.kt
@@ -1,0 +1,5 @@
+package com.stripe.android.paymentelement.confirmation.intent
+
+import com.stripe.android.paymentelement.confirmation.ConfirmationMetadata
+
+internal object DeferredIntentConfirmationTypeKey : ConfirmationMetadata.Key<DeferredIntentConfirmationType>

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationDefinition.kt
@@ -10,6 +10,7 @@ import com.stripe.android.model.ConfirmStripeIntentParams
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.MutableConfirmationMetadata
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.payments.paymentlauncher.InternalPaymentResult
 import com.stripe.android.payments.paymentlauncher.PaymentLauncher
@@ -103,7 +104,11 @@ internal class IntentConfirmationDefinition(
         return when (result) {
             is InternalPaymentResult.Completed -> ConfirmationDefinition.Result.Succeeded(
                 intent = result.intent,
-                deferredIntentConfirmationType = launcherArgs.deferredIntentConfirmationType,
+                metadata = MutableConfirmationMetadata().apply {
+                    launcherArgs.deferredIntentConfirmationType?.let {
+                        set(DeferredIntentConfirmationTypeKey, it)
+                    }
+                }
             )
             is InternalPaymentResult.Failed -> ConfirmationDefinition.Result.Failed(
                 cause = result.throwable,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/SharedPaymentTokenConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/SharedPaymentTokenConfirmationInterceptor.kt
@@ -12,6 +12,7 @@ import com.stripe.android.networking.StripeRepository
 import com.stripe.android.paymentelement.PreparePaymentMethodHandler
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.MutableConfirmationMetadata
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.intent.IntentConfirmationDefinition.Args
 import com.stripe.android.paymentelement.confirmation.utils.updatedWithProductUsage
@@ -94,7 +95,9 @@ internal class SharedPaymentTokenConfirmationInterceptor @AssistedInject constru
 
             ConfirmationDefinition.Action.Complete(
                 intent = intent,
-                deferredIntentConfirmationType = DeferredIntentConfirmationType.None,
+                metadata = MutableConfirmationMetadata().apply {
+                    set(DeferredIntentConfirmationTypeKey, DeferredIntentConfirmationType.None)
+                },
                 completedFullPaymentFlow = false,
             )
         } catch (@Suppress("TooGenericExceptionCaught") exception: Exception) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -31,6 +31,7 @@ import com.stripe.android.model.SetupIntent
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayConfirmationOption
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
+import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationTypeKey
 import com.stripe.android.paymentelement.confirmation.link.LinkConfirmationOption
 import com.stripe.android.paymentelement.confirmation.toConfirmationOption
 import com.stripe.android.payments.core.analytics.ErrorReporter
@@ -261,7 +262,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
             // If we just received a transaction result after process death, we don't error. Instead, we dismiss
             // PaymentSheet and return a `Completed` result to the caller.
             handlePaymentCompleted(
-                deferredIntentConfirmationType = pendingResult.deferredIntentConfirmationType,
+                deferredIntentConfirmationType = pendingResult.metadata[DeferredIntentConfirmationTypeKey],
                 finishImmediately = true,
                 intentId = pendingResult.intent.id,
             )
@@ -591,7 +592,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     private fun processConfirmationResult(result: ConfirmationHandler.Result?) {
         when (result) {
             is ConfirmationHandler.Result.Succeeded -> handlePaymentCompleted(
-                deferredIntentConfirmationType = result.deferredIntentConfirmationType,
+                deferredIntentConfirmationType = result.metadata[DeferredIntentConfirmationTypeKey],
                 finishImmediately = false,
                 intentId = result.intent.id,
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -40,6 +40,7 @@ import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentif
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
+import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationTypeKey
 import com.stripe.android.paymentelement.confirmation.toConfirmationOption
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
@@ -607,14 +608,14 @@ internal class DefaultFlowController @Inject internal constructor(
                 viewModel.paymentSelection?.let { paymentSelection ->
                     eventReporter.onPaymentSuccess(
                         paymentSelection = paymentSelection,
-                        deferredIntentConfirmationType = result.deferredIntentConfirmationType,
+                        deferredIntentConfirmationType = result.metadata[DeferredIntentConfirmationTypeKey],
                         intentId = result.intent.id,
                     )
                 }
 
                 onPaymentResult(
                     paymentResult = PaymentResult.Completed,
-                    deferredIntentConfirmationType = result.deferredIntentConfirmationType,
+                    deferredIntentConfirmationType = result.metadata[DeferredIntentConfirmationTypeKey],
                     shouldLog = false,
                     shouldResetOnCompleted = result.completedFullPaymentFlow,
                     intentId = result.intent.id,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/utils/ConfirmationReportingUtils.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/utils/ConfirmationReportingUtils.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.utils
 
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationTypeKey
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.PaymentSheetConfirmationError
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -27,7 +28,7 @@ internal fun EventReporter.reportPaymentResult(
         when (result) {
             is ConfirmationHandler.Result.Succeeded -> onPaymentSuccess(
                 paymentSelection = selection,
-                deferredIntentConfirmationType = result.deferredIntentConfirmationType,
+                deferredIntentConfirmationType = result.metadata[DeferredIntentConfirmationTypeKey],
                 intentId = result.intent.id,
             )
             is ConfirmationHandler.Result.Failed -> {

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -784,7 +784,6 @@ class CustomerSheetViewModelTest {
                     intent = SetupIntentFactory.create(
                         paymentMethod = CARD_PAYMENT_METHOD
                     ),
-                    deferredIntentConfirmationType = null,
                 )
             )
             assertThat(awaitItem()).isInstanceOf<SelectPaymentMethod>()
@@ -813,7 +812,6 @@ class CustomerSheetViewModelTest {
             awaitResultTurbine.add(
                 ConfirmationHandler.Result.Succeeded(
                     intent = SetupIntentFactory.create(CARD_PAYMENT_METHOD),
-                    deferredIntentConfirmationType = null,
                 )
             )
 
@@ -852,7 +850,6 @@ class CustomerSheetViewModelTest {
                     intent = SetupIntentFactory.create(
                         paymentMethod = CARD_PAYMENT_METHOD,
                     ),
-                    deferredIntentConfirmationType = null,
                 )
             )
 
@@ -1003,7 +1000,6 @@ class CustomerSheetViewModelTest {
             awaitResultTurbine.add(
                 ConfirmationHandler.Result.Succeeded(
                     intent = SetupIntentFactory.create(CARD_PAYMENT_METHOD),
-                    deferredIntentConfirmationType = null,
                 )
             )
 
@@ -1550,7 +1546,6 @@ class CustomerSheetViewModelTest {
                 intent = SetupIntentFactory.create(
                     paymentMethod = PaymentMethodFactory.card(),
                 ),
-                deferredIntentConfirmationType = null,
             )
         )
 
@@ -1623,7 +1618,6 @@ class CustomerSheetViewModelTest {
                 intent = SetupIntentFactory.create(
                     paymentMethod = PaymentMethodFactory.card(),
                 ),
-                deferredIntentConfirmationType = null,
             )
         )
 
@@ -1985,7 +1979,6 @@ class CustomerSheetViewModelTest {
                     intent = SetupIntentFactory.create(
                         paymentMethod = US_BANK_ACCOUNT_VERIFIED,
                     ),
-                    deferredIntentConfirmationType = null,
                 )
             )
 
@@ -2437,7 +2430,6 @@ class CustomerSheetViewModelTest {
                     intent = SetupIntentFactory.create(
                         paymentMethod = CARD_PAYMENT_METHOD,
                     ),
-                    deferredIntentConfirmationType = null,
                 )
             )
 
@@ -2479,7 +2471,6 @@ class CustomerSheetViewModelTest {
                     intent = SetupIntentFactory.create(
                         paymentMethod = US_BANK_ACCOUNT,
                     ),
-                    deferredIntentConfirmationType = null,
                 )
             )
 
@@ -2657,7 +2648,6 @@ class CustomerSheetViewModelTest {
                         intent = SetupIntentFactory.create(
                             paymentMethod = CARD_WITH_NETWORKS_PAYMENT_METHOD,
                         ),
-                        deferredIntentConfirmationType = null,
                     )
                 )
 
@@ -2975,7 +2965,6 @@ class CustomerSheetViewModelTest {
             awaitResultTurbine.add(
                 ConfirmationHandler.Result.Succeeded(
                     intent = SetupIntentFactory.create(acceptedCardPaymentMethod),
-                    deferredIntentConfirmationType = null,
                 )
             )
 
@@ -3174,7 +3163,6 @@ class CustomerSheetViewModelTest {
                         intent = SetupIntentFactory.create(
                             paymentMethod = attachedPaymentMethod,
                         ),
-                        deferredIntentConfirmationType = null,
                     )
                 )
 
@@ -3215,7 +3203,6 @@ class CustomerSheetViewModelTest {
                         intent = SetupIntentFactory.create(
                             paymentMethod = attachedPaymentMethod,
                         ),
-                        deferredIntentConfirmationType = null,
                     )
                 )
 
@@ -3450,7 +3437,6 @@ class CustomerSheetViewModelTest {
                     intent = SetupIntentFactory.create(
                         paymentMethod = CARD_PAYMENT_METHOD,
                     ),
-                    deferredIntentConfirmationType = null,
                 )
             )
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandlerTest.kt
@@ -60,7 +60,6 @@ internal class DefaultLinkConfirmationHandlerTest {
         confirmationHandler.awaitResultTurbine.add(
             item = ConfirmationHandler.Result.Succeeded(
                 intent = configuration.stripeIntent,
-                deferredIntentConfirmationType = null,
             )
         )
 
@@ -101,7 +100,6 @@ internal class DefaultLinkConfirmationHandlerTest {
         confirmationHandler.awaitResultTurbine.add(
             item = ConfirmationHandler.Result.Succeeded(
                 intent = configuration.stripeIntent,
-                deferredIntentConfirmationType = null,
             )
         )
 
@@ -216,7 +214,6 @@ internal class DefaultLinkConfirmationHandlerTest {
         confirmationHandler.awaitResultTurbine.add(
             item = ConfirmationHandler.Result.Succeeded(
                 intent = configuration.stripeIntent,
-                deferredIntentConfirmationType = null,
             )
         )
 
@@ -255,7 +252,6 @@ internal class DefaultLinkConfirmationHandlerTest {
         confirmationHandler.awaitResultTurbine.add(
             item = ConfirmationHandler.Result.Succeeded(
                 intent = configuration.stripeIntent,
-                deferredIntentConfirmationType = null,
             )
         )
 
@@ -287,7 +283,6 @@ internal class DefaultLinkConfirmationHandlerTest {
         confirmationHandler.awaitResultTurbine.add(
             item = ConfirmationHandler.Result.Succeeded(
                 intent = configuration.stripeIntent,
-                deferredIntentConfirmationType = null,
             )
         )
 
@@ -319,7 +314,6 @@ internal class DefaultLinkConfirmationHandlerTest {
         confirmationHandler.awaitResultTurbine.add(
             item = ConfirmationHandler.Result.Succeeded(
                 intent = configuration.stripeIntent,
-                deferredIntentConfirmationType = null,
             )
         )
 
@@ -351,7 +345,6 @@ internal class DefaultLinkConfirmationHandlerTest {
             confirmationHandler.awaitResultTurbine.add(
                 item = ConfirmationHandler.Result.Succeeded(
                     intent = configuration.stripeIntent,
-                    deferredIntentConfirmationType = null,
                 )
             )
 
@@ -387,7 +380,6 @@ internal class DefaultLinkConfirmationHandlerTest {
         confirmationHandler.awaitResultTurbine.add(
             item = ConfirmationHandler.Result.Succeeded(
                 intent = configuration.stripeIntent,
-                deferredIntentConfirmationType = null,
             )
         )
 
@@ -429,7 +421,6 @@ internal class DefaultLinkConfirmationHandlerTest {
             confirmationHandler.awaitResultTurbine.add(
                 item = ConfirmationHandler.Result.Succeeded(
                     intent = configuration.stripeIntent,
-                    deferredIntentConfirmationType = null,
                 )
             )
 
@@ -465,7 +456,6 @@ internal class DefaultLinkConfirmationHandlerTest {
             confirmationHandler.awaitResultTurbine.add(
                 item = ConfirmationHandler.Result.Succeeded(
                     intent = configuration.stripeIntent,
-                    deferredIntentConfirmationType = null,
                 )
             )
 
@@ -501,7 +491,6 @@ internal class DefaultLinkConfirmationHandlerTest {
             confirmationHandler.awaitResultTurbine.add(
                 item = ConfirmationHandler.Result.Succeeded(
                     intent = configuration.stripeIntent,
-                    deferredIntentConfirmationType = null,
                 )
             )
 
@@ -562,7 +551,6 @@ internal class DefaultLinkConfirmationHandlerTest {
             confirmationHandler.awaitResultTurbine.add(
                 item = ConfirmationHandler.Result.Succeeded(
                     intent = configuration.stripeIntent,
-                    deferredIntentConfirmationType = null,
                 )
             )
 
@@ -604,7 +592,6 @@ internal class DefaultLinkConfirmationHandlerTest {
             confirmationHandler.awaitResultTurbine.add(
                 item = ConfirmationHandler.Result.Succeeded(
                     intent = configuration.stripeIntent,
-                    deferredIntentConfirmationType = null,
                 )
             )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationMediatorTest.kt
@@ -8,7 +8,6 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.PaymentIntentFixtures
-import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
 import com.stripe.android.paymentsheet.R
 import kotlinx.coroutines.test.runTest
 import kotlinx.parcelize.Parcelize
@@ -157,7 +156,6 @@ class ConfirmationMediatorTest {
     fun `On complete confirmation action, should return mediator complete action`() = test(
         action = ConfirmationDefinition.Action.Complete(
             intent = INTENT,
-            deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
             completedFullPaymentFlow = true,
         ),
     ) {
@@ -181,7 +179,6 @@ class ConfirmationMediatorTest {
         val completeAction = action.asComplete()
 
         assertThat(completeAction.intent).isEqualTo(INTENT)
-        assertThat(completeAction.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Client)
         assertThat(completeAction.completedFullPaymentFlow).isTrue()
     }
 
@@ -189,7 +186,6 @@ class ConfirmationMediatorTest {
     fun `On complete confirmation action with uncompleted flow, should return expected action`() = test(
         action = ConfirmationDefinition.Action.Complete(
             intent = INTENT,
-            deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
             completedFullPaymentFlow = false,
         ),
     ) {
@@ -213,7 +209,6 @@ class ConfirmationMediatorTest {
         val completeAction = action.asComplete()
 
         assertThat(completeAction.intent).isEqualTo(INTENT)
-        assertThat(completeAction.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Client)
         assertThat(completeAction.completedFullPaymentFlow).isFalse()
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationDefinitionTest.kt
@@ -14,6 +14,7 @@ import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
+import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationTypeKey
 import com.stripe.android.paymentelement.confirmation.intent.IntentConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.intent.IntentConfirmationInterceptor
 import com.stripe.android.paymentelement.confirmation.interceptor.FakeIntentConfirmationInterceptorFactory
@@ -130,7 +131,11 @@ class IntentConfirmationDefinitionTest {
         val completeAction = action.asComplete()
 
         assertThat(completeAction.intent).isEqualTo(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
-        assertThat(completeAction.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Server)
+        assertThat(completeAction.metadata).isEqualTo(
+            MutableConfirmationMetadata().apply {
+                set(DeferredIntentConfirmationTypeKey, DeferredIntentConfirmationType.Server)
+            }
+        )
     }
 
     @Test
@@ -154,7 +159,11 @@ class IntentConfirmationDefinitionTest {
             val completeAction = action.asComplete()
 
             assertThat(completeAction.intent).isEqualTo(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
-            assertThat(completeAction.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Server)
+            assertThat(completeAction.metadata).isEqualTo(
+                MutableConfirmationMetadata().apply {
+                    set(DeferredIntentConfirmationTypeKey, DeferredIntentConfirmationType.Server)
+                }
+            )
             assertThat(completeAction.completedFullPaymentFlow).isFalse()
         }
 
@@ -414,7 +423,11 @@ class IntentConfirmationDefinitionTest {
         val succeededResult = result.asSucceeded()
 
         assertThat(succeededResult.intent).isEqualTo(PaymentIntentFixtures.PI_SUCCEEDED)
-        assertThat(succeededResult.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Client)
+        assertThat(succeededResult.metadata).isEqualTo(
+            MutableConfirmationMetadata().apply {
+                set(DeferredIntentConfirmationTypeKey, DeferredIntentConfirmationType.Client)
+            }
+        )
         assertThat(succeededResult.completedFullPaymentFlow).isTrue()
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationFlowTest.kt
@@ -19,6 +19,7 @@ import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentelement.PreparePaymentMethodHandler
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
+import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationTypeKey
 import com.stripe.android.paymentelement.confirmation.intent.IntentConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.intent.IntentConfirmationInterceptor
 import com.stripe.android.paymentsheet.CreateIntentCallback
@@ -93,8 +94,11 @@ internal class IntentConfirmationFlowTest {
 
         assertThat(completeAction.intent)
             .isEqualTo(DEFERRED_CONFIRMATION_PARAMETERS.paymentMethodMetadata.stripeIntent)
-        assertThat(completeAction.deferredIntentConfirmationType)
-            .isEqualTo(DeferredIntentConfirmationType.None)
+        assertThat(completeAction.metadata).isEqualTo(
+            MutableConfirmationMetadata().apply {
+                set(DeferredIntentConfirmationTypeKey, DeferredIntentConfirmationType.None)
+            }
+        )
         assertThat(completeAction.completedFullPaymentFlow).isTrue()
     }
 
@@ -126,8 +130,11 @@ internal class IntentConfirmationFlowTest {
 
         assertThat(completeAction.intent)
             .isEqualTo(DEFERRED_CONFIRMATION_PARAMETERS.paymentMethodMetadata.stripeIntent)
-        assertThat(completeAction.deferredIntentConfirmationType)
-            .isEqualTo(DeferredIntentConfirmationType.None)
+        assertThat(completeAction.metadata).isEqualTo(
+            MutableConfirmationMetadata().apply {
+                set(DeferredIntentConfirmationTypeKey, DeferredIntentConfirmationType.None)
+            }
+        )
         assertThat(completeAction.completedFullPaymentFlow).isFalse()
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/attestation/AttestationConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/attestation/AttestationConfirmationActivityTest.kt
@@ -18,6 +18,7 @@ import com.stripe.android.model.AndroidVerificationObject
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.ConfirmationTestScenario
+import com.stripe.android.paymentelement.confirmation.MutableConfirmationMetadata
 import com.stripe.android.paymentelement.confirmation.PaymentElementConfirmationTestActivity
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.assertComplete
@@ -87,7 +88,7 @@ internal class AttestationConfirmationActivityTest {
             val successResult = awaitItem().assertComplete().result.assertSucceeded()
 
             assertThat(successResult.intent).isEqualTo(PAYMENT_INTENT.copy(paymentMethod = paymentMethod))
-            assertThat(successResult.deferredIntentConfirmationType).isNull()
+            assertThat(successResult.metadata).isEqualTo(MutableConfirmationMetadata())
         }
     }
 
@@ -122,7 +123,7 @@ internal class AttestationConfirmationActivityTest {
             val successResult = awaitItem().assertComplete().result.assertSucceeded()
 
             assertThat(successResult.intent).isEqualTo(PAYMENT_INTENT.copy(paymentMethod = paymentMethod))
-            assertThat(successResult.deferredIntentConfirmationType).isNull()
+            assertThat(successResult.metadata).isEqualTo(MutableConfirmationMetadata())
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/bacs/BacsConfirmationActivityTest.kt
@@ -17,6 +17,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.ConfirmationTestScenario
+import com.stripe.android.paymentelement.confirmation.MutableConfirmationMetadata
 import com.stripe.android.paymentelement.confirmation.PaymentElementConfirmationTestActivity
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.assertCanceled
@@ -84,7 +85,7 @@ internal class BacsConfirmationActivityTest {
             val successResult = awaitItem().assertComplete().result.assertSucceeded()
 
             assertThat(successResult.intent).isEqualTo(PAYMENT_INTENT.copy(paymentMethod = PAYMENT_METHOD))
-            assertThat(successResult.deferredIntentConfirmationType).isNull()
+            assertThat(successResult.metadata).isEqualTo(MutableConfirmationMetadata())
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationActivityTest.kt
@@ -19,6 +19,7 @@ import com.stripe.android.model.PassiveCaptchaParamsFactory
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.ConfirmationTestScenario
+import com.stripe.android.paymentelement.confirmation.MutableConfirmationMetadata
 import com.stripe.android.paymentelement.confirmation.PaymentElementConfirmationTestActivity
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.assertComplete
@@ -89,7 +90,7 @@ internal class PassiveChallengeConfirmationActivityTest {
             val successResult = awaitItem().assertComplete().result.assertSucceeded()
 
             assertThat(successResult.intent).isEqualTo(PAYMENT_INTENT.copy(paymentMethod = PAYMENT_METHOD))
-            assertThat(successResult.deferredIntentConfirmationType).isNull()
+            assertThat(successResult.metadata).isEqualTo(MutableConfirmationMetadata())
         }
     }
 
@@ -131,7 +132,7 @@ internal class PassiveChallengeConfirmationActivityTest {
             val successResult = awaitItem().assertComplete().result.assertSucceeded()
 
             assertThat(successResult.intent).isEqualTo(PAYMENT_INTENT.copy(paymentMethod = PAYMENT_METHOD))
-            assertThat(successResult.deferredIntentConfirmationType).isNull()
+            assertThat(successResult.metadata).isEqualTo(MutableConfirmationMetadata())
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cpms/CustomPaymentMethodConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cpms/CustomPaymentMethodConfirmationActivityTest.kt
@@ -19,6 +19,7 @@ import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferen
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbacks
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.ConfirmationTestScenario
+import com.stripe.android.paymentelement.confirmation.MutableConfirmationMetadata
 import com.stripe.android.paymentelement.confirmation.PaymentElementConfirmationTestActivity
 import com.stripe.android.paymentelement.confirmation.assertCanceled
 import com.stripe.android.paymentelement.confirmation.assertComplete
@@ -78,7 +79,7 @@ internal class CustomPaymentMethodConfirmationActivityTest {
             val successResult = awaitItem().assertComplete().result.assertSucceeded()
 
             assertThat(successResult.intent).isEqualTo(PAYMENT_INTENT)
-            assertThat(successResult.deferredIntentConfirmationType).isNull()
+            assertThat(successResult.metadata).isEqualTo(MutableConfirmationMetadata())
             assertThat(successResult.completedFullPaymentFlow).isTrue()
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cpms/CustomPaymentMethodConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cpms/CustomPaymentMethodConfirmationDefinitionTest.kt
@@ -11,6 +11,7 @@ import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.EmptyConfirmationLauncherArgs
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationOption
+import com.stripe.android.paymentelement.confirmation.MutableConfirmationMetadata
 import com.stripe.android.paymentelement.confirmation.asCallbackFor
 import com.stripe.android.paymentelement.confirmation.asCanceled
 import com.stripe.android.paymentelement.confirmation.asFail
@@ -161,7 +162,7 @@ class CustomPaymentMethodConfirmationDefinitionTest {
 
         val succeededResult = result.asSucceeded()
         assertThat(succeededResult.intent).isEqualTo(CONFIRMATION_PARAMETERS.intent)
-        assertThat(succeededResult.deferredIntentConfirmationType).isNull()
+        assertThat(succeededResult.metadata).isEqualTo(MutableConfirmationMetadata())
         assertThat(succeededResult.completedFullPaymentFlow).isTrue()
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/cvc/CvcRecollectionConfirmationActivityTest.kt
@@ -17,6 +17,7 @@ import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.ConfirmationTestScenario
 import com.stripe.android.paymentelement.confirmation.ExtendedPaymentElementConfirmationTestActivity
+import com.stripe.android.paymentelement.confirmation.MutableConfirmationMetadata
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.assertComplete
 import com.stripe.android.paymentelement.confirmation.assertConfirming
@@ -80,7 +81,7 @@ internal class CvcRecollectionConfirmationActivityTest {
             val successResult = awaitItem().assertComplete().result.assertSucceeded()
 
             assertThat(successResult.intent).isEqualTo(PAYMENT_INTENT.copy(paymentMethod = PAYMENT_METHOD))
-            assertThat(successResult.deferredIntentConfirmationType).isNull()
+            assertThat(successResult.metadata).isEqualTo(MutableConfirmationMetadata())
         }
     }
 
@@ -118,7 +119,7 @@ internal class CvcRecollectionConfirmationActivityTest {
             val successResult = awaitItem().assertComplete().result.assertSucceeded()
 
             assertThat(successResult.intent).isEqualTo(paymentIntent.copy(paymentMethod = PAYMENT_METHOD))
-            assertThat(successResult.deferredIntentConfirmationType).isNull()
+            assertThat(successResult.metadata).isEqualTo(MutableConfirmationMetadata())
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationActivityTest.kt
@@ -20,6 +20,7 @@ import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferen
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbacks
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.ConfirmationTestScenario
+import com.stripe.android.paymentelement.confirmation.MutableConfirmationMetadata
 import com.stripe.android.paymentelement.confirmation.PaymentElementConfirmationTestActivity
 import com.stripe.android.paymentelement.confirmation.assertCanceled
 import com.stripe.android.paymentelement.confirmation.assertComplete
@@ -84,7 +85,7 @@ internal class ExternalPaymentMethodConfirmationActivityTest {
             val successResult = awaitItem().assertComplete().result.assertSucceeded()
 
             assertThat(successResult.intent).isEqualTo(PAYMENT_INTENT)
-            assertThat(successResult.deferredIntentConfirmationType).isNull()
+            assertThat(successResult.metadata).isEqualTo(MutableConfirmationMetadata())
             assertThat(successResult.completedFullPaymentFlow).isTrue()
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/epms/ExternalPaymentMethodConfirmationDefinitionTest.kt
@@ -12,6 +12,7 @@ import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.EmptyConfirmationLauncherArgs
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationOption
+import com.stripe.android.paymentelement.confirmation.MutableConfirmationMetadata
 import com.stripe.android.paymentelement.confirmation.PAYMENT_INTENT
 import com.stripe.android.paymentelement.confirmation.asCallbackFor
 import com.stripe.android.paymentelement.confirmation.asCanceled
@@ -103,7 +104,7 @@ class ExternalPaymentMethodConfirmationDefinitionTest {
         val successResult = result.asSucceeded()
 
         assertThat(successResult.intent).isEqualTo(PAYMENT_INTENT)
-        assertThat(successResult.deferredIntentConfirmationType).isNull()
+        assertThat(successResult.metadata).isEqualTo(MutableConfirmationMetadata())
         assertThat(successResult.completedFullPaymentFlow).isTrue()
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationActivityTest.kt
@@ -20,6 +20,7 @@ import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.ConfirmationTestScenario
+import com.stripe.android.paymentelement.confirmation.MutableConfirmationMetadata
 import com.stripe.android.paymentelement.confirmation.PaymentElementConfirmationTestActivity
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.assertCanceled
@@ -88,7 +89,7 @@ internal class GooglePayConfirmationActivityTest {
             val successResult = awaitItem().assertComplete().result.assertSucceeded()
 
             assertThat(successResult.intent).isEqualTo(PAYMENT_INTENT.copy(paymentMethod = paymentMethod))
-            assertThat(successResult.deferredIntentConfirmationType).isNull()
+            assertThat(successResult.metadata).isEqualTo(MutableConfirmationMetadata())
             assertThat(successResult.completedFullPaymentFlow).isTrue()
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
@@ -16,6 +16,7 @@ import com.stripe.android.model.PaymentMethodSelectionFlow
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.MutableConfirmationMetadata
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.testing.AbsFakeStripeRepository
 import com.stripe.android.testing.PaymentIntentFactory
@@ -74,7 +75,11 @@ class CheckoutSessionConfirmationInterceptorTest {
 
         val completeAction = result as ConfirmationDefinition.Action.Complete
         assertThat(completeAction.intent).isEqualTo(succeededPaymentIntent)
-        assertThat(completeAction.deferredIntentConfirmationType).isEqualTo(DeferredIntentConfirmationType.Server)
+        assertThat(completeAction.metadata).isEqualTo(
+            MutableConfirmationMetadata().apply {
+                set(DeferredIntentConfirmationTypeKey, DeferredIntentConfirmationType.Server)
+            }
+        )
         assertThat(completeAction.completedFullPaymentFlow).isTrue()
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CustomerSheetAttachPaymentMethodInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CustomerSheetAttachPaymentMethodInterceptorTest.kt
@@ -10,6 +10,7 @@ import com.stripe.android.isInstanceOf
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.MutableConfirmationMetadata
 import com.stripe.android.testing.FakeLogger
 import com.stripe.android.testing.SetupIntentFactory
 import kotlinx.coroutines.test.runTest
@@ -43,7 +44,7 @@ class CustomerSheetAttachPaymentMethodInterceptorTest {
         val completeAction = result as ConfirmationDefinition.Action.Complete
 
         assertThat(completeAction.intent).isEqualTo(setupIntent.copy(paymentMethod = paymentMethod))
-        assertThat(completeAction.deferredIntentConfirmationType).isNull()
+        assertThat(completeAction.metadata).isEqualTo(MutableConfirmationMetadata())
         assertThat(completeAction.completedFullPaymentFlow).isTrue()
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CustomerSheetConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CustomerSheetConfirmationInterceptorTest.kt
@@ -19,6 +19,7 @@ import com.stripe.android.model.PaymentMethodSelectionFlow
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.MutableConfirmationMetadata
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.testing.FakeLogger
 import com.stripe.android.testing.PaymentIntentFactory
@@ -139,7 +140,7 @@ class CustomerSheetConfirmationInterceptorTest {
         val completeAction = result as ConfirmationDefinition.Action.Complete
 
         assertThat(completeAction.intent).isEqualTo(setupIntent.copy(paymentMethod = paymentMethod))
-        assertThat(completeAction.deferredIntentConfirmationType).isNull()
+        assertThat(completeAction.metadata).isEqualTo(MutableConfirmationMetadata())
         assertThat(completeAction.completedFullPaymentFlow).isTrue()
     }
 
@@ -151,7 +152,6 @@ class CustomerSheetConfirmationInterceptorTest {
         ),
         setupInterceptAction = ConfirmationDefinition.Action.Complete(
             intent = SetupIntentFactory.create().copy(paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD),
-            deferredIntentConfirmationType = null,
             completedFullPaymentFlow = true,
         ),
     ) {
@@ -187,7 +187,6 @@ class CustomerSheetConfirmationInterceptorTest {
         ),
         attachInterceptAction = ConfirmationDefinition.Action.Complete(
             intent = SetupIntentFactory.create().copy(paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD),
-            deferredIntentConfirmationType = null,
             completedFullPaymentFlow = true,
         ),
     ) {
@@ -210,7 +209,7 @@ class CustomerSheetConfirmationInterceptorTest {
         val completeAction = result as ConfirmationDefinition.Action.Complete
 
         assertThat(completeAction.intent).isEqualTo(setupIntent.copy(paymentMethod = paymentMethod))
-        assertThat(completeAction.deferredIntentConfirmationType).isNull()
+        assertThat(completeAction.metadata).isEqualTo(MutableConfirmationMetadata())
         assertThat(completeAction.completedFullPaymentFlow).isTrue()
 
         createAttachPaymentMethodInterceptorFactoryCalls.awaitItem()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/ConfirmationTokenConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/ConfirmationTokenConfirmationInterceptorTest.kt
@@ -28,10 +28,12 @@ import com.stripe.android.paymentelement.PaymentMethodOptionsSetupFutureUsagePre
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.ConfirmationTokenFixtures
+import com.stripe.android.paymentelement.confirmation.MutableConfirmationMetadata
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.createIntentConfirmationInterceptor
 import com.stripe.android.paymentelement.confirmation.intent.CreateIntentWithConfirmationTokenCallbackFailureException
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
+import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationTypeKey
 import com.stripe.android.paymentelement.confirmation.intent.IntentConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.intent.IntentConfirmationInterceptor
 import com.stripe.android.paymentsheet.CreateIntentResult
@@ -270,7 +272,9 @@ class ConfirmationTokenConfirmationInterceptorTest {
         assertThat(nextStep).isEqualTo(
             ConfirmationDefinition.Action.Complete<IntentConfirmationDefinition.Args>(
                 intent = PaymentIntentFixtures.PI_SUCCEEDED,
-                deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
+                metadata = MutableConfirmationMetadata().apply {
+                    set(DeferredIntentConfirmationTypeKey, DeferredIntentConfirmationType.Server)
+                },
                 completedFullPaymentFlow = true,
             )
         )
@@ -344,7 +348,9 @@ class ConfirmationTokenConfirmationInterceptorTest {
         assertThat(nextStep).isEqualTo(
             ConfirmationDefinition.Action.Complete<IntentConfirmationDefinition.Args>(
                 intent = intent,
-                deferredIntentConfirmationType = DeferredIntentConfirmationType.None,
+                metadata = MutableConfirmationMetadata().apply {
+                    set(DeferredIntentConfirmationTypeKey, DeferredIntentConfirmationType.None)
+                },
                 completedFullPaymentFlow = true,
             )
         )
@@ -498,7 +504,9 @@ class ConfirmationTokenConfirmationInterceptorTest {
             assertThat(nextStep).isEqualTo(
                 ConfirmationDefinition.Action.Complete<IntentConfirmationDefinition.Args>(
                     intent = PaymentIntentFixtures.PI_SUCCEEDED,
-                    deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
+                    metadata = MutableConfirmationMetadata().apply {
+                        set(DeferredIntentConfirmationTypeKey, DeferredIntentConfirmationType.Server)
+                    },
                     completedFullPaymentFlow = true,
                 )
             )
@@ -539,7 +547,9 @@ class ConfirmationTokenConfirmationInterceptorTest {
             assertThat(nextStep).isEqualTo(
                 ConfirmationDefinition.Action.Complete<IntentConfirmationDefinition.Args>(
                     intent = PaymentIntentFixtures.PI_SUCCEEDED,
-                    deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
+                    metadata = MutableConfirmationMetadata().apply {
+                        set(DeferredIntentConfirmationTypeKey, DeferredIntentConfirmationType.Server)
+                    },
                     completedFullPaymentFlow = true,
                 )
             )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/DeferredIntentConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/DeferredIntentConfirmationInterceptorTest.kt
@@ -20,10 +20,12 @@ import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.MutableConfirmationMetadata
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.createIntentConfirmationInterceptor
 import com.stripe.android.paymentelement.confirmation.intent.CreateIntentCallbackFailureException
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
+import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationTypeKey
 import com.stripe.android.paymentelement.confirmation.intent.IntentConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.intent.IntentConfirmationInterceptor
 import com.stripe.android.paymentelement.confirmation.intent.InvalidDeferredIntentUsageException
@@ -232,7 +234,9 @@ class DeferredIntentConfirmationInterceptorTest {
         assertThat(nextStep).isEqualTo(
             ConfirmationDefinition.Action.Complete<IntentConfirmationDefinition.Args>(
                 intent = PaymentIntentFixtures.PI_SUCCEEDED,
-                deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
+                metadata = MutableConfirmationMetadata().apply {
+                    set(DeferredIntentConfirmationTypeKey, DeferredIntentConfirmationType.Server)
+                },
                 completedFullPaymentFlow = true,
             )
         )
@@ -345,7 +349,9 @@ class DeferredIntentConfirmationInterceptorTest {
         assertThat(nextStep).isEqualTo(
             ConfirmationDefinition.Action.Complete<IntentConfirmationDefinition.Args>(
                 intent = intent,
-                deferredIntentConfirmationType = DeferredIntentConfirmationType.None,
+                metadata = MutableConfirmationMetadata().apply {
+                    set(DeferredIntentConfirmationTypeKey, DeferredIntentConfirmationType.None)
+                },
                 completedFullPaymentFlow = true,
             )
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/SharedPaymentTokenConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/SharedPaymentTokenConfirmationInterceptorTest.kt
@@ -10,9 +10,11 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentelement.PreparePaymentMethodHandler
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
+import com.stripe.android.paymentelement.confirmation.MutableConfirmationMetadata
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.createIntentConfirmationInterceptor
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
+import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationTypeKey
 import com.stripe.android.paymentelement.confirmation.intent.IntentConfirmationDefinition
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -67,7 +69,9 @@ class SharedPaymentTokenConfirmationInterceptorTest {
             assertThat(nextStep).isEqualTo(
                 ConfirmationDefinition.Action.Complete<IntentConfirmationDefinition.Args>(
                     intent = intent,
-                    deferredIntentConfirmationType = DeferredIntentConfirmationType.None,
+                    metadata = MutableConfirmationMetadata().apply {
+                        set(DeferredIntentConfirmationTypeKey, DeferredIntentConfirmationType.None)
+                    },
                     completedFullPaymentFlow = false,
                 )
             )
@@ -114,7 +118,9 @@ class SharedPaymentTokenConfirmationInterceptorTest {
             assertThat(nextStep).isEqualTo(
                 ConfirmationDefinition.Action.Complete<IntentConfirmationDefinition.Args>(
                     intent = intent,
-                    deferredIntentConfirmationType = DeferredIntentConfirmationType.None,
+                    metadata = MutableConfirmationMetadata().apply {
+                        set(DeferredIntentConfirmationTypeKey, DeferredIntentConfirmationType.None)
+                    },
                     completedFullPaymentFlow = false,
                 )
             )
@@ -163,7 +169,9 @@ class SharedPaymentTokenConfirmationInterceptorTest {
             assertThat(nextStep).isEqualTo(
                 ConfirmationDefinition.Action.Complete<IntentConfirmationDefinition.Args>(
                     intent = intent,
-                    deferredIntentConfirmationType = DeferredIntentConfirmationType.None,
+                    metadata = MutableConfirmationMetadata().apply {
+                        set(DeferredIntentConfirmationTypeKey, DeferredIntentConfirmationType.None)
+                    },
                     completedFullPaymentFlow = false,
                 )
             )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationActivityTest.kt
@@ -26,6 +26,7 @@ import com.stripe.android.networking.RequestSurface
 import com.stripe.android.paymentelement.confirmation.CONFIRMATION_PARAMETERS
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.ConfirmationTestScenario
+import com.stripe.android.paymentelement.confirmation.MutableConfirmationMetadata
 import com.stripe.android.paymentelement.confirmation.PaymentElementConfirmationTestActivity
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.assertComplete
@@ -128,7 +129,7 @@ internal class LinkConfirmationActivityTest(private val nativeLinkEnabled: Boole
             val successResult = awaitItem().assertComplete().result.assertSucceeded()
 
             assertThat(successResult.intent).isEqualTo(PAYMENT_INTENT.copy(paymentMethod = paymentMethod))
-            assertThat(successResult.deferredIntentConfirmationType).isNull()
+            assertThat(successResult.metadata).isEqualTo(MutableConfirmationMetadata())
             assertThat(successResult.completedFullPaymentFlow).isTrue()
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/shoppay/ShopPayConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/shoppay/ShopPayConfirmationDefinitionTest.kt
@@ -10,6 +10,7 @@ import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.EmptyConfirmationLauncherArgs
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationOption
+import com.stripe.android.paymentelement.confirmation.MutableConfirmationMetadata
 import com.stripe.android.paymentelement.confirmation.asCallbackFor
 import com.stripe.android.paymentelement.confirmation.asCanceled
 import com.stripe.android.paymentelement.confirmation.asFailed
@@ -149,7 +150,7 @@ internal class ShopPayConfirmationDefinitionTest {
         val succeededResult = result.asSucceeded()
 
         assertThat(succeededResult.intent).isEqualTo(CONFIRMATION_PARAMETERS.intent)
-        assertThat(succeededResult.deferredIntentConfirmationType).isNull()
+        assertThat(succeededResult.metadata).isEqualTo(MutableConfirmationMetadata())
         assertThat(succeededResult.completedFullPaymentFlow).isFalse()
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfirmationHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfirmationHelperTest.kt
@@ -55,7 +55,6 @@ internal class DefaultEmbeddedConfirmationHelperTest {
         confirmationHandler.state.value = ConfirmationHandler.State.Complete(
             ConfirmationHandler.Result.Succeeded(
                 intent = PaymentIntentFixtures.PI_SUCCEEDED,
-                deferredIntentConfirmationType = null,
             )
         )
         assertThat(callbackHelper.stateHelper.stateTurbine.awaitItem()).isNull()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationStarterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfirmationStarterTest.kt
@@ -88,7 +88,6 @@ class EmbeddedConfirmationStarterTest {
             confirmationState = ConfirmationHandler.State.Complete(
                 result = ConfirmationHandler.Result.Succeeded(
                     intent = intent,
-                    deferredIntentConfirmationType = null,
                 ),
             ),
         ) {
@@ -96,7 +95,6 @@ class EmbeddedConfirmationStarterTest {
                 val result = awaitItem().assertSucceeded()
 
                 assertThat(result.intent).isEqualTo(intent)
-                assertThat(result.deferredIntentConfirmationType).isNull()
             }
 
             confirmationStarter.result.test {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/ConfirmationStateHelpers.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/ConfirmationStateHelpers.kt
@@ -22,7 +22,6 @@ internal fun confirmationStateComplete(succeeded: Boolean): ConfirmationHandler.
     val result = if (succeeded) {
         ConfirmationHandler.Result.Succeeded(
             PaymentIntentFixtures.PI_SUCCEEDED,
-            null,
         )
     } else {
         ConfirmationHandler.Result.Failed(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityConfirmationHandlerTest.kt
@@ -10,7 +10,6 @@ import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
-import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.content.EmbeddedConfirmationStateFixtures
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
@@ -50,7 +49,6 @@ internal class FormActivityConfirmationHandlerTest {
         confirmationHandler.state.value = ConfirmationHandler.State.Complete(
             ConfirmationHandler.Result.Succeeded(
                 intent = PaymentIntentFixtures.PI_SUCCEEDED,
-                deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
             )
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -788,7 +788,6 @@ internal class PaymentSheetActivityTest {
             confirmationHandler.state.value = ConfirmationHandler.State.Complete(
                 result = ConfirmationHandler.Result.Succeeded(
                     intent = PAYMENT_INTENT,
-                    deferredIntentConfirmationType = null,
                 )
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -58,11 +58,13 @@ import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferen
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbacks
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.MutableConfirmationMetadata
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.asNew
 import com.stripe.android.paymentelement.confirmation.bacs.BacsConfirmationOption
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayConfirmationOption
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
+import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationTypeKey
 import com.stripe.android.paymentelement.confirmation.intent.InvalidDeferredIntentUsageException
 import com.stripe.android.paymentelement.confirmation.link.LinkConfirmationOption
 import com.stripe.android.paymentelement.confirmation.linkinline.LinkInlineSignupConfirmationOption
@@ -859,7 +861,6 @@ internal class PaymentSheetViewModelTest {
             confirmationState.value = ConfirmationHandler.State.Complete(
                 ConfirmationHandler.Result.Succeeded(
                     intent = PAYMENT_INTENT,
-                    deferredIntentConfirmationType = null,
                 )
             )
 
@@ -970,7 +971,6 @@ internal class PaymentSheetViewModelTest {
             confirmationState.value = ConfirmationHandler.State.Complete(
                 ConfirmationHandler.Result.Succeeded(
                     intent = PAYMENT_INTENT,
-                    deferredIntentConfirmationType = null,
                 )
             )
 
@@ -1005,7 +1005,6 @@ internal class PaymentSheetViewModelTest {
             confirmationState.value = ConfirmationHandler.State.Complete(
                 result = ConfirmationHandler.Result.Succeeded(
                     intent = PAYMENT_INTENT,
-                    deferredIntentConfirmationType = null,
                 )
             )
 
@@ -2017,7 +2016,6 @@ internal class PaymentSheetViewModelTest {
             confirmationState.value = ConfirmationHandler.State.Complete(
                 ConfirmationHandler.Result.Succeeded(
                     intent = PAYMENT_INTENT,
-                    deferredIntentConfirmationType = null,
                 )
             )
 
@@ -2135,7 +2133,6 @@ internal class PaymentSheetViewModelTest {
         confirmationState.value = ConfirmationHandler.State.Complete(
             result = ConfirmationHandler.Result.Succeeded(
                 intent = PAYMENT_INTENT,
-                deferredIntentConfirmationType = null,
             )
         )
 
@@ -2170,7 +2167,9 @@ internal class PaymentSheetViewModelTest {
             confirmationState.value = ConfirmationHandler.State.Complete(
                 ConfirmationHandler.Result.Succeeded(
                     intent = PAYMENT_INTENT,
-                    deferredIntentConfirmationType = DeferredIntentConfirmationType.None,
+                    metadata = MutableConfirmationMetadata().apply {
+                        set(DeferredIntentConfirmationTypeKey, DeferredIntentConfirmationType.None)
+                    },
                 )
             )
 
@@ -2205,7 +2204,9 @@ internal class PaymentSheetViewModelTest {
             confirmationState.value = ConfirmationHandler.State.Complete(
                 ConfirmationHandler.Result.Succeeded(
                     intent = PAYMENT_INTENT,
-                    deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
+                    metadata = MutableConfirmationMetadata().apply {
+                        set(DeferredIntentConfirmationTypeKey, DeferredIntentConfirmationType.Client)
+                    }
                 )
             )
 
@@ -2240,7 +2241,9 @@ internal class PaymentSheetViewModelTest {
             confirmationState.value = ConfirmationHandler.State.Complete(
                 ConfirmationHandler.Result.Succeeded(
                     intent = PAYMENT_INTENT,
-                    deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
+                    metadata = MutableConfirmationMetadata().apply {
+                        set(DeferredIntentConfirmationTypeKey, DeferredIntentConfirmationType.Server)
+                    },
                 )
             )
 
@@ -2565,7 +2568,6 @@ internal class PaymentSheetViewModelTest {
         confirmationState.value = ConfirmationHandler.State.Complete(
             ConfirmationHandler.Result.Succeeded(
                 intent = PaymentIntentFixtures.PI_SUCCEEDED,
-                deferredIntentConfirmationType = null,
             )
         )
 
@@ -2646,7 +2648,6 @@ internal class PaymentSheetViewModelTest {
         confirmationState.value = ConfirmationHandler.State.Complete(
             ConfirmationHandler.Result.Succeeded(
                 intent = PaymentIntentFixtures.PI_SUCCEEDED,
-                deferredIntentConfirmationType = null,
             )
         )
 
@@ -2721,7 +2722,6 @@ internal class PaymentSheetViewModelTest {
         confirmationState.value = ConfirmationHandler.State.Complete(
             ConfirmationHandler.Result.Succeeded(
                 intent = PaymentIntentFixtures.PI_SUCCEEDED,
-                deferredIntentConfirmationType = null,
             )
         )
 
@@ -3355,7 +3355,6 @@ internal class PaymentSheetViewModelTest {
             awaitResultTurbine.add(
                 ConfirmationHandler.Result.Succeeded(
                     intent = stripeIntent,
-                    deferredIntentConfirmationType = null,
                 )
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -51,11 +51,13 @@ import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbacks
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.MutableConfirmationMetadata
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.bacs.BacsConfirmationOption
 import com.stripe.android.paymentelement.confirmation.epms.ExternalPaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayConfirmationOption
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
+import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationTypeKey
 import com.stripe.android.paymentelement.confirmation.intent.InvalidDeferredIntentUsageException
 import com.stripe.android.paymentelement.confirmation.link.LinkConfirmationOption
 import com.stripe.android.paymentelement.confirmation.linkinline.LinkInlineSignupConfirmationOption
@@ -231,7 +233,6 @@ internal class DefaultFlowControllerTest {
         confirmationState.value = ConfirmationHandler.State.Complete(
             ConfirmationHandler.Result.Succeeded(
                 intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
-                deferredIntentConfirmationType = null,
                 completedFullPaymentFlow = false,
             )
         )
@@ -1659,7 +1660,6 @@ internal class DefaultFlowControllerTest {
         confirmationState.value = ConfirmationHandler.State.Complete(
             ConfirmationHandler.Result.Succeeded(
                 intent = PaymentIntentFixtures.PI_SUCCEEDED,
-                deferredIntentConfirmationType = null,
             )
         )
 
@@ -1863,7 +1863,6 @@ internal class DefaultFlowControllerTest {
         confirmationState.value = ConfirmationHandler.State.Complete(
             ConfirmationHandler.Result.Succeeded(
                 intent = PaymentIntentFixtures.PI_SUCCEEDED,
-                deferredIntentConfirmationType = null,
             )
         )
 
@@ -1894,7 +1893,9 @@ internal class DefaultFlowControllerTest {
             confirmationState.value = ConfirmationHandler.State.Complete(
                 ConfirmationHandler.Result.Succeeded(
                     intent = PaymentIntentFixtures.PI_SUCCEEDED,
-                    deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
+                    metadata = MutableConfirmationMetadata().apply {
+                        set(DeferredIntentConfirmationTypeKey, DeferredIntentConfirmationType.Client)
+                    },
                 )
             )
 
@@ -1925,7 +1926,9 @@ internal class DefaultFlowControllerTest {
             confirmationState.value = ConfirmationHandler.State.Complete(
                 ConfirmationHandler.Result.Succeeded(
                     intent = PaymentIntentFixtures.PI_SUCCEEDED,
-                    deferredIntentConfirmationType = DeferredIntentConfirmationType.Server,
+                    metadata = MutableConfirmationMetadata().apply {
+                        set(DeferredIntentConfirmationTypeKey, DeferredIntentConfirmationType.Server)
+                    },
                 )
             )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/ConfirmationReportingUtilsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/ConfirmationReportingUtilsTest.kt
@@ -6,7 +6,9 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.isInstanceOf
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.MutableConfirmationMetadata
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
+import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationTypeKey
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.analytics.PaymentSheetConfirmationError
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -77,7 +79,9 @@ class ConfirmationReportingUtilsTest {
         val eventReporter = FakeEventReporter()
         val result = ConfirmationHandler.Result.Succeeded(
             intent = PaymentIntentFixtures.PI_SUCCEEDED,
-            deferredIntentConfirmationType = DeferredIntentConfirmationType.Client,
+            metadata = MutableConfirmationMetadata().apply {
+                set(DeferredIntentConfirmationTypeKey, DeferredIntentConfirmationType.Client)
+            },
         )
 
         eventReporter.reportPaymentResult(result, PaymentSelection.GooglePay)

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeIntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeIntentConfirmationInterceptor.kt
@@ -12,8 +12,10 @@ import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.MutableConfirmationMetadata
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationType
+import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfirmationTypeKey
 import com.stripe.android.paymentelement.confirmation.intent.IntentConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.intent.IntentConfirmationInterceptor
 import kotlinx.coroutines.channels.Channel
@@ -48,10 +50,15 @@ internal class FakeIntentConfirmationInterceptor : IntentConfirmationInterceptor
         channel.trySend(
             ConfirmationDefinition.Action.Complete(
                 intent = intent,
-                deferredIntentConfirmationType = if (isForceSuccess) {
-                    DeferredIntentConfirmationType.None
-                } else {
-                    DeferredIntentConfirmationType.Server
+                metadata = MutableConfirmationMetadata().apply {
+                    set(
+                        DeferredIntentConfirmationTypeKey,
+                        if (isForceSuccess) {
+                            DeferredIntentConfirmationType.None
+                        } else {
+                            DeferredIntentConfirmationType.Server
+                        }
+                    )
                 },
                 completedFullPaymentFlow = completedFullPaymentFlow,
             )


### PR DESCRIPTION
# Summary
Replace `DeferredIntentConfirmationType` with new `ConfirmationMetadata` type to abstract away intent confirmation details from the confirmation flow.

# Motivation
Makes the confirmation flow more abstract, also helps with Tap to Add to insert confirmation metadata on success and on cancel eventually.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified