### PR TITLE
Add checkout session payment_method_remove playground setting

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
@@ -67,6 +67,8 @@ class CheckoutRequest private constructor(
     val useCheckoutSession: Boolean?,
     @SerialName("checkout_session_payment_method_save")
     val checkoutSessionPaymentMethodSave: FeatureState?,
+    @SerialName("checkout_session_payment_method_remove")
+    val checkoutSessionPaymentMethodRemove: FeatureState?,
 ) {
     @Serializable
     enum class CustomerKeyType {
@@ -112,6 +114,7 @@ class CheckoutRequest private constructor(
         private var customPublishableKey: String? = null
         private var useCheckoutSession: Boolean? = null
         private var checkoutSessionPaymentMethodSave: FeatureState? = null
+        private var checkoutSessionPaymentMethodRemove: FeatureState? = null
 
         fun initialization(initialization: String?) = apply {
             this.initialization = initialization
@@ -233,6 +236,10 @@ class CheckoutRequest private constructor(
             this.checkoutSessionPaymentMethodSave = state
         }
 
+        fun checkoutSessionPaymentMethodRemove(state: FeatureState?) = apply {
+            this.checkoutSessionPaymentMethodRemove = state
+        }
+
         fun build(): CheckoutRequest {
             return CheckoutRequest(
                 initialization = initialization,
@@ -268,6 +275,7 @@ class CheckoutRequest private constructor(
                 customPublishableKey = customPublishableKey,
                 useCheckoutSession = useCheckoutSession,
                 checkoutSessionPaymentMethodSave = checkoutSessionPaymentMethodSave,
+                checkoutSessionPaymentMethodRemove = checkoutSessionPaymentMethodRemove,
             )
         }
     }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CheckoutSessionRemoveSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CheckoutSessionRemoveSettingsDefinition.kt
@@ -1,0 +1,28 @@
+package com.stripe.android.paymentsheet.example.playground.settings
+
+import com.stripe.android.paymentsheet.example.playground.model.CheckoutRequest
+import com.stripe.android.paymentsheet.example.playground.model.FeatureState
+
+/**
+ * Setting to control whether the checkout session is created with
+ * `saved_payment_method_options.payment_method_remove: enabled`.
+ *
+ * When enabled, customers can remove saved payment methods from the checkout session.
+ */
+internal object CheckoutSessionRemoveSettingsDefinition : BooleanSettingsDefinition(
+    defaultValue = true,
+    displayName = "Checkout Session Remove",
+    key = "checkout_session_payment_method_remove"
+) {
+    override fun applicable(
+        configurationData: PlaygroundConfigurationData,
+        settings: Map<PlaygroundSettingDefinition<*>, Any?>,
+    ): Boolean {
+        // Only applicable when using Checkout Session initialization
+        return settings[InitializationTypeSettingsDefinition] == InitializationType.CheckoutSession
+    }
+
+    override fun configure(value: Boolean, checkoutRequestBuilder: CheckoutRequest.Builder) {
+        checkoutRequestBuilder.checkoutSessionPaymentMethodRemove(FeatureState.fromBoolean(value))
+    }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -474,6 +474,7 @@ internal class PlaygroundSettings private constructor(
         val uiSettingDefinitions: List<PlaygroundSettingDefinition.Displayable<*>> = listOf(
             InitializationTypeSettingsDefinition,
             CheckoutSessionSaveSettingsDefinition,
+            CheckoutSessionRemoveSettingsDefinition,
             CustomerSheetPaymentMethodModeDefinition,
             CustomerSessionSettingsDefinition,
             CustomerSessionSaveSettingsDefinition,


### PR DESCRIPTION
## Summary
- Adds a `CheckoutSessionRemoveSettingsDefinition` playground setting to toggle `payment_method_remove` for checkout sessions
- Enables testing PM removal behavior in the playground app

## Motivation
Playground support for manually toggling checkout session PM removal during development and QA.

## Testing
- Verified playground setting appears and toggles correctly

## Part of checkout session SPM management series
Split from #12444. This is PR 1/4 in the checkout session saved payment method removal series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)