### PR TITLE
Add usesCleartextTraffic flag to AndroidManifest via build config property.

### DIFF
--- a/paymentsheet-example/build.gradle
+++ b/paymentsheet-example/build.gradle
@@ -24,6 +24,10 @@ def getSentryDsn() {
     }
 }
 
+def usesCleartextTraffic() {
+    return findProperty('STRIPE_PAYMENTSHEET_EXAMPLE_USES_CLEARTEXT_TRAFFIC') ?: "false"
+}
+
 def directlyToPlayground() {
     return project.hasProperty("DIRECTLY_TO_PLAYGROUND") && project.DIRECTLY_TO_PLAYGROUND.contains("true")
 }
@@ -64,6 +68,7 @@ android {
                 BACKEND_URL: getBackendUrl(),
                 GOOGLE_PLACES_API_KEY: getGooglePlacesApiKey(),
                 SENTRY_DSN: getSentryDsn(),
+                USES_CLEARTEXT_TRAFFIC: usesCleartextTraffic(),
         ]
     }
     buildFeatures {

--- a/paymentsheet-example/src/main/AndroidManifest.xml
+++ b/paymentsheet-example/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
+        android:usesCleartextTraffic="${USES_CLEARTEXT_TRAFFIC}"
         android:theme="@style/AppTheme"
         tools:ignore="AllowBackup">
 


### PR DESCRIPTION
# Summary
Added a build configuration property (`STRIPE_PAYMENTSHEET_EXAMPLE_USES_CLEARTEXT_TRAFFIC`) to control the `usesCleartextTraffic` flag in the AndroidManifest for the paymentsheet-example app.

# Motivation
Allows configuring whether the app permits cleartext network traffic without manually modifying the manifest, supporting easier testing and deployment in different environments.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Changelog
[Added] Build config property to control `usesCleartextTraffic` setting in paymentsheet-example's AndroidManifest.