### PR TITLE
Replace intentConfiguration with initializationMode in embedded configure chain

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
@@ -39,6 +39,7 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheet.TermsDisplay
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.state.CustomerState
+import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.paymentsheet.utils.applicationIsTaskOwner
 import com.stripe.android.uicore.image.rememberDrawablePainter
 import com.stripe.android.uicore.utils.collectAsState
@@ -81,7 +82,8 @@ class EmbeddedPaymentElement @Inject internal constructor(
         intentConfiguration: PaymentSheet.IntentConfiguration,
         configuration: Configuration,
     ): ConfigureResult {
-        return configurationCoordinator.configure(intentConfiguration, configuration)
+        val initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(intentConfiguration)
+        return configurationCoordinator.configure(configuration, initializationMode)
     }
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfigurationCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfigurationCoordinator.kt
@@ -6,7 +6,6 @@ import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.EmbeddedPaymentElement.ConfigureResult
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
@@ -15,8 +14,8 @@ import javax.inject.Singleton
 
 internal interface EmbeddedConfigurationCoordinator {
     suspend fun configure(
-        intentConfiguration: PaymentSheet.IntentConfiguration,
         configuration: EmbeddedPaymentElement.Configuration,
+        initializationMode: PaymentElementLoader.InitializationMode,
     ): ConfigureResult
 }
 
@@ -30,14 +29,14 @@ internal class DefaultEmbeddedConfigurationCoordinator @Inject constructor(
     @ViewModelScope private val viewModelScope: CoroutineScope,
 ) : EmbeddedConfigurationCoordinator {
     override suspend fun configure(
-        intentConfiguration: PaymentSheet.IntentConfiguration,
-        configuration: EmbeddedPaymentElement.Configuration
+        configuration: EmbeddedPaymentElement.Configuration,
+        initializationMode: PaymentElementLoader.InitializationMode,
     ): ConfigureResult {
         return viewModelScope.async {
             confirmationStateHolder.state = null
             configurationHandler.configure(
-                intentConfiguration = intentConfiguration,
                 configuration = configuration,
+                initializationMode = initializationMode,
             ).fold(
                 onSuccess = { state ->
                     handleLoadedState(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfigurationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfigurationHandler.kt
@@ -7,7 +7,6 @@ import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.embedded.InternalRowSelectionCallback
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
@@ -18,8 +17,8 @@ import javax.inject.Provider
 
 internal interface EmbeddedConfigurationHandler {
     suspend fun configure(
-        intentConfiguration: PaymentSheet.IntentConfiguration,
         configuration: EmbeddedPaymentElement.Configuration,
+        initializationMode: PaymentElementLoader.InitializationMode,
     ): Result<PaymentElementLoader.State>
 }
 
@@ -42,15 +41,13 @@ internal class DefaultEmbeddedConfigurationHandler @Inject constructor(
     private var inFlightRequest: InFlightRequest? = null
 
     override suspend fun configure(
-        intentConfiguration: PaymentSheet.IntentConfiguration,
         configuration: EmbeddedPaymentElement.Configuration,
+        initializationMode: PaymentElementLoader.InitializationMode,
     ): Result<PaymentElementLoader.State> {
         val targetConfiguration = configuration.asCommonConfiguration()
 
-        val initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(intentConfiguration)
-
         val arguments = Arguments(
-            intentConfiguration = intentConfiguration,
+            initializationMode = initializationMode,
             configuration = targetConfiguration,
         )
 
@@ -94,7 +91,7 @@ internal class DefaultEmbeddedConfigurationHandler @Inject constructor(
                     ).onSuccess { state ->
                         cache = ConfigurationCache(
                             arguments = Arguments(
-                                intentConfiguration = intentConfiguration,
+                                initializationMode = initializationMode,
                                 configuration = targetConfiguration,
                             ),
                             resultState = state,
@@ -117,7 +114,7 @@ internal class DefaultEmbeddedConfigurationHandler @Inject constructor(
 
     @Parcelize
     data class Arguments(
-        val intentConfiguration: PaymentSheet.IntentConfiguration,
+        val initializationMode: PaymentElementLoader.InitializationMode,
         val configuration: CommonConfiguration,
     ) : Parcelable
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfigurationCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfigurationCoordinatorTest.kt
@@ -59,10 +59,12 @@ internal class DefaultEmbeddedConfigurationCoordinatorTest {
 
         assertThat(
             configurationCoordinator.configure(
-                PaymentSheet.IntentConfiguration(
-                    PaymentSheet.IntentConfiguration.Mode.Payment(5000, "USD"),
-                ),
                 configuration = defaultConfiguration,
+                initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
+                    PaymentSheet.IntentConfiguration(
+                        PaymentSheet.IntentConfiguration.Mode.Payment(5000, "USD"),
+                    )
+                ),
             )
         ).isInstanceOf<EmbeddedPaymentElement.ConfigureResult.Succeeded>()
         stateHelper.stateTurbine.awaitItem().let { state ->
@@ -91,10 +93,12 @@ internal class DefaultEmbeddedConfigurationCoordinatorTest {
 
         assertThat(
             configurationCoordinator.configure(
-                PaymentSheet.IntentConfiguration(
-                    PaymentSheet.IntentConfiguration.Mode.Payment(5000, "USD"),
-                ),
                 configuration = defaultConfiguration,
+                initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
+                    PaymentSheet.IntentConfiguration(
+                        PaymentSheet.IntentConfiguration.Mode.Payment(5000, "USD"),
+                    )
+                ),
             )
         ).isInstanceOf<EmbeddedPaymentElement.ConfigureResult.Succeeded>()
         stateHelper.stateTurbine.awaitItem().let { state ->
@@ -112,10 +116,12 @@ internal class DefaultEmbeddedConfigurationCoordinatorTest {
 
         assertThat(
             configurationCoordinator.configure(
-                PaymentSheet.IntentConfiguration(
-                    PaymentSheet.IntentConfiguration.Mode.Payment(5000, "USD"),
-                ),
                 configuration = defaultConfiguration,
+                initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
+                    PaymentSheet.IntentConfiguration(
+                        PaymentSheet.IntentConfiguration.Mode.Payment(5000, "USD"),
+                    )
+                ),
             )
         ).isInstanceOf<EmbeddedPaymentElement.ConfigureResult.Succeeded>()
         stateHelper.stateTurbine.awaitItem().let { state ->
@@ -125,10 +131,12 @@ internal class DefaultEmbeddedConfigurationCoordinatorTest {
 
         val secondConfigureResult = testScope.async {
             configurationCoordinator.configure(
-                PaymentSheet.IntentConfiguration(
-                    PaymentSheet.IntentConfiguration.Mode.Payment(5000, "USD"),
-                ),
                 configuration = defaultConfiguration,
+                initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
+                    PaymentSheet.IntentConfiguration(
+                        PaymentSheet.IntentConfiguration.Mode.Payment(5000, "USD"),
+                    )
+                ),
             )
         }
 
@@ -147,10 +155,12 @@ internal class DefaultEmbeddedConfigurationCoordinatorTest {
         configurationHandler.emit(Result.success(createPaymentElementLoaderState()))
         assertThat(
             configurationCoordinator.configure(
-                PaymentSheet.IntentConfiguration(
-                    PaymentSheet.IntentConfiguration.Mode.Payment(5000, "USD"),
-                ),
                 configuration = defaultConfiguration,
+                initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
+                    PaymentSheet.IntentConfiguration(
+                        PaymentSheet.IntentConfiguration.Mode.Payment(5000, "USD"),
+                    )
+                ),
             )
         ).isInstanceOf<EmbeddedPaymentElement.ConfigureResult.Succeeded>()
 
@@ -173,10 +183,12 @@ internal class DefaultEmbeddedConfigurationCoordinatorTest {
 
             assertThat(
                 configurationCoordinator.configure(
-                    PaymentSheet.IntentConfiguration(
-                        PaymentSheet.IntentConfiguration.Mode.Payment(5000, "USD"),
-                    ),
                     configuration = defaultConfiguration,
+                    initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
+                        PaymentSheet.IntentConfiguration(
+                            PaymentSheet.IntentConfiguration.Mode.Payment(5000, "USD"),
+                        )
+                    ),
                 )
             ).isInstanceOf<EmbeddedPaymentElement.ConfigureResult.Succeeded>()
         }
@@ -190,10 +202,12 @@ internal class DefaultEmbeddedConfigurationCoordinatorTest {
         configurationHandler.emit(Result.failure(exception))
         assertThat(
             configurationCoordinator.configure(
-                PaymentSheet.IntentConfiguration(
-                    PaymentSheet.IntentConfiguration.Mode.Payment(5000, "USD"),
+                configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
+                initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
+                    PaymentSheet.IntentConfiguration(
+                        PaymentSheet.IntentConfiguration.Mode.Payment(5000, "USD"),
+                    )
                 ),
-                configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build()
             )
         ).isEqualTo(EmbeddedPaymentElement.ConfigureResult.Failed(exception))
     }
@@ -255,8 +269,8 @@ internal class DefaultEmbeddedConfigurationCoordinatorTest {
         }
 
         override suspend fun configure(
-            intentConfiguration: PaymentSheet.IntentConfiguration,
-            configuration: EmbeddedPaymentElement.Configuration
+            configuration: EmbeddedPaymentElement.Configuration,
+            initializationMode: PaymentElementLoader.InitializationMode,
         ): Result<PaymentElementLoader.State> {
             return turbine.awaitItem()
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfigurationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfigurationHandlerTest.kt
@@ -31,10 +31,12 @@ internal class DefaultEmbeddedConfigurationHandlerTest {
         sheetStateHolder.sheetIsOpen = true
         val configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build()
         val result = handler.configure(
-            intentConfiguration = PaymentSheet.IntentConfiguration(
-                mode = PaymentSheet.IntentConfiguration.Mode.Setup(currency = "USD"),
-            ),
             configuration = configuration,
+            initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
+                PaymentSheet.IntentConfiguration(
+                    mode = PaymentSheet.IntentConfiguration.Mode.Setup(currency = "USD"),
+                )
+            ),
         )
         assertThat(result.exceptionOrNull()?.message).isEqualTo("Configuring while a sheet is open is not supported.")
     }
@@ -45,18 +47,22 @@ internal class DefaultEmbeddedConfigurationHandlerTest {
         val configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build()
         savedStateHandle[ConfigurationCache.KEY] = ConfigurationCache(
             arguments = DefaultEmbeddedConfigurationHandler.Arguments(
-                intentConfiguration = PaymentSheet.IntentConfiguration(
-                    mode = PaymentSheet.IntentConfiguration.Mode.Setup(currency = "USD"),
+                initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
+                    PaymentSheet.IntentConfiguration(
+                        mode = PaymentSheet.IntentConfiguration.Mode.Setup(currency = "USD"),
+                    )
                 ),
                 configuration = configuration.asCommonConfiguration(),
             ),
             resultState = loader.createSuccess(configuration.asCommonConfiguration()).getOrThrow(),
         )
         val result = handler.configure(
-            intentConfiguration = PaymentSheet.IntentConfiguration(
-                mode = PaymentSheet.IntentConfiguration.Mode.Setup(currency = "USD"),
-            ),
             configuration = configuration,
+            initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
+                PaymentSheet.IntentConfiguration(
+                    mode = PaymentSheet.IntentConfiguration.Mode.Setup(currency = "USD"),
+                )
+            ),
         )
         assertThat(result.getOrThrow())
             .isInstanceOf<PaymentElementLoader.State>()
@@ -67,10 +73,12 @@ internal class DefaultEmbeddedConfigurationHandlerTest {
         val configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build()
         loader.emit(loader.createSuccess(configuration.asCommonConfiguration()))
         val result = handler.configure(
-            intentConfiguration = PaymentSheet.IntentConfiguration(
-                mode = PaymentSheet.IntentConfiguration.Mode.Setup(currency = "USD"),
-            ),
             configuration = configuration,
+            initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
+                PaymentSheet.IntentConfiguration(
+                    mode = PaymentSheet.IntentConfiguration.Mode.Setup(currency = "USD"),
+                )
+            ),
         )
         assertThat(result.getOrThrow())
             .isInstanceOf<PaymentElementLoader.State>()
@@ -81,17 +89,19 @@ internal class DefaultEmbeddedConfigurationHandlerTest {
         val configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build()
         loader.emit(loader.createSuccess(configuration.asCommonConfiguration()))
 
-        val intentConfiguration = PaymentSheet.IntentConfiguration(
-            mode = PaymentSheet.IntentConfiguration.Mode.Setup(currency = "USD"),
+        val initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
+            PaymentSheet.IntentConfiguration(
+                mode = PaymentSheet.IntentConfiguration.Mode.Setup(currency = "USD"),
+            )
         )
 
         val state1 = handler.configure(
-            intentConfiguration = intentConfiguration,
             configuration = configuration,
+            initializationMode = initializationMode,
         ).getOrThrow()
         val state2 = handler.configure(
-            intentConfiguration = intentConfiguration,
             configuration = configuration,
+            initializationMode = initializationMode,
         ).getOrThrow()
         assertThat(state1).isEqualTo(state2)
     }
@@ -105,17 +115,19 @@ internal class DefaultEmbeddedConfigurationHandlerTest {
             .build()
         loader.emit(loader.createSuccess(configuration2.asCommonConfiguration()))
 
-        val intentConfiguration = PaymentSheet.IntentConfiguration(
-            mode = PaymentSheet.IntentConfiguration.Mode.Setup(currency = "USD"),
+        val initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
+            PaymentSheet.IntentConfiguration(
+                mode = PaymentSheet.IntentConfiguration.Mode.Setup(currency = "USD"),
+            )
         )
 
         val state1 = handler.configure(
-            intentConfiguration = intentConfiguration,
             configuration = configuration1,
+            initializationMode = initializationMode,
         ).getOrThrow()
         val state2 = handler.configure(
-            intentConfiguration = intentConfiguration,
             configuration = configuration2,
+            initializationMode = initializationMode,
         ).getOrThrow()
         assertThat(state1).isNotEqualTo(state2)
     }
@@ -137,16 +149,20 @@ internal class DefaultEmbeddedConfigurationHandlerTest {
         )
 
         val state1 = handler.configure(
-            intentConfiguration = PaymentSheet.IntentConfiguration(
-                mode = PaymentSheet.IntentConfiguration.Mode.Setup(currency = "USD"),
-            ),
             configuration = configuration,
+            initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
+                PaymentSheet.IntentConfiguration(
+                    mode = PaymentSheet.IntentConfiguration.Mode.Setup(currency = "USD"),
+                )
+            ),
         ).getOrThrow()
         val state2 = handler.configure(
-            intentConfiguration = PaymentSheet.IntentConfiguration(
-                mode = PaymentSheet.IntentConfiguration.Mode.Setup(currency = "EUR"),
-            ),
             configuration = configuration,
+            initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
+                PaymentSheet.IntentConfiguration(
+                    mode = PaymentSheet.IntentConfiguration.Mode.Setup(currency = "EUR"),
+                )
+            ),
         ).getOrThrow()
         assertThat(state1).isNotEqualTo(state2)
     }
@@ -156,18 +172,22 @@ internal class DefaultEmbeddedConfigurationHandlerTest {
         val configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build()
         savedStateHandle[ConfigurationCache.KEY] = ConfigurationCache(
             arguments = DefaultEmbeddedConfigurationHandler.Arguments(
-                intentConfiguration = PaymentSheet.IntentConfiguration(
-                    mode = PaymentSheet.IntentConfiguration.Mode.Setup(currency = "USD"),
+                initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
+                    PaymentSheet.IntentConfiguration(
+                        mode = PaymentSheet.IntentConfiguration.Mode.Setup(currency = "USD"),
+                    )
                 ),
                 configuration = configuration.asCommonConfiguration(),
             ),
             resultState = loader.createSuccess(configuration.asCommonConfiguration()).getOrThrow(),
         )
         val result = handler.configure(
-            intentConfiguration = PaymentSheet.IntentConfiguration(
-                mode = PaymentSheet.IntentConfiguration.Mode.Setup(currency = "USD"),
-            ),
             configuration = configuration,
+            initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
+                PaymentSheet.IntentConfiguration(
+                    mode = PaymentSheet.IntentConfiguration.Mode.Setup(currency = "USD"),
+                )
+            ),
         )
         assertThat(result.getOrThrow())
             .isInstanceOf<PaymentElementLoader.State>()
@@ -175,23 +195,25 @@ internal class DefaultEmbeddedConfigurationHandlerTest {
 
     @Test
     fun `results are saved in saved state handle`() = runScenario {
-        val intentConfiguration = PaymentSheet.IntentConfiguration(
-            mode = PaymentSheet.IntentConfiguration.Mode.Setup(currency = "USD"),
+        val initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
+            PaymentSheet.IntentConfiguration(
+                mode = PaymentSheet.IntentConfiguration.Mode.Setup(currency = "USD"),
+            )
         )
         val configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build()
         val loaderResult = loader.createSuccess(configuration.asCommonConfiguration())
         loader.emit(loaderResult)
 
         val result = handler.configure(
-            intentConfiguration = intentConfiguration,
             configuration = configuration,
+            initializationMode = initializationMode,
         )
         val configurationCache = savedStateHandle.get<ConfigurationCache>(ConfigurationCache.KEY)
         assertThat(result.getOrThrow()).isEqualTo(configurationCache!!.resultState)
         assertThat(configurationCache).isEqualTo(
             ConfigurationCache(
                 DefaultEmbeddedConfigurationHandler.Arguments(
-                    intentConfiguration = intentConfiguration,
+                    initializationMode = initializationMode,
                     configuration = configuration.asCommonConfiguration(),
                 ),
                 resultState = loaderResult.getOrThrow(),
@@ -201,15 +223,17 @@ internal class DefaultEmbeddedConfigurationHandlerTest {
 
     @Test
     fun `results are not saved in saved state handle on failure`() = runScenario {
-        val intentConfiguration = PaymentSheet.IntentConfiguration(
-            mode = PaymentSheet.IntentConfiguration.Mode.Setup(currency = "USD"),
+        val initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
+            PaymentSheet.IntentConfiguration(
+                mode = PaymentSheet.IntentConfiguration.Mode.Setup(currency = "USD"),
+            )
         )
         val configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build()
         loader.emit(Result.failure(IllegalStateException("Bad data")))
 
         val result = handler.configure(
-            intentConfiguration = intentConfiguration,
             configuration = configuration,
+            initializationMode = initializationMode,
         )
         assertThat(result.isFailure).isTrue()
         val configurationCache = savedStateHandle.get<ConfigurationCache>(ConfigurationCache.KEY)
@@ -219,8 +243,10 @@ internal class DefaultEmbeddedConfigurationHandlerTest {
     @Test
     fun `parallel calls to configure with the same arguments results in a single call to the loader`() = runScenario {
         val configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build()
-        val intentConfiguration = PaymentSheet.IntentConfiguration(
-            mode = PaymentSheet.IntentConfiguration.Mode.Setup(currency = "USD"),
+        val initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
+            PaymentSheet.IntentConfiguration(
+                mode = PaymentSheet.IntentConfiguration.Mode.Setup(currency = "USD"),
+            )
         )
         val countDownLatch = CountDownLatch(2)
         val testDispatcher = UnconfinedTestDispatcher()
@@ -228,16 +254,16 @@ internal class DefaultEmbeddedConfigurationHandlerTest {
         val first = testScope.async(testDispatcher) {
             countDownLatch.countDown()
             handler.configure(
-                intentConfiguration = intentConfiguration,
                 configuration = configuration,
+                initializationMode = initializationMode,
             ).getOrThrow()
         }
 
         val second = testScope.async(testDispatcher) {
             countDownLatch.countDown()
             handler.configure(
-                intentConfiguration = intentConfiguration,
                 configuration = configuration,
+                initializationMode = initializationMode,
             ).getOrThrow()
         }
 
@@ -256,10 +282,12 @@ internal class DefaultEmbeddedConfigurationHandlerTest {
 
         val first = testScope.backgroundScope.async(Dispatchers.IO) {
             handler.configure(
-                intentConfiguration = PaymentSheet.IntentConfiguration(
-                    mode = PaymentSheet.IntentConfiguration.Mode.Payment(amount = 5000, currency = "USD"),
-                ),
                 configuration = configuration,
+                initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
+                    PaymentSheet.IntentConfiguration(
+                        mode = PaymentSheet.IntentConfiguration.Mode.Payment(amount = 5000, currency = "USD"),
+                    )
+                ),
             ).getOrThrow()
         }
 
@@ -267,10 +295,12 @@ internal class DefaultEmbeddedConfigurationHandlerTest {
 
         val second = testScope.backgroundScope.async(Dispatchers.IO) {
             handler.configure(
-                intentConfiguration = PaymentSheet.IntentConfiguration(
-                    mode = PaymentSheet.IntentConfiguration.Mode.Setup(currency = "USD"),
-                ),
                 configuration = configuration,
+                initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
+                    PaymentSheet.IntentConfiguration(
+                        mode = PaymentSheet.IntentConfiguration.Mode.Setup(currency = "USD"),
+                    )
+                ),
             ).getOrThrow()
         }
 


### PR DESCRIPTION
## Summary
- Create `InitializationMode.DeferredIntent` in `EmbeddedPaymentElement.configure` and pass it downstream instead of the raw `IntentConfiguration`
- Replace `intentConfiguration` parameter with `initializationMode` in `EmbeddedConfigurationCoordinator` and `EmbeddedConfigurationHandler` interfaces and implementations
- Update `Arguments` data class to store `initializationMode` instead of `intentConfiguration`

## Test plan
- [x] `DefaultEmbeddedConfigurationCoordinatorTest` passes
- [x] `DefaultEmbeddedConfigurationHandlerTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)