### PR TITLE
Temporarily disable TestCheckoutSession

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCheckoutSession.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCheckoutSession.kt
@@ -11,6 +11,7 @@ import com.stripe.android.paymentsheet.example.playground.settings.Initializatio
 import com.stripe.android.paymentsheet.example.playground.settings.Merchant
 import com.stripe.android.paymentsheet.example.playground.settings.MerchantSettingsDefinition
 import com.stripe.android.test.core.TestParameters
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -21,6 +22,7 @@ import org.junit.runner.RunWith
  * the checkout session API (/v1/payment_pages/{cs_id}/init and /confirm).
  */
 @RunWith(AndroidJUnit4::class)
+@Ignore("#ir-tallest-solar")
 internal class TestCheckoutSession : BasePlaygroundTest() {
 
     private val testParameters = TestParameters.create(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
`payment_pages` init response is missing `elements_session`, and  `ir-tallest-solar` is preventing us to roll out a fix.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

https://stripe.slack.com/archives/C09MLFD2KU7/p1771341468483399

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
