### PR TITLE
Move `FeatureFlags.enableTapToAdd` to default `TapToAddConnectionManager`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/IsStripeTerminalSdkAvailable.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/IsStripeTerminalSdkAvailable.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.common.taptoadd
 
-import com.stripe.android.core.utils.FeatureFlags
 import javax.inject.Inject
 
 internal fun interface IsStripeTerminalSdkAvailable {
@@ -9,10 +8,6 @@ internal fun interface IsStripeTerminalSdkAvailable {
 
 internal class DefaultIsStripeTerminalSdkAvailable @Inject constructor() : IsStripeTerminalSdkAvailable {
     override fun invoke(): Boolean {
-        if (!FeatureFlags.enableTapToAdd.isEnabled) {
-            return false
-        }
-
         return try {
             // If found, 'core' library was imported
             Class.forName("com.stripe.stripeterminal.TerminalApplicationDelegate")

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddConnectionManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddConnectionManager.kt
@@ -6,6 +6,7 @@ import androidx.annotation.RestrictTo
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.core.exception.StripeException
+import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.paymentelement.TapToAddPreview
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.stripeterminal.external.callable.Callback
@@ -89,7 +90,7 @@ internal class DefaultTapToAddConnectionManager(
 
     override val isSupported: Boolean
         get() {
-            return terminal().supportsReadersOfType(
+            return FeatureFlags.enableTapToAdd.isEnabled && terminal().supportsReadersOfType(
                 deviceType = DeviceType.TAP_TO_PAY_DEVICE,
                 discoveryConfiguration = discoveryConfiguration,
             ).isSupported


### PR DESCRIPTION
# Summary
Move `FeatureFlags.enableTapToAdd` to default `TapToAddConnectionManager`

# Motivation
Fixes issues with `FlowController` which initializes the `TapToAddConnectionManager` before feature flag changes in the settings.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified