### PR TITLE
Hide customer session settings when checkout session is enabled

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomerSessionSettingsDefinition.kt
@@ -12,6 +12,10 @@ internal object CustomerSessionSettingsDefinition : BooleanSettingsDefinition(
         configurationData: PlaygroundConfigurationData,
         settings: Map<PlaygroundSettingDefinition<*>, Any?>,
     ): Boolean {
+        if (settings[InitializationTypeSettingsDefinition] == InitializationType.CheckoutSession) {
+            return false
+        }
+
         return configurationData.integrationType.isPaymentFlow() ||
             configurationData.integrationType.isCustomerFlow()
     }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/InitializationTypeSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/InitializationTypeSettingsDefinition.kt
@@ -32,6 +32,12 @@ internal object InitializationTypeSettingsDefinition :
         return configurationData.integrationType.isPaymentFlow()
     }
 
+    override fun valueUpdated(value: InitializationType, playgroundSettings: PlaygroundSettings) {
+        if (value == InitializationType.CheckoutSession) {
+            playgroundSettings[CustomerSessionSettingsDefinition] = false
+        }
+    }
+
     override fun configure(
         value: InitializationType,
         checkoutRequestBuilder: CheckoutRequest.Builder


### PR DESCRIPTION
## Summary
- When checkout session is selected as the initialization type, customer session settings are no longer relevant
- Hide the "Use Customer Session" toggle and all dependent customer session settings when checkout session is enabled
- Two-pronged approach: `CustomerSessionSettingsDefinition.applicable()` hides the toggle, and `InitializationTypeSettingsDefinition.valueUpdated()` sets customer session to false so dependent settings naturally hide

## Test plan
- [x] Open the PaymentSheet playground
- [x] Select "Checkout Session" as the initialization type
- [x] Verify that "Use Customer Session" toggle and all customer session sub-settings are hidden
- [x] Switch back to a non-checkout-session initialization type
- [x] Verify customer session settings reappear (note: "Use Customer Session" will need to be manually re-enabled since it was set to false)

🤖 Generated with [Claude Code](https://claude.com/claude-code)