### PR TITLE
Use java 25 for all CI tasks.

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -65,8 +65,6 @@ stages:
       - notify-connections-e2e-failure: { }
 workflows:
   check:
-    envs:
-      - JAVA_VERSION: 22
     before_run:
       - prepare_all
     after_run:


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Now that all dependencies are updates to support java 25, we can run java consistently across all jobs.

