### PR TITLE
Add discount code input to CheckoutPlaygroundActivity

### DIFF
--- a/paymentsheet-example/src/main/AndroidManifest.xml
+++ b/paymentsheet-example/src/main/AndroidManifest.xml
@@ -56,7 +56,9 @@
         <activity android:name="com.stripe.android.paymentsheet.example.playground.embedded.EmbeddedExampleActivity" />
         <activity android:name="com.stripe.android.paymentsheet.example.playground.spt.SharedPaymentTokenPlaygroundActivity" />
         <activity android:name="com.stripe.android.paymentsheet.example.playground.LinkControllerPlaygroundActivity" />
-        <activity android:name="com.stripe.android.paymentsheet.example.playground.checkout.CheckoutPlaygroundActivity" />
+        <activity
+            android:name="com.stripe.android.paymentsheet.example.playground.checkout.CheckoutPlaygroundActivity"
+            android:theme="@style/AppTheme.NoActionBar" />
         <activity
             android:name="com.stripe.android.paymentsheet.example.playground.PaymentSheetPlaygroundActivity"
             android:theme="@style/AppTheme.NoActionBar"

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutPlaygroundActivity.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -14,12 +15,18 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Button
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.stripe.android.checkout.Checkout
 import com.stripe.android.checkout.CheckoutSession
@@ -52,6 +59,7 @@ class CheckoutPlaygroundActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
 
         val checkoutState = getCheckoutState(savedInstanceState)
         if (checkoutState == null) {
@@ -82,8 +90,26 @@ class CheckoutPlaygroundActivity : AppCompatActivity() {
 fun CheckoutScreen(checkout: Checkout) {
     val checkoutSession by checkout.checkoutSession.collectAsState()
 
+    var discountCode by rememberSaveable { mutableStateOf("") }
+
     PlaygroundTheme(
         content = {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(PADDING),
+            ) {
+                OutlinedTextField(
+                    value = discountCode,
+                    onValueChange = { discountCode = it },
+                    label = { Text("Discount code") },
+                    singleLine = true,
+                    modifier = Modifier.weight(1f),
+                )
+                Button(onClick = { }) {
+                    Text("Apply")
+                }
+            }
         },
         bottomBarContent = {
             TotalSummary(checkoutSession)


### PR DESCRIPTION
## Summary
- Add a discount code text field and "Apply" button to the checkout playground content area (UI-only scaffolding, no backend integration)
- Fix activity theme to use `NoActionBar` and enable edge-to-edge display, matching other playground activities

## Test plan
- [x] `./gradlew :paymentsheet-example:assembleBaseDebug` builds successfully
- [ ] Launch CheckoutPlaygroundActivity and verify the discount code input and Apply button render correctly
- [ ] Verify system status bar is visible
- [ ] Verify text field state survives configuration changes (rotation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<img width="1080" height="2424" alt="Screenshot_20260302_131407" src="https://github.com/user-attachments/assets/d0d2dc84-971e-473e-997c-0a2d405d504f" />

