### PR TITLE
Add shipping rate selection and options to CheckoutSession API and UI.

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutPlaygroundActivity.kt
@@ -75,6 +75,7 @@ class CheckoutPlaygroundActivity : AppCompatActivity() {
                 applyPromotionCode = viewModel::applyPromotionCode,
                 removePromotionCode = viewModel::removePromotionCode,
                 updateLineItemQuantity = viewModel::updateLineItemQuantity,
+                selectShippingRate = viewModel::selectShippingRate,
                 refresh = viewModel::refresh,
             )
         }
@@ -94,6 +95,7 @@ private fun CheckoutScreen(
     applyPromotionCode: (String) -> Unit,
     removePromotionCode: () -> Unit,
     updateLineItemQuantity: (String, Int) -> Unit,
+    selectShippingRate: (String) -> Unit,
     refresh: () -> Unit,
 ) {
     val checkoutSession by checkout.checkoutSession.collectAsState()
@@ -106,6 +108,7 @@ private fun CheckoutScreen(
         PlaygroundTheme(
             content = {
                 LineItemsSection(checkoutSession, updateLineItemQuantity)
+                ShippingOptionsSection(checkoutSession, selectShippingRate)
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     verticalAlignment = Alignment.CenterVertically,
@@ -207,6 +210,74 @@ private fun LineItemsSection(
                 Text(
                     text = lineTotal,
                     style = MaterialTheme.typography.body2,
+                )
+            }
+        }
+
+        Divider(modifier = Modifier.padding(vertical = PADDING))
+    }
+}
+
+@Composable
+private fun ShippingOptionsSection(session: CheckoutSession, selectShippingRate: (String) -> Unit) {
+    val shippingOptions = session.shippingOptions
+    if (shippingOptions.isEmpty()) return
+
+    val selectedId = session.totalSummary?.shippingRate?.id
+    val currency = session.currency
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = "Shipping",
+            style = MaterialTheme.typography.h6,
+        )
+
+        Spacer(modifier = Modifier.height(PADDING))
+
+        for (option in shippingOptions) {
+            val isSelected = option.id == selectedId
+            val amountText = if (option.amount == 0L) "Free" else formatAmount(option.amount, currency)
+            val subtext = option.deliveryEstimate
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { selectShippingRate(option.id) }
+                    .background(
+                        if (isSelected) {
+                            MaterialTheme.colors.primary.copy(alpha = 0.1f)
+                        } else {
+                            Color.Transparent
+                        }
+                    )
+                    .padding(vertical = PADDING / 2),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = option.displayName,
+                        style = if (isSelected) {
+                            MaterialTheme.typography.subtitle1
+                        } else {
+                            MaterialTheme.typography.body2
+                        },
+                    )
+                    if (subtext != null) {
+                        Text(
+                            text = subtext,
+                            style = MaterialTheme.typography.caption,
+                            color = MaterialTheme.colors.onSurface.copy(alpha = 0.6f),
+                        )
+                    }
+                }
+                Text(
+                    text = amountText,
+                    style = if (isSelected) {
+                        MaterialTheme.typography.subtitle1
+                    } else {
+                        MaterialTheme.typography.body2
+                    },
                 )
             }
         }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutPlaygroundViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutPlaygroundViewModel.kt
@@ -38,6 +38,10 @@ internal class CheckoutPlaygroundViewModel(
         checkout.removePromotionCode()
     }
 
+    fun selectShippingRate(shippingRateId: String) = performWhileLoading {
+        checkout.selectShippingRate(shippingRateId)
+    }
+
     fun refresh() = performWhileLoading {
         checkout.refresh()
     }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
@@ -73,6 +73,13 @@ class Checkout private constructor(
             .updateState()
     }
 
