### PR TITLE
Parse can_detach_payment_method from checkout session init response

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/CheckoutSessionResponse.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/CheckoutSessionResponse.kt
@@ -106,5 +106,10 @@ data class CheckoutSessionResponse(
          * The customer's saved payment methods.
          */
         val paymentMethods: List<PaymentMethod>,
+        /**
+         * Whether the customer has permission to detach saved payment methods.
+         * Defaults to false when not present in the response.
+         */
+        val canDetachPaymentMethod: Boolean,
     ) : StripeModel
 }

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/CheckoutSessionResponseJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/CheckoutSessionResponseJsonParser.kt
@@ -128,7 +128,8 @@ internal class CheckoutSessionResponseJsonParser(
      * {
      *   "customer": {
      *     "id": "cus_xxx",
-     *     "payment_methods": [...]
+     *     "payment_methods": [...],
+     *     "can_detach_payment_method": true
      *   }
      * }
      * ```
@@ -145,10 +146,12 @@ internal class CheckoutSessionResponseJsonParser(
                 PaymentMethodJsonParser().parse(pmsJson.optJSONObject(index))
             }
         } ?: emptyList()
+        val canDetachPaymentMethod = json.optBoolean(FIELD_CAN_DETACH_PAYMENT_METHOD, false)
 
         return CheckoutSessionResponse.Customer(
             id = customerId,
             paymentMethods = paymentMethods,
+            canDetachPaymentMethod = canDetachPaymentMethod,
         )
     }
 
@@ -194,6 +197,7 @@ internal class CheckoutSessionResponseJsonParser(
         private const val FIELD_CUSTOMER = "customer"
         private const val FIELD_CUSTOMER_ID = "id"
         private const val FIELD_PAYMENT_METHODS = "payment_methods"
+        private const val FIELD_CAN_DETACH_PAYMENT_METHOD = "can_detach_payment_method"
         private const val FIELD_SAVED_PAYMENT_METHODS_OFFER_SAVE =
             "customer_managed_saved_payment_methods_offer_save"
         private const val FIELD_OFFER_SAVE_ENABLED = "enabled"

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/CheckoutSessionResponseJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/CheckoutSessionResponseJsonParserTest.kt
@@ -280,4 +280,70 @@ class CheckoutSessionResponseJsonParserTest {
         assertThat(result).isNotNull()
         assertThat(result?.savedPaymentMethodsOfferSave).isNull()
     }
+
+    @Test
+    fun `parse customer with can_detach_payment_method true`() {
+        val json = JSONObject(
+            """
+            {
+                "session_id": "cs_test_abc123",
+                "currency": "usd",
+                "total_summary": {
+                    "due": 1000
+                },
+                "customer": {
+                    "id": "cus_test_customer",
+                    "payment_methods": [],
+                    "can_detach_payment_method": true
+                },
+                "elements_session": ${CheckoutSessionFixtures.MINIMAL_ELEMENTS_SESSION_JSON}
+            }
+            """.trimIndent()
+        )
+        val result = CheckoutSessionResponseJsonParser(isLiveMode = false).parse(json)
+
+        assertThat(result).isNotNull()
+        val customer = result?.customer
+        assertThat(customer).isNotNull()
+        assertThat(customer?.canDetachPaymentMethod).isTrue()
+    }
+
+    @Test
+    fun `parse customer with can_detach_payment_method false`() {
+        val json = JSONObject(
+            """
+            {
+                "session_id": "cs_test_abc123",
+                "currency": "usd",
+                "total_summary": {
+                    "due": 1000
+                },
+                "customer": {
+                    "id": "cus_test_customer",
+                    "payment_methods": [],
+                    "can_detach_payment_method": false
+                },
+                "elements_session": ${CheckoutSessionFixtures.MINIMAL_ELEMENTS_SESSION_JSON}
+            }
+            """.trimIndent()
+        )
+        val result = CheckoutSessionResponseJsonParser(isLiveMode = false).parse(json)
+
+        assertThat(result).isNotNull()
+        val customer = result?.customer
+        assertThat(customer).isNotNull()
+        assertThat(customer?.canDetachPaymentMethod).isFalse()
+    }
+
+    @Test
+    fun `parse customer without can_detach_payment_method defaults to false`() {
+        // Use existing fixture that doesn't have can_detach_payment_method field
+        val result = CheckoutSessionResponseJsonParser(isLiveMode = false)
+            .parse(CheckoutSessionFixtures.CHECKOUT_SESSION_WITH_CUSTOMER_JSON)
+
+        assertThat(result).isNotNull()
+        val customer = result?.customer
+        assertThat(customer).isNotNull()
+        assertThat(customer?.canDetachPaymentMethod).isFalse()
+    }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CustomerStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CustomerStateTest.kt
@@ -149,6 +149,7 @@ class CustomerStateTest {
         val customer = CheckoutSessionResponse.Customer(
             id = "cus_checkout_123",
             paymentMethods = paymentMethods,
+            canDetachPaymentMethod = false,
         )
 
         val customerState = CustomerState.createForCheckoutSession(
@@ -165,6 +166,7 @@ class CustomerStateTest {
         val customer = CheckoutSessionResponse.Customer(
             id = "cus_checkout_empty",
             paymentMethods = emptyList(),
+            canDetachPaymentMethod = false,
         )
 
         val customerState = CustomerState.createForCheckoutSession(
@@ -185,6 +187,7 @@ class CustomerStateTest {
                 PaymentMethodFixtures.SEPA_DEBIT_PAYMENT_METHOD,
                 PaymentMethodFixtures.LINK_PAYMENT_METHOD,
             ),
+            canDetachPaymentMethod = false,
         )
 
         val customerState = CustomerState.createForCheckoutSession(


### PR DESCRIPTION
## Summary
- Parse `customer.can_detach_payment_method` boolean from the checkout session init response (`CheckoutSessionResponse.Customer`)
- Defaults to `false` when not present in the response
- Includes unit tests for the JSON parser

## Motivation
The backend sends `can_detach_payment_method` in the checkout session init response to signal whether PM removal is allowed. This PR adds the parsing layer; subsequent PRs wire it to permissions and API calls.

## Testing
- Added `CheckoutSessionResponseJsonParserTest` cases for `can_detach_payment_method` (true, false, absent)
- Updated `CustomerStateTest` for the new field

## Part of checkout session SPM management series
Split from #12444. This is PR 2/4 in the checkout session saved payment method removal series.
- PR 1: Playground config (#12449)
- **PR 2: Parse from payment_pages** ← this PR
- PR 3: Modeling/Permission changes (base: this branch)
- PR 4: Call new APIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)