### PR TITLE
Fix flaky FinancialConnectionsSheetLiteActivityTest

### DIFF
--- a/financial-connections-lite/src/test/java/com/stripe/android/financialconnections/lite/FinancialConnectionsSheetLiteActivityTest.kt
+++ b/financial-connections-lite/src/test/java/com/stripe/android/financialconnections/lite/FinancialConnectionsSheetLiteActivityTest.kt
@@ -5,11 +5,14 @@ import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
 internal class FinancialConnectionsSheetLiteActivityTest {
 
@@ -21,6 +24,8 @@ internal class FinancialConnectionsSheetLiteActivityTest {
                 FinancialConnectionsSheetLiteActivity::class.java
             )
         ).use { scenario ->
+            advanceUntilIdle()
+
             // Activity should finish gracefully without crashing
             assertThat(scenario.state).isEqualTo(Lifecycle.State.DESTROYED)
         }


### PR DESCRIPTION
## Summary
Fixes flakiness in `FinancialConnectionsSheetLiteActivityTest` by adding `advanceUntilIdle()` to ensure coroutines complete before assertions.

## Problem
The test was checking the activity state immediately after launch without waiting for all coroutines to complete. The activity:
- Launches a coroutine in `onCreate()` (line 68-76 in the activity)
- Calls `finish()` when args are missing (line 54)
- The finish operation and any pending coroutines might not complete before the state check

## Solution
Call `advanceUntilIdle()` to advance the test's coroutine dispatcher and ensure all pending coroutines complete before checking the state. This is the same pattern used in other similar tests throughout the codebase (e.g., `IntentConfirmationChallengeActivityTest`, `PassiveChallengeActivityTest`, `AttestationActivityTest`).

## Test plan
- [x] Run the test locally
- [ ] CI should pass consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)