### PR TITLE
Add full address and address picker support to checkout playground.

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutPlaygroundActivity.kt
@@ -157,24 +157,7 @@ private fun CheckoutScreen(
                     updateShippingAddress = updateShippingAddress,
                 )
                 ShippingOptionsSection(checkoutSession, selectShippingRate)
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(PADDING),
-                ) {
-                    OutlinedTextField(
-                        value = promotionCode,
-                        onValueChange = { promotionCode = it },
-                        label = { Text("Promotion code") },
-                        singleLine = true,
-                        modifier = Modifier.weight(1f),
-                    )
-                    Button(
-                        onClick = { applyPromotionCode(promotionCode) },
-                    ) {
-                        Text("Apply")
-                    }
-                }
+                PromotionCodeInput(promotionCode, { promotionCode = it }, applyPromotionCode)
                 Button(
                     onClick = refresh,
                 ) {
@@ -195,6 +178,32 @@ private fun CheckoutScreen(
             ) {
                 CircularProgressIndicator()
             }
+        }
+    }
+}
+
+@Composable
+private fun PromotionCodeInput(
+    promotionCode: String,
+    onPromotionCodeChange: (String) -> Unit,
+    applyPromotionCode: (String) -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(PADDING),
+    ) {
+        OutlinedTextField(
+            value = promotionCode,
+            onValueChange = onPromotionCodeChange,
+            label = { Text("Promotion code") },
+            singleLine = true,
+            modifier = Modifier.weight(1f),
+        )
+        Button(
+            onClick = { applyPromotionCode(promotionCode) },
+        ) {
+            Text("Apply")
         }
     }
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutPlaygroundViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutPlaygroundViewModel.kt
@@ -57,7 +57,8 @@ internal class CheckoutPlaygroundViewModel(
     }
 
     fun updateShippingAddress(addressDetails: AddressDetails) = performWhileLoading {
-        val country = addressDetails.address?.country ?: return@performWhileLoading
+        val country = addressDetails.address?.country
+            ?: return@performWhileLoading Result.failure(IllegalStateException("Country is required"))
         val address = Address()
             .city(addressDetails.address?.city)
             .country(country)
@@ -65,8 +66,9 @@ internal class CheckoutPlaygroundViewModel(
             .line2(addressDetails.address?.line2)
             .postalCode(addressDetails.address?.postalCode)
             .state(addressDetails.address?.state)
-        checkout.updateShippingAddress(address)
-        _lastAddressDetails.value = addressDetails
+        checkout.updateShippingAddress(address).also {
+            _lastAddressDetails.value = addressDetails
+        }
     }
 
     fun updatePostalCode(postalCode: String) = performWhileLoading {
@@ -75,8 +77,9 @@ internal class CheckoutPlaygroundViewModel(
     }
 
     fun clearShippingAddress() = performWhileLoading {
-        checkout.updateShippingAddress(Address().country("US"))
-        _lastAddressDetails.value = null
+        checkout.updateShippingAddress(Address().country("US")).also {
+            _lastAddressDetails.value = null
+        }
     }
 
     fun refresh() = performWhileLoading {


### PR DESCRIPTION
# Summary

Added a full shipping address input with a picker to the checkout playground. Users can now choose between entering only a postal code or entering a complete shipping address. The selected address is displayed and can be edited or cleared.

# Motivation

To provide a more comprehensive and realistic shipping address entry experience in the checkout playground, allowing better testing of different shipping flows and integration with full shipping address capabilities.

# Testing

- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Changelog

- [Added] Full shipping address input and picker to the checkout playground, supporting selection between postal code and complete address.