### PR TITLE
Load Link icons synchronously

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkController.kt
@@ -773,7 +773,7 @@ class LinkController @Inject internal constructor(
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     constructor(
         @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-        val imageLoader: suspend () -> Drawable,
+        val imageLoader: () -> Drawable,
         val label: String,
         val sublabel: String?,
     ) {

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
@@ -685,11 +685,9 @@ internal fun PaymentMethodPreviewDetails.toPreview(
 
     return LinkController.PaymentMethodPreview(
         imageLoader = {
-            iconLoader.load(
+            iconLoader.loadResource(
                 drawableResourceId = drawableResourceId,
                 drawableResourceIdNight = null,
-                lightThemeIconUrl = null,
-                darkThemeIconUrl = null,
             )
         },
         label = label,
@@ -714,11 +712,9 @@ internal fun ConsumerPaymentDetails.PaymentDetails.toPreview(
 
     return LinkController.PaymentMethodPreview(
         imageLoader = {
-            iconLoader.load(
+            iconLoader.loadResource(
                 drawableResourceId = drawableResourceId,
                 drawableResourceIdNight = null,
-                lightThemeIconUrl = null,
-                darkThemeIconUrl = null,
             )
         },
         label = label,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -306,27 +306,30 @@ internal sealed class PaymentSelection : Parcelable {
             return StripeTheme.colorsLightMutable.component.luminance() < MIN_LUMINANCE_FOR_LIGHT_ICON
         }
 
+        fun loadResource(
+            @DrawableRes drawableResourceId: Int,
+            @DrawableRes drawableResourceIdNight: Int?,
+        ): Drawable {
+            @Suppress("DEPRECATION")
+            return runCatching {
+                ResourcesCompat.getDrawable(
+                    resources,
+                    if (!isDarkTheme()) drawableResourceId else drawableResourceIdNight ?: drawableResourceId,
+                    null
+                )
+            }.getOrNull() ?: emptyDrawable
+        }
+
         suspend fun load(
             @DrawableRes drawableResourceId: Int,
             @DrawableRes drawableResourceIdNight: Int?,
             lightThemeIconUrl: String?,
             darkThemeIconUrl: String?,
         ): Drawable {
-            fun loadResource(): Drawable {
-                @Suppress("DEPRECATION")
-                return runCatching {
-                    ResourcesCompat.getDrawable(
-                        resources,
-                        if (!isDarkTheme()) drawableResourceId else drawableResourceIdNight ?: drawableResourceId,
-                        null
-                    )
-                }.getOrNull() ?: emptyDrawable
-            }
-
             suspend fun loadIcon(url: String): Drawable {
                 return imageLoader.load(url).getOrNull()?.let {
                     BitmapDrawable(resources, it)
-                } ?: loadResource()
+                } ?: loadResource(drawableResourceId, drawableResourceIdNight)
             }
 
             // If the payment option has an icon URL, we prefer it.
@@ -336,7 +339,7 @@ internal sealed class PaymentSelection : Parcelable {
             } else if (lightThemeIconUrl != null) {
                 loadIcon(lightThemeIconUrl)
             } else {
-                loadResource()
+                loadResource(drawableResourceId, drawableResourceIdNight)
             }
         }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Load Link icons synchronously

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
- Fix race condition causing LinkControllerPaymentMethodPreviewScreenshotTest to fail
- Icons were being loaded in a `suspend fun` but the path being called was always synchronous. Updated the code path to just be synchronous to avoid the race conidion

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

No behavior change -- this is just a mechanical refactor