### PR TITLE
Add adjustable quantity option to CheckoutSession in Playground settings.

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
@@ -71,6 +71,8 @@ class CheckoutRequest private constructor(
     val checkoutSessionPaymentMethodRemove: FeatureState?,
     @SerialName("allow_promotion_codes")
     val allowPromotionCodes: Boolean?,
+    @SerialName("adjustable_quantity")
+    val adjustableQuantity: Boolean?,
 ) {
     @Serializable
     enum class CustomerKeyType {
@@ -118,6 +120,7 @@ class CheckoutRequest private constructor(
         private var checkoutSessionPaymentMethodSave: FeatureState? = null
         private var checkoutSessionPaymentMethodRemove: FeatureState? = null
         private var allowPromotionCodes: Boolean? = null
+        private var adjustableQuantity: Boolean? = null
 
         fun initialization(initialization: String?) = apply {
             this.initialization = initialization
@@ -247,6 +250,10 @@ class CheckoutRequest private constructor(
             this.allowPromotionCodes = allowPromotionCodes
         }
 
+        fun adjustableQuantity(adjustableQuantity: Boolean?) = apply {
+            this.adjustableQuantity = adjustableQuantity
+        }
+
         fun build(): CheckoutRequest {
             return CheckoutRequest(
                 initialization = initialization,
@@ -284,6 +291,7 @@ class CheckoutRequest private constructor(
                 checkoutSessionPaymentMethodSave = checkoutSessionPaymentMethodSave,
                 checkoutSessionPaymentMethodRemove = checkoutSessionPaymentMethodRemove,
                 allowPromotionCodes = allowPromotionCodes,
+                adjustableQuantity = adjustableQuantity,
             )
         }
     }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CheckoutSessionAdjustableQuantitySettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CheckoutSessionAdjustableQuantitySettingsDefinition.kt
@@ -1,0 +1,20 @@
+package com.stripe.android.paymentsheet.example.playground.settings
+
+import com.stripe.android.paymentsheet.example.playground.model.CheckoutRequest
+
+internal object CheckoutSessionAdjustableQuantitySettingsDefinition : BooleanSettingsDefinition(
+    defaultValue = true,
+    displayName = "Adjustable Quantity",
+    key = "checkout_session_adjustable_quantity"
+) {
+    override fun applicable(
+        configurationData: PlaygroundConfigurationData,
+        settings: Map<PlaygroundSettingDefinition<*>, Any?>,
+    ): Boolean {
+        return settings[InitializationTypeSettingsDefinition] == InitializationType.CheckoutSession
+    }
+
+    override fun configure(value: Boolean, checkoutRequestBuilder: CheckoutRequest.Builder) {
+        checkoutRequestBuilder.adjustableQuantity(value)
+    }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -475,6 +475,7 @@ internal class PlaygroundSettings private constructor(
             InitializationTypeSettingsDefinition,
             CheckoutSessionSaveSettingsDefinition,
             CheckoutSessionRemoveSettingsDefinition,
+            CheckoutSessionAdjustableQuantitySettingsDefinition,
             AllowPromotionCodesSettingsDefinition,
             CustomerSheetPaymentMethodModeDefinition,
             CustomerSessionSettingsDefinition,


### PR DESCRIPTION
# Summary

Adds an "Adjustable Quantity" setting for the Checkout Session in the Playground example. This allows configuring whether the quantity is adjustable during Checkout Session initialization.

# Motivation

Enables developers to easily test and toggle adjustable quantity support in Checkout Sessions using the Playground app. This is useful for environments where you want to experiment or showcase this Checkout option without code changes.

# Testing

- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Changelog

- [Added] Adjustable Quantity setting for Checkout Session in Playground.