### PR TITLE
Show Toast for errors in Checkout example.

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutPlaygroundActivity.kt
@@ -28,7 +28,9 @@ import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
+import android.widget.Toast
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -37,6 +39,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import com.stripe.android.checkout.Checkout
 import com.stripe.android.checkout.CheckoutSession
 import com.stripe.android.paymentelement.CheckoutSessionPreview
@@ -72,6 +75,8 @@ class CheckoutPlaygroundActivity : AppCompatActivity() {
             CheckoutScreen(
                 checkout = viewModel.checkout,
                 isLoading = viewModel.isLoading,
+                errorMessage = viewModel.errorMessage,
+                clearErrorMessage = viewModel::clearErrorMessage,
                 applyPromotionCode = viewModel::applyPromotionCode,
                 removePromotionCode = viewModel::removePromotionCode,
                 updateLineItemQuantity = viewModel::updateLineItemQuantity,
@@ -93,6 +98,8 @@ class CheckoutPlaygroundActivity : AppCompatActivity() {
 private fun CheckoutScreen(
     checkout: Checkout,
     isLoading: StateFlow<Boolean>,
+    errorMessage: StateFlow<String?>,
+    clearErrorMessage: () -> Unit,
     applyPromotionCode: (String) -> Unit,
     removePromotionCode: () -> Unit,
     updateLineItemQuantity: (String, Int) -> Unit,
@@ -102,7 +109,16 @@ private fun CheckoutScreen(
 ) {
     val checkoutSession by checkout.checkoutSession.collectAsState()
     val loading by isLoading.collectAsState()
+    val error by errorMessage.collectAsState()
     var promotionCode by rememberSaveable { mutableStateOf("") }
+
+    val context = LocalContext.current
+    LaunchedEffect(error) {
+        error?.let {
+            Toast.makeText(context, it, Toast.LENGTH_LONG).show()
+            clearErrorMessage()
+        }
+    }
 
     BackHandler(enabled = loading) { }
 

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutPlaygroundViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutPlaygroundViewModel.kt
@@ -1,14 +1,16 @@
 package com.stripe.android.paymentsheet.example.playground.checkout
 
 import android.app.Application
+import android.util.Log
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.APPLICATION_KEY
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
-import com.stripe.android.checkout.Checkout
-import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.checkout.Address
+import com.stripe.android.checkout.Checkout
+import com.stripe.android.checkout.CheckoutSession
+import com.stripe.android.paymentelement.CheckoutSessionPreview
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -26,6 +28,13 @@ internal class CheckoutPlaygroundViewModel(
 
     private val _isLoading = MutableStateFlow(false)
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
+    private val _errorMessage = MutableStateFlow<String?>(null)
+    val errorMessage: StateFlow<String?> = _errorMessage.asStateFlow()
+
+    fun clearErrorMessage() {
+        _errorMessage.value = null
+    }
 
     fun applyPromotionCode(promotionCode: String) = performWhileLoading {
         checkout.applyPromotionCode(promotionCode)
@@ -52,10 +61,13 @@ internal class CheckoutPlaygroundViewModel(
         checkout.refresh()
     }
 
-    private fun performWhileLoading(block: suspend () -> Unit) {
+    private fun performWhileLoading(block: suspend () -> Result<CheckoutSession>) {
         viewModelScope.launch {
             _isLoading.value = true
-            block()
+            block().onFailure { exception ->
+                Log.e("CheckoutPlaygroundViewModel", "Failed to perform request", exception)
+                _errorMessage.value = exception.message
+            }
             _isLoading.value = false
         }
     }


### PR DESCRIPTION
# Summary
Show error messages in a Toast when checkout network calls fail. The error is surfaced from the ViewModel and displayed to the user.

# Motivation
Previously, failures when applying a promotion code were silently ignored in the UI. This change provides clear feedback to the user when the operation fails, improving the user experience and debuggability.

# Testing
- [x] Manually verified

# Changelog
[Fixed] Show Toast error message on promotion code failures in CheckoutPlaygroundActivity.