### PR TITLE
Use FeatureState.fromBoolean and remove unnecessary createOptions overrides

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionRedisplaySettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionRedisplaySettingsDefinition.kt
@@ -19,18 +19,7 @@ internal object CustomerSessionRedisplaySettingsDefinition : BooleanSettingsDefi
         return settings[CustomerSessionSettingsDefinition] == true
     }
 
-    override fun createOptions(
-        configurationData: PlaygroundConfigurationData
-    ) = listOf(
-        PlaygroundSettingDefinition.Displayable.Option("Enabled", true),
-        PlaygroundSettingDefinition.Displayable.Option("Disabled", false),
-    )
-
     override fun configure(value: Boolean, checkoutRequestBuilder: CheckoutRequest.Builder) {
-        if (value) {
-            checkoutRequestBuilder.paymentMethodRedisplayFeature(FeatureState.Enabled)
-        } else {
-            checkoutRequestBuilder.paymentMethodRedisplayFeature(FeatureState.Disabled)
-        }
+        checkoutRequestBuilder.paymentMethodRedisplayFeature(FeatureState.fromBoolean(value))
     }
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionRemoveLastSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionRemoveLastSettingsDefinition.kt
@@ -20,26 +20,11 @@ internal object CustomerSessionRemoveLastSettingsDefinition : BooleanSettingsDef
         return settings[CustomerSessionSettingsDefinition] == true
     }
 
-    override fun createOptions(
-        configurationData: PlaygroundConfigurationData
-    ) = listOf(
-        PlaygroundSettingDefinition.Displayable.Option("Enabled", true),
-        PlaygroundSettingDefinition.Displayable.Option("Disabled", false),
-    )
-
     override fun configure(value: Boolean, checkoutRequestBuilder: CheckoutRequest.Builder) {
-        if (value) {
-            checkoutRequestBuilder.paymentMethodRemoveLastFeature(FeatureState.Enabled)
-        } else {
-            checkoutRequestBuilder.paymentMethodRemoveLastFeature(FeatureState.Disabled)
-        }
+        checkoutRequestBuilder.paymentMethodRemoveLastFeature(FeatureState.fromBoolean(value))
     }
 
     override fun configure(value: Boolean, customerEphemeralKeyRequestBuilder: CustomerEphemeralKeyRequest.Builder) {
-        if (value) {
-            customerEphemeralKeyRequestBuilder.paymentMethodRemoveLastFeature(FeatureState.Enabled)
-        } else {
-            customerEphemeralKeyRequestBuilder.paymentMethodRemoveLastFeature(FeatureState.Disabled)
-        }
+        customerEphemeralKeyRequestBuilder.paymentMethodRemoveLastFeature(FeatureState.fromBoolean(value))
     }
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionRemoveSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionRemoveSettingsDefinition.kt
@@ -20,29 +20,14 @@ internal object CustomerSessionRemoveSettingsDefinition : BooleanSettingsDefinit
         return settings[CustomerSessionSettingsDefinition] == true
     }
 
-    override fun createOptions(
-        configurationData: PlaygroundConfigurationData
-    ) = listOf(
-        PlaygroundSettingDefinition.Displayable.Option("Enabled", true),
-        PlaygroundSettingDefinition.Displayable.Option("Disabled", false),
-    )
-
     override fun configure(value: Boolean, checkoutRequestBuilder: CheckoutRequest.Builder) {
-        if (value) {
-            checkoutRequestBuilder.paymentMethodRemoveFeature(FeatureState.Enabled)
-        } else {
-            checkoutRequestBuilder.paymentMethodRemoveFeature(FeatureState.Disabled)
-        }
+        checkoutRequestBuilder.paymentMethodRemoveFeature(FeatureState.fromBoolean(value))
     }
 
     override fun configure(
         value: Boolean,
         customerEphemeralKeyRequestBuilder: CustomerEphemeralKeyRequest.Builder
     ) {
-        if (value) {
-            customerEphemeralKeyRequestBuilder.paymentMethodRemoveFeature(FeatureState.Enabled)
-        } else {
-            customerEphemeralKeyRequestBuilder.paymentMethodRemoveFeature(FeatureState.Disabled)
-        }
+        customerEphemeralKeyRequestBuilder.paymentMethodRemoveFeature(FeatureState.fromBoolean(value))
     }
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionSaveSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionSaveSettingsDefinition.kt
@@ -19,18 +19,7 @@ internal object CustomerSessionSaveSettingsDefinition : BooleanSettingsDefinitio
         return settings[CustomerSessionSettingsDefinition] == true
     }
 
-    override fun createOptions(
-        configurationData: PlaygroundConfigurationData
-    ) = listOf(
-        PlaygroundSettingDefinition.Displayable.Option("Enabled", true),
-        PlaygroundSettingDefinition.Displayable.Option("Disabled", false),
-    )
-
     override fun configure(value: Boolean, checkoutRequestBuilder: CheckoutRequest.Builder) {
-        if (value) {
-            checkoutRequestBuilder.paymentMethodSaveFeature(FeatureState.Enabled)
-        } else {
-            checkoutRequestBuilder.paymentMethodSaveFeature(FeatureState.Disabled)
-        }
+        checkoutRequestBuilder.paymentMethodSaveFeature(FeatureState.fromBoolean(value))
     }
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionSetAsDefaultSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionSetAsDefaultSettingsDefinition.kt
@@ -8,19 +8,8 @@ internal object CustomerSessionSetAsDefaultSettingsDefinition : BooleanSettingsD
     displayName = "Customer Session Set As Default Feature",
     key = "customer_session_set_as_default"
 ) {
-    override fun createOptions(
-        configurationData: PlaygroundConfigurationData
-    ) = listOf(
-        PlaygroundSettingDefinition.Displayable.Option("Enabled", true),
-        PlaygroundSettingDefinition.Displayable.Option("Disabled", false),
-    )
-
     override fun configure(value: Boolean, checkoutRequestBuilder: CheckoutRequest.Builder) {
-        if (value) {
-            checkoutRequestBuilder.paymentMethodSetAsDefaultFeature(FeatureState.Enabled)
-        } else {
-            checkoutRequestBuilder.paymentMethodSetAsDefaultFeature(FeatureState.Disabled)
-        }
+        checkoutRequestBuilder.paymentMethodSetAsDefaultFeature(FeatureState.fromBoolean(value))
     }
 
     override fun applicable(

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionSyncDefaultSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionSyncDefaultSettingsDefinition.kt
@@ -8,19 +8,8 @@ internal object CustomerSessionSyncDefaultSettingsDefinition : BooleanSettingsDe
     displayName = "Customer Session Sync Default Feature",
     key = "customer_session_sync_default"
 ) {
-    override fun createOptions(
-        configurationData: PlaygroundConfigurationData
-    ) = listOf(
-        PlaygroundSettingDefinition.Displayable.Option("Enabled", true),
-        PlaygroundSettingDefinition.Displayable.Option("Disabled", false),
-    )
-
     override fun configure(value: Boolean, customerEphemeralKeyRequestBuilder: CustomerEphemeralKeyRequest.Builder) {
-        if (value) {
-            customerEphemeralKeyRequestBuilder.paymentMethodSyncDefaultFeature(FeatureState.Enabled)
-        } else {
-            customerEphemeralKeyRequestBuilder.paymentMethodSyncDefaultFeature(FeatureState.Disabled)
-        }
+        customerEphemeralKeyRequestBuilder.paymentMethodSyncDefaultFeature(FeatureState.fromBoolean(value))
     }
 
     override fun applicable(


### PR DESCRIPTION
## Summary
- Replace verbose `if/else` FeatureState conversion with `FeatureState.fromBoolean(value)` in 6 CustomerSession settings definitions
- Remove unnecessary `createOptions` overrides that duplicated the base class `BooleanSettingsDefinition`

## Motivation
Follow-up from #12382 review feedback:
- https://github.com/stripe/stripe-android/pull/12382#discussion_r2829626530
- https://github.com/stripe/stripe-android/pull/12382#discussion_r2829623745

`CheckoutSessionSaveSettingsDefinition` (added in #12382) already used `FeatureState.fromBoolean` and omitted `createOptions`. This PR applies the same pattern to all other settings definitions for consistency.

## Test plan
- [x] `./gradlew :paymentsheet-example:compileBaseDebugKotlin` — compiles successfully
- [x] `./gradlew :paymentsheet-example:detekt` — passes static analysis
- [x] No behavioral change — `FeatureState.fromBoolean(true)` returns `Enabled`, `fromBoolean(false)` returns `Disabled`, identical to the previous `if/else` logic
- [x] `createOptions` removal changes playground toggle labels from "Enabled"/"Disabled" to the base class default "On"/"Off", matching `CheckoutSessionSaveSettingsDefinition`

🤖 Generated with [Claude Code](https://claude.com/claude-code)