### PR TITLE
Add automatic tax option to CheckoutRequest and Playground settings.

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
@@ -73,6 +73,8 @@ class CheckoutRequest private constructor(
     val allowPromotionCodes: Boolean?,
     @SerialName("adjustable_quantity")
     val adjustableQuantity: Boolean?,
+    @SerialName("automatic_tax")
+    val automaticTax: Boolean?,
 ) {
     @Serializable
     enum class CustomerKeyType {
@@ -121,6 +123,7 @@ class CheckoutRequest private constructor(
         private var checkoutSessionPaymentMethodRemove: FeatureState? = null
         private var allowPromotionCodes: Boolean? = null
         private var adjustableQuantity: Boolean? = null
+        private var automaticTax: Boolean? = null
 
         fun initialization(initialization: String?) = apply {
             this.initialization = initialization
@@ -254,6 +257,10 @@ class CheckoutRequest private constructor(
             this.adjustableQuantity = adjustableQuantity
         }
 
+        fun automaticTax(automaticTax: Boolean?) = apply {
+            this.automaticTax = automaticTax
+        }
+
         fun build(): CheckoutRequest {
             return CheckoutRequest(
                 initialization = initialization,
@@ -292,6 +299,7 @@ class CheckoutRequest private constructor(
                 checkoutSessionPaymentMethodRemove = checkoutSessionPaymentMethodRemove,
                 allowPromotionCodes = allowPromotionCodes,
                 adjustableQuantity = adjustableQuantity,
+                automaticTax = automaticTax,
             )
         }
     }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CheckoutSessionAutomaticTaxSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CheckoutSessionAutomaticTaxSettingsDefinition.kt
@@ -1,0 +1,20 @@
+package com.stripe.android.paymentsheet.example.playground.settings
+
+import com.stripe.android.paymentsheet.example.playground.model.CheckoutRequest
+
+internal object CheckoutSessionAutomaticTaxSettingsDefinition : BooleanSettingsDefinition(
+    defaultValue = true,
+    displayName = "Automatic Tax",
+    key = "checkout_session_automatic_tax"
+) {
+    override fun applicable(
+        configurationData: PlaygroundConfigurationData,
+        settings: Map<PlaygroundSettingDefinition<*>, Any?>,
+    ): Boolean {
+        return settings[InitializationTypeSettingsDefinition] == InitializationType.CheckoutSession
+    }
+
+    override fun configure(value: Boolean, checkoutRequestBuilder: CheckoutRequest.Builder) {
+        checkoutRequestBuilder.automaticTax(value)
+    }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -476,6 +476,7 @@ internal class PlaygroundSettings private constructor(
             CheckoutSessionSaveSettingsDefinition,
             CheckoutSessionRemoveSettingsDefinition,
             CheckoutSessionAdjustableQuantitySettingsDefinition,
+            CheckoutSessionAutomaticTaxSettingsDefinition,
             AllowPromotionCodesSettingsDefinition,
             CustomerSheetPaymentMethodModeDefinition,
             CustomerSessionSettingsDefinition,


### PR DESCRIPTION
# Summary
Added an automatic tax option to `CheckoutRequest` and to Playground settings, allowing users to specify if taxes should be automatically calculated in Checkout sessions.

# Motivation
This feature enables the simulation and testing of automatic tax calculation in the playground interface, supporting Stripe's automatic tax capabilities in a more flexible and configurable way.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Changelog
- [Added] Automatic tax option to `CheckoutRequest` and Playground settings.