### PR TITLE
Add sdk user agent to confirmation challenge webview

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/challenge/confirmation/IntentConfirmationChallengeActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/challenge/confirmation/IntentConfirmationChallengeActivity.kt
@@ -49,6 +49,7 @@ internal class IntentConfirmationChallengeActivity : AppCompatActivity() {
 
             IntentConfirmationChallengeUI(
                 hostUrl = HOST_URL,
+                userAgent = viewModel.userAgent,
                 bridgeHandler = viewModel.bridgeHandler,
                 showProgressIndicator = showProgressIndicator,
                 webViewClientFactory = {

--- a/payments-core/src/main/java/com/stripe/android/challenge/confirmation/IntentConfirmationChallengeUI.kt
+++ b/payments-core/src/main/java/com/stripe/android/challenge/confirmation/IntentConfirmationChallengeUI.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 @Composable
 internal fun IntentConfirmationChallengeUI(
     hostUrl: String,
+    userAgent: String,
     bridgeHandler: ConfirmationChallengeBridgeHandler,
     showProgressIndicator: Boolean,
     webViewClientFactory: () -> WebViewClient,
@@ -43,6 +44,7 @@ internal fun IntentConfirmationChallengeUI(
                 webViewFactory(context).apply {
                     this.webViewClient = webViewClientFactory()
                     addBridgeHandler(bridgeHandler)
+                    updateUserAgent(userAgent)
                     loadUrl(hostUrl)
                 }
             },

--- a/payments-core/src/main/java/com/stripe/android/challenge/confirmation/IntentConfirmationChallengeViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/challenge/confirmation/IntentConfirmationChallengeViewModel.kt
@@ -13,6 +13,7 @@ import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.stripe.android.challenge.confirmation.analytics.IntentConfirmationChallengeAnalyticsEventReporter
 import com.stripe.android.challenge.confirmation.di.DaggerIntentConfirmationChallengeComponent
+import com.stripe.android.challenge.confirmation.di.SDK_USER_AGENT
 import com.stripe.android.core.injection.UIContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -20,12 +21,14 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import javax.inject.Named
 import kotlin.coroutines.CoroutineContext
 
 internal class IntentConfirmationChallengeViewModel @Inject constructor(
     val bridgeHandler: ConfirmationChallengeBridgeHandler,
     @UIContext private val workContext: CoroutineContext,
-    private val analyticsEventReporter: IntentConfirmationChallengeAnalyticsEventReporter
+    private val analyticsEventReporter: IntentConfirmationChallengeAnalyticsEventReporter,
+    @Named(SDK_USER_AGENT) val userAgent: String
 ) : ViewModel(), DefaultLifecycleObserver {
 
     private val _bridgeReady = MutableSharedFlow<Unit>()

--- a/payments-core/src/main/java/com/stripe/android/challenge/confirmation/IntentConfirmationChallengeWebView.kt
+++ b/payments-core/src/main/java/com/stripe/android/challenge/confirmation/IntentConfirmationChallengeWebView.kt
@@ -17,4 +17,10 @@ internal open class IntentConfirmationChallengeWebView(context: Context) : WebVi
     open fun addBridgeHandler(handler: ConfirmationChallengeBridgeHandler) {
         addJavascriptInterface(handler, "Android")
     }
+
+    open fun updateUserAgent(userAgent: String) {
+        settings.apply {
+            userAgentString = "${settings.userAgentString.orEmpty()} [$userAgent]"
+        }
+    }
 }

--- a/payments-core/src/main/java/com/stripe/android/challenge/confirmation/di/IntentConfirmationChallengeModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/challenge/confirmation/di/IntentConfirmationChallengeModule.kt
@@ -16,6 +16,7 @@ import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.core.networking.DefaultAnalyticsRequestExecutor
+import com.stripe.android.core.networking.RequestHeadersFactory
 import com.stripe.android.core.utils.DefaultDurationProvider
 import com.stripe.android.core.utils.DurationProvider
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
@@ -86,5 +87,11 @@ internal interface IntentConfirmationChallengeModule {
         fun provideProductUsage(args: IntentConfirmationChallengeArgs): Set<String> {
             return args.productUsage.toSet()
         }
+
+        @Provides
+        @Named(SDK_USER_AGENT)
+        fun providesSdkUserAgent(): String = RequestHeadersFactory.getUserAgent()
     }
 }
+
+internal const val SDK_USER_AGENT = "SDK_USER_AGENT"

--- a/payments-core/src/test/java/com/stripe/android/challenge/confirmation/FakeIntentConfirmationChallengeWebView.kt
+++ b/payments-core/src/test/java/com/stripe/android/challenge/confirmation/FakeIntentConfirmationChallengeWebView.kt
@@ -22,6 +22,10 @@ internal class FakeIntentConfirmationChallengeWebView(
         calls.add(Call.SetWebViewClient(client))
     }
 
+    override fun updateUserAgent(userAgent: String) {
+        calls.add(Call.UpdateUserAgent(userAgent))
+    }
+
     suspend fun awaitCall() = calls.awaitItem()
 
     fun ensureAllEventsConsumed() = calls.ensureAllEventsConsumed()
@@ -30,5 +34,6 @@ internal class FakeIntentConfirmationChallengeWebView(
         data class LoadUrl(val url: String) : Call
         data class AddBridgeHandler(val handler: ConfirmationChallengeBridgeHandler) : Call
         data class SetWebViewClient(val webViewClient: WebViewClient) : Call
+        data class UpdateUserAgent(val userAgent: String) : Call
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/challenge/confirmation/IntentConfirmationChallengeActivityTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/challenge/confirmation/IntentConfirmationChallengeActivityTest.kt
@@ -188,7 +188,8 @@ internal class IntentConfirmationChallengeActivityTest {
                 return IntentConfirmationChallengeViewModel(
                     bridgeHandler = bridgeHandler,
                     workContext = testDispatcher,
-                    analyticsEventReporter = analyticsReporter
+                    analyticsEventReporter = analyticsReporter,
+                    userAgent = "fake-user-agent"
                 ) as T
             }
         }
@@ -227,7 +228,8 @@ internal class IntentConfirmationChallengeActivityTest {
                 return IntentConfirmationChallengeViewModel(
                     bridgeHandler = bridgeHandler,
                     workContext = testDispatcher,
-                    analyticsEventReporter = FakeIntentConfirmationChallengeAnalyticsEventReporter()
+                    analyticsEventReporter = FakeIntentConfirmationChallengeAnalyticsEventReporter(),
+                    userAgent = "fake-user-agent"
                 ) as T
             }
         }

--- a/payments-core/src/test/java/com/stripe/android/challenge/confirmation/IntentConfirmationChallengeUITest.kt
+++ b/payments-core/src/test/java/com/stripe/android/challenge/confirmation/IntentConfirmationChallengeUITest.kt
@@ -42,6 +42,7 @@ internal class IntentConfirmationChallengeUITest {
         composeTestRule.setContent {
             IntentConfirmationChallengeUI(
                 hostUrl = "http://10.0.2.2:3004",
+                userAgent = "fake-user-agent",
                 bridgeHandler = bridgeHandler,
                 showProgressIndicator = false,
                 webViewFactory = { context ->
@@ -57,6 +58,8 @@ internal class IntentConfirmationChallengeUITest {
         assertThat(fakeWebView?.awaitCall())
             .isEqualTo(FakeIntentConfirmationChallengeWebView.Call.AddBridgeHandler(bridgeHandler))
         assertThat(fakeWebView?.awaitCall())
+            .isEqualTo(FakeIntentConfirmationChallengeWebView.Call.UpdateUserAgent("fake-user-agent"))
+        assertThat(fakeWebView?.awaitCall())
             .isEqualTo(FakeIntentConfirmationChallengeWebView.Call.LoadUrl("http://10.0.2.2:3004"))
         fakeWebView?.ensureAllEventsConsumed()
     }
@@ -64,6 +67,7 @@ internal class IntentConfirmationChallengeUITest {
     private fun setContent(showProgressIndicator: Boolean) = composeTestRule.setContent {
         IntentConfirmationChallengeUI(
             hostUrl = "http://10.0.2.2:3004",
+            userAgent = "fake-user-agent",
             bridgeHandler = FakeConfirmationChallengeBridgeHandler(),
             showProgressIndicator = showProgressIndicator,
             webViewClientFactory = { WebViewClient() }

--- a/payments-core/src/test/java/com/stripe/android/challenge/confirmation/IntentConfirmationChallengeViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/challenge/confirmation/IntentConfirmationChallengeViewModelTest.kt
@@ -168,6 +168,7 @@ internal class IntentConfirmationChallengeViewModelTest {
     ) = IntentConfirmationChallengeViewModel(
         bridgeHandler = bridgeHandler,
         workContext = testDispatcher,
-        analyticsEventReporter = analyticsReporter
+        analyticsEventReporter = analyticsReporter,
+        userAgent = "fake-user-agent"
     )
 }

--- a/payments-core/src/test/java/com/stripe/android/challenge/confirmation/IntentConfirmationChallengeWebViewTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/challenge/confirmation/IntentConfirmationChallengeWebViewTest.kt
@@ -1,0 +1,53 @@
+package com.stripe.android.challenge.confirmation
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.utils.createTestActivityRule
+import com.stripe.android.view.ActivityScenarioFactory
+import org.junit.Rule
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.Test
+
+@RunWith(RobolectricTestRunner::class)
+internal class IntentConfirmationChallengeWebViewTest {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    private val activityScenarioFactory = ActivityScenarioFactory(context)
+
+    @get:Rule
+    internal val testActivityRule = createTestActivityRule<ActivityScenarioFactory.TestActivity>()
+
+    private val webView: IntentConfirmationChallengeWebView by lazy {
+        activityScenarioFactory.createView {
+            IntentConfirmationChallengeWebView(it)
+        }
+    }
+
+    @Test
+    fun `init should set background color to transparent`() {
+        assertThat(webView.background).isNull()
+    }
+
+    @Test
+    fun `init should enable JavaScript`() {
+        assertThat(webView.settings.javaScriptEnabled).isTrue()
+    }
+
+    @Test
+    fun `init should enable DOM storage`() {
+        assertThat(webView.settings.domStorageEnabled).isTrue()
+    }
+
+    @Test
+    fun `updateUserAgent should append user agent suffix`() {
+        val originalUserAgent = webView.settings.userAgentString.orEmpty()
+
+        webView.updateUserAgent("TestAgent/1.0")
+
+        assertThat(webView.settings.userAgentString)
+            .isEqualTo("$originalUserAgent [TestAgent/1.0]")
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add sdk user agent to confirmation challenge webview

Works similar to [PaymentAuthWebView](https://stripe.sourcegraphcloud.com/stripe/stripe-android/-/blob/payments-core/src/main/java/com/stripe/android/view/PaymentAuthWebView.kt?L45-46)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
This will let us hide the close button in stripe js and use a native button
https://git.corp.stripe.com/stripe-internal/pay-server/pull/1356877
https://git.corp.stripe.com/stripe-internal/pay-server/pull/1347585#discussion_r4906033

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
