### PR TITLE
Update confirm title in continue case

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddConfirmationInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddConfirmationInteractor.kt
@@ -5,6 +5,7 @@ import com.stripe.android.common.spms.withLinkState
 import com.stripe.android.common.taptoadd.TapToAddMode
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentIntent
@@ -12,6 +13,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.toConfirmationOption
+import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.utils.buyButtonLabel
@@ -169,9 +171,9 @@ internal class DefaultTapToAddConfirmationInteractor(
         return TapToAddConfirmationInteractor.State(
             cardBrand = paymentMethod.card?.brand ?: CardBrand.Unknown,
             last4 = paymentMethod.card?.last4,
-            title = createLabel(useAmount = true),
+            title = createTitle(),
             primaryButton = TapToAddConfirmationInteractor.State.PrimaryButton(
-                label = createLabel(useAmount = false),
+                label = createButtonLabel(),
                 locked = tapToAddMode == TapToAddMode.Complete,
                 enabled = true,
                 state = TapToAddConfirmationInteractor.State.PrimaryButton.State.Idle,
@@ -188,10 +190,21 @@ internal class DefaultTapToAddConfirmationInteractor(
             .withConfirmationState(initialConfirmationState)
     }
 
-    private fun createLabel(useAmount: Boolean): ResolvableString {
+    private fun createTitle(): ResolvableString {
         return when (tapToAddMode) {
             TapToAddMode.Complete -> buyButtonLabel(
-                amount = paymentMethodMetadata.amount().takeIf { useAmount },
+                amount = paymentMethodMetadata.amount(),
+                primaryButtonLabel = null,
+                isForPaymentIntent = paymentMethodMetadata.stripeIntent is PaymentIntent
+            )
+            TapToAddMode.Continue -> R.string.stripe_tap_to_add_card_added_title.resolvableString
+        }
+    }
+
+    private fun createButtonLabel(): ResolvableString {
+        return when (tapToAddMode) {
+            TapToAddMode.Complete -> buyButtonLabel(
+                amount = null,
                 primaryButtonLabel = null,
                 isForPaymentIntent = paymentMethodMetadata.stripeIntent is PaymentIntent
             )

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/DefaultTapToAddConfirmationInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/DefaultTapToAddConfirmationInteractorTest.kt
@@ -87,7 +87,7 @@ internal class DefaultTapToAddConfirmationInteractorTest {
         interactor.state.test {
             val state = awaitItem()
             assertThat(state.title)
-                .isEqualTo(StripeUiCoreR.string.stripe_continue_button_label.resolvableString)
+                .isEqualTo(R.string.stripe_tap_to_add_card_added_title.resolvableString)
             assertThat(state.primaryButton.label)
                 .isEqualTo(StripeUiCoreR.string.stripe_continue_button_label.resolvableString)
             assertThat(state.primaryButton.locked).isFalse()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Update title on confirm screen when tap to add mode in continue

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://stripe.slack.com/archives/C0A4KKJRHME/p1772232135249689

The previous state showed "continue" multiple times

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [X] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
|  <img width="1080" height="2400" alt="Screenshot_20260305_143705" src="https://github.com/user-attachments/assets/af5577b5-1528-4160-978d-97413851d77b" />  |  <img width="1080" height="2400" alt="Screenshot_20260305_143804" src="https://github.com/user-attachments/assets/85ddf173-1ba1-4031-860f-83718535cc3a" /> |


