### PR TITLE
Remove `CardWithTapUiDefinitionFactory` & merge into the existing `CardUiDefinitionFactory`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionFactory.kt
@@ -186,13 +186,16 @@ internal sealed interface UiDefinitionFactory {
     }
 
     interface Custom : UiDefinitionFactory {
-        fun createSupportedPaymentMethod(): SupportedPaymentMethod
+        fun createSupportedPaymentMethod(
+            metadata: PaymentMethodMetadata,
+        ): SupportedPaymentMethod
 
         fun createFormHeaderInformation(
+            metadata: PaymentMethodMetadata,
             customerHasSavedPaymentMethods: Boolean,
             incentive: PaymentMethodIncentive?,
         ): FormHeaderInformation {
-            return createSupportedPaymentMethod().asFormHeaderInformation(incentive)
+            return createSupportedPaymentMethod(metadata).asFormHeaderInformation(incentive)
         }
 
         fun createFormElements(metadata: PaymentMethodMetadata, arguments: Arguments): List<FormElement>
@@ -223,7 +226,7 @@ internal sealed interface UiDefinitionFactory {
         }
 
         is Custom -> {
-            createSupportedPaymentMethod()
+            createSupportedPaymentMethod(metadata)
         }
 
         is RequiresSharedDataSpec -> {
@@ -254,6 +257,7 @@ internal sealed interface UiDefinitionFactory {
             createFormHeaderInformation(
                 customerHasSavedPaymentMethods = customerHasSavedPaymentMethods,
                 incentive = metadata.paymentMethodIncentive,
+                metadata = metadata,
             )
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -56,25 +56,45 @@ internal object CardDefinition : PaymentMethodDefinition {
     override fun uiDefinitionFactory(
         metadata: PaymentMethodMetadata
     ): UiDefinitionFactory {
-        return if (metadata.isTapToAddSupported) {
-            CardWithTapUiDefinitionFactory
-        } else {
-            CardUiDefinitionFactory
-        }
+        return CardUiDefinitionFactory
     }
 }
 
 private object CardUiDefinitionFactory : UiDefinitionFactory.Custom {
-    override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
-        paymentMethodDefinition = CardDefinition,
-        displayNameResource = PaymentsUiCoreR.string.stripe_paymentsheet_payment_method_card,
-        iconResource = PaymentsUiCoreR.drawable.stripe_ic_paymentsheet_pm_card,
-        iconResourceNight = null,
-        outlinedIconResource = PaymentsUiCoreR.drawable.stripe_ic_paymentsheet_pm_card_outlined,
-        iconRequiresTinting = true,
-    )
+    override fun createSupportedPaymentMethod(
+        metadata: PaymentMethodMetadata,
+    ): SupportedPaymentMethod {
+        val iconResource = if (metadata.isTapToAddSupported) {
+            PaymentsUiCoreR.drawable.stripe_ic_paymentsheet_pm_card_with_tap
+        } else {
+            PaymentsUiCoreR.drawable.stripe_ic_paymentsheet_pm_card
+        }
+
+        val outlinedIconResource = if (metadata.isTapToAddSupported) {
+            PaymentsUiCoreR.drawable.stripe_ic_paymentsheet_pm_card_with_tap
+        } else {
+            PaymentsUiCoreR.drawable.stripe_ic_paymentsheet_pm_card_outlined
+        }
+
+        val subtitle = if (metadata.isTapToAddSupported) {
+            PaymentsUiCoreR.string.stripe_card_with_tap_or_enter_manually
+        } else {
+            null
+        }
+
+        return SupportedPaymentMethod(
+            paymentMethodDefinition = CardDefinition,
+            displayNameResource = PaymentsUiCoreR.string.stripe_paymentsheet_payment_method_card,
+            iconResource = iconResource,
+            iconResourceNight = null,
+            subtitle = subtitle?.resolvableString,
+            outlinedIconResource = outlinedIconResource,
+            iconRequiresTinting = true,
+        )
+    }
 
     override fun createFormHeaderInformation(
+        metadata: PaymentMethodMetadata,
         customerHasSavedPaymentMethods: Boolean,
         incentive: PaymentMethodIncentive?,
     ): FormHeaderInformation {
@@ -83,7 +103,7 @@ private object CardUiDefinitionFactory : UiDefinitionFactory.Custom {
         } else {
             PaymentsUiCoreR.string.stripe_paymentsheet_add_card
         }
-        return createSupportedPaymentMethod().asFormHeaderInformation(incentive).copy(
+        return createSupportedPaymentMethod(metadata).asFormHeaderInformation(incentive).copy(
             displayName = displayName.resolvableString,
             shouldShowIcon = false,
         )
@@ -195,25 +215,6 @@ private object CardUiDefinitionFactory : UiDefinitionFactory.Custom {
                 )
             )
         }
-    }
-}
-
-private object CardWithTapUiDefinitionFactory : UiDefinitionFactory.Custom {
-    override fun createSupportedPaymentMethod() = SupportedPaymentMethod(
-        paymentMethodDefinition = CardDefinition,
-        displayNameResource = PaymentsUiCoreR.string.stripe_paymentsheet_payment_method_card,
-        iconResource = PaymentsUiCoreR.drawable.stripe_ic_paymentsheet_pm_card_with_tap,
-        iconResourceNight = null,
-        outlinedIconResource = PaymentsUiCoreR.drawable.stripe_ic_paymentsheet_pm_card_with_tap,
-        subtitle = PaymentsUiCoreR.string.stripe_card_with_tap_or_enter_manually.resolvableString,
-        iconRequiresTinting = true,
-    )
-
-    override fun createFormElements(
-        metadata: PaymentMethodMetadata,
-        arguments: UiDefinitionFactory.Arguments
-    ): List<FormElement> {
-        return emptyList()
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/InstantDebitsDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/InstantDebitsDefinition.kt
@@ -32,7 +32,9 @@ internal object InstantDebitsDefinition : PaymentMethodDefinition {
 
 private object InstantDebitsUiDefinitionFactory : UiDefinitionFactory.Custom {
 
-    override fun createSupportedPaymentMethod(): SupportedPaymentMethod {
+    override fun createSupportedPaymentMethod(
+        metadata: PaymentMethodMetadata
+    ): SupportedPaymentMethod {
         return SupportedPaymentMethod(
             code = InstantDebitsDefinition.type.code,
             syntheticCode = "link_instant_debits",

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/LinkCardBrandDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/LinkCardBrandDefinition.kt
@@ -32,7 +32,9 @@ internal object LinkCardBrandDefinition : PaymentMethodDefinition {
 
 private object LinkCardBrandDefinitionFactory : UiDefinitionFactory.Custom {
 
-    override fun createSupportedPaymentMethod(): SupportedPaymentMethod {
+    override fun createSupportedPaymentMethod(
+        metadata: PaymentMethodMetadata,
+    ): SupportedPaymentMethod {
         return SupportedPaymentMethod(
             code = InstantDebitsDefinition.type.code,
             syntheticCode = "link_card_brand",

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/UsBankAccountDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/UsBankAccountDefinition.kt
@@ -33,7 +33,9 @@ internal object UsBankAccountDefinition : PaymentMethodDefinition {
 }
 
 private object UsBankAccountUiDefinitionFactory : UiDefinitionFactory.Custom {
-    override fun createSupportedPaymentMethod(): SupportedPaymentMethod = SupportedPaymentMethod(
+    override fun createSupportedPaymentMethod(
+        metadata: PaymentMethodMetadata
+    ): SupportedPaymentMethod = SupportedPaymentMethod(
         code = UsBankAccountDefinition.type.code,
         displayNameResource = R.string.stripe_paymentsheet_payment_method_us_bank_account,
         iconResource = R.drawable.stripe_ic_paymentsheet_pm_bank,
@@ -45,10 +47,11 @@ private object UsBankAccountUiDefinitionFactory : UiDefinitionFactory.Custom {
     )
 
     override fun createFormHeaderInformation(
+        metadata: PaymentMethodMetadata,
         customerHasSavedPaymentMethods: Boolean,
         incentive: PaymentMethodIncentive?,
     ): FormHeaderInformation {
-        return createSupportedPaymentMethod().asFormHeaderInformation(incentive).copy(
+        return createSupportedPaymentMethod(metadata).asFormHeaderInformation(incentive).copy(
             displayName = R.string.stripe_paymentsheet_add_us_bank_account.resolvableString,
             shouldShowIcon = false,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUITest.kt
@@ -180,6 +180,7 @@ internal class VerticalModeFormUITest {
             metadata = PaymentMethodMetadataFactory.create()
         ) as UiDefinitionFactory.Custom
         val headerInformation = customUiDefinitionFactory.createFormHeaderInformation(
+            metadata = PaymentMethodMetadataFactory.create(),
             customerHasSavedPaymentMethods = customerHasSavedPaymentMethods,
             incentive = null,
         )


### PR DESCRIPTION
# Summary
Remove `CardWithTapUiDefinitionFactory`

# Motivation
Initially this was to avoid having a bunch of if statements but after doing some work on making `UiDefinitionFactory` actionable, I realized we needed to share the form elements so I'm going back on this and making supported payment method with `PaymentMethodMetadata`

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified