### PR TITLE
Fix flaky PaparazziSampleScreenshotTest by adding tolerance

### DIFF
--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/screenshottests/FinancialConnectionsShotShowkaseScreenshotTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/screenshottests/FinancialConnectionsShotShowkaseScreenshotTest.kt
@@ -54,6 +54,7 @@ class PaparazziSampleScreenshotTest {
 
     @get:Rule
     val paparazzi = Paparazzi(
+        maxPercentDifference = 0.001,
         // Needed to shrink the screenshot to the height of the composable
         renderingMode = SessionParams.RenderingMode.SHRINK,
     )


### PR DESCRIPTION
## Summary
Fixes flakiness in `PaparazziSampleScreenshotTest` by adding `maxPercentDifference = 0.001` tolerance.

## Problem
The test was using exact pixel matching (default `maxPercentDifference = 0.0`), making it flaky in CI because:
- Font rendering varies slightly between different machines/CI environments
- Anti-aliasing produces minor pixel value differences
- Without tolerance, any tiny difference causes test failure

## Solution
Set `maxPercentDifference = 0.001` (0.1% tolerance), which is the standard configuration used by all other Paparazzi tests in the codebase (see `screenshot-testing/src/main/java/com/stripe/android/screenshottesting/PaparazziRule.kt:156`). This allows for minor rendering variations while still catching real visual regressions.

## Test plan
- [x] Run the test locally
- [ ] CI should pass consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)