### PR TITLE
Add `link.account_lookup.complete` analytics event

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
@@ -544,6 +544,8 @@ internal class DefaultLinkAccountManager @Inject constructor(
             linkAuthTokenClientSecret = null,
         ).onFailure { error ->
             linkEventsReporter.onAccountLookupFailure(error)
+        }.onSuccess {
+            linkEventsReporter.onAccountLookupComplete()
         }.map { consumerSessionLookup ->
             setLinkAccountFromLookupResult(
                 lookup = consumerSessionLookup,
@@ -567,6 +569,8 @@ internal class DefaultLinkAccountManager @Inject constructor(
             linkAuthTokenClientSecret = null,
         ).onFailure { error ->
             linkEventsReporter.onAccountLookupFailure(error)
+        }.onSuccess {
+            linkEventsReporter.onAccountLookupComplete()
         }.map { consumerSessionLookup ->
             setLinkAccountFromLookupResult(
                 lookup = consumerSessionLookup,
@@ -587,6 +591,8 @@ internal class DefaultLinkAccountManager @Inject constructor(
             customerId = null
         ).onFailure { error ->
             linkEventsReporter.onAccountLookupFailure(error)
+        }.onSuccess {
+            linkEventsReporter.onAccountLookupComplete()
         }.map { consumerSessionLookup ->
             setLinkAccountFromLookupResult(
                 lookup = consumerSessionLookup,

--- a/paymentsheet/src/main/java/com/stripe/android/link/analytics/DefaultLinkEventsReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/analytics/DefaultLinkEventsReporter.kt
@@ -75,6 +75,10 @@ internal class DefaultLinkEventsReporter @Inject constructor(
         fireEvent(LinkEvent.AccountLookupFailure, params)
     }
 
+    override fun onAccountLookupComplete() {
+        fireEvent(LinkEvent.AccountLookupComplete)
+    }
+
     override fun onAccountRefreshFailure(error: Throwable) {
         val params = mapOf(FIELD_ERROR_MESSAGE to error.safeAnalyticsMessage).plus(
             ErrorReporter.getAdditionalParamsFromError(error)

--- a/paymentsheet/src/main/java/com/stripe/android/link/analytics/LinkEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/analytics/LinkEvent.kt
@@ -36,6 +36,10 @@ internal sealed class LinkEvent : AnalyticsEvent {
         override val eventName = "link.account_lookup.failure"
     }
 
+    object AccountLookupComplete : LinkEvent() {
+        override val eventName = "link.account_lookup.complete"
+    }
+
     object AccountRefreshFailure : LinkEvent() {
         override val eventName = "link.account_refresh.failure"
     }

--- a/paymentsheet/src/main/java/com/stripe/android/link/analytics/LinkEventsReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/analytics/LinkEventsReporter.kt
@@ -10,6 +10,7 @@ internal interface LinkEventsReporter {
     fun onSignupFailure(isInline: Boolean = false, error: Throwable)
     fun onEmailSuggestionAccepted()
     fun onAccountLookupFailure(error: Throwable)
+    fun onAccountLookupComplete()
     fun onAccountRefreshFailure(error: Throwable)
 
     fun on2FAStart()

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAccountManagerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAccountManagerTest.kt
@@ -179,6 +179,27 @@ class DefaultLinkAccountManagerTest {
     }
 
     @Test
+    fun `lookupConsumer sends analytics event when call succeeds`() = runSuspendTest {
+        val linkEventsReporter = object : AccountManagerEventsReporter() {
+            var callCount = 0
+            override fun onAccountLookupComplete() {
+                callCount += 1
+            }
+        }
+        val fakeLinkAuth = fakeLinkAuth()
+
+        accountManager(linkAuth = fakeLinkAuth, linkEventsReporter = linkEventsReporter)
+            .lookupByEmail(
+                email = TestFactory.EMAIL,
+                emailSource = EmailSource.USER_ACTION,
+                startSession = false,
+                customerId = null
+            )
+
+        assertThat(linkEventsReporter.callCount).isEqualTo(1)
+    }
+
+    @Test
     fun `signInWithUserInput sends correct parameters and starts session for existing user`() = runSuspendTest {
         val fakeLinkAuth = fakeLinkAuth()
         val accountManager = accountManager(linkAuth = fakeLinkAuth)
@@ -1092,6 +1113,8 @@ private open class AccountManagerEventsReporter : FakeLinkEventsReporter() {
     override fun onAccountLookupFailure(error: Throwable) {
         lookupFailureTurbine.add(error)
     }
+
+    override fun onAccountLookupComplete() = Unit
 
     override fun on2FAStartFailure() = Unit
     override fun on2FAStart() = Unit

--- a/paymentsheet/src/test/java/com/stripe/android/link/analytics/FakeLinkEventsReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/analytics/FakeLinkEventsReporter.kt
@@ -34,6 +34,10 @@ internal open class FakeLinkEventsReporter : LinkEventsReporter {
         throw NotImplementedError()
     }
 
+    override fun onAccountLookupComplete() {
+        throw NotImplementedError()
+    }
+
     override fun onAccountRefreshFailure(error: Throwable) {
         throw NotImplementedError()
     }


### PR DESCRIPTION
# Summary
Port the `linkAccountLookupComplete` analytics event from iOS to track successful Link account lookups.

# Motivation
[RUN_LINK_MOBILE-79](http://go/jira/RUN_LINK_MOBILE-79)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

Ran through lookup flows and checked logcat for
```
Event: link.account_lookup.complete
```