+    suspend fun selectShippingRate(shippingRateId: String): Result<CheckoutSession> {
+        val sessionId = state.checkoutSessionResponse.id
+        return component.checkoutSessionRepository
+            .selectShippingRate(sessionId, shippingRateId)
+            .updateState()
+    }
+
     suspend fun refresh(): Result<CheckoutSession> {
         val sessionId = state.checkoutSessionResponse.id
         return component.checkoutSessionRepository

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSession.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSession.kt
@@ -16,6 +16,7 @@ class CheckoutSession internal constructor(
     val currency: String,
     val totalSummary: TotalSummary?,
     val lineItems: List<LineItem>,
+    val shippingOptions: List<ShippingRate>,
 ) : Parcelable {
 
     @Poko
@@ -57,6 +58,7 @@ class CheckoutSession internal constructor(
     @CheckoutSessionPreview
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     class ShippingRate internal constructor(
+        val id: String,
         val amount: Long,
         val displayName: String,
         val deliveryEstimate: String?,
@@ -83,6 +85,7 @@ internal fun CheckoutSessionResponse.asCheckoutSession(): CheckoutSession {
         currency = currency,
         totalSummary = totalSummary?.asTotalSummary(),
         lineItems = lineItems.map { it.asLineItem() },
+        shippingOptions = shippingOptions.map { it.asShippingRate() },
     )
 }
 
@@ -120,6 +123,7 @@ private fun CheckoutSessionResponse.TaxAmount.asTaxAmount(): CheckoutSession.Tax
 @OptIn(CheckoutSessionPreview::class)
 private fun CheckoutSessionResponse.ShippingRate.asShippingRate(): CheckoutSession.ShippingRate {
     return CheckoutSession.ShippingRate(
+        id = id,
         amount = amount,
         displayName = displayName,
         deliveryEstimate = deliveryEstimate,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionRepository.kt
@@ -39,6 +39,11 @@ internal interface CheckoutSessionRepository {
         lineItemId: String,
         quantity: Int,
     ): Result<CheckoutSessionResponse>
+
+    suspend fun selectShippingRate(
+        sessionId: String,
+        shippingRateId: String,
+    ): Result<CheckoutSessionResponse>
 }
 
 internal class DefaultCheckoutSessionRepository @Inject constructor(
@@ -160,6 +165,28 @@ internal class DefaultCheckoutSessionRepository @Inject constructor(
                     "updated_line_item_quantity[line_item_id]" to lineItemId,
                     "updated_line_item_quantity[quantity]" to quantity.toString(),
                     "updated_line_item_quantity[fail_update_on_discount_error]" to "true",
+                ),
+            ),
+            responseJsonParser = CheckoutSessionResponseJsonParser(
+                isLiveMode = options.apiKeyIsLiveMode,
+            ),
+        )
+    }
+
+    override suspend fun selectShippingRate(
+        sessionId: String,
+        shippingRateId: String,
+    ): Result<CheckoutSessionResponse> {
+        val options = createOptions()
+        return executeRequestWithResultParser(
+            stripeErrorJsonParser = stripeErrorJsonParser,
+            stripeNetworkClient = stripeNetworkClient,
+            request = apiRequestFactory.createPost(
+                url = updateUrl(sessionId),
+                options = options,
+                params = mapOf(
+                    "shipping_rate" to shippingRateId,
+                    "elements_session_client[is_aggregation_expected]" to "true",
                 ),
             ),
             responseJsonParser = CheckoutSessionResponseJsonParser(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponse.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponse.kt
@@ -54,6 +54,7 @@ internal data class CheckoutSessionResponse(
     val savedPaymentMethodsOfferSave: SavedPaymentMethodsOfferSave? = null,
     val totalSummary: TotalSummaryResponse? = null,
     val lineItems: List<LineItem> = emptyList(),
+    val shippingOptions: List<ShippingRate> = emptyList(),
 ) : StripeModel {
 
     /**
@@ -140,6 +141,7 @@ internal data class CheckoutSessionResponse(
 
     @Parcelize
     data class ShippingRate(
+        val id: String,
         val amount: Long,
         val displayName: String,
         val deliveryEstimate: String?,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParser.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParser.kt
@@ -43,6 +43,7 @@ internal class CheckoutSessionResponseJsonParser(
         )
         val totalSummary = parseTotalSummaryResponse(json)
         val lineItems = parseLineItems(json.optJSONObject(FIELD_LINE_ITEM_GROUP))
+        val shippingOptions = parseShippingOptions(json)
 
         return CheckoutSessionResponse(
             id = sessionId,
@@ -54,6 +55,7 @@ internal class CheckoutSessionResponseJsonParser(
             savedPaymentMethodsOfferSave = savedPaymentMethodsOfferSave,
             totalSummary = totalSummary,
             lineItems = lineItems,
+            shippingOptions = shippingOptions,
         )
     }
 
@@ -298,14 +300,25 @@ internal class CheckoutSessionResponseJsonParser(
     }
 
     private fun parseShippingRateFromJson(json: JSONObject): CheckoutSessionResponse.ShippingRate? {
+        val id = json.optString(FIELD_ID).takeIf { it.isNotEmpty() } ?: return null
         val amount = json.optLong(FIELD_AMOUNT, -1).takeIf { it >= 0 } ?: return null
         val displayName = json.optString(FIELD_DISPLAY_NAME).takeIf { it.isNotEmpty() } ?: return null
         val deliveryEstimate = parseDeliveryEstimate(json)
         return CheckoutSessionResponse.ShippingRate(
+            id = id,
             amount = amount,
             displayName = displayName,
             deliveryEstimate = deliveryEstimate,
         )
+    }
+
+    private fun parseShippingOptions(json: JSONObject): List<CheckoutSessionResponse.ShippingRate> {
+        val array = json.optJSONArray(FIELD_SHIPPING_OPTIONS) ?: return emptyList()
+        return (0 until array.length()).mapNotNull { i ->
+            val obj = array.optJSONObject(i) ?: return@mapNotNull null
+            val shippingRateJson = obj.optJSONObject(FIELD_SHIPPING_RATE) ?: return@mapNotNull null
+            parseShippingRateFromJson(shippingRateJson)
+        }
     }
 
     private fun parseDeliveryEstimate(json: JSONObject): String? {
@@ -388,6 +401,7 @@ internal class CheckoutSessionResponseJsonParser(
         private const val FIELD_SHIPPING_RATE = "shipping_rate"
         private const val FIELD_SHIPPING = "shipping"
         private const val FIELD_SHIPPING_OPTION = "shipping_option"
+        private const val FIELD_SHIPPING_OPTIONS = "shipping_options"
         private const val FIELD_DELIVERY_ESTIMATE = "delivery_estimate"
         private const val FIELD_LINE_ITEMS = "line_items"
         private const val FIELD_ID = "id"

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/AsCheckoutSessionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/AsCheckoutSessionTest.kt
@@ -96,6 +96,7 @@ class AsCheckoutSessionTest {
         val session = createResponse(
             totalSummary = createTotalSummary(
                 shippingRate = CheckoutSessionResponse.ShippingRate(
+                    id = "shr_standard",
                     amount = 500L,
                     displayName = "Standard Shipping",
                     deliveryEstimate = "5-7 business days",
@@ -103,6 +104,7 @@ class AsCheckoutSessionTest {
             ),
         ).asCheckoutSession()
         val shipping = session.totalSummary!!.shippingRate!!
+        assertThat(shipping.id).isEqualTo("shr_standard")
         assertThat(shipping.amount).isEqualTo(500L)
         assertThat(shipping.displayName).isEqualTo("Standard Shipping")
         assertThat(shipping.deliveryEstimate).isEqualTo("5-7 business days")
@@ -162,11 +164,48 @@ class AsCheckoutSessionTest {
         assertThat(session.lineItems).isEmpty()
     }
 
+    @Test
+    fun `maps shippingOptions`() {
+        val session = createResponse(
+            shippingOptions = listOf(
+                CheckoutSessionResponse.ShippingRate(
+                    id = "shr_standard",
+                    amount = 500L,
+                    displayName = "Standard Shipping",
+                    deliveryEstimate = null,
+                ),
+                CheckoutSessionResponse.ShippingRate(
+                    id = "shr_express",
+                    amount = 1500L,
+                    displayName = "Express Shipping",
+                    deliveryEstimate = "1-3 business days",
+                ),
+            ),
+        ).asCheckoutSession()
+        val options = session.shippingOptions
+        assertThat(options).hasSize(2)
+        assertThat(options[0].id).isEqualTo("shr_standard")
+        assertThat(options[0].amount).isEqualTo(500L)
+        assertThat(options[0].displayName).isEqualTo("Standard Shipping")
+        assertThat(options[0].deliveryEstimate).isNull()
+        assertThat(options[1].id).isEqualTo("shr_express")
+        assertThat(options[1].amount).isEqualTo(1500L)
+        assertThat(options[1].displayName).isEqualTo("Express Shipping")
+        assertThat(options[1].deliveryEstimate).isEqualTo("1-3 business days")
+    }
+
+    @Test
+    fun `empty shippingOptions maps to empty list`() {
+        val session = createResponse().asCheckoutSession()
+        assertThat(session.shippingOptions).isEmpty()
+    }
+
     private fun createResponse(
         id: String = "cs_test_abc123",
         currency: String = "usd",
         totalSummary: TotalSummaryResponse? = null,
         lineItems: List<CheckoutSessionResponse.LineItem> = emptyList(),
+        shippingOptions: List<CheckoutSessionResponse.ShippingRate> = emptyList(),
     ): CheckoutSessionResponse {
         return CheckoutSessionResponse(
             id = id,
@@ -174,6 +213,7 @@ class AsCheckoutSessionTest {
             currency = currency,
             totalSummary = totalSummary,
             lineItems = lineItems,
+            shippingOptions = shippingOptions,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
@@ -285,6 +285,64 @@ class CheckoutTest {
     }
 
     @Test
+    fun `selectShippingRate updates checkoutSession on success`() = runTest {
+        runCreateWithStateScenario { checkout ->
+            networkRule.enqueue(
+                host("api.stripe.com"),
+                method("POST"),
+                path("/v1/payment_pages/cs_test_abc123"),
+                bodyPart("shipping_rate", "shr_express"),
+                bodyPart(urlEncode("elements_session_client[is_aggregation_expected]"), "true"),
+            ) { response ->
+                response.testBodyFromFile("checkout-session-select-shipping-rate.json")
+            }
+
+            checkout.checkoutSession.test {
+                assertThat(awaitItem().shippingOptions).isEmpty()
+
+                val result = checkout.selectShippingRate("shr_express")
+
+                val updated = awaitItem()
+                assertThat(result.getOrThrow()).isEqualTo(updated)
+                val totalSummary = updated.totalSummary
+                assertThat(totalSummary).isNotNull()
+                val shippingRate = requireNotNull(totalSummary!!.shippingRate)
+                assertThat(shippingRate).isNotNull()
+                assertThat(shippingRate.id).isEqualTo("shr_express")
+                assertThat(shippingRate.amount).isEqualTo(1500L)
+                assertThat(shippingRate.displayName).isEqualTo("Express Shipping")
+                assertThat(updated.shippingOptions).hasSize(2)
+                assertThat(updated.shippingOptions[0].id).isEqualTo("shr_standard")
+                assertThat(updated.shippingOptions[1].id).isEqualTo("shr_express")
+            }
+        }
+    }
+
+    @Test
+    fun `selectShippingRate returns failure on error response`() = runTest {
+        runCreateWithStateScenario { checkout ->
+            networkRule.enqueue(
+                host("api.stripe.com"),
+                method("POST"),
+                path("/v1/payment_pages/cs_test_abc123"),
+            ) { response ->
+                response.setResponseCode(400)
+                response.setBody("""{"error": {"message": "Invalid shipping rate"}}""")
+            }
+
+            checkout.checkoutSession.test {
+                val initial = awaitItem()
+
+                val result = checkout.selectShippingRate("shr_invalid")
+                assertThat(result.isFailure).isTrue()
+
+                expectNoEvents()
+                assertThat(checkout.checkoutSession.value).isEqualTo(initial)
+            }
+        }
+    }
+
+    @Test
     fun `configure returns failure when network request fails`() = runConfigureScenario(
         clientSecret = "cs_test_abc123_secret_xyz",
         networkSetup = {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
@@ -371,5 +371,12 @@ class CheckoutSessionConfirmationInterceptorTest {
         ): Result<CheckoutSessionResponse> {
             error("Not expected in this test")
         }
+
+        override suspend fun selectShippingRate(
+            sessionId: String,
+            shippingRateId: String,
+        ): Result<CheckoutSessionResponse> {
+            error("Not expected in this test")
+        }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionFixtures.kt
@@ -5,6 +5,7 @@ import org.json.JSONObject
 /**
  * Fixtures for checkout session responses from `/v1/payment_pages/{id}/init` API.
  */
+@Suppress("LargeClass")
 internal object CheckoutSessionFixtures {
 
     val CHECKOUT_SESSION_RESPONSE_JSON = JSONObject(
@@ -471,6 +472,7 @@ internal object CheckoutSessionFixtures {
                     }
                 ],
                 "shipping_rate": {
+                    "id": "shr_standard",
                     "amount": 500,
                     "display_name": "Standard Shipping",
                     "delivery_estimate": "5-7 business days"
@@ -582,6 +584,7 @@ internal object CheckoutSessionFixtures {
             },
             "shipping": {
                 "shipping_option": {
+                    "id": "shr_express",
                     "amount": 500,
                     "display_name": "Express Shipping",
                     "delivery_estimate": {
@@ -596,6 +599,62 @@ internal object CheckoutSessionFixtures {
                     }
                 }
             },
+            "elements_session": $MINIMAL_ELEMENTS_SESSION_JSON
+        }
+        """.trimIndent()
+    )
+
+    /**
+     * Init response with shipping_options array at the root level.
+     */
+    val CHECKOUT_SESSION_WITH_SHIPPING_OPTIONS_JSON = JSONObject(
+        """
+        {
+            "session_id": "cs_test_abc123",
+            "currency": "usd",
+            "shipping_rate": "shr_standard",
+            "total_summary": {
+                "due": 1500,
+                "subtotal": 1000,
+                "total": 1500
+            },
+            "line_item_group": {
+                "currency": "usd",
+                "total": 1500,
+                "subtotal": 1000,
+                "due": 1500,
+                "shipping_rate": {
+                    "id": "shr_standard",
+                    "amount": 500,
+                    "display_name": "Standard Shipping"
+                }
+            },
+            "shipping_options": [
+                {
+                    "shipping_rate": {
+                        "id": "shr_standard",
+                        "amount": 500,
+                        "display_name": "Standard Shipping",
+                        "currency": "usd"
+                    }
+                },
+                {
+                    "shipping_rate": {
+                        "id": "shr_express",
+                        "amount": 1500,
+                        "display_name": "Express Shipping",
+                        "currency": "usd"
+                    }
+                },
+                {
+                    "shipping_rate": {
+                        "id": "shr_free",
+                        "amount": 0,
+                        "display_name": "Free Shipping",
+                        "currency": "usd"
+                    }
+                }
+            ],
             "elements_session": $MINIMAL_ELEMENTS_SESSION_JSON
         }
         """.trimIndent()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParserTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionResponseJsonParserTest.kt
@@ -434,6 +434,7 @@ class CheckoutSessionResponseJsonParserTest {
 
         // Shipping
         assertThat(totalSummary?.shippingRate).isNotNull()
+        assertThat(totalSummary?.shippingRate?.id).isEqualTo("shr_standard")
         assertThat(totalSummary?.shippingRate?.amount).isEqualTo(500L)
         assertThat(totalSummary?.shippingRate?.displayName).isEqualTo("Standard Shipping")
         assertThat(totalSummary?.shippingRate?.deliveryEstimate).isEqualTo("5-7 business days")
@@ -465,6 +466,7 @@ class CheckoutSessionResponseJsonParserTest {
         val totalSummary = result?.totalSummary
         assertThat(totalSummary).isNotNull()
         assertThat(totalSummary?.shippingRate).isNotNull()
+        assertThat(totalSummary?.shippingRate?.id).isEqualTo("shr_express")
         assertThat(totalSummary?.shippingRate?.amount).isEqualTo(500L)
         assertThat(totalSummary?.shippingRate?.displayName).isEqualTo("Express Shipping")
         assertThat(totalSummary?.shippingRate?.deliveryEstimate).isEqualTo("1-3 business days")
@@ -585,5 +587,37 @@ class CheckoutSessionResponseJsonParserTest {
         assertThat(totalSummary?.discountAmounts).hasSize(1)
         assertThat(totalSummary?.discountAmounts?.get(0)?.amount).isEqualTo(1000L)
         assertThat(totalSummary?.discountAmounts?.get(0)?.displayName).isEqualTo("10OFF")
+    }
+
+    @Test
+    fun `parse shipping options from root level`() {
+        val result = CheckoutSessionResponseJsonParser(isLiveMode = false)
+            .parse(CheckoutSessionFixtures.CHECKOUT_SESSION_WITH_SHIPPING_OPTIONS_JSON)
+
+        assertThat(result).isNotNull()
+        val shippingOptions = result!!.shippingOptions
+        assertThat(shippingOptions).hasSize(3)
+
+        assertThat(shippingOptions[0].id).isEqualTo("shr_standard")
+        assertThat(shippingOptions[0].amount).isEqualTo(500L)
+        assertThat(shippingOptions[0].displayName).isEqualTo("Standard Shipping")
+        assertThat(shippingOptions[0].deliveryEstimate).isNull()
+
+        assertThat(shippingOptions[1].id).isEqualTo("shr_express")
+        assertThat(shippingOptions[1].amount).isEqualTo(1500L)
+        assertThat(shippingOptions[1].displayName).isEqualTo("Express Shipping")
+
+        assertThat(shippingOptions[2].id).isEqualTo("shr_free")
+        assertThat(shippingOptions[2].amount).isEqualTo(0L)
+        assertThat(shippingOptions[2].displayName).isEqualTo("Free Shipping")
+    }
+
+    @Test
+    fun `parse returns empty shipping options when not present`() {
+        val result = CheckoutSessionResponseJsonParser(isLiveMode = false)
+            .parse(CheckoutSessionFixtures.CHECKOUT_SESSION_RESPONSE_JSON)
+
+        assertThat(result).isNotNull()
+        assertThat(result!!.shippingOptions).isEmpty()
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/FakeCheckoutSessionRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/FakeCheckoutSessionRepository.kt
@@ -9,6 +9,7 @@ internal class FakeCheckoutSessionRepository(
     var detachResult: Result<CheckoutSessionResponse> = Result.failure(NotImplementedError()),
     var applyPromotionCodeResult: Result<CheckoutSessionResponse> = Result.failure(NotImplementedError()),
     var updateLineItemQuantityResult: Result<CheckoutSessionResponse> = Result.failure(NotImplementedError()),
+    var selectShippingRateResult: Result<CheckoutSessionResponse> = Result.failure(NotImplementedError()),
 ) : CheckoutSessionRepository {
 
     private val _initRequests = Turbine<String>()
@@ -54,6 +55,11 @@ internal class FakeCheckoutSessionRepository(
     ): Result<CheckoutSessionResponse> {
         return updateLineItemQuantityResult
     }
+
+    override suspend fun selectShippingRate(
+        sessionId: String,
+        shippingRateId: String,
+    ): Result<CheckoutSessionResponse> = selectShippingRateResult
 
     data class DetachRequest(
         val sessionId: String,

--- a/paymentsheet/src/test/resources/checkout-session-select-shipping-rate.json
+++ b/paymentsheet/src/test/resources/checkout-session-select-shipping-rate.json
@@ -1,0 +1,38 @@
+{
+  "session_id": "cs_test_abc123",
+  "currency": "usd",
+  "shipping_rate": "shr_express",
+  "total_summary": {
+    "due": 2500,
+    "subtotal": 1000,
+    "total": 2500
+  },
+  "line_item_group": {
+    "due": 2500,
+    "subtotal": 1000,
+    "total": 2500,
+    "shipping_rate": {
+      "id": "shr_express",
+      "amount": 1500,
+      "display_name": "Express Shipping"
+    }
+  },
+  "shipping_options": [
+    {
+      "shipping_rate": {
+        "id": "shr_standard",
+        "amount": 500,
+        "display_name": "Standard Shipping",
+        "currency": "usd"
+      }
+    },
+    {
+      "shipping_rate": {
+        "id": "shr_express",
+        "amount": 1500,
+        "display_name": "Express Shipping",
+        "currency": "usd"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# Summary
Add support for selecting and displaying shipping rates and options in the Checkout session API. This includes UI rendering of available shipping options, storing them in the session object, and sending selection requests to the backend. Updates the API, UI, repositories, and adds/updates related tests and fixtures.

# Motivation
Enable Checkout consumers to offer selectable shipping methods, improving flexibility and user experience. Previously, no way to enumerate or choose shipping rates from the client UI, limiting supported checkout flows.

# Testing
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | ![after screenshot with shipping option radio or selection rows displayed in Checkout](https://user-images.githubusercontent.com/example/after-shipping-options.png) |

# Changelog
- [Added] Shipping rate selection and shipping options to the Checkout session API and UI.