### PR TITLE
Fix ephemeral key not used for tap-to-add confirmation tokens

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddCollectionHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddCollectionHandler.kt
@@ -127,7 +127,7 @@ internal class DefaultTapToAddCollectionHandler(
         val setupIntent = retrieveSetupIntent(clientSecret)
         val setupIntentWithAttachedPaymentMethod = collectPaymentMethod(setupIntent, metadata)
         val confirmedIntent = confirmSetupIntent(setupIntentWithAttachedPaymentMethod)
-        val paymentMethod = createPaymentMethod(confirmedIntent)
+        val paymentMethod = createPaymentMethod(confirmedIntent, metadata.customerMetadata?.id)
 
         return TapToAddCollectionHandler.CollectionState.Collected(paymentMethod)
     }
@@ -211,7 +211,7 @@ internal class DefaultTapToAddCollectionHandler(
         }
     }
 
-    private fun createPaymentMethod(intent: SetupIntent): PaymentMethod {
+    private fun createPaymentMethod(intent: SetupIntent, customerId: String?): PaymentMethod {
         val paymentMethodDetails = intent.latestAttempt?.paymentMethodDetails
         val presentDetails = paymentMethodDetails?.cardPresentDetails
             ?: paymentMethodDetails?.interacPresentDetails
@@ -232,6 +232,7 @@ internal class DefaultTapToAddCollectionHandler(
             .setCode(PaymentMethod.Type.Card.code)
             .setType(PaymentMethod.Type.Card)
             .setId(generatedCard.id)
+            .setCustomerId(customerId)
             .setCard(
                 PaymentMethod.Card(
                     last4 = generatedCard.cardDetails?.last4,

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddCollectionHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddCollectionHandlerTest.kt
@@ -5,6 +5,7 @@ import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.common.taptoadd.ui.createTapToAddUxConfiguration
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
@@ -161,6 +162,20 @@ class TapToAddCollectionHandlerTest {
     @Test
     fun `handler returns Collected when flow is successfully completed with interac card`() = testSuccessfulFlow(
         useInterac = true,
+    )
+
+    @Test
+    fun `collected payment method has customerId when customer metadata is present`() = testSuccessfulFlow(
+        useInterac = false,
+        metadata = DEFAULT_METADATA,
+        expectedCustomerId = "cus_123",
+    )
+
+    @Test
+    fun `collected payment method has null customerId when customer metadata is absent`() = testSuccessfulFlow(
+        useInterac = false,
+        metadata = METADATA_WITHOUT_CUSTOMER,
+        expectedCustomerId = null,
     )
 
     @Test
@@ -388,6 +403,8 @@ class TapToAddCollectionHandlerTest {
 
     private fun testSuccessfulFlow(
         useInterac: Boolean,
+        metadata: PaymentMethodMetadata = DEFAULT_METADATA,
+        expectedCustomerId: String? = DEFAULT_METADATA.customerMetadata?.id,
     ) = runScenario(
         isConnected = true,
         callbackResult = Result.success(
@@ -397,7 +414,7 @@ class TapToAddCollectionHandlerTest {
         ),
     ) {
         val result = testScope.backgroundScope.async {
-            handler.collect(DEFAULT_METADATA)
+            handler.collect(metadata)
         }
 
         assertThat(retrieverScenario.waitForCallbackCalls.awaitItem()).isNotNull()
@@ -425,6 +442,7 @@ class TapToAddCollectionHandlerTest {
         assertThat(collected.paymentMethod.id).isEqualTo("pm_4563")
         assertThat(collected.paymentMethod.card?.last4).isEqualTo("7294")
         assertThat(collected.paymentMethod.card?.brand).isEqualTo(CardBrand.MasterCard)
+        assertThat(collected.paymentMethod.customerId).isEqualTo(expectedCustomerId)
     }
 
     private fun runScenario(
@@ -758,7 +776,14 @@ class TapToAddCollectionHandlerTest {
 
     private companion object {
         val tapToPayUxConfiguration = createTapToAddUxConfiguration()
-        val DEFAULT_METADATA = PaymentMethodMetadataFactory.create(isTapToAddSupported = true)
+        val DEFAULT_METADATA = PaymentMethodMetadataFactory.create(
+            isTapToAddSupported = true,
+            hasCustomerConfiguration = true,
+        )
+        val METADATA_WITHOUT_CUSTOMER = PaymentMethodMetadataFactory.create(
+            isTapToAddSupported = true,
+            hasCustomerConfiguration = false,
+        )
         val DEFAULT_CALLBACK = CreateCardPresentSetupIntentCallback {
             CreateIntentResult.Success("si_123_secret")
         }


### PR DESCRIPTION
When using confirmation tokens with tap-to-add, the confirmation token API call was made with the publishable key instead of the customer ephemeral key.

The existing key-selection logic in ConfirmationTokenConfirmationInterceptor already checks paymentMethod.customerId to decide which key to use, but TapToAddCollectionHandler was building the PaymentMethod without setting customerId, so the condition always fell through to the publishable key.

Fix by passing metadata.customerMetadata?.id through collectWithIntent() to createPaymentMethod(), which sets it on the PaymentMethod.Builder via setCustomerId(). Add tests to verify the field is populated correctly when customer metadata is present and absent.


Committed-By-Agent: claude

# Summary
<!-- Simple summary of what was changed. -->

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
