### PR TITLE
Register `TapToAddHelper` in `FormActivityRegistrar`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityConfirmationHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityConfirmationHelper.kt
@@ -32,11 +32,11 @@ internal class DefaultFormActivityConfirmationHelper @Inject constructor(
     lifecycleOwner: LifecycleOwner,
     activityResultCaller: ActivityResultCaller,
     @ViewModelScope private val coroutineScope: CoroutineScope,
-    formActivityConfirmationHandlerRegistrar: FormActivityConfirmationHandlerRegistrar
+    formActivityRegistrar: FormActivityRegistrar
 ) : FormActivityConfirmationHelper {
 
     init {
-        formActivityConfirmationHandlerRegistrar.registerAndBootstrap(
+        formActivityRegistrar.registerAndBootstrap(
             activityResultCaller,
             lifecycleOwner,
             paymentMethodMetadata

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityRegistrar.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityRegistrar.kt
@@ -2,11 +2,12 @@ package com.stripe.android.paymentelement.embedded.form
 
 import androidx.activity.result.ActivityResultCaller
 import androidx.lifecycle.LifecycleOwner
+import com.stripe.android.common.taptoadd.TapToAddHelper
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import javax.inject.Inject
 
-internal interface FormActivityConfirmationHandlerRegistrar {
+internal interface FormActivityRegistrar {
     fun registerAndBootstrap(
         activityResultCaller: ActivityResultCaller,
         lifecycleOwner: LifecycleOwner,
@@ -14,9 +15,10 @@ internal interface FormActivityConfirmationHandlerRegistrar {
     )
 }
 
-internal class DefaultFormActivityConfirmationHandlerRegistrar @Inject constructor(
+internal class DefaultFormActivityRegistrar @Inject constructor(
     private val confirmationHandler: ConfirmationHandler,
-) : FormActivityConfirmationHandlerRegistrar {
+    private val tapToAddHelper: TapToAddHelper,
+) : FormActivityRegistrar {
 
     private var isBootstrapped = false
 
@@ -26,6 +28,7 @@ internal class DefaultFormActivityConfirmationHandlerRegistrar @Inject construct
         paymentMethodMetadata: PaymentMethodMetadata
     ) {
         confirmationHandler.register(activityResultCaller, lifecycleOwner)
+        tapToAddHelper.register(activityResultCaller, lifecycleOwner)
         if (!isBootstrapped) {
             confirmationHandler.bootstrap(paymentMethodMetadata)
             isBootstrapped = true

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityViewModelComponent.kt
@@ -153,9 +153,10 @@ internal interface FormActivityViewModelModule {
         @Provides
         @Singleton
         fun providesFormActivityConfirmationHandlerRegistrar(
-            confirmationHandler: ConfirmationHandler
-        ): FormActivityConfirmationHandlerRegistrar {
-            return DefaultFormActivityConfirmationHandlerRegistrar(confirmationHandler)
+            confirmationHandler: ConfirmationHandler,
+            tapToAddHelper: TapToAddHelper,
+        ): FormActivityRegistrar {
+            return DefaultFormActivityRegistrar(confirmationHandler, tapToAddHelper)
         }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/FakeTapToAddHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/FakeTapToAddHelper.kt
@@ -10,11 +10,11 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 
-internal class FakeTapToAddHelper private constructor(
+internal class FakeTapToAddHelper(
     override val hasPreviouslyAttemptedCollection: Boolean = false,
 ) : TapToAddHelper {
-    private val registerCalls = Turbine<RegisterCall>()
-    private val collectCalls = Turbine<PaymentMethodMetadata>()
+    val registerCalls = Turbine<RegisterCall>()
+    val collectCalls = Turbine<PaymentMethodMetadata>()
 
     override val result: SharedFlow<TapToAddResult> =
         MutableSharedFlow<TapToAddResult>().asSharedFlow()
@@ -28,6 +28,11 @@ internal class FakeTapToAddHelper private constructor(
 
     override fun startPaymentMethodCollection(paymentMethodMetadata: PaymentMethodMetadata) {
         collectCalls.add(paymentMethodMetadata)
+    }
+
+    fun validate() {
+        registerCalls.ensureAllEventsConsumed()
+        collectCalls.ensureAllEventsConsumed()
     }
 
     class RegisterCall(
@@ -94,8 +99,7 @@ internal class FakeTapToAddHelper private constructor(
                 )
             )
 
-            helper.collectCalls.ensureAllEventsConsumed()
-            helper.registerCalls.ensureAllEventsConsumed()
+            helper.validate()
         }
 
         fun noOp() = FakeTapToAddHelper()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/DefaultFormActivityConfirmationHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/DefaultFormActivityConfirmationHelperTest.kt
@@ -94,7 +94,7 @@ class DefaultFormActivityConfirmationHelperTest {
         },
         block: suspend Scenario.() -> Unit,
     ) = runTest {
-        val formActivityConfirmationHandlerRegistrar = FakeFormActivityConfirmationHandlerRegistrar()
+        val formActivityRegistrar = FakeFormActivityRegistrar()
         val confirmationHandler = FakeConfirmationHandler()
         val savedStateHandle = SavedStateHandle()
         val selectionHolder = EmbeddedSelectionHolder(savedStateHandle)
@@ -118,10 +118,10 @@ class DefaultFormActivityConfirmationHelperTest {
             lifecycleOwner = testLifecycleOwner,
             activityResultCaller = mock(),
             coroutineScope = this,
-            formActivityConfirmationHandlerRegistrar = formActivityConfirmationHandlerRegistrar,
+            formActivityRegistrar = formActivityRegistrar,
         )
 
-        assertThat(formActivityConfirmationHandlerRegistrar.registerAndBootstrapTurbine.awaitItem()).isNotNull()
+        assertThat(formActivityRegistrar.registerAndBootstrapTurbine.awaitItem()).isNotNull()
         assertThat(stateHelper.updateTurbine.awaitItem()).isEqualTo(ConfirmationHandler.State.Idle)
         // Bootstrap is no longer called during DefaultFormActivityConfirmationHelper initialization
         // It's now called in FormActivityViewModel.inject()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FakeFormActivityRegistrar.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FakeFormActivityRegistrar.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.LifecycleOwner
 import app.cash.turbine.Turbine
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 
-internal class FakeFormActivityConfirmationHandlerRegistrar : FormActivityConfirmationHandlerRegistrar {
+internal class FakeFormActivityRegistrar : FormActivityRegistrar {
     val registerAndBootstrapTurbine = Turbine<RegisterCall>()
 
     override fun registerAndBootstrap(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityConfirmationHandlerTest.kt
@@ -72,7 +72,7 @@ internal class FormActivityConfirmationHandlerTest {
     private fun testScenario(
         block: suspend Scenario.() -> Unit
     ) = runTest {
-        val formActivityConfirmationHandlerRegistrar = FakeFormActivityConfirmationHandlerRegistrar()
+        val formActivityConfirmationHandlerRegistrar = FakeFormActivityRegistrar()
         val confirmationHandler = FakeConfirmationHandler()
         val selectionHolder = EmbeddedSelectionHolder(SavedStateHandle())
         val embeddedState = EmbeddedConfirmationStateFixtures.defaultState()
@@ -91,7 +91,7 @@ internal class FormActivityConfirmationHandlerTest {
             onClickDelegate = onClickOverrideDelegate,
             eventReporter = FakeEventReporter(),
             coroutineScope = this,
-            formActivityConfirmationHandlerRegistrar = formActivityConfirmationHandlerRegistrar,
+            formActivityRegistrar = formActivityConfirmationHandlerRegistrar,
         )
 
         assertThat(formActivityConfirmationHandlerRegistrar.registerAndBootstrapTurbine.awaitItem()).isNotNull()


### PR DESCRIPTION
# Summary
Register `TapToAddHelper` in `FormActivityRegistrar`.

# Motivation
Ensure the `TapToAddActivity` can be launched in Embedded. Forgot to add this in the last PR.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified