### PR TITLE
Add line items display to checkout playground

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutPlaygroundActivity.kt
@@ -101,6 +101,7 @@ private fun CheckoutScreen(
     Box {
         PlaygroundTheme(
             content = {
+                LineItemsSection(checkoutSession)
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     verticalAlignment = Alignment.CenterVertically,
@@ -135,6 +136,34 @@ private fun CheckoutScreen(
                 CircularProgressIndicator()
             }
         }
+    }
+}
+
+@Composable
+private fun LineItemsSection(session: CheckoutSession) {
+    val lineItems = session.lineItems
+    val currency = session.currency
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = "Items",
+            style = MaterialTheme.typography.h6,
+        )
+
+        Spacer(modifier = Modifier.height(PADDING))
+
+        for (item in lineItems) {
+            val quantityLabel = if (item.quantity > 1) " x${item.quantity}" else ""
+            val unitPrice = item.unitAmount?.let { formatAmount(it, currency) }
+            val lineTotal = formatAmount(item.total, currency)
+            SummaryRow(
+                label = "${item.name}$quantityLabel",
+                amount = lineTotal,
+                subtext = if (item.quantity > 1 && unitPrice != null) "$unitPrice each" else null,
+            )
+        }
+
+        Divider(modifier = Modifier.padding(vertical = PADDING))
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSession.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSession.kt
@@ -15,6 +15,7 @@ class CheckoutSession internal constructor(
     val id: String,
     val currency: String,
     val totalSummary: TotalSummary?,
+    val lineItems: List<LineItem>,
 ) : Parcelable {
 
     @Poko
@@ -60,6 +61,18 @@ class CheckoutSession internal constructor(
         val displayName: String,
         val deliveryEstimate: String?,
     ) : Parcelable
+
+    @Poko
+    @Parcelize
+    @CheckoutSessionPreview
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    class LineItem internal constructor(
+        val name: String,
+        val quantity: Int,
+        val unitAmount: Long?,
+        val subtotal: Long,
+        val total: Long,
+    ) : Parcelable
 }
 
 @OptIn(CheckoutSessionPreview::class)
@@ -68,6 +81,7 @@ internal fun CheckoutSessionResponse.asCheckoutSession(): CheckoutSession {
         id = id,
         currency = currency,
         totalSummary = totalSummary?.asTotalSummary(),
+        lineItems = lineItems.map { it.asLineItem() },
     )
 }
 
@@ -108,5 +122,16 @@ private fun CheckoutSessionResponse.ShippingRate.asShippingRate(): CheckoutSessi
         amount = amount,
         displayName = displayName,
         deliveryEstimate = deliveryEstimate,
