### PR TITLE
Allow deselecting card brand

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
@@ -292,7 +292,12 @@ internal class DefaultCardNumberController(
     }
 
     override fun onSelectorItemClicked(item: TextFieldIcon.Selector.Item) {
-        mostRecentUserSelectedBrand.value = CardBrand.fromCode(item.id)
+        val newChoice = CardBrand.fromCode(item.id)
+        if (newChoice == mostRecentUserSelectedBrand.value) {
+            mostRecentUserSelectedBrand.value = null
+        } else {
+            mostRecentUserSelectedBrand.value = newChoice
+        }
     }
 
     override fun onValidationStateChanged(isValidating: Boolean) {

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberControllerTest.kt
@@ -501,6 +501,67 @@ internal class CardNumberControllerTest {
     }
 
     @Test
+    fun `on selector item re-click, card brand should be unknown`() = runTest {
+        FeatureFlags.newCbcSelector.setEnabled(true)
+        val cardNumberController = createController(
+            cardBrandChoiceConfig = CardBrandChoiceConfig.Eligible(
+                preferredBrands = listOf(),
+                initialBrand = null
+            )
+        )
+
+        cardNumberController.trailingIcon.test {
+            cardNumberController.onValueChange("4000002500001001")
+            cardNumberController.onSelectorItemClicked(
+                TextFieldIcon.Selector.Item(
+                    id = CardBrand.CartesBancaires.code,
+                    label = "Cartes Bancaires".resolvableString,
+                    icon = PaymentModelR.drawable.stripe_ic_cartes_bancaires
+                )
+            )
+            idleLooper()
+            skipItems(3)
+            assertThat(awaitItem() as TextFieldIcon.Selector)
+                .isEqualTo(cartesBancaireSelection)
+
+            cardNumberController.onSelectorItemClicked(
+                TextFieldIcon.Selector.Item(
+                    id = CardBrand.CartesBancaires.code,
+                    label = "Cartes Bancaires".resolvableString,
+                    icon = PaymentModelR.drawable.stripe_ic_cartes_bancaires
+                )
+            )
+
+            val item = awaitItem()
+            assertThat(item as TextFieldIcon.Selector)
+                .isEqualTo(
+                    TextFieldIcon.Selector(
+                        message = R.string.stripe_card_brand_choice_choose_card_brand.resolvableString,
+                        currentItem = TextFieldIcon.Selector.Item(
+                            id = CardBrand.Unknown.code,
+                            label = R.string.stripe_card_brand_choice_no_selection.resolvableString,
+                            icon = CardBrand.Unknown.icon
+                        ),
+                        items = listOf(
+                            TextFieldIcon.Selector.Item(
+                                id = CardBrand.CartesBancaires.code,
+                                label = "Cartes Bancaires".resolvableString,
+                                icon = CardBrand.CartesBancaires.icon
+                            ),
+                            TextFieldIcon.Selector.Item(
+                                id = CardBrand.Visa.code,
+                                label = "Visa".resolvableString,
+                                icon = CardBrand.Visa.icon
+                            ),
+                        ),
+                        hide = false,
+                        hasMadeSelection = false
+                    )
+                )
+        }
+    }
+
+    @Test
     fun `on number updated after update to number with no brands, user choice should be re-used if possible`() = runTest {
         FeatureFlags.newCbcSelector.setEnabled(false)
         val cardNumberController = createController(
@@ -576,30 +637,7 @@ internal class CardNumberControllerTest {
             skipItems(1)
             idleLooper()
             assertThat(awaitItem() as TextFieldIcon.Selector)
-                .isEqualTo(
-                    TextFieldIcon.Selector(
-                        message = R.string.stripe_card_brand_choice_choose_card_brand.resolvableString,
-                        currentItem = TextFieldIcon.Selector.Item(
-                            id = CardBrand.CartesBancaires.code,
-                            label = "Cartes Bancaires".resolvableString,
-                            icon = CardBrand.CartesBancaires.icon
-                        ),
-                        items = listOf(
-                            TextFieldIcon.Selector.Item(
-                                id = CardBrand.CartesBancaires.code,
-                                label = "Cartes Bancaires".resolvableString,
-                                icon = CardBrand.CartesBancaires.icon
-                            ),
-                            TextFieldIcon.Selector.Item(
-                                id = CardBrand.Visa.code,
-                                label = "Visa".resolvableString,
-                                icon = CardBrand.Visa.icon
-                            ),
-                        ),
-                        hide = false,
-                        hasMadeSelection = true
-                    )
-                )
+                .isEqualTo(cartesBancaireSelection)
         }
     }
 
@@ -986,6 +1024,28 @@ internal class CardNumberControllerTest {
 
     private companion object {
         const val TEST_TAG = "CardNumberElement"
+        val cartesBancaireSelection = TextFieldIcon.Selector(
+            message = R.string.stripe_card_brand_choice_choose_card_brand.resolvableString,
+            currentItem = TextFieldIcon.Selector.Item(
+                id = CardBrand.CartesBancaires.code,
+                label = "Cartes Bancaires".resolvableString,
+                icon = CardBrand.CartesBancaires.icon
+            ),
+            items = listOf(
+                TextFieldIcon.Selector.Item(
+                    id = CardBrand.CartesBancaires.code,
+                    label = "Cartes Bancaires".resolvableString,
+                    icon = CardBrand.CartesBancaires.icon
+                ),
+                TextFieldIcon.Selector.Item(
+                    id = CardBrand.Visa.code,
+                    label = "Visa".resolvableString,
+                    icon = CardBrand.Visa.icon
+                ),
+            ),
+            hide = false,
+            hasMadeSelection = true
+        )
     }
 }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Allow user to deselect card brand choice

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://docs.google.com/document/d/1VMNW5pCpJc-E1dW5WbJI6MbodH386cxCa2-W3TSCnIU/edit?tab=t.0

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots

https://github.com/user-attachments/assets/843659b8-10f1-413b-858a-cdfc08620212


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
