### PR TITLE
Replace Mockito spy/captor with fake call tracking in PaymentSheetViewModelTest

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -144,12 +144,10 @@ import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
-import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
-import org.mockito.kotlin.spy
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
@@ -207,12 +205,10 @@ internal class PaymentSheetViewModelTest {
         Dispatchers.setMain(testDispatcher)
         val paymentMethods = listOf(CARD_WITH_NETWORKS_PAYMENT_METHOD)
 
-        val savedPaymentMethodRepository = spy(
-            FakeSavedPaymentMethodRepository(
-                onUpdatePaymentMethod = {
-                    Result.success(paymentMethods.first())
-                }
-            )
+        val savedPaymentMethodRepository = FakeSavedPaymentMethodRepository(
+            onUpdatePaymentMethod = {
+                Result.success(paymentMethods.first())
+            }
         )
         val viewModel = createViewModel(
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
@@ -254,17 +250,9 @@ internal class PaymentSheetViewModelTest {
             assertThat(awaitItem()).isInstanceOf<SelectSavedPaymentMethods>()
         }
 
-        val accessCaptor = argumentCaptor<SavedPaymentMethodAccess>()
-
-        verify(savedPaymentMethodRepository).updatePaymentMethod(
-            accessCaptor.capture(),
-            any(),
-            any()
-        )
-
-        val access = accessCaptor.firstValue
-        assertThat(access).isInstanceOf(SavedPaymentMethodAccess.Customer::class.java)
-        with(access as SavedPaymentMethodAccess.Customer) {
+        val updateRequest = savedPaymentMethodRepository.updateRequests.awaitItem()
+        assertThat(updateRequest.access).isInstanceOf(SavedPaymentMethodAccess.Customer::class.java)
+        with(updateRequest.access as SavedPaymentMethodAccess.Customer) {
             assertThat(info.id).isEqualTo("cus_123")
             assertThat(info.ephemeralKeySecret).isEqualTo("ek_123")
             assertThat(info.customerSessionClientSecret).isNull()
@@ -288,12 +276,10 @@ internal class PaymentSheetViewModelTest {
             )
         )
 
-        val savedPaymentMethodRepository = spy(
-            FakeSavedPaymentMethodRepository(
-                onUpdatePaymentMethod = {
-                    Result.success(updatedPaymentMethod)
-                }
-            )
+        val savedPaymentMethodRepository = FakeSavedPaymentMethodRepository(
+            onUpdatePaymentMethod = {
+                Result.success(updatedPaymentMethod)
+            }
         )
         val viewModel = createViewModel(
             customer = EMPTY_CUSTOMER_STATE.copy(paymentMethods = paymentMethods),
@@ -332,19 +318,11 @@ internal class PaymentSheetViewModelTest {
         eventReporter.updatePaymentMethodSucceededCalls.ensureAllEventsConsumed()
         assertThat(updatePaymentMethodSucceededCall.selectedBrand).isEqualTo(CardBrand.Visa)
 
-        val idCaptor = argumentCaptor<String>()
-        val paramsCaptor = argumentCaptor<PaymentMethodUpdateParams>()
-
-        verify(savedPaymentMethodRepository).updatePaymentMethod(
-            any(),
-            idCaptor.capture(),
-            paramsCaptor.capture()
-        )
-
-        assertThat(idCaptor.firstValue).isEqualTo(firstPaymentMethod.id)
+        val updateRequest = savedPaymentMethodRepository.updateRequests.awaitItem()
+        assertThat(updateRequest.paymentMethodId).isEqualTo(firstPaymentMethod.id)
 
         assertThat(
-            paramsCaptor.firstValue.toParamMap()
+            updateRequest.params.toParamMap()
         ).isEqualTo(
             PaymentMethodUpdateParams.createCard(
                 networks = PaymentMethodUpdateParams.Card.Networks(
@@ -369,12 +347,10 @@ internal class PaymentSheetViewModelTest {
 
         val firstPaymentMethod = paymentMethods.first()
 
-        val savedPaymentMethodRepository = spy(
-            FakeSavedPaymentMethodRepository(
-                onUpdatePaymentMethod = {
-                    Result.failure(Exception("No network found!"))
-                }
-            )
+        val savedPaymentMethodRepository = FakeSavedPaymentMethodRepository(
+            onUpdatePaymentMethod = {
+                Result.failure(Exception("No network found!"))
+            }
         )
         val viewModel = createViewModel(
             customer = EMPTY_CUSTOMER_STATE.copy(paymentMethods = paymentMethods),
@@ -2903,7 +2879,7 @@ internal class PaymentSheetViewModelTest {
 
     @Test
     fun `on 'modifyPaymentMethod' with no customer available, should not attempt update`() = runTest {
-        val savedPaymentMethodRepository = spy(FakeSavedPaymentMethodRepository())
+        val savedPaymentMethodRepository = FakeSavedPaymentMethodRepository()
 
         val viewModel = createViewModel(
             customer = null,
@@ -2925,7 +2901,7 @@ internal class PaymentSheetViewModelTest {
                 val interactor = currentScreen.interactor
                 interactor.cardParamsUpdateAction(CardBrand.Visa)
 
-                verify(savedPaymentMethodRepository, never()).updatePaymentMethod(any(), any(), any())
+                savedPaymentMethodRepository.validate()
             }
         }
     }


### PR DESCRIPTION
## Summary
- Remove all 4 `spy()` wrappers from `PaymentSheetViewModelTest`
- Replace `argumentCaptor`/`verify` patterns with `FakeSavedPaymentMethodRepository`'s Turbine-based `updateRequests` channel and `validate()` method
- Remove unused Mockito imports (`argumentCaptor`, `spy`)

## Motivation
Follow-up from [#12482 review](https://github.com/stripe/stripe-android/pull/12482#pullrequestreview-3879172674) — addresses comment about removing mocks from `PaymentSheetViewModelTest`.

## Test plan
- [x] All PaymentSheetViewModelTest tests pass
- [ ] Verify no regressions in payment method update tests

🤖 Generated with [Claude Code](https://claude.ai/claude-code)