### PR TITLE
Inject publishable key and account ID providers into CheckoutSessionRepository

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
@@ -99,7 +99,6 @@ internal class CheckoutSessionConfirmationInterceptor @AssistedInject constructo
                 returnUrl = returnUrl,
                 savePaymentMethod = savePaymentMethod,
             ),
-            options = requestOptions,
         ).fold(
             onSuccess = { response ->
                 val exception = IllegalStateException("No PaymentIntent in checkout session confirm response")

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionRepositoryModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionRepositoryModule.kt
@@ -3,10 +3,13 @@ package com.stripe.android.paymentsheet.repositories
 import com.stripe.android.Stripe
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.IOContext
+import com.stripe.android.core.injection.PUBLISHABLE_KEY
+import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.core.networking.DefaultStripeNetworkClient
 import com.stripe.android.core.version.StripeSdkVersion
 import dagger.Module
 import dagger.Provides
+import javax.inject.Named
 import kotlin.coroutines.CoroutineContext
 
 @Module
@@ -15,6 +18,8 @@ internal object CheckoutSessionRepositoryModule {
     fun provideCheckoutSessionRepository(
         logger: Logger,
         @IOContext workContext: CoroutineContext,
+        @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
+        @Named(STRIPE_ACCOUNT_ID) stripeAccountIdProvider: () -> String?,
     ): CheckoutSessionRepository = DefaultCheckoutSessionRepository(
         stripeNetworkClient = DefaultStripeNetworkClient(
             logger = logger,
@@ -23,5 +28,7 @@ internal object CheckoutSessionRepositoryModule {
         apiVersion = Stripe.API_VERSION,
         sdkVersion = StripeSdkVersion.VERSION,
         appInfo = Stripe.appInfo,
+        publishableKeyProvider = publishableKeyProvider,
+        stripeAccountIdProvider = stripeAccountIdProvider,
     )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -15,7 +15,6 @@ import com.stripe.android.common.taptoadd.TapToAddConnectionManager
 import com.stripe.android.core.Logger
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.IOContext
-import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.utils.FeatureFlag
 import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.core.utils.UserFacingLogger
@@ -421,10 +420,6 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         }
         return checkoutSessionRepository.init(
             sessionId = initializationMode.id,
-            options = ApiRequest.Options(
-                paymentConfiguration.get().publishableKey,
-                paymentConfiguration.get().stripeAccountId,
-            ),
         ).getOrThrow()
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
@@ -399,7 +399,6 @@ class CheckoutSessionConfirmationInterceptorTest {
 
         override suspend fun init(
             sessionId: String,
-            options: ApiRequest.Options,
         ): Result<CheckoutSessionResponse> {
             error("Not expected in this test")
         }
@@ -407,7 +406,6 @@ class CheckoutSessionConfirmationInterceptorTest {
         override suspend fun confirm(
             id: String,
             params: ConfirmCheckoutSessionParams,
-            options: ApiRequest.Options,
         ): Result<CheckoutSessionResponse> {
             confirmCheckoutSessionCalls.add(params)
             return confirmCheckoutSessionResult

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/FakeCheckoutSessionRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/FakeCheckoutSessionRepository.kt
@@ -1,7 +1,5 @@
 package com.stripe.android.paymentsheet.repositories
 
-import com.stripe.android.core.networking.ApiRequest
-
 internal class FakeCheckoutSessionRepository(
     var initResult: Result<CheckoutSessionResponse> = Result.failure(NotImplementedError()),
     var confirmResult: Result<CheckoutSessionResponse> = Result.failure(NotImplementedError()),
@@ -9,12 +7,10 @@ internal class FakeCheckoutSessionRepository(
 
     override suspend fun init(
         sessionId: String,
-        options: ApiRequest.Options,
     ): Result<CheckoutSessionResponse> = initResult
 
     override suspend fun confirm(
         id: String,
         params: ConfirmCheckoutSessionParams,
-        options: ApiRequest.Options,
     ): Result<CheckoutSessionResponse> = confirmResult
 }


### PR DESCRIPTION
## Summary
- Inject `publishableKeyProvider` and `stripeAccountIdProvider` into `DefaultCheckoutSessionRepository` via `CheckoutSessionRepositoryModule`, so the repository constructs `ApiRequest.Options` internally
- Remove the `options: ApiRequest.Options` parameter from `init()` and `confirm()` in the `CheckoutSessionRepository` interface
- Simplify callers (`PaymentElementLoader`, `CheckoutSessionConfirmationInterceptor`) — they no longer need to construct and pass `ApiRequest.Options`

## Motivation
`DefaultCheckoutSessionRepository` uses the same publishable key and stripe account ID for all its API calls. Rather than requiring each caller to construct and pass `ApiRequest.Options`, the repository now receives the providers via DI and builds options internally. This is consistent with how other repositories in the codebase work and simplifies the interface for future API methods (e.g., detach).

Part of the checkout session saved payment method management feature. See #12471 for the full prototype and PR split plan.

## Test plan
- [x] `CheckoutSessionConfirmationInterceptorTest` — 11/11 tests pass
- [x] `DefaultPaymentElementLoaderTest` — all tests pass
- [x] ktlint and detekt pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)