### PR TITLE
Remove dead code after minSDK 21 -> 23 bump

### DIFF
--- a/3ds2sdk/src/main/kotlin/com/stripe/android/stripe3ds2/init/DeviceParamNotAvailableFactoryImpl.kt
+++ b/3ds2sdk/src/main/kotlin/com/stripe/android/stripe3ds2/init/DeviceParamNotAvailableFactoryImpl.kt
@@ -80,34 +80,8 @@ internal class DeviceParamNotAvailableFactoryImpl internal constructor(
                     Reason.PLATFORM_VERSION.toString()
             }
 
-            if (apiVersion < Build.VERSION_CODES.M) {
-                params[DeviceParam.PARAM_TELE_PHONE_COUNT.toString()] =
-                    Reason.PLATFORM_VERSION.toString()
-                params[DeviceParam.PARAM_TELE_IS_HEARING_AID_COMPATIBILITY_SUPPORTED.toString()] =
-                    Reason.PLATFORM_VERSION.toString()
-                params[DeviceParam.PARAM_TELE_IS_TTY_MODE_SUPPORTED.toString()] =
-                    Reason.PLATFORM_VERSION.toString()
-                params[DeviceParam.PARAM_TELE_IS_WORLD_PHONE.toString()] =
-                    Reason.PLATFORM_VERSION.toString()
-                params[DeviceParam.PARAM_BUILD_VERSION_PREVIEW_SDK_INT.toString()] =
-                    Reason.PLATFORM_VERSION.toString()
-                params[DeviceParam.PARAM_BUILD_VERSION_SDK_INT.toString()] =
-                    Reason.PLATFORM_VERSION.toString()
-                params[DeviceParam.PARAM_BUILD_VERSION_SECURITY_PATCH.toString()] =
-                    Reason.PLATFORM_VERSION.toString()
-                params[DeviceParam.PARAM_SYSTEM_DTMF_TONE_TYPE_WHEN_DIALING.toString()] =
-                    Reason.PLATFORM_VERSION.toString()
-                params[DeviceParam.PARAM_SYSTEM_VIBRATE_WHEN_RINGING.toString()] =
-                    Reason.PLATFORM_VERSION.toString()
-            }
-
             if (apiVersion > Build.VERSION_CODES.M) {
                 params[DeviceParam.PARAM_SECURE_SYS_PROP_SETTING_VERSION.toString()] =
-                    Reason.PLATFORM_VERSION.toString()
-            }
-
-            if (apiVersion < Build.VERSION_CODES.LOLLIPOP_MR1) {
-                params[DeviceParam.PARAM_TELE_IS_VOICE_CAPABLE.toString()] =
                     Reason.PLATFORM_VERSION.toString()
             }
 

--- a/camera-core/src/main/java/com/stripe/android/camera/scanui/ViewFinderBackground.kt
+++ b/camera-core/src/main/java/com/stripe/android/camera/scanui/ViewFinderBackground.kt
@@ -6,7 +6,6 @@ import android.graphics.Paint
 import android.graphics.PorterDuff
 import android.graphics.PorterDuffXfermode
 import android.graphics.Rect
-import android.os.Build
 import android.util.AttributeSet
 import android.view.View
 import androidx.annotation.ColorInt
@@ -60,12 +59,7 @@ class ViewFinderBackground(
     private val backgroundColor =
         attributes.getColor(
             R.styleable.StripeViewFinderBackground_stripeBackgroundColor,
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                resources.getColor(R.color.stripeNotFoundBackground, theme)
-            } else {
-                @Suppress("deprecation")
-                resources.getColor(R.color.stripeNotFoundBackground)
-            }
+            resources.getColor(R.color.stripeNotFoundBackground, theme)
         )
 
     private var paintBackground = Paint(Paint.ANTI_ALIAS_FLAG).apply {

--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebView.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebView.kt
@@ -10,7 +10,6 @@ import android.content.res.Configuration
 import android.graphics.Bitmap
 import android.graphics.Rect
 import android.net.Uri
-import android.os.Build
 import android.view.ViewTreeObserver
 import android.webkit.JavascriptInterface
 import android.webkit.JsResult
@@ -369,17 +368,10 @@ internal class StripeConnectWebView private constructor(
         }
 
         override fun onReceivedError(view: WebView, request: WebResourceRequest, error: WebResourceError) {
-            // for some reason errorCode and description are only available in API 23+,
-            // so we simply ignore the description for older devices
-            val errorMessage = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                error.description.toString()
-            } else {
-                null
-            }
             delegate.onReceivedError(
                 requestUrl = request.url.toString(),
                 httpStatusCode = null,
-                errorMessage = errorMessage,
+                errorMessage = error.description.toString(),
                 isMainPageLoad = request.isForMainFrame
             )
         }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/AccountItem.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/AccountItem.kt
