### PR TITLE
Don't show expiration date warning when expiry month and year are missing

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/CardDetailsUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/CardDetailsUI.kt
@@ -253,3 +253,4 @@ private fun CvcField(cardBrand: CardBrand, modifier: Modifier) {
 
 internal const val CARD_EDIT_UI_ERROR_MESSAGE = "card_edit_ui_error_message"
 internal const val CARD_EDIT_UI_FALLBACK_EXPIRY_DATE = "•• / ••"
+internal const val CARD_EDIT_UI_MISSING_EXPIRY_DATE = ""

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/ExpiryDateState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/ExpiryDateState.kt
@@ -19,7 +19,7 @@ internal data class ExpiryDateState(
 ) {
 
     private val textFieldState: TextFieldState = run {
-        if (text == CARD_EDIT_UI_FALLBACK_EXPIRY_DATE) {
+        if (text == CARD_EDIT_UI_FALLBACK_EXPIRY_DATE || text == CARD_EDIT_UI_MISSING_EXPIRY_DATE) {
             TextFieldStateConstants.Error.Blank
         } else {
             dateConfig.determineState(text)
@@ -111,6 +111,10 @@ private fun formattedExpiryDate(
         (monthIsInvalid(expiryMonth) || yearIsInvalid(expiryYear))
     ) {
         return CARD_EDIT_UI_FALLBACK_EXPIRY_DATE
+    }
+
+    if (expiryMonth == null && expiryYear == null) {
+        return CARD_EDIT_UI_MISSING_EXPIRY_DATE
     }
 
     val formattedExpiryMonth = when {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/ExpiryDateStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/ExpiryDateStateTest.kt
@@ -51,8 +51,26 @@ internal class ExpiryDateStateTest {
     }
 
     @Test
+    fun `create should set text to empty when both expiry month and year are null`() {
+        val card = createCard(expiryMonth = null, expiryYear = null)
+
+        val state = ExpiryDateState.create(card, enabled = true)
+
+        assertThat(state.text).isEqualTo(CARD_EDIT_UI_MISSING_EXPIRY_DATE)
+        assertThat(state.expiryMonth).isNull()
+        assertThat(state.expiryYear).isNull()
+    }
+
+    @Test
     fun `shouldShowError should return false for valid expiry date`() {
         val state = ExpiryDateState(text = VALID_EXPIRY_TEXT, enabled = true, validating = false)
+
+        assertThat(state.shouldShowError()).isFalse()
+    }
+
+    @Test
+    fun `shouldShowError should return false for missing expiry date`() {
+        val state = ExpiryDateState(text = CARD_EDIT_UI_MISSING_EXPIRY_DATE, enabled = true, validating = false)
 
         assertThat(state.shouldShowError()).isFalse()
     }


### PR DESCRIPTION
…sing

# Summary
<!-- Simple summary of what was changed. -->
Don't show expiration date warning when expiry month and year are missing

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fixes an issue where cards added via TTA show an expiration date warning just because we don't have an expiration date

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified

# Screen recording
New experience of viewing the update payment method screen for a card just added via TTA:

https://github.com/user-attachments/assets/7ae78aaa-a227-45fc-8fbe-82f803096b6a

