### PR TITLE
Add e2e tests for shop pay

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestShopPay.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestShopPay.kt
@@ -1,0 +1,47 @@
+package com.stripe.android.lpm
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.stripe.android.BasePlaygroundTest
+import com.stripe.android.paymentsheet.example.playground.settings.AutomaticPaymentMethodsSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.Currency
+import com.stripe.android.paymentsheet.example.playground.settings.CurrencySettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.CustomerSessionSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.CustomerSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.CustomerType
+import com.stripe.android.paymentsheet.example.playground.settings.Merchant
+import com.stripe.android.paymentsheet.example.playground.settings.MerchantSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.ShopPaySettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.SupportedPaymentMethodsSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.WalletButtonsPlaygroundType
+import com.stripe.android.paymentsheet.example.playground.settings.WalletButtonsSettingsDefinition
+import com.stripe.android.test.core.AuthorizeAction
+import com.stripe.android.test.core.TestParameters
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+internal class TestShopPay : BasePlaygroundTest() {
+    private val testParameters = TestParameters.create(
+        paymentMethodCode = "shop_pay",
+        requiresBrowser = false,
+        authorizationAction = AuthorizeAction.ShopPay
+    ) { settings ->
+        settings[MerchantSettingsDefinition] = Merchant.US
+        settings[CurrencySettingsDefinition] = Currency.USD
+        settings[CustomerSessionSettingsDefinition] = true
+        settings[CustomerSettingsDefinition] = CustomerType.NEW
+        settings[AutomaticPaymentMethodsSettingsDefinition] = false
+        settings[SupportedPaymentMethodsSettingsDefinition] = "card,shop_pay,klarna,amazon_pay"
+        settings[ShopPaySettingsDefinition] = true
+        settings[WalletButtonsSettingsDefinition] = WalletButtonsPlaygroundType.GPayAlwaysLinkAutoNeverShopPayAuto
+    }
+
+    // PaymentSheet merchant is not gated into Shop Pay, so we're testing with SPT only atm.
+    @Test
+    fun testShopPayWithSpt() {
+        testDriver.confirmNewOrGuestCompleteWithSpt(
+            testParameters = testParameters,
+            buttonTag = "ShopPayButton"
+        )
+    }
+}

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/TestParameters.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/TestParameters.kt
@@ -193,4 +193,11 @@ internal sealed interface AuthorizeAction {
             override val isConsideredDone: Boolean = true
         }
     }
+
+    data object ShopPay : AuthorizeAction {
+        override fun text(isSetup: Boolean) = ""
+
+        override val requiresBrowser = false
+        override val isConsideredDone = false
+    }
 }

--- a/paymentsheet-example/src/main/AndroidManifest.xml
+++ b/paymentsheet-example/src/main/AndroidManifest.xml
@@ -54,7 +54,10 @@
         <activity android:name="com.stripe.android.paymentsheet.example.playground.activity.CustomPaymentMethodActivity" />
         <activity android:name="com.stripe.android.paymentsheet.example.playground.embedded.EmbeddedPlaygroundActivity" />
         <activity android:name="com.stripe.android.paymentsheet.example.playground.embedded.EmbeddedExampleActivity" />
-        <activity android:name="com.stripe.android.paymentsheet.example.playground.spt.SharedPaymentTokenPlaygroundActivity" />
+        <activity
+            android:name="com.stripe.android.paymentsheet.example.playground.spt.SharedPaymentTokenPlaygroundActivity"
+            android:theme="@style/AppTheme.NoActionBar"
+            />
         <activity android:name="com.stripe.android.paymentsheet.example.playground.LinkControllerPlaygroundActivity" />
         <activity
             android:name="com.stripe.android.paymentsheet.example.playground.PaymentSheetPlaygroundActivity"

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/SharedPaymentTokenModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/SharedPaymentTokenModel.kt
@@ -7,6 +7,8 @@ import kotlinx.serialization.Serializable
 class SharedPaymentTokenCreateSessionRequest(
     @SerialName("customerId")
     val customerId: String?,
+    @SerialName("customerEmail")
+    val customerEmail: String?,
     @SerialName("isMobile")
     val isMobile: Boolean,
 )

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/network/SharedPaymentTokenPlaygroundRequester.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/network/SharedPaymentTokenPlaygroundRequester.kt
@@ -14,11 +14,14 @@ import com.stripe.android.paymentsheet.example.playground.model.SharedPaymentTok
 import com.stripe.android.paymentsheet.example.playground.model.SharedPaymentTokenCreateSessionResponse
 import com.stripe.android.paymentsheet.example.playground.settings.CustomerSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.CustomerType
+import com.stripe.android.paymentsheet.example.playground.settings.DefaultBillingAddress
+import com.stripe.android.paymentsheet.example.playground.settings.DefaultBillingAddressSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.PlaygroundSettings
 import com.stripe.android.paymentsheet.example.samples.networking.awaitModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
+import java.util.UUID
 
 internal class SharedPaymentTokenPlaygroundRequester(
     private val playgroundSnapshot: PlaygroundSettings.Snapshot,
@@ -37,8 +40,17 @@ internal class SharedPaymentTokenPlaygroundRequester(
             }
         }
 
+        val email = playgroundSnapshot[DefaultBillingAddressSettingsDefinition].run {
+            when (this) {
+                DefaultBillingAddress.On -> "email@email.com"
+                DefaultBillingAddress.OnWithRandomEmail,
+                DefaultBillingAddress.Off -> "test-${UUID.randomUUID()}@stripe.com"
+            }
+        }
+
         val request = SharedPaymentTokenCreateSessionRequest(
             customerId = customerId,
+            customerEmail = email,
             isMobile = true,
         )
 

--- a/paymentsheet/src/main/java/com/stripe/android/shoppay/ShopPayButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/shoppay/ShopPayButton.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.unit.dp
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.ui.PrimaryButtonTheme
@@ -37,6 +38,7 @@ internal fun ShopPayButton(
             .defaultMinSize(minHeight = PrimaryButtonTheme.shape.height)
             .semantics {
                 contentDescription = buttonDescription
+                testTag = SHOP_PAY_BUTTON_TEST_TAG
             },
         enabled = true,
         shape = RoundedCornerShape(
@@ -59,3 +61,5 @@ internal fun ShopPayButton(
         )
     }
 }
+
+private const val SHOP_PAY_BUTTON_TEST_TAG = "ShopPayButton"


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add e2e tests for shop pay. this test checks that we make it all the way to either the auth or checkout screen.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Shop Pay started using session storage which caused the webview to fail on load for android.

**Why?** DOM storage is disabled by default for android webviews (fixed [here](https://github.com/stripe/stripe-android/pull/12306)). It seems to be enabled by default for WKWebView on iOS.

A test checking to see if the shop pay content is actually presented would have help us catch this earlier

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
