### PR TITLE
Rename `TapToAddLinkFormHelper` to `SavedPaymentMethodLinkFormHelper`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/spms/LinkFormElementFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/spms/LinkFormElementFactory.kt
@@ -1,4 +1,4 @@
-package com.stripe.android.common.taptoadd.ui
+package com.stripe.android.common.spms
 
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkConfigurationCoordinator
@@ -8,7 +8,7 @@ import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.lpmfoundations.paymentmethod.link.LinkFormElement
 import com.stripe.android.uicore.elements.FormElement
 
-internal interface TapToAddLinkFormElementFactory {
+internal interface LinkFormElementFactory {
     fun create(
         signupMode: LinkSignupMode,
         configuration: LinkConfiguration,
@@ -19,7 +19,7 @@ internal interface TapToAddLinkFormElementFactory {
     ): FormElement
 }
 
-internal object DefaultTapToAddLinkFormElementFactory : TapToAddLinkFormElementFactory {
+internal object DefaultLinkFormElementFactory : LinkFormElementFactory {
     override fun create(
         signupMode: LinkSignupMode,
         configuration: LinkConfiguration,

--- a/paymentsheet/src/main/java/com/stripe/android/common/spms/SavedPaymentMethodLinkFormHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/spms/SavedPaymentMethodLinkFormHelper.kt
@@ -1,4 +1,4 @@
-package com.stripe.android.common.taptoadd.ui
+package com.stripe.android.common.spms
 
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.link.LinkConfigurationCoordinator
@@ -11,7 +11,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import javax.inject.Inject
 
-internal interface TapToAddLinkFormHelper {
+internal interface SavedPaymentMethodLinkFormHelper {
     val state: StateFlow<State>
     val formElement: FormElement?
 
@@ -24,28 +24,30 @@ internal interface TapToAddLinkFormHelper {
     }
 }
 
-internal class DefaultTapToAddLinkFormHelper @Inject constructor(
+internal class DefaultSavedPaymentMethodLinkFormHelper @Inject constructor(
     paymentMethodMetadata: PaymentMethodMetadata,
     private val linkConfigurationCoordinator: LinkConfigurationCoordinator,
     private val savedStateHandle: SavedStateHandle,
-    linkFormElementFactory: TapToAddLinkFormElementFactory,
-) : TapToAddLinkFormHelper {
+    linkFormElementFactory: LinkFormElementFactory,
+) : SavedPaymentMethodLinkFormHelper {
     private val linkState = paymentMethodMetadata.linkState
 
     private var storedCheckboxSelection: Boolean
-        get() = savedStateHandle.get<Boolean>(TAP_TO_ADD_LINK_CHECKBOX_SELECTED_KEY) == true
+        get() = savedStateHandle.get<Boolean>(SPM_LINK_CHECKBOX_SELECTED_KEY) == true
         set(value) {
-            savedStateHandle[TAP_TO_ADD_LINK_CHECKBOX_SELECTED_KEY] = value
+            savedStateHandle[SPM_LINK_CHECKBOX_SELECTED_KEY] = value
         }
 
     private var storedLinkInput: UserInput?
-        get() = savedStateHandle[TAP_TO_ADD_LINK_INPUT_KEY]
+        get() = savedStateHandle[SPM_LINK_INPUT_KEY]
         set(value) {
-            savedStateHandle[TAP_TO_ADD_LINK_INPUT_KEY] = value
+            savedStateHandle[SPM_LINK_INPUT_KEY] = value
         }
 
-    private val _state = MutableStateFlow<TapToAddLinkFormHelper.State>(TapToAddLinkFormHelper.State.Unused)
-    override val state: StateFlow<TapToAddLinkFormHelper.State> = _state.asStateFlow()
+    private val _state = MutableStateFlow<SavedPaymentMethodLinkFormHelper.State>(
+        SavedPaymentMethodLinkFormHelper.State.Unused
+    )
+    override val state: StateFlow<SavedPaymentMethodLinkFormHelper.State> = _state.asStateFlow()
 
     override val formElement: FormElement? = if (linkState?.signupMode != null) {
         linkFormElementFactory.create(
@@ -71,16 +73,16 @@ internal class DefaultTapToAddLinkFormHelper @Inject constructor(
     private fun createState(
         useLink: Boolean,
         userInput: UserInput?,
-    ): TapToAddLinkFormHelper.State {
+    ): SavedPaymentMethodLinkFormHelper.State {
         return when {
-            useLink && userInput != null -> TapToAddLinkFormHelper.State.Complete(userInput)
-            useLink -> TapToAddLinkFormHelper.State.Incomplete
-            else -> TapToAddLinkFormHelper.State.Unused
+            useLink && userInput != null -> SavedPaymentMethodLinkFormHelper.State.Complete(userInput)
+            useLink -> SavedPaymentMethodLinkFormHelper.State.Incomplete
+            else -> SavedPaymentMethodLinkFormHelper.State.Unused
         }
     }
 
     private companion object {
-        const val TAP_TO_ADD_LINK_CHECKBOX_SELECTED_KEY = "STRIPE_TAD_TO_ADD_LINK_CHECKBOX_SELECTED"
-        const val TAP_TO_ADD_LINK_INPUT_KEY = "STRIPE_TAD_TO_ADD_LINK_INPUT"
+        const val SPM_LINK_CHECKBOX_SELECTED_KEY = "STRIPE_SPM_LINK_CHECKBOX_SELECTED"
+        const val SPM_LINK_INPUT_KEY = "STRIPE_SPM_LINK_INPUT"
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddViewModelComponent.kt
@@ -7,17 +7,17 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.di.ApplicationIdModule
+import com.stripe.android.common.spms.DefaultLinkFormElementFactory
+import com.stripe.android.common.spms.DefaultSavedPaymentMethodLinkFormHelper
+import com.stripe.android.common.spms.LinkFormElementFactory
+import com.stripe.android.common.spms.SavedPaymentMethodLinkFormHelper
 import com.stripe.android.common.taptoadd.ui.DefaultTapToAddCardAddedInteractor
 import com.stripe.android.common.taptoadd.ui.DefaultTapToAddCollectingInteractor
 import com.stripe.android.common.taptoadd.ui.DefaultTapToAddConfirmationInteractor
-import com.stripe.android.common.taptoadd.ui.DefaultTapToAddLinkFormElementFactory
-import com.stripe.android.common.taptoadd.ui.DefaultTapToAddLinkFormHelper
 import com.stripe.android.common.taptoadd.ui.DefaultTapToAddPaymentMethodHolder
 import com.stripe.android.common.taptoadd.ui.TapToAddCardAddedInteractor
 import com.stripe.android.common.taptoadd.ui.TapToAddCollectingInteractor
 import com.stripe.android.common.taptoadd.ui.TapToAddConfirmationInteractor
-import com.stripe.android.common.taptoadd.ui.TapToAddLinkFormElementFactory
-import com.stripe.android.common.taptoadd.ui.TapToAddLinkFormHelper
 import com.stripe.android.common.taptoadd.ui.TapToAddPaymentMethodHolder
 import com.stripe.android.common.taptoadd.ui.createTapToAddUxConfiguration
 import com.stripe.android.core.injection.CoreCommonModule
@@ -250,9 +250,9 @@ internal interface TapToAddLinkModule {
     ): LinkConfigurationCoordinator
 
     @Binds
-    fun bindsTapToAddLinkFormHelper(
-        tapToAddLinkFormHelper: DefaultTapToAddLinkFormHelper
-    ): TapToAddLinkFormHelper
+    fun bindsLinkFormHelper(
+        linkFormHelper: DefaultSavedPaymentMethodLinkFormHelper
+    ): SavedPaymentMethodLinkFormHelper
 
     companion object {
         @Provides
@@ -265,8 +265,8 @@ internal interface TapToAddLinkModule {
         @Singleton
         fun providesTapToAddLinkFormElementFactory(
             savedStateHandle: SavedStateHandle
-        ): TapToAddLinkFormElementFactory {
-            return DefaultTapToAddLinkFormElementFactory
+        ): LinkFormElementFactory {
+            return DefaultLinkFormElementFactory
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddConfirmationInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddConfirmationInteractor.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.common.taptoadd.ui
 
+import com.stripe.android.common.spms.SavedPaymentMethodLinkFormHelper
 import com.stripe.android.common.taptoadd.TapToAddMode
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.core.strings.ResolvableString
@@ -73,7 +74,7 @@ internal class DefaultTapToAddConfirmationInteractor(
     private val paymentMethod: PaymentMethod,
     private val paymentMethodMetadata: PaymentMethodMetadata,
     private val confirmationHandler: ConfirmationHandler,
-    private val linkFormHelper: TapToAddLinkFormHelper,
+    private val linkFormHelper: SavedPaymentMethodLinkFormHelper,
     private val eventReporter: EventReporter,
     private val onContinue: (paymentSelection: PaymentSelection.Saved) -> Unit,
     private val onComplete: () -> Unit,
@@ -150,7 +151,7 @@ internal class DefaultTapToAddConfirmationInteractor(
     }
 
     private fun createInitialState(
-        initialLinkState: TapToAddLinkFormHelper.State,
+        initialLinkState: SavedPaymentMethodLinkFormHelper.State,
         initialConfirmationState: ConfirmationHandler.State
     ): TapToAddConfirmationInteractor.State {
         return TapToAddConfirmationInteractor.State(
@@ -189,11 +190,11 @@ internal class DefaultTapToAddConfirmationInteractor(
     }
 
     private fun TapToAddConfirmationInteractor.State.withLinkState(
-        linkState: TapToAddLinkFormHelper.State,
+        linkState: SavedPaymentMethodLinkFormHelper.State,
     ): TapToAddConfirmationInteractor.State {
         return copy(
             primaryButton = primaryButton.copy(
-                enabled = linkState !is TapToAddLinkFormHelper.State.Incomplete,
+                enabled = linkState !is SavedPaymentMethodLinkFormHelper.State.Incomplete,
             ),
         )
     }
@@ -237,7 +238,7 @@ internal class DefaultTapToAddConfirmationInteractor(
         @ViewModelScope private val viewModelScope: CoroutineScope,
         private val tapToAddMode: TapToAddMode,
         private val paymentMethodMetadata: PaymentMethodMetadata,
-        private val linkFormHelper: TapToAddLinkFormHelper,
+        private val linkFormHelper: SavedPaymentMethodLinkFormHelper,
         private val confirmationHandler: ConfirmationHandler,
         private val eventReporter: EventReporter,
         private val tapToAddNavigator: Provider<TapToAddNavigator>,

--- a/paymentsheet/src/test/java/com/stripe/android/common/spms/DefaultSavedPaymentMethodLinkFormHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/spms/DefaultSavedPaymentMethodLinkFormHelperTest.kt
@@ -1,10 +1,10 @@
-package com.stripe.android.common.taptoadd.ui
+package com.stripe.android.common.spms
 
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
 import app.cash.turbine.test
-import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.isInstanceOf
 import com.stripe.android.link.LinkConfiguration
@@ -26,7 +26,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
-internal class DefaultTapToAddLinkFormHelperTest {
+internal class DefaultSavedPaymentMethodLinkFormHelperTest {
     @Test
     fun `link form is unavailable when signup mode is not defined`() = runScenario(
         linkState = LinkState(
@@ -36,10 +36,10 @@ internal class DefaultTapToAddLinkFormHelperTest {
         ),
     ) {
         helper.state.test {
-            assertThat(awaitItem()).isEqualTo(TapToAddLinkFormHelper.State.Unused)
+            Truth.assertThat(awaitItem()).isEqualTo(SavedPaymentMethodLinkFormHelper.State.Unused)
         }
 
-        assertThat(helper.formElement).isNull()
+        Truth.assertThat(helper.formElement).isNull()
 
         formElementFactoryCreateCalls.expectNoEvents()
     }
@@ -57,22 +57,22 @@ internal class DefaultTapToAddLinkFormHelperTest {
             ),
         ) {
             helper.state.test {
-                assertThat(awaitItem()).isEqualTo(TapToAddLinkFormHelper.State.Unused)
+                Truth.assertThat(awaitItem()).isEqualTo(SavedPaymentMethodLinkFormHelper.State.Unused)
             }
 
-            assertThat(helper.formElement).isNotNull()
+            Truth.assertThat(helper.formElement).isNotNull()
 
             val factoryCreateCall = formElementFactoryCreateCalls.awaitItem()
 
-            assertThat(factoryCreateCall.signupMode)
+            Truth.assertThat(factoryCreateCall.signupMode)
                 .isEqualTo(LinkSignupMode.InsteadOfSaveForFutureUse)
-            assertThat(factoryCreateCall.configuration)
+            Truth.assertThat(factoryCreateCall.configuration)
                 .isEqualTo(TestFactory.LINK_CONFIGURATION)
-            assertThat(factoryCreateCall.linkConfigurationCoordinator)
+            Truth.assertThat(factoryCreateCall.linkConfigurationCoordinator)
                 .isEqualTo(coordinator)
-            assertThat(factoryCreateCall.previousLinkSignupCheckboxSelection)
+            Truth.assertThat(factoryCreateCall.previousLinkSignupCheckboxSelection)
                 .isFalse()
-            assertThat(factoryCreateCall.userInput).isNull()
+            Truth.assertThat(factoryCreateCall.userInput).isNull()
         }
     }
 
@@ -88,11 +88,11 @@ internal class DefaultTapToAddLinkFormHelperTest {
                 signupMode = LinkSignupMode.AlongsideSaveForFutureUse,
             ),
         ) {
-            assertThat(helper.formElement).isNotNull()
+            Truth.assertThat(helper.formElement).isNotNull()
 
             val factoryCreateCall = formElementFactoryCreateCalls.awaitItem()
 
-            assertThat(factoryCreateCall.signupMode)
+            Truth.assertThat(factoryCreateCall.signupMode)
                 .isEqualTo(LinkSignupMode.InsteadOfSaveForFutureUse)
         }
     }
@@ -115,13 +115,13 @@ internal class DefaultTapToAddLinkFormHelperTest {
             ),
             handle = SavedStateHandle(
                 initialState = mapOf(
-                    TAP_TO_ADD_LINK_INPUT_KEY to userInput,
+                    SPM_LINK_INPUT_KEY to userInput,
                 ),
             ),
         ) {
             val call = formElementFactoryCreateCalls.awaitItem()
 
-            assertThat(call.userInput).isEqualTo(userInput)
+            Truth.assertThat(call.userInput).isEqualTo(userInput)
         }
     }
 
@@ -135,12 +135,12 @@ internal class DefaultTapToAddLinkFormHelperTest {
             ),
             handle = SavedStateHandle(
                 initialState = mapOf(
-                    TAP_TO_ADD_LINK_CHECKBOX_SELECTED_KEY to true,
+                    SPM_LINK_CHECKBOX_SELECTED_KEY to true,
                 ),
             ),
         ) {
             val call = formElementFactoryCreateCalls.awaitItem()
-            assertThat(call.previousLinkSignupCheckboxSelection).isTrue()
+            Truth.assertThat(call.previousLinkSignupCheckboxSelection).isTrue()
         }
 
     @Test
@@ -168,11 +168,11 @@ internal class DefaultTapToAddLinkFormHelperTest {
             call.onLinkInlineSignupStateChanged(viewState)
 
             helper.state.test {
-                assertThat(awaitItem()).isEqualTo(TapToAddLinkFormHelper.State.Unused)
+                Truth.assertThat(awaitItem()).isEqualTo(SavedPaymentMethodLinkFormHelper.State.Unused)
             }
 
-            assertThat(handle.get<Boolean>(TAP_TO_ADD_LINK_CHECKBOX_SELECTED_KEY)).isFalse()
-            assertThat(handle.get<UserInput>(TAP_TO_ADD_LINK_INPUT_KEY)).isNull()
+            Truth.assertThat(handle.get<Boolean>(SPM_LINK_CHECKBOX_SELECTED_KEY)).isFalse()
+            Truth.assertThat(handle.get<UserInput>(SPM_LINK_INPUT_KEY)).isNull()
         }
 
     @Test
@@ -200,11 +200,11 @@ internal class DefaultTapToAddLinkFormHelperTest {
             call.onLinkInlineSignupStateChanged(viewState)
 
             helper.state.test {
-                assertThat(awaitItem()).isEqualTo(TapToAddLinkFormHelper.State.Incomplete)
+                Truth.assertThat(awaitItem()).isEqualTo(SavedPaymentMethodLinkFormHelper.State.Incomplete)
             }
 
-            assertThat(handle.get<Boolean>(TAP_TO_ADD_LINK_CHECKBOX_SELECTED_KEY)).isTrue()
-            assertThat(handle.get<UserInput>(TAP_TO_ADD_LINK_INPUT_KEY)).isNull()
+            Truth.assertThat(handle.get<Boolean>(SPM_LINK_CHECKBOX_SELECTED_KEY)).isTrue()
+            Truth.assertThat(handle.get<UserInput>(SPM_LINK_INPUT_KEY)).isNull()
         }
 
     @Test
@@ -242,15 +242,15 @@ internal class DefaultTapToAddLinkFormHelperTest {
             helper.state.test {
                 val state = awaitItem()
 
-                assertThat(state).isInstanceOf<TapToAddLinkFormHelper.State.Complete>()
+                Truth.assertThat(state).isInstanceOf<SavedPaymentMethodLinkFormHelper.State.Complete>()
 
-                val completeState = state as TapToAddLinkFormHelper.State.Complete
+                val completeState = state as SavedPaymentMethodLinkFormHelper.State.Complete
 
-                assertThat(completeState.userInput).isEqualTo(userInput)
+                Truth.assertThat(completeState.userInput).isEqualTo(userInput)
             }
 
-            assertThat(handle.get<Boolean>(TAP_TO_ADD_LINK_CHECKBOX_SELECTED_KEY)).isTrue()
-            assertThat(handle.get<UserInput>(TAP_TO_ADD_LINK_INPUT_KEY)).isEqualTo(userInput)
+            Truth.assertThat(handle.get<Boolean>(SPM_LINK_CHECKBOX_SELECTED_KEY)).isTrue()
+            Truth.assertThat(handle.get<UserInput>(SPM_LINK_INPUT_KEY)).isEqualTo(userInput)
         }
 
     private fun runScenario(
@@ -262,9 +262,9 @@ internal class DefaultTapToAddLinkFormHelperTest {
         linkConfigurationCoordinator: LinkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
         block: suspend Scenario.() -> Unit,
     ) = runTest {
-        val factory = FakeTapToAddLinkFormElementFactory()
+        val factory = FakeLinkFormElementFactory()
 
-        val helper = DefaultTapToAddLinkFormHelper(
+        val helper = DefaultSavedPaymentMethodLinkFormHelper(
             paymentMethodMetadata = paymentMethodMetadata,
             linkConfigurationCoordinator = linkConfigurationCoordinator,
             savedStateHandle = handle,
@@ -283,12 +283,12 @@ internal class DefaultTapToAddLinkFormHelperTest {
     }
 
     private class Scenario(
-        val helper: TapToAddLinkFormHelper,
+        val helper: SavedPaymentMethodLinkFormHelper,
         val handle: SavedStateHandle,
-        val formElementFactoryCreateCalls: ReceiveTurbine<FakeTapToAddLinkFormElementFactory.Call>,
+        val formElementFactoryCreateCalls: ReceiveTurbine<FakeLinkFormElementFactory.Call>,
     )
 
-    private class FakeTapToAddLinkFormElementFactory : TapToAddLinkFormElementFactory {
+    private class FakeLinkFormElementFactory : LinkFormElementFactory {
         private val _calls = Turbine<Call>()
         val calls: ReceiveTurbine<Call> = _calls
 
@@ -347,7 +347,7 @@ internal class DefaultTapToAddLinkFormHelperTest {
     }
 
     private companion object {
-        const val TAP_TO_ADD_LINK_CHECKBOX_SELECTED_KEY = "STRIPE_TAD_TO_ADD_LINK_CHECKBOX_SELECTED"
-        const val TAP_TO_ADD_LINK_INPUT_KEY = "STRIPE_TAD_TO_ADD_LINK_INPUT"
+        const val SPM_LINK_CHECKBOX_SELECTED_KEY = "STRIPE_SPM_LINK_CHECKBOX_SELECTED"
+        const val SPM_LINK_INPUT_KEY = "STRIPE_SPM_LINK_INPUT"
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/DefaultTapToAddConfirmationInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/DefaultTapToAddConfirmationInteractorTest.kt
@@ -4,6 +4,7 @@ import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.common.spms.SavedPaymentMethodLinkFormHelper
 import com.stripe.android.common.taptoadd.TapToAddMode
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.isInstanceOf
@@ -233,8 +234,8 @@ internal class DefaultTapToAddConfirmationInteractorTest {
     fun `primary button disabled when link form state is Incomplete`() = runScenario(
         paymentMethod = PaymentMethodFactory.card(last4 = "4242"),
         tapToAddMode = TapToAddMode.Complete,
-        linkFormHelper = FakeTapToAddLinkFormHelper(
-            initialState = TapToAddLinkFormHelper.State.Incomplete,
+        linkFormHelper = FakeSavedPaymentMethodLinkFormHelper(
+            initialState = SavedPaymentMethodLinkFormHelper.State.Incomplete,
         ),
     ) {
         interactor.state.test {
@@ -247,8 +248,8 @@ internal class DefaultTapToAddConfirmationInteractorTest {
     fun `primary button enabled when link form state is Unused`() = runScenario(
         paymentMethod = PaymentMethodFactory.card(last4 = "4242"),
         tapToAddMode = TapToAddMode.Complete,
-        linkFormHelper = FakeTapToAddLinkFormHelper(
-            initialState = TapToAddLinkFormHelper.State.Unused,
+        linkFormHelper = FakeSavedPaymentMethodLinkFormHelper(
+            initialState = SavedPaymentMethodLinkFormHelper.State.Unused,
         ),
     ) {
         interactor.state.test {
@@ -261,8 +262,8 @@ internal class DefaultTapToAddConfirmationInteractorTest {
     fun `primary button enabled when link form state is Complete`() = runScenario(
         paymentMethod = PaymentMethodFactory.card(last4 = "4242"),
         tapToAddMode = TapToAddMode.Complete,
-        linkFormHelper = FakeTapToAddLinkFormHelper(
-            initialState = TapToAddLinkFormHelper.State.Complete(
+        linkFormHelper = FakeSavedPaymentMethodLinkFormHelper(
+            initialState = SavedPaymentMethodLinkFormHelper.State.Complete(
                 userInput = UserInput.SignIn(email = "email@email.com")
             ),
         ),
@@ -290,7 +291,7 @@ internal class DefaultTapToAddConfirmationInteractorTest {
         paymentMethodMetadata: PaymentMethodMetadata =
             PaymentMethodMetadataFactory.create(isTapToAddSupported = true),
         initialConfirmationState: ConfirmationHandler.State = ConfirmationHandler.State.Idle,
-        linkFormHelper: TapToAddLinkFormHelper = FakeTapToAddLinkFormHelper(),
+        linkFormHelper: SavedPaymentMethodLinkFormHelper = FakeSavedPaymentMethodLinkFormHelper(),
         block: suspend Scenario.() -> Unit,
     ) = runTest {
         val eventReporter = FakeEventReporter()
@@ -344,11 +345,11 @@ internal class DefaultTapToAddConfirmationInteractorTest {
         val eventReporter: FakeEventReporter,
     )
 
-    private class FakeTapToAddLinkFormHelper(
-        initialState: TapToAddLinkFormHelper.State = TapToAddLinkFormHelper.State.Unused,
+    private class FakeSavedPaymentMethodLinkFormHelper(
+        initialState: SavedPaymentMethodLinkFormHelper.State = SavedPaymentMethodLinkFormHelper.State.Unused,
         override val formElement: LinkFormElement? = null,
-    ) : TapToAddLinkFormHelper {
+    ) : SavedPaymentMethodLinkFormHelper {
         private val _state = MutableStateFlow(initialState)
-        override val state: StateFlow<TapToAddLinkFormHelper.State> = _state.asStateFlow()
+        override val state: StateFlow<SavedPaymentMethodLinkFormHelper.State> = _state.asStateFlow()
     }
 }


### PR DESCRIPTION
# Summary
Rename `TapToAddLinkFormHelper` to `SavedPaymentMethodLinkFormHelper`

# Motivation
Allows it to be more generally used. For Tap to Add, this will be used in a new SPM screen for confirming.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified