### PR TITLE
Fix flaky PaymentMethodMessagingContentTest by removing duplicate compose rule

### DIFF
--- a/payment-method-messaging/src/test/java/com/stripe/android/paymentmethodmessaging/element/PaymentMethodMessagingContentTest.kt
+++ b/payment-method-messaging/src/test/java/com/stripe/android/paymentmethodmessaging/element/PaymentMethodMessagingContentTest.kt
@@ -33,9 +33,6 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 internal class PaymentMethodMessagingContentTest {
     @get:Rule
-    val composeRule = createComposeRule()
-
-    @get:Rule
     val composeCleanupRule = createComposeCleanupRule()
 
     private val testDispatcher = UnconfinedTestDispatcher()
@@ -64,12 +61,12 @@ internal class PaymentMethodMessagingContentTest {
             val content = awaitItem()
             assertThat(content).isNotNull()
 
-            composeRule.setContent {
+            composeTestRule.setContent {
                 content?.Content(PaymentMethodMessagingElement.Appearance().build())
             }
 
-            composeRule.waitForIdle()
-            composeRule.onNodeWithText(text = "buy stuff", substring = true).performClick()
+            composeTestRule.waitForIdle()
+            composeTestRule.onNodeWithText(text = "buy stuff", substring = true).performClick()
 
             intended(
                 allOf(


### PR DESCRIPTION
## Summary
Fixes flakiness in `PaymentMethodMessagingContentTest` by removing the duplicate `composeRule` and using only `composeTestRule` consistently.

## Problem
The test had two Compose rules:
1. `composeRule` (line 36) - a plain compose rule without an activity
2. `composeTestRule` (line 50) - an Android compose rule that creates a `LearnMoreActivity`

The test was using `composeTestRule` to set up the activity for `IntentsRule`, but then using `composeRule` to set content and interact with UI. This created race conditions because:
- The two rules have separate compose environments
- The activity from `composeTestRule` might not be fully synchronized with the plain `composeRule`
- Intent interception requires the activity context, but the UI interactions were on a different compose instance

## Solution
Use only `composeTestRule` consistently throughout the test. This ensures all compose operations happen in the same activity context that `IntentsRule` monitors.

## Test plan
- [x] Run the test locally
- [ ] CI should pass consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)