### PR TITLE
Pass CheckoutSessionResponse through InitializationMode

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetCheckoutSessionTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetCheckoutSessionTest.kt
@@ -48,16 +48,13 @@ internal class PaymentSheetCheckoutSessionTest {
         networkRule = networkRule,
         resultCallback = ::assertCompleted,
     ) { testContext ->
-        // We shouldn't need 2 times, but while we're building it out, we do the request twice.
-        repeat(2) {
-            // Mock checkout session init API
-            networkRule.enqueue(
-                host("api.stripe.com"),
-                method("POST"),
-                path("/v1/payment_pages/cs_test_a1vLTpmgcJO40ZjQpd3GUNHwlwtkT1bejjhpfd0nN05iqoVuJziixjNYIh/init"),
-            ) { response ->
-                response.testBodyFromFile("checkout-session-init.json")
-            }
+        // Mock checkout session init API
+        networkRule.enqueue(
+            host("api.stripe.com"),
+            method("POST"),
+            path("/v1/payment_pages/cs_test_a1vLTpmgcJO40ZjQpd3GUNHwlwtkT1bejjhpfd0nN05iqoVuJziixjNYIh/init"),
+        ) { response ->
+            response.testBodyFromFile("checkout-session-init.json")
         }
 
         val context = ApplicationProvider.getApplicationContext<Context>()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
@@ -101,7 +101,7 @@ class EmbeddedPaymentElement @Inject internal constructor(
         configuration: Configuration,
     ): ConfigureResult {
         val initializationMode = PaymentElementLoader.InitializationMode.CheckoutSession(
-            clientSecret = checkout.state.checkoutSessionClientSecret
+            checkoutSessionResponse = checkout.state.checkoutSessionResponse
         )
         return configurationCoordinator.configure(configuration, initializationMode)
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -486,7 +486,7 @@ class PaymentSheet internal constructor(
         configuration: Configuration,
     ) {
         paymentSheetLauncher.present(
-            mode = InitializationMode.CheckoutSession(checkout.state.checkoutSessionClientSecret),
+            mode = InitializationMode.CheckoutSession(checkout.state.checkoutSessionResponse),
             configuration = configuration,
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -236,7 +236,7 @@ internal class DefaultFlowController @Inject internal constructor(
         callback: PaymentSheet.FlowController.ConfigCallback
     ) {
         configure(
-            mode = PaymentElementLoader.InitializationMode.CheckoutSession(checkout.state.checkoutSessionClientSecret),
+            mode = PaymentElementLoader.InitializationMode.CheckoutSession(checkout.state.checkoutSessionResponse),
             configuration = configuration,
             callback = callback,
         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/LoadSession.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/LoadSession.kt
@@ -6,7 +6,6 @@ import com.stripe.android.model.ElementsSession
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.SavedSelection
-import com.stripe.android.paymentsheet.repositories.CheckoutSessionRepository
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
@@ -18,19 +17,15 @@ internal data class SessionResult(
 )
 
 /**
- * Loads session data via [CheckoutSessionRepository].
+ * Extracts session data from the [CheckoutSessionResponse] already loaded during [Checkout.configure].
  *
  * The checkout session init response contains the elements session and customer data.
  */
-internal class CheckoutSessionLoader @Inject constructor(
-    private val checkoutSessionRepository: CheckoutSessionRepository,
-) {
-    suspend operator fun invoke(
+internal class CheckoutSessionLoader @Inject constructor() {
+    operator fun invoke(
         initializationMode: PaymentElementLoader.InitializationMode.CheckoutSession,
     ): SessionResult {
-        val checkoutSession = checkoutSessionRepository.init(
-            sessionId = initializationMode.id,
-        ).getOrThrow()
+        val checkoutSession = initializationMode.checkoutSessionResponse
 
         val elementsSession = checkoutSession.elementsSession
             ?: throw IllegalStateException("CheckoutSession init response missing elements_session")

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -48,6 +48,7 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.model.SetupIntentClientSecret
 import com.stripe.android.paymentsheet.model.validate
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.ui.core.elements.ExternalPaymentMethodSpec
 import com.stripe.android.ui.core.elements.ExternalPaymentMethodsRepository
@@ -179,24 +180,14 @@ internal interface PaymentElementLoader {
 
         @Parcelize
         data class CheckoutSession(
-            val clientSecret: String,
+            val checkoutSessionResponse: CheckoutSessionResponse,
         ) : InitializationMode() {
-            /**
-             * The checkout session ID extracted from the client secret.
-             */
-            val id: String
-                get() = clientSecret.substringBefore("_secret_")
-
             override fun validate() {
-                if (!clientSecret.startsWith("cs_") || !clientSecret.contains("_secret_")) {
-                    throw IllegalArgumentException(
-                        "Must use a checkout session client secret."
-                    )
-                }
+                // Nothing to validate — the response was already loaded successfully.
             }
 
             override fun integrationMetadata(paymentElementCallbacks: PaymentElementCallbacks?): IntegrationMetadata {
-                return IntegrationMetadata.CheckoutSession(id)
+                return IntegrationMetadata.CheckoutSession(checkoutSessionResponse.id)
             }
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CheckoutSessionLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CheckoutSessionLoaderTest.kt
@@ -5,32 +5,22 @@ import com.stripe.android.isInstanceOf
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
-import com.stripe.android.paymentsheet.repositories.FakeCheckoutSessionRepository
 import com.stripe.android.testing.PaymentMethodFactory
-import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 
 internal class CheckoutSessionLoaderTest {
 
     @Test
-    fun `returns elements session from checkout response`() = runTest {
-        val loader = createLoader(
-            initResult = Result.success(CHECKOUT_SESSION_RESPONSE),
-        )
-
-        val result = loader(INIT_MODE)
+    fun `returns elements session from checkout response`() {
+        val result = createLoader()(initMode(CHECKOUT_SESSION_RESPONSE))
 
         assertThat(result.elementsSession).isEqualTo(CHECKOUT_SESSION_RESPONSE.elementsSession)
     }
 
     @Test
-    fun `returns CheckoutSession customer info when customer present`() = runTest {
-        val loader = createLoader(
-            initResult = Result.success(CHECKOUT_SESSION_RESPONSE),
-        )
-
-        val result = loader(INIT_MODE)
+    fun `returns CheckoutSession customer info when customer present`() {
+        val result = createLoader()(initMode(CHECKOUT_SESSION_RESPONSE))
 
         assertThat(result.customerInfo).isInstanceOf<CustomerInfo.CheckoutSession>()
         val checkoutCustomer = result.customerInfo as CustomerInfo.CheckoutSession
@@ -38,51 +28,32 @@ internal class CheckoutSessionLoaderTest {
     }
 
     @Test
-    fun `returns null customer info when checkout response has no customer`() = runTest {
-        val loader = createLoader(
-            initResult = Result.success(CHECKOUT_SESSION_RESPONSE.copy(customer = null)),
-        )
-
-        val result = loader(INIT_MODE)
+    fun `returns null customer info when checkout response has no customer`() {
+        val result = createLoader()(initMode(CHECKOUT_SESSION_RESPONSE.copy(customer = null)))
 
         assertThat(result.customerInfo).isNull()
     }
 
     @Test
-    fun `throws when checkout response has no elements session`() = runTest {
-        val loader = createLoader(
-            initResult = Result.success(CHECKOUT_SESSION_RESPONSE.copy(elementsSession = null)),
-        )
-
+    fun `throws when checkout response has no elements session`() {
         assertFailsWith<IllegalStateException> {
-            loader(INIT_MODE)
+            createLoader()(initMode(CHECKOUT_SESSION_RESPONSE.copy(elementsSession = null)))
         }
     }
 
-    @Test
-    fun `throws when checkout session repository returns failure`() = runTest {
-        val loader = createLoader(
-            initResult = Result.failure(RuntimeException("network error")),
-        )
-
-        assertFailsWith<RuntimeException> {
-            loader(INIT_MODE)
-        }
+    private fun createLoader(): CheckoutSessionLoader {
+        return CheckoutSessionLoader()
     }
 
-    private fun createLoader(
-        initResult: Result<CheckoutSessionResponse>,
-    ): CheckoutSessionLoader {
-        return CheckoutSessionLoader(
-            checkoutSessionRepository = FakeCheckoutSessionRepository(initResult = initResult),
+    private fun initMode(
+        response: CheckoutSessionResponse,
+    ): PaymentElementLoader.InitializationMode.CheckoutSession {
+        return PaymentElementLoader.InitializationMode.CheckoutSession(
+            checkoutSessionResponse = response,
         )
     }
 
     private companion object {
-        private val INIT_MODE = PaymentElementLoader.InitializationMode.CheckoutSession(
-            clientSecret = "cs_test_123_secret_abc",
-        )
-
         private val CHECKOUT_SESSION_RESPONSE = CheckoutSessionResponse(
             id = "cs_test_123",
             amount = 5099,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -69,11 +69,9 @@ import com.stripe.android.paymentsheet.analytics.FakeLogLinkHoldbackExperiment
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.model.toSavedSelection
-import com.stripe.android.paymentsheet.repositories.CheckoutSessionRepository
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
-import com.stripe.android.paymentsheet.repositories.FakeCheckoutSessionRepository
 import com.stripe.android.paymentsheet.state.PaymentSheetLoadingException.PaymentIntentInTerminalState
 import com.stripe.android.paymentsheet.utils.FakeUserFacingLogger
 import com.stripe.android.testing.FakeErrorReporter
@@ -1632,46 +1630,24 @@ internal class DefaultPaymentElementLoaderTest {
     }
 
     @Test
-    fun `Returns failure if configuring checkout session with invalid prefix`() = runScenario {
-        assertFailsWith<IllegalArgumentException>(
-            "Must use a checkout session client secret (format: cs_*_secret_*)."
-        ) {
-            PaymentElementLoader.InitializationMode.CheckoutSession(
-                clientSecret = "pi_test_123_secret_abc",
-            ).validate()
-        }
-    }
-
-    @Test
-    fun `Returns failure if configuring checkout session without secret part`() = runScenario {
-        assertFailsWith<IllegalArgumentException>(
-            "Must use a checkout session client secret (format: cs_*_secret_*)."
-        ) {
-            PaymentElementLoader.InitializationMode.CheckoutSession(
-                clientSecret = "cs_test_123",
-            ).validate()
-        }
-    }
-
-    @Test
-    fun `CheckoutSession validate succeeds with valid client secret`() = runScenario {
+    fun `CheckoutSession validate is a no-op`() = runScenario {
         PaymentElementLoader.InitializationMode.CheckoutSession(
-            clientSecret = "cs_test_123_secret_abc",
+            checkoutSessionResponse = createCheckoutSessionResponse(canDetachPaymentMethod = true),
         ).validate()
     }
 
     @Test
-    fun `CheckoutSession id property extracts id from client secret`() = runScenario {
+    fun `CheckoutSession id property returns id from response`() = runScenario {
         val checkoutSession = PaymentElementLoader.InitializationMode.CheckoutSession(
-            clientSecret = "cs_test_123_secret_abc",
+            checkoutSessionResponse = createCheckoutSessionResponse(canDetachPaymentMethod = true),
         )
-        assertThat(checkoutSession.id).isEqualTo("cs_test_123")
+        assertThat(checkoutSession.checkoutSessionResponse.id).isEqualTo("cs_test_123")
     }
 
     @Test
-    fun `integrationMetadata returns checkout session with extracted id`() = runScenario {
+    fun `integrationMetadata returns checkout session with id from response`() = runScenario {
         val checkoutSession = PaymentElementLoader.InitializationMode.CheckoutSession(
-            clientSecret = "cs_test_123_secret_abc"
+            checkoutSessionResponse = createCheckoutSessionResponse(canDetachPaymentMethod = true),
         )
         assertThat(checkoutSession.integrationMetadata(null))
             .isEqualTo(IntegrationMetadata.CheckoutSession("cs_test_123"))
@@ -2950,16 +2926,12 @@ internal class DefaultPaymentElementLoaderTest {
             canDetachPaymentMethod = canDetachPaymentMethod,
         )
 
-        runScenario(
-            checkoutSessionRepository = FakeCheckoutSessionRepository(
-                initResult = Result.success(checkoutSessionResponse),
-            ),
-        ) {
+        runScenario {
             val loader = createPaymentElementLoader()
 
             val state = loader.load(
                 initializationMode = PaymentElementLoader.InitializationMode.CheckoutSession(
-                    clientSecret = "cs_test_123_secret_abc",
+                    checkoutSessionResponse = checkoutSessionResponse,
                 ),
                 paymentSheetConfiguration = PaymentSheet.Configuration(
                     merchantDisplayName = "Merchant, Inc.",
@@ -4381,7 +4353,6 @@ internal class DefaultPaymentElementLoaderTest {
     }
 
     private fun runScenario(
-        checkoutSessionRepository: CheckoutSessionRepository = FakeCheckoutSessionRepository(),
         block: suspend Scenario.() -> Unit
     ) {
         val testDispatcher = UnconfinedTestDispatcher()
@@ -4396,7 +4367,6 @@ internal class DefaultPaymentElementLoaderTest {
             testDispatcher = testDispatcher,
             eventReporter = eventReporter,
             prefsRepository = prefsRepository,
-            checkoutSessionRepository = checkoutSessionRepository,
             paymentMethodTypeCaptor = paymentMethodTypeCaptor,
         ).apply {
             runTest {
@@ -4415,7 +4385,6 @@ internal class DefaultPaymentElementLoaderTest {
         val testDispatcher: TestDispatcher,
         val eventReporter: FakeLoadingEventReporter,
         val prefsRepository: FakePrefsRepository,
-        val checkoutSessionRepository: CheckoutSessionRepository,
         val paymentMethodTypeCaptor: ArgumentCaptor<List<PaymentMethod.Type>>,
     )
 
@@ -4497,9 +4466,7 @@ internal class DefaultPaymentElementLoaderTest {
             paymentConfiguration = { PaymentConfiguration(publishableKey = if (isLiveMode) "pk_live" else "pk_test") },
             paymentMethodFilter = paymentMethodFilter,
             cardFundingFilterFactory = PaymentSheetCardFundingFilter.Factory(),
-            checkoutSessionLoader = CheckoutSessionLoader(
-                checkoutSessionRepository = checkoutSessionRepository,
-            ),
+            checkoutSessionLoader = CheckoutSessionLoader(),
             elementsSessionLoader = ElementsSessionLoader(
                 elementsSessionRepository = elementsSessionRepository,
                 errorReporter = errorReporter,


### PR DESCRIPTION
## Summary
- Changes `InitializationMode.CheckoutSession` to hold the already-loaded `CheckoutSessionResponse` instead of a raw client secret string
- Eliminates a redundant `POST /v1/payment_pages/{cs_id}/init` API call that was happening during PaymentSheet load (the same call was already made during `Checkout.configure()`)
- Simplifies `CheckoutSessionLoader` to extract data from the response directly, removing its `CheckoutSessionRepository` dependency and `suspend` modifier

## Test plan
- [x] `./gradlew :paymentsheet:assembleDebug` compiles successfully
- [x] `./gradlew :paymentsheet:testDebugUnitTest` all unit tests pass
- [ ] Verify instrumentation test `PaymentSheetCheckoutSessionTest` passes (removed `repeat(2)` since only one init call is made now)

🤖 Generated with [Claude Code](https://claude.com/claude-code)