### PR TITLE
Flatten CustomerMetadata.Permissions into CustomerMetadata

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -156,15 +156,13 @@ internal class DefaultCustomerSheetLoader(
         ).isReady().first()
         val isGooglePayReadyAndEnabled = configuration.googlePayEnabled && isGooglePaySupportedOnDevice
 
-        val customerMetadata = CustomerMetadata(
+        val customerMetadata = CustomerMetadata.createForCustomerSheet(
+            configuration = configuration,
+            customerSheetSession = customerSheetSession,
             id = customerSheetSession.customerId,
             ephemeralKeySecret = customerSheetSession.customerEphemeralKeySecret,
             customerSessionClientSecret = customerSheetSession.customerSessionClientSecret,
             isPaymentMethodSetAsDefaultEnabled = isPaymentMethodSyncDefaultEnabled,
-            permissions = CustomerMetadata.Permissions.createForCustomerSheet(
-                configuration = configuration,
-                customerSheetSession = customerSheetSession
-            )
         )
 
         return PaymentMethodMetadata.createForCustomerSheet(

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/SaveForFutureUseHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/SaveForFutureUseHelper.kt
@@ -20,7 +20,7 @@ internal fun isSaveForFutureUseValueChangeable(
     return isSaveForFutureUseValueChangeable(
         code = code,
         intent = metadata.stripeIntent,
-        paymentMethodSaveConsentBehavior = metadata.customerMetadata?.permissions?.saveConsent,
+        paymentMethodSaveConsentBehavior = metadata.customerMetadata?.saveConsent,
         hasCustomerConfiguration = metadata.customerMetadata != null,
     )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/CustomerMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/CustomerMetadata.kt
@@ -14,115 +14,132 @@ internal data class CustomerMetadata(
     val ephemeralKeySecret: String,
     val customerSessionClientSecret: String?,
     val isPaymentMethodSetAsDefaultEnabled: Boolean,
-    val permissions: Permissions,
+    val removePaymentMethod: PaymentMethodRemovePermission,
+    val saveConsent: PaymentMethodSaveConsentBehavior,
+    val canRemoveLastPaymentMethod: Boolean,
+    val canRemoveDuplicates: Boolean,
+    val canUpdateFullPaymentMethodDetails: Boolean,
 ) : Parcelable {
+    val canRemovePaymentMethods: Boolean
+        get() = removePaymentMethod == PaymentMethodRemovePermission.Full ||
+            removePaymentMethod == PaymentMethodRemovePermission.Partial
 
-    @Parcelize
-    internal data class Permissions(
-        val removePaymentMethod: PaymentMethodRemovePermission,
-        val saveConsent: PaymentMethodSaveConsentBehavior,
-        val canRemoveLastPaymentMethod: Boolean,
-        val canRemoveDuplicates: Boolean,
-        val canUpdateFullPaymentMethodDetails: Boolean,
-    ) : Parcelable {
-        val canRemovePaymentMethods: Boolean
-            get() = removePaymentMethod == PaymentMethodRemovePermission.Full ||
-                removePaymentMethod == PaymentMethodRemovePermission.Partial
-
-        companion object {
-            internal fun createForPaymentSheetCustomerSession(
-                configuration: CommonConfiguration,
-                customer: ElementsSession.Customer,
-            ): Permissions {
-                val mobilePaymentElementComponent = customer.session.components.mobilePaymentElement
-                val removePaymentMethod = when (mobilePaymentElementComponent) {
-                    is ElementsSession.Customer.Components.MobilePaymentElement.Enabled -> {
-                        when (mobilePaymentElementComponent.paymentMethodRemove) {
-                            ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled ->
-                                PaymentMethodRemovePermission.Full
-                            ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Partial ->
-                                PaymentMethodRemovePermission.Partial
-                            ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Disabled ->
-                                PaymentMethodRemovePermission.None
-                        }
-                    }
-                    is ElementsSession.Customer.Components.MobilePaymentElement.Disabled ->
-                        PaymentMethodRemovePermission.None
-                }
-
-                val canRemoveLastPaymentMethod = configuration.allowsRemovalOfLastSavedPaymentMethod &&
-                    mobilePaymentElementComponent is ElementsSession.Customer.Components.MobilePaymentElement.Enabled &&
-                    mobilePaymentElementComponent.canRemoveLastPaymentMethod
-
-                val saveConsent = when (mobilePaymentElementComponent) {
-                    is ElementsSession.Customer.Components.MobilePaymentElement.Enabled -> {
-                        if (mobilePaymentElementComponent.isPaymentMethodSaveEnabled) {
-                            PaymentMethodSaveConsentBehavior.Enabled
-                        } else {
-                            PaymentMethodSaveConsentBehavior.Disabled(
-                                overrideAllowRedisplay = mobilePaymentElementComponent.allowRedisplayOverride
-                            )
-                        }
-                    }
-                    is ElementsSession.Customer.Components.MobilePaymentElement.Disabled -> {
-                        PaymentMethodSaveConsentBehavior.Disabled(overrideAllowRedisplay = null)
+    companion object {
+        internal fun createForPaymentSheetCustomerSession(
+            configuration: CommonConfiguration,
+            customer: ElementsSession.Customer,
+            id: String,
+            ephemeralKeySecret: String,
+            customerSessionClientSecret: String?,
+            isPaymentMethodSetAsDefaultEnabled: Boolean,
+        ): CustomerMetadata {
+            val mobilePaymentElementComponent = customer.session.components.mobilePaymentElement
+            val removePaymentMethod = when (mobilePaymentElementComponent) {
+                is ElementsSession.Customer.Components.MobilePaymentElement.Enabled -> {
+                    when (mobilePaymentElementComponent.paymentMethodRemove) {
+                        ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled ->
+                            PaymentMethodRemovePermission.Full
+                        ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Partial ->
+                            PaymentMethodRemovePermission.Partial
+                        ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Disabled ->
+                            PaymentMethodRemovePermission.None
                     }
                 }
-
-                return Permissions(
-                    removePaymentMethod = removePaymentMethod,
-                    saveConsent = saveConsent,
-                    canRemoveLastPaymentMethod = canRemoveLastPaymentMethod,
-                    // Should always remove duplicates when using `customer_session`
-                    canRemoveDuplicates = true,
-                    // Should always be enabled when using `customer_session`
-                    canUpdateFullPaymentMethodDetails = true,
-                )
+                is ElementsSession.Customer.Components.MobilePaymentElement.Disabled ->
+                    PaymentMethodRemovePermission.None
             }
 
-            internal fun createForPaymentSheetLegacyEphemeralKey(
-                configuration: CommonConfiguration,
-            ): Permissions {
-                return Permissions(
-                    /*
-                     * Un-scoped legacy ephemeral keys have full permissions to remove/save/modify. This should
-                     * always be set to true.
-                     */
-                    removePaymentMethod = PaymentMethodRemovePermission.Full,
-                    /*
-                     * Legacy ephemeral keys don't have server-side save consent configuration, so we use
-                     * the legacy behavior which shows the save checkbox based on the setup intent usage.
-                     */
-                    saveConsent = PaymentMethodSaveConsentBehavior.Legacy,
-                    /*
-                     * Un-scoped legacy ephemeral keys normally have full permissions to remove the last payment
-                     * method, however we do have client-side configuration option to configure this ability. This
-                     * should eventually be removed in favor of the server-side option available with customer
-                     * sessions.
-                     */
-                    canRemoveLastPaymentMethod = configuration.allowsRemovalOfLastSavedPaymentMethod,
-                    /*
-                     * Removing duplicates is not applicable here since we don't filter out duplicates for for
-                     * un-scoped ephemeral keys.
-                     */
-                    canRemoveDuplicates = false,
-                    canUpdateFullPaymentMethodDetails = false,
-                )
+            val canRemoveLastPaymentMethod = configuration.allowsRemovalOfLastSavedPaymentMethod &&
+                mobilePaymentElementComponent is ElementsSession.Customer.Components.MobilePaymentElement.Enabled &&
+                mobilePaymentElementComponent.canRemoveLastPaymentMethod
+
+            val saveConsent = when (mobilePaymentElementComponent) {
+                is ElementsSession.Customer.Components.MobilePaymentElement.Enabled -> {
+                    if (mobilePaymentElementComponent.isPaymentMethodSaveEnabled) {
+                        PaymentMethodSaveConsentBehavior.Enabled
+                    } else {
+                        PaymentMethodSaveConsentBehavior.Disabled(
+                            overrideAllowRedisplay = mobilePaymentElementComponent.allowRedisplayOverride
+                        )
+                    }
+                }
+                is ElementsSession.Customer.Components.MobilePaymentElement.Disabled -> {
+                    PaymentMethodSaveConsentBehavior.Disabled(overrideAllowRedisplay = null)
+                }
             }
 
-            internal fun createForCustomerSheet(
-                configuration: CustomerSheet.Configuration,
-                customerSheetSession: CustomerSheetSession,
-            ): Permissions {
-                return Permissions(
-                    removePaymentMethod = customerSheetSession.permissions.removePaymentMethod,
-                    saveConsent = customerSheetSession.paymentMethodSaveConsentBehavior,
-                    canRemoveLastPaymentMethod = configuration.allowsRemovalOfLastSavedPaymentMethod,
-                    canRemoveDuplicates = true,
-                    canUpdateFullPaymentMethodDetails =
-                    customerSheetSession.permissions.canUpdateFullPaymentMethodDetails,
-                )
-            }
+            return CustomerMetadata(
+                id = id,
+                ephemeralKeySecret = ephemeralKeySecret,
+                customerSessionClientSecret = customerSessionClientSecret,
+                isPaymentMethodSetAsDefaultEnabled = isPaymentMethodSetAsDefaultEnabled,
+                removePaymentMethod = removePaymentMethod,
+                saveConsent = saveConsent,
+                canRemoveLastPaymentMethod = canRemoveLastPaymentMethod,
+                // Should always remove duplicates when using `customer_session`
+                canRemoveDuplicates = true,
+                // Should always be enabled when using `customer_session`
+                canUpdateFullPaymentMethodDetails = true,
+            )
+        }
+
+        internal fun createForPaymentSheetLegacyEphemeralKey(
+            configuration: CommonConfiguration,
+            id: String,
+            ephemeralKeySecret: String,
+            isPaymentMethodSetAsDefaultEnabled: Boolean,
+        ): CustomerMetadata {
+            return CustomerMetadata(
+                id = id,
+                ephemeralKeySecret = ephemeralKeySecret,
+                customerSessionClientSecret = null,
+                isPaymentMethodSetAsDefaultEnabled = isPaymentMethodSetAsDefaultEnabled,
+                /*
+                 * Un-scoped legacy ephemeral keys have full permissions to remove/save/modify. This should
+                 * always be set to true.
+                 */
+                removePaymentMethod = PaymentMethodRemovePermission.Full,
+                /*
+                 * Legacy ephemeral keys don't have server-side save consent configuration, so we use
+                 * the legacy behavior which shows the save checkbox based on the setup intent usage.
+                 */
+                saveConsent = PaymentMethodSaveConsentBehavior.Legacy,
+                /*
+                 * Un-scoped legacy ephemeral keys normally have full permissions to remove the last payment
+                 * method, however we do have client-side configuration option to configure this ability. This
+                 * should eventually be removed in favor of the server-side option available with customer
+                 * sessions.
+                 */
+                canRemoveLastPaymentMethod = configuration.allowsRemovalOfLastSavedPaymentMethod,
+                /*
+                 * Removing duplicates is not applicable here since we don't filter out duplicates for for
+                 * un-scoped ephemeral keys.
+                 */
+                canRemoveDuplicates = false,
+                canUpdateFullPaymentMethodDetails = false,
+            )
+        }
+
+        internal fun createForCustomerSheet(
+            configuration: CustomerSheet.Configuration,
+            customerSheetSession: CustomerSheetSession,
+            id: String,
+            ephemeralKeySecret: String,
+            customerSessionClientSecret: String?,
+            isPaymentMethodSetAsDefaultEnabled: Boolean,
+        ): CustomerMetadata {
+            return CustomerMetadata(
+                id = id,
+                ephemeralKeySecret = ephemeralKeySecret,
+                customerSessionClientSecret = customerSessionClientSecret,
+                isPaymentMethodSetAsDefaultEnabled = isPaymentMethodSetAsDefaultEnabled,
+                removePaymentMethod = customerSheetSession.permissions.removePaymentMethod,
+                saveConsent = customerSheetSession.paymentMethodSaveConsentBehavior,
+                canRemoveLastPaymentMethod = configuration.allowsRemovalOfLastSavedPaymentMethod,
+                canRemoveDuplicates = true,
+                canUpdateFullPaymentMethodDetails =
+                customerSheetSession.permissions.canUpdateFullPaymentMethodDetails,
+            )
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -324,7 +324,7 @@ internal data class PaymentMethodMetadata(
         code: PaymentMethodCode
     ): PaymentMethod.AllowRedisplay {
         val isSettingUp = hasIntentToSetup(code) || forceSetupFutureUseBehaviorAndNewMandate
-        return customerMetadata?.permissions?.saveConsent?.allowRedisplay(
+        return customerMetadata?.saveConsent?.allowRedisplay(
             isSetupIntent = isSettingUp,
             customerRequestedSave = customerRequestedSave,
         ) ?: PaymentMethod.AllowRedisplay.UNSPECIFIED

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedCommonModule.kt
@@ -115,13 +115,13 @@ internal interface EmbeddedCommonModule {
             selectionHolder: EmbeddedSelectionHolder,
             paymentMethodMetadataFlow: StateFlow<PaymentMethodMetadata?>
         ): CustomerStateHolder {
-            val customerMetadataPermissions = paymentMethodMetadataFlow.mapAsStateFlow {
-                it?.customerMetadata?.permissions
+            val customerMetadata = paymentMethodMetadataFlow.mapAsStateFlow {
+                it?.customerMetadata
             }
             return DefaultCustomerStateHolder(
                 savedStateHandle = savedStateHandle,
                 selection = selectionHolder.selection,
-                customerMetadataPermissions = customerMetadataPermissions
+                customerMetadata = customerMetadata
             )
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedUpdateScreenInteractorFactory.kt
@@ -77,7 +77,7 @@ internal class DefaultEmbeddedUpdateScreenInteractorFactory @Inject constructor(
                     defaultPaymentMethodId = customerStateHolder.customer.value?.defaultPaymentMethodId
                 )
                 ),
-            removeMessage = paymentMethodMetadata.customerMetadata?.permissions?.removePaymentMethod
+            removeMessage = paymentMethodMetadata.customerMetadata?.removePaymentMethod
                 ?.removeMessage(paymentMethodMetadata.merchantName),
             onUpdateSuccess = {
                 manageNavigatorProvider.get().performAction(ManageNavigator.Action.Back)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultCustomerStateHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultCustomerStateHolder.kt
@@ -12,7 +12,7 @@ import com.stripe.android.uicore.utils.mapAsStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 internal class DefaultCustomerStateHolder(
-    private val customerMetadataPermissions: StateFlow<CustomerMetadata.Permissions?>,
+    private val customerMetadata: StateFlow<CustomerMetadata?>,
     private val savedStateHandle: SavedStateHandle,
     private val selection: StateFlow<PaymentSelection?>,
 ) : CustomerStateHolder {
@@ -35,18 +35,18 @@ internal class DefaultCustomerStateHolder(
 
     override val canRemoveDuplicate: StateFlow<Boolean> = combineAsStateFlow(
         customer,
-        customerMetadataPermissions,
-    ) { customerState, customerMetadataPermissions ->
-        return@combineAsStateFlow customerMetadataPermissions?.canRemoveDuplicates ?: false
+        customerMetadata,
+    ) { _, customerMetadata ->
+        return@combineAsStateFlow customerMetadata?.canRemoveDuplicates ?: false
     }
 
     override val canRemove: StateFlow<Boolean> = combineAsStateFlow(
         paymentMethods,
-        customerMetadataPermissions,
-    ) { paymentMethods, customerMetadataPermissions ->
-        customerMetadataPermissions?.run {
-            val hasRemovePermissions = customerMetadataPermissions.canRemovePaymentMethods
-            val hasRemoveLastPaymentMethodPermissions = customerMetadataPermissions.canRemoveLastPaymentMethod
+        customerMetadata,
+    ) { paymentMethods, customerMetadata ->
+        customerMetadata?.run {
+            val hasRemovePermissions = customerMetadata.canRemovePaymentMethods
+            val hasRemoveLastPaymentMethodPermissions = customerMetadata.canRemoveLastPaymentMethod
             when (paymentMethods.size) {
                 0 -> false
                 1 -> hasRemoveLastPaymentMethodPermissions && hasRemovePermissions
@@ -55,7 +55,7 @@ internal class DefaultCustomerStateHolder(
         } ?: false
     }
 
-    override val canUpdateFullPaymentMethodDetails: StateFlow<Boolean> = customerMetadataPermissions.mapAsStateFlow {
+    override val canUpdateFullPaymentMethodDetails: StateFlow<Boolean> = customerMetadata.mapAsStateFlow {
         it?.canUpdateFullPaymentMethodDetails ?: false
     }
 
@@ -89,8 +89,8 @@ internal class DefaultCustomerStateHolder(
             return DefaultCustomerStateHolder(
                 savedStateHandle = viewModel.savedStateHandle,
                 selection = viewModel.selection,
-                customerMetadataPermissions = viewModel.paymentMethodMetadata.mapAsStateFlow {
-                    it?.customerMetadata?.permissions
+                customerMetadata = viewModel.paymentMethodMetadata.mapAsStateFlow {
+                    it?.customerMetadata
                 }
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -397,7 +397,7 @@ internal class SavedPaymentMethodMutator(
                                     viewModel.customerStateHolder.customer.value?.defaultPaymentMethodId
                                 )
                                 ),
-                            removeMessage = paymentMethodMetadata?.customerMetadata?.permissions?.removePaymentMethod
+                            removeMessage = paymentMethodMetadata?.customerMetadata?.removePaymentMethod
                                 ?.removeMessage(paymentMethodMetadata.merchantName),
                             onUpdateSuccess = viewModel.navigationHandler::pop,
                         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactory.kt
@@ -19,7 +19,7 @@ internal object FormArgumentsFactory {
             billingDetailsCollectionConfiguration = metadata.billingDetailsCollectionConfiguration,
             cbcEligibility = metadata.cbcEligibility,
             hasIntentToSetup = metadata.hasIntentToSetup(paymentMethodCode),
-            paymentMethodSaveConsentBehavior = metadata.customerMetadata?.permissions?.saveConsent
+            paymentMethodSaveConsentBehavior = metadata.customerMetadata?.saveConsent
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArguments.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArguments.kt
@@ -82,7 +82,7 @@ internal class USBankAccountFormArguments(
             val isSaveForFutureUseValueChangeable = isSaveForFutureUseValueChangeable(
                 code = selectedPaymentMethodCode,
                 intent = paymentMethodMetadata.stripeIntent,
-                paymentMethodSaveConsentBehavior = paymentMethodMetadata.customerMetadata?.permissions?.saveConsent,
+                paymentMethodSaveConsentBehavior = paymentMethodMetadata.customerMetadata?.saveConsent,
                 hasCustomerConfiguration = paymentMethodMetadata.customerMetadata != null,
             )
             val instantDebits = selectedPaymentMethodCode == PaymentMethod.Type.Link.code
@@ -139,7 +139,7 @@ internal class USBankAccountFormArguments(
             val isSaveForFutureUseValueChangeable = isSaveForFutureUseValueChangeable(
                 code = selectedPaymentMethodCode,
                 intent = paymentMethodMetadata.stripeIntent,
-                paymentMethodSaveConsentBehavior = paymentMethodMetadata.customerMetadata?.permissions?.saveConsent,
+                paymentMethodSaveConsentBehavior = paymentMethodMetadata.customerMetadata?.saveConsent,
                 hasCustomerConfiguration = paymentMethodMetadata.customerMetadata != null,
             )
             val instantDebits = selectedPaymentMethodCode == PaymentMethod.Type.Link.code

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/SaveForFutureUseHelperKtTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/SaveForFutureUseHelperKtTest.kt
@@ -2,7 +2,6 @@ package com.stripe.android.lpmfoundations.luxe
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
-import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
@@ -152,9 +151,7 @@ class SaveForFutureUseHelperKtTest {
             metadata = PaymentMethodMetadataFactory.create(
                 stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
                 hasCustomerConfiguration = true,
-                customerMetadataPermissions = PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA_PERMISSIONS.copy(
-                    saveConsent = PaymentMethodSaveConsentBehavior.Enabled
-                )
+                saveConsent = PaymentMethodSaveConsentBehavior.Enabled,
             )
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/CustomerMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/CustomerMetadataTest.kt
@@ -21,11 +21,11 @@ internal class CustomerMetadataTest {
     fun `Should create 'Permissions' for customer session properly with permissions disabled`() {
         customerSessionPermissionsTest(
             paymentElementDisabled = true,
-        ) { permissions ->
-            assertThat(permissions.canRemovePaymentMethods).isFalse()
-            assertThat(permissions.canRemoveLastPaymentMethod).isFalse()
+        ) { result ->
+            assertThat(result.canRemovePaymentMethods).isFalse()
+            assertThat(result.canRemoveLastPaymentMethod).isFalse()
             // Always true for `customer_session`
-            assertThat(permissions.canRemoveDuplicates).isTrue()
+            assertThat(result.canRemoveDuplicates).isTrue()
         }
     }
 
@@ -35,12 +35,12 @@ internal class CustomerMetadataTest {
             canRemoveLastPaymentMethodConfigValue = true,
             paymentMethodRemoveLast = ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Enabled,
             paymentMethodRemove = ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled,
-        ) { permissions ->
-            assertThat(permissions.removePaymentMethod).isEqualTo(PaymentMethodRemovePermission.Full)
-            assertThat(permissions.canRemovePaymentMethods).isTrue()
-            assertThat(permissions.canRemoveLastPaymentMethod).isTrue()
+        ) { result ->
+            assertThat(result.removePaymentMethod).isEqualTo(PaymentMethodRemovePermission.Full)
+            assertThat(result.canRemovePaymentMethods).isTrue()
+            assertThat(result.canRemoveLastPaymentMethod).isTrue()
             // Always true for `customer_session`
-            assertThat(permissions.canRemoveDuplicates).isTrue()
+            assertThat(result.canRemoveDuplicates).isTrue()
         }
     }
 
@@ -50,12 +50,12 @@ internal class CustomerMetadataTest {
             canRemoveLastPaymentMethodConfigValue = true,
             paymentMethodRemoveLast = ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Enabled,
             paymentMethodRemove = ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Partial,
-        ) { permissions ->
-            assertThat(permissions.removePaymentMethod).isEqualTo(PaymentMethodRemovePermission.Partial)
-            assertThat(permissions.canRemovePaymentMethods).isTrue()
-            assertThat(permissions.canRemoveLastPaymentMethod).isTrue()
+        ) { result ->
+            assertThat(result.removePaymentMethod).isEqualTo(PaymentMethodRemovePermission.Partial)
+            assertThat(result.canRemovePaymentMethods).isTrue()
+            assertThat(result.canRemoveLastPaymentMethod).isTrue()
             // Always true for `customer_session`
-            assertThat(permissions.canRemoveDuplicates).isTrue()
+            assertThat(result.canRemoveDuplicates).isTrue()
         }
     }
 
@@ -65,12 +65,12 @@ internal class CustomerMetadataTest {
             canRemoveLastPaymentMethodConfigValue = true,
             paymentMethodRemoveLast = ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Enabled,
             paymentMethodRemove = ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Disabled
-        ) { permissions ->
-            assertThat(permissions.removePaymentMethod).isEqualTo(PaymentMethodRemovePermission.None)
-            assertThat(permissions.canRemovePaymentMethods).isFalse()
-            assertThat(permissions.canRemoveLastPaymentMethod).isTrue()
+        ) { result ->
+            assertThat(result.removePaymentMethod).isEqualTo(PaymentMethodRemovePermission.None)
+            assertThat(result.canRemovePaymentMethods).isFalse()
+            assertThat(result.canRemoveLastPaymentMethod).isTrue()
             // Always true for `customer_session`
-            assertThat(permissions.canRemoveDuplicates).isTrue()
+            assertThat(result.canRemoveDuplicates).isTrue()
         }
     }
 
@@ -78,8 +78,8 @@ internal class CustomerMetadataTest {
     fun `Should set 'canRemoveLastPaymentMethod' to true if config value is true for legacy ephemeral keys`() {
         legacyEphemeralKeyTestingScenario(
             allowsRemovalOfLastSavedPaymentMethod = true,
-        ) { permissions ->
-            assertThat(permissions.canRemoveLastPaymentMethod).isTrue()
+        ) { result ->
+            assertThat(result.canRemoveLastPaymentMethod).isTrue()
         }
     }
 
@@ -87,8 +87,8 @@ internal class CustomerMetadataTest {
     fun `Should set 'canRemoveLastPaymentMethod' to false if config value is false for legacy ephemeral keys`() {
         legacyEphemeralKeyTestingScenario(
             allowsRemovalOfLastSavedPaymentMethod = false,
-        ) { permissions ->
-            assertThat(permissions.canRemoveLastPaymentMethod).isFalse()
+        ) { result ->
+            assertThat(result.canRemoveLastPaymentMethod).isFalse()
         }
     }
 
@@ -97,8 +97,8 @@ internal class CustomerMetadataTest {
         customerSessionPermissionsTest(
             paymentMethodRemoveLast = ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Disabled,
             canRemoveLastPaymentMethodConfigValue = false,
-        ) { permissions ->
-            assertThat(permissions.canRemoveLastPaymentMethod).isFalse()
+        ) { result ->
+            assertThat(result.canRemoveLastPaymentMethod).isFalse()
         }
 
     @Test
@@ -106,8 +106,8 @@ internal class CustomerMetadataTest {
         customerSessionPermissionsTest(
             paymentElementDisabled = false,
             canRemoveLastPaymentMethodConfigValue = false,
-        ) { permissions ->
-            assertThat(permissions.canRemoveLastPaymentMethod).isFalse()
+        ) { result ->
+            assertThat(result.canRemoveLastPaymentMethod).isFalse()
         }
 
     @Test
@@ -115,8 +115,8 @@ internal class CustomerMetadataTest {
         customerSessionPermissionsTest(
             paymentElementDisabled = true,
             canRemoveLastPaymentMethodConfigValue = true,
-        ) { permissions ->
-            assertThat(permissions.canRemoveLastPaymentMethod).isFalse()
+        ) { result ->
+            assertThat(result.canRemoveLastPaymentMethod).isFalse()
         }
 
     @Test
@@ -124,8 +124,8 @@ internal class CustomerMetadataTest {
         customerSessionPermissionsTest(
             paymentMethodRemoveLast = ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Disabled,
             canRemoveLastPaymentMethodConfigValue = true,
-        ) { permissions ->
-            assertThat(permissions.canRemoveLastPaymentMethod).isFalse()
+        ) { result ->
+            assertThat(result.canRemoveLastPaymentMethod).isFalse()
         }
 
     @Test
@@ -133,8 +133,8 @@ internal class CustomerMetadataTest {
         customerSessionPermissionsTest(
             paymentMethodRemoveLast = ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.NotProvided,
             canRemoveLastPaymentMethodConfigValue = false,
-        ) { permissions ->
-            assertThat(permissions.canRemoveLastPaymentMethod).isFalse()
+        ) { result ->
+            assertThat(result.canRemoveLastPaymentMethod).isFalse()
         }
 
     @Test
@@ -142,8 +142,8 @@ internal class CustomerMetadataTest {
         customerSessionPermissionsTest(
             paymentMethodRemoveLast = ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Enabled,
             canRemoveLastPaymentMethodConfigValue = false,
-        ) { permissions ->
-            assertThat(permissions.canRemoveLastPaymentMethod).isFalse()
+        ) { result ->
+            assertThat(result.canRemoveLastPaymentMethod).isFalse()
         }
 
     @Test
@@ -151,8 +151,8 @@ internal class CustomerMetadataTest {
         customerSessionPermissionsTest(
             paymentMethodRemoveLast = ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.NotProvided,
             canRemoveLastPaymentMethodConfigValue = true,
-        ) { permissions ->
-            assertThat(permissions.canRemoveLastPaymentMethod).isTrue()
+        ) { result ->
+            assertThat(result.canRemoveLastPaymentMethod).isTrue()
         }
 
     @Test
@@ -160,14 +160,14 @@ internal class CustomerMetadataTest {
         customerSessionPermissionsTest(
             paymentMethodRemoveLast = ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Enabled,
             canRemoveLastPaymentMethodConfigValue = true,
-        ) { permissions ->
-            assertThat(permissions.canRemoveLastPaymentMethod).isTrue()
+        ) { result ->
+            assertThat(result.canRemoveLastPaymentMethod).isTrue()
         }
 
     @Test
     fun `Should set saveConsent to Enabled when save is enabled for customer session`() {
-        customerSessionPermissionsTest { permissions ->
-            assertThat(permissions.saveConsent).isEqualTo(PaymentMethodSaveConsentBehavior.Enabled)
+        customerSessionPermissionsTest { result ->
+            assertThat(result.saveConsent).isEqualTo(PaymentMethodSaveConsentBehavior.Enabled)
         }
     }
 
@@ -184,11 +184,15 @@ internal class CustomerMetadataTest {
         val customer = createElementsSessionCustomer(
             mobilePaymentElementComponent = mobilePaymentElement,
         )
-        val permissions = CustomerMetadata.Permissions.createForPaymentSheetCustomerSession(
+        val result = CustomerMetadata.createForPaymentSheetCustomerSession(
             configuration = configuration,
             customer = customer,
+            id = "cus_test",
+            ephemeralKeySecret = "ek_test",
+            customerSessionClientSecret = null,
+            isPaymentMethodSetAsDefaultEnabled = false,
         )
-        assertThat(permissions.saveConsent).isEqualTo(
+        assertThat(result.saveConsent).isEqualTo(
             PaymentMethodSaveConsentBehavior.Disabled(
                 overrideAllowRedisplay = PaymentMethod.AllowRedisplay.ALWAYS,
             )
@@ -199,8 +203,8 @@ internal class CustomerMetadataTest {
     fun `Should set saveConsent to Disabled when MPE is disabled for customer session`() {
         customerSessionPermissionsTest(
             paymentElementDisabled = true,
-        ) { permissions ->
-            assertThat(permissions.saveConsent).isEqualTo(
+        ) { result ->
+            assertThat(result.saveConsent).isEqualTo(
                 PaymentMethodSaveConsentBehavior.Disabled(overrideAllowRedisplay = null)
             )
         }
@@ -210,8 +214,8 @@ internal class CustomerMetadataTest {
     fun `Should set saveConsent to Legacy for legacy ephemeral keys`() {
         legacyEphemeralKeyTestingScenario(
             allowsRemovalOfLastSavedPaymentMethod = true,
-        ) { permissions ->
-            assertThat(permissions.saveConsent).isEqualTo(PaymentMethodSaveConsentBehavior.Legacy)
+        ) { result ->
+            assertThat(result.saveConsent).isEqualTo(PaymentMethodSaveConsentBehavior.Legacy)
         }
     }
 
@@ -219,39 +223,51 @@ internal class CustomerMetadataTest {
     fun `'createForCustomerSheet' should have payment method remove permissions of 'Full'`() {
         val customerSheetSession = createCustomerSheetSession(PaymentMethodRemovePermission.Full)
 
-        val permissions = CustomerMetadata.Permissions.createForCustomerSheet(
+        val result = CustomerMetadata.createForCustomerSheet(
             configuration = createCustomerSheetConfiguration(),
-            customerSheetSession = customerSheetSession
+            customerSheetSession = customerSheetSession,
+            id = "cus_test",
+            ephemeralKeySecret = "ek_test",
+            customerSessionClientSecret = null,
+            isPaymentMethodSetAsDefaultEnabled = false,
         )
 
-        assertThat(permissions.removePaymentMethod).isEqualTo(PaymentMethodRemovePermission.Full)
-        assertThat(permissions.canRemovePaymentMethods).isTrue()
+        assertThat(result.removePaymentMethod).isEqualTo(PaymentMethodRemovePermission.Full)
+        assertThat(result.canRemovePaymentMethods).isTrue()
     }
 
     @Test
     fun `'createForCustomerSheet' should have payment method remove permissions of 'Partial'`() {
         val customerSheetSession = createCustomerSheetSession(PaymentMethodRemovePermission.Partial)
 
-        val permissions = CustomerMetadata.Permissions.createForCustomerSheet(
+        val result = CustomerMetadata.createForCustomerSheet(
             configuration = createCustomerSheetConfiguration(),
-            customerSheetSession = customerSheetSession
+            customerSheetSession = customerSheetSession,
+            id = "cus_test",
+            ephemeralKeySecret = "ek_test",
+            customerSessionClientSecret = null,
+            isPaymentMethodSetAsDefaultEnabled = false,
         )
 
-        assertThat(permissions.removePaymentMethod).isEqualTo(PaymentMethodRemovePermission.Partial)
-        assertThat(permissions.canRemovePaymentMethods).isTrue()
+        assertThat(result.removePaymentMethod).isEqualTo(PaymentMethodRemovePermission.Partial)
+        assertThat(result.canRemovePaymentMethods).isTrue()
     }
 
     @Test
     fun `'createForCustomerSheet' should have payment method remove permissions of 'None'`() {
         val customerSheetSession = createCustomerSheetSession(PaymentMethodRemovePermission.None)
 
-        val permissions = CustomerMetadata.Permissions.createForCustomerSheet(
+        val result = CustomerMetadata.createForCustomerSheet(
             configuration = createCustomerSheetConfiguration(),
-            customerSheetSession = customerSheetSession
+            customerSheetSession = customerSheetSession,
+            id = "cus_test",
+            ephemeralKeySecret = "ek_test",
+            customerSessionClientSecret = null,
+            isPaymentMethodSetAsDefaultEnabled = false,
         )
 
-        assertThat(permissions.removePaymentMethod).isEqualTo(PaymentMethodRemovePermission.None)
-        assertThat(permissions.canRemovePaymentMethods).isFalse()
+        assertThat(result.removePaymentMethod).isEqualTo(PaymentMethodRemovePermission.None)
+        assertThat(result.canRemovePaymentMethods).isFalse()
     }
 
     private fun createEnabledMobilePaymentElement(
@@ -272,15 +288,18 @@ internal class CustomerMetadataTest {
 
     private fun legacyEphemeralKeyTestingScenario(
         allowsRemovalOfLastSavedPaymentMethod: Boolean,
-        block: (CustomerMetadata.Permissions) -> Unit
+        block: (CustomerMetadata) -> Unit
     ) {
-        val permissions = CustomerMetadata.Permissions.createForPaymentSheetLegacyEphemeralKey(
+        val result = CustomerMetadata.createForPaymentSheetLegacyEphemeralKey(
             configuration = createConfiguration(
                 allowsRemovalOfLastSavedPaymentMethod = allowsRemovalOfLastSavedPaymentMethod
-            )
+            ),
+            id = "cus_test",
+            ephemeralKeySecret = "ek_test",
+            isPaymentMethodSetAsDefaultEnabled = false,
         )
 
-        block(permissions)
+        block(result)
     }
 
     private fun createCustomerSheetSession(
@@ -335,7 +354,7 @@ internal class CustomerMetadataTest {
             ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.Enabled,
         paymentMethodRemove: ElementsSession.Customer.Components.PaymentMethodRemoveFeature =
             ElementsSession.Customer.Components.PaymentMethodRemoveFeature.Enabled,
-        block: (CustomerMetadata.Permissions) -> Unit
+        block: (CustomerMetadata) -> Unit
     ) {
         val mobilePaymentElementComponent = if (paymentElementDisabled) {
             ElementsSession.Customer.Components.MobilePaymentElement.Disabled
@@ -351,12 +370,16 @@ internal class CustomerMetadataTest {
             mobilePaymentElementComponent = mobilePaymentElementComponent,
         )
 
-        val permissions = CustomerMetadata.Permissions.createForPaymentSheetCustomerSession(
+        val result = CustomerMetadata.createForPaymentSheetCustomerSession(
             configuration = configuration,
             customer = customer,
+            id = "cus_test",
+            ephemeralKeySecret = "ek_test",
+            customerSessionClientSecret = null,
+            isPaymentMethodSetAsDefaultEnabled = false,
         )
 
-        block(permissions)
+        block(result)
     }
 
     private fun createElementsSessionCustomer(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
@@ -4,6 +4,7 @@ import com.stripe.android.CardBrandFilter
 import com.stripe.android.CardFundingFilter
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.DefaultCardFundingFilter
+import com.stripe.android.common.model.PaymentMethodRemovePermission
 import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.LinkMode
@@ -50,8 +51,13 @@ internal object PaymentMethodMetadataFactory {
         paymentMethodIncentive: PaymentMethodIncentive? = null,
         isPaymentMethodSetAsDefaultEnabled: Boolean = IS_PAYMENT_METHOD_SET_AS_DEFAULT_ENABLED_DEFAULT_VALUE,
         financialConnectionsAvailability: FinancialConnectionsAvailability? = FinancialConnectionsAvailability.Lite,
-        customerMetadataPermissions: CustomerMetadata.Permissions =
-            PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA_PERMISSIONS,
+        removePaymentMethod: PaymentMethodRemovePermission =
+            PaymentMethodRemovePermission.Full,
+        saveConsent: PaymentMethodSaveConsentBehavior =
+            PaymentMethodSaveConsentBehavior.Legacy,
+        canRemoveLastPaymentMethod: Boolean = true,
+        canRemoveDuplicates: Boolean = true,
+        canUpdateFullPaymentMethodDetails: Boolean = false,
         customerSessionClientSecret: String? = null,
         termsDisplay: Map<PaymentMethod.Type, PaymentSheet.TermsDisplay> = emptyMap(),
         forceSetupFutureUseBehaviorAndNewMandate: Boolean = false,
@@ -83,7 +89,11 @@ internal object PaymentMethodMetadataFactory {
             customerMetadata = if (hasCustomerConfiguration) {
                 PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA.copy(
                     isPaymentMethodSetAsDefaultEnabled = isPaymentMethodSetAsDefaultEnabled,
-                    permissions = customerMetadataPermissions,
+                    removePaymentMethod = removePaymentMethod,
+                    saveConsent = saveConsent,
+                    canRemoveLastPaymentMethod = canRemoveLastPaymentMethod,
+                    canRemoveDuplicates = canRemoveDuplicates,
+                    canUpdateFullPaymentMethodDetails = canUpdateFullPaymentMethodDetails,
                     customerSessionClientSecret = customerSessionClientSecret,
                 )
             } else {

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFixtures.kt
@@ -9,20 +9,16 @@ import kotlinx.coroutines.flow.StateFlow
 
 internal object PaymentMethodMetadataFixtures {
 
-    internal val DEFAULT_CUSTOMER_METADATA_PERMISSIONS = CustomerMetadata.Permissions(
-        removePaymentMethod = PaymentMethodRemovePermission.Full,
-        saveConsent = PaymentMethodSaveConsentBehavior.Legacy,
-        canRemoveLastPaymentMethod = true,
-        canRemoveDuplicates = true,
-        canUpdateFullPaymentMethodDetails = false,
-    )
-
     internal val DEFAULT_CUSTOMER_METADATA = CustomerMetadata(
         id = "cus_123",
         ephemeralKeySecret = "ek_123",
         customerSessionClientSecret = null,
         isPaymentMethodSetAsDefaultEnabled = false,
-        permissions = DEFAULT_CUSTOMER_METADATA_PERMISSIONS
+        removePaymentMethod = PaymentMethodRemovePermission.Full,
+        saveConsent = PaymentMethodSaveConsentBehavior.Legacy,
+        canRemoveLastPaymentMethod = true,
+        canRemoveDuplicates = true,
+        canUpdateFullPaymentMethodDetails = false,
     )
 
     internal val DEFAULT_CUSTOMER_INTEGRATION_METADATA = IntegrationMetadata.CustomerSheet(
@@ -42,12 +38,20 @@ internal object PaymentMethodMetadataFixtures {
     internal fun getDefaultCustomerMetadata(
         hasCustomerConfiguration: Boolean = true,
         isPaymentMethodSetAsDefaultEnabled: Boolean = false,
-        permissions: CustomerMetadata.Permissions = DEFAULT_CUSTOMER_METADATA_PERMISSIONS,
+        removePaymentMethod: PaymentMethodRemovePermission = PaymentMethodRemovePermission.Full,
+        saveConsent: PaymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
+        canRemoveLastPaymentMethod: Boolean = true,
+        canRemoveDuplicates: Boolean = true,
+        canUpdateFullPaymentMethodDetails: Boolean = false,
     ): CustomerMetadata? {
         return if (hasCustomerConfiguration) {
             DEFAULT_CUSTOMER_METADATA.copy(
                 isPaymentMethodSetAsDefaultEnabled = isPaymentMethodSetAsDefaultEnabled,
-                permissions = permissions,
+                removePaymentMethod = removePaymentMethod,
+                saveConsent = saveConsent,
+                canRemoveLastPaymentMethod = canRemoveLastPaymentMethod,
+                canRemoveDuplicates = canRemoveDuplicates,
+                canUpdateFullPaymentMethodDetails = canUpdateFullPaymentMethodDetails,
             )
         } else {
             null
@@ -57,13 +61,21 @@ internal object PaymentMethodMetadataFixtures {
     internal fun getDefaultCustomerMetadataFlow(
         hasCustomerConfiguration: Boolean = true,
         isPaymentMethodSetAsDefaultEnabled: Boolean = false,
-        permissions: CustomerMetadata.Permissions = DEFAULT_CUSTOMER_METADATA_PERMISSIONS,
+        removePaymentMethod: PaymentMethodRemovePermission = PaymentMethodRemovePermission.Full,
+        saveConsent: PaymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
+        canRemoveLastPaymentMethod: Boolean = true,
+        canRemoveDuplicates: Boolean = true,
+        canUpdateFullPaymentMethodDetails: Boolean = false,
     ): StateFlow<CustomerMetadata?> {
         return stateFlowOf(
             getDefaultCustomerMetadata(
                 hasCustomerConfiguration = hasCustomerConfiguration,
                 isPaymentMethodSetAsDefaultEnabled = isPaymentMethodSetAsDefaultEnabled,
-                permissions = permissions,
+                removePaymentMethod = removePaymentMethod,
+                saveConsent = saveConsent,
+                canRemoveLastPaymentMethod = canRemoveLastPaymentMethod,
+                canRemoveDuplicates = canRemoveDuplicates,
+                canUpdateFullPaymentMethodDetails = canUpdateFullPaymentMethodDetails,
             )
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -1479,10 +1479,7 @@ internal class PaymentMethodMetadataTest {
             val metadataForSetupIntent = PaymentMethodMetadataFactory.create(
                 stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
                 hasCustomerConfiguration = true,
-                customerMetadataPermissions = PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA_PERMISSIONS
-                    .copy(
-                        saveConsent = PaymentMethodSaveConsentBehavior.Enabled,
-                    ),
+                saveConsent = PaymentMethodSaveConsentBehavior.Enabled,
             )
 
             assertThat(
@@ -1497,10 +1494,7 @@ internal class PaymentMethodMetadataTest {
                     setupFutureUsage = StripeIntent.Usage.OnSession,
                 ),
                 hasCustomerConfiguration = true,
-                customerMetadataPermissions = PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA_PERMISSIONS
-                    .copy(
-                        saveConsent = PaymentMethodSaveConsentBehavior.Enabled,
-                    ),
+                saveConsent = PaymentMethodSaveConsentBehavior.Enabled,
             )
 
             assertThat(
@@ -1515,10 +1509,7 @@ internal class PaymentMethodMetadataTest {
                     paymentMethodOptionsJsonString = PaymentIntentFixtures.PMO_SETUP_FUTURE_USAGE
                 ),
                 hasCustomerConfiguration = true,
-                customerMetadataPermissions = PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA_PERMISSIONS
-                    .copy(
-                        saveConsent = PaymentMethodSaveConsentBehavior.Enabled,
-                    ),
+                saveConsent = PaymentMethodSaveConsentBehavior.Enabled,
             )
 
             assertThat(
@@ -1536,10 +1527,7 @@ internal class PaymentMethodMetadataTest {
             val metadataForSetupIntent = PaymentMethodMetadataFactory.create(
                 stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
                 hasCustomerConfiguration = true,
-                customerMetadataPermissions = PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA_PERMISSIONS
-                    .copy(
-                        saveConsent = PaymentMethodSaveConsentBehavior.Enabled,
-                    ),
+                saveConsent = PaymentMethodSaveConsentBehavior.Enabled,
             )
 
             assertThat(
@@ -1561,10 +1549,7 @@ internal class PaymentMethodMetadataTest {
                     setupFutureUsage = StripeIntent.Usage.OnSession,
                 ),
                 hasCustomerConfiguration = true,
-                customerMetadataPermissions = PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA_PERMISSIONS
-                    .copy(
-                        saveConsent = PaymentMethodSaveConsentBehavior.Enabled,
-                    ),
+                saveConsent = PaymentMethodSaveConsentBehavior.Enabled,
             )
 
             assertThat(
@@ -1586,10 +1571,7 @@ internal class PaymentMethodMetadataTest {
                     paymentMethodOptionsJsonString = PaymentIntentFixtures.PMO_SETUP_FUTURE_USAGE
                 ),
                 hasCustomerConfiguration = true,
-                customerMetadataPermissions = PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA_PERMISSIONS
-                    .copy(
-                        saveConsent = PaymentMethodSaveConsentBehavior.Enabled,
-                    ),
+                saveConsent = PaymentMethodSaveConsentBehavior.Enabled,
             )
 
             assertThat(
@@ -1613,10 +1595,7 @@ internal class PaymentMethodMetadataTest {
             val metadata = PaymentMethodMetadataFactory.create(
                 stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
                 hasCustomerConfiguration = true,
-                customerMetadataPermissions = PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA_PERMISSIONS
-                    .copy(
-                        saveConsent = PaymentMethodSaveConsentBehavior.Enabled,
-                    ),
+                saveConsent = PaymentMethodSaveConsentBehavior.Enabled,
             )
 
             assertThat(
@@ -1633,10 +1612,7 @@ internal class PaymentMethodMetadataTest {
             val metadata = PaymentMethodMetadataFactory.create(
                 stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
                 hasCustomerConfiguration = true,
-                customerMetadataPermissions = PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA_PERMISSIONS
-                    .copy(
-                        saveConsent = PaymentMethodSaveConsentBehavior.Enabled,
-                    ),
+                saveConsent = PaymentMethodSaveConsentBehavior.Enabled,
             )
 
             assertThat(
@@ -1658,12 +1634,9 @@ internal class PaymentMethodMetadataTest {
     fun `allowRedisplay returns Unspecified when consent behavior is Disabled and not setting up`() = runTest {
         val metadata = PaymentMethodMetadataFactory.create(
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
-            customerMetadataPermissions = PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA_PERMISSIONS
-                .copy(
-                    saveConsent = PaymentMethodSaveConsentBehavior.Disabled(
-                        overrideAllowRedisplay = null
-                    ),
-                ),
+            saveConsent = PaymentMethodSaveConsentBehavior.Disabled(
+                overrideAllowRedisplay = null
+            ),
         )
 
         testAllowRedisplayValueForCustomerRequestedSave(
@@ -1677,12 +1650,9 @@ internal class PaymentMethodMetadataTest {
         val metadataForSetupIntent = PaymentMethodMetadataFactory.create(
             stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
             hasCustomerConfiguration = true,
-            customerMetadataPermissions = PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA_PERMISSIONS
-                .copy(
-                    saveConsent = PaymentMethodSaveConsentBehavior.Disabled(
-                        overrideAllowRedisplay = null
-                    ),
-                ),
+            saveConsent = PaymentMethodSaveConsentBehavior.Disabled(
+                overrideAllowRedisplay = null
+            ),
         )
 
         testAllowRedisplayValueForCustomerRequestedSave(
@@ -1695,12 +1665,9 @@ internal class PaymentMethodMetadataTest {
                 setupFutureUsage = StripeIntent.Usage.OnSession,
             ),
             hasCustomerConfiguration = true,
-            customerMetadataPermissions = PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA_PERMISSIONS
-                .copy(
-                    saveConsent = PaymentMethodSaveConsentBehavior.Disabled(
-                        overrideAllowRedisplay = null
-                    ),
-                ),
+            saveConsent = PaymentMethodSaveConsentBehavior.Disabled(
+                overrideAllowRedisplay = null
+            ),
         )
 
         testAllowRedisplayValueForCustomerRequestedSave(
@@ -1713,12 +1680,9 @@ internal class PaymentMethodMetadataTest {
                 paymentMethodOptionsJsonString = PaymentIntentFixtures.PMO_SETUP_FUTURE_USAGE
             ),
             hasCustomerConfiguration = true,
-            customerMetadataPermissions = PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA_PERMISSIONS
-                .copy(
-                    saveConsent = PaymentMethodSaveConsentBehavior.Disabled(
-                        overrideAllowRedisplay = null
-                    ),
-                ),
+            saveConsent = PaymentMethodSaveConsentBehavior.Disabled(
+                overrideAllowRedisplay = null
+            ),
         )
 
         testAllowRedisplayValueForCustomerRequestedSave(
@@ -1733,12 +1697,9 @@ internal class PaymentMethodMetadataTest {
             val metadataForSetupIntent = PaymentMethodMetadataFactory.create(
                 stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
                 hasCustomerConfiguration = true,
-                customerMetadataPermissions = PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA_PERMISSIONS
-                    .copy(
-                        saveConsent = PaymentMethodSaveConsentBehavior.Disabled(
-                            overrideAllowRedisplay = PaymentMethod.AllowRedisplay.ALWAYS
-                        ),
-                    ),
+                saveConsent = PaymentMethodSaveConsentBehavior.Disabled(
+                    overrideAllowRedisplay = PaymentMethod.AllowRedisplay.ALWAYS
+                ),
             )
 
             testAllowRedisplayValueForCustomerRequestedSave(
@@ -1751,12 +1712,9 @@ internal class PaymentMethodMetadataTest {
                     setupFutureUsage = StripeIntent.Usage.OnSession,
                 ),
                 hasCustomerConfiguration = true,
-                customerMetadataPermissions = PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA_PERMISSIONS
-                    .copy(
-                        saveConsent = PaymentMethodSaveConsentBehavior.Disabled(
-                            overrideAllowRedisplay = PaymentMethod.AllowRedisplay.UNSPECIFIED
-                        ),
-                    ),
+                saveConsent = PaymentMethodSaveConsentBehavior.Disabled(
+                    overrideAllowRedisplay = PaymentMethod.AllowRedisplay.UNSPECIFIED
+                ),
             )
 
             testAllowRedisplayValueForCustomerRequestedSave(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardUiDefinitionFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardUiDefinitionFactoryTest.kt
@@ -2,7 +2,6 @@ package com.stripe.android.lpmfoundations.paymentmethod.definitions
 
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA
-import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA_PERMISSIONS
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures.getDefaultCustomerMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.lpmfoundations.paymentmethod.formElements
@@ -225,9 +224,7 @@ class CardUiDefinitionFactoryTest {
                     ),
                     customerMetadata = getDefaultCustomerMetadata(
                         isPaymentMethodSetAsDefaultEnabled = false,
-                        permissions = DEFAULT_CUSTOMER_METADATA_PERMISSIONS.copy(
-                            saveConsent = PaymentMethodSaveConsentBehavior.Enabled
-                        )
+                        saveConsent = PaymentMethodSaveConsentBehavior.Enabled,
                     ),
                 ),
             )
@@ -245,9 +242,7 @@ class CardUiDefinitionFactoryTest {
                 metadata = metadata.copy(
                     stripeIntent = setupIntent,
                     customerMetadata = getDefaultCustomerMetadata(
-                        permissions = DEFAULT_CUSTOMER_METADATA_PERMISSIONS.copy(
-                            saveConsent = PaymentMethodSaveConsentBehavior.Enabled
-                        )
+                        saveConsent = PaymentMethodSaveConsentBehavior.Enabled,
                     ),
                 ),
             )
@@ -265,9 +260,7 @@ class CardUiDefinitionFactoryTest {
                 metadata = metadata.copy(
                     stripeIntent = setupIntent,
                     customerMetadata = getDefaultCustomerMetadata(
-                        permissions = DEFAULT_CUSTOMER_METADATA_PERMISSIONS.copy(
-                            saveConsent = PaymentMethodSaveConsentBehavior.Enabled
-                        )
+                        saveConsent = PaymentMethodSaveConsentBehavior.Enabled,
                     ),
                 ),
             )

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SepaDebitDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SepaDebitDefinitionTest.kt
@@ -2,7 +2,6 @@ package com.stripe.android.lpmfoundations.paymentmethod.definitions
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
-import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.lpmfoundations.paymentmethod.formElements
 import com.stripe.android.model.PaymentIntentFixtures
@@ -69,9 +68,7 @@ class SepaDebitDefinitionTest {
                 stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD.copy(
                     paymentMethodTypes = listOf("sepa_debit")
                 ),
-                customerMetadataPermissions = PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA_PERMISSIONS.copy(
-                    saveConsent = PaymentMethodSaveConsentBehavior.Enabled
-                ),
+                saveConsent = PaymentMethodSaveConsentBehavior.Enabled,
                 hasCustomerConfiguration = true
             )
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperTest.kt
@@ -170,8 +170,8 @@ internal class DefaultEmbeddedContentHelperTest {
             customerStateHolder = DefaultCustomerStateHolder(
                 savedStateHandle = savedStateHandle,
                 selection = selectionHolder.selection,
-                customerMetadataPermissions = stateFlowOf(
-                    PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA.permissions
+                customerMetadata = stateFlowOf(
+                    PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA
                 ),
             ),
             embeddedFormHelperFactory = embeddedFormHelperFactory,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
@@ -443,7 +443,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
         val customerStateHolder = DefaultCustomerStateHolder(
             savedStateHandle = savedStateHandle,
             selection = selectionHolder.selection,
-            customerMetadataPermissions = stateFlowOf(paymentMethodMetadata.customerMetadata?.permissions)
+            customerMetadata = stateFlowOf(paymentMethodMetadata.customerMetadata)
         )
         val sheetStateHolder = SheetStateHolder(savedStateHandle)
         val errorReporter = FakeErrorReporter()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedStateHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedStateHelperTest.kt
@@ -200,8 +200,8 @@ internal class DefaultEmbeddedStateHelperTest {
         val customerStateHolder = DefaultCustomerStateHolder(
             savedStateHandle = savedStateHandle,
             selection = selectionHolder.selection,
-            customerMetadataPermissions = stateFlowOf(
-                PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA.permissions
+            customerMetadata = stateFlowOf(
+                PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA
             ),
         )
         val confirmationStateHolder = EmbeddedConfirmationStateHolder(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentUiTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentUiTest.kt
@@ -166,8 +166,8 @@ internal class EmbeddedContentUiTest {
                 customerStateHolder = DefaultCustomerStateHolder(
                     savedStateHandle = savedStateHandle,
                     selection = selectionHolder.selection,
-                    customerMetadataPermissions = stateFlowOf(
-                        PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA.permissions
+                    customerMetadata = stateFlowOf(
+                        PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA
                     ),
                 ),
                 embeddedFormHelperFactory = embeddedFormHelperFactory,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/InitialManageScreenFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/InitialManageScreenFactoryTest.kt
@@ -45,8 +45,8 @@ internal class InitialManageScreenFactoryTest {
         val customerStateHolder = DefaultCustomerStateHolder(
             savedStateHandle = SavedStateHandle(),
             selection = stateFlowOf(null),
-            customerMetadataPermissions = stateFlowOf(
-                PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA.permissions
+            customerMetadata = stateFlowOf(
+                PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA
             ),
         )
         val factory = InitialManageScreenFactory(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/ManageActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/ManageActivityTest.kt
@@ -9,7 +9,6 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.common.model.PaymentMethodRemovePermission
-import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
@@ -190,13 +189,11 @@ internal class ManageActivityTest {
         paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(
             cbcEligibility = CardBrandChoiceEligibility.Eligible(preferredNetworks = listOf()),
             hasCustomerConfiguration = true,
-            customerMetadataPermissions = CustomerMetadata.Permissions(
-                canRemoveDuplicates = false,
-                removePaymentMethod = PaymentMethodRemovePermission.Full,
-                saveConsent = PaymentMethodSaveConsentBehavior.Legacy,
-                canRemoveLastPaymentMethod = true,
-                canUpdateFullPaymentMethodDetails = false,
-            )
+            canRemoveDuplicates = false,
+            removePaymentMethod = PaymentMethodRemovePermission.Full,
+            saveConsent = PaymentMethodSaveConsentBehavior.Legacy,
+            canRemoveLastPaymentMethod = true,
+            canUpdateFullPaymentMethodDetails = false,
         ),
         paymentMethods: List<PaymentMethod> = defaultPaymentMethods(),
         selection: PaymentSelection? = null,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultCustomerStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultCustomerStateHolderTest.kt
@@ -12,7 +12,6 @@ import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.testing.PaymentMethodFactory
-import com.stripe.android.uicore.utils.mapAsStateFlow
 import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.runTest
@@ -380,20 +379,18 @@ internal class DefaultCustomerStateHolderTest {
         selection: StateFlow<PaymentSelection?> = stateFlowOf(null),
         block: suspend Scenario.() -> Unit
     ) {
-        val customerMetadata: StateFlow<CustomerMetadata> = stateFlowOf(
+        val customerMetadata: StateFlow<CustomerMetadata?> = stateFlowOf(
             DEFAULT_CUSTOMER_METADATA.copy(
-                permissions = CustomerMetadata.Permissions(
-                    removePaymentMethod = paymentMethodRemovePermission,
-                    saveConsent = PaymentMethodSaveConsentBehavior.Legacy,
-                    canRemoveLastPaymentMethod = canRemoveLastPaymentMethod,
-                    canRemoveDuplicates = true,
-                    canUpdateFullPaymentMethodDetails = false,
-                )
+                removePaymentMethod = paymentMethodRemovePermission,
+                saveConsent = PaymentMethodSaveConsentBehavior.Legacy,
+                canRemoveLastPaymentMethod = canRemoveLastPaymentMethod,
+                canRemoveDuplicates = true,
+                canUpdateFullPaymentMethodDetails = false,
             )
         )
 
         val customerStateHolder = DefaultCustomerStateHolder(
-            customerMetadataPermissions = customerMetadata.mapAsStateFlow { it.permissions },
+            customerMetadata = customerMetadata,
             savedStateHandle = savedStateHandle,
             selection = selection,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
@@ -57,13 +57,11 @@ class SavedPaymentMethodMutatorTest {
     fun `canEdit is correct when user has permissions to remove last PM`() = runScenario(
         paymentMethodMetadata = PaymentMethodMetadataFactory.create(
             hasCustomerConfiguration = true,
-            customerMetadataPermissions = CustomerMetadata.Permissions(
-                removePaymentMethod = PaymentMethodRemovePermission.Full,
-                saveConsent = PaymentMethodSaveConsentBehavior.Legacy,
-                canRemoveLastPaymentMethod = true,
-                canRemoveDuplicates = false,
-                canUpdateFullPaymentMethodDetails = false,
-            )
+            removePaymentMethod = PaymentMethodRemovePermission.Full,
+            saveConsent = PaymentMethodSaveConsentBehavior.Legacy,
+            canRemoveLastPaymentMethod = true,
+            canRemoveDuplicates = false,
+            canUpdateFullPaymentMethodDetails = false,
         )
     ) {
         savedPaymentMethodMutator.canEdit.test {
@@ -82,13 +80,11 @@ class SavedPaymentMethodMutatorTest {
     fun `canEdit is correct when when user does not have permissions to remove last PM`() = runScenario(
         paymentMethodMetadata = PaymentMethodMetadataFactory.create(
             hasCustomerConfiguration = true,
-            customerMetadataPermissions = CustomerMetadata.Permissions(
-                removePaymentMethod = PaymentMethodRemovePermission.Full,
-                saveConsent = PaymentMethodSaveConsentBehavior.Legacy,
-                canRemoveLastPaymentMethod = false,
-                canRemoveDuplicates = false,
-                canUpdateFullPaymentMethodDetails = false,
-            )
+            removePaymentMethod = PaymentMethodRemovePermission.Full,
+            saveConsent = PaymentMethodSaveConsentBehavior.Legacy,
+            canRemoveLastPaymentMethod = false,
+            canRemoveDuplicates = false,
+            canUpdateFullPaymentMethodDetails = false,
         )
     ) {
         savedPaymentMethodMutator.canEdit.test {
@@ -207,13 +203,11 @@ class SavedPaymentMethodMutatorTest {
     fun `Sets editing to false when removing the last payment method while editing`() = runScenario(
         paymentMethodMetadata = PaymentMethodMetadataFactory.create(
             hasCustomerConfiguration = true,
-            customerMetadataPermissions = CustomerMetadata.Permissions(
-                removePaymentMethod = PaymentMethodRemovePermission.Full,
-                saveConsent = PaymentMethodSaveConsentBehavior.Legacy,
-                canRemoveLastPaymentMethod = true,
-                canRemoveDuplicates = false,
-                canUpdateFullPaymentMethodDetails = false,
-            )
+            removePaymentMethod = PaymentMethodRemovePermission.Full,
+            saveConsent = PaymentMethodSaveConsentBehavior.Legacy,
+            canRemoveLastPaymentMethod = true,
+            canRemoveDuplicates = false,
+            canUpdateFullPaymentMethodDetails = false,
         )
     ) {
         val customerPaymentMethods = PaymentMethodFixtures.createCards(1)
@@ -238,13 +232,11 @@ class SavedPaymentMethodMutatorTest {
         paymentMethodMetadata =
         PaymentMethodMetadataFactory.create(
             hasCustomerConfiguration = true,
-            customerMetadataPermissions = CustomerMetadata.Permissions(
-                canRemoveDuplicates = true,
-                removePaymentMethod = PaymentMethodRemovePermission.Full,
-                saveConsent = PaymentMethodSaveConsentBehavior.Legacy,
-                canRemoveLastPaymentMethod = true,
-                canUpdateFullPaymentMethodDetails = true,
-            )
+            canRemoveDuplicates = true,
+            removePaymentMethod = PaymentMethodRemovePermission.Full,
+            saveConsent = PaymentMethodSaveConsentBehavior.Legacy,
+            canRemoveLastPaymentMethod = true,
+            canUpdateFullPaymentMethodDetails = true,
         )
     ) {
         val cards = PaymentMethodFixtures.createCards(3)
@@ -267,13 +259,11 @@ class SavedPaymentMethodMutatorTest {
     fun `updatePaymentMethod should be called correctly when 1 PM & cannot remove last PM`() = runScenario(
         paymentMethodMetadata = PaymentMethodMetadataFactory.create(
             hasCustomerConfiguration = true,
-            customerMetadataPermissions = CustomerMetadata.Permissions(
-                canRemoveDuplicates = true,
-                removePaymentMethod = PaymentMethodRemovePermission.Full,
-                saveConsent = PaymentMethodSaveConsentBehavior.Legacy,
-                canRemoveLastPaymentMethod = false,
-                canUpdateFullPaymentMethodDetails = true,
-            )
+            canRemoveDuplicates = true,
+            removePaymentMethod = PaymentMethodRemovePermission.Full,
+            saveConsent = PaymentMethodSaveConsentBehavior.Legacy,
+            canRemoveLastPaymentMethod = false,
+            canUpdateFullPaymentMethodDetails = true,
         )
     ) {
         val cards = PaymentMethodFixtures.createCards(1)
@@ -864,13 +854,11 @@ class SavedPaymentMethodMutatorTest {
             savedPaymentMethodRepository = repository,
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                 hasCustomerConfiguration = true,
-                customerMetadataPermissions = CustomerMetadata.Permissions(
-                    removePaymentMethod = PaymentMethodRemovePermission.Full,
-                    saveConsent = PaymentMethodSaveConsentBehavior.Legacy,
-                    canRemoveLastPaymentMethod = true,
-                    canRemoveDuplicates = shouldRemoveDuplicates,
-                    canUpdateFullPaymentMethodDetails = false,
-                ),
+                removePaymentMethod = PaymentMethodRemovePermission.Full,
+                saveConsent = PaymentMethodSaveConsentBehavior.Legacy,
+                canRemoveLastPaymentMethod = true,
+                canRemoveDuplicates = shouldRemoveDuplicates,
+                canUpdateFullPaymentMethodDetails = false,
                 customerSessionClientSecret = customerSessionClientSecret,
             )
         ) {
@@ -895,13 +883,11 @@ class SavedPaymentMethodMutatorTest {
                         ephemeralKeySecret = "ek_123",
                         customerSessionClientSecret = customerSessionClientSecret,
                         isPaymentMethodSetAsDefaultEnabled = false,
-                        permissions = CustomerMetadata.Permissions(
-                            removePaymentMethod = PaymentMethodRemovePermission.Full,
-                            saveConsent = PaymentMethodSaveConsentBehavior.Legacy,
-                            canRemoveLastPaymentMethod = true,
-                            canRemoveDuplicates = shouldRemoveDuplicates,
-                            canUpdateFullPaymentMethodDetails = false,
-                        ),
+                        removePaymentMethod = PaymentMethodRemovePermission.Full,
+                        saveConsent = PaymentMethodSaveConsentBehavior.Legacy,
+                        canRemoveLastPaymentMethod = true,
+                        canRemoveDuplicates = shouldRemoveDuplicates,
+                        canUpdateFullPaymentMethodDetails = false,
                     ),
                     canRemoveDuplicates = shouldRemoveDuplicates,
                 )
@@ -923,8 +909,8 @@ class SavedPaymentMethodMutatorTest {
         val customerStateHolder = DefaultCustomerStateHolder(
             savedStateHandle = SavedStateHandle(),
             selection = MutableStateFlow(null),
-            customerMetadataPermissions =
-            stateFlowOf(PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA.permissions),
+            customerMetadata =
+            stateFlowOf(PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA),
         )
         runScenario(
             customerStateHolder = customerStateHolder,
@@ -965,9 +951,9 @@ class SavedPaymentMethodMutatorTest {
         customerStateHolder: CustomerStateHolder = DefaultCustomerStateHolder(
             savedStateHandle = SavedStateHandle(),
             selection = selection,
-            customerMetadataPermissions = stateFlowOf(
-                paymentMethodMetadata?.customerMetadata?.permissions
-                    ?: PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA.permissions
+            customerMetadata = stateFlowOf(
+                paymentMethodMetadata?.customerMetadata
+                    ?: PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA
             ),
         ),
         block: suspend Scenario.() -> Unit

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultAnalyticsMetadataFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultAnalyticsMetadataFactoryTest.kt
@@ -824,13 +824,11 @@ class DefaultAnalyticsMetadataFactoryTest {
         ephemeralKeySecret = "ek_123",
         customerSessionClientSecret = "cuss_132_secret_123",
         isPaymentMethodSetAsDefaultEnabled = isPaymentMethodSetAsDefaultEnabled,
-        permissions = CustomerMetadata.Permissions(
-            removePaymentMethod = PaymentMethodRemovePermission.Full,
-            saveConsent = PaymentMethodSaveConsentBehavior.Legacy,
-            canRemoveLastPaymentMethod = true,
-            canRemoveDuplicates = true,
-            canUpdateFullPaymentMethodDetails = true,
-        )
+        removePaymentMethod = PaymentMethodRemovePermission.Full,
+        saveConsent = PaymentMethodSaveConsentBehavior.Legacy,
+        canRemoveLastPaymentMethod = true,
+        canRemoveDuplicates = true,
+        canUpdateFullPaymentMethodDetails = true,
     )
 
     private fun createElementsSessionCustomer(): ElementsSession.Customer {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -155,13 +155,11 @@ internal class DefaultPaymentElementLoaderTest {
                     cardFundingFilter = PaymentSheetCardFundingFilter(ConfigurationDefaults.allowedCardFundingTypes),
                     hasCustomerConfiguration = true,
                     financialConnectionsAvailability = FinancialConnectionsAvailability.Full,
-                    customerMetadataPermissions = CustomerMetadata.Permissions(
-                        canRemoveDuplicates = false,
-                        removePaymentMethod = PaymentMethodRemovePermission.Full,
-                        saveConsent = PaymentMethodSaveConsentBehavior.Legacy,
-                        canRemoveLastPaymentMethod = true,
-                        canUpdateFullPaymentMethodDetails = false,
-                    ),
+                    canRemoveDuplicates = false,
+                    removePaymentMethod = PaymentMethodRemovePermission.Full,
+                    saveConsent = PaymentMethodSaveConsentBehavior.Legacy,
+                    canRemoveLastPaymentMethod = true,
+                    canUpdateFullPaymentMethodDetails = false,
                     clientAttributionMetadata = ClientAttributionMetadata(
                         elementsSessionConfigId = DEFAULT_ELEMENTS_SESSION_CONFIG_ID,
                         paymentIntentCreationFlow = PaymentIntentCreationFlow.Standard,
@@ -2677,15 +2675,16 @@ internal class DefaultPaymentElementLoaderTest {
                 ),
             ).getOrThrow()
 
-            assertThat(state.paymentMethodMetadata.customerMetadata?.permissions).isEqualTo(
-                CustomerMetadata.Permissions(
-                    removePaymentMethod = PaymentMethodRemovePermission.Full,
-                    saveConsent = PaymentMethodSaveConsentBehavior.Disabled(overrideAllowRedisplay = null),
-                    canRemoveLastPaymentMethod = true,
-                    canRemoveDuplicates = true,
-                    canUpdateFullPaymentMethodDetails = true
-                )
-            )
+            assertThat(state.paymentMethodMetadata.customerMetadata?.removePaymentMethod)
+                .isEqualTo(PaymentMethodRemovePermission.Full)
+            assertThat(state.paymentMethodMetadata.customerMetadata?.saveConsent)
+                .isEqualTo(PaymentMethodSaveConsentBehavior.Disabled(overrideAllowRedisplay = null))
+            assertThat(state.paymentMethodMetadata.customerMetadata?.canRemoveLastPaymentMethod)
+                .isEqualTo(true)
+            assertThat(state.paymentMethodMetadata.customerMetadata?.canRemoveDuplicates)
+                .isEqualTo(true)
+            assertThat(state.paymentMethodMetadata.customerMetadata?.canUpdateFullPaymentMethodDetails)
+                .isEqualTo(true)
 
             assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
@@ -2727,15 +2726,16 @@ internal class DefaultPaymentElementLoaderTest {
                 ),
             ).getOrThrow()
 
-            assertThat(state.paymentMethodMetadata.customerMetadata?.permissions).isEqualTo(
-                CustomerMetadata.Permissions(
-                    removePaymentMethod = PaymentMethodRemovePermission.None,
-                    saveConsent = PaymentMethodSaveConsentBehavior.Disabled(overrideAllowRedisplay = null),
-                    canRemoveLastPaymentMethod = true,
-                    canRemoveDuplicates = true,
-                    canUpdateFullPaymentMethodDetails = true
-                )
-            )
+            assertThat(state.paymentMethodMetadata.customerMetadata?.removePaymentMethod)
+                .isEqualTo(PaymentMethodRemovePermission.None)
+            assertThat(state.paymentMethodMetadata.customerMetadata?.saveConsent)
+                .isEqualTo(PaymentMethodSaveConsentBehavior.Disabled(overrideAllowRedisplay = null))
+            assertThat(state.paymentMethodMetadata.customerMetadata?.canRemoveLastPaymentMethod)
+                .isEqualTo(true)
+            assertThat(state.paymentMethodMetadata.customerMetadata?.canRemoveDuplicates)
+                .isEqualTo(true)
+            assertThat(state.paymentMethodMetadata.customerMetadata?.canUpdateFullPaymentMethodDetails)
+                .isEqualTo(true)
 
             assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
@@ -2777,15 +2777,16 @@ internal class DefaultPaymentElementLoaderTest {
                 ),
             ).getOrThrow()
 
-            assertThat(state.paymentMethodMetadata.customerMetadata?.permissions).isEqualTo(
-                CustomerMetadata.Permissions(
-                    removePaymentMethod = PaymentMethodRemovePermission.None,
-                    saveConsent = PaymentMethodSaveConsentBehavior.Disabled(overrideAllowRedisplay = null),
-                    canRemoveLastPaymentMethod = true,
-                    canRemoveDuplicates = true,
-                    canUpdateFullPaymentMethodDetails = true
-                )
-            )
+            assertThat(state.paymentMethodMetadata.customerMetadata?.removePaymentMethod)
+                .isEqualTo(PaymentMethodRemovePermission.None)
+            assertThat(state.paymentMethodMetadata.customerMetadata?.saveConsent)
+                .isEqualTo(PaymentMethodSaveConsentBehavior.Disabled(overrideAllowRedisplay = null))
+            assertThat(state.paymentMethodMetadata.customerMetadata?.canRemoveLastPaymentMethod)
+                .isEqualTo(true)
+            assertThat(state.paymentMethodMetadata.customerMetadata?.canRemoveDuplicates)
+                .isEqualTo(true)
+            assertThat(state.paymentMethodMetadata.customerMetadata?.canUpdateFullPaymentMethodDetails)
+                .isEqualTo(true)
 
             assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
@@ -2827,15 +2828,16 @@ internal class DefaultPaymentElementLoaderTest {
                 ),
             ).getOrThrow()
 
-            assertThat(state.paymentMethodMetadata.customerMetadata?.permissions).isEqualTo(
-                CustomerMetadata.Permissions(
-                    removePaymentMethod = PaymentMethodRemovePermission.Partial,
-                    saveConsent = PaymentMethodSaveConsentBehavior.Disabled(overrideAllowRedisplay = null),
-                    canRemoveLastPaymentMethod = true,
-                    canRemoveDuplicates = true,
-                    canUpdateFullPaymentMethodDetails = true
-                )
-            )
+            assertThat(state.paymentMethodMetadata.customerMetadata?.removePaymentMethod)
+                .isEqualTo(PaymentMethodRemovePermission.Partial)
+            assertThat(state.paymentMethodMetadata.customerMetadata?.saveConsent)
+                .isEqualTo(PaymentMethodSaveConsentBehavior.Disabled(overrideAllowRedisplay = null))
+            assertThat(state.paymentMethodMetadata.customerMetadata?.canRemoveLastPaymentMethod)
+                .isEqualTo(true)
+            assertThat(state.paymentMethodMetadata.customerMetadata?.canRemoveDuplicates)
+                .isEqualTo(true)
+            assertThat(state.paymentMethodMetadata.customerMetadata?.canUpdateFullPaymentMethodDetails)
+                .isEqualTo(true)
 
             assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
@@ -2877,15 +2879,16 @@ internal class DefaultPaymentElementLoaderTest {
                 ),
             ).getOrThrow()
 
-            assertThat(state.paymentMethodMetadata.customerMetadata?.permissions).isEqualTo(
-                CustomerMetadata.Permissions(
-                    removePaymentMethod = PaymentMethodRemovePermission.None,
-                    saveConsent = PaymentMethodSaveConsentBehavior.Disabled(overrideAllowRedisplay = null),
-                    canRemoveLastPaymentMethod = true,
-                    canRemoveDuplicates = true,
-                    canUpdateFullPaymentMethodDetails = true
-                )
-            )
+            assertThat(state.paymentMethodMetadata.customerMetadata?.removePaymentMethod)
+                .isEqualTo(PaymentMethodRemovePermission.None)
+            assertThat(state.paymentMethodMetadata.customerMetadata?.saveConsent)
+                .isEqualTo(PaymentMethodSaveConsentBehavior.Disabled(overrideAllowRedisplay = null))
+            assertThat(state.paymentMethodMetadata.customerMetadata?.canRemoveLastPaymentMethod)
+                .isEqualTo(true)
+            assertThat(state.paymentMethodMetadata.customerMetadata?.canRemoveDuplicates)
+                .isEqualTo(true)
+            assertThat(state.paymentMethodMetadata.customerMetadata?.canUpdateFullPaymentMethodDetails)
+                .isEqualTo(true)
 
             assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
@@ -2910,15 +2913,16 @@ internal class DefaultPaymentElementLoaderTest {
                 ),
             ).getOrThrow()
 
-            assertThat(state.paymentMethodMetadata.customerMetadata?.permissions).isEqualTo(
-                CustomerMetadata.Permissions(
-                    removePaymentMethod = PaymentMethodRemovePermission.Full,
-                    saveConsent = PaymentMethodSaveConsentBehavior.Legacy,
-                    canRemoveLastPaymentMethod = true,
-                    canRemoveDuplicates = false,
-                    canUpdateFullPaymentMethodDetails = false
-                )
-            )
+            assertThat(state.paymentMethodMetadata.customerMetadata?.removePaymentMethod)
+                .isEqualTo(PaymentMethodRemovePermission.Full)
+            assertThat(state.paymentMethodMetadata.customerMetadata?.saveConsent)
+                .isEqualTo(PaymentMethodSaveConsentBehavior.Legacy)
+            assertThat(state.paymentMethodMetadata.customerMetadata?.canRemoveLastPaymentMethod)
+                .isEqualTo(true)
+            assertThat(state.paymentMethodMetadata.customerMetadata?.canRemoveDuplicates)
+                .isEqualTo(false)
+            assertThat(state.paymentMethodMetadata.customerMetadata?.canUpdateFullPaymentMethodDetails)
+                .isEqualTo(false)
 
             assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
@@ -2965,7 +2969,7 @@ internal class DefaultPaymentElementLoaderTest {
                 ),
             ).getOrThrow()
 
-            assertThat(state.paymentMethodMetadata.customerMetadata?.permissions?.removePaymentMethod)
+            assertThat(state.paymentMethodMetadata.customerMetadata?.removePaymentMethod)
                 .isEqualTo(expectedPermission)
 
             assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
@@ -3934,7 +3938,7 @@ internal class DefaultPaymentElementLoaderTest {
         paymentMethodRemoveLastFeature: ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature =
             ElementsSession.Customer.Components.PaymentMethodRemoveLastFeature.NotProvided,
         canRemoveLastPaymentMethodFromConfig: Boolean = true,
-        test: (CustomerMetadata.Permissions) -> Unit,
+        test: (CustomerMetadata) -> Unit,
     ) = runScenario {
         val loader = createPaymentElementLoader(
             customer = ElementsSession.Customer(
@@ -3970,7 +3974,7 @@ internal class DefaultPaymentElementLoaderTest {
             ),
         ).getOrThrow()
 
-        test(requireNotNull(state.paymentMethodMetadata.customerMetadata).permissions)
+        test(requireNotNull(state.paymentMethodMetadata.customerMetadata))
 
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentMethodFilterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentMethodFilterTest.kt
@@ -213,13 +213,11 @@ class DefaultPaymentMethodFilterTest {
                     ephemeralKeySecret = "ek_123",
                     customerSessionClientSecret = "cuss_123",
                     isPaymentMethodSetAsDefaultEnabled = isPaymentMethodSetAsDefaultEnabled,
-                    permissions = CustomerMetadata.Permissions(
-                        removePaymentMethod = PaymentMethodRemovePermission.Full,
-                        saveConsent = PaymentMethodSaveConsentBehavior.Legacy,
-                        canRemoveLastPaymentMethod = false,
-                        canRemoveDuplicates = false,
-                        canUpdateFullPaymentMethodDetails = false,
-                    )
+                    removePaymentMethod = PaymentMethodRemovePermission.Full,
+                    saveConsent = PaymentMethodSaveConsentBehavior.Legacy,
+                    canRemoveLastPaymentMethod = false,
+                    canRemoveDuplicates = false,
+                    canUpdateFullPaymentMethodDetails = false,
                 ),
                 remoteDefaultPaymentMethodId = remoteDefaultPaymentMethodId,
                 localSavedSelection = CompletableDeferred(localSavedSelection),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodTest.kt
@@ -13,7 +13,6 @@ import com.stripe.android.link.ui.inline.LinkSignupMode
 import com.stripe.android.link.ui.inline.SignUpConsentAction
 import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
-import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.PaymentIntentFixtures
@@ -355,9 +354,7 @@ internal class AddPaymentMethodTest {
     @Test
     fun `when customer reuse is not requested, should have allow_redisplay in params`() {
         val metadata = PaymentMethodMetadataFactory.create(
-            customerMetadataPermissions = PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA_PERMISSIONS.copy(
-                saveConsent = PaymentMethodSaveConsentBehavior.Enabled
-            ),
+            saveConsent = PaymentMethodSaveConsentBehavior.Enabled,
         )
 
         val formValues = FormFieldValues(
@@ -378,9 +375,7 @@ internal class AddPaymentMethodTest {
         val metadata = PaymentMethodMetadataFactory.create(
             stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
             hasCustomerConfiguration = true,
-            customerMetadataPermissions = PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA_PERMISSIONS.copy(
-                saveConsent = PaymentMethodSaveConsentBehavior.Enabled
-            ),
+            saveConsent = PaymentMethodSaveConsentBehavior.Enabled,
         )
 
         val formValues = FormFieldValues(
@@ -401,9 +396,7 @@ internal class AddPaymentMethodTest {
         val metadata = PaymentMethodMetadataFactory.create(
             stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD,
             hasCustomerConfiguration = true,
-            customerMetadataPermissions = PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA_PERMISSIONS.copy(
-                saveConsent = PaymentMethodSaveConsentBehavior.Enabled
-            ),
+            saveConsent = PaymentMethodSaveConsentBehavior.Enabled,
         )
 
         val formValues = FormFieldValues(
@@ -423,9 +416,7 @@ internal class AddPaymentMethodTest {
     fun `when customer reuse is not requested with pmo sfu, should have allow_redisplay in params`() {
         val metadata = PaymentMethodMetadataFactory.create(
             hasCustomerConfiguration = true,
-            customerMetadataPermissions = PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA_PERMISSIONS.copy(
-                saveConsent = PaymentMethodSaveConsentBehavior.Enabled
-            ),
+            saveConsent = PaymentMethodSaveConsentBehavior.Enabled,
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
                 paymentMethodOptionsJsonString = PaymentIntentFixtures.PMO_SETUP_FUTURE_USAGE
             )
@@ -448,9 +439,7 @@ internal class AddPaymentMethodTest {
     fun `when customer reuse is requested with reuse and pmo sfu, should have allow_redisplay in params`() {
         val metadata = PaymentMethodMetadataFactory.create(
             hasCustomerConfiguration = true,
-            customerMetadataPermissions = PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA_PERMISSIONS.copy(
-                saveConsent = PaymentMethodSaveConsentBehavior.Enabled
-            ),
+            saveConsent = PaymentMethodSaveConsentBehavior.Enabled,
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
                 paymentMethodOptionsJsonString = PaymentIntentFixtures.PMO_SETUP_FUTURE_USAGE
             )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultVerticalModeFormInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultVerticalModeFormInteractorTest.kt
@@ -9,7 +9,6 @@ import com.stripe.android.common.taptoadd.FakeTapToAddHelper
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
-import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
@@ -239,9 +238,7 @@ internal class DefaultVerticalModeFormInteractorTest {
             billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
                 address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full
             ),
-            customerMetadataPermissions = PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA_PERMISSIONS.copy(
-                saveConsent = PaymentMethodSaveConsentBehavior.Enabled
-            ),
+            saveConsent = PaymentMethodSaveConsentBehavior.Enabled,
             hasCustomerConfiguration = true,
             isPaymentMethodSetAsDefaultEnabled = true,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactoryTest.kt
@@ -107,8 +107,8 @@ class VerticalModeInitialScreenFactoryTest {
         val customerStateHolder = DefaultCustomerStateHolder(
             savedStateHandle = SavedStateHandle(),
             selection = fakeViewModel.selection,
-            customerMetadataPermissions = stateFlowOf(
-                paymentMethodMetadata.customerMetadata?.permissions
+            customerMetadata = stateFlowOf(
+                paymentMethodMetadata.customerMetadata
             )
         )
         if (hasSavedPaymentMethods) {


### PR DESCRIPTION
## Summary
- Remove the nested `CustomerMetadata.Permissions` data class, promoting all 5 permission fields (`removePaymentMethod`, `saveConsent`, `canRemoveLastPaymentMethod`, `canRemoveDuplicates`, `canUpdateFullPaymentMethodDetails`) and the `canRemovePaymentMethods` computed property directly into `CustomerMetadata`
- Move factory methods (`createForPaymentSheetCustomerSession`, `createForPaymentSheetLegacyEphemeralKey`, `createForCustomerSheet`) to `CustomerMetadata.Companion`, each now returning a complete `CustomerMetadata`
- Simplify all call sites to access permission fields directly (e.g. `customerMetadata?.saveConsent` instead of `customerMetadata?.permissions?.saveConsent`)

## Test plan
- [x] `./gradlew :paymentsheet:testDebugUnitTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)