@@ -1,8 +1,6 @@
 package com.stripe.android.financialconnections.features.common
 
 import FinancialConnectionsGenericInfoScreen
-import android.os.Build.VERSION.SDK_INT
-import android.os.Build.VERSION_CODES.M
 import android.view.HapticFeedbackConstants.CONTEXT_CLICK
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -82,7 +80,7 @@ internal fun AccountItem(
                 shape = shape
             )
             .clickableSingle(enabled = viewState != Disabled) {
-                if (SDK_INT >= M) view.performHapticFeedback(CONTEXT_CLICK)
+                view.performHapticFeedback(CONTEXT_CLICK)
                 onAccountClicked(account)
             }
             .alpha(viewState.alpha)

--- a/hcaptcha/src/main/java/com/stripe/hcaptcha/webview/HCaptchaWebViewHelper.kt
+++ b/hcaptcha/src/main/java/com/stripe/hcaptcha/webview/HCaptchaWebViewHelper.kt
@@ -4,7 +4,6 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Color
-import android.os.Build
 import android.os.Handler
 import android.util.Log
 import android.view.View
@@ -141,9 +140,7 @@ internal class HCaptchaWebViewHelper(
 
         override fun onReceivedError(view: WebView, request: WebResourceRequest?, error: WebResourceError?) {
             super.onReceivedError(view, request, error)
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                Log.d(LOG_TAG, "[webview] onReceivedError \"${error?.description}\" (${error?.errorCode})")
-            }
+            Log.d(LOG_TAG, "[webview] onReceivedError \"${error?.description}\" (${error?.errorCode})")
         }
     }
 

--- a/payments-core/src/main/java/com/stripe/android/challenge/confirmation/IntentConfirmationWebViewClient.kt
+++ b/payments-core/src/main/java/com/stripe/android/challenge/confirmation/IntentConfirmationWebViewClient.kt
@@ -2,7 +2,6 @@ package com.stripe.android.challenge.confirmation
 
 import android.net.Uri
 import android.net.http.SslError
-import android.os.Build
 import android.webkit.RenderProcessGoneDetail
 import android.webkit.SslErrorHandler
 import android.webkit.WebResourceError
