### PR TITLE
Move dimensions- prefix to Link experiments only

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/HorizontalModeExperimentsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/HorizontalModeExperimentsTest.kt
@@ -108,10 +108,10 @@ internal class HorizontalModeExperimentsTest {
             method("POST"),
             bodyPart("event_name", "elements.experiment_exposure"),
             bodyPart("experiment_retrieved", experimentAssignment.experimentValue),
-            bodyPart("dimensions-in_app_elements_integration_type", expectedIntegrationType),
-            bodyPart("dimensions-has_saved_payment_method", "false"),
-            bodyPart("dimensions-displayed_payment_method_types", urlEncode("card,afterpay_clearpay,klarna")),
-            bodyPart("dimensions-displayed_payment_method_types_including_wallets", urlEncode("card,afterpay_clearpay,klarna,link")),
+            bodyPart("in_app_elements_integration_type", expectedIntegrationType),
+            bodyPart("has_saved_payment_method", "false"),
+            bodyPart("displayed_payment_method_types", urlEncode("card,afterpay_clearpay,klarna")),
+            bodyPart("displayed_payment_method_types_including_wallets", urlEncode("card,afterpay_clearpay,klarna,link")),
         ) { }
 
         enqueueLogLinkHoldbackExperiments()

--- a/paymentsheet/src/main/java/com/stripe/android/common/analytics/experiment/LoggableExperiment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/analytics/experiment/LoggableExperiment.kt
@@ -61,7 +61,7 @@ internal sealed class LoggableExperiment(
             "mobile_sdk_version" to mobileSdkVersion,
             "elements_session_id" to elementsSessionId,
             "mobile_session_id" to mobileSessionId
-        ).filterNotNullValues()
+        ).filterNotNullValues().mapKeys { "dimensions-${it.key}" }
     ) {
         enum class EmailRecognitionSource(val dimension: String) {
             EMAIL("email"),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -352,7 +352,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
             "experiment_retrieved" to experiment.experiment.experimentValue,
             "arb_id" to experiment.arbId,
             "assignment_group" to experiment.group
-        ) + experiment.dimensions.mapKeys { "dimensions-${it.key}" }
+        ) + experiment.dimensions
     }
 
     class ShopPayWebviewLoadAttempt : PaymentSheetEvent() {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Move dimensions- prefix to Link experiments only

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Previously, all experiment dimensions were prefixed with "dimensions-" in ExperimentExposure. This prefix is only required for Link experiments.

Now, LinkHoldback handles its own prefix, ensuring all future Link experiment dimensions are automatically prefixed, while other experiments like OcsMobileHorizontalMode have clean dimension names.

Committed-By-Agent: claude

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
