### PR TITLE
Use dark theming for Terminal UX in Tap to Add

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddConnectionModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddConnectionModule.kt
@@ -1,0 +1,43 @@
+package com.stripe.android.common.taptoadd
+
+import android.content.Context
+import com.stripe.android.core.injection.IOContext
+import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.paymentsheet.BuildConfig
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import kotlin.coroutines.CoroutineContext
+
+@Module
+internal interface TapToAddConnectionModule {
+    @Binds
+    fun bindsStripeTerminalSdkAvailable(
+        isStripeTerminalSdkAvailable: DefaultIsStripeTerminalSdkAvailable
+    ): IsStripeTerminalSdkAvailable
+
+    @Binds
+    fun bindsTerminalWrapper(
+        terminalWrapper: DefaultTerminalWrapper
+    ): TerminalWrapper
+
+    companion object {
+        @Provides
+        fun providesTapToAddConnectionManager(
+            isStripeTerminalSdkAvailable: IsStripeTerminalSdkAvailable,
+            terminalWrapper: TerminalWrapper,
+            errorReporter: ErrorReporter,
+            applicationContext: Context,
+            @IOContext workContext: CoroutineContext
+        ): TapToAddConnectionManager {
+            return TapToAddConnectionManager.create(
+                applicationContext = applicationContext,
+                isStripeTerminalSdkAvailable = isStripeTerminalSdkAvailable,
+                terminalWrapper = terminalWrapper,
+                errorReporter = errorReporter,
+                isSimulated = BuildConfig.DEBUG,
+                workContext = workContext,
+            )
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddModule.kt
@@ -1,31 +1,22 @@
 package com.stripe.android.common.taptoadd
 
-import android.content.Context
-import com.stripe.android.core.injection.IOContext
 import com.stripe.android.paymentelement.CreateCardPresentSetupIntentCallback
 import com.stripe.android.paymentelement.TapToAddPreview
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import com.stripe.android.payments.core.analytics.ErrorReporter
-import com.stripe.android.paymentsheet.BuildConfig
+import com.stripe.stripeterminal.external.models.TapToPayUxConfiguration
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
-import kotlin.coroutines.CoroutineContext
 
 @OptIn(TapToAddPreview::class)
-@Module
+@Module(
+    includes = [
+        TapToAddConnectionModule::class,
+    ]
+)
 internal interface TapToAddModule {
-    @Binds
-    fun bindsStripeTerminalSdkAvailable(
-        isStripeTerminalSdkAvailable: DefaultIsStripeTerminalSdkAvailable
-    ): IsStripeTerminalSdkAvailable
-
-    @Binds
-    fun bindsTerminalWrapper(
-        terminalWrapper: DefaultTerminalWrapper
-    ): TerminalWrapper
-
     @Binds
     fun bindsCreateCardPresentSetupIntentCallbackRetriever(
         retriever: DefaultCreateCardPresentSetupIntentCallbackRetriever
@@ -41,28 +32,11 @@ internal interface TapToAddModule {
         }
 
         @Provides
-        fun providesTapToAddConnectionManager(
-            isStripeTerminalSdkAvailable: IsStripeTerminalSdkAvailable,
-            terminalWrapper: TerminalWrapper,
-            errorReporter: ErrorReporter,
-            applicationContext: Context,
-            @IOContext workContext: CoroutineContext
-        ): TapToAddConnectionManager {
-            return TapToAddConnectionManager.create(
-                applicationContext = applicationContext,
-                isStripeTerminalSdkAvailable = isStripeTerminalSdkAvailable,
-                terminalWrapper = terminalWrapper,
-                errorReporter = errorReporter,
-                isSimulated = BuildConfig.DEBUG,
-                workContext = workContext,
-            )
-        }
-
-        @Provides
         fun providesTapToAddCollectionHandler(
             isStripeTerminalSdkAvailable: IsStripeTerminalSdkAvailable,
             connectionManager: TapToAddConnectionManager,
             terminalWrapper: TerminalWrapper,
+            tapToPayUxConfiguration: TapToPayUxConfiguration,
             errorReporter: ErrorReporter,
             createCardPresentSetupIntentCallbackRetriever: CreateCardPresentSetupIntentCallbackRetriever
         ): TapToAddCollectionHandler {
@@ -70,6 +44,7 @@ internal interface TapToAddModule {
                 isStripeTerminalSdkAvailable = isStripeTerminalSdkAvailable,
                 connectionManager = connectionManager,
                 terminalWrapper = terminalWrapper,
+                tapToPayUxConfiguration = tapToPayUxConfiguration,
                 errorReporter = errorReporter,
                 createCardPresentSetupIntentCallbackRetriever = createCardPresentSetupIntentCallbackRetriever,
             )

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddViewModelComponent.kt
@@ -15,6 +15,7 @@ import com.stripe.android.common.taptoadd.ui.TapToAddCardAddedInteractor
 import com.stripe.android.common.taptoadd.ui.TapToAddCollectingInteractor
 import com.stripe.android.common.taptoadd.ui.TapToAddConfirmationInteractor
 import com.stripe.android.common.taptoadd.ui.TapToAddPaymentMethodHolder
+import com.stripe.android.common.taptoadd.ui.createTapToAddUxConfiguration
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.core.injection.ENABLE_LOGGING
@@ -47,6 +48,7 @@ import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.analytics.DefaultEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.stripeterminal.external.models.TapToPayUxConfiguration
 import dagger.Binds
 import dagger.BindsInstance
 import dagger.Component
@@ -158,6 +160,12 @@ internal interface TapToAddViewModelModule {
         @Singleton
         @Named(STATUS_BAR_COLOR)
         fun providesStatusBarColor(): Int? = null
+
+        @Provides
+        @Singleton
+        fun providesTapToAddUxConfiguration(): TapToPayUxConfiguration {
+            return createTapToAddUxConfiguration()
+        }
 
         @Provides
         fun providesContext(application: Application): Context {

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddTheme.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddTheme.kt
@@ -7,6 +7,8 @@ import com.stripe.android.paymentsheet.ui.PrimaryButtonColors
 import com.stripe.android.paymentsheet.ui.PrimaryButtonTheme
 import com.stripe.android.uicore.StripeColors
 import com.stripe.android.uicore.StripeTheme
+import com.stripe.stripeterminal.external.models.TapToPayUxConfiguration
+import android.graphics.Color as BaseAndroidColor
 
 @Composable
 internal fun TapToAddTheme(
@@ -50,4 +52,19 @@ private object TapToAddThemeDefaults {
             error = Color.Red,
         ),
     )
+}
+
+internal fun createTapToAddUxConfiguration(): TapToPayUxConfiguration {
+    return TapToPayUxConfiguration.Builder()
+        .darkMode(darkMode = TapToPayUxConfiguration.DarkMode.DARK)
+        .colors(
+            colors = TapToPayUxConfiguration.ColorScheme.Builder()
+                .primary(
+                    primary = TapToPayUxConfiguration.Color.Value(
+                        color = BaseAndroidColor.BLACK
+                    )
+                )
+                .build()
+        )
+        .build()
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedCommonModule.kt
@@ -3,7 +3,7 @@ package com.stripe.android.paymentelement.embedded
 import android.content.Context
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.PaymentConfiguration
-import com.stripe.android.common.taptoadd.TapToAddModule
+import com.stripe.android.common.taptoadd.TapToAddConnectionModule
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.IOContext
@@ -49,7 +49,7 @@ import kotlin.coroutines.CoroutineContext
     includes = [
         StripeRepositoryModule::class,
         CoreCommonModule::class,
-        TapToAddModule::class,
+        TapToAddConnectionModule::class,
         PaymentsIntegrityModule::class,
         PaymentElementRequestSurfaceModule::class,
     ],

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
@@ -6,8 +6,8 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.cards.CardAccountRangeRepository
 import com.stripe.android.cards.DefaultCardAccountRangeRepositoryFactory
 import com.stripe.android.common.taptoadd.DefaultTapToAddHelper
+import com.stripe.android.common.taptoadd.TapToAddConnectionModule
 import com.stripe.android.common.taptoadd.TapToAddHelper
-import com.stripe.android.common.taptoadd.TapToAddModule
 import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
@@ -75,7 +75,7 @@ import javax.inject.Singleton
     ],
     includes = [
         LinkCommonModule::class,
-        TapToAddModule::class,
+        TapToAddConnectionModule::class,
         PaymentsIntegrityModule::class
     ]
 )


### PR DESCRIPTION
# Summary
Use dark theming for Terminal UX in Tap to Add

# Motivation
More closely follow designs using existing Terminal APIs

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Video
https://github.com/user-attachments/assets/146e63e3-aee5-42cc-90c8-3a2590acecc6