### PR TITLE
Report confirmation result from Tap to Add flow

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddContract.kt
@@ -6,6 +6,7 @@ import android.os.Parcelable
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.core.os.BundleCompat
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.paymentsheet.analytics.EventReporter
 import kotlinx.parcelize.Parcelize
 
 internal object TapToAddContract : ActivityResultContract<TapToAddContract.Args, TapToAddResult>() {
@@ -23,6 +24,7 @@ internal object TapToAddContract : ActivityResultContract<TapToAddContract.Args,
     @Parcelize
     data class Args(
         val mode: TapToAddMode,
+        val eventMode: EventReporter.Mode,
         val paymentMethodMetadata: PaymentMethodMetadata,
         val paymentElementCallbackIdentifier: String,
         val productUsage: Set<String>,

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddHelper.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
+import com.stripe.android.paymentsheet.analytics.EventReporter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -45,6 +46,7 @@ internal class DefaultTapToAddHelper(
     private val productUsage: Set<String>,
     private val paymentElementCallbackIdentifier: String,
     private val tapToAddMode: TapToAddMode,
+    private val eventMode: EventReporter.Mode,
     private val savedStateHandle: SavedStateHandle,
 ) : TapToAddHelper {
     private var launcher: ActivityResultLauncher<TapToAddContract.Args>? = null
@@ -87,6 +89,7 @@ internal class DefaultTapToAddHelper(
         launcher?.launch(
             input = TapToAddContract.Args(
                 mode = tapToAddMode,
+                eventMode = eventMode,
                 paymentMethodMetadata = paymentMethodMetadata,
                 paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
                 productUsage = productUsage,
@@ -98,6 +101,7 @@ internal class DefaultTapToAddHelper(
         @Named(PRODUCT_USAGE) private val productUsage: Set<String>,
         @PaymentElementCallbackIdentifier private val paymentElementCallbackIdentifier: String,
         private val savedStateHandle: SavedStateHandle,
+        private val eventMode: EventReporter.Mode,
     ) : TapToAddHelper.Factory {
         override fun create(
             coroutineScope: CoroutineScope,
@@ -106,6 +110,7 @@ internal class DefaultTapToAddHelper(
             return DefaultTapToAddHelper(
                 coroutineScope = coroutineScope,
                 tapToAddMode = tapToAddMode,
+                eventMode = eventMode,
                 paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
                 savedStateHandle = savedStateHandle,
                 productUsage = productUsage,

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddViewModel.kt
@@ -31,6 +31,7 @@ internal class TapToAddViewModel @Inject constructor(
                 savedStateHandle = extras.createSavedStateHandle(),
                 application = extras.requireApplication(),
                 paymentElementCallbackIdentifier = args.paymentElementCallbackIdentifier,
+                eventMode = args.eventMode,
                 productUsage = args.productUsage,
             )
 

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddViewModelComponent.kt
@@ -45,6 +45,8 @@ import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.BuildConfig
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.PrefsRepository
+import com.stripe.android.paymentsheet.analytics.DefaultEventReporter
+import com.stripe.android.paymentsheet.analytics.EventReporter
 import dagger.Binds
 import dagger.BindsInstance
 import dagger.Component
@@ -80,6 +82,7 @@ internal interface TapToAddViewModelComponent {
         fun build(
             @BindsInstance paymentMethodMetadata: PaymentMethodMetadata,
             @BindsInstance tapToAddMode: TapToAddMode,
+            @BindsInstance eventMode: EventReporter.Mode,
             @BindsInstance
             @PaymentElementCallbackIdentifier
             paymentElementCallbackIdentifier: String,
@@ -120,6 +123,11 @@ internal interface TapToAddViewModelModule {
     fun bindsPaymentMethodHolder(
         tapToAddPaymentMethodHolder: DefaultTapToAddPaymentMethodHolder
     ): TapToAddPaymentMethodHolder
+
+    @Binds
+    fun bindsEventReporter(
+        eventReporter: DefaultEventReporter
+    ): EventReporter
 
     @Binds
     fun bindsTapToAddCollectingInteractorFactory(

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddHelperTest.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.testing.TestLifecycleOwner
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.testing.DummyActivityResultCaller
 import com.stripe.android.testing.asCallbackFor
 import kotlinx.coroutines.CoroutineScope
@@ -82,6 +83,7 @@ class TapToAddHelperTest {
     @Test
     fun `startPaymentMethodCollection calls launch with expected params`() = runScenario(
         tapToAddMode = TapToAddMode.Continue,
+        eventMode = EventReporter.Mode.Embedded,
         paymentElementCallbackIdentifier = "mpe_callback_id",
         productUsage = setOf("PaymentSheet", "FlowController")
     ) {
@@ -102,6 +104,7 @@ class TapToAddHelperTest {
         val tapToAddArgs = launchCall as TapToAddContract.Args
 
         assertThat(tapToAddArgs.paymentMethodMetadata).isEqualTo(DEFAULT_METADATA)
+        assertThat(tapToAddArgs.eventMode).isEqualTo(EventReporter.Mode.Embedded)
         assertThat(tapToAddArgs.paymentElementCallbackIdentifier).isEqualTo("mpe_callback_id")
         assertThat(tapToAddArgs.productUsage).containsExactly("PaymentSheet", "FlowController")
         assertThat(tapToAddArgs.mode).isEqualTo(TapToAddMode.Continue)
@@ -126,6 +129,7 @@ class TapToAddHelperTest {
 
     private fun runScenario(
         tapToAddMode: TapToAddMode = TapToAddMode.Complete,
+        eventMode: EventReporter.Mode = EventReporter.Mode.Complete,
         paymentElementCallbackIdentifier: String = "callback_id",
         productUsage: Set<String> = emptySet(),
         savedStateHandle: SavedStateHandle = SavedStateHandle(),
@@ -138,6 +142,7 @@ class TapToAddHelperTest {
                         productUsage = productUsage,
                         paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
                         tapToAddMode = tapToAddMode,
+                        eventMode = eventMode,
                         savedStateHandle = savedStateHandle,
                     ),
                     activityResultCallerScenario = this,
@@ -148,6 +153,7 @@ class TapToAddHelperTest {
 
     private suspend fun createTapToAddHelper(
         tapToAddMode: TapToAddMode = TapToAddMode.Complete,
+        eventMode: EventReporter.Mode = EventReporter.Mode.Complete,
         paymentElementCallbackIdentifier: String = "callback_id",
         productUsage: Set<String> = emptySet(),
         savedStateHandle: SavedStateHandle = SavedStateHandle(),
@@ -158,6 +164,7 @@ class TapToAddHelperTest {
             productUsage = productUsage,
             paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
             tapToAddMode = tapToAddMode,
+            eventMode = eventMode,
         )
     }
 


### PR DESCRIPTION
# Summary
Report confirmation result from Tap to Add flow by observing the state and checking if we have completed a transaction. 

# Motivation
Ensures payments are successfully reported from the SDK.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified