### PR TITLE
Enable updating line item quantity in CheckoutSession and UI.

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutPlaygroundActivity.kt
@@ -74,6 +74,7 @@ class CheckoutPlaygroundActivity : AppCompatActivity() {
                 isLoading = viewModel.isLoading,
                 applyPromotionCode = viewModel::applyPromotionCode,
                 removePromotionCode = viewModel::removePromotionCode,
+                updateLineItemQuantity = viewModel::updateLineItemQuantity,
                 refresh = viewModel::refresh,
             )
         }
@@ -92,6 +93,7 @@ private fun CheckoutScreen(
     isLoading: StateFlow<Boolean>,
     applyPromotionCode: (String) -> Unit,
     removePromotionCode: () -> Unit,
+    updateLineItemQuantity: (String, Int) -> Unit,
     refresh: () -> Unit,
 ) {
     val checkoutSession by checkout.checkoutSession.collectAsState()
@@ -103,7 +105,7 @@ private fun CheckoutScreen(
     Box {
         PlaygroundTheme(
             content = {
-                LineItemsSection(checkoutSession)
+                LineItemsSection(checkoutSession, updateLineItemQuantity)
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     verticalAlignment = Alignment.CenterVertically,
@@ -147,7 +149,10 @@ private fun CheckoutScreen(
 }
 
 @Composable
-private fun LineItemsSection(session: CheckoutSession) {
+private fun LineItemsSection(
+    session: CheckoutSession,
+    updateLineItemQuantity: (String, Int) -> Unit,
+) {
     val lineItems = session.lineItems
     val currency = session.currency
 
@@ -160,14 +165,50 @@ private fun LineItemsSection(session: CheckoutSession) {
         Spacer(modifier = Modifier.height(PADDING))
 
         for (item in lineItems) {
-            val quantityLabel = if (item.quantity > 1) " x${item.quantity}" else ""
             val unitPrice = item.unitAmount?.let { formatAmount(it, currency) }
             val lineTotal = formatAmount(item.total, currency)
-            SummaryRow(
-                label = "${item.name}$quantityLabel",
-                amount = lineTotal,
-                subtext = if (item.quantity > 1 && unitPrice != null) "$unitPrice each" else null,
-            )
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = PADDING / 2),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = item.name,
+                        style = MaterialTheme.typography.body2,
+                    )
+                    if (unitPrice != null) {
+                        Text(
+                            text = "$unitPrice each",
+                            style = MaterialTheme.typography.caption,
+                            color = MaterialTheme.colors.onSurface.copy(alpha = 0.6f),
+                        )
+                    }
+                }
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    IconButton(
+                        onClick = { updateLineItemQuantity(item.id, item.quantity - 1) },
+                        enabled = item.quantity > 1,
+                    ) {
+                        Text("-")
+                    }
+                    Text(
+                        text = "${item.quantity}",
+                        style = MaterialTheme.typography.body2,
+                    )
+                    IconButton(
+                        onClick = { updateLineItemQuantity(item.id, item.quantity + 1) },
+                    ) {
+                        Text("+")
+                    }
+                }
+                Text(
+                    text = lineTotal,
+                    style = MaterialTheme.typography.body2,
+                )
+            }
         }
 
         Divider(modifier = Modifier.padding(vertical = PADDING))

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutPlaygroundViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutPlaygroundViewModel.kt
@@ -30,6 +30,10 @@ internal class CheckoutPlaygroundViewModel(
         checkout.applyPromotionCode(promotionCode)
     }
 
+    fun updateLineItemQuantity(lineItemId: String, quantity: Int) = performWhileLoading {
+        checkout.updateLineItemQuantity(lineItemId, quantity)
+    }
+
     fun removePromotionCode() = performWhileLoading {
         checkout.removePromotionCode()
     }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
@@ -59,6 +59,13 @@ class Checkout private constructor(
             .updateState()
     }
 
+    suspend fun updateLineItemQuantity(lineItemId: String, quantity: Int): Result<CheckoutSession> {
+        val sessionId = state.checkoutSessionResponse.id
+        return component.checkoutSessionRepository
+            .updateLineItemQuantity(sessionId, lineItemId, quantity)
+            .updateState()
+    }
+
     suspend fun removePromotionCode(): Result<CheckoutSession> {
         val sessionId = state.checkoutSessionResponse.id
         return component.checkoutSessionRepository

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSession.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSession.kt
@@ -67,6 +67,7 @@ class CheckoutSession internal constructor(
     @CheckoutSessionPreview
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     class LineItem internal constructor(
+        val id: String,
         val name: String,
         val quantity: Int,
         val unitAmount: Long?,
@@ -128,6 +129,7 @@ private fun CheckoutSessionResponse.ShippingRate.asShippingRate(): CheckoutSessi
 @OptIn(CheckoutSessionPreview::class)
 private fun CheckoutSessionResponse.LineItem.asLineItem(): CheckoutSession.LineItem {
     return CheckoutSession.LineItem(
+        id = id,
         name = name,
         quantity = quantity,
         unitAmount = unitAmount,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionRepository.kt
@@ -33,6 +33,12 @@ internal interface CheckoutSessionRepository {
         sessionId: String,
         promotionCode: String,
     ): Result<CheckoutSessionResponse>
+
+    suspend fun updateLineItemQuantity(
+        sessionId: String,
+        lineItemId: String,
+        quantity: Int,
+    ): Result<CheckoutSessionResponse>
 }
 
 internal class DefaultCheckoutSessionRepository @Inject constructor(
@@ -130,6 +136,30 @@ internal class DefaultCheckoutSessionRepository @Inject constructor(
                 params = mapOf(
                     "promotion_code" to promotionCode,
                     "elements_session_client[is_aggregation_expected]" to "true",
+                ),
+            ),
+            responseJsonParser = CheckoutSessionResponseJsonParser(
+                isLiveMode = options.apiKeyIsLiveMode,
+            ),
+        )
+    }
+
+    override suspend fun updateLineItemQuantity(
+        sessionId: String,
+        lineItemId: String,
+        quantity: Int,
+    ): Result<CheckoutSessionResponse> {
+        val options = createOptions()
+        return executeRequestWithResultParser(
+            stripeErrorJsonParser = stripeErrorJsonParser,
+            stripeNetworkClient = stripeNetworkClient,
+            request = apiRequestFactory.createPost(
+                url = updateUrl(sessionId),
+                options = options,
+                params = mapOf(
+                    "updated_line_item_quantity[line_item_id]" to lineItemId,
+                    "updated_line_item_quantity[quantity]" to quantity.toString(),
+                    "updated_line_item_quantity[fail_update_on_discount_error]" to "true",
                 ),
             ),
             responseJsonParser = CheckoutSessionResponseJsonParser(

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/AsCheckoutSessionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/AsCheckoutSessionTest.kt
@@ -148,6 +148,7 @@ class AsCheckoutSessionTest {
         ).asCheckoutSession()
         val items = session.lineItems
         assertThat(items).hasSize(1)
+        assertThat(items[0].id).isEqualTo("li_1")
         assertThat(items[0].name).isEqualTo("Llama Figure")
         assertThat(items[0].quantity).isEqualTo(2)
         assertThat(items[0].unitAmount).isEqualTo(999L)

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
@@ -10,6 +10,7 @@ import com.stripe.android.networktesting.RequestMatchers.host
 import com.stripe.android.networktesting.RequestMatchers.method
 import com.stripe.android.networktesting.RequestMatchers.path
 import com.stripe.android.networktesting.testBodyFromFile
+import com.stripe.android.core.utils.urlEncode
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.testing.PaymentConfigurationTestRule
@@ -223,6 +224,58 @@ class CheckoutTest {
                 val initial = awaitItem()
 
                 val result = checkout.refresh()
+                assertThat(result.isFailure).isTrue()
+
+                expectNoEvents()
+                assertThat(checkout.checkoutSession.value).isEqualTo(initial)
+            }
+        }
+    }
+
+    @Test
+    fun `updateLineItemQuantity updates checkoutSession on success`() = runTest {
+        runCreateWithStateScenario { checkout ->
+            networkRule.enqueue(
+                host("api.stripe.com"),
+                method("POST"),
+                path("/v1/payment_pages/cs_test_abc123"),
+                bodyPart(urlEncode("updated_line_item_quantity[line_item_id]"), "li_1"),
+                bodyPart(urlEncode("updated_line_item_quantity[quantity]"), "3"),
+                bodyPart(urlEncode("updated_line_item_quantity[fail_update_on_discount_error]"), "true"),
+            ) { response ->
+                response.testBodyFromFile("checkout-session-update-quantity.json")
+            }
+
+            checkout.checkoutSession.test {
+                assertThat(awaitItem().lineItems).isEmpty()
+
+                val result = checkout.updateLineItemQuantity("li_1", 3)
+
+                val updated = awaitItem()
+                assertThat(result.getOrThrow()).isEqualTo(updated)
+                assertThat(updated.lineItems).hasSize(1)
+                assertThat(updated.lineItems[0].id).isEqualTo("li_1")
+                assertThat(updated.lineItems[0].quantity).isEqualTo(3)
+            }
+        }
+    }
+
+    @Test
+    fun `updateLineItemQuantity returns failure on error response`() = runTest {
+        runCreateWithStateScenario { checkout ->
+            networkRule.enqueue(
+                host("api.stripe.com"),
+                method("POST"),
+                path("/v1/payment_pages/cs_test_abc123"),
+            ) { response ->
+                response.setResponseCode(400)
+                response.setBody("""{"error": {"message": "Invalid quantity"}}""")
+            }
+
+            checkout.checkoutSession.test {
+                val initial = awaitItem()
+
+                val result = checkout.updateLineItemQuantity("li_1", -1)
                 assertThat(result.isFailure).isTrue()
 
                 expectNoEvents()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
@@ -363,5 +363,13 @@ class CheckoutSessionConfirmationInterceptorTest {
         ): Result<CheckoutSessionResponse> {
             error("Not expected in this test")
         }
+
+        override suspend fun updateLineItemQuantity(
+            sessionId: String,
+            lineItemId: String,
+            quantity: Int,
+        ): Result<CheckoutSessionResponse> {
+            error("Not expected in this test")
+        }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/FakeCheckoutSessionRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/FakeCheckoutSessionRepository.kt
@@ -8,6 +8,7 @@ internal class FakeCheckoutSessionRepository(
     var confirmResult: Result<CheckoutSessionResponse> = Result.failure(NotImplementedError()),
     var detachResult: Result<CheckoutSessionResponse> = Result.failure(NotImplementedError()),
     var applyPromotionCodeResult: Result<CheckoutSessionResponse> = Result.failure(NotImplementedError()),
+    var updateLineItemQuantityResult: Result<CheckoutSessionResponse> = Result.failure(NotImplementedError()),
 ) : CheckoutSessionRepository {
 
     private val _initRequests = Turbine<String>()
@@ -45,6 +46,14 @@ internal class FakeCheckoutSessionRepository(
         sessionId: String,
         promotionCode: String,
     ): Result<CheckoutSessionResponse> = applyPromotionCodeResult
+
+    override suspend fun updateLineItemQuantity(
+        sessionId: String,
+        lineItemId: String,
+        quantity: Int,
+    ): Result<CheckoutSessionResponse> {
+        return updateLineItemQuantityResult
+    }
 
     data class DetachRequest(
         val sessionId: String,

--- a/paymentsheet/src/test/resources/checkout-session-update-quantity.json
+++ b/paymentsheet/src/test/resources/checkout-session-update-quantity.json
@@ -1,0 +1,18 @@
+{
+  "session_id": "cs_test_abc123",
+  "currency": "usd",
+  "line_item_group": {
+    "due": 2997,
+    "subtotal": 2997,
+    "total": 2997,
+    "line_items": [
+      {
+        "id": "li_1",
+        "name": "Llama Figure",
+        "quantity": 3,
+        "subtotal": 2997,
+        "total": 2997
+      }
+    ]
+  }
+}


### PR DESCRIPTION
# Summary
Added the ability to update the quantity of a line item within a CheckoutSession. The UI now allows increasing or decreasing quantities for each item, and the backend updates are handled accordingly. Relevant domain, repository, and model changes were made to support this.

# Motivation
This change allows users to modify the quantities of products directly within the checkout experience, making the checkout flow more flexible and user-friendly.

# Testing
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

