### PR TITLE
Add "Display Shipping Rates" option to CheckoutSession settings.

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
@@ -75,6 +75,8 @@ class CheckoutRequest private constructor(
     val adjustableQuantity: Boolean?,
     @SerialName("automatic_tax")
     val automaticTax: Boolean?,
+    @SerialName("display_shipping_rates")
+    val displayShippingRates: Boolean?,
 ) {
     @Serializable
     enum class CustomerKeyType {
@@ -124,6 +126,7 @@ class CheckoutRequest private constructor(
         private var allowPromotionCodes: Boolean? = null
         private var adjustableQuantity: Boolean? = null
         private var automaticTax: Boolean? = null
+        private var displayShippingRates: Boolean? = null
 
         fun initialization(initialization: String?) = apply {
             this.initialization = initialization
@@ -261,6 +264,10 @@ class CheckoutRequest private constructor(
             this.automaticTax = automaticTax
         }
 
+        fun displayShippingRates(displayShippingRates: Boolean?) = apply {
+            this.displayShippingRates = displayShippingRates
+        }
+
         fun build(): CheckoutRequest {
             return CheckoutRequest(
                 initialization = initialization,
@@ -300,6 +307,7 @@ class CheckoutRequest private constructor(
                 allowPromotionCodes = allowPromotionCodes,
                 adjustableQuantity = adjustableQuantity,
                 automaticTax = automaticTax,
+                displayShippingRates = displayShippingRates,
             )
         }
     }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CheckoutSessionDisplayShippingRatesSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CheckoutSessionDisplayShippingRatesSettingsDefinition.kt
@@ -1,0 +1,20 @@
+package com.stripe.android.paymentsheet.example.playground.settings
+
+import com.stripe.android.paymentsheet.example.playground.model.CheckoutRequest
+
+internal object CheckoutSessionDisplayShippingRatesSettingsDefinition : BooleanSettingsDefinition(
+    defaultValue = true,
+    displayName = "Display Shipping Rates",
+    key = "checkout_session_display_shipping_rates"
+) {
+    override fun applicable(
+        configurationData: PlaygroundConfigurationData,
+        settings: Map<PlaygroundSettingDefinition<*>, Any?>,
+    ): Boolean {
+        return settings[InitializationTypeSettingsDefinition] == InitializationType.CheckoutSession
+    }
+
+    override fun configure(value: Boolean, checkoutRequestBuilder: CheckoutRequest.Builder) {
+        checkoutRequestBuilder.displayShippingRates(value)
+    }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -477,6 +477,7 @@ internal class PlaygroundSettings private constructor(
             CheckoutSessionRemoveSettingsDefinition,
             CheckoutSessionAdjustableQuantitySettingsDefinition,
             CheckoutSessionAutomaticTaxSettingsDefinition,
+            CheckoutSessionDisplayShippingRatesSettingsDefinition,
             AllowPromotionCodesSettingsDefinition,
             CustomerSheetPaymentMethodModeDefinition,
             CustomerSessionSettingsDefinition,


### PR DESCRIPTION
# Summary
Added a new "Display Shipping Rates" option to CheckoutSession settings in the Playground app. This allows toggling the visibility of shipping rates during the checkout session flow.

# Motivation
To give users the ability to enable or disable the display of shipping rates in the CheckoutSession, improving test coverage and configurability for different checkout scenarios.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *N/A*  | <img src="screenshot-after.png" alt="Display Shipping Rates option in settings UI"> |

# Changelog
- [Added] Display Shipping Rates option to CheckoutSession settings in Playground.