### PR TITLE
Remove old `CardDefinition` test no longer relevant for Tap to Add

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinitionTest.kt
@@ -717,24 +717,6 @@ class CardDefinitionTest {
         assertThat(controller.cardDetailsAction).isNull()
     }
 
-    @Test
-    fun `createFormElements returns empty when tap to add is supported`() {
-        val metadata = PaymentMethodMetadataFactory.create(
-            isTapToAddSupported = true,
-            billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
-                address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never
-            )
-        )
-
-        val formElements = CardDefinition.formElements(
-            metadata = metadata,
-            tapToAddHelper = FakeTapToAddHelper.noOp(),
-        )
-
-        // When tap-to-add is supported, CardWithTapUiDefinitionFactory is used which returns empty form
-        assertThat(formElements).isEmpty()
-    }
-
     private fun createLinkConfiguration(): LinkConfiguration {
         return TestFactory.LINK_CONFIGURATION.copy(
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD


### PR DESCRIPTION
# Summary
Remove old `CardDefinition` test no longer relevant for Tap to Add

# Motivation
Fix `master`

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified