### PR TITLE
Add minSDK, compileSDK, and target SDK version to changelog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## XX.XX.XX - 20XX-XX-XX
 
 Dependencies updated in [12373](https://github.com/stripe/stripe-android/pull/12373), [12410](https://github.com/stripe/stripe-android/pull/12410), [12419](https://github.com/stripe/stripe-android/pull/12419), [12433](https://github.com/stripe/stripe-android/pull/12433), and [12486](https://github.com/stripe/stripe-android/pull/12486):
+- Bumped `minSdkVersion` to `23`.
+- Bumped `compileSdkVersion` and `targetSdkVersion` to `36`.
 - Bumped Kotlin from 2.1.10 to 2.3.10.
 - Bumped Kotlin Coroutines from 1.10.1 to 1.10.2.
 - Bumped Kotlin Serialization from 1.8.0 to 1.10.0.


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This is an important not that wasn't listed in the changelog, so I added it.