### PR TITLE
Handle process death appropriately in Tap to Add

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddViewModelComponent.kt
@@ -10,9 +10,11 @@ import com.stripe.android.common.di.ApplicationIdModule
 import com.stripe.android.common.taptoadd.ui.DefaultTapToAddCardAddedInteractor
 import com.stripe.android.common.taptoadd.ui.DefaultTapToAddCollectingInteractor
 import com.stripe.android.common.taptoadd.ui.DefaultTapToAddConfirmationInteractor
+import com.stripe.android.common.taptoadd.ui.DefaultTapToAddPaymentMethodHolder
 import com.stripe.android.common.taptoadd.ui.TapToAddCardAddedInteractor
 import com.stripe.android.common.taptoadd.ui.TapToAddCollectingInteractor
 import com.stripe.android.common.taptoadd.ui.TapToAddConfirmationInteractor
+import com.stripe.android.common.taptoadd.ui.TapToAddPaymentMethodHolder
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.core.injection.ENABLE_LOGGING
@@ -113,6 +115,11 @@ internal interface TapToAddViewModelModule {
     fun bindsAnalyticsRequestFactory(
         paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory
     ): AnalyticsRequestFactory
+
+    @Binds
+    fun bindsPaymentMethodHolder(
+        tapToAddPaymentMethodHolder: DefaultTapToAddPaymentMethodHolder
+    ): TapToAddPaymentMethodHolder
 
     @Binds
     fun bindsTapToAddCollectingInteractorFactory(

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/InitialTapToAddScreenFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/InitialTapToAddScreenFactory.kt
@@ -3,11 +3,19 @@ package com.stripe.android.common.taptoadd.ui
 import javax.inject.Inject
 
 internal class InitialTapToAddScreenFactory @Inject constructor(
+    private val paymentMethodHolder: TapToAddPaymentMethodHolder,
     private val collectingInteractorFactory: TapToAddCollectingInteractor.Factory,
+    private val confirmationInteractorFactory: TapToAddConfirmationInteractor.Factory
 ) {
     fun createInitialScreen(): TapToAddNavigator.Screen {
-        return TapToAddNavigator.Screen.Collecting(
-            interactor = collectingInteractorFactory.create()
-        )
+        return paymentMethodHolder.paymentMethod?.let {
+            TapToAddNavigator.Screen.Confirmation(
+                interactor = confirmationInteractorFactory.create(it)
+            )
+        } ?: run {
+            TapToAddNavigator.Screen.Collecting(
+                interactor = collectingInteractorFactory.create()
+            )
+        }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddCollectingInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddCollectingInteractor.kt
@@ -47,6 +47,7 @@ internal class DefaultTapToAddCollectingInteractor(
         private val paymentMethodMetadata: PaymentMethodMetadata,
         @ViewModelScope private val coroutineScope: CoroutineScope,
         private val tapToAddCollectionHandler: TapToAddCollectionHandler,
+        private val paymentMethodHolder: TapToAddPaymentMethodHolder,
         private val tapToAddCardAddedInteractorFactory: TapToAddCardAddedInteractor.Factory,
         private val navigator: Provider<TapToAddNavigator>,
     ) : TapToAddCollectingInteractor.Factory {
@@ -56,6 +57,8 @@ internal class DefaultTapToAddCollectingInteractor(
                 coroutineScope = coroutineScope,
                 tapToAddCollectionHandler = tapToAddCollectionHandler,
                 onCollected = { paymentMethod ->
+                    paymentMethodHolder.setPaymentMethod(paymentMethod)
+
                     navigator.get().performAction(
                         action = TapToAddNavigator.Action.NavigateTo(
                             screen = TapToAddNavigator.Screen.CardAdded(

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddPaymentMethodHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddPaymentMethodHolder.kt
@@ -1,0 +1,28 @@
+package com.stripe.android.common.taptoadd.ui
+
+import androidx.lifecycle.SavedStateHandle
+import com.stripe.android.model.PaymentMethod
+import javax.inject.Inject
+import javax.inject.Singleton
+
+internal interface TapToAddPaymentMethodHolder {
+    val paymentMethod: PaymentMethod?
+
+    fun setPaymentMethod(paymentMethod: PaymentMethod?)
+}
+
+@Singleton
+internal class DefaultTapToAddPaymentMethodHolder @Inject constructor(
+    private val savedStateHandle: SavedStateHandle,
+) : TapToAddPaymentMethodHolder {
+    override val paymentMethod: PaymentMethod?
+        get() = savedStateHandle[TAP_TO_ADD_PAYMENT_METHOD_KEY]
+
+    override fun setPaymentMethod(paymentMethod: PaymentMethod?) {
+        savedStateHandle[TAP_TO_ADD_PAYMENT_METHOD_KEY] = paymentMethod
+    }
+
+    private companion object {
+        const val TAP_TO_ADD_PAYMENT_METHOD_KEY = "STRIPE_TAP_TO_ADD_PAYMENT_METHOD"
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/DefaultTapToAddPaymentMethodHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/DefaultTapToAddPaymentMethodHolderTest.kt
@@ -1,0 +1,54 @@
+package com.stripe.android.common.taptoadd.ui
+
+import androidx.lifecycle.SavedStateHandle
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.testing.PaymentMethodFactory
+import org.junit.Test
+
+internal class DefaultTapToAddPaymentMethodHolderTest {
+    @Test
+    fun `paymentMethod returns null when handle has no payment method`() {
+        val savedStateHandle = SavedStateHandle()
+        val holder = DefaultTapToAddPaymentMethodHolder(savedStateHandle)
+
+        assertThat(holder.paymentMethod).isNull()
+        assertThat(savedStateHandle.getPaymentMethod()).isNull()
+    }
+
+    @Test
+    fun `paymentMethod returns value from handle after setPaymentMethod is called`() {
+        val savedStateHandle = SavedStateHandle()
+        val holder = DefaultTapToAddPaymentMethodHolder(savedStateHandle)
+        val paymentMethod = PaymentMethodFactory.card(random = true)
+
+        holder.setPaymentMethod(paymentMethod)
+
+        assertThat(holder.paymentMethod).isEqualTo(paymentMethod)
+        assertThat(savedStateHandle.getPaymentMethod()).isEqualTo(paymentMethod)
+    }
+
+    @Test
+    fun `paymentMethod returns value in handle when initialized`() {
+        val paymentMethod = PaymentMethodFactory.card(random = true)
+        val savedStateHandle = SavedStateHandle().apply { setPaymentMethod(paymentMethod) }
+        val holder = DefaultTapToAddPaymentMethodHolder(savedStateHandle)
+
+        assertThat(holder.paymentMethod).isEqualTo(paymentMethod)
+        assertThat(savedStateHandle.getPaymentMethod()).isEqualTo(paymentMethod)
+    }
+
+    private fun SavedStateHandle.getPaymentMethod(): PaymentMethod? {
+        return get(EXPECTED_HANDLE_KEY)
+    }
+
+    private fun SavedStateHandle.setPaymentMethod(
+        paymentMethod: PaymentMethod,
+    ) {
+        set(EXPECTED_HANDLE_KEY, paymentMethod)
+    }
+
+    private companion object {
+        const val EXPECTED_HANDLE_KEY = "STRIPE_TAP_TO_ADD_PAYMENT_METHOD"
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/FakePaymentMethodHolder.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/FakePaymentMethodHolder.kt
@@ -1,0 +1,20 @@
+package com.stripe.android.common.taptoadd.ui
+
+import app.cash.turbine.ReceiveTurbine
+import app.cash.turbine.Turbine
+import com.stripe.android.model.PaymentMethod
+
+class FakePaymentMethodHolder(
+    override val paymentMethod: PaymentMethod?
+) : TapToAddPaymentMethodHolder {
+    private val _setCalls = Turbine<PaymentMethod?>()
+    val setCalls: ReceiveTurbine<PaymentMethod?> = _setCalls
+
+    override fun setPaymentMethod(paymentMethod: PaymentMethod?) {
+        _setCalls.add(paymentMethod)
+    }
+
+    fun validate() {
+        _setCalls.ensureAllEventsConsumed()
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/InitialTapToAddScreenFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/InitialTapToAddScreenFactoryTest.kt
@@ -4,18 +4,17 @@ import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.isInstanceOf
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.testing.PaymentMethodFactory
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
 internal class InitialTapToAddScreenFactoryTest {
     @Test
-    fun `createInitialScreen returns Collecting screen by default`() = runTest {
-        val collectingInteractorFactory = FakeTapToAddCollectingInteractor.Factory()
-
-        val screenFactory = InitialTapToAddScreenFactory(
-            collectingInteractorFactory = collectingInteractorFactory,
-        )
-
+    fun `createInitialScreen returns Collecting screen by default`() = scenarioTest(
+        paymentMethod = null,
+    ) {
         val screen = screenFactory.createInitialScreen()
 
         assertThat(collectingInteractorFactory.createCalls.awaitItem()).isNotNull()
@@ -24,8 +23,77 @@ internal class InitialTapToAddScreenFactoryTest {
         val collectingScreen = screen as TapToAddNavigator.Screen.Collecting
 
         assertThat(collectingScreen.interactor).isEqualTo(FakeTapToAddCollectingInteractor)
+    }
+
+    @Test
+    fun `createInitialScreen returns Confirmation screen when holder contains a payment method`() {
+        val paymentMethod = PaymentMethodFactory.card(random = true)
+
+        scenarioTest(
+            paymentMethod = paymentMethod,
+        ) {
+            val screen = screenFactory.createInitialScreen()
+
+            val paymentMethodPassedToFactory = confirmationInteractorFactory.createCalls.awaitItem()
+
+            assertThat(paymentMethodPassedToFactory).isEqualTo(paymentMethod)
+            assertThat(screen).isInstanceOf<TapToAddNavigator.Screen.Confirmation>()
+
+            val confirmationScreen = screen as TapToAddNavigator.Screen.Confirmation
+
+            assertThat(confirmationScreen.interactor).isEqualTo(FakeTapToAddConfirmationInteractor)
+        }
+    }
+
+    private fun scenarioTest(
+        paymentMethod: PaymentMethod?,
+        block: suspend Scenario.() -> Unit,
+    ) = runTest {
+        val paymentMethodHolder = FakePaymentMethodHolder(paymentMethod)
+        val collectingInteractorFactory = FakeTapToAddCollectingInteractor.Factory()
+        val confirmationInteractorFactory = FakeTapToAddConfirmationInteractor.Factory()
+
+        val screenFactory = InitialTapToAddScreenFactory(
+            collectingInteractorFactory = collectingInteractorFactory,
+            confirmationInteractorFactory = confirmationInteractorFactory,
+            paymentMethodHolder = paymentMethodHolder,
+        )
+
+        block(
+            Scenario(
+                collectingInteractorFactory = collectingInteractorFactory,
+                confirmationInteractorFactory = confirmationInteractorFactory,
+                screenFactory = screenFactory,
+            )
+        )
 
         collectingInteractorFactory.validate()
+        confirmationInteractorFactory.validate()
+        paymentMethodHolder.validate()
+    }
+
+    private object FakeTapToAddConfirmationInteractor : TapToAddConfirmationInteractor {
+        override val state: StateFlow<TapToAddConfirmationInteractor.State>
+            get() = throw IllegalStateException("Should not be fetched!")
+
+        override fun performAction(action: TapToAddConfirmationInteractor.Action) {
+            throw IllegalStateException("Should not be called!")
+        }
+
+        class Factory : TapToAddConfirmationInteractor.Factory {
+            private val _createCalls = Turbine<PaymentMethod>()
+            val createCalls: ReceiveTurbine<PaymentMethod> = _createCalls
+
+            override fun create(paymentMethod: PaymentMethod): TapToAddConfirmationInteractor {
+                _createCalls.add(paymentMethod)
+
+                return FakeTapToAddConfirmationInteractor
+            }
+
+            fun validate() {
+                _createCalls.ensureAllEventsConsumed()
+            }
+        }
     }
 
     private object FakeTapToAddCollectingInteractor : TapToAddCollectingInteractor {
@@ -44,4 +112,10 @@ internal class InitialTapToAddScreenFactoryTest {
             }
         }
     }
+
+    private class Scenario(
+        val collectingInteractorFactory: FakeTapToAddCollectingInteractor.Factory,
+        val confirmationInteractorFactory: FakeTapToAddConfirmationInteractor.Factory,
+        val screenFactory: InitialTapToAddScreenFactory,
+    )
 }


### PR DESCRIPTION
# Summary
Handle process death appropriately in Tap to Add by storing the collected payment method in the saved state handle if we are still in the Tap to Add flow and displaying the confirmation flow if a payment method is collected.

# Motivation
Ensure Tap to Add works with process death.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified