### PR TITLE
Remove `getprop` command for fetching system info for HCaptcha

### DIFF
--- a/hcaptcha/src/main/html/hcaptcha.html
+++ b/hcaptcha/src/main/html/hcaptcha.html
@@ -33,7 +33,6 @@
 <script type="text/javascript">
     if (window.JSDI) {
         JSON.parse(window.JSDI.getDebugInfo()).forEach(function (v) { window[v] = true; });
-        window.sysDebug = JSON.parse(window.JSDI.getSysDebug());
     }
 </script>
 <script type="text/javascript">


### PR DESCRIPTION
# Summary
Remove `getprop` command for fetching system info for HCaptcha

# Motivation
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-5112

This was primarily used for CI debugging in the original HCaptcha SDK but doesn't provide value here. Merchants were receiving false positive security warnings about this command usage so we prefer to remove it if no useful signaling.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified