### PR TITLE
Remove horizontal mode Android-only A/A experiment

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/ElementsSession.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ElementsSession.kt
@@ -256,7 +256,6 @@ data class ElementsSession(
         LINK_GLOBAL_HOLD_BACK("link_global_holdback"),
         LINK_GLOBAL_HOLD_BACK_AA("link_global_holdback_aa"),
         LINK_AB_TEST("link_ab_test"),
-        OCS_MOBILE_HORIZONTAL_MODE_ANDROID_AA("ocs_mobile_horizontal_mode_android_aa"),
         OCS_MOBILE_HORIZONTAL_MODE_AA("ocs_mobile_horizontal_mode_aa"),
         OCS_MOBILE_HORIZONTAL_MODE("ocs_mobile_horizontal_mode"),
     }

--- a/payments-core/src/test/java/com/stripe/android/model/ElementsSessionFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/ElementsSessionFixtures.kt
@@ -351,7 +351,7 @@ internal object ElementsSessionFixtures {
           "experiments_data": {
               "arb_id": "232dd033-0b45-4456-b834-ecdcb02ab1fb",
               "experiment_assignments": {
-                "ocs_mobile_horizontal_mode_android_aa": "control"
+                "ocs_mobile_horizontal_mode_aa": "control"
               }
             },
           "payment_method_preference": {

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
@@ -217,7 +217,7 @@ class ElementsSessionJsonParserTest {
 
         assertThat(elementsSession.experimentsData).isNotNull()
         assertThat(elementsSession.experimentsData?.experimentAssignments).containsEntry(
-            ElementsSession.ExperimentAssignment.OCS_MOBILE_HORIZONTAL_MODE_ANDROID_AA,
+            ElementsSession.ExperimentAssignment.OCS_MOBILE_HORIZONTAL_MODE_AA,
             "control"
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -260,7 +260,6 @@ internal abstract class BaseSheetViewModel(
         paymentMethodMetadata: PaymentMethodMetadata,
     ) {
         listOf(
-            ElementsSession.ExperimentAssignment.OCS_MOBILE_HORIZONTAL_MODE_ANDROID_AA,
             ElementsSession.ExperimentAssignment.OCS_MOBILE_HORIZONTAL_MODE_AA,
             ElementsSession.ExperimentAssignment.OCS_MOBILE_HORIZONTAL_MODE,
         ).forEach { experimentAssignment ->

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -3284,7 +3284,7 @@ internal class PaymentSheetViewModelTest {
             experimentsData = ElementsSession.ExperimentsData(
                 arbId = "232dd033-0b45-4456-b834-ecdcb02ab1fb",
                 experimentAssignments = mapOf(
-                    ElementsSession.ExperimentAssignment.OCS_MOBILE_HORIZONTAL_MODE_ANDROID_AA to "control"
+                    ElementsSession.ExperimentAssignment.OCS_MOBILE_HORIZONTAL_MODE_AA to "control"
                 )
             ),
             args = ARGS_WITH_AUTOMATIC_LAYOUT,
@@ -3315,7 +3315,7 @@ internal class PaymentSheetViewModelTest {
             experimentsData = ElementsSession.ExperimentsData(
                 arbId = "232dd033-0b45-4456-b834-ecdcb02ab1fb",
                 experimentAssignments = mapOf(
-                    ElementsSession.ExperimentAssignment.OCS_MOBILE_HORIZONTAL_MODE_ANDROID_AA to "control"
+                    ElementsSession.ExperimentAssignment.OCS_MOBILE_HORIZONTAL_MODE_AA to "control"
                 )
             ),
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Removes OCS_MOBILE_HORIZONTAL_MODE_ANDROID_AA experiment as it is no longer needed. The other horizontal mode experiments (OCS_MOBILE_HORIZONTAL_MODE_AA and OCS_MOBILE_HORIZONTAL_MODE) remain active.


Committed-By-Agent: claude

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Ramping this experiment down and starting the overall A/A!

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
