### PR TITLE
Add .envrc for GH_HOST and simplify CLAUDE.md

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+export GH_HOST=github.com

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,15 +24,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Example: `./gradlew :payments-core:testDebugUnitTest`
 
 **GitHub Issue Management**
-- **Read-only operations**: Use `export GH_HOST=github.com &&` prefix to avoid permission prompts
-  - `export GH_HOST=github.com && gh issue list --repo stripe/stripe-android --limit 20` - List recent issues
-  - `export GH_HOST=github.com && gh issue view <issue_number> --repo stripe/stripe-android` - View specific issue
-  - `export GH_HOST=github.com && gh issue view <issue_number> --repo stripe/stripe-android --comments` - View issue with comments
-  - `export GH_HOST=github.com && gh issue list --repo stripe/stripe-android --state all --search "keyword" --limit 30` - Search ALL issues (open/closed) by keyword
-- **Write operations**: Use `GH_HOST=github.com` prefix (keep permission prompts for safety)
-  - `GH_HOST=github.com gh issue create --repo stripe/stripe-android` - Create new issue
-  - `GH_HOST=github.com gh issue edit <issue_number> --repo stripe/stripe-android` - Edit issue
-  - `GH_HOST=github.com gh pr create --repo stripe/stripe-android` - Create pull request
+- `gh issue list --repo stripe/stripe-android --limit 20` - List recent issues
+- `gh issue view <issue_number> --repo stripe/stripe-android` - View specific issue
+- `gh issue view <issue_number> --repo stripe/stripe-android --comments` - View issue with comments
+- `gh issue list --repo stripe/stripe-android --state all --search "keyword" --limit 30` - Search ALL issues (open/closed) by keyword
+- `gh issue create --repo stripe/stripe-android` - Create new issue
+- `gh issue edit <issue_number> --repo stripe/stripe-android` - Edit issue
+- `gh pr create --repo stripe/stripe-android` - Create pull request
 - Always use `--state all` when searching to include closed/resolved issues
 - Always check GitHub issues for similar problems before investigating user reports
 - Use GitHub CLI to distinguish between SDK bugs vs integration issues


### PR DESCRIPTION
## Summary
- Add a `.envrc` file that exports `GH_HOST=github.com` so direnv handles it automatically
- Simplify GitHub Issue Management commands in `CLAUDE.md` by removing the manual `GH_HOST` prefixes

## Test plan
- [x] Verify `direnv allow` activates the `.envrc` and sets `GH_HOST` correctly
- [x] Verify `gh` commands work without manual `GH_HOST` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)