### PR TITLE
Remove automatic tap-to-add launch on card selection

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddHelper.kt
@@ -24,8 +24,6 @@ import javax.inject.Named
 internal interface TapToAddHelper {
     val nextStep: SharedFlow<TapToAddNextStep>
 
-    val hasPreviouslyAttemptedCollection: Boolean
-
     fun register(
         activityResultCaller: ActivityResultCaller,
         lifecycleOwner: LifecycleOwner
@@ -66,15 +64,6 @@ internal class DefaultTapToAddHelper(
         }
 
     private var launcher: ActivityResultLauncher<TapToAddContract.Args>? = null
-
-    private var _hasPreviouslyAttemptedCollection
-        get() = savedStateHandle.get<Boolean>(PREVIOUSLY_COLLECTED_WITH_TAP_TO_ADD_KEY) == true
-        set(value) {
-            savedStateHandle[PREVIOUSLY_COLLECTED_WITH_TAP_TO_ADD_KEY] = value
-        }
-
-    override val hasPreviouslyAttemptedCollection: Boolean
-        get() = _hasPreviouslyAttemptedCollection
 
     private val _nextStep = MutableSharedFlow<TapToAddNextStep>()
     override val nextStep: SharedFlow<TapToAddNextStep> = _nextStep.asSharedFlow()
@@ -126,8 +115,6 @@ internal class DefaultTapToAddHelper(
     }
 
     override fun startPaymentMethodCollection(paymentMethodMetadata: PaymentMethodMetadata) {
-        _hasPreviouslyAttemptedCollection = true
-
         if (collecting) {
             return
         }
@@ -175,7 +162,6 @@ internal class DefaultTapToAddHelper(
     }
 
     private companion object {
-        const val PREVIOUSLY_COLLECTED_WITH_TAP_TO_ADD_KEY = "PREVIOUSLY_COLLECTED_WITH_TAP_TO_ADD"
         const val CURRENTLY_COLLECTING_WITH_TAP_TO_ADD_KEY = "CURRENTLY_COLLECTING_WITH_TAP_TO_ADD"
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -319,28 +319,6 @@ internal data class PaymentMethodMetadata(
         }
     }
 
-    fun actionForCode(
-        code: String,
-        uiDefinitionFactoryArgumentsFactory: UiDefinitionFactory.Arguments.Factory,
-    ) {
-        val definition = supportedPaymentMethodDefinitions().firstOrNull { it.type.code == code }
-            ?: return
-
-        val uiFactory = definition.uiDefinitionFactory(this)
-
-        if (uiFactory !is UiDefinitionFactory.Actionable) {
-            return
-        }
-
-        uiFactory.action(
-            metadata = this,
-            arguments = uiDefinitionFactoryArgumentsFactory.create(
-                metadata = this,
-                requiresMandate = definition.requiresMandate(this),
-            ),
-        )
-    }
-
     fun allowRedisplay(
         customerRequestedSave: PaymentSelection.CustomerRequestedSave,
         code: PaymentMethodCode

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionFactory.kt
@@ -201,10 +201,6 @@ internal sealed interface UiDefinitionFactory {
         fun createFormElements(metadata: PaymentMethodMetadata, arguments: Arguments): List<FormElement>
     }
 
-    interface Actionable {
-        fun action(metadata: PaymentMethodMetadata, arguments: Arguments)
-    }
-
     fun canBeDisplayedInUi(
         definition: PaymentMethodDefinition,
         sharedDataSpecs: List<SharedDataSpec>,
@@ -265,10 +261,6 @@ internal sealed interface UiDefinitionFactory {
             )
         }
 
-        is Actionable -> {
-            null
-        }
-
         is RequiresSharedDataSpec -> {
             val sharedDataSpec = sharedDataSpecs.firstOrNull { it.type == definition.type.code }
             if (sharedDataSpec != null) {
@@ -301,10 +293,6 @@ internal sealed interface UiDefinitionFactory {
                 metadata = metadata,
                 arguments = arguments,
             )
-        }
-
-        is Actionable -> {
-            null
         }
 
         is RequiresSharedDataSpec -> {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -61,7 +61,7 @@ internal object CardDefinition : PaymentMethodDefinition {
     }
 }
 
-private object CardUiDefinitionFactory : UiDefinitionFactory.Custom, UiDefinitionFactory.Actionable {
+private object CardUiDefinitionFactory : UiDefinitionFactory.Custom {
     override fun createSupportedPaymentMethod(
         metadata: PaymentMethodMetadata,
     ): SupportedPaymentMethod {
@@ -92,17 +92,6 @@ private object CardUiDefinitionFactory : UiDefinitionFactory.Custom, UiDefinitio
             outlinedIconResource = outlinedIconResource,
             iconRequiresTinting = true,
         )
-    }
-
-    override fun action(
-        metadata: PaymentMethodMetadata,
-        arguments: UiDefinitionFactory.Arguments
-    ) {
-        val tapToAddHelper = arguments.tapToAddHelper
-
-        if (metadata.isTapToAddSupported && tapToAddHelper?.hasPreviouslyAttemptedCollection == false) {
-            tapToAddHelper.startPaymentMethodCollection(metadata)
-        }
     }
 
     override fun createFormHeaderInformation(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
@@ -265,7 +265,6 @@ internal class DefaultEmbeddedContentHelper @Inject constructor(
             },
             invokeRowSelectionCallback = ::invokeRowSelectionCallback,
             displaysMandatesInFormScreen = isImmediateAction && embeddedViewDisplaysMandateText,
-            runActionForCode = formHelper::runActionForCode,
             onInitiallyDisplayedPaymentMethodVisibilitySnapshot = { visiblePaymentMethods, hiddenPaymentMethods ->
                 eventReporter.onInitiallyDisplayedPaymentMethodVisibilitySnapshot(
                     visiblePaymentMethods = visiblePaymentMethods,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultFormHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultFormHelper.kt
@@ -198,13 +198,6 @@ internal class DefaultFormHelper(
         }
     }
 
-    override fun runActionForCode(paymentMethodCode: PaymentMethodCode) {
-        paymentMethodMetadata.actionForCode(
-            code = paymentMethodCode,
-            uiDefinitionFactoryArgumentsFactory = createArgumentsFactory(paymentMethodCode),
-        )
-    }
-
     private fun supportedPaymentMethodForCode(code: String): SupportedPaymentMethod {
         return requireNotNull(paymentMethodMetadata.supportedPaymentMethodForCode(code = code))
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/FormHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/FormHelper.kt
@@ -24,8 +24,6 @@ internal interface FormHelper {
 
     fun formTypeForCode(paymentMethodCode: PaymentMethodCode): FormType
 
-    fun runActionForCode(paymentMethodCode: PaymentMethodCode)
-
     sealed interface FormType {
         object Empty : FormType
         data class MandateOnly(val mandate: ResolvableString) : FormType

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodInteractor.kt
@@ -78,7 +78,6 @@ internal class DefaultAddPaymentMethodInteractor(
     private val onFormFieldValuesChanged: (FormFieldValues?, String) -> Unit,
     private val reportPaymentMethodTypeSelected: (PaymentMethodCode) -> Unit,
     private val createUSBankAccountFormArguments: (PaymentMethodCode) -> USBankAccountFormArguments,
-    private val actionForCode: (PaymentMethodCode) -> Unit,
     private val coroutineScope: CoroutineScope,
     private val uiContext: CoroutineContext,
     private val onInitiallyDisplayedPaymentMethodVisibilitySnapshot: (List<String>, List<String>) -> Unit,
@@ -109,7 +108,6 @@ internal class DefaultAddPaymentMethodInteractor(
                 clearErrorMessages = viewModel::clearErrorMessages,
                 reportFieldInteraction = viewModel.analyticsListener::reportFieldInteraction,
                 onFormFieldValuesChanged = formHelper::onFormFieldValuesChanged,
-                actionForCode = formHelper::runActionForCode,
                 reportPaymentMethodTypeSelected = viewModel.eventReporter::onSelectPaymentMethod,
                 createUSBankAccountFormArguments = {
                     USBankAccountFormArguments.create(
@@ -171,8 +169,6 @@ internal class DefaultAddPaymentMethodInteractor(
 
         coroutineScope.launch {
             selectedPaymentMethodCode.collect { newSelectedPaymentMethodCode ->
-                actionForCode(newSelectedPaymentMethodCode)
-
                 val newFormArguments = createFormArguments(newSelectedPaymentMethodCode)
                 val newFormElements = formElementsForCode(newSelectedPaymentMethodCode)
                 val newUsBankAccountFormArguments = createUSBankAccountFormArguments(newSelectedPaymentMethodCode)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -91,7 +91,6 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
     temporarySelection: StateFlow<PaymentMethodCode?>,
     selection: StateFlow<PaymentSelection?>,
     paymentMethodIncentiveInteractor: PaymentMethodIncentiveInteractor,
-    private val runActionForCode: (code: String) -> Unit,
     private val formTypeForCode: (code: String) -> FormType,
     private val onFormFieldValuesChanged: (formValues: FormFieldValues, selectedPaymentMethodCode: String) -> Unit,
     private val transitionToManageScreen: () -> Unit,
@@ -133,9 +132,6 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
                 paymentMethodIncentiveInteractor = bankFormInteractor.paymentMethodIncentiveInteractor,
                 formTypeForCode = { code ->
                     formHelper.formTypeForCode(code)
-                },
-                runActionForCode = { code ->
-                    formHelper.runActionForCode(code)
                 },
                 onFormFieldValuesChanged = formHelper::onFormFieldValuesChanged,
                 transitionToManageScreen = {
@@ -529,8 +525,6 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
         when (viewAction) {
             is ViewAction.PaymentMethodSelected -> {
                 reportPaymentMethodTypeSelected(viewAction.selectedPaymentMethodCode)
-
-                runActionForCode(viewAction.selectedPaymentMethodCode)
 
                 val formType = formTypeForCode(viewAction.selectedPaymentMethodCode)
                 val displayFormForMandate = displaysMandatesInFormScreen && formType is FormType.MandateOnly

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/FakeTapToAddHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/FakeTapToAddHelper.kt
@@ -14,9 +14,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 
-internal class FakeTapToAddHelper(
-    override val hasPreviouslyAttemptedCollection: Boolean = false,
-) : TapToAddHelper {
+internal class FakeTapToAddHelper : TapToAddHelper {
     val registerCalls = Turbine<RegisterCall>()
     val collectCalls = Turbine<PaymentMethodMetadata>()
 
@@ -103,10 +101,9 @@ internal class FakeTapToAddHelper(
 
     companion object {
         suspend fun test(
-            hasPreviouslyAttemptedCollection: Boolean = false,
             block: suspend Scenario.() -> Unit,
         ) {
-            val helper = FakeTapToAddHelper(hasPreviouslyAttemptedCollection)
+            val helper = FakeTapToAddHelper()
 
             block(
                 Scenario(

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddHelperTest.kt
@@ -26,27 +26,6 @@ import org.robolectric.RobolectricTestRunner
 class TapToAddHelperTest {
 
     @Test
-    fun `hasPreviouslyAttemptedCollection is initially false`() = runScenario {
-        assertThat(helper.hasPreviouslyAttemptedCollection).isFalse()
-    }
-
-    @Test
-    fun `hasPreviouslyAttemptedCollection is true after startPaymentMethodCollection`() = runScenario {
-        helper.startPaymentMethodCollection(DEFAULT_METADATA)
-
-        assertThat(helper.hasPreviouslyAttemptedCollection).isTrue()
-    }
-
-    @Test
-    fun `hasPreviouslyAttemptedCollection remains true after multiple start calls`() = runScenario {
-        helper.startPaymentMethodCollection(DEFAULT_METADATA)
-        helper.startPaymentMethodCollection(DEFAULT_METADATA)
-        helper.startPaymentMethodCollection(DEFAULT_METADATA)
-
-        assertThat(helper.hasPreviouslyAttemptedCollection).isTrue()
-    }
-
-    @Test
     fun `register uses activity result caller to register callback which updates result state`() = runScenario {
         helper.register(
             activityResultCaller = activityResultCallerScenario.activityResultCaller,
@@ -261,23 +240,6 @@ class TapToAddHelperTest {
         assertThat(tapToAddArgs.paymentElementCallbackIdentifier).isEqualTo("mpe_callback_id")
         assertThat(tapToAddArgs.productUsage).containsExactly("PaymentSheet", "FlowController")
         assertThat(tapToAddArgs.mode).isEqualTo(TapToAddMode.Continue)
-    }
-
-    @Test
-    fun `hasPreviouslyAttemptedCollection persists across instances via SavedStateHandle`() = runTest {
-        val savedStateHandle = SavedStateHandle()
-
-        FakeTapToAddCollectionHandler.test {
-            val helper1 = createTapToAddHelper(savedStateHandle = savedStateHandle)
-
-            assertThat(helper1.hasPreviouslyAttemptedCollection).isFalse()
-            helper1.startPaymentMethodCollection(DEFAULT_METADATA)
-            assertThat(helper1.hasPreviouslyAttemptedCollection).isTrue()
-
-            val helper2 = createTapToAddHelper(savedStateHandle = savedStateHandle)
-
-            assertThat(helper2.hasPreviouslyAttemptedCollection).isTrue()
-        }
     }
 
     private fun runScenario(

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodFormHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodFormHelper.kt
@@ -57,10 +57,6 @@ internal class PaymentMethodFormHelper : FormHelper {
         TODO("Not yet implemented")
     }
 
-    override fun runActionForCode(paymentMethodCode: PaymentMethodCode) {
-        // No-op
-    }
-
     data class GetPaymentMethodParamsCall(
         val formValues: FormFieldValues?,
         val selectedPaymentMethodCode: String

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultAddPaymentMethodInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultAddPaymentMethodInteractorTest.kt
@@ -74,13 +74,8 @@ class DefaultAddPaymentMethodInteractorTest {
 
     @Test
     fun handleViewAction_OnPaymentMethodSelected_selectsPaymentMethod() {
-        val actionForCodeTurbine = Turbine<PaymentMethodCode>()
-
         runScenario(
             initiallySelectedPaymentMethodType = PaymentMethod.Type.Card.code,
-            actionForCode = {
-                actionForCodeTurbine.add(it)
-            }
         ) {
             val expectedCode = PaymentMethod.Type.CashAppPay.code
             interactor.handleViewAction(
@@ -89,7 +84,6 @@ class DefaultAddPaymentMethodInteractorTest {
 
             dispatcher.scheduler.advanceUntilIdle()
 
-            assertThat(actionForCodeTurbine.awaitItem()).isEqualTo(expectedCode)
             assertThat(reportPaymentMethodTypeSelectedTurbine.awaitItem()).isEqualTo(expectedCode)
             assertThat(clearErrorMessagesTurbine.awaitItem()).isNotNull()
             interactor.state.test {
@@ -329,22 +323,6 @@ class DefaultAddPaymentMethodInteractorTest {
         assertThat(visibilityItem.second).isEqualTo(MANY_ITEMS_ONE_PARTIALLY_VISIBLE_EXPECTED_HIDDEN)
     }
 
-    @Test
-    fun init_shouldPerform_actionForCode() {
-        val actionForCodeTurbine = Turbine<PaymentMethodCode>()
-
-        runScenario(
-            dispatcher = UnconfinedTestDispatcher(),
-            initiallySelectedPaymentMethodType = PaymentMethod.Type.Card.code,
-            actionForCode = {
-                actionForCodeTurbine.add(it)
-            }
-        ) {
-            assertThat(actionForCodeTurbine.awaitItem()).isEqualTo(PaymentMethod.Type.Card.code)
-            assertThat(clearErrorMessagesTurbine.awaitItem()).isNotNull()
-        }
-    }
-
     private fun runScenario(
         initiallySelectedPaymentMethodType: PaymentMethodCode = PaymentMethod.Type.Card.code,
         selection: StateFlow<PaymentSelection?> = MutableStateFlow(null),
@@ -364,7 +342,6 @@ class DefaultAddPaymentMethodInteractorTest {
             )
         },
         formElementsForCode: (PaymentMethodCode) -> List<FormElement> = { emptyList() },
-        actionForCode: (PaymentMethodCode) -> Unit = {},
         createUSBankAccountFormArguments: (PaymentMethodCode) -> USBankAccountFormArguments = { mock() },
         dispatcher: TestDispatcher = StandardTestDispatcher(TestCoroutineScheduler()),
         testBlock: suspend TestParams.() -> Unit
@@ -397,9 +374,6 @@ class DefaultAddPaymentMethodInteractorTest {
                 reportPaymentMethodTypeSelectedTurbine.add(it)
             },
             createUSBankAccountFormArguments = createUSBankAccountFormArguments,
-            actionForCode = { code ->
-                actionForCode(code)
-            },
             coroutineScope = CoroutineScope(dispatcher),
             validationRequested = validationRequestedSource,
             isLiveMode = true,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -782,22 +782,6 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
     }
 
     @Test
-    fun handleViewAction_PaymentMethodSelected_callsRunActionForCode() {
-        val actionForCode = Turbine<PaymentMethodCode>()
-
-        runScenario(
-            formTypeForCode = { FormHelper.FormType.UserInteractionRequired },
-            actionForCode = { actionForCode.add(it) }
-        ) {
-            interactor.handleViewAction(ViewAction.PaymentMethodSelected("card"))
-            assertThat(actionForCode.awaitItem()).isEqualTo("card")
-            assertThat(reportPaymentMethodTypeSelectedTurbine.awaitItem()).isEqualTo("card")
-            assertThat(transitionToFormScreenTurbine.awaitItem()).isEqualTo("card")
-            assertThat(reportFormShownTurbine.awaitItem()).isEqualTo("card")
-        }
-    }
-
-    @Test
     fun handleViewAction_PaymentMethodSelected_transitionsToFormScreen_whenSelectedIsUsBank() {
         runScenario(
             formTypeForCode = { FormHelper.FormType.UserInteractionRequired },
@@ -1727,7 +1711,6 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
         invokeRowSelectionCallback: (() -> Unit)? = null,
         initialWalletsState: WalletsState? = null,
         displaysMandatesInFormScreen: Boolean = false,
-        actionForCode: (PaymentMethodCode) -> Unit = {},
         testBlock: suspend TestParams.() -> Unit
     ) {
         val processing: MutableStateFlow<Boolean> = MutableStateFlow(initialProcessing)
@@ -1756,9 +1739,6 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
             temporarySelection = temporarySelection,
             selection = selection,
             paymentMethodIncentiveInteractor = paymentMethodIncentiveInteractor,
-            runActionForCode = { code ->
-                actionForCode(code)
-            },
             formTypeForCode = formTypeForCode,
             onFormFieldValuesChanged = { formValues: FormFieldValues, selectedPaymentMethodCode: String ->
                 onFormFieldValuesChangedTurbine.add(Pair(formValues, selectedPaymentMethodCode))


### PR DESCRIPTION
Removes the action mechanism that automatically launched tap-to-add payment method collection when users selected the card payment method for the first time. This simplifies the codebase by eliminating the Actionable interface, actionForCode call chain, and hasPreviouslyAttemptedCollection tracking that were only used for this single behavior.

Manual tap-to-add triggering via the "Tap to Pay" button remains fully functional.


Committed-By-Agent: claude

# Summary
<!-- Simple summary of what was changed. -->
Remove automatic tap-to-add launch on card selection

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Updated designs for private preview

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [X] Manually verified

# Screen recording


https://github.com/user-attachments/assets/331e844a-2e06-49dc-a3aa-8b3a7a296cb6


