### PR TITLE
Remove `PaymentMethodCreateParams` in `LinkPaymentDetails.Saved` & rename attributes in `LinkPaymentDetails.New`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkPaymentDetails.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkPaymentDetails.kt
@@ -12,12 +12,9 @@ import kotlinx.parcelize.Parcelize
  * needed to confirm the Stripe Intent.
  *
  * @param paymentDetails The [ConsumerPaymentDetails.PaymentDetails] selected by the user
- * @param paymentMethodCreateParams The [PaymentMethodCreateParams] to be used to confirm
- *                                  the Stripe Intent.
  */
 internal sealed class LinkPaymentDetails(
-    open val paymentDetails: ConsumerPaymentDetails.PaymentDetails,
-    open val paymentMethodCreateParams: PaymentMethodCreateParams
+    open val paymentDetails: ConsumerPaymentDetails.PaymentDetails
 ) : Parcelable {
 
     /**
@@ -26,21 +23,23 @@ internal sealed class LinkPaymentDetails(
     @Parcelize
     class Saved(
         override val paymentDetails: ConsumerPaymentDetails.Passthrough,
-        override val paymentMethodCreateParams: PaymentMethodCreateParams,
         val paymentMethod: PaymentMethod,
-    ) : LinkPaymentDetails(paymentDetails, paymentMethodCreateParams)
+    ) : LinkPaymentDetails(paymentDetails)
 
     /**
      * A new [ConsumerPaymentDetails.PaymentDetails], whose data was just collected from the user.
      * Must hold the original [PaymentMethodCreateParams] too in case we need to populate the form
      * fields with the user-entered values.
+     *
+     * @param confirmParams The [PaymentMethodCreateParams] to be used to confirm the Stripe Intent.
+     * @param originalParams The original [PaymentMethodCreateParams] created from the customer's input.
      */
     @Parcelize
     class New(
         override val paymentDetails: ConsumerPaymentDetails.PaymentDetails,
-        override val paymentMethodCreateParams: PaymentMethodCreateParams,
-        val originalParams: PaymentMethodCreateParams
-    ) : LinkPaymentDetails(paymentDetails, paymentMethodCreateParams) {
+        val confirmParams: PaymentMethodCreateParams,
+        val originalParams: PaymentMethodCreateParams,
+    ) : LinkPaymentDetails(paymentDetails) {
 
         /**
          * Build a flat map of the values entered by the user when creating this payment method,

--- a/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
@@ -245,7 +245,7 @@ internal class LinkApiRepository @Inject constructor(
 
             LinkPaymentDetails.New(
                 paymentDetails = paymentDetails,
-                paymentMethodCreateParams = createParams,
+                confirmParams = createParams,
                 originalParams = paymentMethodCreateParams,
             )
         }.onFailure {
@@ -307,21 +307,13 @@ internal class LinkApiRepository @Inject constructor(
         ).onFailure {
             errorReporter.report(ErrorReporter.ExpectedErrorEvent.LINK_SHARE_CARD_FAILURE, StripeException.create(it))
         }.map { paymentMethod ->
-            val paymentMethodId = paymentMethod.id
             LinkPaymentDetails.Saved(
                 paymentDetails = ConsumerPaymentDetails.Passthrough(
                     id = id,
                     last4 = paymentMethodCreateParams.cardLast4().orEmpty(),
-                    paymentMethodId = paymentMethodId,
+                    paymentMethodId = paymentMethod.id,
                     billingEmailAddress = paymentMethod.billingDetails?.email,
                     billingAddress = paymentMethod.billingDetails?.toConsumerBillingAddress(),
-                ),
-                paymentMethodCreateParams = PaymentMethodCreateParams.createLink(
-                    paymentDetailsId = paymentMethodId,
-                    consumerSessionClientSecret = consumerSessionClientSecret,
-                    extraParams = extraConfirmationParams(paymentMethodCreateParams.toParamMap()),
-                    clientAttributionMetadata = clientAttributionMetadata,
-                    originalPaymentMethodCode = paymentMethodCreateParams.typeCode
                 ),
                 paymentMethod = paymentMethod,
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinition.kt
@@ -167,7 +167,7 @@ internal class LinkInlineSignupConfirmationDefinition(
         }
 
         return PaymentMethodConfirmationOption.New(
-            createParams = paymentMethodCreateParams,
+            createParams = confirmParams,
             optionsParams = optionsParams,
             extraParams = extraParams,
             shouldSave = saveOption.shouldSave(),

--- a/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
@@ -164,7 +164,7 @@ internal object TestFactory {
 
     val LINK_NEW_PAYMENT_DETAILS = LinkPaymentDetails.New(
         paymentDetails = CONSUMER_PAYMENT_DETAILS_CARD,
-        paymentMethodCreateParams = PAYMENT_METHOD_CREATE_PARAMS,
+        confirmParams = PAYMENT_METHOD_CREATE_PARAMS,
         originalParams = mock()
     )
 
@@ -175,7 +175,6 @@ internal object TestFactory {
 
     val LINK_SAVED_PAYMENT_DETAILS = LinkPaymentDetails.Saved(
         paymentDetails = CONSUMER_PAYMENT_DETAILS_PASSTHROUGH,
-        paymentMethodCreateParams = PAYMENT_METHOD_CREATE_PARAMS,
         paymentMethod = PaymentMethod.Builder()
             .setId(CONSUMER_PAYMENT_DETAILS_PASSTHROUGH.paymentMethodId)
             .setType(PaymentMethod.Type.Card)
@@ -190,7 +189,6 @@ internal object TestFactory {
 
     val LINK_SAVED_PAYMENT_DETAILS_WITH_BILLING = LinkPaymentDetails.Saved(
         paymentDetails = CONSUMER_PAYMENT_DETAILS_PASSTHROUGH,
-        paymentMethodCreateParams = PAYMENT_METHOD_CREATE_PARAMS,
         paymentMethod = PaymentMethod.Builder()
             .setId(CONSUMER_PAYMENT_DETAILS_PASSTHROUGH.paymentMethodId)
             .setType(PaymentMethod.Type.Card)

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAccountManagerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAccountManagerTest.kt
@@ -474,7 +474,7 @@ class DefaultLinkAccountManagerTest {
     fun `shareCardPaymentDetails makes correct calls`() = runSuspendTest {
         val newPaymentDetails = LinkPaymentDetails.New(
             paymentDetails = TestFactory.LINK_NEW_PAYMENT_DETAILS.paymentDetails,
-            paymentMethodCreateParams = TestFactory.LINK_NEW_PAYMENT_DETAILS.paymentMethodCreateParams,
+            confirmParams = TestFactory.LINK_NEW_PAYMENT_DETAILS.confirmParams,
             originalParams = PaymentMethodCreateParams.create(
                 card = PaymentMethodCreateParamsFixtures.CARD,
             )

--- a/paymentsheet/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
@@ -387,7 +387,7 @@ class LinkApiRepositoryTest {
                 clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
             ).getOrThrow()
 
-            assertThat(linkDetails.paymentMethodCreateParams.allowRedisplay).isEqualTo(allowRedisplay)
+            assertThat(linkDetails.confirmParams.allowRedisplay).isEqualTo(allowRedisplay)
         }
     }
 
@@ -460,7 +460,7 @@ class LinkApiRepositoryTest {
 
         assertThat(newLinkPaymentDetails.paymentDetails)
             .isEqualTo(paymentDetails.paymentDetails.first())
-        assertThat(newLinkPaymentDetails.paymentMethodCreateParams)
+        assertThat(newLinkPaymentDetails.confirmParams)
             .isEqualTo(
                 PaymentMethodCreateParams.createLink(
                     paymentDetails.paymentDetails.first().id,
@@ -627,16 +627,6 @@ class LinkApiRepositoryTest {
                         postalCode = "94111",
                         countryCode = CountryCode.create("US")
                     )
-                )
-            )
-        assertThat(savedLinkPaymentDetails.paymentMethodCreateParams)
-            .isEqualTo(
-                PaymentMethodCreateParams.createLink(
-                    PaymentMethodFixtures.CARD_PAYMENT_METHOD.id,
-                    consumerSessionSecret,
-                    PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
-                    extraParams = mapOf("card" to mapOf("cvc" to "123")),
-                    originalPaymentMethodCode = "card",
                 )
             )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
@@ -236,7 +236,6 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
                     last4 = "4242",
                     paymentMethodId = "pm_1",
                 ),
-                paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                 paymentMethod = PaymentMethod.Builder()
                     .setId("pm_1")
                     .setType(PaymentMethod.Type.Card)
@@ -458,7 +457,7 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
                             nickname = null,
                             billingAddress = null,
                         ),
-                        paymentMethodCreateParams = expectedCreateParams,
+                        confirmParams = expectedCreateParams,
                         originalParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                     )
                 ),
@@ -523,7 +522,6 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
                         last4 = "4242",
                         paymentMethodId = "pm_1",
                     ),
-                    paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                     paymentMethod = paymentMethod,
                 )
             ),
@@ -638,7 +636,7 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
                         postalCode = "42424"
                     )
                 ),
-                paymentMethodCreateParams = mock(),
+                confirmParams = mock(),
                 originalParams = mock(),
             )
         ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
@@ -35,7 +35,6 @@ internal object LinkTestUtils {
                 postalCode = "42424"
             )
         ),
-        paymentMethodCreateParams = mock(),
         paymentMethod = PaymentMethod.Builder()
             .setId("pm_123")
             .setType(PaymentMethod.Type.Card)
@@ -70,7 +69,7 @@ internal object LinkTestUtils {
                 postalCode = "42424"
             )
         ),
-        paymentMethodCreateParams = mock(),
+        confirmParams = mock(),
         originalParams = mock()
     )
 

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeLinkConfigurationCoordinator.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeLinkConfigurationCoordinator.kt
@@ -46,7 +46,7 @@ internal class FakeLinkConfigurationCoordinator(
                     postalCode = "42424"
                 )
             ),
-            paymentMethodCreateParams = mock(),
+            confirmParams = mock(),
             originalParams = mock(),
         )
     ),


### PR DESCRIPTION
# Summary
Remove `PaymentMethodCreateParams` in `LinkPaymentDetails.Saved` & rename attributes in `LinkPaymentDetails.New`

# Motivation
Setting up support for allowing Link accounts to be created with saved payment methods

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified