### PR TITLE
Remove Parcelable and @Parcelize from CheckoutSession and inner classes.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSession.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSession.kt
@@ -1,14 +1,11 @@
 package com.stripe.android.checkout
 
-import android.os.Parcelable
 import androidx.annotation.RestrictTo
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import dev.drewhamilton.poko.Poko
-import kotlinx.parcelize.Parcelize
 
 @Poko
-@Parcelize
 @CheckoutSessionPreview
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class CheckoutSession internal constructor(
@@ -17,10 +14,9 @@ class CheckoutSession internal constructor(
     val totalSummary: TotalSummary?,
     val lineItems: List<LineItem>,
     val shippingOptions: List<ShippingRate>,
-) : Parcelable {
+) {
 
     @Poko
-    @Parcelize
     @CheckoutSessionPreview
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     class TotalSummary internal constructor(
@@ -31,19 +27,17 @@ class CheckoutSession internal constructor(
         val taxAmounts: List<TaxAmount>,
         val shippingRate: ShippingRate?,
         val appliedBalance: Long?,
-    ) : Parcelable
+    )
 
     @Poko
-    @Parcelize
     @CheckoutSessionPreview
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     class DiscountAmount internal constructor(
         val amount: Long,
         val displayName: String,
-    ) : Parcelable
+    )
 
     @Poko
-    @Parcelize
     @CheckoutSessionPreview
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     class TaxAmount internal constructor(
@@ -51,10 +45,9 @@ class CheckoutSession internal constructor(
         val inclusive: Boolean,
         val displayName: String,
         val percentage: Double,
-    ) : Parcelable
+    )
 
     @Poko
-    @Parcelize
     @CheckoutSessionPreview
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     class ShippingRate internal constructor(
@@ -62,10 +55,9 @@ class CheckoutSession internal constructor(
         val amount: Long,
         val displayName: String,
         val deliveryEstimate: String?,
-    ) : Parcelable
+    )
 
     @Poko
-    @Parcelize
     @CheckoutSessionPreview
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     class LineItem internal constructor(
@@ -75,7 +67,7 @@ class CheckoutSession internal constructor(
         val unitAmount: Long?,
         val subtotal: Long,
         val total: Long,
-    ) : Parcelable
+    )
 }
 
 @OptIn(CheckoutSessionPreview::class)


### PR DESCRIPTION
# Summary
Removed `Parcelable` and `@Parcelize` annotations from `CheckoutSession` and all its inner classes. Updated classes to be regular Kotlin classes.

# Motivation
`Parcelable` is another interface that isn't needed. Merchants should use Checkout.state if they need to use checkout between activities.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Changelog
[Removed] `Parcelable` and `@Parcelize` from `CheckoutSession` and its inner classes. These classes can no longer be passed as Parcelables.