### PR TITLE
Add hasBodyPart matcher and update tests for body param presence checks.

### DIFF
--- a/network-testing/src/main/java/com/stripe/android/networktesting/RequestMatchers.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/RequestMatchers.kt
@@ -94,6 +94,15 @@ object RequestMatchers {
         }
     }
 
+    fun hasBodyPart(name: String): RequestMatcher {
+        return ToStringRequestMatcher("hasBodyPart($name)") { request ->
+            request.bodyText.substringAfter("?")
+                .split("&")
+                .map { it.substringBefore("=") }
+                .contains(name)
+        }
+    }
+
     fun bodyPart(name: String, value: String): RequestMatcher {
         return ToStringRequestMatcher("bodyPart($name, $value)") { request ->
             request.bodyText.substringAfter("?")

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetConfirmationTokenTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetConfirmationTokenTest.kt
@@ -4,6 +4,7 @@ import com.stripe.android.core.utils.urlEncode
 import com.stripe.android.networktesting.RequestMatcher
 import com.stripe.android.networktesting.RequestMatchers
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
+import com.stripe.android.networktesting.RequestMatchers.hasBodyPart
 import com.stripe.android.networktesting.RequestMatchers.host
 import com.stripe.android.networktesting.RequestMatchers.method
 import com.stripe.android.networktesting.RequestMatchers.not
@@ -286,7 +287,7 @@ internal class PaymentSheetConfirmationTokenTest {
     private fun clientContext(isLiveMode: Boolean, isPayment: Boolean = true): RequestMatcher {
         // The client_context param is only sent in test mode when creating a confirmation token
         return if (isLiveMode) {
-            not(bodyPart(urlEncode("client_context[mode]"), ".+".toRegex()))
+            not(hasBodyPart(urlEncode("client_context[mode]")))
         } else {
             // we only verify client context is not null here
             bodyPart(
@@ -307,12 +308,7 @@ internal class PaymentSheetConfirmationTokenTest {
                 "123"
             )
         } else {
-            not(
-                bodyPart(
-                    urlEncode("payment_method_options[card][cvc]"),
-                    ".+".toRegex()
-                )
-            )
+            not(hasBodyPart(urlEncode("payment_method_options[card][cvc]")))
         }
     }
 
@@ -333,19 +329,9 @@ internal class PaymentSheetConfirmationTokenTest {
             )
         } else {
             RequestMatchers.composite(
-                not(
-                    bodyPart(
-                        urlEncode("mandate_data[customer_acceptance][type]"),
-                        ".+".toRegex()
-                    )
-                ),
+                not(hasBodyPart(urlEncode("mandate_data[customer_acceptance][type]"))),
                 if (isPayment) {
-                    not(
-                        bodyPart(
-                            urlEncode("setup_future_usage"),
-                            ".+".toRegex()
-                        )
-                    )
+                    not(hasBodyPart(urlEncode("setup_future_usage")))
                 } else {
                     bodyPart(
                         urlEncode("setup_future_usage"),

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutTest.kt
@@ -12,6 +12,7 @@ import com.stripe.android.networktesting.RequestMatchers.not
 import com.stripe.android.networktesting.RequestMatchers.path
 import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.core.utils.urlEncode
+import com.stripe.android.networktesting.RequestMatchers.hasBodyPart
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.testing.PaymentConfigurationTestRule
@@ -407,10 +408,10 @@ class CheckoutTest {
                 path("/v1/payment_pages/cs_test_abc123"),
                 bodyPart(urlEncode("tax_region[country]"), "US"),
                 bodyPart(urlEncode("tax_region[postal_code]"), "80202"),
-                not(bodyPart(urlEncode("tax_region[city]"), "")),
-                not(bodyPart(urlEncode("tax_region[state]"), "")),
-                not(bodyPart(urlEncode("tax_region[line1]"), "")),
-                not(bodyPart(urlEncode("tax_region[line2]"), "")),
+                not(hasBodyPart(urlEncode("tax_region[city]"))),
+                not(hasBodyPart(urlEncode("tax_region[state]"))),
+                not(hasBodyPart(urlEncode("tax_region[line1]"))),
+                not(hasBodyPart(urlEncode("tax_region[line2]"))),
                 bodyPart(urlEncode("elements_session_client[is_aggregation_expected]"), "true"),
             ) { response ->
                 response.testBodyFromFile("checkout-session-update-shipping-address.json")


### PR DESCRIPTION
# Summary
Added a new `hasBodyPart` matcher to `RequestMatchers` for checking the presence of body params in requests. Updated test code to use this matcher instead of the previous value-based checks for cases where only the existence of a parameter matters.

# Motivation
This change improves test clarity and reliability by enabling checks for the presence of request body parameters directly, rather than relying on value checks with regex. It makes tests easier to read and maintain.

# Testing
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Changelog
[Added] Introduced the `hasBodyPart` matcher to `RequestMatchers` for validating body parameter presence in tests. Updated existing tests to use this matcher.