### PR TITLE
Set Checkout Session Automatic Tax default to false in settings.

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CheckoutSessionAutomaticTaxSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/CheckoutSessionAutomaticTaxSettingsDefinition.kt
@@ -3,7 +3,7 @@ package com.stripe.android.paymentsheet.example.playground.settings
 import com.stripe.android.paymentsheet.example.playground.model.CheckoutRequest
 
 internal object CheckoutSessionAutomaticTaxSettingsDefinition : BooleanSettingsDefinition(
-    defaultValue = true,
+    defaultValue = false,
     displayName = "Automatic Tax",
     key = "checkout_session_automatic_tax"
 ) {


### PR DESCRIPTION
# Summary
Set the default value of "Automatic Tax" in checkout session settings to `false` instead of `true`.

# Motivation
This needs more integration work, true was a poor default.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Changelog
[Changed] Set Automatic Tax default value to false in checkout session settings.