### PR TITLE
Eliminate redundant consumers/sessions/lookup call

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/LinkTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/LinkTest.kt
@@ -15,6 +15,7 @@ import com.stripe.android.networktesting.RequestMatchers.host
 import com.stripe.android.networktesting.RequestMatchers.method
 import com.stripe.android.networktesting.RequestMatchers.not
 import com.stripe.android.networktesting.RequestMatchers.path
+import com.stripe.android.networktesting.ResponseReplacement
 import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentsheet.utils.ProductIntegrationType
 import com.stripe.android.paymentsheet.utils.ProductIntegrationTypeProvider
@@ -1202,5 +1203,54 @@ internal class LinkTest {
                 value = "12oBEhVjc21yKkFYNnhMVTlXbXdBQUFJRmEaJDUzNTFkNjNhLTZkNGMtND"
             ),
         )
+    }
+
+    @Test
+    fun testSingleConsumerLookupWithLinkEnabled() = runProductIntegrationTest(
+        networkRule = networkRule,
+        integrationType = integrationType,
+        resultCallback = ::assertCompleted,
+    ) { testContext ->
+        networkRule.enqueue(
+            host("api.stripe.com"),
+            method("GET"),
+            path("/v1/elements/sessions"),
+        ) { response ->
+            response.testBodyFromFile(
+                filename = "elements-sessions-requires_payment_method_with_horizontal_mode_experiment.json",
+                replacements = listOf(
+                    ResponseReplacement(
+                        "[EXPERIMENT_ASSIGNMENTS_HERE]",
+                        """{ "link_global_holdback": "control" }"""
+                    ),
+                )
+            )
+        }
+
+        // Only ONE lookup should happen (during Link initialization).
+        // The holdback experiment should NOT trigger a second lookup.
+        networkRule.enqueue(
+            method("POST"),
+            path("/v1/consumers/sessions/lookup"),
+        ) { response ->
+            response.testBodyFromFile("consumer-session-lookup-success.json")
+        }
+
+        testContext.launch(
+            configuration = PaymentSheet.Configuration(
+                merchantDisplayName = "Example, Inc.",
+                paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+                defaultBillingDetails = PaymentSheet.BillingDetails(
+                    email = "test@example.com",
+                ),
+            )
+        )
+
+        // PaymentSheet loaded successfully with only one lookup call.
+        // networkRule.validate() (called by the test harness) will fail if
+        // a second consumers/sessions/lookup was attempted.
+        page.waitForCardForm()
+
+        testContext.markTestSucceeded()
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/common/analytics/experiment/LogLinkHoldbackExperiment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/analytics/experiment/LogLinkHoldbackExperiment.kt
@@ -18,6 +18,7 @@ import com.stripe.android.model.ElementsSession.Flag.ELEMENTS_ENABLE_LINK_SPM
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.injection.LinkDisabledApiRepository
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
+import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.paymentsheet.state.RetrieveCustomerEmail
 import kotlinx.coroutines.CoroutineScope
@@ -83,8 +84,19 @@ internal class DefaultLogLinkHoldbackExperiment @Inject constructor(
 
         val defaultValues = state.getDefaultValues()
 
-        val isReturningUser = customerEmail != null &&
-            isReturningUser(email = customerEmail, sessionId = elementsSession.elementsSessionId)
+        val linkState = state.paymentMethodMetadata.linkState
+        val isReturningUser = when {
+            customerEmail == null -> false
+            linkState != null -> {
+                // Link is enabled — the consumer lookup already happened during initialization.
+                // Derive the answer from loginState instead of making a redundant API call.
+                linkState.loginState != LinkState.LoginState.LoggedOut
+            }
+            else -> {
+                // Link is disabled — perform the lookup for experiment logging.
+                isReturningUser(email = customerEmail, sessionId = elementsSession.elementsSessionId)
+            }
+        }
 
         val useLinkNative: Boolean = state.paymentMethodMetadata.linkState?.configuration?.let {
             linkConfigurationCoordinator.linkGate(it).useNativeLink

--- a/paymentsheet/src/test/java/com/stripe/android/common/analytics/experiment/LogLinkGlobalHoldbackExposureTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/analytics/experiment/LogLinkGlobalHoldbackExposureTest.kt
@@ -27,6 +27,7 @@ import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.paymentsheet.state.RetrieveCustomerEmail
 import com.stripe.android.testing.FakeLogger
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.utils.FakeCustomerRepository
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -164,7 +165,7 @@ class LogLinkGlobalHoldbackExposureTest {
     }
 
     @Test
-    fun `invoke should log exposure with returning user when user is returning`() = runTest {
+    fun `invoke should log exposure with returning user when link enabled and user needs verification`() = runTest {
         val elementsSession = createElementsSession(
             experimentsData = ElementsSession.ExperimentsData(
                 arbId = "test_arb_id",
@@ -176,12 +177,76 @@ class LogLinkGlobalHoldbackExposureTest {
         val state = createElementsState(
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                 linkState = LinkState(
-                    // preset link configuration with existing email.
                     configuration = TestFactory.LINK_CONFIGURATION,
                     loginState = LinkState.LoginState.NeedsVerification,
                     signupMode = null
                 )
             )
+        )
+
+        // Set lookup to fail — if the code incorrectly makes an API call,
+        // the test will fail. Link is enabled, so isReturningUser should be
+        // derived from loginState (NeedsVerification != LoggedOut → true).
+        linkRepository.lookupConsumerWithoutBackendLoggingResult =
+            Result.failure(AssertionError("Lookup should not be called when Link is enabled"))
+
+        logLinkHoldbackExperiment(
+            experimentAssignments = listOf(LINK_GLOBAL_HOLD_BACK),
+            elementsSession = elementsSession,
+            state = state
+        )
+
+        val exposureCall = eventReporter.experimentExposureCalls.awaitItem()
+        val experiment = exposureCall.experiment
+        assertTrue(experiment is LoggableExperiment.LinkHoldback)
+        assertThat(experiment.group).isEqualTo("holdback")
+        assertThat(experiment.isReturningLinkUser).isTrue()
+    }
+
+    @Test
+    fun `invoke should not log exposure and log error when link disabled and lookup fails`() = runTest {
+        val elementsSession = createElementsSession(
+            experimentsData = ElementsSession.ExperimentsData(
+                arbId = "test_arb_id",
+                experimentAssignments = mapOf(
+                    LINK_GLOBAL_HOLD_BACK to "holdback"
+                )
+            ),
+        )
+        // Link disabled (no linkState), but email available via config.
+        val state = createElementsState(
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(linkState = null),
+            defaultBillingDetails = PaymentSheet.BillingDetails(email = "test@example.com"),
+        )
+
+        linkRepository.lookupConsumerWithoutBackendLoggingResult = Result.failure<ConsumerSessionLookup>(
+            IllegalArgumentException("Test exception")
+        )
+
+        logLinkHoldbackExperiment(
+            experimentAssignments = listOf(LINK_GLOBAL_HOLD_BACK),
+            elementsSession = elementsSession,
+            state = state
+        )
+
+        eventReporter.experimentExposureCalls.expectNoEvents()
+        assertThat(logger.errorLogs.last().first).isEqualTo("Failed to log Global holdback exposure")
+    }
+
+    @Test
+    fun `invoke should log exposure with returning user when link disabled and lookup succeeds`() = runTest {
+        val elementsSession = createElementsSession(
+            experimentsData = ElementsSession.ExperimentsData(
+                arbId = "test_arb_id",
+                experimentAssignments = mapOf(
+                    LINK_GLOBAL_HOLD_BACK to "holdback"
+                )
+            ),
+        )
+        // Link disabled (no linkState), but email available via config.
+        val state = createElementsState(
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(linkState = null),
+            defaultBillingDetails = PaymentSheet.BillingDetails(email = "test@example.com"),
         )
 
         linkRepository.lookupConsumerWithoutBackendLoggingResult = Result.success(
@@ -200,7 +265,7 @@ class LogLinkGlobalHoldbackExposureTest {
         )
 
         val lookupCall = linkRepository.awaitLookupWithoutBackendLogging()
-        assertEquals(lookupCall.email, TestFactory.LINK_CONFIGURATION.customerInfo.email!!)
+        assertEquals("test@example.com", lookupCall.email)
 
         val exposureCall = eventReporter.experimentExposureCalls.awaitItem()
         val experiment = exposureCall.experiment
@@ -210,7 +275,7 @@ class LogLinkGlobalHoldbackExposureTest {
     }
 
     @Test
-    fun `invoke should not log exposure and log local error if lookup fails`() = runTest {
+    fun `invoke should log exposure with non-returning user when link enabled and user is logged out`() = runTest {
         val elementsSession = createElementsSession(
             experimentsData = ElementsSession.ExperimentsData(
                 arbId = "test_arb_id",
@@ -222,67 +287,24 @@ class LogLinkGlobalHoldbackExposureTest {
         val state = createElementsState(
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                 linkState = LinkState(
-                    // preset link configuration with existing email.
                     configuration = TestFactory.LINK_CONFIGURATION,
-                    loginState = LinkState.LoginState.NeedsVerification,
+                    loginState = LinkState.LoginState.LoggedOut,
                     signupMode = null
                 )
             )
         )
 
-        linkRepository.lookupConsumerWithoutBackendLoggingResult = Result.failure<ConsumerSessionLookup>(
-            IllegalArgumentException("Test exception")
-        )
+        // Set lookup to fail — if the code incorrectly makes an API call,
+        // the test will fail. Link is enabled, so isReturningUser should be
+        // derived from loginState (LoggedOut → false).
+        linkRepository.lookupConsumerWithoutBackendLoggingResult =
+            Result.failure(AssertionError("Lookup should not be called when Link is enabled"))
 
         logLinkHoldbackExperiment(
             experimentAssignments = listOf(LINK_GLOBAL_HOLD_BACK),
             elementsSession = elementsSession,
             state = state
         )
-
-        eventReporter.experimentExposureCalls.expectNoEvents()
-        assertThat(logger.errorLogs.last().first).isEqualTo("Failed to log Global holdback exposure")
-    }
-
-    @Test
-    fun `invoke should log exposure with non-returning user when user is not returning`() = runTest {
-        val elementsSession = createElementsSession(
-            experimentsData = ElementsSession.ExperimentsData(
-                arbId = "test_arb_id",
-                experimentAssignments = mapOf(
-                    LINK_GLOBAL_HOLD_BACK to "holdback"
-                )
-            ),
-        )
-        val state = createElementsState(
-            paymentMethodMetadata = PaymentMethodMetadataFactory.create(
-                linkState = LinkState(
-                    // preset link configuration with existing email.
-                    configuration = TestFactory.LINK_CONFIGURATION,
-                    loginState = LinkState.LoginState.NeedsVerification,
-                    signupMode = null
-                )
-            )
-        )
-
-        linkRepository.lookupConsumerWithoutBackendLoggingResult = Result.success(
-            ConsumerSessionLookup(
-                // simulate a non-returning user
-                exists = false,
-                consumerSession = CONSUMER_SESSION,
-                errorMessage = null,
-                publishableKey = PUBLISHABLE_KEY
-            )
-        )
-
-        logLinkHoldbackExperiment(
-            experimentAssignments = listOf(LINK_GLOBAL_HOLD_BACK),
-            elementsSession = elementsSession,
-            state = state
-        )
-
-        val lookupCall = linkRepository.awaitLookupWithoutBackendLogging()
-        assertEquals(lookupCall.email, TestFactory.LINK_CONFIGURATION.customerInfo.email!!)
 
         val exposureCall = eventReporter.experimentExposureCalls.awaitItem()
         assertTrue(exposureCall.experiment is LoggableExperiment.LinkHoldback)
@@ -491,9 +513,12 @@ class LogLinkGlobalHoldbackExposureTest {
         )
 
     private fun createElementsState(
-        paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create()
+        paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+        defaultBillingDetails: PaymentSheet.BillingDetails? = null,
     ): PaymentElementLoader.State {
-        val configuration = CommonConfigurationFactory.create()
+        val configuration = CommonConfigurationFactory.create(
+            defaultBillingDetails = defaultBillingDetails,
+        )
         return PaymentElementLoader.State(
             config = configuration,
             customer = null,


### PR DESCRIPTION
## Summary
- When Link is enabled with a customer email, eliminates the redundant second `POST /v1/consumers/sessions/lookup` call during initialization by deriving `isReturningUser` from the already-available `linkState.loginState`
- Preserves the API lookup path for the Link-disabled holdback experiment scenario
- Makes `LogLinkHoldbackExperiment.invoke()` a `suspend` function with the caller (`PaymentElementLoader`) managing the non-blocking `launch`, making the fire-and-forget intent explicit at the call site

## Test plan
- [x] Unit tests updated in `LogLinkGlobalHoldbackExposureTest` — covers Link enabled (returning/non-returning via loginState), Link disabled (lookup succeeds/fails), and error cases
- [x] `DefaultPaymentElementLoaderTest` passes (holdback experiment invocation still works)
- [x] Integration test added in `PaymentSheetTest` — enqueues exactly one lookup; `networkRule.validate()` fails if a second occurs
- [x] Detekt passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)