### PR TITLE
Disallow customer config with CheckoutSession initialization mode in PaymentSheet.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
@@ -13,6 +13,7 @@ import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferen
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheet.TermsDisplay
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
+import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -48,8 +49,13 @@ internal data class CommonConfiguration(
         return ConfigurationDefaults.allowedCardFundingTypes
     }
 
-    fun validate(isLiveMode: Boolean, @PaymentElementCallbackIdentifier callbackIdentifier: String) {
+    fun validate(
+        initializationMode: PaymentElementLoader.InitializationMode,
+        isLiveMode: Boolean,
+        @PaymentElementCallbackIdentifier callbackIdentifier: String,
+    ) {
         customerAndMerchantValidate()
+        checkoutSessionValidate(initializationMode)
         externalPaymentMethodsValidate(isLiveMode)
         confirmationTokenValidate(isLiveMode, callbackIdentifier)
 
@@ -74,6 +80,15 @@ internal data class CommonConfiguration(
                         " the Customer ID cannot be an empty string."
                 )
             }
+        }
+    }
+
+    private fun checkoutSessionValidate(initializationMode: PaymentElementLoader.InitializationMode) {
+        if (initializationMode is PaymentElementLoader.InitializationMode.CheckoutSession && customer != null) {
+            throw IllegalArgumentException(
+                "configuration.customer must not be set when using CheckoutSession initialization mode. " +
+                    "Customer information is provided by the checkout session."
+            )
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -46,8 +46,9 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
             try {
                 starterArgs.initializationMode.validate()
                 starterArgs.config.asCommonConfiguration().validate(
-                    PaymentConfiguration.getInstance(this).isLiveMode(),
-                    starterArgs.paymentElementCallbackIdentifier
+                    initializationMode = starterArgs.initializationMode,
+                    isLiveMode = PaymentConfiguration.getInstance(this).isLiveMode(),
+                    callbackIdentifier = starterArgs.paymentElementCallbackIdentifier,
                 )
             } catch (e: IllegalArgumentException) {
                 finishWithError(e)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -259,7 +259,11 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         val configuration = integrationConfiguration.commonConfiguration
         // Validate configuration before loading
         initializationMode.validate()
-        configuration.validate(paymentConfiguration.get().isLiveMode(), paymentElementCallbackIdentifier)
+        configuration.validate(
+            initializationMode = initializationMode,
+            isLiveMode = paymentConfiguration.get().isLiveMode(),
+            callbackIdentifier = paymentElementCallbackIdentifier,
+        )
 
         eventReporter.onLoadStarted(metadata.initializedViaCompose)
         tapToAddConnectionManager.connect()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtxTest.kt
@@ -7,6 +7,8 @@ import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbacks
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.uicore.StripeThemeDefaults
 import com.stripe.android.utils.PaymentElementCallbackTestRule
 import org.junit.Rule
@@ -34,7 +36,11 @@ class PaymentSheetConfigurationKtxTest {
             message = "When a CustomerConfiguration is passed to PaymentSheet, " +
                 "the ephemeralKeySecret cannot be an empty string."
         ) {
-            configWithBlankEphemeralKeySecret.validate(isLiveMode = false, callbackIdentifier = "")
+            configWithBlankEphemeralKeySecret.validate(
+                initializationMode = DEFAULT_INITIALIZATION_MODE,
+                isLiveMode = false,
+                callbackIdentifier = "",
+            )
         }
     }
 
@@ -50,8 +56,16 @@ class PaymentSheetConfigurationKtxTest {
 
     @Test
     fun `'validate' should succeed when ephemeral key secret is of correct format`() {
-        getConfig("ek_askljdlkasfhgasdfjls").validate(isLiveMode = false, callbackIdentifier = "")
-        getConfig("ek_test_iiuwfhdaiuhasdvkcjn32n").validate(isLiveMode = false, callbackIdentifier = "")
+        getConfig("ek_askljdlkasfhgasdfjls").validate(
+            initializationMode = DEFAULT_INITIALIZATION_MODE,
+            isLiveMode = false,
+            callbackIdentifier = "",
+        )
+        getConfig("ek_test_iiuwfhdaiuhasdvkcjn32n").validate(
+            initializationMode = DEFAULT_INITIALIZATION_MODE,
+            isLiveMode = false,
+            callbackIdentifier = "",
+        )
     }
 
     @Test
@@ -61,7 +75,11 @@ class PaymentSheetConfigurationKtxTest {
                 IllegalArgumentException::class,
                 message = "`ephemeralKeySecret` format does not match expected client secret formatting"
             ) {
-                getConfig(ephemeralKeySecret).validate(isLiveMode = false, callbackIdentifier = "")
+                getConfig(ephemeralKeySecret).validate(
+                    initializationMode = DEFAULT_INITIALIZATION_MODE,
+                    isLiveMode = false,
+                    callbackIdentifier = "",
+                )
             }
         }
 
@@ -88,7 +106,11 @@ class PaymentSheetConfigurationKtxTest {
             message = "When a CustomerConfiguration is passed to PaymentSheet, " +
                 "the customerSessionClientSecret cannot be an empty string."
         ) {
-            configWithBlankCustomerSessionClientSecret.validate(isLiveMode = false, callbackIdentifier = "")
+            configWithBlankCustomerSessionClientSecret.validate(
+                initializationMode = DEFAULT_INITIALIZATION_MODE,
+                isLiveMode = false,
+                callbackIdentifier = "",
+            )
         }
     }
 
@@ -108,8 +130,9 @@ class PaymentSheetConfigurationKtxTest {
                 "secret. See CustomerSession API: https://docs.stripe.com/api/customer_sessions/create"
         ) {
             configWithEphemeralKeySecretAsCustomerSessionClientSecret.validate(
+                initializationMode = DEFAULT_INITIALIZATION_MODE,
                 isLiveMode = false,
-                callbackIdentifier = ""
+                callbackIdentifier = "",
             )
         }
     }
@@ -129,7 +152,11 @@ class PaymentSheetConfigurationKtxTest {
             message = "Argument does not look like a CustomerSession client secret. " +
                 "See CustomerSession API: https://docs.stripe.com/api/customer_sessions/create"
         ) {
-            configWithInvalidCustomerSessionClientSecret.validate(isLiveMode = false, callbackIdentifier = "")
+            configWithInvalidCustomerSessionClientSecret.validate(
+                initializationMode = DEFAULT_INITIALIZATION_MODE,
+                isLiveMode = false,
+                callbackIdentifier = "",
+            )
         }
     }
 
@@ -141,7 +168,11 @@ class PaymentSheetConfigurationKtxTest {
             .asCommonConfiguration()
 
         // Should not throw
-        configWithValidExternalPaymentMethods.validate(isLiveMode = false, callbackIdentifier = "")
+        configWithValidExternalPaymentMethods.validate(
+            initializationMode = DEFAULT_INITIALIZATION_MODE,
+            isLiveMode = false,
+            callbackIdentifier = "",
+        )
     }
 
     @Test
@@ -158,7 +189,11 @@ class PaymentSheetConfigurationKtxTest {
                 "See https://docs.stripe.com/payments/external-payment-methods?platform=android#available-external-" +
                 "payment-methods"
         ) {
-            configWithInvalidExternalPaymentMethod.validate(isLiveMode = false, callbackIdentifier = "")
+            configWithInvalidExternalPaymentMethod.validate(
+                initializationMode = DEFAULT_INITIALIZATION_MODE,
+                isLiveMode = false,
+                callbackIdentifier = "",
+            )
         }
     }
 
@@ -170,7 +205,11 @@ class PaymentSheetConfigurationKtxTest {
             .asCommonConfiguration()
 
         // Should not throw
-        configWithEmptyExternalPaymentMethods.validate(isLiveMode = false, callbackIdentifier = "")
+        configWithEmptyExternalPaymentMethods.validate(
+            initializationMode = DEFAULT_INITIALIZATION_MODE,
+            isLiveMode = false,
+            callbackIdentifier = "",
+        )
     }
 
     @Test
@@ -187,7 +226,11 @@ class PaymentSheetConfigurationKtxTest {
                 "See https://docs.stripe.com/payments/external-payment-methods?platform=android#available-external" +
                 "-payment-methods"
         ) {
-            configWithMultipleInvalidExternalPaymentMethods.validate(isLiveMode = false, callbackIdentifier = "")
+            configWithMultipleInvalidExternalPaymentMethods.validate(
+                initializationMode = DEFAULT_INITIALIZATION_MODE,
+                isLiveMode = false,
+                callbackIdentifier = "",
+            )
         }
     }
 
@@ -199,7 +242,11 @@ class PaymentSheetConfigurationKtxTest {
             .asCommonConfiguration()
 
         // Should not throw when in live mode
-        configWithInvalidExternalPaymentMethods.validate(isLiveMode = true, callbackIdentifier = "")
+        configWithInvalidExternalPaymentMethods.validate(
+            initializationMode = DEFAULT_INITIALIZATION_MODE,
+            isLiveMode = true,
+            callbackIdentifier = "",
+        )
     }
 
     @Test
@@ -225,6 +272,7 @@ class PaymentSheetConfigurationKtxTest {
             message = "createIntentWithConfirmationTokenCallback must be used with CustomerSession."
         ) {
             configWithLegacyKey.validate(
+                initializationMode = DEFAULT_INITIALIZATION_MODE,
                 isLiveMode = false,
                 callbackIdentifier = callbackIdentifier
             )
@@ -250,6 +298,7 @@ class PaymentSheetConfigurationKtxTest {
             .asCommonConfiguration()
 
         configWithLegacyKey.validate(
+            initializationMode = DEFAULT_INITIALIZATION_MODE,
             isLiveMode = true,
             callbackIdentifier = callbackIdentifier
         )
@@ -274,6 +323,7 @@ class PaymentSheetConfigurationKtxTest {
             .asCommonConfiguration()
 
         configWithCustomerSession.validate(
+            initializationMode = DEFAULT_INITIALIZATION_MODE,
             isLiveMode = false,
             callbackIdentifier = callbackIdentifier
         )
@@ -293,12 +343,63 @@ class PaymentSheetConfigurationKtxTest {
             .asCommonConfiguration()
 
         configWithoutCustomer.validate(
+            DEFAULT_INITIALIZATION_MODE,
             isLiveMode = false,
             callbackIdentifier = callbackIdentifier
         )
     }
 
+    @Test
+    fun `'validate' should fail when using CheckoutSession mode with non-null customer`() {
+        val configWithCustomer = configuration.asCommonConfiguration()
+        val checkoutSessionMode = PaymentElementLoader.InitializationMode.CheckoutSession(
+            checkoutSessionResponse = CheckoutSessionResponse(
+                id = "cs_test_123",
+                amount = 5099,
+                currency = "usd",
+            ),
+        )
+
+        assertFailsWith(
+            IllegalArgumentException::class,
+            message = "configuration.customer must not be set when using CheckoutSession initialization mode. " +
+                "Customer information is provided by the checkout session."
+        ) {
+            configWithCustomer.validate(
+                initializationMode = checkoutSessionMode,
+                isLiveMode = false,
+                callbackIdentifier = ""
+            )
+        }
+    }
+
+    @Test
+    fun `'validate' should succeed when using CheckoutSession mode with null customer`() {
+        val configWithoutCustomer = configuration.newBuilder()
+            .customer(null)
+            .build()
+            .asCommonConfiguration()
+        val checkoutSessionMode = PaymentElementLoader.InitializationMode.CheckoutSession(
+            checkoutSessionResponse = CheckoutSessionResponse(
+                id = "cs_test_123",
+                amount = 5099,
+                currency = "usd",
+            ),
+        )
+
+        // Should not throw
+        configWithoutCustomer.validate(
+            initializationMode = checkoutSessionMode,
+            isLiveMode = false,
+            callbackIdentifier = ""
+        )
+    }
+
     private companion object {
+        val DEFAULT_INITIALIZATION_MODE = PaymentElementLoader.InitializationMode.PaymentIntent(
+            clientSecret = "pi_123_secret_456",
+        )
+
         val configuration = PaymentSheet.Configuration(
             merchantDisplayName = "Merchant, Inc.",
             customer = PaymentSheet.CustomerConfiguration(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -265,6 +265,33 @@ internal class DefaultPaymentElementLoaderTest {
     }
 
     @Test
+    fun `load with CheckoutSession mode and non-null customer returns failure`() = runScenario {
+        val result = createPaymentElementLoader().load(
+            initializationMode = PaymentElementLoader.InitializationMode.CheckoutSession(
+                checkoutSessionResponse = createCheckoutSessionResponse(canDetachPaymentMethod = true),
+            ),
+            paymentSheetConfiguration = PaymentSheet.Configuration(
+                merchantDisplayName = "Some name",
+                customer = PaymentSheet.CustomerConfiguration(
+                    id = "cus_123",
+                    ephemeralKeySecret = "ek_123",
+                ),
+            ),
+            metadata = PaymentElementLoader.Metadata(
+                initializedViaCompose = false,
+            ),
+        )
+
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()?.message).isEqualTo(
+            "configuration.customer must not be set when using CheckoutSession initialization mode. " +
+                "Customer information is provided by the checkout session."
+        )
+
+        assertThat(eventReporter.loadFailedTurbine.awaitItem()).isNotNull()
+    }
+
+    @Test
     fun `load without customer should return expected result`() = runScenario {
         val loader = createPaymentElementLoader(
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_WITHOUT_LINK,


### PR DESCRIPTION
# Summary

Disallow setting a customer configuration when initializing PaymentSheet with CheckoutSession mode. The code now throws an exception if a customer config is provided alongside CheckoutSession. Updated validation logic and added corresponding tests to ensure correct behavior.

# Motivation

Prevent users from setting redundant or conflicting customer information when using CheckoutSession initialization, as customer details should be provided by the checkout session itself rather than configuration.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

# Changelog

- [Fixed] Disallowed setting a customer configuration when using CheckoutSession initialization mode in PaymentSheet. An exception is now thrown if configuration.customer is set in this scenario.