### PR TITLE
Add refresh functionality to Checkout

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutPlaygroundActivity.kt
@@ -74,6 +74,7 @@ class CheckoutPlaygroundActivity : AppCompatActivity() {
                 isLoading = viewModel.isLoading,
                 applyPromotionCode = viewModel::applyPromotionCode,
                 removePromotionCode = viewModel::removePromotionCode,
+                refresh = viewModel::refresh,
             )
         }
     }
@@ -91,6 +92,7 @@ private fun CheckoutScreen(
     isLoading: StateFlow<Boolean>,
     applyPromotionCode: (String) -> Unit,
     removePromotionCode: () -> Unit,
+    refresh: () -> Unit,
 ) {
     val checkoutSession by checkout.checkoutSession.collectAsState()
     val loading by isLoading.collectAsState()
@@ -118,6 +120,11 @@ private fun CheckoutScreen(
                     ) {
                         Text("Apply")
                     }
+                }
+                Button(
+                    onClick = refresh,
+                ) {
+                    Text("Refresh")
                 }
             },
             bottomBarContent = {

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutPlaygroundViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutPlaygroundViewModel.kt
@@ -34,6 +34,10 @@ internal class CheckoutPlaygroundViewModel(
         checkout.removePromotionCode()
     }
 
+    fun refresh() = performWhileLoading {
+        checkout.refresh()
+    }
+
     private fun performWhileLoading(block: suspend () -> Unit) {
         viewModelScope.launch {
             _isLoading.value = true

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
@@ -66,6 +66,13 @@ class Checkout private constructor(
             .updateState()
     }
 
+    suspend fun refresh(): Result<CheckoutSession> {
+        val sessionId = state.checkoutSessionResponse.id
+        return component.checkoutSessionRepository
+            .init(sessionId)
+            .updateState()
+    }
+
     private fun Result<CheckoutSessionResponse>.updateState(): Result<CheckoutSession> {
         return map { response ->
             state = State(response)

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
@@ -76,9 +76,10 @@ class CheckoutTest {
             checkout.checkoutSession.test {
                 assertThat(awaitItem().totalSummary).isNull()
 
-                checkout.applyPromotionCode("10OFF")
+                val result = checkout.applyPromotionCode("10OFF")
 
                 val updated = awaitItem()
+                assertThat(result.getOrThrow()).isEqualTo(updated)
                 val totalSummary = updated.totalSummary
                 assertThat(totalSummary).isNotNull()
                 assertThat(totalSummary!!.discountAmounts).hasSize(1)
@@ -126,9 +127,10 @@ class CheckoutTest {
             checkout.checkoutSession.test {
                 assertThat(awaitItem().totalSummary).isNull()
 
-                checkout.applyPromotionCode("  10OFF  ")
+                val result = checkout.applyPromotionCode("  10OFF  ")
 
                 val updated = awaitItem()
+                assertThat(result.getOrThrow()).isEqualTo(updated)
                 assertThat(updated.totalSummary).isNotNull()
             }
         }
@@ -149,9 +151,10 @@ class CheckoutTest {
             checkout.checkoutSession.test {
                 assertThat(awaitItem().totalSummary).isNull()
 
-                checkout.removePromotionCode()
+                val result = checkout.removePromotionCode()
 
                 val updated = awaitItem()
+                assertThat(result.getOrThrow()).isEqualTo(updated)
                 assertThat(updated.totalSummary).isNotNull()
             }
         }
@@ -173,6 +176,53 @@ class CheckoutTest {
                 val initial = awaitItem()
 
                 val result = checkout.removePromotionCode()
+                assertThat(result.isFailure).isTrue()
+
+                expectNoEvents()
+                assertThat(checkout.checkoutSession.value).isEqualTo(initial)
+            }
+        }
+    }
+
+    @Test
+    fun `refresh updates checkoutSession on success`() = runTest {
+        runCreateWithStateScenario { checkout ->
+            networkRule.enqueue(
+                host("api.stripe.com"),
+                method("POST"),
+                path("/v1/payment_pages/cs_test_abc123/init"),
+            ) { response ->
+                response.testBodyFromFile("checkout-session-apply-discount.json")
+            }
+
+            checkout.checkoutSession.test {
+                assertThat(awaitItem().totalSummary).isNull()
+
+                val result = checkout.refresh()
+
+                val updated = awaitItem()
+                assertThat(result.getOrThrow()).isEqualTo(updated)
+                assertThat(updated.totalSummary).isNotNull()
+            }
+        }
+    }
+
+    @Test
+    fun `refresh returns failure on error response`() = runTest {
+        runCreateWithStateScenario { checkout ->
+            networkRule.enqueue(
+                host("api.stripe.com"),
+                method("POST"),
+                path("/v1/payment_pages/cs_test_abc123/init"),
+            ) { response ->
+                response.setResponseCode(500)
+                response.setBody("""{"error": {"message": "Internal server error"}}""")
+            }
+
+            checkout.checkoutSession.test {
+                val initial = awaitItem()
+
+                val result = checkout.refresh()
                 assertThat(result.isFailure).isTrue()
 
                 expectNoEvents()


### PR DESCRIPTION
## Summary
- Add `refresh()` method to `Checkout` that re-calls the init endpoint to get fresh session state without performing any mutation
- Add refresh button to the checkout playground for testing
- Add tests for refresh success and failure cases, and improve existing tests to validate returned results match the flow emissions

## Test plan
- [x] Unit tests pass: `./gradlew :paymentsheet:testDebugUnitTest --tests "com.stripe.android.checkout.CheckoutTest"`
- [x] Build succeeds: `./gradlew :paymentsheet:assembleDebug :paymentsheet-example:assembleBaseDebug`
- [ ] Manual: open checkout playground, tap Refresh, verify session state updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)