### PR TITLE
Add allow_promotion_codes playground setting

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
@@ -69,6 +69,8 @@ class CheckoutRequest private constructor(
     val checkoutSessionPaymentMethodSave: FeatureState?,
     @SerialName("checkout_session_payment_method_remove")
     val checkoutSessionPaymentMethodRemove: FeatureState?,
+    @SerialName("allow_promotion_codes")
+    val allowPromotionCodes: Boolean?,
 ) {
     @Serializable
     enum class CustomerKeyType {
@@ -115,6 +117,7 @@ class CheckoutRequest private constructor(
         private var useCheckoutSession: Boolean? = null
         private var checkoutSessionPaymentMethodSave: FeatureState? = null
         private var checkoutSessionPaymentMethodRemove: FeatureState? = null
+        private var allowPromotionCodes: Boolean? = null
 
         fun initialization(initialization: String?) = apply {
             this.initialization = initialization
@@ -240,6 +243,10 @@ class CheckoutRequest private constructor(
             this.checkoutSessionPaymentMethodRemove = state
         }
 
+        fun allowPromotionCodes(allowPromotionCodes: Boolean?) = apply {
+            this.allowPromotionCodes = allowPromotionCodes
+        }
+
         fun build(): CheckoutRequest {
             return CheckoutRequest(
                 initialization = initialization,
@@ -276,6 +283,7 @@ class CheckoutRequest private constructor(
                 useCheckoutSession = useCheckoutSession,
                 checkoutSessionPaymentMethodSave = checkoutSessionPaymentMethodSave,
                 checkoutSessionPaymentMethodRemove = checkoutSessionPaymentMethodRemove,
+                allowPromotionCodes = allowPromotionCodes,
             )
         }
     }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/AllowPromotionCodesSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/AllowPromotionCodesSettingsDefinition.kt
@@ -1,0 +1,20 @@
+package com.stripe.android.paymentsheet.example.playground.settings
+
+import com.stripe.android.paymentsheet.example.playground.model.CheckoutRequest
+
+internal object AllowPromotionCodesSettingsDefinition : BooleanSettingsDefinition(
+    defaultValue = true,
+    displayName = "Allow Promotion Codes",
+    key = "allowPromotionCodes"
+) {
+    override fun applicable(
+        configurationData: PlaygroundConfigurationData,
+        settings: Map<PlaygroundSettingDefinition<*>, Any?>,
+    ): Boolean {
+        return settings[InitializationTypeSettingsDefinition] == InitializationType.CheckoutSession
+    }
+
+    override fun configure(value: Boolean, checkoutRequestBuilder: CheckoutRequest.Builder) {
+        checkoutRequestBuilder.allowPromotionCodes(value)
+    }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -475,6 +475,7 @@ internal class PlaygroundSettings private constructor(
             InitializationTypeSettingsDefinition,
             CheckoutSessionSaveSettingsDefinition,
             CheckoutSessionRemoveSettingsDefinition,
+            AllowPromotionCodesSettingsDefinition,
             CustomerSheetPaymentMethodModeDefinition,
             CustomerSessionSettingsDefinition,
             CustomerSessionSaveSettingsDefinition,


### PR DESCRIPTION
## Summary
- Adds a new `allow_promotion_codes` boolean field to `CheckoutRequest` sent to the backend checkout endpoint
- Creates `AllowPromotionCodesSettingsDefinition` playground setting (defaults to `true`, only applicable for checkout session flows)
- Registers the setting in `PlaygroundSettings` alongside other checkout session settings

## Test plan
- [x] `./gradlew :paymentsheet-example:assembleBaseDebug` builds successfully
- [ ] Open playground, select Checkout Session initialization, verify "Allow Promotion Codes" toggle appears
- [ ] Toggle off, verify the setting is excluded from the checkout request
- [ ] Switch to non-checkout initialization, verify the toggle is hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)