### PR TITLE
Fix save_payment_method sent for guests in checkout session confirmation

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
@@ -3,6 +3,8 @@ package com.stripe.android.paymentelement.confirmation.intent
 import android.content.Context
 import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.PaymentMethod
@@ -33,6 +35,7 @@ import dagger.assisted.AssistedInject
  */
 internal class CheckoutSessionConfirmationInterceptor @AssistedInject constructor(
     @Assisted private val checkoutSessionId: String,
+    @Assisted private val customerMetadata: CustomerMetadata?,
     @Assisted private val clientAttributionMetadata: ClientAttributionMetadata,
     context: Context,
     private val stripeRepository: StripeRepository,
@@ -41,6 +44,8 @@ internal class CheckoutSessionConfirmationInterceptor @AssistedInject constructo
 ) : IntentConfirmationInterceptor {
 
     private val returnUrl: String = DefaultReturnUrl.create(context).value
+    private val isSaveEnabled: Boolean =
+        customerMetadata?.saveConsent is PaymentMethodSaveConsentBehavior.Enabled
 
     override suspend fun intercept(
         intent: StripeIntent,
@@ -54,7 +59,7 @@ internal class CheckoutSessionConfirmationInterceptor @AssistedInject constructo
             onSuccess = { paymentMethod ->
                 confirmCheckoutSession(
                     paymentMethod = paymentMethod,
-                    savePaymentMethod = confirmationOption.shouldSave,
+                    savePaymentMethod = confirmationOption.shouldSave.takeIf { isSaveEnabled },
                 )
             },
             onFailure = { error ->
@@ -149,6 +154,7 @@ internal class CheckoutSessionConfirmationInterceptor @AssistedInject constructo
     interface Factory {
         fun create(
             checkoutSessionId: String,
+            customerMetadata: CustomerMetadata?,
             clientAttributionMetadata: ClientAttributionMetadata,
         ): CheckoutSessionConfirmationInterceptor
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CustomerSheetConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CustomerSheetConfirmationInterceptor.kt
@@ -4,6 +4,7 @@ import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.core.Logger
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.customersheet.util.isUnverifiedUSBankAccount
+import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.ConfirmPaymentIntentParams
@@ -128,8 +129,7 @@ internal class CustomerSheetIntentConfirmationInterceptorFactory @Inject constru
 ) : IntentConfirmationInterceptor.Factory {
     override suspend fun create(
         integrationMetadata: IntegrationMetadata,
-        customerId: String?,
-        ephemeralKeySecret: String?,
+        customerMetadata: CustomerMetadata?,
         clientAttributionMetadata: ClientAttributionMetadata
     ): IntentConfirmationInterceptor {
         return when (integrationMetadata) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationDefinition.kt
@@ -41,9 +41,8 @@ internal class IntentConfirmationDefinition(
         val interceptor: IntentConfirmationInterceptor
         try {
             interceptor = intentConfirmationInterceptorFactory.create(
-                integrationMetadata = confirmationArgs.paymentMethodMetadata.integrationMetadata,
-                customerId = paymentMethodMetadata.customerMetadata?.id,
-                ephemeralKeySecret = paymentMethodMetadata.customerMetadata?.ephemeralKeySecret,
+                integrationMetadata = paymentMethodMetadata.integrationMetadata,
+                customerMetadata = paymentMethodMetadata.customerMetadata,
                 clientAttributionMetadata = paymentMethodMetadata.clientAttributionMetadata,
             )
         } catch (e: CallbackNotFoundException) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationInterceptor.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentelement.confirmation.intent
 
 import com.stripe.android.SharedPaymentTokenSessionPreview
 import com.stripe.android.core.exception.StripeException
+import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.ConfirmPaymentIntentParams
@@ -30,8 +31,7 @@ internal interface IntentConfirmationInterceptor {
     interface Factory {
         suspend fun create(
             integrationMetadata: IntegrationMetadata,
-            customerId: String?,
-            ephemeralKeySecret: String?,
+            customerMetadata: CustomerMetadata?,
             clientAttributionMetadata: ClientAttributionMetadata,
         ): IntentConfirmationInterceptor
     }
@@ -52,8 +52,7 @@ internal class DefaultIntentConfirmationInterceptorFactory @Inject constructor(
 ) : IntentConfirmationInterceptor.Factory {
     override suspend fun create(
         integrationMetadata: IntegrationMetadata,
-        customerId: String?,
-        ephemeralKeySecret: String?,
+        customerMetadata: CustomerMetadata?,
         clientAttributionMetadata: ClientAttributionMetadata,
     ): IntentConfirmationInterceptor {
         return when (integrationMetadata) {
@@ -70,8 +69,8 @@ internal class DefaultIntentConfirmationInterceptorFactory @Inject constructor(
                 confirmationTokenConfirmationInterceptorFactory.create(
                     intentConfiguration = integrationMetadata.intentConfiguration,
                     createIntentCallback = deferredIntentCallbackRetriever.waitForConfirmationTokenCallback(),
-                    customerId = customerId,
-                    ephemeralKeySecret = ephemeralKeySecret,
+                    customerId = customerMetadata?.id,
+                    ephemeralKeySecret = customerMetadata?.ephemeralKeySecret,
                     clientAttributionMetadata = clientAttributionMetadata,
                 )
             }
@@ -97,6 +96,7 @@ internal class DefaultIntentConfirmationInterceptorFactory @Inject constructor(
             is IntegrationMetadata.CheckoutSession -> {
                 checkoutSessionConfirmationInterceptorFactory.create(
                     checkoutSessionId = integrationMetadata.id,
+                    customerMetadata = customerMetadata,
                     clientAttributionMetadata = clientAttributionMetadata,
                 )
             }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -26,6 +26,7 @@ import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContra
 import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLauncherFactory
 import com.stripe.android.lpmfoundations.luxe.LpmRepositoryTestHelpers
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
+import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.PaymentMethod
@@ -86,8 +87,7 @@ internal object CustomerSheetTestHelper {
             object : IntentConfirmationInterceptor.Factory {
                 override suspend fun create(
                     integrationMetadata: IntegrationMetadata,
-                    customerId: String?,
-                    ephemeralKeySecret: String?,
+                    customerMetadata: CustomerMetadata?,
                     clientAttributionMetadata: ClientAttributionMetadata,
                 ): IntentConfirmationInterceptor {
                     return FakeIntentConfirmationInterceptor().apply {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationUtils.kt
@@ -13,6 +13,7 @@ import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.link.analytics.FakeLinkAnalyticsHelper
 import com.stripe.android.link.analytics.FakeLinkEventsReporter
 import com.stripe.android.link.analytics.LinkEventsReporter
+import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
 import com.stripe.android.model.ClientAttributionMetadata
@@ -53,8 +54,7 @@ import javax.inject.Provider
 @OptIn(SharedPaymentTokenSessionPreview::class)
 internal suspend fun createIntentConfirmationInterceptor(
     integrationMetadata: IntegrationMetadata,
-    customerId: String? = null,
-    ephemeralKeySecret: String? = null,
+    customerMetadata: CustomerMetadata? = null,
     stripeRepository: StripeRepository = object : AbsFakeStripeRepository() {},
     publishableKeyProvider: () -> String = { "pk" },
     errorReporter: ErrorReporter = FakeErrorReporter(),
@@ -143,10 +143,12 @@ internal suspend fun createIntentConfirmationInterceptor(
         checkoutSessionConfirmationInterceptorFactory = object : CheckoutSessionConfirmationInterceptor.Factory {
             override fun create(
                 checkoutSessionId: String,
+                customerMetadata: CustomerMetadata?,
                 clientAttributionMetadata: ClientAttributionMetadata,
             ): CheckoutSessionConfirmationInterceptor {
                 return CheckoutSessionConfirmationInterceptor(
                     checkoutSessionId = checkoutSessionId,
+                    customerMetadata = customerMetadata,
                     clientAttributionMetadata = clientAttributionMetadata,
                     context = ApplicationProvider.getApplicationContext(),
                     stripeRepository = stripeRepository,
@@ -157,8 +159,7 @@ internal suspend fun createIntentConfirmationInterceptor(
         },
     ).create(
         integrationMetadata = integrationMetadata,
-        customerId = customerId,
-        ephemeralKeySecret = ephemeralKeySecret,
+        customerMetadata = customerMetadata,
         clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationDefinitionTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentelement.confirmation
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.ClientAttributionMetadata
@@ -486,8 +487,7 @@ class IntentConfirmationDefinitionTest {
             object : IntentConfirmationInterceptor.Factory {
                 override suspend fun create(
                     integrationMetadata: IntegrationMetadata,
-                    customerId: String?,
-                    ephemeralKeySecret: String?,
+                    customerMetadata: CustomerMetadata?,
                     clientAttributionMetadata: ClientAttributionMetadata,
                 ): IntentConfirmationInterceptor {
                     return FakeIntentConfirmationInterceptor()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/IntentConfirmationFlowTest.kt
@@ -4,6 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.SharedPaymentTokenSessionPreview
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.customersheet.FakeStripeRepository
+import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.ClientAttributionMetadata
@@ -274,8 +275,7 @@ internal class IntentConfirmationFlowTest {
             object : IntentConfirmationInterceptor.Factory {
                 override suspend fun create(
                     integrationMetadata: IntegrationMetadata,
-                    customerId: String?,
-                    ephemeralKeySecret: String?,
+                    customerMetadata: CustomerMetadata?,
                     clientAttributionMetadata: ClientAttributionMetadata,
                 ): IntentConfirmationInterceptor {
                     return createIntentConfirmationInterceptor(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
@@ -5,6 +5,9 @@ import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.isInstanceOf
 import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.PaymentIntent
@@ -33,24 +36,8 @@ import org.robolectric.RobolectricTestRunner
 class CheckoutSessionConfirmationInterceptorTest {
 
     @Test
-    fun `intercept with succeeded payment intent returns Complete action`() = runScenario(
-        createPaymentMethodResult = Result.success(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
-        confirmCheckoutSessionResult = Result.success(
-            createCheckoutSessionResponse(
-                PaymentIntentFactory.create(status = StripeIntent.Status.Succeeded)
-            )
-        ),
-    ) {
-        val result = interceptor.intercept(
-            intent = PaymentIntentFactory.create(),
-            confirmationOption = PaymentMethodConfirmationOption.New(
-                createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
-                optionsParams = null,
-                extraParams = null,
-                shouldSave = false,
-            ),
-            shippingValues = null,
-        )
+    fun `intercept with succeeded payment intent returns Complete action`() = runScenario {
+        val result = interceptNewPm()
 
         assertThat(result).isInstanceOf<ConfirmationDefinition.Action.Complete<IntentConfirmationDefinition.Args>>()
 
@@ -68,23 +55,13 @@ class CheckoutSessionConfirmationInterceptorTest {
 
     @Test
     fun `intercept with requires_action payment intent returns Launch action`() = runScenario(
-        createPaymentMethodResult = Result.success(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
         confirmCheckoutSessionResult = Result.success(
             createCheckoutSessionResponse(
                 PaymentIntentFactory.create(status = StripeIntent.Status.RequiresAction)
             )
         ),
     ) {
-        val result = interceptor.intercept(
-            intent = PaymentIntentFactory.create(),
-            confirmationOption = PaymentMethodConfirmationOption.New(
-                createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
-                optionsParams = null,
-                extraParams = null,
-                shouldSave = false,
-            ),
-            shippingValues = null,
-        )
+        val result = interceptNewPm()
 
         assertThat(result).isInstanceOf<ConfirmationDefinition.Action.Launch<IntentConfirmationDefinition.Args>>()
 
@@ -102,16 +79,7 @@ class CheckoutSessionConfirmationInterceptorTest {
         runScenario(
             createPaymentMethodResult = Result.failure(error),
         ) {
-            val result = interceptor.intercept(
-                intent = PaymentIntentFactory.create(),
-                confirmationOption = PaymentMethodConfirmationOption.New(
-                    createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
-                    optionsParams = null,
-                    extraParams = null,
-                    shouldSave = false,
-                ),
-                shippingValues = null,
-            )
+            val result = interceptNewPm()
 
             assertThat(result).isInstanceOf<ConfirmationDefinition.Action.Fail<IntentConfirmationDefinition.Args>>()
 
@@ -126,19 +94,9 @@ class CheckoutSessionConfirmationInterceptorTest {
         val error = RuntimeException("Checkout session confirmation failed")
 
         runScenario(
-            createPaymentMethodResult = Result.success(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
             confirmCheckoutSessionResult = Result.failure(error),
         ) {
-            val result = interceptor.intercept(
-                intent = PaymentIntentFactory.create(),
-                confirmationOption = PaymentMethodConfirmationOption.New(
-                    createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
-                    optionsParams = null,
-                    extraParams = null,
-                    shouldSave = false,
-                ),
-                shippingValues = null,
-            )
+            val result = interceptNewPm()
 
             assertThat(result).isInstanceOf<ConfirmationDefinition.Action.Fail<IntentConfirmationDefinition.Args>>()
 
@@ -150,21 +108,9 @@ class CheckoutSessionConfirmationInterceptorTest {
 
     @Test
     fun `intercept fails when confirm response has no payment intent`() = runScenario(
-        createPaymentMethodResult = Result.success(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
-        confirmCheckoutSessionResult = Result.success(
-            createCheckoutSessionResponse(paymentIntent = null)
-        ),
+        confirmCheckoutSessionResult = Result.success(createCheckoutSessionResponse(paymentIntent = null)),
     ) {
-        val result = interceptor.intercept(
-            intent = PaymentIntentFactory.create(),
-            confirmationOption = PaymentMethodConfirmationOption.New(
-                createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
-                optionsParams = null,
-                extraParams = null,
-                shouldSave = false,
-            ),
-            shippingValues = null,
-        )
+        val result = interceptNewPm()
 
         assertThat(result).isInstanceOf<ConfirmationDefinition.Action.Fail<IntentConfirmationDefinition.Args>>()
 
@@ -174,21 +120,8 @@ class CheckoutSessionConfirmationInterceptorTest {
     }
 
     @Test
-    fun `intercept with saved payment method and succeeded payment intent returns Complete action`() = runScenario(
-        confirmCheckoutSessionResult = Result.success(
-            createCheckoutSessionResponse(
-                PaymentIntentFactory.create(status = StripeIntent.Status.Succeeded)
-            )
-        ),
-    ) {
-        val result = interceptor.intercept(
-            intent = PaymentIntentFactory.create(),
-            confirmationOption = PaymentMethodConfirmationOption.Saved(
-                paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
-                optionsParams = null,
-            ),
-            shippingValues = null,
-        )
+    fun `intercept with saved payment method and succeeded payment intent returns Complete action`() = runScenario {
+        val result = interceptSavedPm()
 
         assertThat(result).isInstanceOf<ConfirmationDefinition.Action.Complete<IntentConfirmationDefinition.Args>>()
 
@@ -213,14 +146,7 @@ class CheckoutSessionConfirmationInterceptorTest {
                 )
             ),
         ) {
-            val result = interceptor.intercept(
-                intent = PaymentIntentFactory.create(),
-                confirmationOption = PaymentMethodConfirmationOption.Saved(
-                    paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
-                    optionsParams = null,
-                ),
-                shippingValues = null,
-            )
+            val result = interceptSavedPm()
 
             assertThat(result).isInstanceOf<ConfirmationDefinition.Action.Launch<IntentConfirmationDefinition.Args>>()
 
@@ -238,14 +164,7 @@ class CheckoutSessionConfirmationInterceptorTest {
         runScenario(
             confirmCheckoutSessionResult = Result.failure(error),
         ) {
-            val result = interceptor.intercept(
-                intent = PaymentIntentFactory.create(),
-                confirmationOption = PaymentMethodConfirmationOption.Saved(
-                    paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
-                    optionsParams = null,
-                ),
-                shippingValues = null,
-            )
+            val result = interceptSavedPm()
 
             assertThat(result).isInstanceOf<ConfirmationDefinition.Action.Fail<IntentConfirmationDefinition.Args>>()
 
@@ -256,77 +175,59 @@ class CheckoutSessionConfirmationInterceptorTest {
     }
 
     @Test
-    fun `intercept with new payment method passes shouldSave true when save checkbox checked`() = runScenario(
-        createPaymentMethodResult = Result.success(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
-        confirmCheckoutSessionResult = Result.success(
-            createCheckoutSessionResponse(
-                PaymentIntentFactory.create(status = StripeIntent.Status.Succeeded)
-            )
-        ),
+    fun `intercept with new payment method passes shouldSave true when save is enabled and checkbox checked`() =
+        runScenario(
+            customerMetadata = SAVE_ENABLED_CUSTOMER_METADATA,
+        ) {
+            interceptNewPm(shouldSave = true)
+
+            val params = confirmCheckoutSessionCalls.awaitItem().toParamMap()
+            assertThat(params["save_payment_method"]).isEqualTo(true)
+        }
+
+    @Test
+    fun `intercept with new payment method passes shouldSave false when save is enabled and checkbox unchecked`() =
+        runScenario(
+            customerMetadata = SAVE_ENABLED_CUSTOMER_METADATA,
+        ) {
+            interceptNewPm(shouldSave = false)
+
+            val params = confirmCheckoutSessionCalls.awaitItem().toParamMap()
+            assertThat(params["save_payment_method"]).isEqualTo(false)
+        }
+
+    @Test
+    fun `intercept with new payment method omits savePaymentMethod when save is disabled`() = runScenario(
+        customerMetadata = SAVE_DISABLED_CUSTOMER_METADATA,
     ) {
-        interceptor.intercept(
-            intent = PaymentIntentFactory.create(),
-            confirmationOption = PaymentMethodConfirmationOption.New(
-                createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
-                optionsParams = null,
-                extraParams = null,
-                shouldSave = true,
-            ),
-            shippingValues = null,
-        )
+        interceptNewPm()
 
         val params = confirmCheckoutSessionCalls.awaitItem().toParamMap()
-        assertThat(params["save_payment_method"]).isEqualTo(true)
+        assertThat(params).doesNotContainKey("save_payment_method")
     }
 
     @Test
-    fun `intercept with new payment method passes shouldSave false when save checkbox unchecked`() = runScenario(
-        createPaymentMethodResult = Result.success(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
-        confirmCheckoutSessionResult = Result.success(
-            createCheckoutSessionResponse(
-                PaymentIntentFactory.create(status = StripeIntent.Status.Succeeded)
-            )
-        ),
-    ) {
-        interceptor.intercept(
-            intent = PaymentIntentFactory.create(),
-            confirmationOption = PaymentMethodConfirmationOption.New(
-                createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
-                optionsParams = null,
-                extraParams = null,
-                shouldSave = false,
-            ),
-            shippingValues = null,
-        )
+    fun `intercept with new payment method omits savePaymentMethod for guest`() = runScenario {
+        interceptNewPm()
 
         val params = confirmCheckoutSessionCalls.awaitItem().toParamMap()
-        assertThat(params["save_payment_method"]).isEqualTo(false)
+        assertThat(params).doesNotContainKey("save_payment_method")
     }
 
     @Test
-    fun `intercept with saved payment method passes null for savePaymentMethod`() = runScenario(
-        confirmCheckoutSessionResult = Result.success(
-            createCheckoutSessionResponse(
-                PaymentIntentFactory.create(status = StripeIntent.Status.Succeeded)
-            )
-        ),
-    ) {
-        interceptor.intercept(
-            intent = PaymentIntentFactory.create(),
-            confirmationOption = PaymentMethodConfirmationOption.Saved(
-                paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
-                optionsParams = null,
-            ),
-            shippingValues = null,
-        )
+    fun `intercept with saved payment method passes null for savePaymentMethod`() = runScenario {
+        interceptSavedPm()
 
         val params = confirmCheckoutSessionCalls.awaitItem().toParamMap()
         assertThat(params).doesNotContainKey("save_payment_method")
     }
 
     private fun runScenario(
-        createPaymentMethodResult: Result<PaymentMethod> = Result.failure(NotImplementedError()),
-        confirmCheckoutSessionResult: Result<CheckoutSessionResponse> = Result.failure(NotImplementedError()),
+        createPaymentMethodResult: Result<PaymentMethod> = Result.success(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+        confirmCheckoutSessionResult: Result<CheckoutSessionResponse> = Result.success(
+            createCheckoutSessionResponse(PaymentIntentFactory.create(status = StripeIntent.Status.Succeeded))
+        ),
+        customerMetadata: CustomerMetadata? = null,
         block: suspend Scenario.() -> Unit,
     ) {
         val confirmCheckoutSessionCalls = Turbine<ConfirmCheckoutSessionParams>()
@@ -342,6 +243,7 @@ class CheckoutSessionConfirmationInterceptorTest {
 
         val interceptor = CheckoutSessionConfirmationInterceptor(
             checkoutSessionId = "cs_test_123",
+            customerMetadata = customerMetadata,
             clientAttributionMetadata = ClientAttributionMetadata(
                 elementsSessionConfigId = "test_session_id",
                 paymentIntentCreationFlow = PaymentIntentCreationFlow.Standard,
@@ -366,7 +268,22 @@ class CheckoutSessionConfirmationInterceptorTest {
     private data class Scenario(
         val interceptor: CheckoutSessionConfirmationInterceptor,
         val confirmCheckoutSessionCalls: ReceiveTurbine<ConfirmCheckoutSessionParams>,
-    )
+    ) {
+        suspend fun interceptNewPm(
+            shouldSave: Boolean = false,
+        ): ConfirmationDefinition.Action<IntentConfirmationDefinition.Args> = interceptor.intercept(
+            intent = PaymentIntentFactory.create(),
+            confirmationOption = NEW_PM_OPTION.copy(shouldSave = shouldSave),
+            shippingValues = null,
+        )
+
+        suspend fun interceptSavedPm(): ConfirmationDefinition.Action<IntentConfirmationDefinition.Args> =
+            interceptor.intercept(
+                intent = PaymentIntentFactory.create(),
+                confirmationOption = SAVED_PM_OPTION,
+                shippingValues = null,
+            )
+    }
 
     private fun createCheckoutSessionResponse(paymentIntent: PaymentIntent?): CheckoutSessionResponse {
         return CheckoutSessionResponse(
@@ -389,6 +306,28 @@ class CheckoutSessionConfirmationInterceptorTest {
         ): Result<PaymentMethod> {
             return createPaymentMethodResult
         }
+    }
+
+    private companion object {
+        val NEW_PM_OPTION = PaymentMethodConfirmationOption.New(
+            createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+            optionsParams = null,
+            extraParams = null,
+            shouldSave = false,
+        )
+
+        val SAVED_PM_OPTION = PaymentMethodConfirmationOption.Saved(
+            paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+            optionsParams = null,
+        )
+
+        val SAVE_ENABLED_CUSTOMER_METADATA = PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA.copy(
+            saveConsent = PaymentMethodSaveConsentBehavior.Enabled,
+        )
+
+        val SAVE_DISABLED_CUSTOMER_METADATA = PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA.copy(
+            saveConsent = PaymentMethodSaveConsentBehavior.Disabled(overrideAllowRedisplay = null),
+        )
     }
 
     private class FakeConfirmCheckoutSessionRepository(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/ConfirmationInterceptorTestUtil.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/ConfirmationInterceptorTestUtil.kt
@@ -4,6 +4,7 @@ import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.SharedPaymentTokenSessionPreview
 import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
@@ -36,7 +37,7 @@ import javax.inject.Provider
 
 @OptIn(SharedPaymentTokenSessionPreview::class)
 internal data class InterceptorTestScenario(
-    val ephemeralKeySecret: String? = null,
+    val customerMetadata: CustomerMetadata? = null,
     val stripeRepository: StripeRepository = object : AbsFakeStripeRepository() {},
     val publishableKeyProvider: () -> String = { "pk" },
     val errorReporter: ErrorReporter = FakeErrorReporter(),
@@ -54,7 +55,7 @@ internal fun runInterceptorScenario(
 ) = runTest {
     val interceptor = createIntentConfirmationInterceptor(
         integrationMetadata = integrationMetadata,
-        ephemeralKeySecret = scenario.ephemeralKeySecret,
+        customerMetadata = scenario.customerMetadata,
         stripeRepository = scenario.stripeRepository,
         publishableKeyProvider = scenario.publishableKeyProvider,
         errorReporter = scenario.errorReporter,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/ConfirmationTokenConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/ConfirmationTokenConfirmationInterceptorTest.kt
@@ -10,6 +10,7 @@ import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
 import com.stripe.android.model.AndroidVerificationObject
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmationToken
@@ -517,7 +518,7 @@ class ConfirmationTokenConfirmationInterceptorTest {
         runInterceptorScenario(
             integrationMetadata = defaultIntegrationMetadata,
             scenario = InterceptorTestScenario(
-                ephemeralKeySecret = "ek_test_123",
+                customerMetadata = PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA,
                 stripeRepository = object : AbsFakeStripeRepository() {
                     override suspend fun createConfirmationToken(
                         confirmationTokenParams: ConfirmationTokenParams,
@@ -568,7 +569,7 @@ class ConfirmationTokenConfirmationInterceptorTest {
         )
 
         val interceptor = createIntentConfirmationInterceptor(
-            ephemeralKeySecret = "ek_test_123",
+            customerMetadata = PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA,
             integrationMetadata = defaultIntegrationMetadata,
             stripeRepository = object : AbsFakeStripeRepository() {
                 override suspend fun createConfirmationToken(
@@ -747,7 +748,7 @@ class ConfirmationTokenConfirmationInterceptorTest {
         val observedParams = mutableListOf<ConfirmationTokenParams>()
 
         val interceptor = createIntentConfirmationInterceptor(
-            ephemeralKeySecret = "ek_test_123",
+            customerMetadata = PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA,
             integrationMetadata = defaultIntegrationMetadata,
             stripeRepository = object : AbsFakeStripeRepository() {
                 override suspend fun createConfirmationToken(
@@ -793,7 +794,7 @@ class ConfirmationTokenConfirmationInterceptorTest {
         val observedParams = mutableListOf<ConfirmationTokenParams>()
 
         val interceptor = createIntentConfirmationInterceptor(
-            ephemeralKeySecret = "ek_test_123",
+            customerMetadata = PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA,
             integrationMetadata = defaultIntegrationMetadata,
             stripeRepository = object : AbsFakeStripeRepository() {
                 override suspend fun createConfirmationToken(
@@ -839,7 +840,7 @@ class ConfirmationTokenConfirmationInterceptorTest {
         val observedParams = mutableListOf<ConfirmationTokenParams>()
 
         val interceptor = createIntentConfirmationInterceptor(
-            ephemeralKeySecret = "ek_test_123",
+            customerMetadata = PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA,
             integrationMetadata = IntegrationMetadata.DeferredIntent.WithConfirmationToken(
                 intentConfiguration = PaymentSheet.IntentConfiguration(
                     mode = PaymentSheet.IntentConfiguration.Mode.Payment(
@@ -893,7 +894,7 @@ class ConfirmationTokenConfirmationInterceptorTest {
         val observedParams = mutableListOf<ConfirmationTokenParams>()
 
         val interceptor = createIntentConfirmationInterceptor(
-            ephemeralKeySecret = "ek_test_123",
+            customerMetadata = PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA,
             integrationMetadata = IntegrationMetadata.DeferredIntent.WithConfirmationToken(
                 intentConfiguration = PaymentSheet.IntentConfiguration(
                     mode = PaymentSheet.IntentConfiguration.Mode.Payment(
@@ -947,7 +948,7 @@ class ConfirmationTokenConfirmationInterceptorTest {
         val observedParams = mutableListOf<ConfirmationTokenParams>()
 
         val interceptor = createIntentConfirmationInterceptor(
-            ephemeralKeySecret = "ek_test_123",
+            customerMetadata = PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA,
             publishableKeyProvider = { "pk_test_123" },
             integrationMetadata = IntegrationMetadata.DeferredIntent.WithConfirmationToken(
                 intentConfiguration = PaymentSheet.IntentConfiguration(
@@ -1234,7 +1235,7 @@ class ConfirmationTokenConfirmationInterceptorTest {
         runInterceptorScenario(
             integrationMetadata = integrationMetadata,
             scenario = InterceptorTestScenario(
-                ephemeralKeySecret = "ek_test_123",
+                customerMetadata = PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA,
                 publishableKeyProvider = { if (isLiveMode) "pk_live_123" else "pk_test_123" },
                 stripeRepository = createFakeStripeRepositoryForConfirmationToken(
                     observedParams,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/FakeIntentConfirmationInterceptorFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/interceptor/FakeIntentConfirmationInterceptorFactory.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentelement.confirmation.interceptor
 
+import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.paymentelement.confirmation.intent.IntentConfirmationInterceptor
@@ -11,8 +12,7 @@ internal open class FakeIntentConfirmationInterceptorFactory(
     lateinit var interceptor: FakeIntentConfirmationInterceptor
     override suspend fun create(
         integrationMetadata: IntegrationMetadata,
-        customerId: String?,
-        ephemeralKeySecret: String?,
+        customerMetadata: CustomerMetadata?,
         clientAttributionMetadata: ClientAttributionMetadata,
     ): IntentConfirmationInterceptor {
         interceptor = FakeIntentConfirmationInterceptor().apply(enqueueStep)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -49,6 +49,7 @@ import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.TestFactory
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.ui.LinkButtonTestTag
+import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ClientAttributionMetadata
@@ -1261,8 +1262,7 @@ internal class PaymentSheetActivityTest {
                     object : IntentConfirmationInterceptor.Factory {
                         override suspend fun create(
                             integrationMetadata: IntegrationMetadata,
-                            customerId: String?,
-                            ephemeralKeySecret: String?,
+                            customerMetadata: CustomerMetadata?,
                             clientAttributionMetadata: ClientAttributionMetadata,
                         ): IntentConfirmationInterceptor {
                             return fakeIntentConfirmationInterceptor


### PR DESCRIPTION
## Summary
- When saving is disabled or the customer is a guest, `save_payment_method=false` was incorrectly sent to the checkout session confirm API, causing an API error
- Refactors `IntentConfirmationInterceptor.Factory.create` to accept `CustomerMetadata?` instead of separate `customerId`/`ephemeralKeySecret` params
- Uses `customerMetadata?.saveConsent` to conditionally omit `save_payment_method` when saving is not enabled

## Motivation
The checkout session confirm endpoint rejects `save_payment_method=false` when `saved_payment_method_options[payment_method_save]` is disabled. Because `PaymentMethodConfirmationOption.New.shouldSave` is a non-nullable `Boolean`, `false` was always sent even for guests who have no save capability.

## Testing
- Added tests for save-disabled and guest scenarios in `CheckoutSessionConfirmationInterceptorTest`
- Updated all affected test files to match the new `Factory.create` signature

## Test plan
- [x] Verify existing checkout session confirmation tests pass
- [x] Verify guest user flow does not send `save_payment_method`
- [x] Verify save-disabled flow does not send `save_payment_method`
- [x] Verify save-enabled flow correctly sends `save_payment_method=true/false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)