### PR TITLE
Replace @RestrictTo with internal in paymentsheet module

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/LinkButtonState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/LinkButtonState.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.link.ui
 
-import androidx.annotation.RestrictTo
 import com.stripe.android.link.ui.wallet.DefaultPaymentUI
 import com.stripe.android.link.ui.wallet.toDefaultPaymentUI
 import com.stripe.android.model.DisplayablePaymentDetails
@@ -8,7 +7,6 @@ import com.stripe.android.model.DisplayablePaymentDetails
 /**
  * Represents different states of the Link wallet button
  */
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 internal sealed class LinkButtonState {
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/model/DeferredIntentParams.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/model/DeferredIntentParams.kt
@@ -1,29 +1,24 @@
 package com.stripe.android.model
 
 import android.os.Parcelable
-import androidx.annotation.RestrictTo
 import com.stripe.android.core.model.StripeJsonUtils
 import com.stripe.android.core.model.StripeModel
 import kotlinx.parcelize.Parcelize
 import org.json.JSONObject
 
 @Parcelize
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-data class DeferredIntentParams(
+internal data class DeferredIntentParams(
     val mode: Mode,
     val paymentMethodTypes: List<String>,
     val paymentMethodConfigurationId: String?,
     val onBehalfOf: String?,
 ) : StripeModel {
 
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    @Parcelize
     sealed interface Mode : Parcelable {
         val code: String
         val currency: String?
         val setupFutureUsage: StripeIntent.Usage?
 
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         @Parcelize
         data class Payment(
             val amount: Long,
@@ -35,7 +30,6 @@ data class DeferredIntentParams(
             override val code: String get() = "payment"
         }
 
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         @Parcelize
         data class Setup(
             override val currency: String?,
@@ -62,7 +56,6 @@ data class DeferredIntentParams(
         }
     }
 
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     companion object {
         fun parseModeFromJson(deferredIntentParamsJson: JSONObject): Mode? {
             return when (deferredIntentParamsJson.optString("mode")) {

--- a/paymentsheet/src/main/java/com/stripe/android/model/ElementsSession.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/model/ElementsSession.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.model
 
-import androidx.annotation.RestrictTo
 import com.stripe.android.core.model.StripeModel
 import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.model.PaymentMethod.Type.Link
@@ -9,9 +8,8 @@ import java.util.UUID
 
 private val LinkSupportedFundingSources = setOf("card", "bank_account")
 
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Parcelize
-data class ElementsSession(
+internal data class ElementsSession(
     val linkSettings: LinkSettings?,
     val paymentMethodSpecs: String?,
     val externalPaymentMethodData: String?,
@@ -99,7 +97,6 @@ data class ElementsSession(
     val onBehalfOf: String?
         get() = accountId.takeIf { !it.equals(merchantId) }
 
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Parcelize
     data class LinkSettings(
         val linkFundingSources: List<String>,
@@ -118,26 +115,22 @@ data class ElementsSession(
         val linkSupportedPaymentMethodsOnboardingEnabled: List<String>,
     ) : StripeModel
 
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Parcelize
     data class ExperimentsData(
         val arbId: String,
         val experimentAssignments: Map<ExperimentAssignment, String>
     ) : StripeModel
 
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Parcelize
     data class CardBrandChoice(
         val eligible: Boolean,
         val preferredNetworks: List<String>,
     ) : StripeModel
 
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Parcelize
     sealed interface CustomPaymentMethod : StripeModel {
         val type: String
 
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         @Parcelize
         data class Available(
             override val type: String,
@@ -145,7 +138,6 @@ data class ElementsSession(
             val logoUrl: String,
         ) : CustomPaymentMethod
 
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         @Parcelize
         data class Unavailable(
             override val type: String,
@@ -153,14 +145,12 @@ data class ElementsSession(
         ) : CustomPaymentMethod
     }
 
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Parcelize
     data class Customer(
         val paymentMethods: List<PaymentMethod>,
         val defaultPaymentMethod: String?,
         val session: Session,
     ) : StripeModel {
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         @Parcelize
         data class Session(
             val id: String,
@@ -171,19 +161,15 @@ data class ElementsSession(
             val components: Components,
         ) : StripeModel
 
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         @Parcelize
         data class Components(
             val mobilePaymentElement: MobilePaymentElement,
             val customerSheet: CustomerSheet,
         ) : StripeModel {
-            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
             sealed interface MobilePaymentElement : StripeModel {
-                @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
                 @Parcelize
                 data object Disabled : MobilePaymentElement
 
-                @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
                 @Parcelize
                 data class Enabled(
                     val isPaymentMethodSaveEnabled: Boolean,
@@ -197,13 +183,10 @@ data class ElementsSession(
                 }
             }
 
-            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
             sealed interface CustomerSheet : StripeModel {
-                @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
                 @Parcelize
                 data object Disabled : CustomerSheet
 
-                @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
                 @Parcelize
                 data class Enabled(
                     val paymentMethodRemove: PaymentMethodRemoveFeature,
@@ -215,14 +198,12 @@ data class ElementsSession(
                 }
             }
 
-            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
             enum class PaymentMethodRemoveFeature {
                 Enabled,
                 Partial,
                 Disabled,
             }
 
-            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
             enum class PaymentMethodRemoveLastFeature {
                 Enabled,
                 Disabled,
@@ -237,7 +218,6 @@ data class ElementsSession(
     /**
      * Flags declared here will be parsed and include in the [ElementsSession] object.
      */
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     enum class Flag(val flagValue: String) {
         ELEMENTS_DISABLE_FC_LITE("elements_disable_fc_lite"),
         ELEMENTS_PREFER_FC_LITE("elements_prefer_fc_lite"),
@@ -255,7 +235,6 @@ data class ElementsSession(
     /**
      * Experiments declared here will be parsed and include in the [ElementsSession] object.
      */
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     enum class ExperimentAssignment(val experimentValue: String) {
         LINK_GLOBAL_HOLD_BACK("link_global_holdback"),
         LINK_GLOBAL_HOLD_BACK_AA("link_global_holdback_aa"),
@@ -264,7 +243,6 @@ data class ElementsSession(
         OCS_MOBILE_HORIZONTAL_MODE("ocs_mobile_horizontal_mode"),
     }
 
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     companion object {
         fun createFromFallback(
             stripeIntent: StripeIntent,

--- a/paymentsheet/src/main/java/com/stripe/android/model/ElementsSessionParams.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/model/ElementsSessionParams.kt
@@ -1,13 +1,10 @@
 package com.stripe.android.model
 
 import android.os.Parcelable
-import androidx.annotation.RestrictTo
 import kotlinx.parcelize.Parcelize
 import java.util.Locale
 
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-@Parcelize
-sealed interface ElementsSessionParams : Parcelable {
+internal sealed interface ElementsSessionParams : Parcelable {
 
     val type: String
     val clientSecret: String?
@@ -24,7 +21,6 @@ sealed interface ElementsSessionParams : Parcelable {
     val link: Link
     val countryOverride: String?
 
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Parcelize
     data class PaymentIntentType(
         override val clientSecret: String,
@@ -50,7 +46,6 @@ sealed interface ElementsSessionParams : Parcelable {
             get() = null
     }
 
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Parcelize
     data class SetupIntentType(
         override val clientSecret: String,
@@ -76,7 +71,6 @@ sealed interface ElementsSessionParams : Parcelable {
             get() = null
     }
 
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Parcelize
     data class DeferredIntentType(
         override val locale: String? = Locale.getDefault().toLanguageTag(),
@@ -103,7 +97,6 @@ sealed interface ElementsSessionParams : Parcelable {
             get() = emptyList()
     }
 
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Parcelize
     data class SellerDetails(
         val networkId: String,
@@ -117,7 +110,6 @@ sealed interface ElementsSessionParams : Parcelable {
         }
     }
 
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Parcelize
     data class Link(
         val disallowFundingSourceCreation: Set<String> = emptySet(),

--- a/paymentsheet/src/main/java/com/stripe/android/model/parsers/DeferredPaymentIntentJsonParser.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/model/parsers/DeferredPaymentIntentJsonParser.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.model.parsers
 
-import androidx.annotation.RestrictTo
 import com.stripe.android.core.model.StripeJsonUtils.optString
 import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.core.model.parsers.ModelJsonParser.Companion.jsonArrayToList
@@ -8,8 +7,7 @@ import com.stripe.android.model.DeferredIntentParams
 import com.stripe.android.model.PaymentIntent
 import org.json.JSONObject
 
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-class DeferredPaymentIntentJsonParser(
+internal class DeferredPaymentIntentJsonParser(
     private val elementsSessionId: String?,
     private val paymentMode: DeferredIntentParams.Mode.Payment,
     private val isLiveMode: Boolean,

--- a/paymentsheet/src/main/java/com/stripe/android/model/parsers/DeferredSetupIntentJsonParser.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/model/parsers/DeferredSetupIntentJsonParser.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.model.parsers
 
-import androidx.annotation.RestrictTo
 import com.stripe.android.core.model.StripeJsonUtils.optString
 import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.core.model.parsers.ModelJsonParser.Companion.jsonArrayToList
@@ -8,8 +7,7 @@ import com.stripe.android.model.DeferredIntentParams
 import com.stripe.android.model.SetupIntent
 import org.json.JSONObject
 
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-class DeferredSetupIntentJsonParser(
+internal class DeferredSetupIntentJsonParser(
     private val elementsSessionId: String?,
     private val setupMode: DeferredIntentParams.Mode.Setup,
     private val isLiveMode: Boolean,

--- a/paymentsheet/src/main/java/com/stripe/android/model/parsers/ElementsSessionJsonParser.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/model/parsers/ElementsSessionJsonParser.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.model.parsers
 
-import androidx.annotation.RestrictTo
 import com.stripe.android.core.model.StripeJsonUtils
 import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.core.model.parsers.ModelJsonParser.Companion.jsonArrayToList
@@ -16,8 +15,7 @@ import org.json.JSONArray
 import org.json.JSONObject
 import java.util.UUID
 
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-class ElementsSessionJsonParser(
+internal class ElementsSessionJsonParser(
     private val params: ElementsSessionParams,
     private val isLiveMode: Boolean,
     private val timeProvider: () -> Long = {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/callbacks/PaymentElementCallbackIdentifier.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/callbacks/PaymentElementCallbackIdentifier.kt
@@ -1,8 +1,6 @@
 package com.stripe.android.paymentelement.callbacks
 
-import androidx.annotation.RestrictTo
 import javax.inject.Qualifier
 
 @Qualifier
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-annotation class PaymentElementCallbackIdentifier
+internal annotation class PaymentElementCallbackIdentifier

--- a/paymentsheet/src/main/java/com/stripe/android/payments/financialconnections/GetFinancialConnectionsAvailability.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/payments/financialconnections/GetFinancialConnectionsAvailability.kt
@@ -1,11 +1,9 @@
 package com.stripe.android.payments.financialconnections
 
-import androidx.annotation.RestrictTo
 import com.stripe.android.core.utils.FeatureFlags.financialConnectionsFullSdkUnavailable
 import com.stripe.android.model.ElementsSession
 
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-object GetFinancialConnectionsAvailability {
+internal object GetFinancialConnectionsAvailability {
 
     operator fun invoke(
         elementsSession: ElementsSession?,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodConfirmInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodConfirmInteractor.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentsheet.verticalmode
 
-import androidx.annotation.RestrictTo
 import androidx.lifecycle.viewModelScope
 import com.stripe.android.common.spms.DefaultLinkFormElementFactory
 import com.stripe.android.common.spms.DefaultSavedPaymentMethodLinkFormHelper
@@ -33,7 +32,6 @@ internal interface SavedPaymentMethodConfirmInteractor {
     }
 }
 
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 internal class DefaultSavedPaymentMethodConfirmInteractor(
     val initialSelection: PaymentSelection.Saved,
     val displayName: ResolvableString,

--- a/paymentsheet/src/test/java/com/stripe/android/payments/financialconnections/GetFinancialConnectionsAvailabilityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/payments/financialconnections/GetFinancialConnectionsAvailabilityTest.kt
@@ -101,7 +101,7 @@ class GetFinancialConnectionsAvailabilityTest {
         )
     }
 
-    fun createSession(flags: Map<ElementsSession.Flag, Boolean>): ElementsSession {
+    private fun createSession(flags: Map<ElementsSession.Flag, Boolean>): ElementsSession {
         return mock<ElementsSession> {
             on { this.flags } doReturn flags
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeLogLinkHoldbackExperiment.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeLogLinkHoldbackExperiment.kt
@@ -26,6 +26,6 @@ internal class FakeLogLinkHoldbackExperiment : LogLinkHoldbackExperiment {
     }
 }
 
-data class ExperimentCall(
+internal data class ExperimentCall(
     val experiment: ElementsSession.ExperimentAssignment
 )


### PR DESCRIPTION
## Summary
- Replace `@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)` with `internal` visibility modifier for classes only used within the paymentsheet module
- Remove redundant `@RestrictTo` annotations on classes that were already `internal`
- Fix test visibility to match newly-internal production types

## Test plan
- [x] `./gradlew :paymentsheet:testDebugUnitTest` passes (4845/4846, 1 pre-existing flaky test)
- [x] `./gradlew :paymentsheet:compileDebugKotlin` succeeds
- [x] `./gradlew :crypto-onramp:compileDebugKotlin` succeeds
- [x] `./gradlew :payment-element-test-pages:compileDebugKotlin` succeeds
- [x] `./gradlew :paymentsheet-example:compileBaseDebugKotlin` succeeds
- [x] `./gradlew :payments:compileDebugKotlin` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)