### PR TITLE
Fix discount_amounts parsing to read coupon.name

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParser.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParser.kt
@@ -249,7 +249,7 @@ internal class CheckoutSessionResponseJsonParser(
         return (0 until array.length()).mapNotNull { i ->
             val obj = array.optJSONObject(i) ?: return@mapNotNull null
             val amount = obj.optLong(FIELD_AMOUNT, -1).takeIf { it >= 0 } ?: return@mapNotNull null
-            val displayName = obj.optJSONObject(FIELD_DISCOUNT)?.optString(FIELD_NAME)
+            val displayName = obj.optJSONObject(FIELD_COUPON)?.optString(FIELD_NAME)
                 ?.takeIf { it.isNotEmpty() } ?: return@mapNotNull null
             CheckoutSessionResponse.DiscountAmount(amount = amount, displayName = displayName)
         }
@@ -353,7 +353,7 @@ internal class CheckoutSessionResponseJsonParser(
         private const val FIELD_AMOUNT = "amount"
         private const val FIELD_APPLIED_BALANCE = "applied_balance"
         private const val FIELD_DISCOUNT_AMOUNTS = "discount_amounts"
-        private const val FIELD_DISCOUNT = "discount"
+        private const val FIELD_COUPON = "coupon"
         private const val FIELD_NAME = "name"
         private const val FIELD_TAX_AMOUNTS = "tax_amounts"
         private const val FIELD_INCLUSIVE = "inclusive"

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionFixtures.kt
@@ -425,14 +425,38 @@ internal object CheckoutSessionFixtures {
                 "discount_amounts": [
                     {
                         "amount": 500,
-                        "discount": {
-                            "name": "SUMMER10"
+                        "coupon": {
+                            "object": "coupon",
+                            "name": "SUMMER10",
+                            "amount_off": null,
+                            "currency": null,
+                            "duration": "once",
+                            "duration_in_months": null,
+                            "has_applies_to_products": false,
+                            "percent_off": 10.0
+                        },
+                        "currency": "usd",
+                        "promotion_code": {
+                            "object": "promotion_code",
+                            "code": "SUMMER10"
                         }
                     },
                     {
                         "amount": 250,
-                        "discount": {
-                            "name": "LOYALTY5"
+                        "coupon": {
+                            "object": "coupon",
+                            "name": "LOYALTY5",
+                            "amount_off": null,
+                            "currency": null,
+                            "duration": "once",
+                            "duration_in_months": null,
+                            "has_applies_to_products": false,
+                            "percent_off": 5.0
+                        },
+                        "currency": "usd",
+                        "promotion_code": {
+                            "object": "promotion_code",
+                            "code": "LOYALTY5"
                         }
                     }
                 ],

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParserTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParserTest.kt
@@ -479,4 +479,52 @@ class CheckoutSessionResponseJsonParserTest {
         assertThat(result).isNotNull()
         assertThat(result?.totalSummary).isNull()
     }
+
+    @Test
+    fun `parse discount amounts from coupon field`() {
+        val json = JSONObject(
+            """
+            {
+                "session_id": "cs_test_abc123",
+                "currency": "usd",
+                "total_summary": {
+                    "due": 4099,
+                    "subtotal": 5099,
+                    "total": 4099
+                },
+                "line_item_group": {
+                    "due": 4099,
+                    "subtotal": 5099,
+                    "total": 4099,
+                    "discount_amounts": [
+                        {
+                            "amount": 1000,
+                            "coupon": {
+                                "object": "coupon",
+                                "name": "10OFF",
+                                "amount_off": 1000,
+                                "currency": "usd",
+                                "duration": "once"
+                            },
+                            "currency": "usd",
+                            "promotion_code": {
+                                "object": "promotion_code",
+                                "code": "10OFF"
+                            }
+                        }
+                    ]
+                }
+            }
+            """.trimIndent()
+        )
+        val result = CheckoutSessionResponseJsonParser(isLiveMode = false).parse(json)
+
+        assertThat(result).isNotNull()
+        assertThat(result?.amount).isEqualTo(4099L)
+        val totalSummary = result?.totalSummary
+        assertThat(totalSummary).isNotNull()
+        assertThat(totalSummary?.discountAmounts).hasSize(1)
+        assertThat(totalSummary?.discountAmounts?.get(0)?.amount).isEqualTo(1000L)
+        assertThat(totalSummary?.discountAmounts?.get(0)?.displayName).isEqualTo("10OFF")
+    }
 }

--- a/paymentsheet/src/test/resources/checkout-session-apply-discount.json
+++ b/paymentsheet/src/test/resources/checkout-session-apply-discount.json
@@ -1,0 +1,34 @@
+{
+  "session_id": "cs_test_abc123",
+  "currency": "usd",
+  "total_summary": {
+    "due": 4099,
+    "subtotal": 5099,
+    "total": 4099
+  },
+  "line_item_group": {
+    "due": 4099,
+    "subtotal": 5099,
+    "total": 4099,
+    "discount_amounts": [
+      {
+        "amount": 1000,
+        "coupon": {
+          "object": "coupon",
+          "name": "10OFF",
+          "amount_off": 1000,
+          "currency": "usd",
+          "duration": "once",
+          "duration_in_months": null,
+          "has_applies_to_products": false,
+          "percent_off": null
+        },
+        "currency": "usd",
+        "promotion_code": {
+          "object": "promotion_code",
+          "code": "10OFF"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- The `CheckoutSessionResponseJsonParser` was reading `discount.name` for discount display names, but the real API response nests the name under `coupon.name`
- Updated test fixtures to match the real API response shape
- Added a dedicated parser test for discount amount parsing

## Test plan
- [x] `CheckoutSessionResponseJsonParserTest` passes with all existing and new tests
- [x] Verify discount names display correctly in the checkout playground

🤖 Generated with [Claude Code](https://claude.com/claude-code)