### PR TITLE
Move checkout session API into standalone CheckoutSessionRepository

### DIFF
--- a/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
@@ -7,8 +7,6 @@ import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.networking.StripeResponse
 import com.stripe.android.model.BankStatuses
 import com.stripe.android.model.CardMetadata
-import com.stripe.android.model.CheckoutSessionResponse
-import com.stripe.android.model.ConfirmCheckoutSessionParams
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.ConfirmationToken
@@ -438,21 +436,6 @@ abstract class AbsFakeStripeRepository : StripeRepository {
         params: ElementsSessionParams,
         options: ApiRequest.Options
     ): Result<ElementsSession> {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun initCheckoutSession(
-        sessionId: String,
-        options: ApiRequest.Options,
-    ): Result<CheckoutSessionResponse> {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun confirmCheckoutSession(
-        checkoutSessionId: String,
-        confirmCheckoutSessionParams: ConfirmCheckoutSessionParams,
-        options: ApiRequest.Options,
-    ): Result<CheckoutSessionResponse> {
         TODO("Not yet implemented")
     }
 

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/ElementsSessionJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/ElementsSessionJsonParser.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.model.parsers
 
+import androidx.annotation.RestrictTo
 import com.stripe.android.core.model.StripeJsonUtils
 import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.core.model.parsers.ModelJsonParser.Companion.jsonArrayToList
@@ -15,7 +16,8 @@ import org.json.JSONArray
 import org.json.JSONObject
 import java.util.UUID
 
-internal class ElementsSessionJsonParser(
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class ElementsSessionJsonParser(
     private val params: ElementsSessionParams,
     private val isLiveMode: Boolean,
     private val timeProvider: () -> Long = {

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -48,8 +48,6 @@ import com.stripe.android.core.version.StripeSdkVersion
 import com.stripe.android.exception.CardException
 import com.stripe.android.model.BankStatuses
 import com.stripe.android.model.CardMetadata
-import com.stripe.android.model.CheckoutSessionResponse
-import com.stripe.android.model.ConfirmCheckoutSessionParams
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.ConfirmStripeIntentParams
@@ -84,7 +82,6 @@ import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.Token
 import com.stripe.android.model.TokenParams
 import com.stripe.android.model.parsers.CardMetadataJsonParser
-import com.stripe.android.model.parsers.CheckoutSessionResponseJsonParser
 import com.stripe.android.model.parsers.ConfirmationTokenJsonParser
 import com.stripe.android.model.parsers.ConsumerPaymentDetailsJsonParser
 import com.stripe.android.model.parsers.ConsumerPaymentDetailsShareJsonParser
@@ -116,8 +113,6 @@ import java.io.IOException
 import java.net.HttpURLConnection
 import java.security.Security
 import java.util.Locale
-import java.util.TimeZone
-import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Named
 import kotlin.coroutines.CoroutineContext
@@ -1545,47 +1540,6 @@ class StripeApiRepository @JvmOverloads internal constructor(
             params = params,
             options = options,
             analyticsEvent = null,
-        )
-    }
-
-    override suspend fun initCheckoutSession(
-        sessionId: String,
-        options: ApiRequest.Options,
-    ): Result<CheckoutSessionResponse> {
-        return fetchStripeModelResult(
-            apiRequest = apiRequestFactory.createPost(
-                url = getApiUrl("payment_pages/$sessionId/init"),
-                options = options,
-                params = mapOf(
-                    "browser_locale" to Locale.getDefault().toLanguageTag(),
-                    "browser_timezone" to TimeZone.getDefault().id,
-                    "eid" to UUID.randomUUID().toString(),
-                    "redirect_type" to "embedded",
-                    "elements_session_client[is_aggregation_expected]" to "true",
-                ),
-            ),
-            jsonParser = CheckoutSessionResponseJsonParser(
-                isLiveMode = options.apiKeyIsLiveMode,
-            ),
-        )
-    }
-
-    override suspend fun confirmCheckoutSession(
-        checkoutSessionId: String,
-        confirmCheckoutSessionParams: ConfirmCheckoutSessionParams,
-        options: ApiRequest.Options,
-    ): Result<CheckoutSessionResponse> {
-        return fetchStripeModelResult(
-            apiRequest = apiRequestFactory.createPost(
-                url = getApiUrl(
-                    "payment_pages/$checkoutSessionId/confirm"
-                ),
-                options = options,
-                params = confirmCheckoutSessionParams.toParamMap(),
-            ),
-            jsonParser = CheckoutSessionResponseJsonParser(
-                isLiveMode = options.apiKeyIsLiveMode,
-            ),
         )
     }
 

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -8,8 +8,6 @@ import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.networking.StripeResponse
 import com.stripe.android.model.BankStatuses
 import com.stripe.android.model.CardMetadata
-import com.stripe.android.model.CheckoutSessionResponse
-import com.stripe.android.model.ConfirmCheckoutSessionParams
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.ConfirmationToken
@@ -407,35 +405,6 @@ interface StripeRepository {
         params: ElementsSessionParams,
         options: ApiRequest.Options,
     ): Result<ElementsSession>
-
-    /**
-     * Initialize a checkout session by calling the `/v1/payment_pages/{cs_id}/init` endpoint.
-     *
-     * @param sessionId The checkout session parameters including session ID.
-     * @param options API request options including the publishable key.
-     * @return A [CheckoutSessionResponse] containing checkout metadata and embedded [ElementsSession].
-     */
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    suspend fun initCheckoutSession(
-        sessionId: String,
-        options: ApiRequest.Options,
-    ): Result<CheckoutSessionResponse>
-
-    /**
-     * Confirms a checkout session by calling the `/v1/payment_pages/{checkoutSessionId}/confirm` endpoint.
-     *
-     * @param checkoutSessionId The checkout session ID (e.g., "cs_test_xxx").
-     * @param paymentMethodId The payment method ID to use for confirmation.
-     * @param returnUrl The URL to redirect to after confirmation (required for ui_mode=custom).
-     * @param options API request options including the publishable key.
-     * @return A [CheckoutSessionResponse] containing the confirmed [PaymentIntent].
-     */
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    suspend fun confirmCheckoutSession(
-        checkoutSessionId: String,
-        confirmCheckoutSessionParams: ConfirmCheckoutSessionParams,
-        options: ApiRequest.Options,
-    ): Result<CheckoutSessionResponse>
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     suspend fun retrieveCardMetadata(

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataKtx.kt
@@ -1,8 +1,8 @@
 package com.stripe.android.lpmfoundations.paymentmethod
 
 import com.stripe.android.common.model.CommonConfiguration
-import com.stripe.android.model.CheckoutSessionResponse
 import com.stripe.android.model.ElementsSession
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 
 internal fun CheckoutSessionResponse.SavedPaymentMethodsOfferSave.toSaveConsentBehavior():
     PaymentMethodSaveConsentBehavior {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.ClientAttributionMetadata
-import com.stripe.android.model.ConfirmCheckoutSessionParams
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
@@ -15,6 +14,8 @@ import com.stripe.android.paymentelement.confirmation.MutableConfirmationMetadat
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.intent.IntentConfirmationDefinition.Args
 import com.stripe.android.payments.DefaultReturnUrl
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionRepository
+import com.stripe.android.paymentsheet.repositories.ConfirmCheckoutSessionParams
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -35,6 +36,7 @@ internal class CheckoutSessionConfirmationInterceptor @AssistedInject constructo
     @Assisted private val clientAttributionMetadata: ClientAttributionMetadata,
     context: Context,
     private val stripeRepository: StripeRepository,
+    private val checkoutSessionRepository: CheckoutSessionRepository,
     private val requestOptions: ApiRequest.Options,
 ) : IntentConfirmationInterceptor {
 
@@ -89,9 +91,9 @@ internal class CheckoutSessionConfirmationInterceptor @AssistedInject constructo
         paymentMethod: PaymentMethod,
         savePaymentMethod: Boolean?,
     ): ConfirmationDefinition.Action<Args> {
-        return stripeRepository.confirmCheckoutSession(
-            checkoutSessionId = checkoutSessionId,
-            confirmCheckoutSessionParams = ConfirmCheckoutSessionParams(
+        return checkoutSessionRepository.confirm(
+            id = checkoutSessionId,
+            params = ConfirmCheckoutSessionParams(
                 paymentMethodId = paymentMethod.id,
                 clientAttributionMetadata = clientAttributionMetadata,
                 returnUrl = returnUrl,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/DefaultIntentConfirmationModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/DefaultIntentConfirmationModule.kt
@@ -1,9 +1,15 @@
 package com.stripe.android.paymentelement.confirmation.intent
 
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionRepositoryModule
 import dagger.Binds
 import dagger.Module
 
-@Module(includes = [IntentConfirmationModule::class])
+@Module(
+    includes = [
+        IntentConfirmationModule::class,
+        CheckoutSessionRepositoryModule::class,
+    ]
+)
 internal interface DefaultIntentConfirmationModule {
     @Binds
     fun bindsIntentConfirmationInterceptorFactory(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionRepository.kt
@@ -1,0 +1,89 @@
+package com.stripe.android.paymentsheet.repositories
+
+import com.stripe.android.core.AppInfo
+import com.stripe.android.core.model.parsers.StripeErrorJsonParser
+import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.core.networking.StripeNetworkClient
+import com.stripe.android.core.networking.executeRequestWithResultParser
+import com.stripe.android.core.version.StripeSdkVersion
+import java.util.Locale
+import java.util.TimeZone
+import java.util.UUID
+
+internal interface CheckoutSessionRepository {
+    suspend fun init(
+        sessionId: String,
+        options: ApiRequest.Options,
+    ): Result<CheckoutSessionResponse>
+
+    suspend fun confirm(
+        id: String,
+        params: ConfirmCheckoutSessionParams,
+        options: ApiRequest.Options,
+    ): Result<CheckoutSessionResponse>
+}
+
+internal class DefaultCheckoutSessionRepository(
+    private val stripeNetworkClient: StripeNetworkClient,
+    apiVersion: String,
+    sdkVersion: String = StripeSdkVersion.VERSION,
+    appInfo: AppInfo?,
+) : CheckoutSessionRepository {
+    private val apiRequestFactory = ApiRequest.Factory(
+        appInfo = appInfo,
+        apiVersion = apiVersion,
+        sdkVersion = sdkVersion,
+    )
+    private val stripeErrorJsonParser = StripeErrorJsonParser()
+
+    override suspend fun init(
+        sessionId: String,
+        options: ApiRequest.Options,
+    ): Result<CheckoutSessionResponse> {
+        return executeRequestWithResultParser(
+            stripeErrorJsonParser = stripeErrorJsonParser,
+            stripeNetworkClient = stripeNetworkClient,
+            request = apiRequestFactory.createPost(
+                url = initUrl(sessionId),
+                options = options,
+                params = mapOf(
+                    "browser_locale" to Locale.getDefault().toLanguageTag(),
+                    "browser_timezone" to TimeZone.getDefault().id,
+                    "eid" to UUID.randomUUID().toString(),
+                    "redirect_type" to "embedded",
+                    "elements_session_client[is_aggregation_expected]" to "true",
+                ),
+            ),
+            responseJsonParser = CheckoutSessionResponseJsonParser(
+                isLiveMode = options.apiKeyIsLiveMode,
+            ),
+        )
+    }
+
+    override suspend fun confirm(
+        id: String,
+        params: ConfirmCheckoutSessionParams,
+        options: ApiRequest.Options,
+    ): Result<CheckoutSessionResponse> {
+        return executeRequestWithResultParser(
+            stripeErrorJsonParser = stripeErrorJsonParser,
+            stripeNetworkClient = stripeNetworkClient,
+            request = apiRequestFactory.createPost(
+                url = confirmUrl(id),
+                options = options,
+                params = params.toParamMap(),
+            ),
+            responseJsonParser = CheckoutSessionResponseJsonParser(
+                isLiveMode = options.apiKeyIsLiveMode,
+            ),
+        )
+    }
+
+    private companion object {
+        private fun initUrl(sessionId: String): String =
+            "${ApiRequest.API_HOST}/v1/payment_pages/$sessionId/init"
+
+        private fun confirmUrl(checkoutSessionId: String): String =
+            "${ApiRequest.API_HOST}/v1/payment_pages/$checkoutSessionId/confirm"
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionRepositoryModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionRepositoryModule.kt
@@ -1,0 +1,27 @@
+package com.stripe.android.paymentsheet.repositories
+
+import com.stripe.android.Stripe
+import com.stripe.android.core.Logger
+import com.stripe.android.core.injection.IOContext
+import com.stripe.android.core.networking.DefaultStripeNetworkClient
+import com.stripe.android.core.version.StripeSdkVersion
+import dagger.Module
+import dagger.Provides
+import kotlin.coroutines.CoroutineContext
+
+@Module
+internal object CheckoutSessionRepositoryModule {
+    @Provides
+    fun provideCheckoutSessionRepository(
+        logger: Logger,
+        @IOContext workContext: CoroutineContext,
+    ): CheckoutSessionRepository = DefaultCheckoutSessionRepository(
+        stripeNetworkClient = DefaultStripeNetworkClient(
+            logger = logger,
+            workContext = workContext,
+        ),
+        apiVersion = Stripe.API_VERSION,
+        sdkVersion = StripeSdkVersion.VERSION,
+        appInfo = Stripe.appInfo,
+    )
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponse.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponse.kt
@@ -1,7 +1,10 @@
-package com.stripe.android.model
+package com.stripe.android.paymentsheet.repositories
 
 import androidx.annotation.RestrictTo
 import com.stripe.android.core.model.StripeModel
+import com.stripe.android.model.ElementsSession
+import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.PaymentMethod
 import kotlinx.parcelize.Parcelize
 
 /**

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParser.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParser.kt
@@ -1,11 +1,13 @@
-package com.stripe.android.model.parsers
+package com.stripe.android.paymentsheet.repositories
 
 import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.core.model.parsers.ModelJsonParser.Companion.jsonArrayToList
-import com.stripe.android.model.CheckoutSessionResponse
 import com.stripe.android.model.DeferredIntentParams
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.ElementsSessionParams
+import com.stripe.android.model.parsers.ElementsSessionJsonParser
+import com.stripe.android.model.parsers.PaymentIntentJsonParser
+import com.stripe.android.model.parsers.PaymentMethodJsonParser
 import org.json.JSONObject
 
 /**

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ConfirmCheckoutSessionParams.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ConfirmCheckoutSessionParams.kt
@@ -1,6 +1,7 @@
-package com.stripe.android.model
+package com.stripe.android.paymentsheet.repositories
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.model.ClientAttributionMetadata
 
 /**
  * Parameters for confirming a checkout session via the confirm API

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CustomerState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CustomerState.kt
@@ -1,9 +1,9 @@
 package com.stripe.android.paymentsheet.state
 
 import android.os.Parcelable
-import com.stripe.android.model.CheckoutSessionResponse
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import kotlinx.parcelize.Parcelize
 
 @Parcelize

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -34,12 +34,10 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilt
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardFundingFilterFactory
 import com.stripe.android.lpmfoundations.paymentmethod.create
 import com.stripe.android.lpmfoundations.paymentmethod.toSaveConsentBehavior
-import com.stripe.android.model.CheckoutSessionResponse
 import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
-import com.stripe.android.networking.StripeRepository
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
@@ -54,6 +52,8 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.model.SetupIntentClientSecret
 import com.stripe.android.paymentsheet.model.validate
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionRepository
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
 import com.stripe.android.ui.core.elements.ExternalPaymentMethodSpec
@@ -231,7 +231,7 @@ internal interface PaymentElementLoader {
 @Singleton
 @SuppressWarnings("LargeClass")
 internal class DefaultPaymentElementLoader @Inject constructor(
-    private val stripeRepository: StripeRepository,
+    private val checkoutSessionRepository: CheckoutSessionRepository,
     private val prefsRepositoryFactory: PrefsRepository.Factory,
     private val googlePayRepositoryFactory: GooglePayRepositoryFactory,
     private val elementsSessionRepository: ElementsSessionRepository,
@@ -419,7 +419,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         if (initializationMode !is PaymentElementLoader.InitializationMode.CheckoutSession) {
             return null
         }
-        return stripeRepository.initCheckoutSession(
+        return checkoutSessionRepository.init(
             sessionId = initializationMode.id,
             options = ApiRequest.Options(
                 paymentConfiguration.get().publishableKey,

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/FakeStripeRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/FakeStripeRepository.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.customersheet
 
 import com.stripe.android.core.networking.ApiRequest
-import com.stripe.android.model.CheckoutSessionResponse
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.SetupIntent
@@ -12,15 +11,7 @@ class FakeStripeRepository(
     private val createPaymentMethodResult: Result<PaymentMethod> = Result.failure(NotImplementedError()),
     private val retrieveSetupIntent: Result<SetupIntent> = Result.failure(NotImplementedError()),
     private val retrieveIntent: Result<StripeIntent> = Result.failure(NotImplementedError()),
-    private val initCheckoutSessionResult: Result<CheckoutSessionResponse> = Result.failure(NotImplementedError()),
 ) : AbsFakeStripeRepository() {
-
-    override suspend fun initCheckoutSession(
-        sessionId: String,
-        options: ApiRequest.Options,
-    ): Result<CheckoutSessionResponse> {
-        return initCheckoutSessionResult
-    }
 
     override suspend fun createPaymentMethod(
         paymentMethodCreateParams: PaymentMethodCreateParams,

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataKtxTest.kt
@@ -1,10 +1,10 @@
 package com.stripe.android.lpmfoundations.paymentmethod
 
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.model.CheckoutSessionResponse
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import org.junit.Test
 
 internal class PaymentMethodMetadataKtxTest {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationUtils.kt
@@ -42,6 +42,7 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.cvcrecollection.CvcRecollectionHandlerImpl
 import com.stripe.android.paymentsheet.paymentdatacollection.bacs.BacsMandateConfirmationLauncherFactory
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcRecollectionLauncherFactory
+import com.stripe.android.paymentsheet.repositories.FakeCheckoutSessionRepository
 import com.stripe.android.paymentsheet.utils.FakeUserFacingLogger
 import com.stripe.android.testing.AbsFakeStripeRepository
 import com.stripe.android.testing.FakeErrorReporter
@@ -149,6 +150,7 @@ internal suspend fun createIntentConfirmationInterceptor(
                     clientAttributionMetadata = clientAttributionMetadata,
                     context = ApplicationProvider.getApplicationContext(),
                     stripeRepository = stripeRepository,
+                    checkoutSessionRepository = FakeCheckoutSessionRepository(),
                     requestOptions = requestOptions,
                 )
             }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionFixtures.kt
@@ -1,4 +1,4 @@
-package com.stripe.android.model
+package com.stripe.android.paymentsheet.repositories
 
 import org.json.JSONObject
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParserTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParserTest.kt
@@ -1,9 +1,7 @@
-package com.stripe.android.model.parsers
+package com.stripe.android.paymentsheet.repositories
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.CardBrand
-import com.stripe.android.model.CheckoutSessionFixtures
-import com.stripe.android.model.CheckoutSessionResponse
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/ConfirmCheckoutSessionParamsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/ConfirmCheckoutSessionParamsTest.kt
@@ -1,6 +1,9 @@
-package com.stripe.android.model
+package com.stripe.android.paymentsheet.repositories
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.ClientAttributionMetadata
+import com.stripe.android.model.PaymentIntentCreationFlow
+import com.stripe.android.model.PaymentMethodSelectionFlow
 import kotlin.test.Test
 
 class ConfirmCheckoutSessionParamsTest {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/FakeCheckoutSessionRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/FakeCheckoutSessionRepository.kt
@@ -1,0 +1,20 @@
+package com.stripe.android.paymentsheet.repositories
+
+import com.stripe.android.core.networking.ApiRequest
+
+internal class FakeCheckoutSessionRepository(
+    var initResult: Result<CheckoutSessionResponse> = Result.failure(NotImplementedError()),
+    var confirmResult: Result<CheckoutSessionResponse> = Result.failure(NotImplementedError()),
+) : CheckoutSessionRepository {
+
+    override suspend fun init(
+        sessionId: String,
+        options: ApiRequest.Options,
+    ): Result<CheckoutSessionResponse> = initResult
+
+    override suspend fun confirm(
+        id: String,
+        params: ConfirmCheckoutSessionParams,
+        options: ApiRequest.Options,
+    ): Result<CheckoutSessionResponse> = confirmResult
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CustomerStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CustomerStateTest.kt
@@ -1,10 +1,10 @@
 package com.stripe.android.paymentsheet.state
 
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.model.CheckoutSessionResponse
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.testing.PaymentMethodFactory
 import kotlinx.coroutines.test.runTest
 import org.junit.Test


### PR DESCRIPTION
## Summary
- Move `initCheckoutSession` and `confirmCheckoutSession` out of the `StripeRepository` god-object into a dedicated `CheckoutSessionRepository` (interface + `DefaultCheckoutSessionRepository`) in the paymentsheet module
- Relocate `CheckoutSessionResponse`, `ConfirmCheckoutSessionParams`, and `CheckoutSessionResponseJsonParser` from payments-core to paymentsheet, where they are exclusively used
- Remove the two checkout session methods from `StripeRepository`, `StripeApiRepository`, `AbsFakeStripeRepository`, and `FakeStripeRepository`

## Test plan
- [x] `./gradlew :paymentsheet:testDebugUnitTest` — all tests pass
- [x] `./gradlew :payments-core:testDebugUnitTest` — passes (2 pre-existing flaky UI widget failures unrelated to this change)
- [x] `./gradlew :payments-core-testing:assembleDebug` — builds successfully
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)