### PR TITLE
Fix flaky StripeComponentControllerTest with executePendingTransactions

### DIFF
--- a/connect/src/test/java/com/stripe/android/connect/StripeComponentControllerTest.kt
+++ b/connect/src/test/java/com/stripe/android/connect/StripeComponentControllerTest.kt
@@ -35,14 +35,17 @@ class StripeComponentControllerTest {
 
     @Test
     fun `show and dismiss shows and dismisses the dialog fragment respectively`() {
-        val controller = activityController.create().start().resume().get().controller
+        val activity = activityController.create().start().resume().get()
+        val controller = activity.controller
         assertThat(controller.dialogFragment.isAdded).isFalse()
 
         controller.show()
+        activity.supportFragmentManager.executePendingTransactions()
         awaitMainLooper()
         assertThat(controller.dialogFragment.isAdded).isTrue()
 
         controller.dismiss()
+        activity.supportFragmentManager.executePendingTransactions()
         awaitMainLooper()
         assertThat(controller.dialogFragment.isAdded).isFalse()
     }
@@ -55,6 +58,7 @@ class StripeComponentControllerTest {
         val controller = TestComponentController(activity, activity.embeddedComponentManager)
         val dialogFragment = controller.dialogFragment
         controller.show()
+        activity.supportFragmentManager.executePendingTransactions()
         awaitMainLooper()
 
         // Second controller should obtain the DF that was added.
@@ -67,6 +71,7 @@ class StripeComponentControllerTest {
         // Show the DF
         val firstActivity = activityController.create().start().resume().get()
         firstActivity.controller.show()
+        firstActivity.supportFragmentManager.executePendingTransactions()
         awaitMainLooper()
         val firstDialogFragment = firstActivity.controller.dialogFragment
 


### PR DESCRIPTION
## Summary
Fixes flakiness in `StripeComponentControllerTest` by adding `executePendingTransactions()` to ensure fragment transactions complete before assertions.

## Problem
Fragment transactions in Robolectric are asynchronous - when you call `show()` or `dismiss()` on a DialogFragment, the transaction is posted to the message queue but not immediately executed. Using only `ShadowLooper.shadowMainLooper().idle()` doesn't guarantee the fragment transactions have completed, causing race conditions where:
- `isAdded` is checked before the fragment is actually added
- Fragment state is checked before transactions complete

## Solution
Call `supportFragmentManager.executePendingTransactions()` immediately after `show()` and `dismiss()` operations. This forces Android to execute all pending fragment transactions synchronously before proceeding, ensuring the fragment state is updated before assertions run.

This is a standard pattern for testing fragments in Robolectric environments where you need deterministic execution of fragment lifecycle operations.

## Test plan
- [x] Run the tests locally
- [ ] CI should pass consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)