### PR TITLE
Add custom email option to playground default billing address

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomEmailSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CustomEmailSettingsDefinition.kt
@@ -1,0 +1,76 @@
+package com.stripe.android.paymentsheet.example.playground.settings
+
+import com.stripe.android.customersheet.CustomerSheet
+import com.stripe.android.link.LinkController
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.example.playground.PlaygroundState
+
+internal object CustomEmailSettingsDefinition :
+    PlaygroundSettingDefinition<String>,
+    PlaygroundSettingDefinition.Displayable<String>,
+    PlaygroundSettingDefinition.Saveable<String> {
+
+    override fun applicable(
+        configurationData: PlaygroundConfigurationData,
+        settings: Map<PlaygroundSettingDefinition<*>, Any?>,
+    ): Boolean {
+        return settings[DefaultBillingAddressSettingsDefinition] == DefaultBillingAddress.OnWithCustomEmail
+    }
+
+    override fun configure(
+        value: String,
+        configurationBuilder: PaymentSheet.Configuration.Builder,
+        playgroundState: PlaygroundState.Payment,
+        configurationData: PlaygroundSettingDefinition.PaymentSheetConfigurationData
+    ) {
+        configurationData.customEmail = value
+    }
+
+    override fun configure(
+        value: String,
+        configurationBuilder: EmbeddedPaymentElement.Configuration.Builder,
+        playgroundState: PlaygroundState.Payment,
+        configurationData: PlaygroundSettingDefinition.EmbeddedConfigurationData
+    ) {
+        configurationData.customEmail = value
+    }
+
+    override fun configure(
+        value: String,
+        configurationBuilder: CustomerSheet.Configuration.Builder,
+        playgroundState: PlaygroundState.Customer,
+        configurationData: PlaygroundSettingDefinition.CustomerSheetConfigurationData
+    ) {
+        configurationData.customEmail = value
+    }
+
+    override fun configure(
+        value: String,
+        configurationBuilder: PaymentSheet.Configuration.Builder,
+        playgroundState: PlaygroundState.SharedPaymentToken,
+        configurationData: PlaygroundSettingDefinition.PaymentSheetConfigurationData
+    ) {
+        configurationData.customEmail = value
+    }
+
+    override fun configure(
+        value: String,
+        configurationBuilder: LinkController.Configuration.Builder,
+        playgroundState: PlaygroundState.Payment,
+        configurationData: PlaygroundSettingDefinition.LinkControllerConfigurationData
+    ) {
+        configurationData.customEmail = value
+    }
+
+    override val key: String = "customEmail"
+    override val displayName: String = "Custom Email"
+    override val defaultValue: String = ""
+
+    override fun createOptions(
+        configurationData: PlaygroundConfigurationData
+    ) = emptyList<PlaygroundSettingDefinition.Displayable.Option<String>>()
+
+    override fun convertToString(value: String): String = value
+    override fun convertToValue(value: String): String = value
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/DefaultBillingAddressSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/DefaultBillingAddressSettingsDefinition.kt
@@ -24,6 +24,7 @@ internal object DefaultBillingAddressSettingsDefinition :
     ) = listOf(
         option("On", DefaultBillingAddress.On),
         option("On with random email", DefaultBillingAddress.OnWithRandomEmail),
+        option("On with custom email", DefaultBillingAddress.OnWithCustomEmail),
         option("Off", DefaultBillingAddress.Off),
     )
 
@@ -33,7 +34,7 @@ internal object DefaultBillingAddressSettingsDefinition :
         playgroundState: PlaygroundState.Payment,
         configurationData: PlaygroundSettingDefinition.PaymentSheetConfigurationData
     ) {
-        createBillingDetails(value)?.let { billingDetails ->
+        createBillingDetails(value, configurationData.customEmail)?.let { billingDetails ->
             configurationBuilder.defaultBillingDetails(billingDetails)
         }
     }
@@ -44,7 +45,7 @@ internal object DefaultBillingAddressSettingsDefinition :
         playgroundState: PlaygroundState.Payment,
         configurationData: PlaygroundSettingDefinition.EmbeddedConfigurationData
     ) {
-        createBillingDetails(value)?.let { billingDetails ->
+        createBillingDetails(value, configurationData.customEmail)?.let { billingDetails ->
             configurationBuilder.defaultBillingDetails(billingDetails)
         }
     }
@@ -55,7 +56,7 @@ internal object DefaultBillingAddressSettingsDefinition :
         playgroundState: PlaygroundState.Customer,
         configurationData: PlaygroundSettingDefinition.CustomerSheetConfigurationData
     ) {
-        createBillingDetails(value)?.let { billingDetails ->
+        createBillingDetails(value, configurationData.customEmail)?.let { billingDetails ->
             configurationBuilder.defaultBillingDetails(billingDetails)
         }
     }
@@ -66,7 +67,7 @@ internal object DefaultBillingAddressSettingsDefinition :
         playgroundState: PlaygroundState.SharedPaymentToken,
         configurationData: PlaygroundSettingDefinition.PaymentSheetConfigurationData
     ) {
-        createBillingDetails(value)?.let { billingDetails ->
+        createBillingDetails(value, configurationData.customEmail)?.let { billingDetails ->
             configurationBuilder.defaultBillingDetails(billingDetails)
         }
     }
@@ -77,15 +78,19 @@ internal object DefaultBillingAddressSettingsDefinition :
         playgroundState: PlaygroundState.Payment,
         configurationData: PlaygroundSettingDefinition.LinkControllerConfigurationData
     ) {
-        createBillingDetails(value)?.let { billingDetails ->
+        createBillingDetails(value, configurationData.customEmail)?.let { billingDetails ->
             configurationBuilder.defaultBillingDetails(billingDetails)
         }
     }
 
-    private fun createBillingDetails(value: DefaultBillingAddress): PaymentSheet.BillingDetails? {
+    private fun createBillingDetails(
+        value: DefaultBillingAddress,
+        customEmail: String? = null
+    ): PaymentSheet.BillingDetails? {
         val email = when (value) {
             DefaultBillingAddress.On -> "email@email.com"
             DefaultBillingAddress.OnWithRandomEmail -> "email_${UUID.randomUUID()}@email.com"
+            DefaultBillingAddress.OnWithCustomEmail -> customEmail?.takeIf { it.isNotEmpty() }
             DefaultBillingAddress.Off -> null
         }
 
@@ -110,5 +115,6 @@ internal object DefaultBillingAddressSettingsDefinition :
 internal enum class DefaultBillingAddress(override val value: String) : ValueEnum {
     On("on"),
     OnWithRandomEmail("on_with_random_email"),
+    OnWithCustomEmail("on_with_custom_email"),
     Off("off"),
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettingDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettingDefinition.kt
@@ -117,6 +117,8 @@ internal interface PlaygroundSettingDefinition<T> {
         private val billingDetailsCollectionConfigurationBuilder: BillingDetailsCollectionConfigurationBuilder =
             BillingDetailsCollectionConfigurationBuilder()
     ) {
+        var customEmail: String? = null
+
         // Billing details is a nested configuration, but we have individual settings for it in the
         // UI, this helper keeps all of the configurations, rather than just the most recent.
         fun updateBillingDetails(
@@ -136,6 +138,8 @@ internal interface PlaygroundSettingDefinition<T> {
         private val billingDetailsCollectionConfigurationBuilder: BillingDetailsCollectionConfigurationBuilder =
             BillingDetailsCollectionConfigurationBuilder()
     ) {
+        var customEmail: String? = null
+
         // Billing details is a nested configuration, but we have individual settings for it in the
         // UI, this helper keeps all of the configurations, rather than just the most recent.
         fun updateBillingDetails(
@@ -155,6 +159,8 @@ internal interface PlaygroundSettingDefinition<T> {
         private val billingDetailsCollectionConfigurationBuilder: BillingDetailsCollectionConfigurationBuilder =
             BillingDetailsCollectionConfigurationBuilder()
     ) {
+        var customEmail: String? = null
+
         // Billing details is a nested configuration, but we have individual settings for it in the
         // UI, this helper keeps all of the configurations, rather than just the most recent.
         fun updateBillingDetails(
@@ -174,6 +180,8 @@ internal interface PlaygroundSettingDefinition<T> {
         private val billingDetailsCollectionConfigurationBuilder: BillingDetailsCollectionConfigurationBuilder =
             BillingDetailsCollectionConfigurationBuilder()
     ) {
+        var customEmail: String? = null
+
         // Billing details is a nested configuration, but we have individual settings for it in the
         // UI, this helper keeps all of the configurations, rather than just the most recent.
         fun updateBillingDetails(

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -499,6 +499,7 @@ internal class PlaygroundSettings private constructor(
             GooglePaySettingsDefinition,
             GooglePayCustomerSheetSettingsDefinition,
             DefaultBillingAddressSettingsDefinition,
+            CustomEmailSettingsDefinition,
             AttachBillingDetailsToPaymentMethodSettingsDefinition,
             CollectNameSettingsDefinition,
             CollectEmailSettingsDefinition,


### PR DESCRIPTION
<currently draft bc I'm not sure I like this solution>

# Summary
<!-- Simple summary of what was changed. -->
Add support for specifying a custom email address in the playground when using default billing details. The new option works similarly to the existing supported payment methods field.

Changes:
- Add "On with custom email" option to Default Billing Address setting
- Create CustomEmailSettingsDefinition for email input field
- Add customEmail property to configuration data classes
- Update billing details creation to use custom email when selected
- The custom email field only appears when "On with custom email" is selected


Committed-By-Agent: claude

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Makes it easier to test new link accounts -- I can specify a random email address and it's not overridden everytime I "reload" in the playground app. This enables me to see changes to that new link account across a couple different runs of the app

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified
