### PR TITLE
When user cancels TTA after adding card and link unavailable, show sa…

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddHelper.kt
@@ -102,7 +102,7 @@ internal class DefaultTapToAddHelper(
                         paymentSelection,
                     )
                 } else {
-                    null
+                    TapToAddNextStep.ShowSavedPaymentMethods(paymentSelection)
                 }
             }
             TapToAddResult.Complete -> TapToAddNextStep.Complete

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddNextStep.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddNextStep.kt
@@ -7,6 +7,8 @@ internal sealed interface TapToAddNextStep {
 
     data class Continue(val paymentSelection: PaymentSelection.Saved) : TapToAddNextStep
 
+    data class ShowSavedPaymentMethods(val paymentSelection: PaymentSelection.Saved) : TapToAddNextStep
+
     data class ConfirmSavedPaymentMethod(
         val paymentSelection: PaymentSelection.Saved
     ) : TapToAddNextStep

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityConfirmationHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityConfirmationHelper.kt
@@ -56,6 +56,13 @@ internal class DefaultFormActivityConfirmationHelper @Inject constructor(
                         )
                         null
                     }
+                    is TapToAddNextStep.ShowSavedPaymentMethods -> {
+                        FormResult.Complete(
+                            selection = result.paymentSelection,
+                            hasBeenConfirmed = false,
+                            customerState = customerStateHolder.customer.value,
+                        )
+                    }
                     TapToAddNextStep.Complete -> {
                         FormResult.Complete(
                             selection = null,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -223,12 +223,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
 
         updateSelection(args.state.paymentSelection)
 
-        navigationHandler.resetTo(
-            determineInitialBackStack(
-                paymentMethodMetadata = args.state.paymentMethodMetadata,
-                customerStateHolder = customerStateHolder,
-            )
-        )
+        navigateToInitialScreens()
 
         viewModelScope.launch {
             tapToAddHelper.nextStep.collect { result ->
@@ -246,6 +241,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
                         ).plus(savedPaymentMethodConfirmScreen)
                         navigationHandler.resetTo(newScreens)
                     }
+                    is TapToAddNextStep.ShowSavedPaymentMethods -> navigateToInitialScreens()
                     TapToAddNextStep.Complete -> {
                         errorReporter.report(
                             ErrorReporter.UnexpectedErrorEvent.TAP_TO_ADD_FLOW_CONTROLLER_RECEIVED_COMPLETE_RESULT,
@@ -259,6 +255,15 @@ internal class PaymentOptionsViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    private fun navigateToInitialScreens() {
+        navigationHandler.resetTo(
+            determineInitialBackStack(
+                paymentMethodMetadata = args.state.paymentMethodMetadata,
+                customerStateHolder = customerStateHolder,
+            )
+        )
     }
 
     override fun registerFromActivity(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -260,6 +260,10 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                         ).plus(savedPaymentMethodConfirmScreen)
                         navigationHandler.resetTo(newScreens)
                     }
+                    is TapToAddNextStep.ShowSavedPaymentMethods -> {
+                        val paymentMethodMetadata = paymentMethodMetadata.value ?: return@collect
+                        navigateToInitialScreens(paymentMethodMetadata)
+                    }
                     TapToAddNextStep.Complete -> {
                         _paymentSheetResult.tryEmit(PaymentSheetResult.Completed())
                     }
@@ -383,6 +387,10 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         }
 
         resetViewState(errorMessage)
+        navigateToInitialScreens(metadata)
+    }
+
+    private fun navigateToInitialScreens(metadata: PaymentMethodMetadata) {
         navigationHandler.resetTo(
             determineInitialBackStack(
                 paymentMethodMetadata = metadata,

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddHelperTest.kt
@@ -69,7 +69,7 @@ class TapToAddHelperTest {
                 tapToAddResult,
                 helper = helper,
                 activityResultCallerScenario = activityResultCallerScenario,
-                expectedNextStep = null,
+                expectedNextStep = TapToAddNextStep.ShowSavedPaymentMethods(expectedPaymentSelection),
                 testScope = testScope,
             )
 
@@ -97,7 +97,7 @@ class TapToAddHelperTest {
                 tapToAddResult,
                 helper = helper,
                 activityResultCallerScenario = activityResultCallerScenario,
-                expectedNextStep = null,
+                expectedNextStep = TapToAddNextStep.ShowSavedPaymentMethods(expectedPaymentSelection),
                 testScope = testScope,
             )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -1223,7 +1223,7 @@ internal class PaymentOptionsViewModelTest {
     }
 
     @Test
-    fun `When tap to add result is Canceled with payment selection, screens are updated`() = runTest {
+    fun `When tap to add next step is confirm spm, screens are updated`() = runTest {
         val expectedPaymentSelection = PaymentSelection.Saved(CARD_PAYMENT_METHOD)
         val customerStateHolder = FakeCustomerStateHolder()
 
@@ -1245,6 +1245,29 @@ internal class PaymentOptionsViewModelTest {
                 )
 
                 assertThat(awaitItem()).isInstanceOf<PaymentSheetScreen.SavedPaymentMethodConfirm>()
+            }
+        }
+    }
+
+    @Test
+    fun `When tap to add next step is show spm, screens are updated`() = runTest {
+        FakeTapToAddHelper.Factory.test {
+            val viewModel = createViewModel(
+                tapToAddHelperFactory = tapToAddHelperFactory,
+            )
+
+            createCalls.awaitItem()
+
+            viewModel.navigationHandler.currentScreen.test {
+                awaitItem()
+
+                tapToAddHelperFactory.getCreatedHelper()?.emitNextStep(
+                    TapToAddNextStep.ShowSavedPaymentMethods(
+                        PaymentSelection.Saved(CARD_PAYMENT_METHOD),
+                    )
+                )
+
+                assertThat(awaitItem()).isInstanceOf<SelectSavedPaymentMethods>()
             }
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -3399,7 +3399,7 @@ internal class PaymentSheetViewModelTest {
     }
 
     @Test
-    fun `When tap to add result is Canceled with payment selection, screens are updated`() = runTest {
+    fun `When tap to add next step is confirm spm, screens are updated`() = runTest {
         val expectedPaymentSelection = PaymentSelection.Saved(CARD_PAYMENT_METHOD)
         val customerStateHolder = FakeCustomerStateHolder()
 
@@ -3421,6 +3421,31 @@ internal class PaymentSheetViewModelTest {
                 )
 
                 assertThat(awaitItem()).isInstanceOf<PaymentSheetScreen.SavedPaymentMethodConfirm>()
+            }
+        }
+    }
+
+    @Test
+    fun `When tap to add result is is show spm, screens are updated`() = runTest {
+        FakeTapToAddHelper.Factory.test {
+            val viewModel = createViewModel(
+                tapToAddHelperFactory = tapToAddHelperFactory,
+            )
+
+            createCalls.awaitItem()
+
+            viewModel.navigationHandler.currentScreen.test {
+                awaitItem()
+
+                tapToAddHelperFactory.getCreatedHelper()?.emitNextStep(
+                    TapToAddNextStep.ShowSavedPaymentMethods(
+                        PaymentSelection.Saved(
+                            CARD_PAYMENT_METHOD
+                        )
+                    )
+                )
+
+                assertThat(awaitItem()).isInstanceOf<SelectSavedPaymentMethods>()
             }
         }
     }


### PR DESCRIPTION
…ved pms screen

# Summary
<!-- Simple summary of what was changed. -->
When user cancels TTA after adding card and link unavailable, show saved pms screen

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Design feedback: https://stripe.slack.com/archives/C0A4KKJRHME/p1772062566224689

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [X] Manually verified
# Screen recording


https://github.com/user-attachments/assets/ae3fc04d-c0a0-438d-bdce-a910fd6ba4a9

