### PR TITLE
Rename `LinkPaymentDetails.Saved` to `LinkPaymentDetails.Passthrough`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkPaymentDetails.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkPaymentDetails.kt
@@ -18,10 +18,13 @@ internal sealed class LinkPaymentDetails(
 ) : Parcelable {
 
     /**
-     * A [ConsumerPaymentDetails.PaymentDetails] that is already saved to the consumer's account.
+     * A [ConsumerPaymentDetails.PaymentDetails] that is already saved to the Link consumer's account.
+     *
+     * @param paymentMethod The [PaymentMethod] object that represents the Link payment method stored in the user's
+     *   consumer account.
      */
     @Parcelize
-    class Saved(
+    class Passthrough(
         override val paymentDetails: ConsumerPaymentDetails.Passthrough,
         val paymentMethod: PaymentMethod,
     ) : LinkPaymentDetails(paymentDetails)

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
@@ -230,7 +230,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
 
     override suspend fun shareCardPaymentDetails(
         cardPaymentDetails: LinkPaymentDetails.New
-    ): Result<LinkPaymentDetails.Saved> {
+    ): Result<LinkPaymentDetails.Passthrough> {
         return runCatching {
             requireNotNull(linkAccountHolder.linkAccountInfo.value.account)
         }.mapCatching { account ->

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
@@ -122,7 +122,7 @@ internal interface LinkAccountManager {
 
     suspend fun shareCardPaymentDetails(
         cardPaymentDetails: LinkPaymentDetails.New,
-    ): Result<LinkPaymentDetails.Saved>
+    ): Result<LinkPaymentDetails.Passthrough>
 
     suspend fun sharePaymentDetails(
         paymentDetailsId: String,

--- a/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
@@ -121,7 +121,7 @@ internal class DefaultLinkConfirmationHandler @Inject constructor(
                     paymentMethodMetadata = paymentMethodMetadata,
                 )
             }
-            is LinkPaymentDetails.Saved -> {
+            is LinkPaymentDetails.Passthrough -> {
                 savedConfirmationArgs(
                     paymentDetails = paymentDetails,
                     cvc = cvc,
@@ -190,7 +190,7 @@ internal class DefaultLinkConfirmationHandler @Inject constructor(
     }
 
     private fun savedConfirmationArgs(
-        paymentDetails: LinkPaymentDetails.Saved,
+        paymentDetails: LinkPaymentDetails.Passthrough,
         cvc: String?,
         paymentMethodMetadata: PaymentMethodMetadata,
     ): ConfirmationHandler.Args {

--- a/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
@@ -287,7 +287,7 @@ internal class LinkApiRepository @Inject constructor(
         id: String,
         consumerSessionClientSecret: String,
         clientAttributionMetadata: ClientAttributionMetadata,
-    ): Result<LinkPaymentDetails.Saved> = withContext(workContext) {
+    ): Result<LinkPaymentDetails.Passthrough> = withContext(workContext) {
         val allowRedisplay = paymentMethodCreateParams.allowRedisplay?.let {
             mapOf(ALLOW_REDISPLAY_PARAM to it.value)
         } ?: emptyMap()
@@ -307,7 +307,7 @@ internal class LinkApiRepository @Inject constructor(
         ).onFailure {
             errorReporter.report(ErrorReporter.ExpectedErrorEvent.LINK_SHARE_CARD_FAILURE, StripeException.create(it))
         }.map { paymentMethod ->
-            LinkPaymentDetails.Saved(
+            LinkPaymentDetails.Passthrough(
                 paymentDetails = ConsumerPaymentDetails.Passthrough(
                     id = id,
                     last4 = paymentMethodCreateParams.cardLast4().orEmpty(),

--- a/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
@@ -126,7 +126,7 @@ internal interface LinkRepository {
         id: String,
         consumerSessionClientSecret: String,
         clientAttributionMetadata: ClientAttributionMetadata,
-    ): Result<LinkPaymentDetails.Saved>
+    ): Result<LinkPaymentDetails.Passthrough>
 
     suspend fun sharePaymentDetails(
         consumerSessionClientSecret: String,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinition.kt
@@ -133,7 +133,7 @@ internal class LinkInlineSignupConfirmationDefinition(
 
                 linkPaymentDetails.toNewOption(saveOption, configuration, extraParams)
             }
-            is LinkPaymentDetails.Saved -> {
+            is LinkPaymentDetails.Passthrough -> {
                 linkStore.markLinkAsUsed()
 
                 linkPaymentDetails.toSavedOption(saveOption)
@@ -142,7 +142,7 @@ internal class LinkInlineSignupConfirmationDefinition(
         }
     }
 
-    private fun LinkPaymentDetails.Saved.toSavedOption(
+    private fun LinkPaymentDetails.Passthrough.toSavedOption(
         saveOption: LinkInlineSignupConfirmationOption.PaymentMethodSaveOption,
     ): PaymentMethodConfirmationOption.Saved {
         return PaymentMethodConfirmationOption.Saved(

--- a/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
@@ -175,7 +175,7 @@ internal object TestFactory {
         encodedPaymentMethod = "{\"id\": \"pm_123\"}",
     )
 
-    val LINK_SAVED_PAYMENT_DETAILS = LinkPaymentDetails.Saved(
+    val LINK_PASSTHROUGH_PAYMENT_DETAILS = LinkPaymentDetails.Passthrough(
         paymentDetails = CONSUMER_PAYMENT_DETAILS_PASSTHROUGH,
         paymentMethod = PaymentMethod.Builder()
             .setId(CONSUMER_PAYMENT_DETAILS_PASSTHROUGH.paymentMethodId)
@@ -189,7 +189,7 @@ internal object TestFactory {
             .build(),
     )
 
-    val LINK_SAVED_PAYMENT_DETAILS_WITH_BILLING = LinkPaymentDetails.Saved(
+    val LINK_PASSTHROUGH_PAYMENT_DETAILS_WITH_BILLING = LinkPaymentDetails.Passthrough(
         paymentDetails = CONSUMER_PAYMENT_DETAILS_PASSTHROUGH,
         paymentMethod = PaymentMethod.Builder()
             .setId(CONSUMER_PAYMENT_DETAILS_PASSTHROUGH.paymentMethodId)

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAccountManagerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAccountManagerTest.kt
@@ -489,7 +489,7 @@ class DefaultLinkAccountManagerTest {
                 id: String,
                 consumerSessionClientSecret: String,
                 clientAttributionMetadata: ClientAttributionMetadata,
-            ): Result<LinkPaymentDetails.Saved> {
+            ): Result<LinkPaymentDetails.Passthrough> {
                 val paymentDetailsMatch = paymentMethodCreateParams == newPaymentDetails.originalParams &&
                     id == newPaymentDetails.paymentDetails.id
                 if (paymentDetailsMatch && consumerSessionClientSecret == TestFactory.CLIENT_SECRET) {
@@ -516,7 +516,7 @@ class DefaultLinkAccountManagerTest {
         assertThat(result.isSuccess).isTrue()
         val linkPaymentDetails = result.getOrThrow()
         assertThat(linkPaymentDetails.paymentDetails.id)
-            .isEqualTo(TestFactory.LINK_SAVED_PAYMENT_DETAILS.paymentDetails.id)
+            .isEqualTo(TestFactory.LINK_PASSTHROUGH_PAYMENT_DETAILS.paymentDetails.id)
 
         assertThat(linkRepository.shareCardPaymentDetailsCallCount).isEqualTo(1)
         assertThat(accountManager.linkAccountInfo.value.account).isNotNull()

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/FakeLinkAccountManager.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/FakeLinkAccountManager.kt
@@ -89,8 +89,8 @@ internal open class FakeLinkAccountManager(
     var createCardPaymentDetailsResult: Result<LinkPaymentDetails.New> = Result.success(
         value = TestFactory.LINK_NEW_PAYMENT_DETAILS
     )
-    var shareCardPaymentDetailsResult: Result<LinkPaymentDetails.Saved> = Result.success(
-        value = TestFactory.LINK_SAVED_PAYMENT_DETAILS
+    var shareCardPaymentDetailsResult: Result<LinkPaymentDetails.Passthrough> = Result.success(
+        value = TestFactory.LINK_PASSTHROUGH_PAYMENT_DETAILS
     )
     var createBankAccountPaymentDetailsResult: Result<ConsumerPaymentDetails.BankAccount> = Result.success(
         value = TestFactory.CONSUMER_PAYMENT_DETAILS_BANK_ACCOUNT
@@ -208,7 +208,7 @@ internal open class FakeLinkAccountManager(
 
     override suspend fun shareCardPaymentDetails(
         cardPaymentDetails: LinkPaymentDetails.New
-    ): Result<LinkPaymentDetails.Saved> {
+    ): Result<LinkPaymentDetails.Passthrough> {
         return shareCardPaymentDetailsResult
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandlerTest.kt
@@ -255,7 +255,7 @@ internal class DefaultLinkConfirmationHandlerTest {
             )
         )
 
-        val savedPaymentDetails = TestFactory.LINK_SAVED_PAYMENT_DETAILS
+        val savedPaymentDetails = TestFactory.LINK_PASSTHROUGH_PAYMENT_DETAILS
         val result = handler.confirm(
             paymentDetails = savedPaymentDetails,
             linkAccount = TestFactory.LINK_ACCOUNT,
@@ -266,7 +266,7 @@ internal class DefaultLinkConfirmationHandlerTest {
         assertThat(result).isEqualTo(Result.Succeeded)
         confirmationHandler.startTurbine.awaitItem().assertSavedConfirmationArgs(
             configuration = configuration,
-            paymentDetails = TestFactory.LINK_SAVED_PAYMENT_DETAILS,
+            paymentDetails = TestFactory.LINK_PASSTHROUGH_PAYMENT_DETAILS,
             cvc = CVC
         )
     }
@@ -286,7 +286,7 @@ internal class DefaultLinkConfirmationHandlerTest {
             )
         )
 
-        val savedPaymentDetailsWithBilling = TestFactory.LINK_SAVED_PAYMENT_DETAILS_WITH_BILLING
+        val savedPaymentDetailsWithBilling = TestFactory.LINK_PASSTHROUGH_PAYMENT_DETAILS_WITH_BILLING
         val result = handler.confirm(
             paymentDetails = savedPaymentDetailsWithBilling,
             linkAccount = TestFactory.LINK_ACCOUNT,
@@ -318,7 +318,7 @@ internal class DefaultLinkConfirmationHandlerTest {
         )
 
         val result = handler.confirm(
-            paymentDetails = TestFactory.LINK_SAVED_PAYMENT_DETAILS,
+            paymentDetails = TestFactory.LINK_PASSTHROUGH_PAYMENT_DETAILS,
             linkAccount = TestFactory.LINK_ACCOUNT,
             cvc = CVC,
             billingPhone = null
@@ -327,7 +327,7 @@ internal class DefaultLinkConfirmationHandlerTest {
         assertThat(result).isEqualTo(Result.Succeeded)
         confirmationHandler.startTurbine.awaitItem().assertSavedConfirmationArgs(
             configuration = configuration,
-            paymentDetails = TestFactory.LINK_SAVED_PAYMENT_DETAILS,
+            paymentDetails = TestFactory.LINK_PASSTHROUGH_PAYMENT_DETAILS,
             cvc = null
         )
     }
@@ -595,7 +595,7 @@ internal class DefaultLinkConfirmationHandlerTest {
                 )
             )
 
-            val savedPaymentDetails = TestFactory.LINK_SAVED_PAYMENT_DETAILS
+            val savedPaymentDetails = TestFactory.LINK_PASSTHROUGH_PAYMENT_DETAILS
             val result = handler.confirm(
                 paymentDetails = savedPaymentDetails,
                 linkAccount = TestFactory.LINK_ACCOUNT,
@@ -606,7 +606,7 @@ internal class DefaultLinkConfirmationHandlerTest {
             assertThat(result).isEqualTo(Result.Succeeded)
             confirmationHandler.startTurbine.awaitItem().assertSavedConfirmationArgs(
                 configuration = configuration,
-                paymentDetails = TestFactory.LINK_SAVED_PAYMENT_DETAILS,
+                paymentDetails = TestFactory.LINK_PASSTHROUGH_PAYMENT_DETAILS,
                 cvc = CVC,
                 passiveCaptchaParams = null
             )
@@ -639,7 +639,7 @@ internal class DefaultLinkConfirmationHandlerTest {
 
     private fun ConfirmationHandler.Args.assertSavedConfirmationArgs(
         configuration: LinkConfiguration,
-        paymentDetails: LinkPaymentDetails.Saved,
+        paymentDetails: LinkPaymentDetails.Passthrough,
         cvc: String?,
         passiveCaptchaParams: PassiveCaptchaParams? = PASSIVE_CAPTCHA_PARAMS
     ) {

--- a/paymentsheet/src/test/java/com/stripe/android/link/repositories/FakeLinkRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/repositories/FakeLinkRepository.kt
@@ -37,7 +37,7 @@ internal open class FakeLinkRepository : LinkRepository {
     var createLinkAccountSessionResult = Result.success(TestFactory.LINK_ACCOUNT_SESSION)
     var createCardPaymentDetailsResult = Result.success(TestFactory.LINK_NEW_PAYMENT_DETAILS)
     var createBankAccountPaymentDetailsResult = Result.success(TestFactory.CONSUMER_PAYMENT_DETAILS_BANK_ACCOUNT)
-    var shareCardPaymentDetailsResult = Result.success(TestFactory.LINK_SAVED_PAYMENT_DETAILS)
+    var shareCardPaymentDetailsResult = Result.success(TestFactory.LINK_PASSTHROUGH_PAYMENT_DETAILS)
     var sharePaymentDetails = Result.success(TestFactory.LINK_SHARE_PAYMENT_DETAILS)
     var createPaymentMethod = Result.success(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
     var logOutResult = Result.success(TestFactory.CONSUMER_SESSION)
@@ -173,7 +173,7 @@ internal open class FakeLinkRepository : LinkRepository {
         id: String,
         consumerSessionClientSecret: String,
         clientAttributionMetadata: ClientAttributionMetadata,
-    ): Result<LinkPaymentDetails.Saved> = shareCardPaymentDetailsResult
+    ): Result<LinkPaymentDetails.Passthrough> = shareCardPaymentDetailsResult
 
     override suspend fun sharePaymentDetails(
         consumerSessionClientSecret: String,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
@@ -231,7 +231,7 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
     @Test
     fun `'action' should return 'Launch' after successful sign-in & attach`() = test(
         attachNewCardToAccountResult = Result.success(
-            LinkPaymentDetails.Saved(
+            LinkPaymentDetails.Passthrough(
                 paymentDetails = ConsumerPaymentDetails.Passthrough(
                     id = "csmrpd_123",
                     last4 = "4242",
@@ -544,7 +544,7 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
 
         actionTest(
             attachNewCardToAccountResult = Result.success(
-                LinkPaymentDetails.Saved(
+                LinkPaymentDetails.Passthrough(
                     paymentDetails = ConsumerPaymentDetails.Passthrough(
                         id = "csmrpd_123",
                         last4 = "4242",

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -1369,7 +1369,7 @@ internal class PaymentOptionsViewModelTest {
 
     private fun createLinkViewModel(): PaymentOptionsViewModel {
         val linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(
-            attachNewCardToAccountResult = Result.success(LinkTestUtils.LINK_SAVED_PAYMENT_DETAILS),
+            attachNewCardToAccountResult = Result.success(LinkTestUtils.LINK_PASSTHROUGH_PAYMENT_DETAILS),
             accountStatus = AccountStatus.Verified(consentPresentation = null),
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -3615,7 +3615,7 @@ internal class PaymentSheetViewModelTest {
 
     private fun FakeConfirmationHandler.Scenario.createLinkViewModel(): PaymentSheetViewModel {
         val linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(
-            attachNewCardToAccountResult = Result.success(LinkTestUtils.LINK_SAVED_PAYMENT_DETAILS),
+            attachNewCardToAccountResult = Result.success(LinkTestUtils.LINK_PASSTHROUGH_PAYMENT_DETAILS),
             accountStatus = AccountStatus.Verified(consentPresentation = null),
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
@@ -20,7 +20,7 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 
 internal object LinkTestUtils {
-    val LINK_SAVED_PAYMENT_DETAILS = LinkPaymentDetails.Saved(
+    val LINK_PASSTHROUGH_PAYMENT_DETAILS = LinkPaymentDetails.Passthrough(
         paymentDetails = ConsumerPaymentDetails.Passthrough(
             id = "csmrpd_123",
             last4 = "4242",


### PR DESCRIPTION
# Summary
Rename `LinkPaymentDetails.Saved` to `LinkPaymentDetails.Passthrough`

# Motivation
`LinkPaymentDetails.Saved` will now represent payment methods already saved to a Stripe merchant

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified