### PR TITLE
Handle canceled case from Terminal APIs in Tap to Add

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddCollectingInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddCollectingInteractor.kt
@@ -23,6 +23,7 @@ internal class DefaultTapToAddCollectingInteractor(
     private val tapToAddCollectionHandler: TapToAddCollectionHandler,
     private val onCollected: (paymentMethod: PaymentMethod) -> Unit,
     private val onFailedCollection: (message: ResolvableString) -> Unit,
+    private val onCanceled: () -> Unit,
 ) : TapToAddCollectingInteractor {
     init {
         coroutineScope.launch {
@@ -39,6 +40,9 @@ internal class DefaultTapToAddCollectingInteractor(
                 onFailedCollection(
                     collectionState.displayMessage ?: collectionState.error.stripeErrorMessage()
                 )
+            }
+            is TapToAddCollectionHandler.CollectionState.Canceled -> {
+                onCanceled()
             }
         }
     }
@@ -75,7 +79,12 @@ internal class DefaultTapToAddCollectingInteractor(
                             ),
                         ),
                     )
-                }
+                },
+                onCanceled = {
+                    navigator.get().performAction(
+                        action = TapToAddNavigator.Action.Close,
+                    )
+                },
             )
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/DefaultTapToAddCollectingInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/DefaultTapToAddCollectingInteractorTest.kt
@@ -72,6 +72,16 @@ internal class DefaultTapToAddCollectingInteractorTest {
         }
     }
 
+    @Test
+    fun `onCanceled is invoked when collection is canceled`() {
+        runScenario(
+            collectResult = TapToAddCollectionHandler.CollectionState.Canceled,
+        ) {
+            assertThat(collectionHandlerScenario.collectCalls.awaitItem()).isNotNull()
+            assertThat(onCanceled.awaitItem()).isNotNull()
+        }
+    }
+
     private fun runScenario(
         metadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(isTapToAddSupported = true),
         collectResult: TapToAddCollectionHandler.CollectionState =
@@ -82,6 +92,7 @@ internal class DefaultTapToAddCollectingInteractorTest {
 
         val onCollected = Turbine<PaymentMethod>()
         val onFailedCollection = Turbine<ResolvableString>()
+        val onCanceled = Turbine<Unit>()
 
         FakeTapToAddCollectionHandler.test(collectResult) {
             val scenario = Scenario(
@@ -91,9 +102,11 @@ internal class DefaultTapToAddCollectingInteractorTest {
                     tapToAddCollectionHandler = handler,
                     onCollected = { onCollected.add(it) },
                     onFailedCollection = { onFailedCollection.add(it) },
+                    onCanceled = { onCanceled.add(Unit) },
                 ),
                 onCollected = onCollected,
                 onFailedCollection = onFailedCollection,
+                onCanceled = onCanceled,
                 collectionHandlerScenario = this,
             )
             testScope.advanceUntilIdle()
@@ -105,6 +118,7 @@ internal class DefaultTapToAddCollectingInteractorTest {
         val interactor: TapToAddCollectingInteractor,
         val onCollected: ReceiveTurbine<PaymentMethod>,
         val onFailedCollection: ReceiveTurbine<ResolvableString>,
+        val onCanceled: ReceiveTurbine<Unit>,
         val collectionHandlerScenario: FakeTapToAddCollectionHandler.Scenario,
     )
 }


### PR DESCRIPTION
# Summary
Handle canceled case from Terminal APIs in Tap to Add by checking the error provided from the Terminal APIs. This was previously showing the error screen.

# Motivation
Ensure users who directly cancel from the Terminal tap flow are exited from the Payment Element tap flow as well.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Video
https://github.com/user-attachments/assets/f9c545e7-8479-4110-8e7e-e44a68bcad3d