### PR TITLE
Handle continue and complete tap to add results in PaymentSheet

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -307,6 +307,9 @@ interface ErrorReporter : FraudDetectionErrorReporter {
         TAP_TO_ADD_FLOW_CONTROLLER_RECEIVED_COMPLETE_RESULT(
             "elements.tap_to_add.flow_controller_received_complete_result"
         ),
+        TAP_TO_ADD_PAYMENT_SHEET_RECEIVED_CONTINUE_RESULT(
+            "elements.tap_to_add.payment_sheet_received_continue_result"
+        ),
         TAP_TO_ADD_NO_GENERATED_CARD_AFTER_SUCCESSFUL_INTENT_CONFIRMATION(
             partialEventName = "elements.tap_to_add.no_generated_card_after_successful_intent_confirmation"
         );

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -16,6 +16,7 @@ import com.stripe.android.common.analytics.experiment.LoggableExperiment
 import com.stripe.android.common.taptoadd.FakeTapToAddHelper
 import com.stripe.android.common.taptoadd.TapToAddHelper
 import com.stripe.android.common.taptoadd.TapToAddMode
+import com.stripe.android.common.taptoadd.TapToAddResult
 import com.stripe.android.core.Logger
 import com.stripe.android.core.StripeError
 import com.stripe.android.core.exception.APIException
@@ -3339,6 +3340,62 @@ internal class PaymentSheetViewModelTest {
         verify(eventReporter, never()).onExperimentExposure(
             any<LoggableExperiment.OcsMobileHorizontalMode>()
         )
+    }
+
+    @Test
+    fun `Tap to add helper is created with mode complete`() = runTest {
+        FakeTapToAddHelper.Factory.test {
+            createViewModel(
+                tapToAddHelperFactory = tapToAddHelperFactory,
+            )
+
+            val createCall = createCalls.awaitItem()
+            assertThat(createCall.tapToAddMode).isEqualTo(TapToAddMode.Complete)
+        }
+    }
+
+    @Test
+    fun `When tap to add result is Complete, activity completes with completed status`() = runTest {
+        FakeTapToAddHelper.Factory.test {
+            val viewModel = createViewModel(
+                tapToAddHelperFactory = tapToAddHelperFactory,
+            )
+
+            createCalls.awaitItem()
+
+            viewModel.paymentSheetResult.test {
+                tapToAddHelperFactory.getCreatedHelper()?.emitResult(
+                    TapToAddResult.Complete
+                )
+
+                val result = awaitItem()
+                assertThat(result).isInstanceOf<PaymentSheetResult.Completed>()
+            }
+        }
+    }
+
+    @Test
+    fun `When tap to add result is Continue, error is reported`() = runTest {
+        val errorReporter = FakeErrorReporter()
+
+        FakeTapToAddHelper.Factory.test {
+            createViewModel(
+                tapToAddHelperFactory = tapToAddHelperFactory,
+                errorReporter = errorReporter,
+            )
+
+            createCalls.awaitItem()
+
+            tapToAddHelperFactory.getCreatedHelper()?.emitResult(
+                TapToAddResult.Continue(
+                    PaymentSelection.Saved(CARD_PAYMENT_METHOD)
+                )
+            )
+
+            assertThat(errorReporter.getLoggedErrors()).containsExactly(
+                ErrorReporter.UnexpectedErrorEvent.TAP_TO_ADD_PAYMENT_SHEET_RECEIVED_CONTINUE_RESULT.eventName
+            )
+        }
     }
 
     private fun testConfirmationStateRestorationAfterPaymentSuccess(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Handle continue and complete tap to add results in PaymentSheet

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
[TTA task](https://docs.google.com/document/d/1NuG4b9uW9FpDwggFsRuVYuNG-uZiRH3svZhT-FxEnx0/edit?tab=t.w9c2pwgf0pkn): "Handle tap to add results in Payment Element integrations"

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified

# Screen recording
(with fake tap to add activity)

https://github.com/user-attachments/assets/42b68d58-a24d-48ac-bf4d-9e87af32cf30

