### PR TITLE
Add US_TAX merchant option with USD currency and US country code.

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/MerchantSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/MerchantSettingsDefinition.kt
@@ -43,6 +43,7 @@ internal object MerchantSettingsDefinition :
         }.map { country ->
             option(country.name, convertToValue(country.code.value))
         }.toList() + listOf(
+            option(Merchant.US_TAX.name, convertToValue(Merchant.US_TAX.value)),
             option(Merchant.StripeShop.name, convertToValue(Merchant.StripeShop.value)),
             option(Merchant.Custom.name, convertToValue(Merchant.Custom.value))
         )
@@ -99,6 +100,7 @@ internal object MerchantSettingsDefinition :
                 Merchant.IT -> Currency.EUR
                 Merchant.TH -> Currency.THB
                 Merchant.StripeShop -> Currency.USD
+                Merchant.US_TAX -> Currency.USD
                 Merchant.Custom -> Currency.USD
             }
         }
@@ -120,6 +122,7 @@ enum class Merchant(override val value: String) : ValueEnum {
     IT("IT"),
     TH("TH"),
     StripeShop("stripe_shop_test"),
+    US_TAX("us_tax"),
     Custom("custom")
 }
 
@@ -141,6 +144,7 @@ val Merchant.countryCode: String
             Merchant.IT -> value
             Merchant.TH -> value
             Merchant.StripeShop -> "US"
+            Merchant.US_TAX -> "US"
             Merchant.Custom -> "US"
         }
     }


### PR DESCRIPTION
# Summary
Added a new "US_TAX" merchant option to Merchant settings, defaulting to USD currency and US country code.

# Motivation
To support merchants specifically dealing with US tax scenarios, enabling easy selection of a merchant preset configured for USD and US.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Changelog
- [Added] US_TAX merchant option with USD currency and US country code