### PR TITLE
Attach release APK using GitHub Actions; remove manual upload from script.

### DIFF
--- a/.github/workflows/attach_release_apk.yml
+++ b/.github/workflows/attach_release_apk.yml
@@ -1,0 +1,25 @@
+name: Attach release APK
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  attach-apk:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
+      - uses: ./.github/actions/stripe_setup
+      - name: Build paymentsheet-example APK
+        run: ./gradlew :paymentsheet-example:assembleBaseRelease
+      - name: Attach APK to release
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          gh release upload "$GITHUB_REF_NAME" \
+            paymentsheet-example/build/outputs/apk/base/release/paymentsheet-example-base-release.apk#"paymentsheet-example-release-${VERSION}.apk"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/scripts/deploy/create_github_release.rb
+++ b/scripts/deploy/create_github_release.rb
@@ -14,7 +14,6 @@ def create_github_release
     execute_or_fail("git checkout #{@deploy_branch}")
     execute_or_fail("git pull")
 
-    build_example_release_apk
     tag_release
 
     begin
@@ -27,7 +26,6 @@ def create_github_release
         )
 
         @release_url = release_response.url
-        upload_example_apk_to_release(@release_url)
 
         rputs "Created new release"
         open_url(release_response.html_url)
@@ -111,24 +109,6 @@ private def changelog_entries_for_version
     end
 
     raise ArgumentError.new("Version #{@version} not found in changelog. Have you finished merging the version bump PR?")
-end
-
-private def build_example_release_apk
-    gnupg_env do |env|
-        Subprocess.check_call(
-            ['./gradlew', ':paymentsheet-example:assembleBaseRelease'],
-            env: env
-        )
-    end
-end
-
-private def upload_example_apk_to_release(release_url)
-    octokit_client.upload_asset(
-        release_url,
-        "../stripe-android/paymentsheet-example/build/outputs/apk/base/release/paymentsheet-example-base-release.apk",
-        name: "paymentsheet-example-release-#{@version}.apk",
-        content_type: "application/vnd.android.package-archive"
-    )
 end
 
 private def octokit_client


### PR DESCRIPTION
# Summary
Moved the attachment of release APKs to GitHub Actions on release publish, removing manual building and uploading from the deployment script.

# Motivation
Automating APK attachment to releases streamlines the release process and reduces manual steps/errors during deployments.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Changelog
[Changed] APKs are now attached to GitHub releases automatically via Actions; manual upload from deployment script removed.