### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/actions/stripe_setup/action.yml
+++ b/.github/actions/stripe_setup/action.yml
@@ -12,4 +12,4 @@ runs:
         distribution: 'temurin'
         java-version: '25'
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4
+      uses: gradle/actions/setup-gradle@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/stripe_setup
       - name: End-to-end tests
         run: ./gradlew :stripe-test-e2e:testDebugUnitTest
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: unit-test-report
@@ -35,11 +35,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/stripe_setup
       - name: Build example projects
         run: ./gradlew :paymentsheet-example:assembleBaseAndroidTest
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: test-failures
@@ -52,7 +52,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/stripe_setup
       - name: Upload release bundle to Emerge
         run: ./gradlew :paymentsheet-example:emergeUploadBaseReleaseAab
@@ -67,7 +67,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Check for untranslated strings
         run: cd scripts && ruby lokalise/check_untranslated_strings.rb
         env:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -63,7 +63,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`

--- a/.github/workflows/dokka.yml
+++ b/.github/workflows/dokka.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/stripe_setup
       - name: Generate Dokka Documentation
         run: ./gradlew :dokkaGenerate

--- a/.github/workflows/end_to_end_tests.yml
+++ b/.github/workflows/end_to_end_tests.yml
@@ -10,14 +10,14 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/stripe_setup
       - name: End-to-end tests
         env:
           STRIPE_END_TO_END_TESTS_BACKEND_URL: ${{ secrets.STRIPE_END_TO_END_TESTS_BACKEND_URL }}
           STRIPE_END_TO_END_TESTS_PUBLISHABLE_KEY: ${{ secrets.STRIPE_END_TO_END_TESTS_PUBLISHABLE_KEY }}
         run: ./gradlew :stripe-test-e2e:testDebugUnitTest
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: unit-test-report

--- a/.github/workflows/fetch_translations.yml
+++ b/.github/workflows/fetch_translations.yml
@@ -11,7 +11,7 @@ jobs:
       contents: read
     steps:
       - name: Check out the current state
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Fetch translations
         run: cd scripts && ./localize.sh
         shell: bash
@@ -22,12 +22,12 @@ jobs:
         run: echo "TIMESTAMP=$(date +'%Y%m%d-%H%M%S')" >> $GITHUB_OUTPUT
       - name: Generate translations app token
         id: generate-translations-app-token
-        uses: actions/create-github-app-token@eaddb9eb7e4226c68cf4b39f167c83e5bd132b3e
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf
         with:
           app-id: ${{ secrets.ANDROID_TRANSLATIONS_APP_ID }}
           private-key: ${{ secrets.ANDROID_TRANSLATIONS_APP_PRIVATE_KEY }}
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0
         id: create-pull-request
         with:
           token: ${{ steps.generate-translations-app-token.outputs.token }}

--- a/.github/workflows/financialconnections_pull_request.yml
+++ b/.github/workflows/financialconnections_pull_request.yml
@@ -8,7 +8,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/stripe_setup
       - name: Upload release bundle to Emerge
         run: ./gradlew :financial-connections-example:emergeUploadReleaseAab

--- a/.github/workflows/identity_pull_request.yml
+++ b/.github/workflows/identity_pull_request.yml
@@ -10,14 +10,14 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.base_ref }}
       - uses: ./.github/actions/stripe_setup
       - name: Build base branch
         run: ./gradlew :identity-example:assembleRelease && mv identity-example/build/outputs/apk/theme1/release/identity-example-theme1-release.apk identity-example/build/outputs/apk/theme1/release/identity-example-release-base.apk
       - name: Upload APK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: identity-base-apk
           path: identity-example/build/outputs/apk/theme1/release/identity-example-release-base.apk
@@ -29,12 +29,12 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/stripe_setup
       - name: Build PR branch
         run: ./gradlew :identity-example:assembleRelease && mv identity-example/build/outputs/apk/theme1/release/identity-example-theme1-release.apk identity-example/build/outputs/apk/theme1/release/identity-example-release-pr.apk
       - name: Upload APK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: identity-pr-apk
           path: identity-example/build/outputs/apk/theme1/release/identity-example-release-pr.apk
@@ -46,9 +46,9 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download APKs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: apk
           pattern: identity-*-apk
@@ -62,13 +62,13 @@ jobs:
 
       # Post comment with output
 
-      - uses: peter-evans/find-comment@d2dae40ed151c634e4189471272b57e76ec19ba8
+      - uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad
         id: find_comment
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body-includes: Diffuse output
 
-      - uses: peter-evans/create-or-update-comment@a35cf36e5301d70b76f316e867e7788a55a31dae
+      - uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9
         if: ${{ steps.diffuse.outputs.diff-raw != null || steps.find_comment.outputs.comment-id != null }}
         with:
           body: |
@@ -81,7 +81,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload diffuse output
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: diffuse-output
           path: ${{ steps.diffuse.outputs.diff-file }}
@@ -92,7 +92,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/stripe_setup
       - name: Upload release bundle to Emerge
         run: ./gradlew :identity-example:emergeUploadTheme1ReleaseAab

--- a/.github/workflows/notify_risky_change.yml
+++ b/.github/workflows/notify_risky_change.yml
@@ -12,12 +12,12 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: peter-evans/find-comment@a54c31d7fa095754bfef525c0c8e5e5674c4b4b1
+      - uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad
         id: find_comment
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body-includes: Risky Change
-      - uses: peter-evans/create-or-update-comment@67dcc547d311b736a8e6c5c236542148a47adc3d
+      - uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9
         with:
           body: |
             Risky Change

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,14 +17,14 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: master
       - uses: ./.github/actions/stripe_setup
       - name: Build in master
         run: ./gradlew :paymentsheet-example:assembleBaseRelease && mv paymentsheet-example/build/outputs/apk/base/release/paymentsheet-example-base-release.apk paymentsheet-example/build/outputs/apk/base/release/paymentsheet-example-release-master.apk
       - name: Upload APK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: paymentsheet-base-apk
           path: paymentsheet-example/build/outputs/apk/base/release/paymentsheet-example-release-master.apk
@@ -35,12 +35,12 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/stripe_setup
       - name: Build from PR
         run: ./gradlew :paymentsheet-example:assembleBaseRelease && mv paymentsheet-example/build/outputs/apk/base/release/paymentsheet-example-base-release.apk paymentsheet-example/build/outputs/apk/base/release/paymentsheet-example-release-pr.apk
       - name: Upload APK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: paymentsheet-pr-apk
           path: paymentsheet-example/build/outputs/apk/base/release/paymentsheet-example-release-pr.apk
@@ -52,9 +52,9 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download APKs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: apk
           pattern: paymentsheet-*-apk
@@ -68,13 +68,13 @@ jobs:
 
       # Post comment with output
 
-      - uses: peter-evans/find-comment@d2dae40ed151c634e4189471272b57e76ec19ba8
+      - uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad
         id: find_comment
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body-includes: Diffuse output
 
-      - uses: peter-evans/create-or-update-comment@a35cf36e5301d70b76f316e867e7788a55a31dae
+      - uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9
         if: ${{ steps.diffuse.outputs.diff-raw != null || steps.find_comment.outputs.comment-id != null }}
         with:
           body: |
@@ -87,7 +87,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload diffuse output
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: diffuse-output
           path: ${{ steps.diffuse.outputs.diff-file }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/stripe_setup
       - name: Upload Identity example release bundle to Emerge
         run: ./gradlew :identity-example:emergeUploadTheme1ReleaseAab
@@ -26,7 +26,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/stripe_setup
       - name: Upload Financial Connections example release bundle to Emerge
         run: ./gradlew :financial-connections-example:emergeUploadReleaseAab
@@ -36,7 +36,7 @@ jobs:
       - name: Assemble Release
         run: ./gradlew :financial-connections-example:assembleRelease
       - name: Firebase App Distribution
-        uses: wzieba/Firebase-Distribution-Github-Action@a41b2f7ab3f7c2631b6a73fb2f660b517cef45a9
+        uses: wzieba/Firebase-Distribution-Github-Action@bd494989dd4bec0343f78adee87fe66e48279ad6
         with:
           appId: "1:527113280969:android:3c57e90cbb8c0397d95c18"
           serviceCredentialsFileContent: ${{ secrets.FINANCIAL_CONNECTIONS_GOOGLE_CLOUD_KEY }}
@@ -47,7 +47,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/stripe_setup
       - name: Upload Payment Sheet example release bundle to Emerge
         run: ./gradlew :paymentsheet-example:emergeUploadBaseReleaseAab
@@ -57,7 +57,7 @@ jobs:
       - name: Assemble Release
         run: ./gradlew :paymentsheet-example:assembleBaseRelease
       - name: Firebase App Distribution
-        uses: wzieba/Firebase-Distribution-Github-Action@a41b2f7ab3f7c2631b6a73fb2f660b517cef45a9
+        uses: wzieba/Firebase-Distribution-Github-Action@bd494989dd4bec0343f78adee87fe66e48279ad6
         with:
           appId: "1:577365562050:android:5b7e92d18f8ca8d1e9a15b"
           serviceCredentialsFileContent: ${{ secrets.PAYMENTS_GOOGLE_CLOUD_KEY }}


### PR DESCRIPTION
## Summary
- Update `actions/checkout` v4 → v6
- Update `actions/upload-artifact` v4 → v7
- Update `actions/download-artifact` v4 → v8
- Update `actions/create-github-app-token` v1.5.1 → v2.2.1
- Update `gradle/actions/setup-gradle` v4 → v5
- Update `peter-evans/find-comment` v1.3.0/v2.4.0 → v4.0.0
- Update `peter-evans/create-or-update-comment` v1.4.5/v2.1.1 → v5.0.0
- Update `peter-evans/create-pull-request` v5.0.2 → v8.1.0
- Update `wzieba/Firebase-Distribution-Github-Action` v1.7.0 → v1.7.1

## Test plan
- [x] CI workflows pass on this PR
- [x] Verify no regressions in artifact upload/download behavior
- [ ] Verify translation fetch workflow still works (next scheduled run or manual trigger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)