### PR TITLE
Extract SavedPaymentMethodRepository from CustomerRepository for SavedPaymentMethodMutator

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedCommonModule.kt
@@ -31,6 +31,8 @@ import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.LoadingEventReporter
 import com.stripe.android.paymentsheet.repositories.CustomerApiRepository
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
+import com.stripe.android.paymentsheet.repositories.DefaultSavedPaymentMethodRepository
+import com.stripe.android.paymentsheet.repositories.SavedPaymentMethodRepository
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import dagger.Binds
 import dagger.Module
@@ -65,6 +67,11 @@ internal interface EmbeddedCommonModule {
 
     @Binds
     fun bindsCustomerRepository(repository: CustomerApiRepository): CustomerRepository
+
+    @Binds
+    fun bindsSavedPaymentMethodRepository(
+        repository: DefaultSavedPaymentMethodRepository,
+    ): SavedPaymentMethodRepository
 
     @Binds
     fun bindsPaymentAnalyticsRequestFactory(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
@@ -24,7 +24,7 @@ import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded
 import com.stripe.android.paymentsheet.SavedPaymentMethodMutator
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.repositories.CustomerRepository
+import com.stripe.android.paymentsheet.repositories.SavedPaymentMethodRepository
 import com.stripe.android.paymentsheet.state.WalletsState
 import com.stripe.android.paymentsheet.ui.DefaultWalletButtonsInteractor
 import com.stripe.android.paymentsheet.ui.WalletButtonsContent
@@ -73,7 +73,7 @@ internal class DefaultEmbeddedContentHelper @Inject constructor(
     private val errorReporter: ErrorReporter,
     @IOContext private val workContext: CoroutineContext,
     @UIContext private val uiContext: CoroutineContext,
-    private val customerRepository: CustomerRepository,
+    private val savedPaymentMethodRepository: SavedPaymentMethodRepository,
     private val selectionHolder: EmbeddedSelectionHolder,
     private val embeddedLinkHelper: EmbeddedLinkHelper,
     private val rowSelectionImmediateActionHandler: EmbeddedRowSelectionImmediateActionHandler,
@@ -287,7 +287,7 @@ internal class DefaultEmbeddedContentHelper @Inject constructor(
             coroutineScope = coroutineScope,
             workContext = workContext,
             uiContext = uiContext,
-            customerRepository = customerRepository,
+            savedPaymentMethodRepository = savedPaymentMethodRepository,
             selection = selectionHolder.selection,
             setSelection = ::setSelection,
             customerStateHolder = customerStateHolder,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/ManageSavedPaymentMethodMutatorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/ManageSavedPaymentMethodMutatorFactory.kt
@@ -10,7 +10,7 @@ import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.SavedPaymentMethod
 import com.stripe.android.paymentsheet.SavedPaymentMethodMutator
 import com.stripe.android.paymentsheet.analytics.EventReporter
-import com.stripe.android.paymentsheet.repositories.CustomerRepository
+import com.stripe.android.paymentsheet.repositories.SavedPaymentMethodRepository
 import com.stripe.android.paymentsheet.ui.PaymentMethodRemovalDelayMillis
 import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.CoroutineScope
@@ -22,7 +22,7 @@ import kotlin.coroutines.CoroutineContext
 
 internal class ManageSavedPaymentMethodMutatorFactory @Inject constructor(
     private val eventReporter: EventReporter,
-    private val customerRepository: CustomerRepository,
+    private val savedPaymentMethodRepository: SavedPaymentMethodRepository,
     private val selectionHolder: EmbeddedSelectionHolder,
     private val customerStateHolder: CustomerStateHolder,
     private val manageNavigatorProvider: Provider<ManageNavigator>,
@@ -39,7 +39,7 @@ internal class ManageSavedPaymentMethodMutatorFactory @Inject constructor(
             coroutineScope = viewModelScope,
             workContext = workContext,
             uiContext = uiContext,
-            customerRepository = customerRepository,
+            savedPaymentMethodRepository = savedPaymentMethodRepository,
             selection = selectionHolder.selection,
             setSelection = selectionHolder::set,
             customerStateHolder = customerStateHolder,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -39,7 +39,7 @@ import com.stripe.android.paymentsheet.model.PaymentSelection.Link
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.AddFirstPaymentMethod
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.SelectSavedPaymentMethods
-import com.stripe.android.paymentsheet.repositories.CustomerRepository
+import com.stripe.android.paymentsheet.repositories.SavedPaymentMethodRepository
 import com.stripe.android.paymentsheet.state.WalletsProcessingState
 import com.stripe.android.paymentsheet.state.WalletsState
 import com.stripe.android.paymentsheet.ui.DefaultAddPaymentMethodInteractor
@@ -67,7 +67,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
     private val errorReporter: ErrorReporter,
     val linkPaymentLauncher: LinkPaymentLauncher,
     eventReporter: EventReporter,
-    customerRepository: CustomerRepository,
+    savedPaymentMethodRepository: SavedPaymentMethodRepository,
     @IOContext workContext: CoroutineContext,
     savedStateHandle: SavedStateHandle,
     linkHandler: LinkHandler,
@@ -78,7 +78,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
 ) : BaseSheetViewModel(
     config = args.configuration,
     eventReporter = eventReporter,
-    customerRepository = customerRepository,
+    savedPaymentMethodRepository = savedPaymentMethodRepository,
     workContext = workContext,
     savedStateHandle = savedStateHandle,
     linkHandler = linkHandler,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -48,7 +48,7 @@ import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.Args
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcCompletionState
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcRecollectionInteractor
-import com.stripe.android.paymentsheet.repositories.CustomerRepository
+import com.stripe.android.paymentsheet.repositories.SavedPaymentMethodRepository
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.paymentsheet.state.PaymentSheetState
 import com.stripe.android.paymentsheet.state.WalletsProcessingState
@@ -82,7 +82,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     internal val args: PaymentSheetContract.Args,
     eventReporter: EventReporter,
     private val paymentElementLoader: PaymentElementLoader,
-    customerRepository: CustomerRepository,
+    savedPaymentMethodRepository: SavedPaymentMethodRepository,
     private val logger: Logger,
     @IOContext workContext: CoroutineContext,
     savedStateHandle: SavedStateHandle,
@@ -98,7 +98,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
 ) : BaseSheetViewModel(
     config = args.config,
     eventReporter = eventReporter,
-    customerRepository = customerRepository,
+    savedPaymentMethodRepository = savedPaymentMethodRepository,
     workContext = workContext,
     savedStateHandle = savedStateHandle,
     linkHandler = linkHandler,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
@@ -45,8 +45,10 @@ import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.Cvc
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.DefaultCvcRecollectionInteractor
 import com.stripe.android.paymentsheet.repositories.CustomerApiRepository
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
+import com.stripe.android.paymentsheet.repositories.DefaultSavedPaymentMethodRepository
 import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
 import com.stripe.android.paymentsheet.repositories.RealElementsSessionRepository
+import com.stripe.android.paymentsheet.repositories.SavedPaymentMethodRepository
 import com.stripe.android.paymentsheet.state.CreateLinkState
 import com.stripe.android.paymentsheet.state.DefaultAnalyticsMetadataFactory
 import com.stripe.android.paymentsheet.state.DefaultCreateLinkState
@@ -89,6 +91,11 @@ internal abstract class PaymentSheetCommonModule {
 
     @Binds
     abstract fun bindsCustomerRepository(repository: CustomerApiRepository): CustomerRepository
+
+    @Binds
+    abstract fun bindsSavedPaymentMethodRepository(
+        repository: DefaultSavedPaymentMethodRepository,
+    ): SavedPaymentMethodRepository
 
     @Binds
     abstract fun bindsErrorReporter(errorReporter: RealErrorReporter): ErrorReporter

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/SavedPaymentMethodRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/SavedPaymentMethodRepository.kt
@@ -1,0 +1,70 @@
+package com.stripe.android.paymentsheet.repositories
+
+import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
+import com.stripe.android.model.Customer
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodUpdateParams
+import javax.inject.Inject
+
+/**
+ * Repository for managing saved payment methods. This abstracts over the underlying
+ * implementation (e.g. CustomerRepository for legacy/customer-session flows, or
+ * CheckoutSessionRepository for checkout session flows).
+ */
+internal interface SavedPaymentMethodRepository {
+    suspend fun detachPaymentMethod(
+        customerMetadata: CustomerMetadata,
+        paymentMethodId: String,
+        canRemoveDuplicates: Boolean,
+    ): Result<PaymentMethod>
+
+    suspend fun updatePaymentMethod(
+        customerMetadata: CustomerMetadata,
+        paymentMethodId: String,
+        params: PaymentMethodUpdateParams,
+    ): Result<PaymentMethod>
+
+    suspend fun setDefaultPaymentMethod(
+        customerMetadata: CustomerMetadata,
+        paymentMethodId: String?,
+    ): Result<Customer>
+}
+
+internal class DefaultSavedPaymentMethodRepository @Inject constructor(
+    private val customerRepository: CustomerRepository,
+) : SavedPaymentMethodRepository {
+
+    private fun CustomerMetadata.toCustomerInfo() = CustomerRepository.CustomerInfo(
+        id = id,
+        ephemeralKeySecret = ephemeralKeySecret,
+        customerSessionClientSecret = customerSessionClientSecret,
+    )
+
+    override suspend fun detachPaymentMethod(
+        customerMetadata: CustomerMetadata,
+        paymentMethodId: String,
+        canRemoveDuplicates: Boolean,
+    ): Result<PaymentMethod> = customerRepository.detachPaymentMethod(
+        customerInfo = customerMetadata.toCustomerInfo(),
+        paymentMethodId = paymentMethodId,
+        canRemoveDuplicates = canRemoveDuplicates,
+    )
+
+    override suspend fun updatePaymentMethod(
+        customerMetadata: CustomerMetadata,
+        paymentMethodId: String,
+        params: PaymentMethodUpdateParams,
+    ): Result<PaymentMethod> = customerRepository.updatePaymentMethod(
+        customerInfo = customerMetadata.toCustomerInfo(),
+        paymentMethodId = paymentMethodId,
+        params = params,
+    )
+
+    override suspend fun setDefaultPaymentMethod(
+        customerMetadata: CustomerMetadata,
+        paymentMethodId: String?,
+    ): Result<Customer> = customerRepository.setDefaultPaymentMethod(
+        customerInfo = customerMetadata.toCustomerInfo(),
+        paymentMethodId = paymentMethodId,
+    )
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -29,7 +29,7 @@ import com.stripe.android.paymentsheet.analytics.PaymentSheetAnalyticsListener
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.navigation.NavigationHandler
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
-import com.stripe.android.paymentsheet.repositories.CustomerRepository
+import com.stripe.android.paymentsheet.repositories.SavedPaymentMethodRepository
 import com.stripe.android.paymentsheet.state.WalletsProcessingState
 import com.stripe.android.paymentsheet.state.WalletsState
 import com.stripe.android.paymentsheet.ui.PrimaryButton
@@ -55,7 +55,7 @@ import kotlin.coroutines.CoroutineContext
 internal abstract class BaseSheetViewModel(
     val config: PaymentSheet.Configuration,
     val eventReporter: EventReporter,
-    val customerRepository: CustomerRepository,
+    val savedPaymentMethodRepository: SavedPaymentMethodRepository,
     val workContext: CoroutineContext = Dispatchers.IO,
     val savedStateHandle: SavedStateHandle,
     val linkHandler: LinkHandler,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperTest.kt
@@ -20,8 +20,8 @@ import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.uicore.utils.stateFlowOf
 import com.stripe.android.utils.AnalyticEventCallbackRule
-import com.stripe.android.utils.FakeCustomerRepository
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
+import com.stripe.android.utils.FakeSavedPaymentMethodRepository
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
 import com.stripe.android.utils.RecordingLinkPaymentLauncher
 import kotlinx.coroutines.CoroutineScope
@@ -161,7 +161,7 @@ internal class DefaultEmbeddedContentHelperTest {
             eventReporter = eventReporter,
             workContext = Dispatchers.Unconfined,
             uiContext = Dispatchers.Unconfined,
-            customerRepository = FakeCustomerRepository(),
+            savedPaymentMethodRepository = FakeSavedPaymentMethodRepository(),
             selectionHolder = selectionHolder,
             embeddedLinkHelper = object : EmbeddedLinkHelper {
                 override val linkEmail: StateFlow<String?> = stateFlowOf(null)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentUiTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentUiTest.kt
@@ -24,8 +24,8 @@ import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.createComposeCleanupRule
 import com.stripe.android.uicore.utils.stateFlowOf
 import com.stripe.android.utils.AnalyticEventCallbackRule
-import com.stripe.android.utils.FakeCustomerRepository
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
+import com.stripe.android.utils.FakeSavedPaymentMethodRepository
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
 import com.stripe.android.utils.RecordingLinkPaymentLauncher
 import kotlinx.coroutines.CoroutineScope
@@ -157,7 +157,7 @@ internal class EmbeddedContentUiTest {
                 eventReporter = eventReporter,
                 workContext = Dispatchers.Unconfined,
                 uiContext = Dispatchers.Unconfined,
-                customerRepository = FakeCustomerRepository(),
+                savedPaymentMethodRepository = FakeSavedPaymentMethodRepository(),
                 selectionHolder = selectionHolder,
                 embeddedLinkHelper = object : EmbeddedLinkHelper {
                     override val linkEmail: StateFlow<String?> = stateFlowOf(null)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperOpenCardScanAutomaticallyTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperOpenCardScanAutomaticallyTest.kt
@@ -33,9 +33,9 @@ import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.ui.core.elements.CardDetailsSectionController
 import com.stripe.android.uicore.elements.FormElement
-import com.stripe.android.utils.FakeCustomerRepository
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
 import com.stripe.android.utils.FakePaymentElementLoader
+import com.stripe.android.utils.FakeSavedPaymentMethodRepository
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
@@ -148,7 +148,9 @@ internal class FormHelperOpenCardScanAutomaticallyTest {
             PaymentOptionsViewModel(
                 args = args,
                 eventReporter = FakeEventReporter(),
-                customerRepository = FakeCustomerRepository(customer?.paymentMethods ?: emptyList()),
+                savedPaymentMethodRepository = FakeSavedPaymentMethodRepository(
+                    customer?.paymentMethods ?: emptyList()
+                ),
                 workContext = testDispatcher,
                 savedStateHandle = thisSavedStateHandle,
                 linkHandler = linkHandler,
@@ -187,7 +189,9 @@ internal class FormHelperOpenCardScanAutomaticallyTest {
                 args = ARGS_CUSTOMER_WITH_GOOGLEPAY,
                 eventReporter = FakeEventReporter(),
                 paymentElementLoader = paymentElementLoader,
-                customerRepository = FakeCustomerRepository(customer?.paymentMethods ?: emptyList()),
+                savedPaymentMethodRepository = FakeSavedPaymentMethodRepository(
+                    customer?.paymentMethods ?: emptyList()
+                ),
                 logger = Logger.noop(),
                 workContext = testDispatcher,
                 savedStateHandle = thisSavedStateHandle,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -48,8 +48,8 @@ import com.stripe.android.paymentsheet.ui.getLabel
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.RetryRule
 import com.stripe.android.uicore.elements.bottomsheet.BottomSheetContentTestTag
-import com.stripe.android.utils.FakeCustomerRepository
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
+import com.stripe.android.utils.FakeSavedPaymentMethodRepository
 import com.stripe.android.utils.InjectableActivityScenario
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
 import com.stripe.android.utils.TestUtils.idleLooper
@@ -464,7 +464,7 @@ internal class PaymentOptionsActivityTest {
             PaymentOptionsViewModel(
                 args = args,
                 eventReporter = eventReporter,
-                customerRepository = FakeCustomerRepository(),
+                savedPaymentMethodRepository = FakeSavedPaymentMethodRepository(),
                 workContext = testDispatcher,
                 savedStateHandle = savedStateHandle,
                 linkHandler = linkHandler,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -54,7 +54,7 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.AddFirstPaymentMethod
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.SelectSavedPaymentMethods
-import com.stripe.android.paymentsheet.repositories.CustomerRepository
+import com.stripe.android.paymentsheet.repositories.SavedPaymentMethodRepository
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.PaymentSheetState
 import com.stripe.android.paymentsheet.state.WalletLocation
@@ -101,7 +101,7 @@ internal class PaymentOptionsViewModelTest {
     private val standardTestDispatcher = StandardTestDispatcher()
 
     private val eventReporter = mock<EventReporter>()
-    private val customerRepository = mock<CustomerRepository>()
+    private val savedPaymentMethodRepository = mock<SavedPaymentMethodRepository>()
     private val linkPaymentLauncher = mock<LinkPaymentLauncher>()
 
     private val linkGate = FakeLinkGate()
@@ -810,7 +810,9 @@ internal class PaymentOptionsViewModelTest {
         val cards = PaymentMethodFactory.cards(3)
         val paymentMethodToRemove = cards.first()
 
-        whenever(customerRepository.detachPaymentMethod(any(), eq(paymentMethodToRemove.id), eq(false))).thenReturn(
+        whenever(
+            savedPaymentMethodRepository.detachPaymentMethod(any(), eq(paymentMethodToRemove.id), eq(false))
+        ).thenReturn(
             Result.success(paymentMethodToRemove)
         )
 
@@ -1406,7 +1408,7 @@ internal class PaymentOptionsViewModelTest {
                 )
             ),
             eventReporter = eventReporter,
-            customerRepository = customerRepository,
+            savedPaymentMethodRepository = savedPaymentMethodRepository,
             workContext = workContext,
             savedStateHandle = savedStateHandle,
             linkHandler = linkHandler,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -97,10 +97,10 @@ import com.stripe.android.testing.createComposeCleanupRule
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.ui.core.elements.TEST_TAG_DIALOG_CONFIRM_BUTTON
 import com.stripe.android.uicore.elements.bottomsheet.BottomSheetContentTestTag
-import com.stripe.android.utils.FakeCustomerRepository
 import com.stripe.android.utils.FakeIntentConfirmationInterceptor
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
 import com.stripe.android.utils.FakePaymentElementLoader
+import com.stripe.android.utils.FakeSavedPaymentMethodRepository
 import com.stripe.android.utils.InjectableActivityScenario
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
 import com.stripe.android.utils.RecordingLinkPaymentLauncher
@@ -1250,7 +1250,7 @@ internal class PaymentSheetActivityTest {
                     paymentSelection = initialPaymentSelection,
                     cbcEligibility = cbcEligibility,
                 ),
-                customerRepository = FakeCustomerRepository(paymentMethods),
+                savedPaymentMethodRepository = FakeSavedPaymentMethodRepository(paymentMethods),
                 logger = Logger.noop(),
                 workContext = testDispatcher,
                 savedStateHandle = savedStateHandle,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -36,6 +36,7 @@ import com.stripe.android.link.ui.inline.SignUpConsentAction
 import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.link.utils.errorMessage
 import com.stripe.android.lpmfoundations.luxe.LpmRepositoryTestHelpers
+import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilter
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.CardDefinition
 import com.stripe.android.model.CardBrand
@@ -97,7 +98,7 @@ import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.SelectSaved
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.Args
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcCompletionState
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.CvcRecollectionInteractor
-import com.stripe.android.paymentsheet.repositories.CustomerRepository
+import com.stripe.android.paymentsheet.repositories.SavedPaymentMethodRepository
 import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
@@ -124,9 +125,9 @@ import com.stripe.android.ui.core.Amount
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.utils.BankFormScreenStateFactory
-import com.stripe.android.utils.FakeCustomerRepository
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
 import com.stripe.android.utils.FakePaymentElementLoader
+import com.stripe.android.utils.FakeSavedPaymentMethodRepository
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
 import com.stripe.android.utils.PaymentElementCallbackTestRule
 import com.stripe.android.utils.RelayingPaymentElementLoader
@@ -206,8 +207,8 @@ internal class PaymentSheetViewModelTest {
         Dispatchers.setMain(testDispatcher)
         val paymentMethods = listOf(CARD_WITH_NETWORKS_PAYMENT_METHOD)
 
-        val customerRepository = spy(
-            FakeCustomerRepository(
+        val savedPaymentMethodRepository = spy(
+            FakeSavedPaymentMethodRepository(
                 onUpdatePaymentMethod = {
                     Result.success(paymentMethods.first())
                 }
@@ -228,7 +229,7 @@ internal class PaymentSheetViewModelTest {
                 paymentMethods = paymentMethods,
                 defaultPaymentMethodId = null,
             ),
-            customerRepository = customerRepository
+            savedPaymentMethodRepository = savedPaymentMethodRepository
         )
 
         viewModel.navigationHandler.currentScreen.test {
@@ -253,21 +254,19 @@ internal class PaymentSheetViewModelTest {
             assertThat(awaitItem()).isInstanceOf<SelectSavedPaymentMethods>()
         }
 
-        val customerInfoCaptor = argumentCaptor<CustomerRepository.CustomerInfo>()
+        val customerMetadataCaptor = argumentCaptor<CustomerMetadata>()
 
-        verify(customerRepository).updatePaymentMethod(
-            customerInfoCaptor.capture(),
+        verify(savedPaymentMethodRepository).updatePaymentMethod(
+            customerMetadataCaptor.capture(),
             any(),
             any()
         )
 
-        assertThat(customerInfoCaptor.firstValue).isEqualTo(
-            CustomerRepository.CustomerInfo(
-                id = "cus_123",
-                ephemeralKeySecret = "ek_123",
-                customerSessionClientSecret = null,
-            )
-        )
+        with(customerMetadataCaptor.firstValue) {
+            assertThat(id).isEqualTo("cus_123")
+            assertThat(ephemeralKeySecret).isEqualTo("ek_123")
+            assertThat(customerSessionClientSecret).isNull()
+        }
     }
 
     @Test
@@ -287,8 +286,8 @@ internal class PaymentSheetViewModelTest {
             )
         )
 
-        val customerRepository = spy(
-            FakeCustomerRepository(
+        val savedPaymentMethodRepository = spy(
+            FakeSavedPaymentMethodRepository(
                 onUpdatePaymentMethod = {
                     Result.success(updatedPaymentMethod)
                 }
@@ -296,7 +295,7 @@ internal class PaymentSheetViewModelTest {
         )
         val viewModel = createViewModel(
             customer = EMPTY_CUSTOMER_STATE.copy(paymentMethods = paymentMethods),
-            customerRepository = customerRepository,
+            savedPaymentMethodRepository = savedPaymentMethodRepository,
             eventReporter = eventReporter
         )
 
@@ -334,7 +333,7 @@ internal class PaymentSheetViewModelTest {
         val idCaptor = argumentCaptor<String>()
         val paramsCaptor = argumentCaptor<PaymentMethodUpdateParams>()
 
-        verify(customerRepository).updatePaymentMethod(
+        verify(savedPaymentMethodRepository).updatePaymentMethod(
             any(),
             idCaptor.capture(),
             paramsCaptor.capture()
@@ -368,8 +367,8 @@ internal class PaymentSheetViewModelTest {
 
         val firstPaymentMethod = paymentMethods.first()
 
-        val customerRepository = spy(
-            FakeCustomerRepository(
+        val savedPaymentMethodRepository = spy(
+            FakeSavedPaymentMethodRepository(
                 onUpdatePaymentMethod = {
                     Result.failure(Exception("No network found!"))
                 }
@@ -377,7 +376,7 @@ internal class PaymentSheetViewModelTest {
         )
         val viewModel = createViewModel(
             customer = EMPTY_CUSTOMER_STATE.copy(paymentMethods = paymentMethods),
-            customerRepository = customerRepository,
+            savedPaymentMethodRepository = savedPaymentMethodRepository,
             eventReporter = eventReporter
         )
 
@@ -1712,7 +1711,7 @@ internal class PaymentSheetViewModelTest {
                 signupMode = null,
             ),
             customer = null,
-            customerRepository = FakeCustomerRepository(PAYMENT_METHODS),
+            savedPaymentMethodRepository = FakeSavedPaymentMethodRepository(PAYMENT_METHODS),
             linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(
                 linkAttestationCheck = FakeLinkAttestationCheck().apply {
                     result = LinkAttestationCheck.Result.AccountError(
@@ -1741,7 +1740,7 @@ internal class PaymentSheetViewModelTest {
                 signupMode = null,
             ),
             customer = null,
-            customerRepository = FakeCustomerRepository(PAYMENT_METHODS),
+            savedPaymentMethodRepository = FakeSavedPaymentMethodRepository(PAYMENT_METHODS),
             linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(
                 linkAttestationCheck = FakeLinkAttestationCheck().apply {
                     result = LinkAttestationCheck.Result.AccountError(
@@ -2902,11 +2901,11 @@ internal class PaymentSheetViewModelTest {
 
     @Test
     fun `on 'modifyPaymentMethod' with no customer available, should not attempt update`() = runTest {
-        val customerRepository = spy(FakeCustomerRepository())
+        val savedPaymentMethodRepository = spy(FakeSavedPaymentMethodRepository())
 
         val viewModel = createViewModel(
             customer = null,
-            customerRepository = customerRepository,
+            savedPaymentMethodRepository = savedPaymentMethodRepository,
         )
 
         viewModel.navigationHandler.currentScreen.test {
@@ -2924,7 +2923,7 @@ internal class PaymentSheetViewModelTest {
                 val interactor = currentScreen.interactor
                 interactor.cardParamsUpdateAction(CardBrand.Visa)
 
-                verify(customerRepository, never()).updatePaymentMethod(any(), any(), any())
+                verify(savedPaymentMethodRepository, never()).updatePaymentMethod(any(), any(), any())
             }
         }
     }
@@ -3483,8 +3482,8 @@ internal class PaymentSheetViewModelTest {
         customer: CustomerState? = EMPTY_CUSTOMER_STATE.copy(paymentMethods = PAYMENT_METHODS),
         linkConfigurationCoordinator: LinkConfigurationCoordinator =
             this@PaymentSheetViewModelTest.linkConfigurationCoordinator,
-        customerRepository: CustomerRepository =
-            FakeCustomerRepository(customer?.paymentMethods ?: emptyList()),
+        savedPaymentMethodRepository: SavedPaymentMethodRepository =
+            FakeSavedPaymentMethodRepository(customer?.paymentMethods ?: emptyList()),
         shouldFailLoad: Boolean = false,
         linkState: LinkState? = null,
         isGooglePayReady: Boolean = false,
@@ -3521,7 +3520,7 @@ internal class PaymentSheetViewModelTest {
             stripeIntent = stripeIntent,
             customer = customer,
             linkConfigurationCoordinator = linkConfigurationCoordinator,
-            customerRepository = customerRepository,
+            savedPaymentMethodRepository = savedPaymentMethodRepository,
             shouldFailLoad = shouldFailLoad,
             linkState = linkState,
             isGooglePayReady = isGooglePayReady,
@@ -3545,7 +3544,9 @@ internal class PaymentSheetViewModelTest {
         stripeIntent: StripeIntent = PAYMENT_INTENT,
         customer: CustomerState? = EMPTY_CUSTOMER_STATE.copy(paymentMethods = PAYMENT_METHODS),
         linkConfigurationCoordinator: LinkConfigurationCoordinator = this.linkConfigurationCoordinator,
-        customerRepository: CustomerRepository = FakeCustomerRepository(customer?.paymentMethods ?: emptyList()),
+        savedPaymentMethodRepository: SavedPaymentMethodRepository = FakeSavedPaymentMethodRepository(
+            customer?.paymentMethods ?: emptyList()
+        ),
         shouldFailLoad: Boolean = false,
         linkState: LinkState? = null,
         isGooglePayReady: Boolean = false,
@@ -3582,7 +3583,7 @@ internal class PaymentSheetViewModelTest {
                 args = args,
                 eventReporter = eventReporter,
                 paymentElementLoader = paymentElementLoader,
-                customerRepository = customerRepository,
+                savedPaymentMethodRepository = savedPaymentMethodRepository,
                 logger = Logger.noop(),
                 workContext = testDispatcher,
                 savedStateHandle = thisSavedStateHandle,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
@@ -19,12 +19,12 @@ import com.stripe.android.paymentsheet.PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
-import com.stripe.android.paymentsheet.repositories.CustomerRepository
+import com.stripe.android.paymentsheet.repositories.SavedPaymentMethodRepository
 import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.uicore.utils.stateFlowOf
-import com.stripe.android.utils.FakeCustomerRepository
+import com.stripe.android.utils.FakeSavedPaymentMethodRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.TestScope
@@ -151,7 +151,7 @@ class SavedPaymentMethodMutatorTest {
     @Test
     fun `removePaymentMethod triggers async removal`() {
         var calledDetach = false
-        val customerRepository = FakeCustomerRepository(
+        val savedPaymentMethodRepository = FakeSavedPaymentMethodRepository(
             onDetachPaymentMethod = { paymentMethodId ->
                 assertThat(paymentMethodId).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_METHOD.id)
                 calledDetach = true
@@ -160,7 +160,7 @@ class SavedPaymentMethodMutatorTest {
         )
 
         runScenario(
-            customerRepository = customerRepository,
+            savedPaymentMethodRepository = savedPaymentMethodRepository,
         ) {
             customerStateHolder.setCustomerState(
                 createCustomerState(
@@ -186,7 +186,7 @@ class SavedPaymentMethodMutatorTest {
     @Test
     fun `removePaymentMethod with no CustomerConfiguration available, should not attempt detach`() {
         var calledDetach = false
-        val customerRepository = FakeCustomerRepository(
+        val savedPaymentMethodRepository = FakeSavedPaymentMethodRepository(
             onDetachPaymentMethod = {
                 calledDetach = true
                 throw AssertionError("Not expected")
@@ -194,7 +194,7 @@ class SavedPaymentMethodMutatorTest {
         )
 
         runScenario(
-            customerRepository = customerRepository,
+            savedPaymentMethodRepository = savedPaymentMethodRepository,
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
         ) {
             savedPaymentMethodMutator.removePaymentMethod(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
@@ -350,7 +350,7 @@ class SavedPaymentMethodMutatorTest {
     fun `updatePaymentMethod performRemove callback`() {
         val displayableSavedPaymentMethod = PaymentMethodFactory.cards(1).first().toDisplayableSavedPaymentMethod()
         val calledDetach = Turbine<Boolean>()
-        val customerRepository = FakeCustomerRepository(
+        val savedPaymentMethodRepository = FakeSavedPaymentMethodRepository(
             onDetachPaymentMethod = { paymentMethodId ->
                 assertThat(paymentMethodId).isEqualTo(displayableSavedPaymentMethod.paymentMethod.id)
                 calledDetach.add(true)
@@ -358,7 +358,7 @@ class SavedPaymentMethodMutatorTest {
             }
         )
 
-        runScenario(customerRepository = customerRepository) {
+        runScenario(savedPaymentMethodRepository = savedPaymentMethodRepository) {
             customerStateHolder.setCustomerState(
                 createCustomerState(
                     paymentMethods = listOf(displayableSavedPaymentMethod.paymentMethod),
@@ -384,7 +384,7 @@ class SavedPaymentMethodMutatorTest {
     fun `removePaymentMethodInEditScreen calls prePaymentMethodRemoveActions and postPaymentMethodRemoveActions`() {
         val displayableSavedPaymentMethod = PaymentMethodFactory.cards(1).first().toDisplayableSavedPaymentMethod()
         val calledDetach = Turbine<Boolean>()
-        val customerRepository = FakeCustomerRepository(
+        val savedPaymentMethodRepository = FakeSavedPaymentMethodRepository(
             onDetachPaymentMethod = { paymentMethodId ->
                 assertThat(paymentMethodId).isEqualTo(displayableSavedPaymentMethod.paymentMethod.id)
                 calledDetach.add(true)
@@ -392,7 +392,7 @@ class SavedPaymentMethodMutatorTest {
             }
         )
 
-        runScenario(customerRepository = customerRepository) {
+        runScenario(savedPaymentMethodRepository = savedPaymentMethodRepository) {
             customerStateHolder.setCustomerState(
                 createCustomerState(
                     paymentMethods = listOf(displayableSavedPaymentMethod.paymentMethod),
@@ -416,7 +416,7 @@ class SavedPaymentMethodMutatorTest {
     fun `updatePaymentMethod performRemove failure callback`() {
         val displayableSavedPaymentMethod = PaymentMethodFactory.cards(1).first().toDisplayableSavedPaymentMethod()
         val calledDetach = Turbine<Boolean>()
-        val customerRepository = FakeCustomerRepository(
+        val savedPaymentMethodRepository = FakeSavedPaymentMethodRepository(
             onDetachPaymentMethod = { paymentMethodId ->
                 assertThat(paymentMethodId).isEqualTo(displayableSavedPaymentMethod.paymentMethod.id)
                 calledDetach.add(true)
@@ -424,7 +424,7 @@ class SavedPaymentMethodMutatorTest {
             }
         )
 
-        runScenario(customerRepository = customerRepository) {
+        runScenario(savedPaymentMethodRepository = savedPaymentMethodRepository) {
             customerStateHolder.setCustomerState(
                 createCustomerState(
                     paymentMethods = listOf(displayableSavedPaymentMethod.paymentMethod),
@@ -447,7 +447,7 @@ class SavedPaymentMethodMutatorTest {
     fun `updatePaymentMethod updateExecutor callback`() {
         val displayableSavedPaymentMethod = PaymentMethodFactory.cards(1).first().toDisplayableSavedPaymentMethod()
         val calledUpdate = Turbine<Boolean>()
-        val customerRepository = FakeCustomerRepository(
+        val savedPaymentMethodRepository = FakeSavedPaymentMethodRepository(
             onUpdatePaymentMethod = {
                 calledUpdate.add(true)
                 Result.success(
@@ -458,7 +458,7 @@ class SavedPaymentMethodMutatorTest {
             }
         )
 
-        runScenario(customerRepository = customerRepository) {
+        runScenario(savedPaymentMethodRepository = savedPaymentMethodRepository) {
             customerStateHolder.setCustomerState(
                 createCustomerState(
                     paymentMethods = listOf(displayableSavedPaymentMethod.paymentMethod),
@@ -485,7 +485,7 @@ class SavedPaymentMethodMutatorTest {
     @Test
     fun `updatePaymentMethod updateExecutor analytics events received`() {
         val displayableSavedPaymentMethod = PaymentMethodFactory.cards(1).first().toDisplayableSavedPaymentMethod()
-        val customerRepository = FakeCustomerRepository(
+        val savedPaymentMethodRepository = FakeSavedPaymentMethodRepository(
             onUpdatePaymentMethod = {
                 Result.success(
                     displayableSavedPaymentMethod.paymentMethod.copy(
@@ -495,7 +495,7 @@ class SavedPaymentMethodMutatorTest {
             }
         )
 
-        runScenario(customerRepository = customerRepository) {
+        runScenario(savedPaymentMethodRepository = savedPaymentMethodRepository) {
             customerStateHolder.setCustomerState(
                 createCustomerState(
                     paymentMethods = listOf(displayableSavedPaymentMethod.paymentMethod),
@@ -515,7 +515,7 @@ class SavedPaymentMethodMutatorTest {
     fun `modifyCardPaymentMethod updates card`() {
         val displayableSavedPaymentMethod = PaymentMethodFactory.cards(1).first().toDisplayableSavedPaymentMethod()
         val calledUpdate = Turbine<Boolean>()
-        val customerRepository = FakeCustomerRepository(
+        val savedPaymentMethodRepository = FakeSavedPaymentMethodRepository(
             onUpdatePaymentMethod = {
                 calledUpdate.add(true)
                 Result.success(
@@ -526,7 +526,7 @@ class SavedPaymentMethodMutatorTest {
             }
         )
 
-        runScenario(customerRepository = customerRepository) {
+        runScenario(savedPaymentMethodRepository = savedPaymentMethodRepository) {
             customerStateHolder.setCustomerState(
                 createCustomerState(
                     paymentMethods = listOf(displayableSavedPaymentMethod.paymentMethod),
@@ -553,9 +553,9 @@ class SavedPaymentMethodMutatorTest {
     fun `successful card modification updates selected payment method if already selected`() {
         val paymentMethod = PaymentMethodFactory.cards(1).first()
         val selection = MutableStateFlow<PaymentSelection?>(PaymentSelection.Saved(paymentMethod))
-        val customerRepository = createRepositoryThatUpdatesCard(paymentMethod)
+        val savedPaymentMethodRepository = createRepositoryThatUpdatesCard(paymentMethod)
 
-        runScenario(customerRepository = customerRepository, selection = selection) {
+        runScenario(savedPaymentMethodRepository = savedPaymentMethodRepository, selection = selection) {
             setupCustomerState(paymentMethod)
             savedPaymentMethodMutator.modifyCardPaymentMethod(
                 paymentMethod = paymentMethod,
@@ -576,9 +576,9 @@ class SavedPaymentMethodMutatorTest {
         val selection = MutableStateFlow<PaymentSelection?>(
             PaymentSelection.Saved(paymentMethod.copy(id = differentPaymentMethodId))
         )
-        val customerRepository = createRepositoryThatUpdatesCard(paymentMethod)
+        val savedPaymentMethodRepository = createRepositoryThatUpdatesCard(paymentMethod)
 
-        runScenario(customerRepository = customerRepository, selection = selection) {
+        runScenario(savedPaymentMethodRepository = savedPaymentMethodRepository, selection = selection) {
             setupCustomerState(paymentMethod)
 
             savedPaymentMethodMutator.modifyCardPaymentMethod(
@@ -593,9 +593,9 @@ class SavedPaymentMethodMutatorTest {
         }
     }
 
-    private fun createRepositoryThatUpdatesCard(paymentMethod: PaymentMethod): FakeCustomerRepository {
+    private fun createRepositoryThatUpdatesCard(paymentMethod: PaymentMethod): FakeSavedPaymentMethodRepository {
         val displayable = paymentMethod.toDisplayableSavedPaymentMethod()
-        return FakeCustomerRepository(
+        return FakeSavedPaymentMethodRepository(
             onUpdatePaymentMethod = {
                 Result.success(
                     displayable.paymentMethod.copy(
@@ -609,7 +609,7 @@ class SavedPaymentMethodMutatorTest {
     @Test
     fun `modifyCardPaymentMethod analytics events received`() {
         val displayableSavedPaymentMethod = PaymentMethodFactory.cards(1).first().toDisplayableSavedPaymentMethod()
-        val customerRepository = FakeCustomerRepository(
+        val savedPaymentMethodRepository = FakeSavedPaymentMethodRepository(
             onUpdatePaymentMethod = {
                 Result.success(
                     displayableSavedPaymentMethod.paymentMethod.copy(
@@ -619,7 +619,7 @@ class SavedPaymentMethodMutatorTest {
             }
         )
 
-        runScenario(customerRepository = customerRepository) {
+        runScenario(savedPaymentMethodRepository = savedPaymentMethodRepository) {
             customerStateHolder.setCustomerState(
                 createCustomerState(
                     paymentMethods = listOf(displayableSavedPaymentMethod.paymentMethod),
@@ -639,13 +639,13 @@ class SavedPaymentMethodMutatorTest {
     fun `updatePaymentMethod updateExecutor failure callback`() {
         val displayableSavedPaymentMethod = PaymentMethodFactory.cards(1).first().toDisplayableSavedPaymentMethod()
         val calledUpdate = Turbine<Boolean>()
-        val customerRepository = FakeCustomerRepository(
+        val savedPaymentMethodRepository = FakeSavedPaymentMethodRepository(
             onUpdatePaymentMethod = {
                 calledUpdate.add(true)
                 Result.failure(IllegalStateException("Test failure"))
             }
         )
-        runScenario(customerRepository = customerRepository) {
+        runScenario(savedPaymentMethodRepository = savedPaymentMethodRepository) {
             customerStateHolder.setCustomerState(
                 createCustomerState(
                     paymentMethods = listOf(displayableSavedPaymentMethod.paymentMethod),
@@ -672,13 +672,13 @@ class SavedPaymentMethodMutatorTest {
     @Test
     fun `updatePaymentMethod updateExecutor failure analytics events received`() {
         val displayableSavedPaymentMethod = PaymentMethodFactory.cards(1).first().toDisplayableSavedPaymentMethod()
-        val customerRepository = FakeCustomerRepository(
+        val savedPaymentMethodRepository = FakeSavedPaymentMethodRepository(
             onUpdatePaymentMethod = {
                 Result.failure(IllegalStateException("Test failure"))
             }
         )
 
-        runScenario(customerRepository = customerRepository) {
+        runScenario(savedPaymentMethodRepository = savedPaymentMethodRepository) {
             customerStateHolder.setCustomerState(
                 createCustomerState(
                     paymentMethods = listOf(displayableSavedPaymentMethod.paymentMethod),
@@ -695,12 +695,12 @@ class SavedPaymentMethodMutatorTest {
 
     @Test
     fun `setDefaultPaymentMethod updates default payment method on success`() {
-        val customerRepository = FakeCustomerRepository(
+        val savedPaymentMethodRepository = FakeSavedPaymentMethodRepository(
             onSetDefaultPaymentMethod = { Result.success(mock()) }
         )
         val paymentMethods = PaymentMethodFixtures.createCards(3)
 
-        runScenario(customerRepository = customerRepository) {
+        runScenario(savedPaymentMethodRepository = savedPaymentMethodRepository) {
             customerStateHolder.setCustomerState(
                 createCustomerState(
                     paymentMethods = paymentMethods,
@@ -723,7 +723,7 @@ class SavedPaymentMethodMutatorTest {
         val paymentMethods = PaymentMethodFixtures.createCards(3)
 
         runScenario(
-            customerRepository = FakeCustomerRepository(
+            savedPaymentMethodRepository = FakeSavedPaymentMethodRepository(
                 onSetDefaultPaymentMethod = { Result.success(mock()) }
             )
         ) {
@@ -748,13 +748,13 @@ class SavedPaymentMethodMutatorTest {
     fun `setDefaultPaymentMethod success analytics events received`() {
         val paymentMethods = PaymentMethodFixtures.createCards(3)
 
-        val customerRepository = FakeCustomerRepository(
+        val savedPaymentMethodRepository = FakeSavedPaymentMethodRepository(
             onSetDefaultPaymentMethod = {
                 Result.success(mock())
             }
         )
 
-        runScenario(customerRepository = customerRepository) {
+        runScenario(savedPaymentMethodRepository = savedPaymentMethodRepository) {
             customerStateHolder.setCustomerState(
                 createCustomerState(
                     paymentMethods = paymentMethods,
@@ -771,7 +771,7 @@ class SavedPaymentMethodMutatorTest {
     fun `setDefaultPaymentMethod failed analytics events received`() {
         val paymentMethods = PaymentMethodFixtures.createCards(3)
 
-        val customerRepository = FakeCustomerRepository(
+        val savedPaymentMethodRepository = FakeSavedPaymentMethodRepository(
             onSetDefaultPaymentMethod = {
                 Result.failure(IllegalStateException("Test failure"))
             }
@@ -779,7 +779,7 @@ class SavedPaymentMethodMutatorTest {
 
         val eventReporter = FakeEventReporter()
 
-        runScenario(eventReporter = eventReporter, customerRepository = customerRepository) {
+        runScenario(eventReporter = eventReporter, savedPaymentMethodRepository = savedPaymentMethodRepository) {
             customerStateHolder.setCustomerState(
                 createCustomerState(
                     paymentMethods = paymentMethods,
@@ -853,7 +853,7 @@ class SavedPaymentMethodMutatorTest {
     }
 
     private fun removeDuplicatesTest(shouldRemoveDuplicates: Boolean) {
-        val repository = FakeCustomerRepository()
+        val repository = FakeSavedPaymentMethodRepository()
 
         val customerSessionClientSecret = if (shouldRemoveDuplicates) {
             "customer_session_client_secret"
@@ -861,7 +861,7 @@ class SavedPaymentMethodMutatorTest {
             null
         }
         runScenario(
-            customerRepository = repository,
+            savedPaymentMethodRepository = repository,
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                 hasCustomerConfiguration = true,
                 customerMetadataPermissions = CustomerMetadata.Permissions(
@@ -888,12 +888,20 @@ class SavedPaymentMethodMutatorTest {
             assertThat(postPaymentMethodRemovedTurbine.awaitItem()).isEqualTo(Unit)
 
             assertThat(repository.detachRequests.awaitItem()).isEqualTo(
-                FakeCustomerRepository.DetachRequest(
+                FakeSavedPaymentMethodRepository.DetachRequest(
                     paymentMethodId = paymentMethod.id,
-                    customerInfo = CustomerRepository.CustomerInfo(
+                    customerMetadata = CustomerMetadata(
                         id = "cus_123",
                         ephemeralKeySecret = "ek_123",
                         customerSessionClientSecret = customerSessionClientSecret,
+                        isPaymentMethodSetAsDefaultEnabled = false,
+                        permissions = CustomerMetadata.Permissions(
+                            removePaymentMethod = PaymentMethodRemovePermission.Full,
+                            saveConsent = PaymentMethodSaveConsentBehavior.Legacy,
+                            canRemoveLastPaymentMethod = true,
+                            canRemoveDuplicates = shouldRemoveDuplicates,
+                            canUpdateFullPaymentMethodDetails = false,
+                        ),
                     ),
                     canRemoveDuplicates = shouldRemoveDuplicates,
                 )
@@ -948,7 +956,7 @@ class SavedPaymentMethodMutatorTest {
 
     @Suppress("LongMethod")
     private fun runScenario(
-        customerRepository: CustomerRepository = FakeCustomerRepository(),
+        savedPaymentMethodRepository: SavedPaymentMethodRepository = FakeSavedPaymentMethodRepository(),
         eventReporter: FakeEventReporter = FakeEventReporter(),
         selection: MutableStateFlow<PaymentSelection?> = MutableStateFlow(null),
         paymentMethodMetadata: PaymentMethodMetadata? = PaymentMethodMetadataFactory.create(
@@ -977,7 +985,7 @@ class SavedPaymentMethodMutatorTest {
                 coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
                 workContext = coroutineContext,
                 uiContext = coroutineContext,
-                customerRepository = customerRepository,
+                savedPaymentMethodRepository = savedPaymentMethodRepository,
                 selection = selection,
                 setSelection = { selection.value = it },
                 customerStateHolder = customerStateHolder,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/FakeBaseSheetViewModel.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/FakeBaseSheetViewModel.kt
@@ -19,8 +19,8 @@ import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.state.WalletsProcessingState
 import com.stripe.android.paymentsheet.state.WalletsState
 import com.stripe.android.paymentsheet.ui.PrimaryButton
-import com.stripe.android.utils.FakeCustomerRepository
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
+import com.stripe.android.utils.FakeSavedPaymentMethodRepository
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -42,7 +42,7 @@ internal class FakeBaseSheetViewModel private constructor(
 ) : BaseSheetViewModel(
     config = PaymentSheet.Configuration.Builder("Example, Inc.").build(),
     eventReporter = FakeEventReporter(),
-    customerRepository = FakeCustomerRepository(),
+    savedPaymentMethodRepository = FakeSavedPaymentMethodRepository(),
     workContext = Dispatchers.IO,
     savedStateHandle = savedStateHandle,
     linkHandler = linkHandler,

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeSavedPaymentMethodRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeSavedPaymentMethodRepository.kt
@@ -1,0 +1,93 @@
+package com.stripe.android.utils
+
+import app.cash.turbine.ReceiveTurbine
+import app.cash.turbine.Turbine
+import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
+import com.stripe.android.model.Customer
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodUpdateParams
+import com.stripe.android.paymentsheet.repositories.SavedPaymentMethodRepository
+
+internal class FakeSavedPaymentMethodRepository(
+    private val paymentMethods: List<PaymentMethod> = emptyList(),
+    private val onDetachPaymentMethod: (paymentMethodId: String) -> Result<PaymentMethod> = { paymentMethodId ->
+        paymentMethods.find { it.id == paymentMethodId }?.let {
+            Result.success(it)
+        } ?: Result.failure(IllegalArgumentException("Could not find payment method to remove"))
+    },
+    private val onUpdatePaymentMethod: () -> Result<PaymentMethod> = {
+        Result.failure(NotImplementedError())
+    },
+    private val onSetDefaultPaymentMethod: () -> Result<Customer> = {
+        Result.failure(NotImplementedError())
+    },
+) : SavedPaymentMethodRepository {
+    private val _detachRequests = Turbine<DetachRequest>()
+    val detachRequests: ReceiveTurbine<DetachRequest> = _detachRequests
+
+    private val _updateRequests = Turbine<UpdateRequest>()
+    val updateRequests: ReceiveTurbine<UpdateRequest> = _updateRequests
+
+    private val _setDefaultPaymentMethodRequests = Turbine<SetDefaultRequest>()
+    val setDefaultPaymentMethodRequests: ReceiveTurbine<SetDefaultRequest> = _setDefaultPaymentMethodRequests
+
+    override suspend fun detachPaymentMethod(
+        customerMetadata: CustomerMetadata,
+        paymentMethodId: String,
+        canRemoveDuplicates: Boolean,
+    ): Result<PaymentMethod> {
+        _detachRequests.add(
+            DetachRequest(
+                paymentMethodId = paymentMethodId,
+                customerMetadata = customerMetadata,
+                canRemoveDuplicates = canRemoveDuplicates,
+            )
+        )
+        return onDetachPaymentMethod(paymentMethodId)
+    }
+
+    override suspend fun updatePaymentMethod(
+        customerMetadata: CustomerMetadata,
+        paymentMethodId: String,
+        params: PaymentMethodUpdateParams,
+    ): Result<PaymentMethod> {
+        _updateRequests.add(
+            UpdateRequest(
+                paymentMethodId = paymentMethodId,
+                customerMetadata = customerMetadata,
+                params = params,
+            )
+        )
+        return onUpdatePaymentMethod()
+    }
+
+    override suspend fun setDefaultPaymentMethod(
+        customerMetadata: CustomerMetadata,
+        paymentMethodId: String?,
+    ): Result<Customer> {
+        _setDefaultPaymentMethodRequests.add(
+            SetDefaultRequest(
+                paymentMethodId = paymentMethodId,
+                customerMetadata = customerMetadata,
+            )
+        )
+        return onSetDefaultPaymentMethod()
+    }
+
+    data class DetachRequest(
+        val paymentMethodId: String,
+        val customerMetadata: CustomerMetadata,
+        val canRemoveDuplicates: Boolean,
+    )
+
+    data class UpdateRequest(
+        val paymentMethodId: String,
+        val customerMetadata: CustomerMetadata,
+        val params: PaymentMethodUpdateParams,
+    )
+
+    data class SetDefaultRequest(
+        val paymentMethodId: String?,
+        val customerMetadata: CustomerMetadata,
+    )
+}


### PR DESCRIPTION
## Summary

Extract a new `SavedPaymentMethodRepository` interface that wraps `CustomerRepository` for saved payment method operations (detach, update, set default). `SavedPaymentMethodMutator` now depends on this interface instead of `CustomerRepository` directly.

This is a pure refactoring with no behavioral changes — preparation for checkout session support where detach will route to a different API.

## Motivation

`SavedPaymentMethodMutator` currently depends on `CustomerRepository` directly, which couples it to the legacy customer API. For checkout session flows, saved payment method operations (e.g., detach) need to route to different endpoints. Introducing `SavedPaymentMethodRepository` as an abstraction layer allows a future checkout session implementation to be swapped in without modifying `SavedPaymentMethodMutator`.

See https://github.com/stripe/stripe-android/pull/12471#discussion_r2862925643 for more context.
Part of the checkout session saved payment method management work (prototype in #12471).

## Changes

**New files:**
- `SavedPaymentMethodRepository.kt` — interface with `detachPaymentMethod`, `updatePaymentMethod`, `setDefaultPaymentMethod` methods taking `CustomerMetadata` directly (instead of `CustomerRepository.CustomerInfo`)
- `DefaultSavedPaymentMethodRepository` — `@Inject` implementation that delegates to `CustomerRepository`, mapping `CustomerMetadata` → `CustomerInfo`
- `FakeSavedPaymentMethodRepository` — test fake with Turbine-based call tracking and configurable return values

**Modified files:**
- `SavedPaymentMethodMutator` — constructor param changed from `CustomerRepository` to `SavedPaymentMethodRepository`, passes `customerMetadata` directly
- `BaseSheetViewModel`, `PaymentSheetViewModel`, `PaymentOptionsViewModel` — updated constructor param
- `ManageSavedPaymentMethodMutatorFactory`, `DefaultEmbeddedContentHelper` — updated injected dependency
- `PaymentSheetCommonModule`, `EmbeddedCommonModule` — added `@Binds` for `SavedPaymentMethodRepository`
- Test files updated to use `FakeSavedPaymentMethodRepository`

## Design note: FakeSavedPaymentMethodRepository vs DefaultSavedPaymentMethodRepository(FakeCustomerRepository)

Tests use `FakeSavedPaymentMethodRepository` (faking at the interface boundary) rather than wrapping `DefaultSavedPaymentMethodRepository(FakeCustomerRepository(...))`. This keeps ViewModel tests focused on ViewModel behavior and decoupled from `DefaultSavedPaymentMethodRepository` internals. The `CustomerMetadata` → `CustomerInfo` mapping in `DefaultSavedPaymentMethodRepository` should be covered by its own unit tests.

## Testing
- [x] Modified tests
- All 423 affected tests pass across 8 test classes

## Changelog
N/A — internal refactoring only, no user-facing changes.