### PR TITLE
Use `elements/session` feature flag to control who can use Tap to Add

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/ElementsSession.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ElementsSession.kt
@@ -93,6 +93,9 @@ data class ElementsSession(
     val enableCardFundFiltering: Boolean
         get() = flags[Flag.ELEMENTS_MOBILE_CARD_FUND_FILTERING] == true
 
+    val isTapToAddEnabled: Boolean
+        get() = flags[Flag.ELEMENTS_MOBILE_ANDROID_TAP_TO_ADD_ENABLED] == true
+
     val onBehalfOf: String?
         get() = accountId.takeIf { !it.equals(merchantId) }
 
@@ -245,7 +248,8 @@ data class ElementsSession(
             "elements_mobile_force_setup_future_use_behavior_and_new_mandate_text"
         ),
         ELEMENTS_MOBILE_ATTEST_ON_INTENT_CONFIRMATION("elements_mobile_attest_on_intent_confirmation"),
-        ELEMENTS_MOBILE_CARD_FUND_FILTERING("elements_mobile_card_funding_filtering")
+        ELEMENTS_MOBILE_CARD_FUND_FILTERING("elements_mobile_card_funding_filtering"),
+        ELEMENTS_MOBILE_ANDROID_TAP_TO_ADD_ENABLED("elements_mobile_android_tap_to_add_enabled")
     }
 
     /**

--- a/payments-core/src/test/java/com/stripe/android/model/ElementsSessionTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/ElementsSessionTest.kt
@@ -202,6 +202,42 @@ class ElementsSessionTest {
         assertThat(session.enableCardFundFiltering).isFalse()
     }
 
+    @Test
+    fun `ELEMENTS_MOBILE_ANDROID_TAP_TO_ADD_ENABLED flag has correct value`() {
+        assertThat(ElementsSession.Flag.ELEMENTS_MOBILE_ANDROID_TAP_TO_ADD_ENABLED.flagValue)
+            .isEqualTo("elements_mobile_android_tap_to_add_enabled")
+    }
+
+    @Test
+    fun `isTapToAddEnabled returns true when flag is enabled`() {
+        val session = createElementsSession(
+            passiveCaptcha = null,
+            flags = mapOf(ElementsSession.Flag.ELEMENTS_MOBILE_ANDROID_TAP_TO_ADD_ENABLED to true)
+        )
+
+        assertThat(session.isTapToAddEnabled).isTrue()
+    }
+
+    @Test
+    fun `isTapToAddEnabled returns false when flag is disabled`() {
+        val session = createElementsSession(
+            passiveCaptcha = null,
+            flags = mapOf(ElementsSession.Flag.ELEMENTS_MOBILE_ANDROID_TAP_TO_ADD_ENABLED to false)
+        )
+
+        assertThat(session.isTapToAddEnabled).isFalse()
+    }
+
+    @Test
+    fun `isTapToAddEnabled returns false when flag is missing`() {
+        val session = createElementsSession(
+            passiveCaptcha = null,
+            flags = emptyMap()
+        )
+
+        assertThat(session.isTapToAddEnabled).isFalse()
+    }
+
     private fun createElementsSession(
         passiveCaptcha: PassiveCaptchaParams? = null,
         flags: Map<ElementsSession.Flag, Boolean> = emptyMap(),

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
@@ -1731,6 +1731,69 @@ class ElementsSessionJsonParserTest {
             .isEqualTo(enabled)
     }
 
+    @Test
+    fun `parse elements_mobile_android_tap_to_add_enabled flag when present`() {
+        testTapToAddEnabledFlag(enabled = true)
+        testTapToAddEnabledFlag(enabled = false)
+    }
+
+    @Test
+    fun `parse elements_mobile_android_tap_to_add_enabled flag when missing`() {
+        val parser = ElementsSessionJsonParser(
+            ElementsSessionParams.PaymentIntentType(
+                clientSecret = "secret",
+                externalPaymentMethods = emptyList(),
+                customPaymentMethods = emptyList(),
+                appId = APP_ID
+            ),
+            isLiveMode = false,
+        )
+
+        val session = parser.parse(ElementsSessionFixtures.EXPANDED_PAYMENT_INTENT_JSON)
+
+        assertThat(session?.flags?.get(ElementsSession.Flag.ELEMENTS_MOBILE_ANDROID_TAP_TO_ADD_ENABLED))
+            .isNull()
+    }
+
+    private fun testTapToAddEnabledFlag(enabled: Boolean) {
+        val parser = ElementsSessionJsonParser(
+            ElementsSessionParams.PaymentIntentType(
+                clientSecret = "secret",
+                externalPaymentMethods = emptyList(),
+                customPaymentMethods = emptyList(),
+                appId = APP_ID
+            ),
+            isLiveMode = false,
+        )
+
+        val json = JSONObject(
+            """
+            {
+              "payment_method_preference": {
+                "object": "payment_method_preference",
+                "country_code": "US",
+                "payment_intent": {
+                  "id": "pi_123",
+                  "object": "payment_intent",
+                  "amount": 1099,
+                  "currency": "usd",
+                  "status": "requires_payment_method"
+                },
+                "ordered_payment_method_types": ["card"]
+              },
+              "flags": {
+                "elements_mobile_android_tap_to_add_enabled": $enabled
+              }
+            }
+            """.trimIndent()
+        )
+
+        val session = parser.parse(json)
+
+        assertThat(session?.flags?.get(ElementsSession.Flag.ELEMENTS_MOBILE_ANDROID_TAP_TO_ADD_ENABLED))
+            .isEqualTo(enabled)
+    }
+
     companion object {
         private const val APP_ID = "com.app.id"
     }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -396,7 +396,9 @@ internal data class PaymentMethodMetadata(
                 integrationMetadata = integrationMetadata,
                 analyticsMetadata = analyticsMetadata,
                 experimentsData = elementsSession.experimentsData,
-                isTapToAddSupported = isTapToAddSupported && customerMetadata != null,
+                isTapToAddSupported = isTapToAddSupported &&
+                    elementsSession.isTapToAddEnabled &&
+                    customerMetadata != null,
             )
         }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -1389,7 +1389,8 @@ internal class PaymentMethodMetadataTest {
         passiveCaptchaParams: PassiveCaptchaParams? = PassiveCaptchaParamsFactory.passiveCaptchaParams(),
         experimentsData: ElementsSession.ExperimentsData? = null,
         flags: Map<ElementsSession.Flag, Boolean> = mapOf(
-            ElementsSession.Flag.ELEMENTS_ENABLE_PASSIVE_CAPTCHA to true
+            ElementsSession.Flag.ELEMENTS_ENABLE_PASSIVE_CAPTCHA to true,
+            ElementsSession.Flag.ELEMENTS_MOBILE_ANDROID_TAP_TO_ADD_ENABLED to true,
         ),
     ): ElementsSession {
         return ElementsSession(
@@ -2195,6 +2196,34 @@ internal class PaymentMethodMetadataTest {
             isGooglePayReady = false,
             linkStateResult = null,
             customerMetadata = null,
+            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent("cs_123"),
+            clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
+            integrationMetadata = IntegrationMetadata.IntentFirst("cs_123"),
+            analyticsMetadata = AnalyticsMetadata(emptyMap()),
+            isTapToAddSupported = true,
+        )
+
+        assertThat(metadata.isTapToAddSupported).isFalse()
+    }
+
+    @Test
+    fun `createForPaymentElement sets isTapToAddSupported to false when elements session flag is false`() {
+        val elementsSession = createElementsSession(
+            intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            flags = mapOf(
+                ElementsSession.Flag.ELEMENTS_ENABLE_PASSIVE_CAPTCHA to true,
+                ElementsSession.Flag.ELEMENTS_MOBILE_ANDROID_TAP_TO_ADD_ENABLED to false,
+            ),
+        )
+
+        val metadata = PaymentMethodMetadata.createForPaymentElement(
+            elementsSession = elementsSession,
+            configuration = PaymentSheetFixtures.CONFIG_CUSTOMER.asCommonConfiguration(),
+            sharedDataSpecs = emptyList(),
+            externalPaymentMethodSpecs = emptyList(),
+            isGooglePayReady = false,
+            linkStateResult = null,
+            customerMetadata = DEFAULT_CUSTOMER_METADATA,
             initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent("cs_123"),
             clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
             integrationMetadata = IntegrationMetadata.IntentFirst("cs_123"),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -547,6 +547,49 @@ internal class DefaultPaymentElementLoaderTest {
             }
         }
 
+    @Test
+    fun `isTapToAddSupported should be false when elements session has tap to add flag disabled`() =
+        runScenario {
+            FakeTapToAddConnectionManager.test(
+                isSupported = true,
+                isConnected = true,
+            ) {
+                val elementsSessionRepository = FakeElementsSessionRepository(
+                    stripeIntent = PaymentIntentFactory.create(),
+                    error = null,
+                    linkSettings = null,
+                    flags = mapOf(
+                        ElementsSession.Flag.ELEMENTS_ENABLE_PASSIVE_CAPTCHA to true,
+                        ElementsSession.Flag.ELEMENTS_MOBILE_ANDROID_TAP_TO_ADD_ENABLED to false,
+                    ),
+                )
+                val loader = createPaymentElementLoader(
+                    stripeIntent = PaymentIntentFactory.create(),
+                    isGooglePayReady = true,
+                    customerRepo = FakeCustomerRepository(paymentMethods = emptyList()),
+                    tapToAddConnectionManager = tapToAddConnectionManager,
+                    elementsSessionRepository = elementsSessionRepository,
+                )
+
+                val result = loader.load(
+                    initializationMode = PaymentElementLoader.InitializationMode.SetupIntent(
+                        clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value
+                    ),
+                    paymentSheetConfiguration = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
+                    metadata = PaymentElementLoader.Metadata(
+                        initializedViaCompose = false,
+                    ),
+                ).getOrThrow()
+
+                assertThat(connectCalls.awaitItem()).isNotNull()
+
+                assertThat(result.paymentMethodMetadata.isTapToAddSupported).isFalse()
+
+                assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+                assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
+            }
+        }
+
     @OptIn(WalletButtonsPreview::class)
     @Test
     fun `Should default to no payment method when using wallet buttons & google is saved selection`() =

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeElementsSessionRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeElementsSessionRepository.kt
@@ -20,6 +20,7 @@ internal class FakeElementsSessionRepository(
     private val passiveCaptchaParams: PassiveCaptchaParams? = null,
     private val flags: Map<ElementsSession.Flag, Boolean> = mapOf(
         ElementsSession.Flag.ELEMENTS_ENABLE_PASSIVE_CAPTCHA to true,
+        ElementsSession.Flag.ELEMENTS_MOBILE_ANDROID_TAP_TO_ADD_ENABLED to true,
     )
 ) : ElementsSessionRepository {
     data class Params(


### PR DESCRIPTION
# Summary
Use `elements/session` feature flag to control who can use Tap to Add

# Motivation
Allow for enabling/disabling Tap to Add for merchants as needed.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified