### PR TITLE
Only run checkout sessions test with compose.

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetCheckoutSessionTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetCheckoutSessionTest.kt
@@ -1,15 +1,12 @@
 package com.stripe.android.paymentsheet
 
-import com.google.testing.junit.testparameterinjector.TestParameter
-import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.checkout.Checkout
 import com.stripe.android.networktesting.RequestMatchers.host
 import com.stripe.android.networktesting.RequestMatchers.method
 import com.stripe.android.networktesting.RequestMatchers.path
 import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentelement.CheckoutSessionPreview
-import com.stripe.android.paymentsheet.utils.IntegrationType
-import com.stripe.android.paymentsheet.utils.IntegrationTypeProvider
 import com.stripe.android.paymentsheet.utils.TestRules
 import com.stripe.android.paymentsheet.utils.assertCompleted
 import com.stripe.android.paymentsheet.utils.runPaymentSheetTest
@@ -18,7 +15,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @OptIn(CheckoutSessionPreview::class)
-@RunWith(TestParameterInjector::class)
+@RunWith(AndroidJUnit4::class)
 internal class PaymentSheetCheckoutSessionTest {
     @get:Rule
     val testRules: TestRules = TestRules.create()
@@ -27,9 +24,6 @@ internal class PaymentSheetCheckoutSessionTest {
     private val networkRule = testRules.networkRule
 
     private val page: PaymentSheetPage = PaymentSheetPage(composeTestRule)
-
-    @TestParameter(valuesProvider = IntegrationTypeProvider::class)
-    lateinit var integrationType: IntegrationType
 
     private val defaultConfiguration = PaymentSheet.Configuration(
         merchantDisplayName = "Checkout Session Test",
@@ -50,7 +44,6 @@ internal class PaymentSheetCheckoutSessionTest {
     @Test
     fun testSuccessfulCardPaymentWithCheckoutSession() = runPaymentSheetTest(
         networkRule = networkRule,
-        integrationType = integrationType,
         resultCallback = ::assertCompleted,
     ) { testContext ->
         // Mock checkout session init API


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
We don't need to test other variants, so just simplifying the test setup.