### PR TITLE
close gaps in confirmation bootstrap tests

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedStateHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedStateHelperTest.kt
@@ -44,6 +44,7 @@ internal class DefaultEmbeddedStateHelperTest {
             )
         }
 
+        confirmationHandler.bootstrapTurbine.awaitItem()
         assertThat(embeddedContentHelper.dataLoadedTurbine.awaitItem().appearance)
             .isEqualTo(Embedded(Embedded.RowStyle.FlatWithRadio.default))
     }
@@ -63,6 +64,7 @@ internal class DefaultEmbeddedStateHelperTest {
             )
         }
 
+        confirmationHandler.bootstrapTurbine.awaitItem()
         assertThat(StripeTheme.colorsLightMutable.componentBorder)
             .isEqualTo(
                 Color(
@@ -87,6 +89,7 @@ internal class DefaultEmbeddedStateHelperTest {
         )
         selectionHolder.previousNewSelections.putParcelable("card", PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
 
+        confirmationHandler.bootstrapTurbine.awaitItem()
         assertThat(stateHelper.state).isNotNull()
         assertThat(confirmationStateHolder.state).isNotNull()
         assertThat(customerStateHolder.customer.value).isEqualTo(PaymentSheetFixtures.EMPTY_CUSTOMER_STATE)
@@ -114,6 +117,7 @@ internal class DefaultEmbeddedStateHelperTest {
             formSheetAction(EmbeddedPaymentElement.FormSheetAction.Confirm)
         }
 
+        confirmationHandler.bootstrapTurbine.awaitItem()
         assertThat(embeddedContentHelper.dataLoadedTurbine.awaitItem()).isNotNull()
     }
 
@@ -132,6 +136,7 @@ internal class DefaultEmbeddedStateHelperTest {
             formSheetAction(EmbeddedPaymentElement.FormSheetAction.Confirm)
         }
 
+        confirmationHandler.bootstrapTurbine.awaitItem()
         assertThat(embeddedContentHelper.dataLoadedTurbine.awaitItem()).isNotNull()
     }
 
@@ -151,6 +156,7 @@ internal class DefaultEmbeddedStateHelperTest {
             embeddedViewDisplaysMandateText(false)
         }
 
+        confirmationHandler.bootstrapTurbine.awaitItem()
         assertThat(embeddedContentHelper.dataLoadedTurbine.awaitItem()).isNotNull()
     }
 
@@ -191,6 +197,13 @@ internal class DefaultEmbeddedStateHelperTest {
         }
     }
 
+    @Test
+    fun `confirmation handler is bootstrapped when state is set`() = testScenario {
+        setState()
+        assertThat(confirmationHandler.bootstrapTurbine.awaitItem().paymentMethodMetadata).isNotNull()
+        embeddedContentHelper.dataLoadedTurbine.awaitItem()
+    }
+
     private fun testScenario(
         rowSelectionCallback: InternalRowSelectionCallback? = null,
         block: suspend Scenario.() -> Unit,
@@ -210,13 +223,14 @@ internal class DefaultEmbeddedStateHelperTest {
             coroutineScope = CoroutineScope(Dispatchers.Unconfined),
         )
         val embeddedContentHelper = FakeEmbeddedContentHelper()
+        val confirmationHandler = FakeConfirmationHandler()
         val stateHelper = DefaultEmbeddedStateHelper(
             selectionHolder = selectionHolder,
             customerStateHolder = customerStateHolder,
             confirmationStateHolder = confirmationStateHolder,
             embeddedContentHelper = embeddedContentHelper,
             internalRowSelectionCallback = { rowSelectionCallback },
-            confirmationHandler = FakeConfirmationHandler(),
+            confirmationHandler = confirmationHandler,
         )
 
         Scenario(
@@ -225,9 +239,11 @@ internal class DefaultEmbeddedStateHelperTest {
             selectionHolder = selectionHolder,
             embeddedContentHelper = embeddedContentHelper,
             stateHelper = stateHelper,
+            confirmationHandler = confirmationHandler,
         ).block()
 
         embeddedContentHelper.validate()
+        confirmationHandler.validate()
     }
 
     private class Scenario(
@@ -236,6 +252,7 @@ internal class DefaultEmbeddedStateHelperTest {
         val selectionHolder: EmbeddedSelectionHolder,
         val embeddedContentHelper: FakeEmbeddedContentHelper,
         val stateHelper: EmbeddedStateHelper,
+        val confirmationHandler: FakeConfirmationHandler,
     ) {
         fun setState(
             paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerConfirmationHandlerTest.kt
@@ -1,0 +1,26 @@
+package com.stripe.android.paymentsheet.flowcontroller
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+internal class DefaultFlowControllerConfirmationHandlerTest {
+    @Test
+    fun `bootstrap delegates to confirmation handler`() = runTest {
+        val confirmationHandler = FakeConfirmationHandler()
+        val handler = DefaultFlowControllerConfirmationHandler(
+            coroutineScope = TestScope(),
+            confirmationHandler = confirmationHandler,
+        )
+
+        val metadata = PaymentMethodMetadataFactory.create()
+        handler.bootstrap(metadata)
+
+        assertThat(confirmationHandler.bootstrapTurbine.awaitItem().paymentMethodMetadata)
+            .isEqualTo(metadata)
+        confirmationHandler.validate()
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandlerTest.kt
@@ -9,6 +9,7 @@ import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbacks
 import com.stripe.android.paymentsheet.FLOW_CONTROLLER_DEFAULT_CALLBACK_IDENTIFIER
@@ -412,6 +413,36 @@ class FlowControllerConfigurationHandlerTest {
         }
 
         configureTurbine.awaitComplete()
+    }
+
+    @Test
+    fun `confirmation handler is bootstrapped after successful configuration`() = runTest {
+        FakeFlowControllerConfirmationHandler.test(
+            initialState = ConfirmationHandler.State.Idle,
+        ) {
+            val configureErrors = Turbine<Throwable?>()
+            val configurationHandler = FlowControllerConfigurationHandler(
+                paymentElementLoader = defaultPaymentSheetLoader(),
+                uiContext = testDispatcher,
+                viewModel = viewModel,
+                paymentSelectionUpdater = { _, _, newState, _, _ -> newState.paymentSelection },
+                confirmationHandler = handler,
+            )
+
+            configurationHandler.configure(
+                scope = this@runTest,
+                initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
+                    clientSecret = PaymentSheetFixtures.CLIENT_SECRET,
+                ),
+                configuration = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
+                initializedViaCompose = false,
+            ) { _, exception ->
+                configureErrors.add(exception)
+            }
+
+            assertThat(configureErrors.awaitItem()).isNull()
+            assertThat(bootstrapTurbine.awaitItem().paymentMethodMetadata).isNotNull()
+        }
     }
 
     private fun defaultPaymentSheetLoader(): PaymentElementLoader {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
 Close gaps in confirmation bootstrap test coverage. Added tests verifying `ConfirmationHandler.bootstrap()` is called from `DefaultEmbeddedStateHelper`, `DefaultFlowControllerConfirmationHandler`, and `FlowControllerConfigurationHandler`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
`ConfirmationHandler.bootstrap(paymentMethodMetadata)` is called from several classes to pre-warm confirmation prerequisites (passive challenges, attestation). Some of these call sites lacked test coverage verifying the bootstrap call occurs. This change closes those gaps.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified
