### PR TITLE
Add checkout session customer and save offer models with parsing

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/CheckoutSessionResponse.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/CheckoutSessionResponse.kt
@@ -43,4 +43,75 @@ data class CheckoutSessionResponse(
      * Only populated in responses from the confirm API.
      */
     val paymentIntent: PaymentIntent? = null,
-) : StripeModel
+
+    /**
+     * Customer data from the checkout session init response.
+     * This is parsed from the top-level "customer" field in the init response.
+     * For checkout sessions, customer is associated server-side when the session is created,
+     * so we get customer data directly in the init response rather than through customer session auth.
+     */
+    val customer: Customer? = null,
+
+    /**
+     * Server-side flag controlling the "Save for future use" checkbox.
+     * Parsed from `customer_managed_saved_payment_methods_offer_save` in the init response.
+     */
+    val savedPaymentMethodsOfferSave: SavedPaymentMethodsOfferSave? = null,
+) : StripeModel {
+
+    /**
+     * Controls whether the "Save for future use" checkbox is shown and its initial state.
+     *
+     * This data comes from the checkout session's `customer_managed_saved_payment_methods_offer_save`
+     * configuration, which is set when creating the checkout session.
+     */
+    @Parcelize
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    data class SavedPaymentMethodsOfferSave(
+        /**
+         * Whether the save checkbox should be shown to the user.
+         */
+        val enabled: Boolean,
+        /**
+         * The initial state of the checkbox.
+         */
+        val status: Status,
+    ) : StripeModel {
+        /**
+         * Represents the initial checked state of the save checkbox.
+         */
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        enum class Status {
+            /**
+             * Checkbox should be pre-checked (user has previously agreed to save).
+             */
+            ACCEPTED,
+
+            /**
+             * Checkbox should be unchecked by default.
+             */
+            NOT_ACCEPTED,
+        }
+    }
+
+    /**
+     * Customer data from checkout session.
+     *
+     * This is simpler than [ElementsSession.Customer] because checkout sessions don't use
+     * customer session authentication - the customer is associated server-side when the
+     * checkout session is created.
+     */
+    @Parcelize
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    data class Customer(
+        /**
+         * The customer ID (e.g., "cus_xxx").
+         */
+        val id: String,
+
+        /**
+         * The customer's saved payment methods.
+         */
+        val paymentMethods: List<PaymentMethod>,
+    ) : StripeModel
+}

--- a/payments-core/src/test/java/com/stripe/android/model/CheckoutSessionFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/CheckoutSessionFixtures.kt
@@ -259,4 +259,148 @@ internal object CheckoutSessionFixtures {
         }
         """.trimIndent()
     )
+
+    /**
+     * Init response with customer data (for SPM support).
+     * Customer is at the top level, not inside elements_session.
+     */
+    val CHECKOUT_SESSION_WITH_CUSTOMER_JSON = JSONObject(
+        """
+        {
+            "session_id": "cs_test_abc123",
+            "currency": "usd",
+            "total_summary": {
+                "due": 1000
+            },
+            "customer": {
+                "id": "cus_test_customer",
+                "payment_methods": [
+                    {
+                        "id": "pm_card_visa",
+                        "object": "payment_method",
+                        "type": "card",
+                        "card": {
+                            "brand": "visa",
+                            "last4": "4242",
+                            "exp_month": 12,
+                            "exp_year": 2030
+                        },
+                        "livemode": false,
+                        "created": 1734000000
+                    },
+                    {
+                        "id": "pm_card_mastercard",
+                        "object": "payment_method",
+                        "type": "card",
+                        "card": {
+                            "brand": "mastercard",
+                            "last4": "5555",
+                            "exp_month": 6,
+                            "exp_year": 2028
+                        },
+                        "livemode": false,
+                        "created": 1734000000
+                    }
+                ]
+            },
+            "elements_session": $MINIMAL_ELEMENTS_SESSION_JSON
+        }
+        """.trimIndent()
+    )
+
+    /**
+     * Init response with customer but no saved payment methods.
+     */
+    val CHECKOUT_SESSION_WITH_EMPTY_CUSTOMER_JSON = JSONObject(
+        """
+        {
+            "session_id": "cs_test_abc123",
+            "currency": "usd",
+            "total_summary": {
+                "due": 1000
+            },
+            "customer": {
+                "id": "cus_test_empty_customer",
+                "payment_methods": []
+            },
+            "elements_session": $MINIMAL_ELEMENTS_SESSION_JSON
+        }
+        """.trimIndent()
+    )
+
+    /**
+     * Init response without customer (guest checkout).
+     */
+    val CHECKOUT_SESSION_WITHOUT_CUSTOMER_JSON = JSONObject(
+        """
+        {
+            "session_id": "cs_test_abc123",
+            "currency": "usd",
+            "total_summary": {
+                "due": 1000
+            },
+            "elements_session": $MINIMAL_ELEMENTS_SESSION_JSON
+        }
+        """.trimIndent()
+    )
+
+    /**
+     * Init response with save offer enabled and status not_accepted.
+     */
+    val CHECKOUT_SESSION_WITH_SAVE_ENABLED_JSON = JSONObject(
+        """
+        {
+            "session_id": "cs_test_abc123",
+            "currency": "usd",
+            "total_summary": {
+                "due": 1000
+            },
+            "customer_managed_saved_payment_methods_offer_save": {
+                "enabled": true,
+                "status": "not_accepted"
+            },
+            "elements_session": $MINIMAL_ELEMENTS_SESSION_JSON
+        }
+        """.trimIndent()
+    )
+
+    /**
+     * Init response with save offer enabled and status accepted.
+     */
+    val CHECKOUT_SESSION_WITH_SAVE_ACCEPTED_JSON = JSONObject(
+        """
+        {
+            "session_id": "cs_test_abc123",
+            "currency": "usd",
+            "total_summary": {
+                "due": 1000
+            },
+            "customer_managed_saved_payment_methods_offer_save": {
+                "enabled": true,
+                "status": "accepted"
+            },
+            "elements_session": $MINIMAL_ELEMENTS_SESSION_JSON
+        }
+        """.trimIndent()
+    )
+
+    /**
+     * Init response with save offer disabled.
+     */
+    val CHECKOUT_SESSION_WITH_SAVE_DISABLED_JSON = JSONObject(
+        """
+        {
+            "session_id": "cs_test_abc123",
+            "currency": "usd",
+            "total_summary": {
+                "due": 1000
+            },
+            "customer_managed_saved_payment_methods_offer_save": {
+                "enabled": false,
+                "status": "not_accepted"
+            },
+            "elements_session": $MINIMAL_ELEMENTS_SESSION_JSON
+        }
+        """.trimIndent()
+    )
 }

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/CheckoutSessionResponseJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/CheckoutSessionResponseJsonParserTest.kt
@@ -1,8 +1,11 @@
 package com.stripe.android.model.parsers
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.CardBrand
 import com.stripe.android.model.CheckoutSessionFixtures
+import com.stripe.android.model.CheckoutSessionResponse
 import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
 import org.json.JSONObject
 import org.junit.Test
@@ -177,5 +180,104 @@ class CheckoutSessionResponseJsonParserTest {
 
         // Verify next_action is parsed
         assertThat(paymentIntent?.nextActionType).isEqualTo(StripeIntent.NextActionType.RedirectToUrl)
+    }
+
+    @Test
+    fun `parse init response with customer and saved payment methods`() {
+        val result = CheckoutSessionResponseJsonParser(isLiveMode = false)
+            .parse(CheckoutSessionFixtures.CHECKOUT_SESSION_WITH_CUSTOMER_JSON)
+
+        assertThat(result).isNotNull()
+        assertThat(result?.id).isEqualTo("cs_test_abc123")
+        assertThat(result?.amount).isEqualTo(1000L)
+
+        // Verify customer is parsed from top-level
+        val customer = result?.customer
+        assertThat(customer).isNotNull()
+        assertThat(customer?.id).isEqualTo("cus_test_customer")
+
+        // Verify payment methods are parsed
+        val paymentMethods = customer?.paymentMethods
+        assertThat(paymentMethods).hasSize(2)
+        assertThat(paymentMethods?.get(0)?.id).isEqualTo("pm_card_visa")
+        assertThat(paymentMethods?.get(0)?.type).isEqualTo(PaymentMethod.Type.Card)
+        assertThat(paymentMethods?.get(0)?.card?.last4).isEqualTo("4242")
+        assertThat(paymentMethods?.get(0)?.card?.brand).isEqualTo(CardBrand.Visa)
+
+        assertThat(paymentMethods?.get(1)?.id).isEqualTo("pm_card_mastercard")
+        assertThat(paymentMethods?.get(1)?.card?.last4).isEqualTo("5555")
+        assertThat(paymentMethods?.get(1)?.card?.brand).isEqualTo(CardBrand.MasterCard)
+    }
+
+    @Test
+    fun `parse init response with customer but empty payment methods`() {
+        val result = CheckoutSessionResponseJsonParser(isLiveMode = false)
+            .parse(CheckoutSessionFixtures.CHECKOUT_SESSION_WITH_EMPTY_CUSTOMER_JSON)
+
+        assertThat(result).isNotNull()
+        assertThat(result?.customer).isNotNull()
+        assertThat(result?.customer?.id).isEqualTo("cus_test_empty_customer")
+        assertThat(result?.customer?.paymentMethods).isEmpty()
+    }
+
+    @Test
+    fun `parse init response without customer returns null customer`() {
+        val result = CheckoutSessionResponseJsonParser(isLiveMode = false)
+            .parse(CheckoutSessionFixtures.CHECKOUT_SESSION_WITHOUT_CUSTOMER_JSON)
+
+        assertThat(result).isNotNull()
+        assertThat(result?.id).isEqualTo("cs_test_abc123")
+        assertThat(result?.customer).isNull()
+    }
+
+    @Test
+    fun `parse init response with save offer enabled and status not_accepted`() {
+        val result = CheckoutSessionResponseJsonParser(isLiveMode = false)
+            .parse(CheckoutSessionFixtures.CHECKOUT_SESSION_WITH_SAVE_ENABLED_JSON)
+
+        assertThat(result).isNotNull()
+        val offerSave = result?.savedPaymentMethodsOfferSave
+        assertThat(offerSave).isNotNull()
+        assertThat(offerSave?.enabled).isTrue()
+        assertThat(offerSave?.status).isEqualTo(
+            CheckoutSessionResponse.SavedPaymentMethodsOfferSave.Status.NOT_ACCEPTED
+        )
+    }
+
+    @Test
+    fun `parse init response with save offer enabled and status accepted`() {
+        val result = CheckoutSessionResponseJsonParser(isLiveMode = false)
+            .parse(CheckoutSessionFixtures.CHECKOUT_SESSION_WITH_SAVE_ACCEPTED_JSON)
+
+        assertThat(result).isNotNull()
+        val offerSave = result?.savedPaymentMethodsOfferSave
+        assertThat(offerSave).isNotNull()
+        assertThat(offerSave?.enabled).isTrue()
+        assertThat(offerSave?.status).isEqualTo(
+            CheckoutSessionResponse.SavedPaymentMethodsOfferSave.Status.ACCEPTED
+        )
+    }
+
+    @Test
+    fun `parse init response with save offer disabled`() {
+        val result = CheckoutSessionResponseJsonParser(isLiveMode = false)
+            .parse(CheckoutSessionFixtures.CHECKOUT_SESSION_WITH_SAVE_DISABLED_JSON)
+
+        assertThat(result).isNotNull()
+        val offerSave = result?.savedPaymentMethodsOfferSave
+        assertThat(offerSave).isNotNull()
+        assertThat(offerSave?.enabled).isFalse()
+        assertThat(offerSave?.status).isEqualTo(
+            CheckoutSessionResponse.SavedPaymentMethodsOfferSave.Status.NOT_ACCEPTED
+        )
+    }
+
+    @Test
+    fun `parse init response without save offer returns null`() {
+        val result = CheckoutSessionResponseJsonParser(isLiveMode = false)
+            .parse(CheckoutSessionFixtures.CHECKOUT_SESSION_WITHOUT_CUSTOMER_JSON)
+
+        assertThat(result).isNotNull()
+        assertThat(result?.savedPaymentMethodsOfferSave).isNull()
     }
 }


### PR DESCRIPTION
## Summary
Example query: go/o/req_06ouncR6Hq9vvn

This PR adds foundation data models and JSON parsing for checkout session SPM (Saved Payment Method) support:

- Add `SavedPaymentMethodsOfferSave` nested class to `CheckoutSessionResponse` for controlling "Save for future use" checkbox visibility and initial state
- Add `Customer` nested class to `CheckoutSessionResponse` for checkout session customer data
- Add `parseCustomer()` and `parseSavedPaymentMethodsOfferSave()` methods to `CheckoutSessionResponseJsonParser`
- Add `checkoutSessionOfferSave` field to `ElementsSession` for downstream use
- Add comprehensive test fixtures and unit tests for parsing

This is PR 1 of 5 in the checkout session SPM support feature set.

## Motivation
#12344 

## Test plan
- [x] Unit tests added for `CheckoutSessionResponseJsonParser`:
  - Parse customer with saved payment methods
  - Parse customer with empty payment methods
  - Parse response without customer (guest checkout)
  - Parse save offer enabled/disabled states
  - Parse save offer accepted/not_accepted status
- [x] All existing tests pass
- [x] `./gradlew :payments-core:testDebugUnitTest` passes
- [x] `./gradlew :paymentsheet:compileDebugKotlin` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)