### PR TITLE
Add `twint_recurring_beta_1` beta flag in `StripeApiBeta`

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -590,6 +590,7 @@ public final class com/stripe/android/Stripe$Companion {
 }
 
 public final class com/stripe/android/StripeApiBeta : java/lang/Enum {
+	public static final field TwintRecurring Lcom/stripe/android/StripeApiBeta;
 	public static final field WeChatPayV1 Lcom/stripe/android/StripeApiBeta;
 	public final fun getCode ()Ljava/lang/String;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;

--- a/payments-core/src/main/java/com/stripe/android/StripeApiBeta.kt
+++ b/payments-core/src/main/java/com/stripe/android/StripeApiBeta.kt
@@ -4,5 +4,6 @@ package com.stripe.android
  * Enums of beta headers allowed to be override when initializing [Stripe].
  */
 enum class StripeApiBeta(val code: String) {
-    WeChatPayV1("wechat_pay_beta=v1")
+    WeChatPayV1("wechat_pay_beta=v1"),
+    TwintRecurring("twint_recurring_beta_1")
 }


### PR DESCRIPTION
# Summary
After the launch of TWINT off session support through a beta flag, this commit add the support in `StripeApiBeta`.

# Motivation
The existing Stripe constructor only accepted typed beta flags from `StripeApiBeta`. This PR adds support for off-session TWINT payment.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Changelog
- [Added] Support for off-session TWINT beta flag

