### PR TITLE
Remove wallet type from `PaymentSelection`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -498,7 +498,6 @@ internal class PaymentSheetViewModel @Inject internal constructor(
             updateSelection(
                 selection = PaymentSelection.Saved(
                     paymentMethod = it.paymentMethod,
-                    walletType = it.walletType,
                     paymentMethodOptionsParams = paymentMethodOptionsParams
                 )
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -240,17 +240,12 @@ internal class DefaultEventReporter @Inject internal constructor(
         deferredIntentConfirmationType: DeferredIntentConfirmationType?,
         intentId: String?,
     ) {
-        // Wallets are treated as a saved payment method after confirmation, so we need
-        // to "reset" to the correct PaymentSelection for accurate reporting.
-        val savedSelection = (paymentSelection as? PaymentSelection.Saved)
-
-        val realSelection = savedSelection?.walletType?.paymentSelection ?: paymentSelection
         val duration = durationProvider.end(DurationProvider.Key.Checkout)
 
         fireEvent(
             PaymentSheetEvent.Payment(
                 mode = mode,
-                paymentSelection = realSelection,
+                paymentSelection = paymentSelection,
                 duration = duration,
                 result = PaymentSheetEvent.Payment.Result.Success,
                 deferredIntentConfirmationType = deferredIntentConfirmationType,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -159,15 +159,9 @@ internal sealed class PaymentSelection : Parcelable {
     @Parcelize
     data class Saved(
         val paymentMethod: PaymentMethod,
-        val walletType: WalletType? = null,
         val paymentMethodOptionsParams: PaymentMethodOptionsParams? = null,
         val linkInput: UserInput? = null,
     ) : PaymentSelection() {
-
-        enum class WalletType(val paymentSelection: PaymentSelection) {
-            GooglePay(PaymentSelection.GooglePay), Link(Link())
-        }
-
         val showMandateAbovePrimaryButton: Boolean
             get() {
                 return paymentMethod.type == PaymentMethod.Type.SepaDebit
@@ -353,7 +347,7 @@ internal val PaymentSelection.isLink: Boolean
         is PaymentSelection.Link -> true
         is PaymentSelection.New.Card -> linkInput != null
         is PaymentSelection.New -> false
-        is PaymentSelection.Saved -> walletType == PaymentSelection.Saved.WalletType.Link
+        is PaymentSelection.Saved -> linkInput != null
         is PaymentSelection.CustomPaymentMethod,
         is PaymentSelection.ExternalPaymentMethod -> false
         is PaymentSelection.ShopPay -> false
@@ -396,16 +390,7 @@ private fun getSavedIcon(selection: PaymentSelection.Saved): Int {
         return R.drawable.stripe_ic_paymentsheet_link_arrow
     }
 
-    return when (val resourceId = selection.paymentMethod.getSavedPaymentMethodIcon(forPaymentOption = true)) {
-        R.drawable.stripe_ic_paymentsheet_card_unknown_ref -> {
-            when (selection.walletType) {
-                PaymentSelection.Saved.WalletType.Link -> getLinkIcon(iconOnly = true)
-                PaymentSelection.Saved.WalletType.GooglePay -> R.drawable.stripe_google_pay_mark
-                else -> resourceId
-            }
-        }
-        else -> resourceId
-    }
+    return selection.paymentMethod.getSavedPaymentMethodIcon(forPaymentOption = true)
 }
 
 internal val PaymentSelection.lightThemeIconUrl: String?
@@ -448,13 +433,7 @@ internal val PaymentSelection.label: ResolvableString
     }
 
 private fun getSavedLabel(selection: PaymentSelection.Saved): ResolvableString? {
-    return selection.paymentMethod.getLabel(canShowSublabel = true) ?: run {
-        when (selection.walletType) {
-            PaymentSelection.Saved.WalletType.Link -> StripeR.string.stripe_link.resolvableString
-            PaymentSelection.Saved.WalletType.GooglePay -> StripeR.string.stripe_google_pay.resolvableString
-            else -> null
-        }
-    }
+    return selection.paymentMethod.getLabel(canShowSublabel = true)
 }
 
 internal val PaymentSelection.paymentMethodType: String

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentOptionFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentOptionFactoryTest.kt
@@ -74,76 +74,6 @@ class PaymentOptionFactoryTest {
     }
 
     @Test
-    fun `create() with saved card params with known brand from wallet should return expected object`() {
-        val paymentOption = factory.create(
-            PaymentSelection.Saved(
-                paymentMethod = card(CardBrand.Visa),
-                walletType = PaymentSelection.Saved.WalletType.GooglePay
-            )
-        )
-        assertThat(paymentOption.drawableResourceId).isEqualTo(R.drawable.stripe_ic_paymentsheet_card_visa_ref)
-        assertThat(paymentOption.label).isEqualTo("···· 4242")
-        assertThat(paymentOption.paymentMethodType).isEqualTo("card")
-        assertThat(paymentOption.billingDetails).isNull()
-    }
-
-    @Test
-    fun `create() with saved card params with unknown brand from Link wallet should return expected object`() {
-        val paymentOption = factory.create(
-            PaymentSelection.Saved(
-                paymentMethod = card(),
-                walletType = PaymentSelection.Saved.WalletType.Link
-            )
-        )
-        assertThat(paymentOption.drawableResourceId).isEqualTo(R.drawable.stripe_ic_paymentsheet_link_arrow)
-        assertThat(paymentOption.label).isEqualTo("···· 4242")
-        assertThat(paymentOption.paymentMethodType).isEqualTo("card")
-        assertThat(paymentOption.billingDetails).isNull()
-    }
-
-    @Test
-    fun `create() with saved card params without last 4 digits from Link wallet should return expected object`() {
-        val paymentOption = factory.create(
-            PaymentSelection.Saved(
-                paymentMethod = card(last4 = null),
-                walletType = PaymentSelection.Saved.WalletType.Link
-            )
-        )
-        assertThat(paymentOption.drawableResourceId).isEqualTo(R.drawable.stripe_ic_paymentsheet_link_arrow)
-        assertThat(paymentOption.label).isEqualTo("Link")
-        assertThat(paymentOption.paymentMethodType).isEqualTo("card")
-        assertThat(paymentOption.billingDetails).isNull()
-    }
-
-    @Test
-    fun `create() with saved card params with unknown brand from Google wallet should return expected object`() {
-        val paymentOption = factory.create(
-            PaymentSelection.Saved(
-                paymentMethod = card(),
-                walletType = PaymentSelection.Saved.WalletType.GooglePay
-            )
-        )
-        assertThat(paymentOption.drawableResourceId).isEqualTo(R.drawable.stripe_google_pay_mark)
-        assertThat(paymentOption.label).isEqualTo("···· 4242")
-        assertThat(paymentOption.paymentMethodType).isEqualTo("card")
-        assertThat(paymentOption.billingDetails).isNull()
-    }
-
-    @Test
-    fun `create() with saved card params without last 4 digits from Google wallet should return expected object`() {
-        val paymentOption = factory.create(
-            PaymentSelection.Saved(
-                paymentMethod = card(last4 = null),
-                walletType = PaymentSelection.Saved.WalletType.GooglePay
-            )
-        )
-        assertThat(paymentOption.drawableResourceId).isEqualTo(R.drawable.stripe_google_pay_mark)
-        assertThat(paymentOption.label).isEqualTo("Google Pay")
-        assertThat(paymentOption.paymentMethodType).isEqualTo("card")
-        assertThat(paymentOption.billingDetails).isNull()
-    }
-
-    @Test
     fun `create() with card and Link inline signup should return card icon and label`() {
         val paymentOption = factory.create(
             PaymentSelection.New.Card(
@@ -294,18 +224,6 @@ class PaymentOptionFactoryTest {
                 phone = null
             )
         )
-    }
-
-    private fun card(
-        brand: CardBrand = CardBrand.Unknown,
-        last4: String? = "4242"
-    ): PaymentMethod {
-        return PaymentMethod.Builder()
-            .setId("pm_1")
-            .setCode("card")
-            .setType(PaymentMethod.Type.Card)
-            .setCard(PaymentMethod.Card(last4 = last4, brand = brand, displayBrand = brand.code))
-            .build()
     }
 
     private companion object {


### PR DESCRIPTION
# Summary
Remove wallet type from `PaymentSelection`

# Motivation
Removing redundant type that is no longer used since the confirmation refactors. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified