### PR TITLE
Add support for proxy IP address in paymentsheet-example app.

### DIFF
--- a/paymentsheet-example/build.gradle
+++ b/paymentsheet-example/build.gradle
@@ -16,6 +16,10 @@ def getGooglePlacesApiKey() {
     return findProperty('STRIPE_PAYMENTSHEET_EXAMPLE_GOOGLE_PLACES_API_KEY') ?: ""
 }
 
+def getProxyIpAddress() {
+    return findProperty('STRIPE_PAYMENTSHEET_EXAMPLE_PROXY_IP_ADDRESS') ?: ""
+}
+
 def getSentryDsn() {
     if (gradle.ext.isCi || gradle.ext.isBrowserstackBuild) {
         return findProperty('STRIPE_PAYMENTSHEET_EXAMPLE_SENTRY_DSN') ?: ""
@@ -63,6 +67,7 @@ android {
         buildConfigField "boolean", "IS_RUNNING_IN_CI", "$gradle.ext.isCi"
         buildConfigField "boolean", "IS_BROWSERSTACK_BUILD", "$gradle.ext.isBrowserstackBuild"
         buildConfigField "boolean", "DIRECTLY_TO_PLAYGROUND", "${directlyToPlayground()}"
+        buildConfigField "String", "PROXY_IP_ADDRESS", "\"${getProxyIpAddress()}\""
 
         manifestPlaceholders = [
                 BACKEND_URL: getBackendUrl(),

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/ExampleApplication.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/ExampleApplication.kt
@@ -1,11 +1,30 @@
 package com.stripe.android.paymentsheet.example
 
+import android.annotation.SuppressLint
 import android.app.Application
 import android.os.StrictMode
+import com.stripe.android.core.networking.ConnectionFactory
+import com.stripe.android.core.networking.StripeRequest
+import java.net.HttpURLConnection
+import java.net.InetSocketAddress
+import java.net.Proxy
+import java.net.URL
+import java.security.SecureRandom
+import java.security.cert.X509Certificate
+import javax.net.ssl.HttpsURLConnection
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLSocketFactory
+import javax.net.ssl.TrustManager
+import javax.net.ssl.X509TrustManager
 
 class ExampleApplication : Application() {
 
     override fun onCreate() {
+        val proxyIpAddress = BuildConfig.PROXY_IP_ADDRESS
+        if (proxyIpAddress.isNotEmpty()) {
+            ConnectionFactory.Default.connectionOpener = ProxyConnectionOpener(proxyIpAddress)
+        }
+
         StrictMode.setThreadPolicy(
             StrictMode.ThreadPolicy.Builder()
                 .detectAll()
@@ -36,5 +55,50 @@ class ExampleApplication : Application() {
 
     private companion object {
         private const val IS_PENALTY_DEATH_ENABLED = false
+    }
+}
+
+@Suppress("EmptyFunctionBlock", "MagicNumber")
+class ProxyConnectionOpener(
+    private val ipAddress: String
+) : ConnectionFactory.ConnectionOpener {
+    override fun open(
+        request: StripeRequest,
+        callback: HttpURLConnection.(request: StripeRequest) -> Unit
+    ): HttpsURLConnection {
+        val socketAddress = InetSocketAddress.createUnresolved(ipAddress, 8888)
+        val proxy = Proxy(Proxy.Type.HTTP, socketAddress)
+
+        return (URL(request.url).openConnection(proxy) as HttpsURLConnection).apply {
+            sslSocketFactory = trustAllSocketFactory()
+            callback(request)
+        }
+    }
+
+    @SuppressLint("CustomX509TrustManager", "TrustAllX509TrustManager")
+    private fun trustAllSocketFactory(): SSLSocketFactory {
+        val trustAllCerts = arrayOf<TrustManager>(
+            object : X509TrustManager {
+                override fun checkClientTrusted(
+                    chain: Array<out X509Certificate>?,
+                    authType: String?
+                ) {
+                }
+
+                override fun checkServerTrusted(
+                    chain: Array<out X509Certificate>?,
+                    authType: String?
+                ) {
+                }
+
+                override fun getAcceptedIssuers(): Array<X509Certificate> {
+                    return emptyArray()
+                }
+            }
+        )
+
+        val sslContext = SSLContext.getInstance("SSL")
+        sslContext.init(null, trustAllCerts, SecureRandom())
+        return sslContext.socketFactory
     }
 }


### PR DESCRIPTION
# Summary
Add support for specifying a proxy IP address for backend connections in the paymentsheet-example app. The proxy IP is configurable via a Gradle property, and if set, all network requests are routed through the proxy.

# Motivation
This change enables developers to test the paymentsheet-example app with network traffic routed through a proxy, which is useful for debugging, monitoring, or simulating different network conditions.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Changelog
- [Added] Support for proxy IP address configuration in paymentsheet-example app via the `STRIPE_PAYMENTSHEET_EXAMPLE_PROXY_IP_ADDRESS` property.