### PR TITLE
[Identity] Fix crash when errorCause is null on Identity error screen

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityNavGraph.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityNavGraph.kt
@@ -305,9 +305,8 @@ internal fun IdentityNavGraph(
                         if (ErrorDestination.shouldFail(it)) {
                             verificationFlowFinishable.finishWithResult(
                                 IdentityVerificationSheet.VerificationFlowResult.Failed(
-                                    requireNotNull(identityViewModel.errorCause.value) {
-                                        "cause of error is null"
-                                    }
+                                    identityViewModel.errorCause.value
+                                        ?: IllegalStateException("Unknown verification error")
                                 )
                             )
                         } else {


### PR DESCRIPTION
Fixes: https://github.com/stripe/stripe-android/issues/12432

Fixes an Identity crash when the error screen back button is tapped with shouldFail=true and errorCause is null.

Instead of crashing on requireNotNull, we now return VerificationFlowResult.Failed with a fallback throwable.

