### PR TITLE
Add Wero payments support (private preview) to PaymentSheet.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ Dependencies updated in [12373](https://github.com/stripe/stripe-android/pull/12
 - Bumped WorkManager from 2.9.0 to 2.11.1.
 - Bumped Material from 1.12.0 to 1.13.0.
 
+### PaymentSheet
+* [Added] Added support for Wero payments (private preview).
+
 ## 22.8.1 - 2026-02-17
 
 ### Identity


### PR DESCRIPTION
# Summary
Added support for Wero payments (private preview) to PaymentSheet.

# Motivation
This change enables PaymentSheet to support the Wero payment method, giving users in private preview access to this new payment option.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Changelog
- [Added] Added support for Wero payments (private preview) to PaymentSheet.