+    )
+}
+
+@OptIn(CheckoutSessionPreview::class)
+private fun CheckoutSessionResponse.LineItem.asLineItem(): CheckoutSession.LineItem {
+    return CheckoutSession.LineItem(
+        name = name,
+        quantity = quantity,
+        unitAmount = unitAmount,
+        subtotal = subtotal,
+        total = total,
     )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponse.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponse.kt
@@ -53,6 +53,7 @@ internal data class CheckoutSessionResponse(
      */
     val savedPaymentMethodsOfferSave: SavedPaymentMethodsOfferSave? = null,
     val totalSummary: TotalSummaryResponse? = null,
+    val lineItems: List<LineItem> = emptyList(),
 ) : StripeModel {
 
     /**
@@ -142,5 +143,15 @@ internal data class CheckoutSessionResponse(
         val amount: Long,
         val displayName: String,
         val deliveryEstimate: String?,
+    ) : StripeModel
+
+    @Parcelize
+    data class LineItem(
+        val id: String,
+        val name: String,
+        val quantity: Int,
+        val unitAmount: Long?,
+        val subtotal: Long,
+        val total: Long,
     ) : StripeModel
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParser.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParser.kt
@@ -42,6 +42,7 @@ internal class CheckoutSessionResponseJsonParser(
             json.optJSONObject(FIELD_SAVED_PAYMENT_METHODS_OFFER_SAVE)
         )
         val totalSummary = parseTotalSummaryResponse(json)
+        val lineItems = parseLineItems(json.optJSONObject(FIELD_LINE_ITEM_GROUP))
 
         return CheckoutSessionResponse(
             id = sessionId,
@@ -52,6 +53,7 @@ internal class CheckoutSessionResponseJsonParser(
             customer = customer,
             savedPaymentMethodsOfferSave = savedPaymentMethodsOfferSave,
             totalSummary = totalSummary,
+            lineItems = lineItems,
         )
     }
 
@@ -331,6 +333,29 @@ internal class CheckoutSessionResponseJsonParser(
         }
     }
 
+    private fun parseLineItems(
+        lineItemGroup: JSONObject?,
+    ): List<CheckoutSessionResponse.LineItem> {
+        val array = lineItemGroup?.optJSONArray(FIELD_LINE_ITEMS) ?: return emptyList()
+        return (0 until array.length()).mapNotNull { i ->
+            val obj = array.optJSONObject(i) ?: return@mapNotNull null
+            val id = obj.optString(FIELD_ID).takeIf { it.isNotEmpty() } ?: return@mapNotNull null
+            val name = obj.optString(FIELD_NAME).takeIf { it.isNotEmpty() } ?: return@mapNotNull null
+            val quantity = obj.optInt(FIELD_QUANTITY, -1).takeIf { it > 0 } ?: return@mapNotNull null
+            val subtotal = obj.optLong(FIELD_SUBTOTAL, -1).takeIf { it >= 0 } ?: return@mapNotNull null
+            val total = obj.optLong(FIELD_TOTAL, -1).takeIf { it >= 0 } ?: return@mapNotNull null
+            val unitAmount = if (quantity > 0) total / quantity else null
+            CheckoutSessionResponse.LineItem(
+                id = id,
+                name = name,
+                quantity = quantity,
+                unitAmount = unitAmount,
+                subtotal = subtotal,
+                total = total,
+            )
+        }
+    }
+
     private companion object {
         private const val FIELD_SESSION_ID = "session_id"
         private const val FIELD_CURRENCY = "currency"
@@ -364,5 +389,8 @@ internal class CheckoutSessionResponseJsonParser(
         private const val FIELD_SHIPPING = "shipping"
         private const val FIELD_SHIPPING_OPTION = "shipping_option"
         private const val FIELD_DELIVERY_ESTIMATE = "delivery_estimate"
+        private const val FIELD_LINE_ITEMS = "line_items"
+        private const val FIELD_ID = "id"
+        private const val FIELD_QUANTITY = "quantity"
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/AsCheckoutSessionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/AsCheckoutSessionTest.kt
@@ -132,16 +132,47 @@ class AsCheckoutSessionTest {
         assertThat(session.totalSummary!!.appliedBalance).isNull()
     }
 
+    @Test
+    fun `maps lineItems`() {
+        val session = createResponse(
+            lineItems = listOf(
+                CheckoutSessionResponse.LineItem(
+                    id = "li_1",
+                    name = "Llama Figure",
+                    quantity = 2,
+                    unitAmount = 999L,
+                    subtotal = 1998L,
+                    total = 1998L,
+                ),
+            ),
+        ).asCheckoutSession()
+        val items = session.lineItems
+        assertThat(items).hasSize(1)
+        assertThat(items[0].name).isEqualTo("Llama Figure")
+        assertThat(items[0].quantity).isEqualTo(2)
+        assertThat(items[0].unitAmount).isEqualTo(999L)
+        assertThat(items[0].subtotal).isEqualTo(1998L)
+        assertThat(items[0].total).isEqualTo(1998L)
+    }
+
+    @Test
+    fun `empty lineItems maps to empty list`() {
+        val session = createResponse().asCheckoutSession()
+        assertThat(session.lineItems).isEmpty()
+    }
+
     private fun createResponse(
         id: String = "cs_test_abc123",
         currency: String = "usd",
         totalSummary: TotalSummaryResponse? = null,
+        lineItems: List<CheckoutSessionResponse.LineItem> = emptyList(),
     ): CheckoutSessionResponse {
         return CheckoutSessionResponse(
             id = id,
             amount = 1000L,
             currency = currency,
             totalSummary = totalSummary,
+            lineItems = lineItems,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionFixtures.kt
@@ -520,6 +520,48 @@ internal object CheckoutSessionFixtures {
     )
 
     /**
+     * Init response with multiple line items.
+     */
+    val CHECKOUT_SESSION_WITH_MULTIPLE_LINE_ITEMS_JSON = JSONObject(
+        """
+        {
+            "session_id": "cs_test_abc123",
+            "currency": "usd",
+            "total_summary": {
+                "due": 4497,
+                "subtotal": 4497,
+                "total": 4497
+            },
+            "line_item_group": {
+                "currency": "usd",
+                "total": 4497,
+                "subtotal": 4497,
+                "due": 4497,
+                "line_items": [
+                    {
+                        "id": "li_item1",
+                        "object": "item",
+                        "name": "Llama Figure",
+                        "quantity": 2,
+                        "subtotal": 1998,
+                        "total": 1998
+                    },
+                    {
+                        "id": "li_item2",
+                        "object": "item",
+                        "name": "Alpaca Plushie",
+                        "quantity": 1,
+                        "subtotal": 2499,
+                        "total": 2499
+                    }
+                ]
+            },
+            "elements_session": $MINIMAL_ELEMENTS_SESSION_JSON
+        }
+        """.trimIndent()
+    )
+
+    /**
      * Init response with shipping from shipping.shipping_option fallback path.
      */
     val CHECKOUT_SESSION_WITH_SHIPPING_OPTION_JSON = JSONObject(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParserTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParserTest.kt
@@ -53,6 +53,65 @@ class CheckoutSessionResponseJsonParserTest {
     }
 
     @Test
+    fun `parse checkout session response includes line items`() {
+        val result = CheckoutSessionResponseJsonParser(
+            isLiveMode = false,
+        ).parse(CheckoutSessionFixtures.CHECKOUT_SESSION_RESPONSE_JSON)
+
+        assertThat(result).isNotNull()
+        val lineItems = result!!.lineItems
+        assertThat(lineItems).hasSize(1)
+        assertThat(lineItems[0].id).isEqualTo("li_1SrjAuLu5o3P18ZpVBMMs98l")
+        assertThat(lineItems[0].name).isEqualTo("Llama Figure")
+        assertThat(lineItems[0].quantity).isEqualTo(1)
+        assertThat(lineItems[0].subtotal).isEqualTo(999L)
+        assertThat(lineItems[0].total).isEqualTo(999L)
+        assertThat(lineItems[0].unitAmount).isEqualTo(999L)
+    }
+
+    @Test
+    fun `parse multiple line items`() {
+        val result = CheckoutSessionResponseJsonParser(
+            isLiveMode = false,
+        ).parse(CheckoutSessionFixtures.CHECKOUT_SESSION_WITH_MULTIPLE_LINE_ITEMS_JSON)
+
+        assertThat(result).isNotNull()
+        val lineItems = result!!.lineItems
+        assertThat(lineItems).hasSize(2)
+
+        assertThat(lineItems[0].id).isEqualTo("li_item1")
+        assertThat(lineItems[0].name).isEqualTo("Llama Figure")
+        assertThat(lineItems[0].quantity).isEqualTo(2)
+        assertThat(lineItems[0].subtotal).isEqualTo(1998L)
+        assertThat(lineItems[0].total).isEqualTo(1998L)
+        assertThat(lineItems[0].unitAmount).isEqualTo(999L)
+
+        assertThat(lineItems[1].id).isEqualTo("li_item2")
+        assertThat(lineItems[1].name).isEqualTo("Alpaca Plushie")
+        assertThat(lineItems[1].quantity).isEqualTo(1)
+        assertThat(lineItems[1].subtotal).isEqualTo(2499L)
+        assertThat(lineItems[1].total).isEqualTo(2499L)
+        assertThat(lineItems[1].unitAmount).isEqualTo(2499L)
+    }
+
+    @Test
+    fun `parse returns empty line items when no line_item_group`() {
+        val json = JSONObject(
+            """
+            {
+                "session_id": "cs_test_123",
+                "currency": "usd",
+                "total_summary": { "due": 1000, "subtotal": 1000, "total": 1000 }
+            }
+            """.trimIndent()
+        )
+        val result = CheckoutSessionResponseJsonParser(isLiveMode = false).parse(json)
+
+        assertThat(result).isNotNull()
+        assertThat(result!!.lineItems).isEmpty()
+    }
+
+    @Test
     fun `parse returns null when session_id is missing`() {
         val json = JSONObject(
             """


### PR DESCRIPTION
## Summary
- Parse `line_items` from the checkout session API response's `line_item_group` into a new `LineItem` model on both `CheckoutSessionResponse` and `CheckoutSession`
- Compute `unitAmount` from `total / quantity` during parsing
- Display line items in the checkout playground UI content area above the total summary, showing name, quantity, unit price, and line total

## Test plan
- [x] Parser tests verify single and multiple line items are correctly parsed
- [x] Parser test verifies empty line items when no `line_item_group` present
- [x] Mapping tests verify `CheckoutSessionResponse.LineItem` maps to `CheckoutSession.LineItem`
- [x] Playground app builds successfully
- [ ] Manual: launch checkout playground and verify line items appear above total summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)