### PR TITLE
Create shared PaymentConfigurationModule

### DIFF
--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/di/OnrampModule.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/di/OnrampModule.kt
@@ -4,7 +4,6 @@ import android.app.Application
 import android.content.Context
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.BuildConfig
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.Stripe
 import com.stripe.android.common.di.MobileSessionIdModule
 import com.stripe.android.core.ApiVersion
@@ -22,6 +21,7 @@ import com.stripe.android.link.LinkController
 import com.stripe.android.networking.RequestSurface
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
+import com.stripe.android.payments.core.injection.PaymentConfigurationModule
 import dagger.Module
 import dagger.Provides
 import javax.inject.Named
@@ -29,7 +29,7 @@ import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
 @Module(
-    includes = [MobileSessionIdModule::class],
+    includes = [MobileSessionIdModule::class, PaymentConfigurationModule::class],
     subcomponents = [OnrampPresenterComponent::class]
 )
 internal class OnrampModule {
@@ -48,16 +48,6 @@ internal class OnrampModule {
         workContext = context,
         logger = logger
     )
-
-    @Provides
-    @Named(PUBLISHABLE_KEY)
-    fun providePublishableKey(context: Context): () -> String =
-        { PaymentConfiguration.getInstance(context).publishableKey }
-
-    @Provides
-    @Named(STRIPE_ACCOUNT_ID)
-    fun provideStripeAccountId(context: Context): () -> String? =
-        { PaymentConfiguration.getInstance(context).stripeAccountId }
 
     @Provides
     fun provideRequestSurface(): RequestSurface = RequestSurface.CryptoOnramp

--- a/payment-method-messaging/src/main/java/com/stripe/android/paymentmethodmessaging/element/PaymentMethodMessagingModule.kt
+++ b/payment-method-messaging/src/main/java/com/stripe/android/paymentmethodmessaging/element/PaymentMethodMessagingModule.kt
@@ -3,9 +3,7 @@ package com.stripe.android.paymentmethodmessaging.element
 import android.app.Application
 import android.content.Context
 import com.stripe.android.BuildConfig
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.injection.ENABLE_LOGGING
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.core.utils.DefaultDurationProvider
@@ -16,6 +14,7 @@ import com.stripe.android.paymentmethodmessaging.element.analytics.PaymentMethod
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.analytics.RealErrorReporter
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
+import com.stripe.android.payments.core.injection.PaymentConfigurationModule
 import com.stripe.android.uicore.image.StripeImageLoader
 import com.stripe.android.uicore.isSystemDarkTheme
 import dagger.Binds
@@ -25,7 +24,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import javax.inject.Named
 
-@Module
+@Module(includes = [PaymentConfigurationModule::class])
 internal interface PaymentMethodMessagingModule {
 
     @Binds
@@ -68,17 +67,6 @@ internal interface PaymentMethodMessagingModule {
             application: Application
         ): () -> Boolean {
             return application::isSystemDarkTheme
-        }
-
-        @Provides
-        @Named(PUBLISHABLE_KEY)
-        fun providePublishableKey(
-            configuration: PaymentConfiguration
-        ): () -> String = { configuration.publishableKey }
-
-        @Provides
-        fun paymentConfiguration(application: Application): PaymentConfiguration {
-            return PaymentConfiguration.getInstance(application)
         }
 
         @Provides

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentConfigurationModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentConfigurationModule.kt
@@ -1,0 +1,32 @@
+package com.stripe.android.payments.core.injection
+
+import android.content.Context
+import androidx.annotation.RestrictTo
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.injection.PUBLISHABLE_KEY
+import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
+import dagger.Module
+import dagger.Provides
+import javax.inject.Named
+import javax.inject.Provider
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Module
+class PaymentConfigurationModule {
+    @Provides
+    fun providePaymentConfiguration(context: Context): PaymentConfiguration {
+        return PaymentConfiguration.getInstance(context)
+    }
+
+    @Provides
+    @Named(PUBLISHABLE_KEY)
+    fun providePublishableKey(
+        paymentConfiguration: Provider<PaymentConfiguration>
+    ): () -> String = { paymentConfiguration.get().publishableKey }
+
+    @Provides
+    @Named(STRIPE_ACCOUNT_ID)
+    fun provideStripeAccountId(
+        paymentConfiguration: Provider<PaymentConfiguration>
+    ): () -> String? = { paymentConfiguration.get().stripeAccountId }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddViewModelComponent.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import androidx.activity.result.ActivityResultCaller
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.SavedStateHandle
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.di.ApplicationIdModule
 import com.stripe.android.common.spms.DefaultLinkFormElementFactory
 import com.stripe.android.common.spms.DefaultSavedPaymentMethodLinkFormHelper
@@ -23,8 +22,6 @@ import com.stripe.android.common.taptoadd.ui.createTapToAddUxConfiguration
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.core.injection.ENABLE_LOGGING
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
-import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.core.utils.DefaultDurationProvider
@@ -53,6 +50,7 @@ import com.stripe.android.paymentelement.confirmation.linkinline.LinkInlineSignu
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.analytics.RealErrorReporter
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
+import com.stripe.android.payments.core.injection.PaymentConfigurationModule
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.BuildConfig
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
@@ -69,7 +67,6 @@ import dagger.Subcomponent
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import javax.inject.Named
-import javax.inject.Provider
 import javax.inject.Singleton
 
 @Component(
@@ -81,6 +78,7 @@ import javax.inject.Singleton
         DefaultConfirmationModule::class,
         DefaultIntentConfirmationModule::class,
         LinkInlineSignupConfirmationModule::class,
+        PaymentConfigurationModule::class,
         PaymentElementRequestSurfaceModule::class,
         TapToAddViewModelModule::class,
         TapToAddModule::class,
@@ -208,23 +206,6 @@ internal interface TapToAddViewModelModule {
         fun provideViewModelScope(): CoroutineScope {
             return CoroutineScope(Dispatchers.Main)
         }
-
-        @Provides
-        fun providePaymentConfiguration(appContext: Context): PaymentConfiguration {
-            return PaymentConfiguration.getInstance(appContext)
-        }
-
-        @Provides
-        @Named(PUBLISHABLE_KEY)
-        fun providePublishableKey(
-            paymentConfiguration: Provider<PaymentConfiguration>
-        ): () -> String = { paymentConfiguration.get().publishableKey }
-
-        @Provides
-        @Named(STRIPE_ACCOUNT_ID)
-        fun provideStripeAccountId(
-            paymentConfiguration: Provider<PaymentConfiguration>
-        ): () -> String? = { paymentConfiguration.get().stripeAccountId }
 
         @OptIn(ExperimentalAnalyticEventCallbackApi::class)
         @Provides

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetDataCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetDataCommonModule.kt
@@ -1,16 +1,13 @@
 package com.stripe.android.customersheet.injection
 
-import android.content.Context
 import com.stripe.android.BuildConfig
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.injection.ENABLE_LOGGING
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
-import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.analytics.RealErrorReporter
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
+import com.stripe.android.payments.core.injection.PaymentConfigurationModule
 import com.stripe.android.paymentsheet.repositories.CustomerApiRepository
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import dagger.Binds
@@ -18,9 +15,8 @@ import dagger.Module
 import dagger.Provides
 import java.util.Calendar
 import javax.inject.Named
-import javax.inject.Provider
 
-@Module
+@Module(includes = [PaymentConfigurationModule::class])
 internal interface CustomerSheetDataCommonModule {
     @Binds
     fun bindsCustomerRepository(repository: CustomerApiRepository): CustomerRepository
@@ -34,31 +30,6 @@ internal interface CustomerSheetDataCommonModule {
     fun bindsErrorReporter(errorReporter: RealErrorReporter): ErrorReporter
 
     companion object {
-        /**
-         * Provides a non-singleton PaymentConfiguration.
-         *
-         * Should be fetched only when it's needed, to allow client to set the publishableKey and
-         * stripeAccountId in PaymentConfiguration any time before presenting Customer Sheet.
-         *
-         * Should always be injected with [Lazy] or [Provider].
-         */
-        @Provides
-        fun providePaymentConfiguration(appContext: Context): PaymentConfiguration {
-            return PaymentConfiguration.getInstance(appContext)
-        }
-
-        @Provides
-        @Named(PUBLISHABLE_KEY)
-        fun providePublishableKey(
-            paymentConfiguration: Provider<PaymentConfiguration>
-        ): () -> String = { paymentConfiguration.get().publishableKey }
-
-        @Provides
-        @Named(STRIPE_ACCOUNT_ID)
-        fun provideStripeAccountId(
-            paymentConfiguration: Provider<PaymentConfiguration>
-        ): () -> String? = { paymentConfiguration.get().stripeAccountId }
-
         @Provides
         @Named(PRODUCT_USAGE)
         fun providesProductUsage(): Set<String> = setOf("CustomerSheet")

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
@@ -5,12 +5,9 @@ import android.content.Context
 import android.content.res.Resources
 import androidx.core.os.LocaleListCompat
 import com.stripe.android.BuildConfig
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.IOContext
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
-import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.core.injection.UIContext
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.networking.AnalyticsRequestFactory
@@ -28,6 +25,7 @@ import com.stripe.android.paymentelement.confirmation.ALLOWS_MANUAL_CONFIRMATION
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.analytics.RealErrorReporter
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
+import com.stripe.android.payments.core.injection.PaymentConfigurationModule
 import com.stripe.android.payments.financialconnections.DefaultIsFinancialConnectionsAvailable
 import com.stripe.android.payments.financialconnections.IsFinancialConnectionsSdkAvailable
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
@@ -40,10 +38,9 @@ import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.Dispatchers
 import javax.inject.Named
-import javax.inject.Provider
 import kotlin.coroutines.CoroutineContext
 
-@Module
+@Module(includes = [PaymentConfigurationModule::class])
 internal interface CustomerSheetViewModelModule {
     @Binds
     fun bindsUserFacingLogger(impl: RealUserFacingLogger): UserFacingLogger
@@ -75,19 +72,6 @@ internal interface CustomerSheetViewModelModule {
 
     @Suppress("TooManyFunctions")
     companion object {
-        /**
-         * Provides a non-singleton PaymentConfiguration.
-         *
-         * Should be fetched only when it's needed, to allow client to set the publishableKey and
-         * stripeAccountId in PaymentConfiguration any time before presenting Customer Sheet.
-         *
-         * Should always be injected with [Lazy] or [Provider].
-         */
-        @Provides
-        fun paymentConfiguration(application: Application): PaymentConfiguration {
-            return PaymentConfiguration.getInstance(application)
-        }
-
         @Provides
         @PaymentElementCallbackIdentifier
         fun providesPaymentElementCallbackIdentifier(): String {
@@ -99,18 +83,6 @@ internal interface CustomerSheetViewModelModule {
         fun providesIsFinancialConnectionsAvailable(): IsFinancialConnectionsSdkAvailable {
             return DefaultIsFinancialConnectionsAvailable
         }
-
-        @Provides
-        @Named(PUBLISHABLE_KEY)
-        fun providePublishableKey(
-            paymentConfiguration: Provider<PaymentConfiguration>
-        ): () -> String = { paymentConfiguration.get().publishableKey }
-
-        @Provides
-        @Named(STRIPE_ACCOUNT_ID)
-        fun provideStripeAccountId(
-            paymentConfiguration: Provider<PaymentConfiguration>
-        ): () -> String? = { paymentConfiguration.get().stripeAccountId }
 
         @Provides
         internal fun providesErrorReporter(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedCommonModule.kt
@@ -1,14 +1,10 @@
 package com.stripe.android.paymentelement.embedded
 
-import android.content.Context
 import androidx.lifecycle.SavedStateHandle
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.taptoadd.TapToAddConnectionModule
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.IOContext
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
-import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.core.injection.UIContext
 import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.core.utils.DefaultDurationProvider
@@ -25,6 +21,7 @@ import com.stripe.android.paymentelement.confirmation.ALLOWS_MANUAL_CONFIRMATION
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.analytics.RealErrorReporter
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
+import com.stripe.android.payments.core.injection.PaymentConfigurationModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.BuildConfig
 import com.stripe.android.paymentsheet.CustomerStateHolder
@@ -41,7 +38,6 @@ import dagger.Provides
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Named
-import javax.inject.Provider
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
@@ -52,6 +48,7 @@ import kotlin.coroutines.CoroutineContext
         TapToAddConnectionModule::class,
         PaymentsIntegrityModule::class,
         PaymentElementRequestSurfaceModule::class,
+        PaymentConfigurationModule::class,
     ],
 )
 internal interface EmbeddedCommonModule {
@@ -103,31 +100,6 @@ internal interface EmbeddedCommonModule {
         @Singleton
         @Named(ALLOWS_MANUAL_CONFIRMATION)
         fun provideAllowsManualConfirmation() = true
-
-        /**
-         * Provides a non-singleton PaymentConfiguration.
-         *
-         * Should be fetched only when it's needed, to allow client to set the publishableKey and
-         * stripeAccountId in PaymentConfiguration any time before configuring the FlowController
-         * or presenting Payment Sheet.
-         *
-         * Should always be injected with [Lazy] or [Provider].
-         */
-        @Provides
-        fun providePaymentConfiguration(appContext: Context): PaymentConfiguration {
-            return PaymentConfiguration.getInstance(appContext)
-        }
-
-        @Provides
-        @Named(PUBLISHABLE_KEY)
-        fun providePublishableKey(
-            paymentConfiguration: Provider<PaymentConfiguration>
-        ): () -> String = { paymentConfiguration.get().publishableKey }
-
-        @Provides
-        @Named(STRIPE_ACCOUNT_ID)
-        fun provideStripeAccountId(paymentConfiguration: Provider<PaymentConfiguration>):
-            () -> String? = { paymentConfiguration.get().stripeAccountId }
 
         @Provides
         @Singleton

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AutocompleteViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AutocompleteViewModelModule.kt
@@ -3,13 +3,12 @@ package com.stripe.android.paymentsheet.injection
 import android.app.Application
 import android.content.Context
 import com.stripe.android.BuildConfig
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.injection.ENABLE_LOGGING
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
+import com.stripe.android.payments.core.injection.PaymentConfigurationModule
 import com.stripe.android.paymentsheet.addresselement.AutocompleteContract
 import com.stripe.android.paymentsheet.addresselement.AutocompleteViewModel
 import com.stripe.android.paymentsheet.addresselement.analytics.AddressLauncherEventReporter
@@ -22,7 +21,7 @@ import dagger.Provides
 import javax.inject.Named
 import javax.inject.Singleton
 
-@Module
+@Module(includes = [PaymentConfigurationModule::class])
 internal interface AutocompleteViewModelModule {
     @Binds
     fun bindsAnalyticsRequestFactory(
@@ -52,13 +51,6 @@ internal interface AutocompleteViewModelModule {
         @Provides
         @Named(ENABLE_LOGGING)
         fun providesEnableLogging(): Boolean = BuildConfig.DEBUG
-
-        @Provides
-        @Named(PUBLISHABLE_KEY)
-        @Singleton
-        fun providesPublishableKey(
-            context: Context
-        ): () -> String = { PaymentConfiguration.getInstance(context).publishableKey }
 
         @Provides
         @Singleton

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
@@ -1,16 +1,12 @@
 package com.stripe.android.paymentsheet.injection
 
-import android.content.Context
 import androidx.lifecycle.SavedStateHandle
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.cards.CardAccountRangeRepository
 import com.stripe.android.cards.DefaultCardAccountRangeRepositoryFactory
 import com.stripe.android.common.taptoadd.DefaultTapToAddHelper
 import com.stripe.android.common.taptoadd.TapToAddConnectionModule
 import com.stripe.android.common.taptoadd.TapToAddHelper
 import com.stripe.android.core.injection.ENABLE_LOGGING
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
-import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.core.utils.DefaultDurationProvider
 import com.stripe.android.core.utils.DurationProvider
@@ -34,6 +30,7 @@ import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentif
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.analytics.RealErrorReporter
+import com.stripe.android.payments.core.injection.PaymentConfigurationModule
 import com.stripe.android.paymentsheet.BuildConfig
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
@@ -62,11 +59,9 @@ import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.paymentsheet.state.PaymentMethodFilter
 import com.stripe.android.paymentsheet.state.RetrieveCustomerEmail
 import dagger.Binds
-import dagger.Lazy
 import dagger.Module
 import dagger.Provides
 import javax.inject.Named
-import javax.inject.Provider
 import javax.inject.Singleton
 
 @SuppressWarnings("TooManyFunctions")
@@ -78,7 +73,8 @@ import javax.inject.Singleton
     includes = [
         LinkCommonModule::class,
         TapToAddConnectionModule::class,
-        PaymentsIntegrityModule::class
+        PaymentsIntegrityModule::class,
+        PaymentConfigurationModule::class,
     ]
 )
 internal abstract class PaymentSheetCommonModule {
@@ -173,35 +169,10 @@ internal abstract class PaymentSheetCommonModule {
             return LinkAccountHolder(savedStateHandle)
         }
 
-        /**
-         * Provides a non-singleton PaymentConfiguration.
-         *
-         * Should be fetched only when it's needed, to allow client to set the publishableKey and
-         * stripeAccountId in PaymentConfiguration any time before configuring the FlowController
-         * or presenting Payment Sheet.
-         *
-         * Should always be injected with [Lazy] or [Provider].
-         */
-        @Provides
-        fun providePaymentConfiguration(appContext: Context): PaymentConfiguration {
-            return PaymentConfiguration.getInstance(appContext)
-        }
-
         @Provides
         fun provideCustomerStateHolderFactory(): CustomerStateHolder.Factory {
             return DefaultCustomerStateHolder.Factory
         }
-
-        @Provides
-        @Named(PUBLISHABLE_KEY)
-        fun providePublishableKey(
-            paymentConfiguration: Provider<PaymentConfiguration>
-        ): () -> String = { paymentConfiguration.get().publishableKey }
-
-        @Provides
-        @Named(STRIPE_ACCOUNT_ID)
-        fun provideStripeAccountId(paymentConfiguration: Provider<PaymentConfiguration>):
-            () -> String? = { paymentConfiguration.get().stripeAccountId }
 
         @Provides
         @Singleton

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/di/USBankAccountFormViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/di/USBankAccountFormViewModelModule.kt
@@ -4,36 +4,25 @@ import android.app.Application
 import android.content.Context
 import android.content.res.Resources
 import com.stripe.android.BuildConfig
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.injection.ENABLE_LOGGING
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
+import com.stripe.android.payments.core.injection.PaymentConfigurationModule
 import dagger.Module
 import dagger.Provides
 import javax.inject.Named
 
 @Module(
-    subcomponents = [USBankAccountFormViewModelSubcomponent::class]
+    subcomponents = [USBankAccountFormViewModelSubcomponent::class],
+    includes = [PaymentConfigurationModule::class],
 )
 internal class USBankAccountFormViewModelModule {
     @Provides
     fun providesAppContext(application: Application): Context = application
 
     @Provides
-    fun providePaymentConfiguration(appContext: Context): PaymentConfiguration {
-        return PaymentConfiguration.getInstance(appContext)
-    }
-
-    @Provides
     fun providesResources(appContext: Context): Resources {
         return appContext.resources
     }
-
-    @Provides
-    @Named(PUBLISHABLE_KEY)
-    fun providePublishableKey(
-        appContext: Context
-    ): () -> String = { PaymentConfiguration.getInstance(appContext).publishableKey }
 
     @Provides
     @Named(PRODUCT_USAGE)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/di/PollingViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/di/PollingViewModelModule.kt
@@ -2,10 +2,9 @@ package com.stripe.android.paymentsheet.paymentdatacollection.polling.di
 
 import android.app.Application
 import android.content.Context
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.injection.ENABLE_LOGGING
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
+import com.stripe.android.payments.core.injection.PaymentConfigurationModule
 import com.stripe.android.paymentsheet.BuildConfig
 import com.stripe.android.paymentsheet.paymentdatacollection.polling.DefaultTimeProvider
 import com.stripe.android.paymentsheet.paymentdatacollection.polling.TimeProvider
@@ -16,7 +15,10 @@ import dagger.Module
 import dagger.Provides
 import javax.inject.Named
 
-@Module(subcomponents = [PollingViewModelSubcomponent::class])
+@Module(
+    subcomponents = [PollingViewModelSubcomponent::class],
+    includes = [PaymentConfigurationModule::class],
+)
 internal interface PollingViewModelModule {
 
     @Binds
@@ -29,17 +31,6 @@ internal interface PollingViewModelModule {
 
         @Provides
         fun providesAppContext(application: Application): Context = application
-
-        @Provides
-        fun providePaymentConfiguration(appContext: Context): PaymentConfiguration {
-            return PaymentConfiguration.getInstance(appContext)
-        }
-
-        @Provides
-        @Named(PUBLISHABLE_KEY)
-        fun providePublishableKey(
-            appContext: Context
-        ): () -> String = { PaymentConfiguration.getInstance(appContext).publishableKey }
 
         @Provides
         @Named(PRODUCT_USAGE)


### PR DESCRIPTION
## Summary
- Extract duplicated `PaymentConfiguration`, `publishableKey`, and `stripeAccountId` Dagger providers into a new shared `PaymentConfigurationModule` in `payments-core`
- Update 10 modules across `paymentsheet`, `crypto-onramp`, and `payment-method-messaging` to include the shared module and remove their local copies
- Net removal of ~140 lines of duplicated code

## Test plan
- [x] `./gradlew :payments-core:compileDebugKotlin :payments-core:kspDebugKotlin` passes (Dagger codegen succeeds)
- [x] `./gradlew :paymentsheet:compileDebugKotlin :paymentsheet:kspDebugKotlin` passes
- [x] `./gradlew :crypto-onramp:compileDebugKotlin :crypto-onramp:kspDebugKotlin` passes
- [x] `./gradlew :payment-method-messaging:compileDebugKotlin :payment-method-messaging:kspDebugKotlin` passes
- [x] `./gradlew :payments-core:testDebugUnitTest :paymentsheet:testDebugUnitTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)