### PR TITLE
Extract CLAUDE.md into skills for better discoverability

### DIFF
--- a/.claude/skills/github-issues/SKILL.md
+++ b/.claude/skills/github-issues/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: github-issues
+description: Use when working with GitHub issues or pull requests for the stripe/stripe-android repository
+---
+
+# GitHub Issues
+
+## Read-Only Operations
+
+Use `export GH_HOST=github.com &&` prefix to avoid permission prompts:
+
+- `export GH_HOST=github.com && gh issue list --repo stripe/stripe-android --limit 20` — List recent issues
+- `export GH_HOST=github.com && gh issue view <issue_number> --repo stripe/stripe-android` — View specific issue
+- `export GH_HOST=github.com && gh issue view <issue_number> --repo stripe/stripe-android --comments` — View issue with comments
+- `export GH_HOST=github.com && gh issue list --repo stripe/stripe-android --state all --search "keyword" --limit 30` — Search ALL issues (open/closed) by keyword
+
+## Write Operations
+
+Use `GH_HOST=github.com` prefix (keep permission prompts for safety):
+
+- `GH_HOST=github.com gh issue create --repo stripe/stripe-android` — Create new issue
+- `GH_HOST=github.com gh issue edit <issue_number> --repo stripe/stripe-android` — Edit issue
+- `GH_HOST=github.com gh pr create --repo stripe/stripe-android` — Create pull request
+
+## Best Practices
+
+- Always use `--state all` when searching to include closed/resolved issues
+- Always check GitHub issues for similar problems before investigating user reports
+- Use GitHub CLI to distinguish between SDK bugs vs integration issues

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: testing
+description: Use when writing tests, running tests, modifying test code, or choosing test patterns for this project
+---
+
+# Testing
+
+## Running Tests
+
+- `./gradlew test` — Run unit tests for all modules
+- `./gradlew testDebugUnitTest` — Run debug unit tests only
+- `./gradlew connectedAndroidTest` — Run instrumentation tests (requires device)
+- `./gradlew :<module>:test` — Run all tests for a specific module
+- `./gradlew :<module>:testDebugUnitTest` — Run debug unit tests for a specific module
+  - Module names from settings.gradle: `:payments-core`, `:paymentsheet`, `:financial-connections`, `:identity`, `:connect`, etc.
+  - Example: `./gradlew :payments-core:testDebugUnitTest`
+
+## Testing Stack
+
+- Unit tests with JUnit, **fakes** (preferred over mocks), and Truth assertions
+- **Turbine** for Flow testing and for call tracking/verification in fakes
+- Instrumentation tests using Espresso and AndroidX Test
+- Robolectric for Android unit tests
+- Screenshot testing with Paparazzi and custom screenshot-testing module
+- Compose UI tests with `createComposeRule()`
+
+## Testing Patterns
+
+**Fakes over mocks** — Create `FakeClassName` implementations when possible. Use mocks or indirect testing only when necessary.
+
+**`runScenario` pattern** — Define a private `runScenario` function per test class that encapsulates fixture setup, exposing dependencies via lambda parameters or a `Scenario` data class receiver:
+- Simple tests: lambda parameters `runScenario { sut, fakeDep1, fakeDep2 -> ... }`
+- Stateful/coroutine tests: `Scenario` data class + `runTest` integration
+- Configurable tests: add parameters with defaults for behavioral variations
+
+**Flow testing:** `flow.test { assertThat(awaitItem()).isEqualTo(expected) }`
+
+**Compose testing:** `composeTestRule.onNodeWithText("text").assertIsDisplayed()`
+
+**Truth assertions:** `assertThat(actual).isEqualTo(expected)`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,45 +2,6 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Commands
-
-**Build and Test**
-- `./gradlew build` - Build all modules
-- `./gradlew test` - Run unit tests for all modules
-- `./gradlew testDebugUnitTest` - Run debug unit tests only
-- `./gradlew connectedAndroidTest` - Run instrumentation tests (requires device)
-- `./gradlew :payments:test` - Run tests for a specific module
-- `./gradlew :example:assembleDebug` - Build example app
-- `./gradlew :paymentsheet-example:assembleBaseDebug` - Build PaymentSheet example app
-
-**Code Quality**
-- `./gradlew detekt` - Run static analysis with Detekt
-
-**Documentation**
-- `./gradlew :dokkaGenerate` - Generate API documentation (outputs to docs/)
-
-**Testing Individual Modules**
-- Use module names from settings.gradle: `:payments-core`, `:paymentsheet`, `:financial-connections`, `:identity`, `:connect`, etc.
-- Example: `./gradlew :payments-core:testDebugUnitTest`
-
-**GitHub Issue Management**
-- **Read-only operations**: Use `export GH_HOST=github.com &&` prefix to avoid permission prompts
-  - `export GH_HOST=github.com && gh issue list --repo stripe/stripe-android --limit 20` - List recent issues
-  - `export GH_HOST=github.com && gh issue view <issue_number> --repo stripe/stripe-android` - View specific issue
-  - `export GH_HOST=github.com && gh issue view <issue_number> --repo stripe/stripe-android --comments` - View issue with comments
-  - `export GH_HOST=github.com && gh issue list --repo stripe/stripe-android --state all --search "keyword" --limit 30` - Search ALL issues (open/closed) by keyword
-- **Write operations**: Use `GH_HOST=github.com` prefix (keep permission prompts for safety)
-  - `GH_HOST=github.com gh issue create --repo stripe/stripe-android` - Create new issue
-  - `GH_HOST=github.com gh issue edit <issue_number> --repo stripe/stripe-android` - Edit issue
-  - `GH_HOST=github.com gh pr create --repo stripe/stripe-android` - Create pull request
-- Always use `--state all` when searching to include closed/resolved issues
-- Always check GitHub issues for similar problems before investigating user reports
-- Use GitHub CLI to distinguish between SDK bugs vs integration issues
-
-**Internal Tools**
-- Jira boards: MOBILESDK and RUN_MOBILESDK
-- Trailhead space: mobile-sdk
-
 ## Architecture
 
 This is the **Stripe Android SDK**, a multi-module Android library for payment processing and financial services.
@@ -81,21 +42,9 @@ This is the **Stripe Android SDK**, a multi-module Android library for payment p
 - Paparazzi for screenshot testing
 - Custom deployment and versioning scripts in scripts/
 
-**Testing Strategy**
-- Unit tests with JUnit, **fakes** (preferred over mocks), and Truth assertions  
-- Use **Turbine** for Flow testing and for call tracking/verification in fakes
-- Instrumentation tests using Espresso and AndroidX Test
-- Robolectric for Android unit tests  
-- Screenshot testing with Paparazzi and custom screenshot-testing module
-- Compose UI tests with createComposeRule()
+**Testing**
+- Fakes over mocks, Turbine for Flow testing, `runScenario` pattern for test setup
 
-**Testing Patterns**
-- Prefer **fakes over mocks** - create `FakeClassName` implementations when possible
-- Use mocks or indirect testing only when necessary
-- Prefer **`runScenario` pattern** to reduce test boilerplate — define a private `runScenario` function per test class that encapsulates fixture setup, exposing dependencies via lambda parameters or a `Scenario` data class receiver
-  - Simple tests: lambda parameters `runScenario { sut, fakeDep1, fakeDep2 -> ... }`
-  - Stateful/coroutine tests: `Scenario` data class + `runTest` integration
-  - Configurable tests: add parameters with defaults for behavioral variations
-- Flow testing: `flow.test { assertThat(awaitItem()).isEqualTo(expected) }`
-- Compose testing: `composeTestRule.onNodeWithText("text").assertIsDisplayed()`
-- Truth assertions: `assertThat(actual).isEqualTo(expected)`
+**Internal Tools**
+- Jira boards: MOBILESDK and RUN_MOBILESDK
+- Trailhead space: mobile-sdk


### PR DESCRIPTION
## Summary
- Slims down CLAUDE.md to focus on architecture and project overview
- Extracts build commands, testing commands/patterns, and GitHub issue management into three Claude Code skills in `.claude/skills/`
- Adds a brief testing philosophy line to CLAUDE.md's Architecture section so key conventions (fakes over mocks, Turbine, runScenario) are visible even when skills aren't loaded

## Test plan
- [x] Verify skills are discovered by Claude Code when relevant tasks are performed (building, testing, GitHub issues)
- [x] Verify CLAUDE.md still provides sufficient architectural context on its own

🤖 Generated with [Claude Code](https://claude.com/claude-code)