### PR TITLE
Support saved payment methods with Link Inline Signup

### DIFF
--- a/payments-model/src/main/java/com/stripe/android/repository/ConsumersApiService.kt
+++ b/payments-model/src/main/java/com/stripe/android/repository/ConsumersApiService.kt
@@ -122,6 +122,13 @@ interface ConsumersApiService {
         requestOptions: ApiRequest.Options,
     ): Result<ConsumerPaymentDetails>
 
+    suspend fun createPaymentDetails(
+        consumerSessionClientSecret: String,
+        paymentMethodId: String,
+        requestSurface: String,
+        requestOptions: ApiRequest.Options,
+    ): Result<ConsumerPaymentDetails>
+
     suspend fun sharePaymentDetails(
         consumerSessionClientSecret: String,
         paymentDetailsId: String,
@@ -444,6 +451,30 @@ class ConsumersApiServiceImpl(
         )
     }
 
+    override suspend fun createPaymentDetails(
+        consumerSessionClientSecret: String,
+        paymentMethodId: String,
+        requestSurface: String,
+        requestOptions: ApiRequest.Options
+    ): Result<ConsumerPaymentDetails> {
+        return executeRequestWithResultParser(
+            stripeErrorJsonParser = stripeErrorJsonParser,
+            stripeNetworkClient = stripeNetworkClient,
+            request = apiRequestFactory.createPost(
+                url = createPaymentDetailsFromPaymentMethod,
+                options = requestOptions,
+                params = mapOf(
+                    "request_surface" to requestSurface,
+                    "payment_method_id" to paymentMethodId,
+                    "credentials" to mapOf(
+                        "consumer_session_client_secret" to consumerSessionClientSecret
+                    ),
+                )
+            ),
+            responseJsonParser = ConsumerPaymentDetailsJsonParser,
+        )
+    }
+
     override suspend fun sharePaymentDetails(
         consumerSessionClientSecret: String,
         paymentDetailsId: String,
@@ -603,6 +634,12 @@ class ConsumersApiServiceImpl(
          */
         private val createPaymentDetails: String
             get() = getApiUrl("consumers/payment_details")
+
+        /**
+         * @return `https://api.stripe.com/v1/consumers/payment_details/from_payment_method`
+         */
+        private val createPaymentDetailsFromPaymentMethod: String
+            get() = getApiUrl("consumers/payment_details/from_payment_method")
 
         /**
          * @return `https://api.stripe.com/v1/consumers/link_account_sessions`

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddViewModelComponent.kt
@@ -49,6 +49,7 @@ import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.injection.ConfirmationHandlerModule
 import com.stripe.android.paymentelement.confirmation.injection.DefaultConfirmationModule
 import com.stripe.android.paymentelement.confirmation.intent.DefaultIntentConfirmationModule
+import com.stripe.android.paymentelement.confirmation.linkinline.LinkInlineSignupConfirmationModule
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.analytics.RealErrorReporter
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
@@ -79,6 +80,7 @@ import javax.inject.Singleton
         ConfirmationHandlerModule::class,
         DefaultConfirmationModule::class,
         DefaultIntentConfirmationModule::class,
+        LinkInlineSignupConfirmationModule::class,
         PaymentElementRequestSurfaceModule::class,
         TapToAddViewModelModule::class,
         TapToAddModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkConfigurationCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkConfigurationCoordinator.kt
@@ -6,6 +6,7 @@ import com.stripe.android.link.injection.LinkComponent
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.model.ConsumerSession
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.uicore.utils.flatMapLatestAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
@@ -37,6 +38,11 @@ internal interface LinkConfigurationCoordinator {
         configuration: LinkConfiguration,
         paymentMethodCreateParams: PaymentMethodCreateParams
     ): Result<LinkPaymentDetails>
+
+    suspend fun attachExistingCardToAccount(
+        configuration: LinkConfiguration,
+        paymentMethod: PaymentMethod,
+    ): Result<LinkPaymentDetails.Saved>
 
     suspend fun logOut(
         configuration: LinkConfiguration,
@@ -113,6 +119,14 @@ internal class RealLinkConfigurationCoordinator @Inject internal constructor(
                 linkPaymentDetails
             }
         }
+    }
+
+    override suspend fun attachExistingCardToAccount(
+        configuration: LinkConfiguration,
+        paymentMethod: PaymentMethod
+    ): Result<LinkPaymentDetails.Saved> {
+        val accountManager = getLinkPaymentLauncherComponent(configuration).linkAccountManager
+        return accountManager.createPaymentDetailsFromPaymentMethod(paymentMethod)
     }
 
     override suspend fun logOut(

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkPaymentDetails.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkPaymentDetails.kt
@@ -50,4 +50,16 @@ internal sealed class LinkPaymentDetails(
          */
         fun buildFormValues() = convertToFormValuesMap(originalParams.toParamMap())
     }
+
+    /**
+     * A new [ConsumerPaymentDetails.PaymentDetails], whose data comes from the user's already saved
+     * payment method.
+     *
+     * @param paymentMethod The [PaymentMethod] object that is already saved with a Stripe merchant.
+     */
+    @Parcelize
+    class Saved(
+        override val paymentDetails: ConsumerPaymentDetails.PaymentDetails,
+        val paymentMethod: PaymentMethod,
+    ) : LinkPaymentDetails(paymentDetails)
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
@@ -116,6 +116,10 @@ internal interface LinkAccountManager {
         paymentMethodCreateParams: PaymentMethodCreateParams
     ): Result<LinkPaymentDetails.New>
 
+    suspend fun createPaymentDetailsFromPaymentMethod(
+        paymentMethod: PaymentMethod,
+    ): Result<LinkPaymentDetails.Saved>
+
     suspend fun createBankAccountPaymentDetails(
         bankAccountId: String,
     ): Result<ConsumerPaymentDetails.PaymentDetails>

--- a/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/confirmation/DefaultLinkConfirmationHandler.kt
@@ -123,7 +123,14 @@ internal class DefaultLinkConfirmationHandler @Inject constructor(
             }
             is LinkPaymentDetails.Passthrough -> {
                 savedConfirmationArgs(
-                    paymentDetails = paymentDetails,
+                    paymentMethod = paymentDetails.paymentMethod,
+                    cvc = cvc,
+                    paymentMethodMetadata = paymentMethodMetadata,
+                )
+            }
+            is LinkPaymentDetails.Saved -> {
+                savedConfirmationArgs(
+                    paymentMethod = paymentDetails.paymentMethod,
                     cvc = cvc,
                     paymentMethodMetadata = paymentMethodMetadata,
                 )
@@ -190,13 +197,13 @@ internal class DefaultLinkConfirmationHandler @Inject constructor(
     }
 
     private fun savedConfirmationArgs(
-        paymentDetails: LinkPaymentDetails.Passthrough,
+        paymentMethod: PaymentMethod,
         cvc: String?,
         paymentMethodMetadata: PaymentMethodMetadata,
     ): ConfirmationHandler.Args {
         return ConfirmationHandler.Args(
             confirmationOption = PaymentMethodConfirmationOption.Saved(
-                paymentMethod = paymentDetails.paymentMethod,
+                paymentMethod = paymentMethod,
                 optionsParams = PaymentMethodOptionsParams.Card(
                     setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession,
                     cvc = cvc?.takeIf {

--- a/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
@@ -256,6 +256,26 @@ internal class LinkApiRepository @Inject constructor(
         }
     }
 
+    override suspend fun createPaymentDetailsFromPaymentMethod(
+        paymentMethod: PaymentMethod,
+        userEmail: String,
+        stripeIntent: StripeIntent,
+        consumerSessionClientSecret: String,
+        clientAttributionMetadata: ClientAttributionMetadata
+    ): Result<LinkPaymentDetails.Saved> {
+        return consumersApiService.createPaymentDetails(
+            consumerSessionClientSecret = consumerSessionClientSecret,
+            paymentMethodId = paymentMethod.id,
+            requestSurface = requestSurface.value,
+            requestOptions = apiRequestOptions,
+        ).mapCatching {
+            LinkPaymentDetails.Saved(
+                paymentDetails = it.paymentDetails.first(),
+                paymentMethod = paymentMethod,
+            )
+        }
+    }
+
     override suspend fun createBankAccountPaymentDetails(
         bankAccountId: String,
         userEmail: String,

--- a/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
@@ -114,6 +114,14 @@ internal interface LinkRepository {
         clientAttributionMetadata: ClientAttributionMetadata,
     ): Result<LinkPaymentDetails.New>
 
+    suspend fun createPaymentDetailsFromPaymentMethod(
+        paymentMethod: PaymentMethod,
+        userEmail: String,
+        stripeIntent: StripeIntent,
+        consumerSessionClientSecret: String,
+        clientAttributionMetadata: ClientAttributionMetadata,
+    ): Result<LinkPaymentDetails.Saved>
+
     suspend fun createBankAccountPaymentDetails(
         bankAccountId: String,
         userEmail: String,

--- a/paymentsheet/src/test/java/com/stripe/android/link/FakeConsumersApiService.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/FakeConsumersApiService.kt
@@ -28,12 +28,16 @@ internal open class FakeConsumersApiService : ConsumersApiService {
         consumerSession = TestFactory.CONSUMER_SESSION,
         linkAuthIntent = null
     )
+    var createPaymentDetailsFromPaymentMethodResult = Result.success(
+        ConsumerPaymentDetails(paymentDetails = listOf(TestFactory.CONSUMER_PAYMENT_DETAILS_CARD))
+    )
 
     val signUpCalls = arrayListOf<SignUpCall>()
     val mobileSignUpCalls = arrayListOf<SignUpCall>()
     val lookupCalls = arrayListOf<LookupCall>()
     val mobileLookupCalls = arrayListOf<MobileLookupCall>()
     val sharePaymentDetailsCalls = arrayListOf<SharePaymentDetailsCall>()
+    val createPaymentDetailsFromPaymentMethodCalls = arrayListOf<CreatePaymentDetailsFromPaymentMethodCall>()
 
     override suspend fun signUp(
         params: SignUpParams,
@@ -162,6 +166,23 @@ internal open class FakeConsumersApiService : ConsumersApiService {
         TODO("Not yet implemented")
     }
 
+    override suspend fun createPaymentDetails(
+        consumerSessionClientSecret: String,
+        paymentMethodId: String,
+        requestSurface: String,
+        requestOptions: ApiRequest.Options
+    ): Result<ConsumerPaymentDetails> {
+        createPaymentDetailsFromPaymentMethodCalls.add(
+            CreatePaymentDetailsFromPaymentMethodCall(
+                consumerSessionClientSecret = consumerSessionClientSecret,
+                paymentMethodId = paymentMethodId,
+                requestSurface = requestSurface,
+                requestOptions = requestOptions,
+            )
+        )
+        return createPaymentDetailsFromPaymentMethodResult
+    }
+
     override suspend fun sharePaymentDetails(
         consumerSessionClientSecret: String,
         paymentDetailsId: String,
@@ -238,5 +259,12 @@ internal open class FakeConsumersApiService : ConsumersApiService {
 
     data class SharePaymentDetailsCall(
         val extraParams: Map<String, Any?>,
+    )
+
+    data class CreatePaymentDetailsFromPaymentMethodCall(
+        val consumerSessionClientSecret: String,
+        val paymentMethodId: String,
+        val requestSurface: String,
+        val requestOptions: ApiRequest.Options,
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkConfigurationCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkConfigurationCoordinatorTest.kt
@@ -1,11 +1,19 @@
 package com.stripe.android.link
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.isInstanceOf
 import com.stripe.android.link.account.FakeLinkAccountManager
+import com.stripe.android.link.account.LinkAccountManager
+import com.stripe.android.link.attestation.FakeLinkAttestationCheck
+import com.stripe.android.link.attestation.LinkAttestationCheck
+import com.stripe.android.link.gate.FakeLinkGate
+import com.stripe.android.link.gate.LinkGate
 import com.stripe.android.link.injection.LinkComponent
+import com.stripe.android.link.injection.LinkInlineSignupAssistedViewModelFactory
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.link.utils.FakeAndroidKeyStore
+import com.stripe.android.testing.PaymentMethodFactory
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -57,6 +65,67 @@ class LinkConfigurationCoordinatorTest {
                 configuration = TestFactory.LINK_CONFIGURATION.copy(merchantName = "anotherName")
             )
         ).isNotEqualTo(component)
+    }
+
+    @Test
+    fun `attachExistingCardToAccount delegates to LinkAccountManager and returns Saved result`() = runTest {
+        val paymentMethod = PaymentMethodFactory.card(random = true)
+        val accountManager = FakeLinkAccountManager().apply {
+            createPaymentDetailsFromPaymentMethodResult = Result.success(
+                LinkPaymentDetails.Saved(
+                    paymentDetails = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD,
+                    paymentMethod = paymentMethod,
+                )
+            )
+        }
+        val coordinator = RealLinkConfigurationCoordinator(
+            linkComponentFactory = FakeLinkComponent.Factory(
+                linkAccountManager = accountManager,
+            )
+        )
+
+        val result = coordinator.attachExistingCardToAccount(
+            configuration = TestFactory.LINK_CONFIGURATION,
+            paymentMethod = paymentMethod,
+        )
+
+        assertThat(result.isSuccess).isTrue()
+        assertThat(result.getOrNull()).isInstanceOf<LinkPaymentDetails.Saved>()
+
+        val linkPaymentDetails = result.getOrNull() as LinkPaymentDetails.Saved
+
+        assertThat(linkPaymentDetails.paymentMethod).isEqualTo(paymentMethod)
+        assertThat(linkPaymentDetails.paymentDetails).isEqualTo(TestFactory.CONSUMER_PAYMENT_DETAILS_CARD)
+
+        assertThat(accountManager.awaitCreatePaymentDetailsFromPaymentMethodTurbineCall())
+            .isEqualTo(paymentMethod)
+
+        accountManager.ensureAllEventsConsumed()
+    }
+
+    private class FakeLinkComponent private constructor(
+        override val linkAccountManager: LinkAccountManager,
+        override val configuration: LinkConfiguration,
+        override val linkGate: LinkGate,
+        override val linkAttestationCheck: LinkAttestationCheck,
+        override val inlineSignupViewModelFactory: LinkInlineSignupAssistedViewModelFactory,
+    ) : LinkComponent() {
+        class Factory(
+            private val linkAccountManager: LinkAccountManager = FakeLinkAccountManager(),
+            private val linkGate: LinkGate = FakeLinkGate(),
+            private val linkAttestationCheck: LinkAttestationCheck = FakeLinkAttestationCheck(),
+            private val inlineSignupViewModelFactory: LinkInlineSignupAssistedViewModelFactory = mock()
+        ) : LinkComponent.Factory {
+            override fun create(configuration: LinkConfiguration): LinkComponent {
+                return FakeLinkComponent(
+                    linkAccountManager = linkAccountManager,
+                    configuration = configuration,
+                    linkGate = linkGate,
+                    linkAttestationCheck = linkAttestationCheck,
+                    inlineSignupViewModelFactory = inlineSignupViewModelFactory,
+                )
+            }
+        }
     }
 
     companion object {

--- a/paymentsheet/src/test/java/com/stripe/android/link/repositories/FakeLinkRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/repositories/FakeLinkRepository.kt
@@ -17,6 +17,7 @@ import com.stripe.android.model.EmailSource
 import com.stripe.android.model.IncentiveEligibilitySession
 import com.stripe.android.model.LinkAccountSession
 import com.stripe.android.model.LinkMode
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.SharePaymentDetails
@@ -36,6 +37,12 @@ internal open class FakeLinkRepository : LinkRepository {
     var mobileConsumerSignUpResult = Result.success(TestFactory.CONSUMER_SESSION_SIGN_UP)
     var createLinkAccountSessionResult = Result.success(TestFactory.LINK_ACCOUNT_SESSION)
     var createCardPaymentDetailsResult = Result.success(TestFactory.LINK_NEW_PAYMENT_DETAILS)
+    var createPaymentDetailsFromPaymentMethodResult = Result.success(
+        LinkPaymentDetails.Saved(
+            paymentDetails = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD,
+            paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+        )
+    )
     var createBankAccountPaymentDetailsResult = Result.success(TestFactory.CONSUMER_PAYMENT_DETAILS_BANK_ACCOUNT)
     var shareCardPaymentDetailsResult = Result.success(TestFactory.LINK_PASSTHROUGH_PAYMENT_DETAILS)
     var sharePaymentDetails = Result.success(TestFactory.LINK_SHARE_PAYMENT_DETAILS)
@@ -160,6 +167,14 @@ internal open class FakeLinkRepository : LinkRepository {
         consumerSessionClientSecret: String,
         clientAttributionMetadata: ClientAttributionMetadata,
     ) = createCardPaymentDetailsResult
+
+    override suspend fun createPaymentDetailsFromPaymentMethod(
+        paymentMethod: PaymentMethod,
+        userEmail: String,
+        stripeIntent: StripeIntent,
+        consumerSessionClientSecret: String,
+        clientAttributionMetadata: ClientAttributionMetadata,
+    ): Result<LinkPaymentDetails.Saved> = createPaymentDetailsFromPaymentMethodResult
 
     override suspend fun createBankAccountPaymentDetails(
         bankAccountId: String,

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElementTest.kt
@@ -30,6 +30,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentB
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardFundingFilter
 import com.stripe.android.model.ConsumerSession
 import com.stripe.android.model.LinkMode
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -225,6 +226,13 @@ class LinkFormElementTest {
             configuration: LinkConfiguration,
             paymentMethodCreateParams: PaymentMethodCreateParams
         ): Result<LinkPaymentDetails> {
+            error("Not implemented!")
+        }
+
+        override suspend fun attachExistingCardToAccount(
+            configuration: LinkConfiguration,
+            paymentMethod: PaymentMethod
+        ): Result<LinkPaymentDetails.Saved> {
             error("Not implemented!")
         }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
@@ -364,11 +364,17 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
     }
 
     @Test
-    fun `'action' with saved link option returns immediately with saved payment option`() =
+    fun `'action' with saved link option calls attachExistingCardToAccount and returns saved payment option`() =
         test(
+            attachExistingCardToAccountResult = Result.success(
+                LinkPaymentDetails.Saved(
+                    paymentDetails = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD,
+                    paymentMethod = PaymentMethodFactory.card(),
+                )
+            ),
             initialAccountStatus = AccountStatus.Verified(consentPresentation = null),
         ) {
-            val savedOption = createLinkInlineSignupConfirmationOptionSaved()
+            val savedOption = createSavedLinkInlineSignupConfirmationOption()
 
             val action = definition.action(
                 confirmationOption = savedOption,
@@ -377,6 +383,10 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
 
             val getAccountStatusFlowCall = coordinatorScenario.getAccountStatusFlowCalls.awaitItem()
             assertThat(getAccountStatusFlowCall.configuration).isEqualTo(savedOption.linkConfiguration)
+
+            val attachExistingCardCall = coordinatorScenario.attachExistingCardToAccountCalls.awaitItem()
+            assertThat(attachExistingCardCall.configuration).isEqualTo(savedOption.linkConfiguration)
+            assertThat(attachExistingCardCall.paymentMethod).isEqualTo(savedOption.paymentMethod)
 
             assertThat(action).isInstanceOf<ConfirmationDefinition.Action.Launch<Unit>>()
             val launchAction = action.asLaunch()
@@ -387,7 +397,37 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
             assertThat(savedConfirmationOption.paymentMethod).isEqualTo(savedOption.paymentMethod)
             assertThat(savedConfirmationOption.optionsParams).isEqualTo(savedOption.optionsParams)
 
+            assertThat(storeScenario.markAsUsedCalls.awaitItem()).isNotNull()
+
             coordinatorScenario.attachNewCardToAccountCalls.expectNoEvents()
+        }
+
+    @Test
+    fun `'action' with saved link option returns original option when attachExistingCardToAccount fails`() =
+        test(
+            attachExistingCardToAccountResult = Result.failure(IllegalStateException("API error")),
+            initialAccountStatus = AccountStatus.Verified(consentPresentation = null),
+        ) {
+            val savedOption = createSavedLinkInlineSignupConfirmationOption()
+
+            val action = definition.action(
+                confirmationOption = savedOption,
+                confirmationArgs = CONFIRMATION_PARAMETERS,
+            )
+
+            assertThat(coordinatorScenario.getAccountStatusFlowCalls.awaitItem()).isNotNull()
+
+            val attachExistingCardCall = coordinatorScenario.attachExistingCardToAccountCalls.awaitItem()
+            assertThat(attachExistingCardCall.paymentMethod).isEqualTo(savedOption.paymentMethod)
+
+            assertThat(action).isInstanceOf<ConfirmationDefinition.Action.Launch<Unit>>()
+
+            val launchAction = action.asLaunch()
+            val nextConfirmationOption = launchAction.launcherArguments.nextConfirmationOption
+
+            assertThat(nextConfirmationOption).isInstanceOf<PaymentMethodConfirmationOption.Saved>()
+            assertThat(nextConfirmationOption.asSaved().paymentMethod).isEqualTo(savedOption.paymentMethod)
+            assertThat(nextConfirmationOption.asSaved().optionsParams).isEqualTo(savedOption.optionsParams)
         }
 
     private fun testSkippedLinkSignupOnSignInError(
@@ -643,29 +683,15 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
     private fun test(
         attachNewCardToAccountResult: Result<LinkPaymentDetails> = Result.success(
             LinkPaymentDetails.New(
-                paymentDetails = ConsumerPaymentDetails.Card(
-                    id = "pm_123",
-                    last4 = "4242",
-                    expiryYear = 2024,
-                    expiryMonth = 4,
-                    brand = CardBrand.DinersClub,
-                    cvcCheck = CvcCheck.Fail,
-                    isDefault = false,
-                    networks = emptyList(),
-                    funding = ConsumerPaymentDetails.Card.Funding.Credit,
-                    nickname = null,
-                    billingAddress = ConsumerPaymentDetails.BillingAddress(
-                        name = null,
-                        line1 = null,
-                        line2 = null,
-                        locality = null,
-                        administrativeArea = null,
-                        countryCode = CountryCode.US,
-                        postalCode = "42424"
-                    )
-                ),
+                paymentDetails = DEFAULT_CONSUMER_CARD,
                 confirmParams = mock(),
                 originalParams = mock(),
+            )
+        ),
+        attachExistingCardToAccountResult: Result<LinkPaymentDetails.Saved> = Result.success(
+            LinkPaymentDetails.Saved(
+                paymentDetails = DEFAULT_CONSUMER_CARD,
+                paymentMethod = PaymentMethodFactory.card(),
             )
         ),
         signInResult: Result<Boolean> = Result.success(true),
@@ -676,6 +702,7 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
     ) = runTest {
         RecordingLinkConfigurationCoordinator.test(
             attachNewCardToAccountResult = attachNewCardToAccountResult,
+            attachExistingCardToAccountResult = attachExistingCardToAccountResult,
             signInResult = signInResult,
             initialAccountStatus = initialAccountStatus,
             accountStatusOnSignIn = accountStatusOnSignIn,
@@ -785,10 +812,16 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
         )
     }
 
-    private fun createLinkInlineSignupConfirmationOptionSaved(
+    private fun createSavedLinkInlineSignupConfirmationOption(
         paymentMethod: PaymentMethod = PaymentMethodFactory.card(),
         optionsParams: PaymentMethodOptionsParams? = null,
-        userInput: UserInput = UserInput.SignIn(email = "saved@test.com"),
+        userInput: UserInput = UserInput.SignUp(
+            email = "email@email.com",
+            phone = "1234567890",
+            country = "CA",
+            name = "John Doe",
+            consentAction = SignUpConsentAction.Checkbox,
+        ),
     ): LinkInlineSignupConfirmationOption.Saved {
         return LinkInlineSignupConfirmationOption.Saved(
             paymentMethod = paymentMethod,
@@ -868,6 +901,7 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
 
     private class RecordingLinkConfigurationCoordinator private constructor(
         private val attachNewCardToAccountResult: Result<LinkPaymentDetails>,
+        private val attachExistingCardToAccountResult: Result<LinkPaymentDetails.Saved>,
         private val signInResult: Result<Boolean>,
         initialAccountStatus: AccountStatus,
         private val accountStatusOnSignIn: AccountStatus,
@@ -875,6 +909,7 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
         private val getAccountStatusFlowCalls = Turbine<GetAccountStatusFlowCall>()
         private val signInCalls = Turbine<SignInCall>()
         private val attachNewCardToAccountCalls = Turbine<AttachNewCardToAccountCall>()
+        private val attachExistingCardToAccountCalls = Turbine<AttachExistingCardToAccountCall>()
 
         private val accountStatusFlow = MutableStateFlow(initialAccountStatus)
 
@@ -921,6 +956,15 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
             return attachNewCardToAccountResult
         }
 
+        override suspend fun attachExistingCardToAccount(
+            configuration: LinkConfiguration,
+            paymentMethod: PaymentMethod,
+        ): Result<LinkPaymentDetails.Saved> {
+            attachExistingCardToAccountCalls.add(AttachExistingCardToAccountCall(configuration, paymentMethod))
+
+            return attachExistingCardToAccountResult
+        }
+
         override suspend fun logOut(configuration: LinkConfiguration): Result<ConsumerSession> {
             throw NotImplementedError()
         }
@@ -939,16 +983,23 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
             val paymentMethodCreateParams: PaymentMethodCreateParams,
         )
 
+        data class AttachExistingCardToAccountCall(
+            val configuration: LinkConfiguration,
+            val paymentMethod: PaymentMethod,
+        )
+
         class Scenario(
             val coordinator: LinkConfigurationCoordinator,
             val getAccountStatusFlowCalls: ReceiveTurbine<GetAccountStatusFlowCall>,
             val signInCalls: ReceiveTurbine<SignInCall>,
             val attachNewCardToAccountCalls: ReceiveTurbine<AttachNewCardToAccountCall>,
+            val attachExistingCardToAccountCalls: ReceiveTurbine<AttachExistingCardToAccountCall>,
         )
 
         companion object {
             suspend fun test(
                 attachNewCardToAccountResult: Result<LinkPaymentDetails>,
+                attachExistingCardToAccountResult: Result<LinkPaymentDetails.Saved>,
                 signInResult: Result<Boolean>,
                 initialAccountStatus: AccountStatus,
                 accountStatusOnSignIn: AccountStatus,
@@ -956,6 +1007,7 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
             ) {
                 val coordinator = RecordingLinkConfigurationCoordinator(
                     attachNewCardToAccountResult = attachNewCardToAccountResult,
+                    attachExistingCardToAccountResult = attachExistingCardToAccountResult,
                     signInResult = signInResult,
                     initialAccountStatus = initialAccountStatus,
                     accountStatusOnSignIn = accountStatusOnSignIn,
@@ -966,14 +1018,40 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
                         coordinator = coordinator,
                         getAccountStatusFlowCalls = coordinator.getAccountStatusFlowCalls,
                         signInCalls = coordinator.signInCalls,
-                        attachNewCardToAccountCalls = coordinator.attachNewCardToAccountCalls
+                        attachNewCardToAccountCalls = coordinator.attachNewCardToAccountCalls,
+                        attachExistingCardToAccountCalls = coordinator.attachExistingCardToAccountCalls,
                     )
                 )
 
                 coordinator.getAccountStatusFlowCalls.ensureAllEventsConsumed()
                 coordinator.signInCalls.ensureAllEventsConsumed()
                 coordinator.attachNewCardToAccountCalls.ensureAllEventsConsumed()
+                coordinator.attachExistingCardToAccountCalls.ensureAllEventsConsumed()
             }
         }
+    }
+
+    private companion object {
+        private val DEFAULT_CONSUMER_CARD = ConsumerPaymentDetails.Card(
+            id = "pm_123",
+            last4 = "4242",
+            expiryYear = 2024,
+            expiryMonth = 4,
+            brand = CardBrand.DinersClub,
+            cvcCheck = CvcCheck.Fail,
+            isDefault = false,
+            networks = emptyList(),
+            funding = ConsumerPaymentDetails.Card.Funding.Credit,
+            nickname = null,
+            billingAddress = ConsumerPaymentDetails.BillingAddress(
+                name = null,
+                line1 = null,
+                line2 = null,
+                locality = null,
+                administrativeArea = null,
+                countryCode = CountryCode.US,
+                postalCode = "42424"
+            )
+        )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeLinkConfigurationCoordinator.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeLinkConfigurationCoordinator.kt
@@ -15,7 +15,9 @@ import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.ConsumerSession
 import com.stripe.android.model.CvcCheck
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
@@ -23,6 +25,25 @@ import kotlinx.coroutines.flow.flowOf
 import org.mockito.kotlin.mock
 
 internal class FakeLinkConfigurationCoordinator(
+    private val attachExistingCardToAccountResult: Result<LinkPaymentDetails.Saved> = Result.success(
+        LinkPaymentDetails.Saved(
+            paymentDetails = ConsumerPaymentDetails.Card(
+                id = "csmrpd_saved",
+                last4 = "4242",
+                isDefault = false,
+                nickname = null,
+                billingAddress = null,
+                billingEmailAddress = null,
+                expiryYear = 2024,
+                expiryMonth = 4,
+                brand = CardBrand.Visa,
+                networks = emptyList(),
+                cvcCheck = CvcCheck.Pass,
+                funding = ConsumerPaymentDetails.Card.Funding.Credit,
+            ),
+            paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+        )
+    ),
     private val attachNewCardToAccountResult: Result<LinkPaymentDetails> = Result.success(
         LinkPaymentDetails.New(
             paymentDetails = ConsumerPaymentDetails.Card(
@@ -85,6 +106,13 @@ internal class FakeLinkConfigurationCoordinator(
         paymentMethodCreateParams: PaymentMethodCreateParams
     ): Result<LinkPaymentDetails> {
         return attachNewCardToAccountResult
+    }
+
+    override suspend fun attachExistingCardToAccount(
+        configuration: LinkConfiguration,
+        paymentMethod: PaymentMethod
+    ): Result<LinkPaymentDetails.Saved> {
+        return attachExistingCardToAccountResult
     }
 
     override suspend fun logOut(configuration: LinkConfiguration): Result<ConsumerSession> {


### PR DESCRIPTION
# Summary
Support saved payment methods with Link Inline Signup

# Motivation
Allows Tap to Add users to sign up with Link

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Video
https://github.com/user-attachments/assets/26508c42-c756-474e-9802-c3d493483a01