### PR TITLE
Set explicit JVM target for lint module

### DIFF
--- a/lint/build.gradle
+++ b/lint/build.gradle
@@ -6,6 +6,17 @@ apply from: rootProject.file('build-configuration/detekt.gradle')
 apply from: rootProject.file('build-configuration/ktlint.gradle')
 apply from: rootProject.file('build-configuration/configurations.gradle')
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set("JVM_21")
+    }
+}
+
 check.dependsOn('ktlint')
 
 dependencies {


### PR DESCRIPTION
## Summary
- The lint module had no explicit `jvmTarget`, so Kotlin defaulted to the running JDK version
- Java 25 produces class files with major version 69, which the binary-compatibility-validator's bundled ASM cannot parse, causing `apiCheck` to fail
- Sets an explicit JVM target of 21 for both Java and Kotlin compilation, preventing breakage on future JDK upgrades

## Test plan
- [x] `./gradlew apiCheck` passes on Java 25

🤖 Generated with [Claude Code](https://claude.com/claude-code)