### PR TITLE
Add link test cases to HCaptcha Network Tests

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/HCaptchaTokenTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/HCaptchaTokenTest.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet
 
+import androidx.test.espresso.Espresso.closeSoftKeyboard
 import androidx.test.espresso.intent.rule.IntentsRule
 import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.core.utils.urlEncode
@@ -19,9 +20,13 @@ import com.stripe.android.testing.FeatureFlagTestRule
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
+import kotlin.time.Duration.Companion.seconds
 
 internal class HCaptchaTokenTest {
-    private val testRules: TestRules = TestRules.create()
+    // The /v1/consumers/sessions/log_out request is launched async from a GlobalScope. We want to make sure it happens,
+    // but it's okay if it takes a bit to happen.
+    private val networkRule = NetworkRule(validationTimeout = 5.seconds)
+    private val testRules: TestRules = TestRules.create(networkRule = networkRule)
     private val featureFlagTestRule = FeatureFlagTestRule(
         featureFlag = FeatureFlags.enablePassiveCaptcha,
         isEnabled = true
@@ -32,8 +37,6 @@ internal class HCaptchaTokenTest {
         .around(IntentsRule())
         .around(featureFlagTestRule)
         .around(testRules)
-
-    private val networkRule = testRules.networkRule
 
     @Test
     fun newPaymentMethod_withPassiveCaptchaEnabled_includesHCaptchaTokenInConfirmRequest() = runProductIntegrationTest(
@@ -57,6 +60,42 @@ internal class HCaptchaTokenTest {
             }
         ) { testContext ->
             setupPaymentMethCreateWithDeferredTest(testContext)
+        }
+
+    @Test
+    fun linkPaymentMethodMode_withPassiveCaptchaEnabled_includesHCaptchaTokenInConfirmRequest() =
+        runProductIntegrationTest(
+            networkRule = networkRule,
+            integrationType = ProductIntegrationType.PaymentSheet,
+            resultCallback = ::assertCompleted,
+        ) { testContext ->
+            setupLinkWithCaptchaTest(
+                testContext = testContext,
+                elementsSessionFile = LINK_PMM_ELEMENTS_SESSION_FILE,
+            ) {
+                enqueueConsumerPaymentDetails()
+
+                enqueuePaymentIntentConfirmWithHCaptcha(NEW_PM_HCAPTCHA_TOKEN_PATH)
+            }
+        }
+
+    @Test
+    fun linkPassthroughMode_withPassiveCaptchaEnabled_includesHCaptchaTokenInConfirmRequest() =
+        runProductIntegrationTest(
+            networkRule = networkRule,
+            integrationType = ProductIntegrationType.PaymentSheet,
+            resultCallback = ::assertCompleted,
+        ) { testContext ->
+            setupLinkWithCaptchaTest(
+                testContext = testContext,
+                elementsSessionFile = LINK_PASSTHROUGH_ELEMENTS_SESSION_FILE,
+            ) {
+                enqueueConsumerPaymentDetails()
+
+                enqueueConsumerPaymentDetailsShare()
+
+                enqueuePaymentIntentConfirmWithHCaptcha(SAVED_PM_HCAPTCHA_TOKEN_PATH)
+            }
         }
 
     private fun setupNewPaymentMethodTest(testContext: ProductIntegrationTestRunnerContext) {
@@ -88,7 +127,80 @@ internal class HCaptchaTokenTest {
         verticalModePage.fillOutCardDetails()
     }
 
+    private fun setupLinkWithCaptchaTest(
+        testContext: ProductIntegrationTestRunnerContext,
+        elementsSessionFile: String,
+        enqueuePaymentDetailsAndConfirm: () -> Unit,
+    ) {
+        enqueueElementsSessionWithLinkAndCaptcha(elementsSessionFile)
+        testContext.launch()
+
+        val page = createPaymentSheetPage()
+        page.fillOutCardDetails()
+
+        enqueueConsumerSessionLookup()
+
+        page.clickOnLinkCheckbox()
+        page.fillOutLinkEmail()
+        page.fillOutLinkPhone()
+
+        closeSoftKeyboard()
+
+        enqueueConsumerSignUp()
+
+        enqueuePaymentDetailsAndConfirm()
+
+        enqueueConsumerLogout()
+
+        page.clickPrimaryButton()
+    }
+
     private fun createPaymentSheetPage() = PaymentSheetPage(testRules.compose)
+
+    private fun enqueueConsumerSessionLookup() {
+        networkRule.enqueue(
+            method("POST"),
+            path("/v1/consumers/sessions/lookup"),
+        ) { response ->
+            response.testBodyFromFile("consumer-session-lookup-success.json")
+        }
+    }
+
+    private fun enqueueConsumerSignUp() {
+        networkRule.enqueue(
+            method("POST"),
+            path("/v1/consumers/accounts/sign_up"),
+        ) { response ->
+            response.testBodyFromFile("consumer-accounts-signup-success.json")
+        }
+    }
+
+    private fun enqueueConsumerPaymentDetails() {
+        networkRule.enqueue(
+            method("POST"),
+            path("/v1/consumers/payment_details")
+        ) { response ->
+            response.testBodyFromFile("consumer-payment-details-success.json")
+        }
+    }
+
+    private fun enqueueConsumerPaymentDetailsShare() {
+        networkRule.enqueue(
+            method("POST"),
+            path("/v1/consumers/payment_details/share"),
+        ) { response ->
+            response.testBodyFromFile("consumer-payment-details-share-success.json")
+        }
+    }
+
+    private fun enqueueConsumerLogout() {
+        networkRule.enqueue(
+            method("POST"),
+            path("/v1/consumers/sessions/log_out"),
+        ) { response ->
+            response.testBodyFromFile("consumer-session-logout-success.json")
+        }
+    }
 
     private fun enqueueDeferredIntentRequests() {
         networkRule.enqueue(
@@ -118,6 +230,14 @@ internal class HCaptchaTokenTest {
                 STANDARD_ELEMENTS_SESSION_FILE
             },
             additionalReplacements = EMPTY_PAYMENT_METHODS_REPLACEMENTS
+        )
+    }
+
+    private fun enqueueElementsSessionWithLinkAndCaptcha(file: String) {
+        enqueueElementsSessionWithCaptchaEnabled(
+            networkRule = networkRule,
+            baseFile = file,
+            additionalReplacements = emptyList()
         )
     }
 
@@ -153,7 +273,7 @@ internal class HCaptchaTokenTest {
         networkRule.enqueue(
             method("POST"),
             path(PAYMENT_INTENT_CONFIRM_PATH),
-            bodyPart(urlEncode(tokenPath), HCAPTCHA_TOKEN),
+            bodyPart(urlEncode(tokenPath), HCAPTCHA_TOKEN)
         ) { response ->
             response.testBodyFromFile(PAYMENT_INTENT_CONFIRM_FILE)
         }
@@ -175,6 +295,9 @@ internal class HCaptchaTokenTest {
         private const val NEW_PM_HCAPTCHA_TOKEN_PATH = "payment_method_data[radar_options][hcaptcha_token]"
         private const val SAVED_PM_HCAPTCHA_TOKEN_PATH = "radar_options[hcaptcha_token]"
 
+        private const val LINK_PMM_ELEMENTS_SESSION_FILE = "elements-sessions-requires_payment_method.json"
+        private const val LINK_PASSTHROUGH_ELEMENTS_SESSION_FILE =
+            "elements-sessions-requires_pm_with_link_ps_mode.json"
         private const val STANDARD_ELEMENTS_SESSION_FILE = "elements-sessions-with_pi_and_default_pms_enabled.json"
         private const val DEFERRED_INTENT_ELEMENTS_SESSION_FILE =
             "elements-sessions-deferred_intent_and_default_pms_enabled.json"


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add link test cases to HCaptcha Network Tests

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
More test coverage. Link pms have logic that helps us determine whether a saved pm is passthrough mode is actually a new card. While we have unit tests for these scenarios, having network tests for link would be great to ensure we're not omitting radar data in the request

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
