### PR TITLE
Add TotalSummary to CheckoutSession with order summary UI

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutPlaygroundActivity.kt
@@ -1,3 +1,5 @@
+@file:OptIn(CheckoutSessionPreview::class)
+
 package com.stripe.android.paymentsheet.example.playground.checkout
 
 import android.content.Context
@@ -5,12 +7,27 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 import com.stripe.android.checkout.Checkout
+import com.stripe.android.checkout.CheckoutSession
 import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentsheet.example.playground.PlaygroundTheme
+import com.stripe.android.paymentsheet.example.samples.ui.PADDING
+import com.stripe.android.uicore.format.CurrencyFormatter
 
-@CheckoutSessionPreview
 class CheckoutPlaygroundActivity : AppCompatActivity() {
     companion object {
         const val CHECKOUT_STATE_KEY = "CHECKOUT_STATE_KEY"
@@ -45,7 +62,7 @@ class CheckoutPlaygroundActivity : AppCompatActivity() {
         checkout = Checkout.createWithState(checkoutState)
 
         setContent {
-            CheckoutScreen()
+            CheckoutScreen(checkout)
         }
     }
 
@@ -62,6 +79,159 @@ class CheckoutPlaygroundActivity : AppCompatActivity() {
 }
 
 @Composable
-fun CheckoutScreen() {
-    Text("Added in a follow up.")
+fun CheckoutScreen(checkout: Checkout) {
+    val checkoutSession by checkout.checkoutSession.collectAsState()
+
+    PlaygroundTheme(
+        content = {
+        },
+        bottomBarContent = {
+            TotalSummary(checkoutSession)
+        },
+    )
+}
+
+@Composable
+private fun TotalSummary(session: CheckoutSession) {
+    val summary = session.totalSummary
+    val currency = session.currency
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = "Total Summary",
+            style = MaterialTheme.typography.h6,
+        )
+
+        Spacer(modifier = Modifier.height(PADDING))
+
+        if (summary == null) {
+            Text(
+                text = "No total summary available",
+                style = MaterialTheme.typography.body2,
+                color = MaterialTheme.colors.onSurface.copy(alpha = 0.6f),
+            )
+            return@Column
+        }
+
+        val appliedBalance = summary.appliedBalance
+
+        SummaryRow(
+            label = "Subtotal",
+            amount = formatAmount(summary.subtotal, currency),
+            bold = true,
+        )
+
+        DiscountRows(summary.discountAmounts, currency)
+        summary.shippingRate?.let { ShippingRow(it, currency) }
+        TaxRows(summary.taxAmounts, currency)
+        if (appliedBalance != null && appliedBalance != 0L) {
+            AppliedBalanceRow(appliedBalance, currency)
+        }
+
+        Divider(modifier = Modifier.padding(vertical = PADDING))
+
+        SummaryRow(
+            label = "Total due",
+            amount = formatAmount(summary.totalDueToday, currency),
+            bold = true,
+        )
+    }
+}
+
+@Composable
+private fun SummaryRow(
+    label: String,
+    amount: String,
+    bold: Boolean = false,
+    subtext: String? = null,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = PADDING / 2),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        val textStyle = if (bold) MaterialTheme.typography.subtitle1 else MaterialTheme.typography.body2
+        Column {
+            Text(
+                text = label,
+                style = textStyle,
+            )
+            if (subtext != null) {
+                Text(
+                    text = subtext,
+                    style = MaterialTheme.typography.caption,
+                    color = MaterialTheme.colors.onSurface.copy(alpha = 0.6f),
+                )
+            }
+        }
+        Text(
+            text = amount,
+            style = textStyle,
+        )
+    }
+}
+
+@Composable
+private fun DiscountRows(discounts: List<CheckoutSession.DiscountAmount>, currency: String) {
+    for (discount in discounts) {
+        SummaryRow(
+            label = discount.displayName,
+            amount = "-${formatAmount(discount.amount, currency)}",
+        )
+    }
+}
+
+@Composable
+private fun ShippingRow(shipping: CheckoutSession.ShippingRate, currency: String) {
+    val amountText = if (shipping.amount == 0L) "Free" else formatAmount(shipping.amount, currency)
+    val subtext = buildString {
+        append(shipping.displayName)
+        shipping.deliveryEstimate?.let {
+            append(" ($it)")
+        }
+    }
+    SummaryRow(
+        label = "Shipping",
+        amount = amountText,
+        subtext = subtext,
+    )
+}
+
+@Composable
+private fun TaxRows(taxAmounts: List<CheckoutSession.TaxAmount>, currency: String) {
+    if (taxAmounts.isEmpty()) return
+    val allSameRate = taxAmounts.map { it.percentage }.distinct().size == 1
+    for (tax in taxAmounts) {
+        val label = if (allSameRate && taxAmounts.size > 1) {
+            "Tax ${formatPercentage(tax.percentage)}"
+        } else {
+            tax.displayName
+        }
+        val inclusiveAnnotation = if (tax.inclusive) " (included)" else ""
+        SummaryRow(
+            label = "$label$inclusiveAnnotation",
+            amount = formatAmount(tax.amount, currency),
+        )
+    }
+}
+
+@Composable
+private fun AppliedBalanceRow(appliedBalance: Long, currency: String) {
+    SummaryRow(
+        label = "Applied balance",
+        amount = "-${formatAmount(-appliedBalance, currency)}",
+    )
+}
+
+private fun formatAmount(amount: Long, currencyCode: String): String {
+    return CurrencyFormatter.format(amount, currencyCode)
+}
+
+private fun formatPercentage(percentage: Double): String {
+    return if (percentage == percentage.toLong().toDouble()) {
+        "${percentage.toLong()}%"
+    } else {
+        "$percentage%"
+    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSession.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSession.kt
@@ -13,9 +13,88 @@ import kotlinx.parcelize.Parcelize
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class CheckoutSession internal constructor(
     val id: String,
-) : Parcelable
+    val currency: String,
+    val totalSummary: TotalSummary?,
+) : Parcelable {
+
+    @Poko
+    @Parcelize
+    @CheckoutSessionPreview
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    class TotalSummary internal constructor(
+        val subtotal: Long,
+        val totalDueToday: Long,
+        val totalAmountDue: Long,
+        val discountAmounts: List<DiscountAmount>,
+        val taxAmounts: List<TaxAmount>,
+        val shippingRate: ShippingRate?,
+        val appliedBalance: Long?,
+    ) : Parcelable
+
+    @Poko
+    @Parcelize
+    @CheckoutSessionPreview
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    class DiscountAmount internal constructor(
+        val amount: Long,
+        val displayName: String,
+    ) : Parcelable
+
+    @Poko
+    @Parcelize
+    @CheckoutSessionPreview
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    class TaxAmount internal constructor(
+        val amount: Long,
+        val inclusive: Boolean,
+        val displayName: String,
+        val percentage: Double,
+    ) : Parcelable
+
+    @Poko
+    @Parcelize
+    @CheckoutSessionPreview
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    class ShippingRate internal constructor(
+        val amount: Long,
+        val displayName: String,
+        val deliveryEstimate: String?,
+    ) : Parcelable
+}
 
 @OptIn(CheckoutSessionPreview::class)
 internal fun CheckoutSessionResponse.asCheckoutSession(): CheckoutSession {
-    return CheckoutSession(id = id)
+    return CheckoutSession(
+        id = id,
+        currency = currency,
+        totalSummary = totalSummary?.let { summary ->
+            CheckoutSession.TotalSummary(
+                subtotal = summary.subtotal,
+                totalDueToday = summary.totalDueToday,
+                totalAmountDue = summary.totalAmountDue,
+                discountAmounts = summary.discountAmounts.map { discount ->
+                    CheckoutSession.DiscountAmount(
+                        amount = discount.amount,
+                        displayName = discount.displayName,
+                    )
+                },
+                taxAmounts = summary.taxAmounts.map { tax ->
+                    CheckoutSession.TaxAmount(
+                        amount = tax.amount,
+                        inclusive = tax.inclusive,
+                        displayName = tax.displayName,
+                        percentage = tax.percentage,
+                    )
+                },
+                shippingRate = summary.shippingRate?.let { shipping ->
+                    CheckoutSession.ShippingRate(
+                        amount = shipping.amount,
+                        displayName = shipping.displayName,
+                        deliveryEstimate = shipping.deliveryEstimate,
+                    )
+                },
+                appliedBalance = summary.appliedBalance,
+            )
+        },
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponse.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponse.kt
@@ -54,6 +54,7 @@ data class CheckoutSessionResponse(
      * Parsed from `customer_managed_saved_payment_methods_offer_save` in the init response.
      */
     val savedPaymentMethodsOfferSave: SavedPaymentMethodsOfferSave? = null,
+    val totalSummary: TotalSummaryResponse? = null,
 ) : StripeModel {
 
     /**
@@ -114,5 +115,41 @@ data class CheckoutSessionResponse(
          * Defaults to false when not present in the response.
          */
         val canDetachPaymentMethod: Boolean,
+    ) : StripeModel
+
+    @Parcelize
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    data class TotalSummaryResponse(
+        val subtotal: Long,
+        val totalDueToday: Long,
+        val totalAmountDue: Long,
+        val discountAmounts: List<DiscountAmount>,
+        val taxAmounts: List<TaxAmount>,
+        val shippingRate: ShippingRate?,
+        val appliedBalance: Long?,
+    ) : StripeModel
+
+    @Parcelize
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    data class DiscountAmount(
+        val amount: Long,
+        val displayName: String,
+    ) : StripeModel
+
+    @Parcelize
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    data class TaxAmount(
+        val amount: Long,
+        val inclusive: Boolean,
+        val displayName: String,
+        val percentage: Double,
+    ) : StripeModel
+
+    @Parcelize
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    data class ShippingRate(
+        val amount: Long,
+        val displayName: String,
+        val deliveryEstimate: String?,
     ) : StripeModel
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParser.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParser.kt
@@ -41,6 +41,7 @@ internal class CheckoutSessionResponseJsonParser(
         val savedPaymentMethodsOfferSave = parseSavedPaymentMethodsOfferSave(
             json.optJSONObject(FIELD_SAVED_PAYMENT_METHODS_OFFER_SAVE)
         )
+        val totalSummary = parseTotalSummaryResponse(json)
 
         return CheckoutSessionResponse(
             id = sessionId,
@@ -50,6 +51,7 @@ internal class CheckoutSessionResponseJsonParser(
             paymentIntent = paymentIntent,
             customer = customer,
             savedPaymentMethodsOfferSave = savedPaymentMethodsOfferSave,
+            totalSummary = totalSummary,
         )
     }
 
@@ -112,12 +114,20 @@ internal class CheckoutSessionResponseJsonParser(
     }
 
     /**
-     * Extracts amount from `total_summary.due` in response JSON.
+     * Extracts amount from `total_summary.due` or `line_item_group.due` in response JSON.
      */
     private fun extractDueAmount(json: JSONObject): Long? {
-        val totalSummary = json.optJSONObject(FIELD_TOTAL_SUMMARY) ?: return null
-        val due = totalSummary.optLong(FIELD_DUE, -1)
-        return if (due >= 0) due else null
+        val totalSummary = json.optJSONObject(FIELD_TOTAL_SUMMARY)
+        if (totalSummary != null) {
+            val due = totalSummary.optLong(FIELD_DUE, -1)
+            if (due >= 0) return due
+        }
+        val lineItemGroup = json.optJSONObject(FIELD_LINE_ITEM_GROUP)
+        if (lineItemGroup != null) {
+            val due = lineItemGroup.optLong(FIELD_DUE, -1)
+            if (due >= 0) return due
+        }
+        return null
     }
 
     /**
@@ -188,6 +198,139 @@ internal class CheckoutSessionResponseJsonParser(
         )
     }
 
+    /**
+     * Parses the total summary from the response JSON.
+     *
+     * Reads subtotal/due/total from `total_summary` (preferred) or `line_item_group` (fallback).
+     * Parses discount_amounts, tax_amounts, and shipping_rate from `line_item_group`.
+     * Reads applied_balance from `total_summary`.
+     */
+    private fun parseTotalSummaryResponse(json: JSONObject): CheckoutSessionResponse.TotalSummaryResponse? {
+        val totalSummary = json.optJSONObject(FIELD_TOTAL_SUMMARY)
+        val lineItemGroup = json.optJSONObject(FIELD_LINE_ITEM_GROUP)
+
+        // Need at least one source for amounts
+        if (totalSummary == null && lineItemGroup == null) return null
+
+        val subtotal = totalSummary?.optLong(FIELD_SUBTOTAL, -1)?.takeIf { it >= 0 }
+            ?: lineItemGroup?.optLong(FIELD_SUBTOTAL, -1)?.takeIf { it >= 0 }
+            ?: return null
+
+        val totalDueToday = totalSummary?.optLong(FIELD_DUE, -1)?.takeIf { it >= 0 }
+            ?: lineItemGroup?.optLong(FIELD_DUE, -1)?.takeIf { it >= 0 }
+            ?: return null
+
+        val totalAmountDue = totalSummary?.optLong(FIELD_TOTAL, -1)?.takeIf { it >= 0 }
+            ?: lineItemGroup?.optLong(FIELD_TOTAL, -1)?.takeIf { it >= 0 }
+            ?: return null
+
+        val discountAmounts = parseDiscountAmounts(lineItemGroup)
+        val taxAmounts = parseTaxAmounts(lineItemGroup)
+        val shippingRate = parseShippingRate(lineItemGroup, json)
+        val appliedBalance = totalSummary?.let {
+            if (it.has(FIELD_APPLIED_BALANCE)) it.optLong(FIELD_APPLIED_BALANCE) else null
+        }
+
+        return CheckoutSessionResponse.TotalSummaryResponse(
+            subtotal = subtotal,
+            totalDueToday = totalDueToday,
+            totalAmountDue = totalAmountDue,
+            discountAmounts = discountAmounts,
+            taxAmounts = taxAmounts,
+            shippingRate = shippingRate,
+            appliedBalance = appliedBalance,
+        )
+    }
+
+    private fun parseDiscountAmounts(
+        lineItemGroup: JSONObject?,
+    ): List<CheckoutSessionResponse.DiscountAmount> {
+        val array = lineItemGroup?.optJSONArray(FIELD_DISCOUNT_AMOUNTS) ?: return emptyList()
+        return (0 until array.length()).mapNotNull { i ->
+            val obj = array.optJSONObject(i) ?: return@mapNotNull null
+            val amount = obj.optLong(FIELD_AMOUNT, -1).takeIf { it >= 0 } ?: return@mapNotNull null
+            val displayName = obj.optJSONObject(FIELD_DISCOUNT)?.optString(FIELD_NAME)
+                ?.takeIf { it.isNotEmpty() } ?: return@mapNotNull null
+            CheckoutSessionResponse.DiscountAmount(amount = amount, displayName = displayName)
+        }
+    }
+
+    private fun parseTaxAmounts(
+        lineItemGroup: JSONObject?,
+    ): List<CheckoutSessionResponse.TaxAmount> {
+        val array = lineItemGroup?.optJSONArray(FIELD_TAX_AMOUNTS) ?: return emptyList()
+        return (0 until array.length()).mapNotNull { i ->
+            val obj = array.optJSONObject(i) ?: return@mapNotNull null
+            val amount = obj.optLong(FIELD_AMOUNT, -1).takeIf { it >= 0 } ?: return@mapNotNull null
+            val inclusive = obj.optBoolean(FIELD_INCLUSIVE, false)
+            val taxRate = obj.optJSONObject(FIELD_TAX_RATE) ?: return@mapNotNull null
+            val displayName = taxRate.optString(FIELD_DISPLAY_NAME).takeIf { it.isNotEmpty() }
+                ?: return@mapNotNull null
+            val percentage = taxRate.optDouble(FIELD_PERCENTAGE, Double.NaN)
+            if (percentage.isNaN()) return@mapNotNull null
+            CheckoutSessionResponse.TaxAmount(
+                amount = amount,
+                inclusive = inclusive,
+                displayName = displayName,
+                percentage = percentage,
+            )
+        }
+    }
+
+    private fun parseShippingRate(
+        lineItemGroup: JSONObject?,
+        rootJson: JSONObject,
+    ): CheckoutSessionResponse.ShippingRate? {
+        // Primary: line_item_group.shipping_rate
+        val shippingRateJson = lineItemGroup?.optJSONObject(FIELD_SHIPPING_RATE)
+        if (shippingRateJson != null) {
+            return parseShippingRateFromJson(shippingRateJson)
+        }
+        // Fallback: shipping.shipping_option
+        val shippingOption = rootJson.optJSONObject(FIELD_SHIPPING)
+            ?.optJSONObject(FIELD_SHIPPING_OPTION)
+        if (shippingOption != null) {
+            return parseShippingRateFromJson(shippingOption)
+        }
+        return null
+    }
+
+    private fun parseShippingRateFromJson(json: JSONObject): CheckoutSessionResponse.ShippingRate? {
+        val amount = json.optLong(FIELD_AMOUNT, -1).takeIf { it >= 0 } ?: return null
+        val displayName = json.optString(FIELD_DISPLAY_NAME).takeIf { it.isNotEmpty() } ?: return null
+        val deliveryEstimate = parseDeliveryEstimate(json)
+        return CheckoutSessionResponse.ShippingRate(
+            amount = amount,
+            displayName = displayName,
+            deliveryEstimate = deliveryEstimate,
+        )
+    }
+
+    private fun parseDeliveryEstimate(json: JSONObject): String? {
+        if (!json.has(FIELD_DELIVERY_ESTIMATE)) return null
+        // If it's a string, use directly
+        val stringValue = json.optString(FIELD_DELIVERY_ESTIMATE).takeIf { it.isNotEmpty() }
+        if (stringValue != null && !json.optJSONObject(FIELD_DELIVERY_ESTIMATE).let { it != null }) {
+            return stringValue
+        }
+        // If it's an object with minimum/maximum, format as "N-M business days"
+        val estimateObj = json.optJSONObject(FIELD_DELIVERY_ESTIMATE) ?: return null
+        val minimum = estimateObj.optJSONObject("minimum")
+        val maximum = estimateObj.optJSONObject("maximum")
+        val minValue = minimum?.optInt("value", -1)?.takeIf { it >= 0 }
+        val maxValue = maximum?.optInt("value", -1)?.takeIf { it >= 0 }
+        val unit = minimum?.optString("unit")
+            ?: maximum?.optString("unit")
+            ?: "business_day"
+        val unitDisplay = unit.replace("_", " ") + "s"
+        return when {
+            minValue != null && maxValue != null -> "$minValue-$maxValue $unitDisplay"
+            minValue != null -> "$minValue+ $unitDisplay"
+            maxValue != null -> "Up to $maxValue $unitDisplay"
+            else -> null
+        }
+    }
+
     private companion object {
         private const val FIELD_SESSION_ID = "session_id"
         private const val FIELD_CURRENCY = "currency"
@@ -204,5 +347,22 @@ internal class CheckoutSessionResponseJsonParser(
             "customer_managed_saved_payment_methods_offer_save"
         private const val FIELD_OFFER_SAVE_ENABLED = "enabled"
         private const val FIELD_OFFER_SAVE_STATUS = "status"
+        private const val FIELD_LINE_ITEM_GROUP = "line_item_group"
+        private const val FIELD_SUBTOTAL = "subtotal"
+        private const val FIELD_TOTAL = "total"
+        private const val FIELD_AMOUNT = "amount"
+        private const val FIELD_APPLIED_BALANCE = "applied_balance"
+        private const val FIELD_DISCOUNT_AMOUNTS = "discount_amounts"
+        private const val FIELD_DISCOUNT = "discount"
+        private const val FIELD_NAME = "name"
+        private const val FIELD_TAX_AMOUNTS = "tax_amounts"
+        private const val FIELD_INCLUSIVE = "inclusive"
+        private const val FIELD_TAX_RATE = "tax_rate"
+        private const val FIELD_DISPLAY_NAME = "display_name"
+        private const val FIELD_PERCENTAGE = "percentage"
+        private const val FIELD_SHIPPING_RATE = "shipping_rate"
+        private const val FIELD_SHIPPING = "shipping"
+        private const val FIELD_SHIPPING_OPTION = "shipping_option"
+        private const val FIELD_DELIVERY_ESTIMATE = "delivery_estimate"
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/AsCheckoutSessionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/AsCheckoutSessionTest.kt
@@ -1,0 +1,167 @@
+package com.stripe.android.checkout
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse.TotalSummaryResponse
+import org.junit.Test
+
+@OptIn(CheckoutSessionPreview::class)
+class AsCheckoutSessionTest {
+
+    @Test
+    fun `maps id`() {
+        val session = createResponse(id = "cs_test_123").asCheckoutSession()
+        assertThat(session.id).isEqualTo("cs_test_123")
+    }
+
+    @Test
+    fun `maps currency`() {
+        val session = createResponse(currency = "eur").asCheckoutSession()
+        assertThat(session.currency).isEqualTo("eur")
+    }
+
+    @Test
+    fun `null totalSummary maps to null`() {
+        val session = createResponse(totalSummary = null).asCheckoutSession()
+        assertThat(session.totalSummary).isNull()
+    }
+
+    @Test
+    fun `maps totalSummary subtotal`() {
+        val session = createResponse(
+            totalSummary = createTotalSummary(subtotal = 5000L),
+        ).asCheckoutSession()
+        assertThat(session.totalSummary?.subtotal).isEqualTo(5000L)
+    }
+
+    @Test
+    fun `maps totalSummary totalDueToday`() {
+        val session = createResponse(
+            totalSummary = createTotalSummary(totalDueToday = 4044L),
+        ).asCheckoutSession()
+        assertThat(session.totalSummary?.totalDueToday).isEqualTo(4044L)
+    }
+
+    @Test
+    fun `maps totalSummary totalAmountDue`() {
+        val session = createResponse(
+            totalSummary = createTotalSummary(totalAmountDue = 3000L),
+        ).asCheckoutSession()
+        assertThat(session.totalSummary?.totalAmountDue).isEqualTo(3000L)
+    }
+
+    @Test
+    fun `maps discountAmounts`() {
+        val session = createResponse(
+            totalSummary = createTotalSummary(
+                discountAmounts = listOf(
+                    CheckoutSessionResponse.DiscountAmount(amount = 500L, displayName = "SUMMER10"),
+                    CheckoutSessionResponse.DiscountAmount(amount = 250L, displayName = "LOYALTY5"),
+                ),
+            ),
+        ).asCheckoutSession()
+        val discounts = session.totalSummary!!.discountAmounts
+        assertThat(discounts).hasSize(2)
+        assertThat(discounts[0].amount).isEqualTo(500L)
+        assertThat(discounts[0].displayName).isEqualTo("SUMMER10")
+        assertThat(discounts[1].amount).isEqualTo(250L)
+        assertThat(discounts[1].displayName).isEqualTo("LOYALTY5")
+    }
+
+    @Test
+    fun `maps taxAmounts`() {
+        val session = createResponse(
+            totalSummary = createTotalSummary(
+                taxAmounts = listOf(
+                    CheckoutSessionResponse.TaxAmount(
+                        amount = 294L,
+                        inclusive = false,
+                        displayName = "Sales Tax",
+                        percentage = 6.875,
+                    ),
+                ),
+            ),
+        ).asCheckoutSession()
+        val taxes = session.totalSummary!!.taxAmounts
+        assertThat(taxes).hasSize(1)
+        assertThat(taxes[0].amount).isEqualTo(294L)
+        assertThat(taxes[0].inclusive).isFalse()
+        assertThat(taxes[0].displayName).isEqualTo("Sales Tax")
+        assertThat(taxes[0].percentage).isEqualTo(6.875)
+    }
+
+    @Test
+    fun `maps shippingRate`() {
+        val session = createResponse(
+            totalSummary = createTotalSummary(
+                shippingRate = CheckoutSessionResponse.ShippingRate(
+                    amount = 500L,
+                    displayName = "Standard Shipping",
+                    deliveryEstimate = "5-7 business days",
+                ),
+            ),
+        ).asCheckoutSession()
+        val shipping = session.totalSummary!!.shippingRate!!
+        assertThat(shipping.amount).isEqualTo(500L)
+        assertThat(shipping.displayName).isEqualTo("Standard Shipping")
+        assertThat(shipping.deliveryEstimate).isEqualTo("5-7 business days")
+    }
+
+    @Test
+    fun `null shippingRate maps to null`() {
+        val session = createResponse(
+            totalSummary = createTotalSummary(shippingRate = null),
+        ).asCheckoutSession()
+        assertThat(session.totalSummary!!.shippingRate).isNull()
+    }
+
+    @Test
+    fun `maps appliedBalance`() {
+        val session = createResponse(
+            totalSummary = createTotalSummary(appliedBalance = -200L),
+        ).asCheckoutSession()
+        assertThat(session.totalSummary!!.appliedBalance).isEqualTo(-200L)
+    }
+
+    @Test
+    fun `null appliedBalance maps to null`() {
+        val session = createResponse(
+            totalSummary = createTotalSummary(appliedBalance = null),
+        ).asCheckoutSession()
+        assertThat(session.totalSummary!!.appliedBalance).isNull()
+    }
+
+    private fun createResponse(
+        id: String = "cs_test_abc123",
+        currency: String = "usd",
+        totalSummary: TotalSummaryResponse? = null,
+    ): CheckoutSessionResponse {
+        return CheckoutSessionResponse(
+            id = id,
+            amount = 1000L,
+            currency = currency,
+            totalSummary = totalSummary,
+        )
+    }
+
+    private fun createTotalSummary(
+        subtotal: Long = 1000L,
+        totalDueToday: Long = 1000L,
+        totalAmountDue: Long = 1000L,
+        discountAmounts: List<CheckoutSessionResponse.DiscountAmount> = emptyList(),
+        taxAmounts: List<CheckoutSessionResponse.TaxAmount> = emptyList(),
+        shippingRate: CheckoutSessionResponse.ShippingRate? = null,
+        appliedBalance: Long? = null,
+    ): TotalSummaryResponse {
+        return TotalSummaryResponse(
+            subtotal = subtotal,
+            totalDueToday = totalDueToday,
+            totalAmountDue = totalAmountDue,
+            discountAmounts = discountAmounts,
+            taxAmounts = taxAmounts,
+            shippingRate = shippingRate,
+            appliedBalance = appliedBalance,
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionFixtures.kt
@@ -403,4 +403,135 @@ internal object CheckoutSessionFixtures {
         }
         """.trimIndent()
     )
+
+    /**
+     * Init response with full order summary: discounts, taxes, and shipping.
+     */
+    val CHECKOUT_SESSION_WITH_ORDER_SUMMARY_JSON = JSONObject(
+        """
+        {
+            "session_id": "cs_test_abc123",
+            "currency": "usd",
+            "total_summary": {
+                "due": 4044,
+                "subtotal": 5000,
+                "total": 4044
+            },
+            "line_item_group": {
+                "currency": "usd",
+                "total": 4044,
+                "subtotal": 5000,
+                "due": 4044,
+                "discount_amounts": [
+                    {
+                        "amount": 500,
+                        "discount": {
+                            "name": "SUMMER10"
+                        }
+                    },
+                    {
+                        "amount": 250,
+                        "discount": {
+                            "name": "LOYALTY5"
+                        }
+                    }
+                ],
+                "tax_amounts": [
+                    {
+                        "amount": 294,
+                        "inclusive": false,
+                        "tax_rate": {
+                            "display_name": "Sales Tax",
+                            "percentage": 6.875
+                        }
+                    }
+                ],
+                "shipping_rate": {
+                    "amount": 500,
+                    "display_name": "Standard Shipping",
+                    "delivery_estimate": "5-7 business days"
+                }
+            },
+            "elements_session": $MINIMAL_ELEMENTS_SESSION_JSON
+        }
+        """.trimIndent()
+    )
+
+    /**
+     * Init response without total_summary but with line_item_group (fallback path).
+     */
+    val CHECKOUT_SESSION_WITHOUT_TOTAL_SUMMARY_JSON = JSONObject(
+        """
+        {
+            "session_id": "cs_test_abc123",
+            "currency": "usd",
+            "line_item_group": {
+                "currency": "usd",
+                "total": 2000,
+                "subtotal": 2000,
+                "due": 2000
+            },
+            "elements_session": $MINIMAL_ELEMENTS_SESSION_JSON
+        }
+        """.trimIndent()
+    )
+
+    /**
+     * Init response with applied balance.
+     */
+    val CHECKOUT_SESSION_WITH_APPLIED_BALANCE_JSON = JSONObject(
+        """
+        {
+            "session_id": "cs_test_abc123",
+            "currency": "usd",
+            "total_summary": {
+                "due": 800,
+                "subtotal": 1000,
+                "total": 1000,
+                "applied_balance": -200
+            },
+            "elements_session": $MINIMAL_ELEMENTS_SESSION_JSON
+        }
+        """.trimIndent()
+    )
+
+    /**
+     * Init response with shipping from shipping.shipping_option fallback path.
+     */
+    val CHECKOUT_SESSION_WITH_SHIPPING_OPTION_JSON = JSONObject(
+        """
+        {
+            "session_id": "cs_test_abc123",
+            "currency": "usd",
+            "total_summary": {
+                "due": 1500,
+                "subtotal": 1000,
+                "total": 1500
+            },
+            "line_item_group": {
+                "currency": "usd",
+                "total": 1500,
+                "subtotal": 1000,
+                "due": 1500
+            },
+            "shipping": {
+                "shipping_option": {
+                    "amount": 500,
+                    "display_name": "Express Shipping",
+                    "delivery_estimate": {
+                        "minimum": {
+                            "value": 1,
+                            "unit": "business_day"
+                        },
+                        "maximum": {
+                            "value": 3,
+                            "unit": "business_day"
+                        }
+                    }
+                }
+            },
+            "elements_session": $MINIMAL_ELEMENTS_SESSION_JSON
+        }
+        """.trimIndent()
+    )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParserTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParserTest.kt
@@ -344,4 +344,139 @@ class CheckoutSessionResponseJsonParserTest {
         assertThat(customer).isNotNull()
         assertThat(customer?.canDetachPaymentMethod).isFalse()
     }
+
+    @Test
+    fun `parse full order summary with discounts, taxes, and shipping`() {
+        val result = CheckoutSessionResponseJsonParser(isLiveMode = false)
+            .parse(CheckoutSessionFixtures.CHECKOUT_SESSION_WITH_ORDER_SUMMARY_JSON)
+
+        assertThat(result).isNotNull()
+        assertThat(result?.amount).isEqualTo(4044L)
+
+        val totalSummary = result?.totalSummary
+        assertThat(totalSummary).isNotNull()
+        assertThat(totalSummary?.subtotal).isEqualTo(5000L)
+        assertThat(totalSummary?.totalDueToday).isEqualTo(4044L)
+        assertThat(totalSummary?.totalAmountDue).isEqualTo(4044L)
+
+        // Discounts
+        assertThat(totalSummary?.discountAmounts).hasSize(2)
+        assertThat(totalSummary?.discountAmounts?.get(0)?.amount).isEqualTo(500L)
+        assertThat(totalSummary?.discountAmounts?.get(0)?.displayName).isEqualTo("SUMMER10")
+        assertThat(totalSummary?.discountAmounts?.get(1)?.amount).isEqualTo(250L)
+        assertThat(totalSummary?.discountAmounts?.get(1)?.displayName).isEqualTo("LOYALTY5")
+
+        // Taxes
+        assertThat(totalSummary?.taxAmounts).hasSize(1)
+        assertThat(totalSummary?.taxAmounts?.get(0)?.amount).isEqualTo(294L)
+        assertThat(totalSummary?.taxAmounts?.get(0)?.inclusive).isFalse()
+        assertThat(totalSummary?.taxAmounts?.get(0)?.displayName).isEqualTo("Sales Tax")
+        assertThat(totalSummary?.taxAmounts?.get(0)?.percentage).isEqualTo(6.875)
+
+        // Shipping
+        assertThat(totalSummary?.shippingRate).isNotNull()
+        assertThat(totalSummary?.shippingRate?.amount).isEqualTo(500L)
+        assertThat(totalSummary?.shippingRate?.displayName).isEqualTo("Standard Shipping")
+        assertThat(totalSummary?.shippingRate?.deliveryEstimate).isEqualTo("5-7 business days")
+
+        // No applied balance
+        assertThat(totalSummary?.appliedBalance).isNull()
+    }
+
+    @Test
+    fun `parse applied balance`() {
+        val result = CheckoutSessionResponseJsonParser(isLiveMode = false)
+            .parse(CheckoutSessionFixtures.CHECKOUT_SESSION_WITH_APPLIED_BALANCE_JSON)
+
+        assertThat(result).isNotNull()
+        val totalSummary = result?.totalSummary
+        assertThat(totalSummary).isNotNull()
+        assertThat(totalSummary?.subtotal).isEqualTo(1000L)
+        assertThat(totalSummary?.totalDueToday).isEqualTo(800L)
+        assertThat(totalSummary?.totalAmountDue).isEqualTo(1000L)
+        assertThat(totalSummary?.appliedBalance).isEqualTo(-200L)
+    }
+
+    @Test
+    fun `parse shipping option fallback`() {
+        val result = CheckoutSessionResponseJsonParser(isLiveMode = false)
+            .parse(CheckoutSessionFixtures.CHECKOUT_SESSION_WITH_SHIPPING_OPTION_JSON)
+
+        assertThat(result).isNotNull()
+        val totalSummary = result?.totalSummary
+        assertThat(totalSummary).isNotNull()
+        assertThat(totalSummary?.shippingRate).isNotNull()
+        assertThat(totalSummary?.shippingRate?.amount).isEqualTo(500L)
+        assertThat(totalSummary?.shippingRate?.displayName).isEqualTo("Express Shipping")
+        assertThat(totalSummary?.shippingRate?.deliveryEstimate).isEqualTo("1-3 business days")
+    }
+
+    @Test
+    fun `parse without total_summary falls back to line_item_group`() {
+        val result = CheckoutSessionResponseJsonParser(isLiveMode = false)
+            .parse(CheckoutSessionFixtures.CHECKOUT_SESSION_WITHOUT_TOTAL_SUMMARY_JSON)
+
+        assertThat(result).isNotNull()
+        assertThat(result?.amount).isEqualTo(2000L)
+
+        val totalSummary = result?.totalSummary
+        assertThat(totalSummary).isNotNull()
+        assertThat(totalSummary?.subtotal).isEqualTo(2000L)
+        assertThat(totalSummary?.totalDueToday).isEqualTo(2000L)
+        assertThat(totalSummary?.totalAmountDue).isEqualTo(2000L)
+        assertThat(totalSummary?.discountAmounts).isEmpty()
+        assertThat(totalSummary?.taxAmounts).isEmpty()
+        assertThat(totalSummary?.shippingRate).isNull()
+        assertThat(totalSummary?.appliedBalance).isNull()
+    }
+
+    @Test
+    fun `parse with empty discount and tax arrays`() {
+        val json = JSONObject(
+            """
+            {
+                "session_id": "cs_test_abc123",
+                "currency": "usd",
+                "total_summary": {
+                    "due": 1000,
+                    "subtotal": 1000,
+                    "total": 1000
+                },
+                "line_item_group": {
+                    "currency": "usd",
+                    "total": 1000,
+                    "subtotal": 1000,
+                    "due": 1000,
+                    "discount_amounts": [],
+                    "tax_amounts": []
+                },
+                "elements_session": ${CheckoutSessionFixtures.MINIMAL_ELEMENTS_SESSION_JSON}
+            }
+            """.trimIndent()
+        )
+        val result = CheckoutSessionResponseJsonParser(isLiveMode = false).parse(json)
+
+        assertThat(result).isNotNull()
+        val totalSummary = result?.totalSummary
+        assertThat(totalSummary).isNotNull()
+        assertThat(totalSummary?.discountAmounts).isEmpty()
+        assertThat(totalSummary?.taxAmounts).isEmpty()
+    }
+
+    @Test
+    fun `parse returns null totalSummary when neither total_summary nor line_item_group has subtotal`() {
+        val json = JSONObject(
+            """
+            {
+                "session_id": "cs_test_123",
+                "currency": "usd",
+                "total_summary": { "due": 1000 }
+            }
+            """.trimIndent()
+        )
+        val result = CheckoutSessionResponseJsonParser(isLiveMode = false).parse(json)
+
+        assertThat(result).isNotNull()
+        assertThat(result?.totalSummary).isNull()
+    }
 }


### PR DESCRIPTION
## Summary
- Parse `total_summary` from checkout session init response including subtotal, total due today, discounts, taxes, shipping rate, and applied balance
- Add `TotalSummary` and related model types to `CheckoutSession` and `CheckoutSessionResponse`
- Render an order summary in the checkout playground activity with extracted composables (`DiscountRows`, `ShippingRow`, `TaxRows`, `AppliedBalanceRow`)

## Test plan
- [x] `./gradlew :paymentsheet-example:compileBaseDebugKotlin` passes
- [x] Unit tests for JSON parsing (`CheckoutSessionResponseJsonParserTest`)
- [x] Unit tests for `CheckoutSession` mapping (`CheckoutTest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)