@@ -10,7 +9,6 @@ import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient
-import androidx.annotation.RequiresApi
 
 internal class IntentConfirmationWebViewClient(
     private val hostUrl: String,
@@ -24,7 +22,6 @@ internal class IntentConfirmationWebViewClient(
         return true
     }
 
-    @RequiresApi(Build.VERSION_CODES.M)
     override fun onReceivedError(view: WebView?, request: WebResourceRequest?, error: WebResourceError?) {
         super.onReceivedError(view, request, error)
         if (!urlsMatch(request?.url?.toString(), hostUrl)) return
@@ -33,21 +30,6 @@ internal class IntentConfirmationWebViewClient(
                 message = error?.description?.toString(),
                 errorCode = error?.errorCode,
                 url = request?.url?.toString(),
-                webViewErrorType = "generic_resource_error"
-            )
-        )
-    }
-
-    // Pre-23
-    @Suppress("DEPRECATION")
-    override fun onReceivedError(view: WebView?, errorCode: Int, description: String?, failingUrl: String?) {
-        super.onReceivedError(view, errorCode, description, failingUrl)
-        if (!urlsMatch(failingUrl, hostUrl)) return
-        errorHandler(
-            WebViewError(
-                message = description,
-                errorCode = errorCode,
-                url = failingUrl,
                 webViewErrorType = "generic_resource_error"
             )
         )

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/utils/DrawablePainter.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/utils/DrawablePainter.kt
@@ -18,7 +18,6 @@ package com.stripe.android.paymentsheet.example.utils
 
 import android.graphics.drawable.Animatable
 import android.graphics.drawable.Drawable
-import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.view.View
@@ -102,15 +101,12 @@ class DrawablePainter(
     }
 
     override fun applyLayoutDirection(layoutDirection: LayoutDirection): Boolean {
-        if (Build.VERSION.SDK_INT >= 23) {
-            return drawable.setLayoutDirection(
-                when (layoutDirection) {
-                    LayoutDirection.Ltr -> View.LAYOUT_DIRECTION_LTR
-                    LayoutDirection.Rtl -> View.LAYOUT_DIRECTION_RTL
-                }
-            )
-        }
-        return false
+        return drawable.setLayoutDirection(
+            when (layoutDirection) {
+                LayoutDirection.Ltr -> View.LAYOUT_DIRECTION_LTR
+                LayoutDirection.Rtl -> View.LAYOUT_DIRECTION_RTL
+            }
+        )
     }
 
     override val intrinsicSize: Size get() = drawableIntrinsicSize

--- a/paymentsheet/src/main/java/com/stripe/android/common/ui/DelegateDrawable.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/ui/DelegateDrawable.kt
@@ -69,7 +69,6 @@ class DelegateDrawable(
         delegate.isFilterBitmap = filter
     }
 
-    @RequiresApi(Build.VERSION_CODES.M)
     override fun isFilterBitmap(): Boolean {
         return delegate.isFilterBitmap
     }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/image/DrawablePainter.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/image/DrawablePainter.kt
@@ -6,7 +6,6 @@ import android.graphics.drawable.Animatable
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Drawable
-import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.view.View
@@ -106,15 +105,12 @@ internal class DrawablePainter(
     }
 
     override fun applyLayoutDirection(layoutDirection: LayoutDirection): Boolean {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            return drawable.setLayoutDirection(
-                when (layoutDirection) {
-                    LayoutDirection.Ltr -> View.LAYOUT_DIRECTION_LTR
-                    LayoutDirection.Rtl -> View.LAYOUT_DIRECTION_RTL
-                }
-            )
-        }
-        return false
+        return drawable.setLayoutDirection(
+            when (layoutDirection) {
+                LayoutDirection.Ltr -> View.LAYOUT_DIRECTION_LTR
+                LayoutDirection.Rtl -> View.LAYOUT_DIRECTION_RTL
+            }
+        )
     }
 
     override val intrinsicSize: Size get() = drawableIntrinsicSize


### PR DESCRIPTION
## Summary
- Remove always-true `SDK_INT >= M` checks across 6 files (simplified to just the true branch)
- Remove dead pre-23 code blocks in `DeviceParamNotAvailableFactoryImpl` (`apiVersion < M` and `apiVersion < LOLLIPOP_MR1`)
- Remove deprecated pre-23 `onReceivedError` override in `IntentConfirmationWebViewClient` (also fixes a double-reporting bug where `errorHandler` was called twice for main-frame errors)
- Remove redundant `@RequiresApi(M)` annotation from `DelegateDrawable.isFilterBitmap()`
- Clean up unused imports (`Build`, `Build.VERSION.SDK_INT`, `Build.VERSION_CODES.M`, `RequiresApi`)

## Test plan
- [x] `./gradlew :3ds2sdk:testDebugUnitTest` passes
- [x] `./gradlew :payments-core:testDebugUnitTest` passes
- [x] `./gradlew :paymentsheet:testDebugUnitTest` passes
- [x] `./gradlew :stripe-ui-core:testDebugUnitTest` passes
- [x] `./gradlew :camera-core:testDebugUnitTest` passes
- [x] `./gradlew :connect:testDebugUnitTest` passes
- [x] `./gradlew :financial-connections:testDebugUnitTest` passes
- [x] `./gradlew :hcaptcha:testDebugUnitTest` passes
- [x] `./gradlew detekt` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)