### PR TITLE
Simplify gh commands in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,15 +24,15 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Example: `./gradlew :payments-core:testDebugUnitTest`
 
 **GitHub Issue Management**
-- **Read-only operations**: Use `export GH_HOST=github.com &&` prefix to avoid permission prompts
-  - `export GH_HOST=github.com && gh issue list --repo stripe/stripe-android --limit 20` - List recent issues
-  - `export GH_HOST=github.com && gh issue view <issue_number> --repo stripe/stripe-android` - View specific issue
-  - `export GH_HOST=github.com && gh issue view <issue_number> --repo stripe/stripe-android --comments` - View issue with comments
-  - `export GH_HOST=github.com && gh issue list --repo stripe/stripe-android --state all --search "keyword" --limit 30` - Search ALL issues (open/closed) by keyword
-- **Write operations**: Use `GH_HOST=github.com` prefix (keep permission prompts for safety)
-  - `GH_HOST=github.com gh issue create --repo stripe/stripe-android` - Create new issue
-  - `GH_HOST=github.com gh issue edit <issue_number> --repo stripe/stripe-android` - Edit issue
-  - `GH_HOST=github.com gh pr create --repo stripe/stripe-android` - Create pull request
+- **Read-only operations**:
+  - `gh issue list --limit 20` - List recent issues
+  - `gh issue view <issue_number>` - View specific issue
+  - `gh issue view <issue_number> --comments` - View issue with comments
+  - `gh issue list --state all --search "keyword" --limit 30` - Search ALL issues (open/closed) by keyword
+- **Write operations**:
+  - `gh issue create` - Create new issue
+  - `gh issue edit <issue_number>` - Edit issue
+  - `gh pr create` - Create pull request
 - Always use `--state all` when searching to include closed/resolved issues
 - Always check GitHub issues for similar problems before investigating user reports
 - Use GitHub CLI to distinguish between SDK bugs vs integration issues


### PR DESCRIPTION
## Summary
- Remove `export GH_HOST` and `--repo` flags from gh command examples in CLAUDE.md
- The gh CLI infers the repo from the local git remote, so neither is needed

## Test plan
- [x] Verified `gh` commands work without `--repo` flag in the local clone

🤖 Generated with [Claude Code](https://claude.com/claude-code)