### PR TITLE
Update MIGRATING.md for v23.0.0

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,5 +1,9 @@
 # Migration Guide
 
+## Migrating from versions < 23.0.0
+- The SDK now requires Android 6.0+ (API level 23+)
+- The SDK now targets `compileSdkVersion` and `targetSdkVersion` 36
+
 ## Migrating from versions < 22.0.0
 SDK v22 introduces breaking changes organized into four categories:
 


### PR DESCRIPTION
## Summary
- Add migration guide entry for v23.0.0 covering the `minSdkVersion` bump to 23 (Android 6.0+) and `compileSdkVersion`/`targetSdkVersion` bump to 36.

## Motivation
No API changes in this major version — only platform requirement updates that merchants need to be aware of.

## Testing
N/A — documentation-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)