### PR TITLE
Make build config compatible with AGP 9.

### DIFF
--- a/3ds2playground/build.gradle
+++ b/3ds2playground/build.gradle
@@ -4,7 +4,6 @@ apply plugin: 'org.jetbrains.kotlin.plugin.parcelize'
 android {
     defaultConfig {
         applicationId = "com.stripe.android.stripe3ds2playground"
-        minSdk = 21
 
         versionCode = 1
         versionName = "1.0"

--- a/3ds2sdk/build.gradle
+++ b/3ds2sdk/build.gradle
@@ -3,8 +3,6 @@ apply plugin: 'org.jetbrains.kotlin.plugin.parcelize'
 
 android {
     defaultConfig {
-        // Required by Section 2.2 Minimum Supported Platform Versions of SDK—Device Information
-        minSdkVersion 21
         consumerProguardFiles "consumer-rules.pro"
 
         vectorDrawables.useSupportLibrary = true
@@ -60,10 +58,12 @@ android {
         disable += "ResourceName"
     }
 
-    kotlinOptions {
-        freeCompilerArgs += [
-                "-Xconsistent-data-class-copy-visibility"
-        ]
+    kotlin {
+        compilerOptions {
+            freeCompilerArgs.addAll([
+                    "-Xconsistent-data-class-copy-visibility"
+            ])
+        }
     }
 }
 

--- a/camera-core/build.gradle
+++ b/camera-core/build.gradle
@@ -1,5 +1,11 @@
 apply from: configs.androidLibrary
 
+android {
+    buildFeatures {
+        buildConfig = true
+    }
+}
+
 dependencies {
     implementation project(":stripe-core")
 

--- a/connect-example/build.gradle
+++ b/connect-example/build.gradle
@@ -79,20 +79,17 @@ android {
         viewBinding true
     }
 
-    testOptions {
-        kotlinOptions {
-            freeCompilerArgs += ["-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"]
-        }
-    }
-
-    kotlinOptions {
-        freeCompilerArgs += [
-                "-opt-in=kotlinx.coroutines.FlowPreview",
-                "-Xcontext-parameters",
-                "-Xannotation-default-target=param-property"
-        ]
-        if (gradle.ext.isCi) {
-            kotlinOptions.allWarningsAsErrors = true
+    kotlin {
+        compilerOptions {
+            freeCompilerArgs.addAll([
+                    "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
+                    "-opt-in=kotlinx.coroutines.FlowPreview",
+                    "-Xcontext-parameters",
+                    "-Xannotation-default-target=param-property"
+            ])
+            if (gradle.ext.isCi) {
+                allWarningsAsErrors = true
+            }
         }
     }
 }

--- a/connect/build.gradle
+++ b/connect/build.gradle
@@ -88,6 +88,7 @@ android {
 
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 
     testOptions {
@@ -99,19 +100,19 @@ android {
             }
         }
 
-        kotlinOptions {
-            freeCompilerArgs += ["-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"]
-        }
     }
 
-    kotlinOptions {
-        freeCompilerArgs += [
-                "-opt-in=kotlinx.coroutines.FlowPreview",
-                "-Xcontext-parameters",
-                "-Xannotation-default-target=param-property"
-        ]
-        if (gradle.ext.isCi) {
-            kotlinOptions.allWarningsAsErrors = true
+    kotlin {
+        compilerOptions {
+            freeCompilerArgs.addAll([
+                    "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
+                    "-opt-in=kotlinx.coroutines.FlowPreview",
+                    "-Xcontext-parameters",
+                    "-Xannotation-default-target=param-property"
+            ])
+            if (gradle.ext.isCi) {
+                allWarningsAsErrors = true
+            }
         }
     }
 }

--- a/crypto-onramp-example/build.gradle
+++ b/crypto-onramp-example/build.gradle
@@ -16,6 +16,7 @@ android {
     }
 
     buildFeatures {
+        buildConfig true
         viewBinding true
         compose true
     }

--- a/crypto-onramp/api/crypto-onramp.api
+++ b/crypto-onramp/api/crypto-onramp.api
@@ -1,10 +1,3 @@
-public final class com/stripe/android/crypto/onramp/BuildConfig {
-	public static final field BUILD_TYPE Ljava/lang/String;
-	public static final field DEBUG Z
-	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
-	public fun <init> ()V
-}
-
 public final class com/stripe/android/crypto/onramp/model/CryptoNetwork$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }

--- a/financial-connections-core/api/financial-connections-core.api
+++ b/financial-connections-core/api/financial-connections-core.api
@@ -90,13 +90,6 @@ public abstract interface class com/stripe/android/financialconnections/Financia
 	public abstract fun onFinancialConnectionsSheetResult (Lcom/stripe/android/financialconnections/FinancialConnectionsSheetForTokenResult;)V
 }
 
-public final class com/stripe/android/financialconnections/core/BuildConfig {
-	public static final field BUILD_TYPE Ljava/lang/String;
-	public static final field DEBUG Z
-	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
-	public fun <init> ()V
-}
-
 public final class com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetActivityResult$Canceled : com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetActivityResult {
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field INSTANCE Lcom/stripe/android/financialconnections/launcher/FinancialConnectionsSheetActivityResult$Canceled;

--- a/financial-connections-core/build.gradle
+++ b/financial-connections-core/build.gradle
@@ -17,11 +17,13 @@ dependencies {
 }
 
 android {
-    kotlinOptions {
-        freeCompilerArgs += [
-                "-opt-in=kotlin.RequiresOptIn",
-                "-Xconsistent-data-class-copy-visibility",
-        ]
+    kotlin {
+        compilerOptions {
+            freeCompilerArgs.addAll([
+                    "-opt-in=kotlin.RequiresOptIn",
+                    "-Xconsistent-data-class-copy-visibility",
+            ])
+        }
     }
 }
 

--- a/financial-connections-example/build.gradle
+++ b/financial-connections-example/build.gradle
@@ -48,6 +48,7 @@ android {
     }
 
     buildFeatures {
+        buildConfig true
         compose true
     }
 }

--- a/financial-connections-lite/api/financial-connections-lite.api
+++ b/financial-connections-lite/api/financial-connections-lite.api
@@ -1,7 +1,0 @@
-public final class com/stripe/android/financialconnections/lite/BuildConfig {
-	public static final field BUILD_TYPE Ljava/lang/String;
-	public static final field DEBUG Z
-	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
-	public fun <init> ()V
-}
-

--- a/financial-connections-lite/build.gradle
+++ b/financial-connections-lite/build.gradle
@@ -47,11 +47,13 @@ dependencies {
 }
 
 android {
-    kotlinOptions {
-        freeCompilerArgs += [
-                "-opt-in=kotlin.RequiresOptIn",
-                "-Xconsistent-data-class-copy-visibility",
-        ]
+    kotlin {
+        compilerOptions {
+            freeCompilerArgs.addAll([
+                    "-opt-in=kotlin.RequiresOptIn",
+                    "-Xconsistent-data-class-copy-visibility",
+            ])
+        }
     }
 }
 

--- a/financial-connections/build.gradle
+++ b/financial-connections/build.gradle
@@ -8,6 +8,9 @@ apply plugin: 'app.cash.paparazzi'
 apply plugin: 'com.google.devtools.ksp'
 
 android {
+    buildFeatures {
+        buildConfig = true
+    }
     defaultConfig {
         testApplicationId "com.stripe.android.financialconnections.test"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -87,12 +90,14 @@ android {
         compose true
     }
 
-    kotlinOptions {
-        freeCompilerArgs += [
-                "-opt-in=kotlin.RequiresOptIn",
-                "-opt-in=androidx.compose.material.ExperimentalMaterialApi",
-                "-Xconsistent-data-class-copy-visibility",
-        ]
+    kotlin {
+        compilerOptions {
+            freeCompilerArgs.addAll([
+                    "-opt-in=kotlin.RequiresOptIn",
+                    "-opt-in=androidx.compose.material.ExperimentalMaterialApi",
+                    "-Xconsistent-data-class-copy-visibility",
+            ])
+        }
     }
 }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSingletonSharedComponentHolder.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSingletonSharedComponentHolder.kt
@@ -2,8 +2,8 @@ package com.stripe.android.financialconnections.di
 
 import android.app.Application
 import com.stripe.android.core.Logger
+import com.stripe.android.financialconnections.BuildConfig
 import com.stripe.android.financialconnections.domain.IntegrityVerdictManager
-import com.stripe.attestation.BuildConfig
 import com.stripe.attestation.IntegrityRequestManager
 import com.stripe.attestation.IntegrityStandardRequestManager
 import com.stripe.attestation.RealStandardIntegrityManagerFactory

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,6 @@ POM_DEVELOPER_ID=stripe
 POM_DEVELOPER_NAME=Stripe
 POM_DEVELOPER_EMAIL=support+android@stripe.com
 
-android.defaults.buildfeatures.buildconfig=true
 android.enableJetifier=false
 android.enableR8.fullMode=true
 android.nonFinalResIds=true

--- a/hcaptcha/build.gradle
+++ b/hcaptcha/build.gradle
@@ -35,37 +35,44 @@ android {
 }
 
 // Generate the HTML class for hCaptcha
-android.libraryVariants.all { variant ->
-    def variantName = variant.name.capitalize()
-    def packageName = "com.stripe.hcaptcha"
-    def outputDir = file("${project.buildDir}/generated/source/hcaptcha/${variant.name}/${packageName.replaceAll('\\.', '/')}")
-    def generateTask = project.task("generate${variantName}JavaClassFromStaticHtml") {
-        group 'Generate'
-        description "Generate HTML java class"
+def hcaptchaPackageName = "com.stripe.hcaptcha"
+def hcaptchaPackagePath = hcaptchaPackageName.replaceAll('\\.', '/')
+def hcaptchaGenBaseDir = project.layout.buildDirectory.dir("generated/source/hcaptcha/main")
+def hcaptchaGenDir = project.layout.buildDirectory.dir("generated/source/hcaptcha/main/${hcaptchaPackagePath}")
+def templateFile = project.layout.projectDirectory.file("src/main/html/HCaptchaHtml.java.tml")
+def htmlFile = project.layout.projectDirectory.file("src/main/html/hcaptcha.html")
 
-        def outputJavaClass = file("$outputDir/HCaptchaHtml.kt")
-        def template = file("$projectDir/src/main/html/HCaptchaHtml.java.tml").text
-        def htmlFile = file("$projectDir/src/main/html/hcaptcha.html")
+def generateHtmlClass = tasks.register("generateJavaClassFromStaticHtml") {
+    group 'Generate'
+    description "Generate HTML java class"
 
-        doFirst {
-            def html = htmlFile
-                    .readLines()
-                    .stream()
-                    .collect(Collectors.joining("\n"))
+    inputs.file(templateFile)
+    inputs.file(htmlFile)
+    outputs.dir(hcaptchaGenDir)
 
-            def engine = new SimpleTemplateEngine()
-            def src = engine.createTemplate(template).make([
-                    "htmlContent": html,
-                    "packageName": packageName
-            ])
+    doFirst {
+        def html = htmlFile.getAsFile().readLines()
+                .stream()
+                .collect(Collectors.joining("\n"))
 
-            outputDir.mkdirs()
-            outputJavaClass.write(src.toString())
-        }
+        def engine = new SimpleTemplateEngine()
+        def src = engine.createTemplate(templateFile.getAsFile().text).make([
+                "htmlContent": html,
+                "packageName": hcaptchaPackageName
+        ])
+
+        def outDir = hcaptchaGenDir.get().asFile
+        outDir.mkdirs()
+        new File(outDir, "HCaptchaHtml.kt").write(src.toString())
     }
+}
 
-    // preBuild.dependsOn generateTask
-    variant.registerJavaGeneratingTask(generateTask, outputDir)
+android.sourceSets.main.kotlin.srcDirs += hcaptchaGenBaseDir
+
+tasks.configureEach {
+    if (name.startsWith("compile") && name.contains("Kotlin")) {
+        dependsOn(generateHtmlClass)
+    }
 }
 
 ext {

--- a/identity-example/build.gradle
+++ b/identity-example/build.gradle
@@ -32,6 +32,7 @@ android {
     buildFeatures {
         viewBinding true
         compose true
+        buildConfig = true
     }
 
     flavorDimensions += "theme"

--- a/identity/api/identity.api
+++ b/identity/api/identity.api
@@ -1,10 +1,3 @@
-public final class com/stripe/android/identity/BuildConfig {
-	public static final field BUILD_TYPE Ljava/lang/String;
-	public static final field DEBUG Z
-	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
-	public fun <init> ()V
-}
-
 public abstract interface class com/stripe/android/identity/IdentityVerificationSheet {
 	public static final field Companion Lcom/stripe/android/identity/IdentityVerificationSheet$Companion;
 	public abstract fun present (Ljava/lang/String;Ljava/lang/String;)V

--- a/payments-core-testing/build.gradle
+++ b/payments-core-testing/build.gradle
@@ -2,6 +2,9 @@ apply from: configs.androidLibrary
 apply plugin: 'org.jetbrains.kotlin.plugin.parcelize'
 
 android {
+    buildFeatures {
+        buildConfig true
+    }
     defaultConfig {
         buildConfigField "boolean", "IS_RUNNING_IN_CI", "$gradle.ext.isCi"
     }

--- a/payments-core/build.gradle
+++ b/payments-core/build.gradle
@@ -107,19 +107,23 @@ android {
             }
         }
 
-        kotlinOptions {
-            freeCompilerArgs += [
+    }
+
+    kotlin {
+        compilerOptions {
+            freeCompilerArgs.addAll([
                     "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
                     "-Xcontext-parameters",
                     "-Xannotation-default-target=param-property",
                     "-Xconsistent-data-class-copy-visibility",
-            ]
+            ])
         }
     }
 
     buildFeatures {
         compose = true
         viewBinding true
+        buildConfig = true
     }
 
     packagingOptions {

--- a/payments-model/api/payments-model.api
+++ b/payments-model/api/payments-model.api
@@ -405,10 +405,3 @@ public final class com/stripe/android/model/TokenizationMethod : java/lang/Enum 
 	public static fun values ()[Lcom/stripe/android/model/TokenizationMethod;
 }
 
-public final class com/stripe/payments/model/BuildConfig {
-	public static final field BUILD_TYPE Ljava/lang/String;
-	public static final field DEBUG Z
-	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
-	public fun <init> ()V
-}
-

--- a/payments-model/build.gradle
+++ b/payments-model/build.gradle
@@ -6,9 +6,9 @@ apply plugin: 'org.jetbrains.kotlin.plugin.parcelize'
 apply plugin: 'dev.drewhamilton.poko'
 
 android {
-    testOptions {
-        kotlinOptions {
-            freeCompilerArgs += ["-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"]
+    kotlin {
+        compilerOptions {
+            freeCompilerArgs.addAll(["-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"])
         }
     }
 }

--- a/payments-ui-core/build.gradle
+++ b/payments-ui-core/build.gradle
@@ -61,6 +61,7 @@ android {
     buildFeatures {
         compose = true
         viewBinding = true
+        buildConfig = true
     }
 
     testOptions {
@@ -73,8 +74,10 @@ android {
         }
     }
 
-    kotlinOptions {
-        freeCompilerArgs += ["-opt-in=kotlinx.coroutines.FlowPreview", "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"]
+    kotlin {
+        compilerOptions {
+            freeCompilerArgs.addAll(["-opt-in=kotlinx.coroutines.FlowPreview", "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"])
+        }
     }
 }
 

--- a/payments/api/payments.api
+++ b/payments/api/payments.api
@@ -1,7 +1,0 @@
-public final class com/stripe/android/payments/BuildConfig {
-	public static final field BUILD_TYPE Ljava/lang/String;
-	public static final field DEBUG Z
-	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
-	public fun <init> ()V
-}
-

--- a/payments/build.gradle
+++ b/payments/build.gradle
@@ -1,7 +1,4 @@
 apply from: configs.androidLibrary
-
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
 apply plugin: 'signing'
 apply plugin: 'maven-publish'
 

--- a/paymentsheet-example/build.gradle
+++ b/paymentsheet-example/build.gradle
@@ -67,6 +67,7 @@ android {
         ]
     }
     buildFeatures {
+        buildConfig true
         viewBinding true
         compose true
     }

--- a/paymentsheet/build.gradle
+++ b/paymentsheet/build.gradle
@@ -134,6 +134,7 @@ android {
     buildFeatures {
         compose = true
         viewBinding true
+        buildConfig = true
     }
 
     testOptions {
@@ -145,20 +146,20 @@ android {
             }
         }
 
-        kotlinOptions {
-            freeCompilerArgs += ["-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"]
-        }
     }
 
-    kotlinOptions {
-        freeCompilerArgs += [
-                "-opt-in=kotlinx.coroutines.FlowPreview",
-                "-Xcontext-parameters",
-                "-Xannotation-default-target=param-property",
-                "-Xconsistent-data-class-copy-visibility"
-        ]
-        if (gradle.ext.isCi) {
-            kotlinOptions.allWarningsAsErrors = true
+    kotlin {
+        compilerOptions {
+            freeCompilerArgs.addAll([
+                    "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
+                    "-opt-in=kotlinx.coroutines.FlowPreview",
+                    "-Xcontext-parameters",
+                    "-Xannotation-default-target=param-property",
+                    "-Xconsistent-data-class-copy-visibility"
+            ])
+            if (gradle.ext.isCi) {
+                allWarningsAsErrors = true
+            }
         }
     }
 }

--- a/stripe-attestation/api/stripe-attestation.api
+++ b/stripe-attestation/api/stripe-attestation.api
@@ -1,7 +1,0 @@
-public final class com/stripe/attestation/BuildConfig {
-	public static final field BUILD_TYPE Ljava/lang/String;
-	public static final field DEBUG Z
-	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
-	public fun <init> ()V
-}
-

--- a/stripe-attestation/build.gradle
+++ b/stripe-attestation/build.gradle
@@ -28,19 +28,19 @@ android {
             }
         }
 
-        kotlinOptions {
-            freeCompilerArgs += ["-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"]
-        }
     }
 
-    kotlinOptions {
-        freeCompilerArgs += [
-                "-opt-in=kotlinx.coroutines.FlowPreview",
-                "-Xcontext-parameters",
-                "-Xannotation-default-target=param-property"
-        ]
-        if (gradle.ext.isCi) {
-            kotlinOptions.allWarningsAsErrors = true
+    kotlin {
+        compilerOptions {
+            freeCompilerArgs.addAll([
+                    "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
+                    "-opt-in=kotlinx.coroutines.FlowPreview",
+                    "-Xcontext-parameters",
+                    "-Xannotation-default-target=param-property"
+            ])
+            if (gradle.ext.isCi) {
+                allWarningsAsErrors = true
+            }
         }
     }
 }

--- a/stripe-core/build.gradle
+++ b/stripe-core/build.gradle
@@ -12,10 +12,15 @@ ext {
 }
 
 android {
-    kotlinOptions {
-        freeCompilerArgs += [
-                "-Xconsistent-data-class-copy-visibility"
-        ]
+    buildFeatures {
+        buildConfig = true
+    }
+    kotlin {
+        compilerOptions {
+            freeCompilerArgs.addAll([
+                    "-Xconsistent-data-class-copy-visibility"
+            ])
+        }
     }
 }
 

--- a/stripe-ui-core/build.gradle
+++ b/stripe-ui-core/build.gradle
@@ -16,6 +16,7 @@ ext {
 android {
     buildFeatures {
         compose true
+        buildConfig = true
     }
 
     testOptions {

--- a/wechatpay/api/wechatpay.api
+++ b/wechatpay/api/wechatpay.api
@@ -1,10 +1,3 @@
-public final class com/stripe/android/payments/wechatpay/BuildConfig {
-	public static final field BUILD_TYPE Ljava/lang/String;
-	public static final field DEBUG Z
-	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
-	public fun <init> ()V
-}
-
 public final class com/stripe/android/payments/wechatpay/reflection/DefaultWeChatPayReflectionHelper : com/stripe/android/payments/wechatpay/reflection/WeChatPayReflectionHelper {
 	public fun <init> ()V
 	public fun createIWXAPIEventHandler (Ljava/lang/reflect/InvocationHandler;)Ljava/lang/Object;


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
The build config fields are off by default, and the gradle property turning it on/off is no longer supported in AGP 9.

This change makes the required changes before a larger PR that updates the plugin.