### PR TITLE
Enable FC Tests

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestUSBankAccount.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestUSBankAccount.kt
@@ -150,7 +150,6 @@ internal class TestUSBankAccount : BasePlaygroundTest() {
         )
     }
 
-    @Ignore("#ir-bumper-lonely")
     @Test
     fun testUSBankAccountLiteSuccess() {
         testDriver.confirmUSBankAccount(

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -1567,11 +1567,11 @@ internal class PlaygroundTestDriver(
         }
 
         onWebView()
-            .withElementByTestId("agree-button")
+            .withElementByTestId("institution-default")
             .perform(webClick())
 
         onWebView()
-            .withElementByTestId("institution-default")
+            .withElementByTestId("agree-button")
             .perform(webClick())
 
         onWebView()


### PR DESCRIPTION
# Summary
To mitigate `ir-bumper-lonely`, we turned off 1 failing FC tests in #12467. This was failing because the test expected the consent page to appear before the institution picker. The consent page is now presented after the institution picker. This test has been updated to reflect this new flow.

# Motivation
Closes https://jira.corp.stripe.com/browse/INCIDENT-46117

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

