### PR TITLE
Eliminate CustomerRepository.CustomerInfo data class

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/analytics/experiment/LogLinkHoldbackExperiment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/analytics/experiment/LogLinkHoldbackExperiment.kt
@@ -17,7 +17,6 @@ import com.stripe.android.model.ElementsSession.Flag.ELEMENTS_DISABLE_LINK_GLOBA
 import com.stripe.android.model.ElementsSession.Flag.ELEMENTS_ENABLE_LINK_SPM
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.injection.LinkDisabledApiRepository
-import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.paymentsheet.state.RetrieveCustomerEmail
@@ -181,12 +180,7 @@ internal class DefaultLogLinkHoldbackExperiment @Inject constructor(
     private suspend fun PaymentElementLoader.State.getEmail(): String? =
         paymentMethodMetadata.linkState?.configuration?.customerInfo?.email ?: retrieveCustomerEmail(
             configuration = config,
-            customer = paymentMethodMetadata.customerMetadata?.let { customerMetadata ->
-                CustomerRepository.CustomerInfo(
-                    id = customerMetadata.id,
-                    ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
-                    customerSessionClientSecret = customerMetadata.customerSessionClientSecret
-                )
-            }
+            customerId = paymentMethodMetadata.customerMetadata?.id,
+            ephemeralKeySecret = paymentMethodMetadata.customerMetadata?.ephemeralKeySecret,
         )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/StripeCustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/StripeCustomerAdapter.kt
@@ -67,11 +67,8 @@ internal class StripeCustomerAdapter @Inject internal constructor(
 
         return getCustomerEphemeralKey().map { customerEphemeralKey ->
             customerRepository.getPaymentMethods(
-                customerInfo = CustomerRepository.CustomerInfo(
-                    id = customerEphemeralKey.customerId,
-                    ephemeralKeySecret = customerEphemeralKey.ephemeralKey,
-                    customerSessionClientSecret = null,
-                ),
+                customerId = customerEphemeralKey.customerId,
+                ephemeralKeySecret = customerEphemeralKey.ephemeralKey,
                 types = requestedTypes,
                 silentlyFail = false,
             ).getOrElse {
@@ -88,12 +85,9 @@ internal class StripeCustomerAdapter @Inject internal constructor(
     ): CustomerAdapter.Result<PaymentMethod> {
         return getCustomerEphemeralKey().map { customerEphemeralKey ->
             customerRepository.attachPaymentMethod(
-                customerInfo = CustomerRepository.CustomerInfo(
-                    id = customerEphemeralKey.customerId,
-                    ephemeralKeySecret = customerEphemeralKey.ephemeralKey,
-                    customerSessionClientSecret = null,
-                ),
-                paymentMethodId = paymentMethodId
+                customerId = customerEphemeralKey.customerId,
+                ephemeralKeySecret = customerEphemeralKey.ephemeralKey,
+                paymentMethodId = paymentMethodId,
             ).getOrElse {
                 return CustomerAdapter.Result.failure(
                     cause = it,
@@ -108,11 +102,8 @@ internal class StripeCustomerAdapter @Inject internal constructor(
     ): CustomerAdapter.Result<PaymentMethod> {
         return getCustomerEphemeralKey().mapCatching { customerEphemeralKey ->
             customerRepository.detachPaymentMethod(
-                customerInfo = CustomerRepository.CustomerInfo(
-                    id = customerEphemeralKey.customerId,
-                    ephemeralKeySecret = customerEphemeralKey.ephemeralKey,
-                    customerSessionClientSecret = null,
-                ),
+                customerId = customerEphemeralKey.customerId,
+                ephemeralKeySecret = customerEphemeralKey.ephemeralKey,
                 paymentMethodId = paymentMethodId,
                 canRemoveDuplicates = false,
             ).getOrElse {
@@ -130,13 +121,10 @@ internal class StripeCustomerAdapter @Inject internal constructor(
     ): CustomerAdapter.Result<PaymentMethod> {
         return getCustomerEphemeralKey().mapCatching { customerEphemeralKey ->
             customerRepository.updatePaymentMethod(
-                customerInfo = CustomerRepository.CustomerInfo(
-                    id = customerEphemeralKey.customerId,
-                    ephemeralKeySecret = customerEphemeralKey.ephemeralKey,
-                    customerSessionClientSecret = null,
-                ),
+                customerId = customerEphemeralKey.customerId,
+                ephemeralKeySecret = customerEphemeralKey.ephemeralKey,
                 paymentMethodId = paymentMethodId,
-                params = params
+                params = params,
             ).getOrElse {
                 return CustomerAdapter.Result.failure(
                     cause = it,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSource.kt
@@ -38,11 +38,8 @@ internal class CustomerSessionPaymentMethodDataSource @Inject constructor(
         return withContext(workContext) {
             elementsSessionManager.fetchCustomerSessionEphemeralKey().mapCatching { ephemeralKey ->
                 customerRepository.updatePaymentMethod(
-                    customerInfo = CustomerRepository.CustomerInfo(
-                        id = ephemeralKey.customerId,
-                        ephemeralKeySecret = ephemeralKey.ephemeralKey,
-                        customerSessionClientSecret = ephemeralKey.customerSessionClientSecret,
-                    ),
+                    customerId = ephemeralKey.customerId,
+                    ephemeralKeySecret = ephemeralKey.ephemeralKey,
                     paymentMethodId = paymentMethodId,
                     params = params,
                 ).getOrThrow()
@@ -65,13 +62,11 @@ internal class CustomerSessionPaymentMethodDataSource @Inject constructor(
         return withContext(workContext) {
             elementsSessionManager.fetchCustomerSessionEphemeralKey().mapCatching { ephemeralKey ->
                 customerRepository.detachPaymentMethod(
-                    customerInfo = CustomerRepository.CustomerInfo(
-                        id = ephemeralKey.customerId,
-                        ephemeralKeySecret = ephemeralKey.ephemeralKey,
-                        customerSessionClientSecret = ephemeralKey.customerSessionClientSecret,
-                    ),
-                    canRemoveDuplicates = true,
+                    customerId = ephemeralKey.customerId,
+                    ephemeralKeySecret = ephemeralKey.ephemeralKey,
+                    customerSessionClientSecret = ephemeralKey.customerSessionClientSecret,
                     paymentMethodId = paymentMethodId,
+                    canRemoveDuplicates = true,
                 ).getOrThrow()
             }.toCustomerSheetDataResult()
         }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSource.kt
@@ -98,12 +98,9 @@ internal class CustomerSessionSavedSelectionDataSource @Inject constructor(
     ) {
         val paymentMethodId = (selection as? SavedSelection.PaymentMethod)?.id
         customerRepository.setDefaultPaymentMethod(
+            customerId = ephemeralKey.customerId,
+            ephemeralKeySecret = ephemeralKey.ephemeralKey,
             paymentMethodId = paymentMethodId,
-            customerInfo = CustomerRepository.CustomerInfo(
-                id = ephemeralKey.customerId,
-                ephemeralKeySecret = ephemeralKey.ephemeralKey,
-                customerSessionClientSecret = ephemeralKey.customerSessionClientSecret,
-            )
         ).getOrThrow()
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutator.kt
@@ -10,7 +10,6 @@ import com.stripe.android.model.PaymentMethodUpdateParams
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
-import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.repositories.SavedPaymentMethodAccess
 import com.stripe.android.paymentsheet.repositories.SavedPaymentMethodRepository
 import com.stripe.android.paymentsheet.ui.DefaultAddPaymentMethodInteractor
@@ -468,11 +467,9 @@ private fun PaymentMethodMetadata.toAccess(): SavedPaymentMethodAccess? {
             sessionId = integration.id,
         )
         else -> SavedPaymentMethodAccess.Customer(
-            info = CustomerRepository.CustomerInfo(
-                id = cm.id,
-                ephemeralKeySecret = cm.ephemeralKeySecret,
-                customerSessionClientSecret = cm.customerSessionClientSecret,
-            ),
+            id = cm.id,
+            ephemeralKeySecret = cm.ephemeralKeySecret,
+            customerSessionClientSecret = cm.customerSessionClientSecret,
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerApiRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerApiRepository.kt
@@ -37,20 +37,22 @@ internal class CustomerApiRepository @Inject constructor(
 ) : CustomerRepository {
 
     override suspend fun retrieveCustomer(
-        customerInfo: CustomerRepository.CustomerInfo
+        customerId: String,
+        ephemeralKeySecret: String,
     ): Customer? {
         return stripeRepository.retrieveCustomer(
-            customerInfo.id,
+            customerId,
             productUsageTokens,
             ApiRequest.Options(
-                customerInfo.ephemeralKeySecret,
+                ephemeralKeySecret,
                 lazyPaymentConfig.get().stripeAccountId
             )
         ).getOrNull()
     }
 
     override suspend fun getPaymentMethods(
-        customerInfo: CustomerRepository.CustomerInfo,
+        customerId: String,
+        ephemeralKeySecret: String,
         types: List<PaymentMethod.Type>,
         silentlyFail: Boolean,
     ): Result<List<PaymentMethod>> = withContext(workContext) {
@@ -64,13 +66,13 @@ internal class CustomerApiRepository @Inject constructor(
             async {
                 stripeRepository.getPaymentMethods(
                     listPaymentMethodsParams = ListPaymentMethodsParams(
-                        customerId = customerInfo.id,
+                        customerId = customerId,
                         limit = 100,
                         paymentMethodType = paymentMethodType,
                     ),
                     productUsageTokens = productUsageTokens,
                     requestOptions = ApiRequest.Options(
-                        apiKey = customerInfo.ephemeralKeySecret,
+                        apiKey = ephemeralKeySecret,
                         stripeAccount = lazyPaymentConfig.get().stripeAccountId,
                     ),
                 ).onFailure {
@@ -103,36 +105,70 @@ internal class CustomerApiRepository @Inject constructor(
     }
 
     override suspend fun detachPaymentMethod(
-        customerInfo: CustomerRepository.CustomerInfo,
+        customerId: String,
+        ephemeralKeySecret: String,
         paymentMethodId: String,
-        canRemoveDuplicates: Boolean
+        canRemoveDuplicates: Boolean,
     ): Result<PaymentMethod> {
+        val requestOptions = ApiRequest.Options(
+            apiKey = ephemeralKeySecret,
+            stripeAccount = lazyPaymentConfig.get().stripeAccountId,
+        )
+
+        val detachOne: suspend (String) -> Result<PaymentMethod> = { pmId ->
+            stripeRepository.detachPaymentMethod(
+                productUsageTokens = productUsageTokens,
+                paymentMethodId = pmId,
+                requestOptions = requestOptions,
+            )
+        }
+
         val result = if (canRemoveDuplicates) {
             detachPaymentMethodAndDuplicates(
-                customerInfo,
-                paymentMethodId
+                customerId = customerId,
+                ephemeralKeySecret = ephemeralKeySecret,
+                paymentMethodId = paymentMethodId,
+                detachOne = detachOne,
             )
         } else {
-            if (customerInfo.customerSessionClientSecret != null) {
-                stripeRepository.detachPaymentMethod(
-                    customerSessionClientSecret = customerInfo.customerSessionClientSecret,
-                    productUsageTokens = productUsageTokens,
-                    paymentMethodId = paymentMethodId,
-                    requestOptions = ApiRequest.Options(
-                        apiKey = customerInfo.ephemeralKeySecret,
-                        stripeAccount = lazyPaymentConfig.get().stripeAccountId,
-                    )
-                )
-            } else {
-                stripeRepository.detachPaymentMethod(
-                    productUsageTokens = productUsageTokens,
-                    paymentMethodId = paymentMethodId,
-                    requestOptions = ApiRequest.Options(
-                        apiKey = customerInfo.ephemeralKeySecret,
-                        stripeAccount = lazyPaymentConfig.get().stripeAccountId,
-                    )
-                )
-            }
+            detachOne(paymentMethodId)
+        }
+
+        return result.onFailure {
+            logger.error("Failed to detach payment method $paymentMethodId.", it)
+        }
+    }
+
+    override suspend fun detachPaymentMethod(
+        customerId: String,
+        ephemeralKeySecret: String,
+        customerSessionClientSecret: String,
+        paymentMethodId: String,
+        canRemoveDuplicates: Boolean,
+    ): Result<PaymentMethod> {
+        val requestOptions = ApiRequest.Options(
+            apiKey = ephemeralKeySecret,
+            stripeAccount = lazyPaymentConfig.get().stripeAccountId,
+        )
+
+        val detachOne: suspend (String) -> Result<PaymentMethod> = { pmId ->
+            stripeRepository.detachPaymentMethod(
+                customerSessionClientSecret = customerSessionClientSecret,
+                productUsageTokens = productUsageTokens,
+                paymentMethodId = pmId,
+                requestOptions = requestOptions,
+            )
+        }
+
+        val result = if (canRemoveDuplicates) {
+            detachPaymentMethodAndDuplicates(
+                customerId = customerId,
+                ephemeralKeySecret = ephemeralKeySecret,
+                paymentMethodId = paymentMethodId,
+                detachOne = detachOne,
+            )
+        } else {
+            detachOne(paymentMethodId)
         }
 
         return result.onFailure {
@@ -141,15 +177,16 @@ internal class CustomerApiRepository @Inject constructor(
     }
 
     override suspend fun attachPaymentMethod(
-        customerInfo: CustomerRepository.CustomerInfo,
-        paymentMethodId: String
+        customerId: String,
+        ephemeralKeySecret: String,
+        paymentMethodId: String,
     ): Result<PaymentMethod> =
         stripeRepository.attachPaymentMethod(
-            customerId = customerInfo.id,
+            customerId = customerId,
             productUsageTokens = productUsageTokens,
             paymentMethodId = paymentMethodId,
             requestOptions = ApiRequest.Options(
-                apiKey = customerInfo.ephemeralKeySecret,
+                apiKey = ephemeralKeySecret,
                 stripeAccount = lazyPaymentConfig.get().stripeAccountId,
             )
         ).onFailure {
@@ -157,7 +194,8 @@ internal class CustomerApiRepository @Inject constructor(
         }
 
     override suspend fun updatePaymentMethod(
-        customerInfo: CustomerRepository.CustomerInfo,
+        customerId: String,
+        ephemeralKeySecret: String,
         paymentMethodId: String,
         params: PaymentMethodUpdateParams,
     ): Result<PaymentMethod> =
@@ -165,7 +203,7 @@ internal class CustomerApiRepository @Inject constructor(
             paymentMethodId = paymentMethodId,
             paymentMethodUpdateParams = params,
             options = ApiRequest.Options(
-                apiKey = customerInfo.ephemeralKeySecret,
+                apiKey = ephemeralKeySecret,
                 stripeAccount = lazyPaymentConfig.get().stripeAccountId,
             )
         ).onFailure {
@@ -173,13 +211,14 @@ internal class CustomerApiRepository @Inject constructor(
         }
 
     override suspend fun setDefaultPaymentMethod(
-        customerInfo: CustomerRepository.CustomerInfo,
-        paymentMethodId: String?
+        customerId: String,
+        ephemeralKeySecret: String,
+        paymentMethodId: String?,
     ): Result<Customer> = stripeRepository.setDefaultPaymentMethod(
         paymentMethodId = paymentMethodId,
-        customerId = customerInfo.id,
+        customerId = customerId,
         options = ApiRequest.Options(
-            apiKey = customerInfo.ephemeralKeySecret,
+            apiKey = ephemeralKeySecret,
             stripeAccount = lazyPaymentConfig.get().stripeAccountId,
         )
     )
@@ -226,17 +265,22 @@ internal class CustomerApiRepository @Inject constructor(
      *
      * This function should eventually be replaced by an endpoint that does this logic in the backend.
      *
-     * @param customerInfo authentication information that can perform detaching operations.
+     * @param customerId the customer's ID
+     * @param ephemeralKeySecret the ephemeral key secret
      * @param paymentMethodId the id of the payment method to remove and to compare with for stored duplicates
+     * @param detachOne a function that detaches a single payment method by its ID
      *
      * @return a result containing the requested payment method to remove
      */
-    private suspend fun CustomerRepository.detachPaymentMethodAndDuplicates(
-        customerInfo: CustomerRepository.CustomerInfo,
+    private suspend fun detachPaymentMethodAndDuplicates(
+        customerId: String,
+        ephemeralKeySecret: String,
         paymentMethodId: String,
+        detachOne: suspend (String) -> Result<PaymentMethod>,
     ): Result<PaymentMethod> = with(CoroutineScope(workContext)) {
         val paymentMethods = getPaymentMethods(
-            customerInfo = customerInfo,
+            customerId = customerId,
+            ephemeralKeySecret = ephemeralKeySecret,
             // We only support removing duplicate cards.
             types = listOf(PaymentMethod.Type.Card),
             silentlyFail = false,
@@ -251,11 +295,7 @@ internal class CustomerApiRepository @Inject constructor(
              * If we don't find the requested payment method in the retrieved list, attempt remove it anyways. It
              * could be that the payment method is not a card but a saved US Bank Account or SEPA Debit PM.
              */
-            return@with detachPaymentMethod(
-                customerInfo = customerInfo,
-                paymentMethodId = paymentMethodId,
-                canRemoveDuplicates = false,
-            )
+            return@with detachOne(paymentMethodId)
         }
 
         /*
@@ -275,11 +315,7 @@ internal class CustomerApiRepository @Inject constructor(
          */
         val paymentMethodAsyncRemovals = paymentMethodsToRemove.map { paymentMethod ->
             async {
-                detachPaymentMethod(
-                    customerInfo = customerInfo,
-                    paymentMethodId = paymentMethod.id,
-                    canRemoveDuplicates = false,
-                ).onFailure { exception ->
+                detachOne(paymentMethod.id).onFailure { exception ->
                     failureResults.add(
                         DuplicatePaymentMethodDetachFailureException.DuplicateDetachFailure(
                             paymentMethodId = paymentMethod.id,
@@ -297,10 +333,6 @@ internal class CustomerApiRepository @Inject constructor(
         }
 
         // Remove the original payment method
-        return detachPaymentMethod(
-            customerInfo = customerInfo,
-            paymentMethodId = paymentMethodId,
-            canRemoveDuplicates = false,
-        )
+        return detachOne(paymentMethodId)
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerRepository.kt
@@ -11,7 +11,10 @@ internal interface CustomerRepository {
     /**
      * Retrieve a Customer by ID using an ephemeral key.
      */
-    suspend fun retrieveCustomer(customerInfo: CustomerInfo): Customer?
+    suspend fun retrieveCustomer(
+        customerId: String,
+        ephemeralKeySecret: String,
+    ): Customer?
 
     /**
      * Retrieve a Customer's payment methods of all types requested.
@@ -19,42 +22,52 @@ internal interface CustomerRepository {
      * types that failed.
      */
     suspend fun getPaymentMethods(
-        customerInfo: CustomerInfo,
+        customerId: String,
+        ephemeralKeySecret: String,
         types: List<PaymentMethod.Type>,
         silentlyFail: Boolean,
     ): Result<List<PaymentMethod>>
 
     /**
-     * Detach a payment method from the Customer and return the modified [PaymentMethod].
+     * Detach a payment method from the Customer using a legacy ephemeral key.
      */
     suspend fun detachPaymentMethod(
-        customerInfo: CustomerInfo,
+        customerId: String,
+        ephemeralKeySecret: String,
         paymentMethodId: String,
-        canRemoveDuplicates: Boolean
+        canRemoveDuplicates: Boolean,
+    ): Result<PaymentMethod>
+
+    /**
+     * Detach a payment method from the Customer using a customer session.
+     */
+    suspend fun detachPaymentMethod(
+        customerId: String,
+        ephemeralKeySecret: String,
+        customerSessionClientSecret: String,
+        paymentMethodId: String,
+        canRemoveDuplicates: Boolean,
     ): Result<PaymentMethod>
 
     /**
      * Attach a payment method to the Customer and return the modified [PaymentMethod].
      */
     suspend fun attachPaymentMethod(
-        customerInfo: CustomerInfo,
-        paymentMethodId: String
+        customerId: String,
+        ephemeralKeySecret: String,
+        paymentMethodId: String,
     ): Result<PaymentMethod>
 
     suspend fun updatePaymentMethod(
-        customerInfo: CustomerInfo,
+        customerId: String,
+        ephemeralKeySecret: String,
         paymentMethodId: String,
-        params: PaymentMethodUpdateParams
+        params: PaymentMethodUpdateParams,
     ): Result<PaymentMethod>
 
     suspend fun setDefaultPaymentMethod(
-        customerInfo: CustomerInfo,
+        customerId: String,
+        ephemeralKeySecret: String,
         paymentMethodId: String?,
     ): Result<Customer>
-
-    data class CustomerInfo(
-        val id: String,
-        val ephemeralKeySecret: String,
-        val customerSessionClientSecret: String?,
-    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/SavedPaymentMethodRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/SavedPaymentMethodRepository.kt
@@ -11,7 +11,9 @@ import javax.inject.Inject
  */
 internal sealed interface SavedPaymentMethodAccess {
     data class Customer(
-        val info: CustomerRepository.CustomerInfo,
+        val id: String,
+        val ephemeralKeySecret: String,
+        val customerSessionClientSecret: String?,
     ) : SavedPaymentMethodAccess
 
     data class CheckoutSession(
@@ -62,11 +64,22 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
             }
         }
         is SavedPaymentMethodAccess.Customer -> {
-            customerRepository.detachPaymentMethod(
-                customerInfo = access.info,
-                paymentMethodId = paymentMethodId,
-                canRemoveDuplicates = canRemoveDuplicates,
-            )
+            if (access.customerSessionClientSecret != null) {
+                customerRepository.detachPaymentMethod(
+                    customerId = access.id,
+                    ephemeralKeySecret = access.ephemeralKeySecret,
+                    customerSessionClientSecret = access.customerSessionClientSecret,
+                    paymentMethodId = paymentMethodId,
+                    canRemoveDuplicates = canRemoveDuplicates,
+                )
+            } else {
+                customerRepository.detachPaymentMethod(
+                    customerId = access.id,
+                    ephemeralKeySecret = access.ephemeralKeySecret,
+                    paymentMethodId = paymentMethodId,
+                    canRemoveDuplicates = canRemoveDuplicates,
+                )
+            }
         }
     }
 
@@ -80,7 +93,8 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
         }
         is SavedPaymentMethodAccess.Customer -> {
             customerRepository.updatePaymentMethod(
-                customerInfo = access.info,
+                customerId = access.id,
+                ephemeralKeySecret = access.ephemeralKeySecret,
                 paymentMethodId = paymentMethodId,
                 params = params,
             )
@@ -96,7 +110,8 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
         }
         is SavedPaymentMethodAccess.Customer -> {
             customerRepository.setDefaultPaymentMethod(
-                customerInfo = access.info,
+                customerId = access.id,
+                ephemeralKeySecret = access.ephemeralKeySecret,
                 paymentMethodId = paymentMethodId,
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CreateLinkState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CreateLinkState.kt
@@ -24,7 +24,6 @@ import com.stripe.android.paymentelement.confirmation.utils.sellerBusinessName
 import com.stripe.android.payments.financialconnections.GetFinancialConnectionsAvailability
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
-import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
@@ -32,7 +31,8 @@ internal interface CreateLinkState {
     suspend operator fun invoke(
         elementsSession: ElementsSession,
         configuration: CommonConfiguration,
-        customer: CustomerRepository.CustomerInfo?,
+        customerId: String?,
+        ephemeralKeySecret: String?,
         initializationMode: PaymentElementLoader.InitializationMode,
         clientAttributionMetadata: ClientAttributionMetadata,
     ): LinkStateResult
@@ -70,7 +70,8 @@ internal class DefaultCreateLinkState @Inject constructor(
     override suspend fun invoke(
         elementsSession: ElementsSession,
         configuration: CommonConfiguration,
-        customer: CustomerRepository.CustomerInfo?,
+        customerId: String?,
+        ephemeralKeySecret: String?,
         initializationMode: PaymentElementLoader.InitializationMode,
         clientAttributionMetadata: ClientAttributionMetadata,
     ): LinkStateResult {
@@ -86,7 +87,8 @@ internal class DefaultCreateLinkState @Inject constructor(
 
         val linkConfiguration = createLinkConfigurationWithoutValidation(
             configuration = configuration,
-            customer = customer,
+            customerId = customerId,
+            ephemeralKeySecret = ephemeralKeySecret,
             elementsSession = elementsSession,
             initializationMode = initializationMode,
             clientAttributionMetadata = clientAttributionMetadata,
@@ -201,7 +203,8 @@ internal class DefaultCreateLinkState @Inject constructor(
     // Validation is done in getLinkDisabledReasons.
     private suspend fun createLinkConfigurationWithoutValidation(
         configuration: CommonConfiguration,
-        customer: CustomerRepository.CustomerInfo?,
+        customerId: String?,
+        ephemeralKeySecret: String?,
         elementsSession: ElementsSession,
         initializationMode: PaymentElementLoader.InitializationMode,
         clientAttributionMetadata: ClientAttributionMetadata,
@@ -214,7 +217,8 @@ internal class DefaultCreateLinkState @Inject constructor(
         val customerPhone = getCustomerPhone(shippingDetails, configuration)
         val customerEmail = retrieveCustomerEmail(
             configuration = configuration,
-            customer = customer
+            customerId = customerId,
+            ephemeralKeySecret = ephemeralKeySecret,
         )
         val customerInfo = LinkConfiguration.CustomerInfo(
             name = configuration.defaultBillingDetails?.name,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/LoadSession.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/LoadSession.kt
@@ -7,7 +7,6 @@ import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
-import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
 import javax.inject.Inject
 
@@ -144,17 +143,14 @@ internal sealed interface CustomerInfo {
     ) : CustomerInfo
 }
 
-internal fun CustomerInfo.toCustomerInfo(): CustomerRepository.CustomerInfo? = when (this) {
-    is CustomerInfo.CustomerSession -> CustomerRepository.CustomerInfo(
-        id = id,
-        ephemeralKeySecret = ephemeralKeySecret,
-        customerSessionClientSecret = customerSessionClientSecret,
-    )
-    is CustomerInfo.Legacy -> CustomerRepository.CustomerInfo(
-        id = id,
-        ephemeralKeySecret = ephemeralKeySecret,
-        customerSessionClientSecret = null,
-    )
-    // Checkout sessions don't use ephemeral keys for customer API calls.
+internal fun CustomerInfo.customerIdOrNull(): String? = when (this) {
+    is CustomerInfo.CustomerSession -> id
+    is CustomerInfo.Legacy -> id
+    is CustomerInfo.CheckoutSession -> null
+}
+
+internal fun CustomerInfo.ephemeralKeySecretOrNull(): String? = when (this) {
+    is CustomerInfo.CustomerSession -> ephemeralKeySecret
+    is CustomerInfo.Legacy -> ephemeralKeySecret
     is CustomerInfo.CheckoutSession -> null
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -310,7 +310,8 @@ internal class DefaultPaymentElementLoader @Inject constructor(
             createLinkState(
                 elementsSession = elementsSession,
                 configuration = configuration,
-                customer = customerInfo?.toCustomerInfo(),
+                customerId = customerInfo?.customerIdOrNull(),
+                ephemeralKeySecret = customerInfo?.ephemeralKeySecretOrNull(),
                 initializationMode = initializationMode,
                 clientAttributionMetadata = clientAttributionMetadata,
             )
@@ -609,11 +610,8 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         val customerSessionClientSecret = customerSession?.customerSessionClientSecret
 
         val paymentMethods = customerRepository.getPaymentMethods(
-            customerInfo = CustomerRepository.CustomerInfo(
-                id = customerConfig.id,
-                ephemeralKeySecret = customerConfig.ephemeralKeySecret,
-                customerSessionClientSecret = customerSessionClientSecret,
-            ),
+            customerId = customerConfig.id,
+            ephemeralKeySecret = customerConfig.ephemeralKeySecret,
             types = paymentMethodTypes,
             silentlyFail = metadata.stripeIntent.isLiveMode,
         ).getOrThrow()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/RetrieveCustomerEmail.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/RetrieveCustomerEmail.kt
@@ -12,14 +12,16 @@ import javax.inject.Inject
  *
  * @param customerRepository The repository to fetch customer information.
  * @param configuration The common configuration containing default billing details.
- * @param customer The customer information to retrieve the email from.
+ * @param customerId The customer ID to retrieve the email from.
+ * @param ephemeralKeySecret The ephemeral key secret to authenticate the request.
  * @return The customer's email if available, otherwise null.
  */
 internal interface RetrieveCustomerEmail {
 
     suspend operator fun invoke(
         configuration: CommonConfiguration,
-        customer: CustomerRepository.CustomerInfo?
+        customerId: String?,
+        ephemeralKeySecret: String?,
     ): String?
 }
 
@@ -29,9 +31,17 @@ internal class DefaultRetrieveCustomerEmail @Inject constructor(
 
     override suspend operator fun invoke(
         configuration: CommonConfiguration,
-        customer: CustomerRepository.CustomerInfo?
+        customerId: String?,
+        ephemeralKeySecret: String?,
     ): String? {
         return configuration.defaultBillingDetails?.email
-            ?: customer?.let { customerRepository.retrieveCustomer(it) }?.email
+            ?: if (customerId != null && ephemeralKeySecret != null) {
+                customerRepository.retrieveCustomer(
+                    customerId = customerId,
+                    ephemeralKeySecret = ephemeralKeySecret,
+                )?.email
+            } else {
+                null
+            }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
@@ -191,7 +191,8 @@ class CustomerAdapterTest {
     fun `retrievePaymentMethods filters with paymentMethodTypes`() = runTest {
         val customerRepository = mock<CustomerRepository>()
 
-        whenever(customerRepository.getPaymentMethods(any(), any(), any())).thenReturn(Result.success(emptyList()))
+        whenever(customerRepository.getPaymentMethods(any(), any(), any(), any()))
+            .thenReturn(Result.success(emptyList()))
 
         val adapter = createAdapter(
             customerRepository = customerRepository,
@@ -199,7 +200,8 @@ class CustomerAdapterTest {
         )
         adapter.retrievePaymentMethods()
         verify(customerRepository).getPaymentMethods(
-            customerInfo = any(),
+            customerId = any(),
+            ephemeralKeySecret = any(),
             types = eq(
                 listOf(
                     PaymentMethod.Type.Card,
@@ -248,7 +250,8 @@ class CustomerAdapterTest {
         adapter.retrievePaymentMethods()
 
         verify(customerRepository).getPaymentMethods(
-            customerInfo = any(),
+            customerId = any(),
+            ephemeralKeySecret = any(),
             types = eq(
                 listOf(
                     PaymentMethod.Type.Card,

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSourceTest.kt
@@ -101,8 +101,9 @@ class CustomerSessionPaymentMethodDataSourceTest {
         val detachRequest = customerRepository.detachRequests.awaitItem()
 
         assertThat(detachRequest.paymentMethodId).isEqualTo("pm_1")
-        assertThat(detachRequest.customerInfo.id).isEqualTo("cus_1")
-        assertThat(detachRequest.customerInfo.ephemeralKeySecret).isEqualTo("ek_123")
+        assertThat(detachRequest.customerId).isEqualTo("cus_1")
+        assertThat(detachRequest.ephemeralKeySecret).isEqualTo("ek_123")
+        assertThat(detachRequest.customerSessionClientSecret).isEqualTo("cuss_123")
         assertThat(detachRequest.canRemoveDuplicates).isTrue()
 
         assertThat(result).isInstanceOf<CustomerSheetDataResult.Success<PaymentMethod>>()
@@ -193,8 +194,8 @@ class CustomerSessionPaymentMethodDataSourceTest {
         val detachRequest = customerRepository.updateRequests.awaitItem()
 
         assertThat(detachRequest.paymentMethodId).isEqualTo("pm_1")
-        assertThat(detachRequest.customerInfo.id).isEqualTo("cus_1")
-        assertThat(detachRequest.customerInfo.ephemeralKeySecret).isEqualTo("ek_123")
+        assertThat(detachRequest.customerId).isEqualTo("cus_1")
+        assertThat(detachRequest.ephemeralKeySecret).isEqualTo("ek_123")
         assertThat(detachRequest.params).isEqualTo(updateParams)
 
         assertThat(result).isInstanceOf<CustomerSheetDataResult.Success<PaymentMethod>>()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -253,9 +253,9 @@ internal class PaymentSheetViewModelTest {
         val updateRequest = savedPaymentMethodRepository.updateRequests.awaitItem()
         assertThat(updateRequest.access).isInstanceOf(SavedPaymentMethodAccess.Customer::class.java)
         with(updateRequest.access as SavedPaymentMethodAccess.Customer) {
-            assertThat(info.id).isEqualTo("cus_123")
-            assertThat(info.ephemeralKeySecret).isEqualTo("ek_123")
-            assertThat(info.customerSessionClientSecret).isNull()
+            assertThat(id).isEqualTo("cus_123")
+            assertThat(ephemeralKeySecret).isEqualTo("ek_123")
+            assertThat(customerSessionClientSecret).isNull()
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/SavedPaymentMethodMutatorTest.kt
@@ -18,7 +18,6 @@ import com.stripe.android.paymentsheet.PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
-import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.repositories.SavedPaymentMethodAccess
 import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.testing.PaymentMethodFactory
@@ -917,11 +916,9 @@ class SavedPaymentMethodMutatorTest {
                 FakeSavedPaymentMethodRepository.DetachRequest(
                     paymentMethodId = paymentMethod.id,
                     access = SavedPaymentMethodAccess.Customer(
-                        info = CustomerRepository.CustomerInfo(
-                            id = "cus_123",
-                            ephemeralKeySecret = "ek_123",
-                            customerSessionClientSecret = customerSessionClientSecret,
-                        ),
+                        id = "cus_123",
+                        ephemeralKeySecret = "ek_123",
+                        customerSessionClientSecret = customerSessionClientSecret,
                     ),
                     canRemoveDuplicates = shouldRemoveDuplicates,
                 )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerRepositoryTest.kt
@@ -59,11 +59,8 @@ internal class CustomerRepositoryTest {
             )
 
             repository.getPaymentMethods(
-                CustomerRepository.CustomerInfo(
-                    id = "customer_id",
-                    ephemeralKeySecret = "ephemeral_key",
-                    customerSessionClientSecret = null,
-                ),
+                customerId = "customer_id",
+                ephemeralKeySecret = "ephemeral_key",
                 listOf(PaymentMethod.Type.Card),
                 true,
             )
@@ -91,11 +88,8 @@ internal class CustomerRepositoryTest {
             )
 
             repository.getPaymentMethods(
-                CustomerRepository.CustomerInfo(
-                    id = "customer_id",
-                    ephemeralKeySecret = "ephemeral_key",
-                    customerSessionClientSecret = null,
-                ),
+                customerId = "customer_id",
+                ephemeralKeySecret = "ephemeral_key",
                 listOf(PaymentMethod.Type.Card, PaymentMethod.Type.PayPal),
                 true,
             )
@@ -167,11 +161,8 @@ internal class CustomerRepositoryTest {
             }
 
             val result = repository.getPaymentMethods(
-                CustomerRepository.CustomerInfo(
-                    id = "customer_id",
-                    ephemeralKeySecret = "ephemeral_key",
-                    customerSessionClientSecret = null,
-                ),
+                customerId = "customer_id",
+                ephemeralKeySecret = "ephemeral_key",
                 listOf(PaymentMethod.Type.Card),
                 true,
             ).getOrThrow()
@@ -227,11 +218,8 @@ internal class CustomerRepositoryTest {
         }
 
         val result = repository.getPaymentMethods(
-            CustomerRepository.CustomerInfo(
-                id = "customer_id",
-                ephemeralKeySecret = "ephemeral_key",
-                customerSessionClientSecret = null,
-            ),
+            customerId = "customer_id",
+            ephemeralKeySecret = "ephemeral_key",
             listOf(PaymentMethod.Type.Card),
             true,
         ).getOrThrow()
@@ -249,11 +237,8 @@ internal class CustomerRepositoryTest {
             )
 
             val result = repository.getPaymentMethods(
-                CustomerRepository.CustomerInfo(
-                    id = "customer_id",
-                    ephemeralKeySecret = "ephemeral_key",
-                    customerSessionClientSecret = null,
-                ),
+                customerId = "customer_id",
+                ephemeralKeySecret = "ephemeral_key",
                 listOf(PaymentMethod.Type.Card),
                 silentlyFail = true,
             )
@@ -271,11 +256,8 @@ internal class CustomerRepositoryTest {
             )
 
             val result = repository.getPaymentMethods(
-                CustomerRepository.CustomerInfo(
-                    id = "customer_id",
-                    ephemeralKeySecret = "ephemeral_key",
-                    customerSessionClientSecret = null,
-                ),
+                customerId = "customer_id",
+                ephemeralKeySecret = "ephemeral_key",
                 listOf(PaymentMethod.Type.Card),
                 silentlyFail = false,
             )
@@ -300,11 +282,8 @@ internal class CustomerRepositoryTest {
 
             // Requesting 3 payment method types, the first request will fail
             val result = repository.getPaymentMethods(
-                CustomerRepository.CustomerInfo(
-                    id = "customer_id",
-                    ephemeralKeySecret = "ephemeral_key",
-                    customerSessionClientSecret = null,
-                ),
+                customerId = "customer_id",
+                ephemeralKeySecret = "ephemeral_key",
                 listOf(PaymentMethod.Type.Card, PaymentMethod.Type.Card, PaymentMethod.Type.Card),
                 silentlyFail = true,
             )
@@ -336,11 +315,8 @@ internal class CustomerRepositoryTest {
 
             // Requesting 3 payment method types, the first request will fail
             val result = repository.getPaymentMethods(
-                CustomerRepository.CustomerInfo(
-                    id = "customer_id",
-                    ephemeralKeySecret = "ephemeral_key",
-                    customerSessionClientSecret = null,
-                ),
+                customerId = "customer_id",
+                ephemeralKeySecret = "ephemeral_key",
                 listOf(PaymentMethod.Type.Card, PaymentMethod.Type.Card, PaymentMethod.Type.Card),
                 silentlyFail = false,
             )
@@ -366,11 +342,8 @@ internal class CustomerRepositoryTest {
             )
 
             val result = repository.detachPaymentMethod(
-                customerInfo = CustomerRepository.CustomerInfo(
-                    id = "customer_id",
-                    ephemeralKeySecret = "ephemeral_key",
-                    customerSessionClientSecret = null,
-                ),
+                customerId = "customer_id",
+                ephemeralKeySecret = "ephemeral_key",
                 paymentMethodId = "payment_method_id",
                 canRemoveDuplicates = false,
             )
@@ -386,11 +359,8 @@ internal class CustomerRepositoryTest {
             )
 
             val result = repository.detachPaymentMethod(
-                customerInfo = CustomerRepository.CustomerInfo(
-                    id = "customer_id",
-                    ephemeralKeySecret = "ephemeral_key",
-                    customerSessionClientSecret = null,
-                ),
+                customerId = "customer_id",
+                ephemeralKeySecret = "ephemeral_key",
                 paymentMethodId = "payment_method_id",
                 canRemoveDuplicates = false,
             )
@@ -408,11 +378,9 @@ internal class CustomerRepositoryTest {
             )
 
             val result = repository.detachPaymentMethod(
-                customerInfo = CustomerRepository.CustomerInfo(
-                    id = "customer_id",
-                    ephemeralKeySecret = "ephemeral_key",
-                    customerSessionClientSecret = "cuss_123",
-                ),
+                customerId = "customer_id",
+                ephemeralKeySecret = "ephemeral_key",
+                customerSessionClientSecret = "cuss_123",
                 paymentMethodId = "payment_method_id",
                 canRemoveDuplicates = false,
             )
@@ -436,7 +404,8 @@ internal class CustomerRepositoryTest {
             val paymentMethodToRemove = paymentMethodsToRemove.first()
 
             repository.detachPaymentMethod(
-                customerInfo = FAKE_CUSTOMER_INFO,
+                customerId = FAKE_CUSTOMER_ID,
+                ephemeralKeySecret = FAKE_EPHEMERAL_KEY,
                 paymentMethodId = paymentMethodToRemove.id,
                 canRemoveDuplicates = true,
             )
@@ -461,7 +430,8 @@ internal class CustomerRepositoryTest {
             )
 
             repository.detachPaymentMethod(
-                customerInfo = FAKE_CUSTOMER_INFO,
+                customerId = FAKE_CUSTOMER_ID,
+                ephemeralKeySecret = FAKE_EPHEMERAL_KEY,
                 paymentMethodId = usBankAccount.id,
                 canRemoveDuplicates = true,
             )
@@ -485,7 +455,8 @@ internal class CustomerRepositoryTest {
             val paymentMethodToRemove = paymentMethods.first()
 
             repository.detachPaymentMethod(
-                customerInfo = FAKE_CUSTOMER_INFO,
+                customerId = FAKE_CUSTOMER_ID,
+                ephemeralKeySecret = FAKE_EPHEMERAL_KEY,
                 paymentMethodId = paymentMethodToRemove.id,
                 canRemoveDuplicates = false,
             )
@@ -514,7 +485,8 @@ internal class CustomerRepositoryTest {
             )
 
             val result = repository.detachPaymentMethod(
-                customerInfo = FAKE_CUSTOMER_INFO,
+                customerId = FAKE_CUSTOMER_ID,
+                ephemeralKeySecret = FAKE_EPHEMERAL_KEY,
                 paymentMethodId = paymentMethods.first().id,
                 canRemoveDuplicates = true,
             )
@@ -542,12 +514,9 @@ internal class CustomerRepositoryTest {
             )
 
             val result = repository.attachPaymentMethod(
-                CustomerRepository.CustomerInfo(
-                    id = "customer_id",
-                    ephemeralKeySecret = "ephemeral_key",
-                    customerSessionClientSecret = null,
-                ),
-                "payment_method_id"
+                customerId = "customer_id",
+                ephemeralKeySecret = "ephemeral_key",
+                paymentMethodId = "payment_method_id",
             )
 
             assertThat(result).isEqualTo(
@@ -562,12 +531,9 @@ internal class CustomerRepositoryTest {
             givenAttachPaymentMethodReturns(error)
 
             val result = repository.attachPaymentMethod(
-                CustomerRepository.CustomerInfo(
-                    id = "customer_id",
-                    ephemeralKeySecret = "ephemeral_key",
-                    customerSessionClientSecret = null,
-                ),
-                "payment_method_id"
+                customerId = "customer_id",
+                ephemeralKeySecret = "ephemeral_key",
+                paymentMethodId = "payment_method_id",
             )
 
             assertThat(result).isEqualTo(error)
@@ -580,11 +546,8 @@ internal class CustomerRepositoryTest {
             givenUpdatePaymentMethodReturns(success)
 
             val result = repository.updatePaymentMethod(
-                CustomerRepository.CustomerInfo(
-                    id = "customer_id",
-                    ephemeralKeySecret = "ephemeral_key",
-                    customerSessionClientSecret = null,
-                ),
+                customerId = "customer_id",
+                ephemeralKeySecret = "ephemeral_key",
                 paymentMethodId = "payment_method_id",
                 params = PaymentMethodUpdateParams.createCard()
             )
@@ -599,11 +562,8 @@ internal class CustomerRepositoryTest {
             givenUpdatePaymentMethodReturns(error)
 
             val result = repository.updatePaymentMethod(
-                CustomerRepository.CustomerInfo(
-                    id = "customer_id",
-                    ephemeralKeySecret = "ephemeral_key",
-                    customerSessionClientSecret = null,
-                ),
+                customerId = "customer_id",
+                ephemeralKeySecret = "ephemeral_key",
                 paymentMethodId = "payment_method_id",
                 params = PaymentMethodUpdateParams.createCard()
             )
@@ -759,10 +719,7 @@ internal class CustomerRepositoryTest {
     }
 
     private companion object {
-        val FAKE_CUSTOMER_INFO = CustomerRepository.CustomerInfo(
-            id = "customer_id",
-            ephemeralKeySecret = "ek_123",
-            customerSessionClientSecret = null,
-        )
+        const val FAKE_CUSTOMER_ID = "customer_id"
+        const val FAKE_EPHEMERAL_KEY = "ek_123"
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/DefaultSavedPaymentMethodRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/DefaultSavedPaymentMethodRepositoryTest.kt
@@ -102,11 +102,9 @@ class DefaultSavedPaymentMethodRepositoryTest {
         )
 
         private val CUSTOMER_ACCESS = SavedPaymentMethodAccess.Customer(
-            info = CustomerRepository.CustomerInfo(
-                id = "cus_456",
-                ephemeralKeySecret = "ek_456",
-                customerSessionClientSecret = "css_456",
-            ),
+            id = "cus_456",
+            ephemeralKeySecret = "ek_456",
+            customerSessionClientSecret = "css_456",
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultCreateLinkStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultCreateLinkStateTest.kt
@@ -69,7 +69,8 @@ internal class DefaultCreateLinkStateTest {
         createLinkState(
             elementsSession = elementsSession,
             configuration = configuration,
-            customer = null,
+            customerId = null,
+            ephemeralKeySecret = null,
             initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
                 clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value
             ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -721,7 +721,8 @@ internal class DefaultPaymentElementLoaderTest {
     fun `load() with customer should fetch only supported payment method types`() =
         runScenario {
             val customerRepository = mock<CustomerRepository> {
-                whenever(it.getPaymentMethods(any(), any(), any())).thenReturn(Result.success(emptyList()))
+                whenever(it.getPaymentMethods(any<String>(), any(), any(), any()))
+                    .thenReturn(Result.success(emptyList()))
             }
 
             val paymentMethodTypes = listOf(
@@ -748,6 +749,7 @@ internal class DefaultPaymentElementLoaderTest {
             )
 
             verify(customerRepository).getPaymentMethods(
+                any<String>(),
                 any(),
                 capture(paymentMethodTypeCaptor),
                 any(),
@@ -763,7 +765,8 @@ internal class DefaultPaymentElementLoaderTest {
     fun `when allowsDelayedPaymentMethods is false then delayed payment methods are filtered out`() =
         runScenario {
             val customerRepository = mock<CustomerRepository> {
-                whenever(it.getPaymentMethods(any(), any(), any())).thenReturn(Result.success(emptyList()))
+                whenever(it.getPaymentMethods(any<String>(), any(), any(), any()))
+                    .thenReturn(Result.success(emptyList()))
             }
 
             val loader = createPaymentElementLoader(
@@ -788,6 +791,7 @@ internal class DefaultPaymentElementLoaderTest {
             )
 
             verify(customerRepository).getPaymentMethods(
+                any<String>(),
                 any(),
                 capture(paymentMethodTypeCaptor),
                 any(),
@@ -894,9 +898,10 @@ internal class DefaultPaymentElementLoaderTest {
         val result = createPaymentElementLoader(
             customerRepo = object : FakeCustomerRepository() {
                 override suspend fun getPaymentMethods(
-                    customerInfo: CustomerRepository.CustomerInfo,
+                    customerId: String,
+                    ephemeralKeySecret: String,
                     types: List<PaymentMethod.Type>,
-                    silentlyFail: Boolean
+                    silentlyFail: Boolean,
                 ): Result<List<PaymentMethod>> {
                     requestPaymentMethodTypes = types
                     return Result.success(
@@ -3257,11 +3262,8 @@ internal class DefaultPaymentElementLoaderTest {
             )
 
             verify(customerRepository).retrieveCustomer(
-                CustomerRepository.CustomerInfo(
-                    id = "cus_1",
-                    ephemeralKeySecret = "ek_123",
-                    customerSessionClientSecret = "cuss_1",
-                )
+                customerId = "cus_1",
+                ephemeralKeySecret = "ek_123",
             )
 
             assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeCustomerRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeCustomerRepository.kt
@@ -43,24 +43,28 @@ internal open class FakeCustomerRepository(
     var error: Throwable? = null
 
     override suspend fun retrieveCustomer(
-        customerInfo: CustomerRepository.CustomerInfo
+        customerId: String,
+        ephemeralKeySecret: String,
     ): Customer? = onRetrieveCustomer()
 
     override suspend fun getPaymentMethods(
-        customerInfo: CustomerRepository.CustomerInfo,
+        customerId: String,
+        ephemeralKeySecret: String,
         types: List<PaymentMethod.Type>,
         silentlyFail: Boolean,
     ): Result<List<PaymentMethod>> = onGetPaymentMethods()
 
     override suspend fun detachPaymentMethod(
-        customerInfo: CustomerRepository.CustomerInfo,
+        customerId: String,
+        ephemeralKeySecret: String,
         paymentMethodId: String,
         canRemoveDuplicates: Boolean,
     ): Result<PaymentMethod> {
         _detachRequests.add(
             DetachRequest(
                 paymentMethodId = paymentMethodId,
-                customerInfo = customerInfo,
+                customerId = customerId,
+                ephemeralKeySecret = ephemeralKeySecret,
                 canRemoveDuplicates = canRemoveDuplicates,
             )
         )
@@ -68,20 +72,43 @@ internal open class FakeCustomerRepository(
         return onDetachPaymentMethod(paymentMethodId)
     }
 
+    override suspend fun detachPaymentMethod(
+        customerId: String,
+        ephemeralKeySecret: String,
+        customerSessionClientSecret: String,
+        paymentMethodId: String,
+        canRemoveDuplicates: Boolean,
+    ): Result<PaymentMethod> {
+        _detachRequests.add(
+            DetachRequest(
+                paymentMethodId = paymentMethodId,
+                customerId = customerId,
+                ephemeralKeySecret = ephemeralKeySecret,
+                canRemoveDuplicates = canRemoveDuplicates,
+                customerSessionClientSecret = customerSessionClientSecret,
+            )
+        )
+
+        return onDetachPaymentMethod(paymentMethodId)
+    }
+
     override suspend fun attachPaymentMethod(
-        customerInfo: CustomerRepository.CustomerInfo,
-        paymentMethodId: String
+        customerId: String,
+        ephemeralKeySecret: String,
+        paymentMethodId: String,
     ): Result<PaymentMethod> = onAttachPaymentMethod()
 
     override suspend fun updatePaymentMethod(
-        customerInfo: CustomerRepository.CustomerInfo,
+        customerId: String,
+        ephemeralKeySecret: String,
         paymentMethodId: String,
-        params: PaymentMethodUpdateParams
+        params: PaymentMethodUpdateParams,
     ): Result<PaymentMethod> {
         _updateRequests.add(
             UpdateRequest(
                 paymentMethodId = paymentMethodId,
-                customerInfo = customerInfo,
+                customerId = customerId,
+                ephemeralKeySecret = ephemeralKeySecret,
                 params = params,
             )
         )
@@ -90,11 +117,16 @@ internal open class FakeCustomerRepository(
     }
 
     override suspend fun setDefaultPaymentMethod(
-        customerInfo: CustomerRepository.CustomerInfo,
-        paymentMethodId: String?
+        customerId: String,
+        ephemeralKeySecret: String,
+        paymentMethodId: String?,
     ): Result<Customer> {
         _setDefaultPaymentMethodRequests.add(
-            SetDefaultRequest(paymentMethodId = paymentMethodId, customerInfo = customerInfo)
+            SetDefaultRequest(
+                paymentMethodId = paymentMethodId,
+                customerId = customerId,
+                ephemeralKeySecret = ephemeralKeySecret,
+            )
         )
 
         return onSetDefaultPaymentMethod()
@@ -102,18 +134,22 @@ internal open class FakeCustomerRepository(
 
     data class DetachRequest(
         val paymentMethodId: String,
-        val customerInfo: CustomerRepository.CustomerInfo,
+        val customerId: String,
+        val ephemeralKeySecret: String,
         val canRemoveDuplicates: Boolean,
+        val customerSessionClientSecret: String? = null,
     )
 
     data class UpdateRequest(
         val paymentMethodId: String,
-        val customerInfo: CustomerRepository.CustomerInfo,
+        val customerId: String,
+        val ephemeralKeySecret: String,
         val params: PaymentMethodUpdateParams,
     )
 
     data class SetDefaultRequest(
         val paymentMethodId: String?,
-        val customerInfo: CustomerRepository.CustomerInfo,
+        val customerId: String,
+        val ephemeralKeySecret: String,
     )
 }


### PR DESCRIPTION
## Summary
- Remove the `CustomerRepository.CustomerInfo` wrapper data class, replacing it with explicit `customerId: String` and `ephemeralKeySecret: String` parameters on all `CustomerRepository` methods
- Add two `detachPaymentMethod` overloads: one for legacy ephemeral-key flows and one for customer-session flows (with `customerSessionClientSecret`)
- Update all callers (`StripeCustomerAdapter`, `PaymentElementLoader`, `CreateLinkState`, `RetrieveCustomerEmail`, `SavedPaymentMethodMutator`, `LogLinkHoldbackExperiment`, etc.) and their tests

## Motivation
Extracted from #12506. This is a standalone prep refactor that simplifies the `CustomerRepository` interface by removing an unnecessary indirection layer (`CustomerInfo`). Downstream PRs will build on this to further simplify `CustomerMetadata` and `SavedPaymentMethodAccess`.

## Test plan
- [x] `./gradlew :paymentsheet:testDebugUnitTest` — all tests pass
- [x] `./gradlew :paymentsheet:detekt` — no violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)