### PR TITLE
Fix Link form disabled after Tap to Add confirmation failed or canceled

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddConfirmationInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddConfirmationInteractor.kt
@@ -219,9 +219,17 @@ internal class DefaultTapToAddConfirmationInteractor(
             }
         }
 
+        val formEnabled = when (confirmationState) {
+            is ConfirmationHandler.State.Complete -> {
+                confirmationState.result !is ConfirmationHandler.Result.Succeeded
+            }
+            is ConfirmationHandler.State.Confirming -> false
+            is ConfirmationHandler.State.Idle -> true
+        }
+
         return copy(
             form = form.copy(
-                enabled = confirmationState is ConfirmationHandler.State.Idle,
+                enabled = formEnabled,
             ),
             primaryButton = primaryButton.copy(
                 state = primaryButtonState,


### PR DESCRIPTION
# Summary
Fix Link form disabled after Tap to Add confirmation failed or canceled

# Motivation
Ensure Link form can be updated after TTA failure or cancelation.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified