### PR TITLE
Add runScenario test pattern guidance to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,10 @@ This is the **Stripe Android SDK**, a multi-module Android library for payment p
 **Testing Patterns**
 - Prefer **fakes over mocks** - create `FakeClassName` implementations when possible
 - Use mocks or indirect testing only when necessary
+- Prefer **`runScenario` pattern** to reduce test boilerplate — define a private `runScenario` function per test class that encapsulates fixture setup, exposing dependencies via lambda parameters or a `Scenario` data class receiver
+  - Simple tests: lambda parameters `runScenario { sut, fakeDep1, fakeDep2 -> ... }`
+  - Stateful/coroutine tests: `Scenario` data class + `runTest` integration
+  - Configurable tests: add parameters with defaults for behavioral variations
 - Flow testing: `flow.test { assertThat(awaitItem()).isEqualTo(expected) }`
 - Compose testing: `composeTestRule.onNodeWithText("text").assertIsDisplayed()`
 - Truth assertions: `assertThat(actual).isEqualTo(expected)`


### PR DESCRIPTION
## Summary
- Adds guidance to the Testing Patterns section in CLAUDE.md to prefer the `runScenario` pattern when writing tests
- The pattern is already well-established in the codebase (48 test files, 733+ usages) but was not documented as a preferred practice

## Motivation
Without explicit guidance, new tests may be written with repeated boilerplate setup in each test method. The `runScenario` pattern encapsulates fixture initialization into a single private helper per test class, keeping test methods focused on assertions.

## Test plan
- [x] Verified the guidance matches existing codebase patterns

🤖 Generated with [Claude Code](https://claude.ai/code)