### PR TITLE
Refactor: centralize sessionId handling with withSessionId helper.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/Checkout.kt
@@ -52,46 +52,43 @@ class Checkout private constructor(
     private val _checkoutSession = MutableStateFlow(state.checkoutSessionResponse.asCheckoutSession())
     val checkoutSession: StateFlow<CheckoutSession> = _checkoutSession.asStateFlow()
 
-    suspend fun applyPromotionCode(promotionCode: String): Result<CheckoutSession> {
-        val sessionId = state.checkoutSessionResponse.id
-        return component.checkoutSessionRepository
-            .applyPromotionCode(sessionId, promotionCode.trim())
-            .updateState()
+    suspend fun applyPromotionCode(
+        promotionCode: String,
+    ): Result<CheckoutSession> = withSessionId { sessionId ->
+        component.checkoutSessionRepository.applyPromotionCode(sessionId, promotionCode.trim())
     }
 
-    suspend fun updateLineItemQuantity(lineItemId: String, quantity: Int): Result<CheckoutSession> {
-        val sessionId = state.checkoutSessionResponse.id
-        return component.checkoutSessionRepository
-            .updateLineItemQuantity(sessionId, lineItemId, quantity)
-            .updateState()
+    suspend fun updateLineItemQuantity(
+        lineItemId: String,
+        quantity: Int,
+    ): Result<CheckoutSession> = withSessionId { sessionId ->
+        component.checkoutSessionRepository.updateLineItemQuantity(sessionId, lineItemId, quantity)
     }
 
-    suspend fun removePromotionCode(): Result<CheckoutSession> {
-        val sessionId = state.checkoutSessionResponse.id
-        return component.checkoutSessionRepository
-            .applyPromotionCode(sessionId, "")
-            .updateState()
+    suspend fun removePromotionCode(): Result<CheckoutSession> = withSessionId { sessionId ->
+        component.checkoutSessionRepository.applyPromotionCode(sessionId, "")
     }
 
-    suspend fun selectShippingRate(shippingRateId: String): Result<CheckoutSession> {
-        val sessionId = state.checkoutSessionResponse.id
-        return component.checkoutSessionRepository
-            .selectShippingRate(sessionId, shippingRateId)
-            .updateState()
+    suspend fun selectShippingRate(
+        shippingRateId: String,
+    ): Result<CheckoutSession> = withSessionId { sessionId ->
+        component.checkoutSessionRepository.selectShippingRate(sessionId, shippingRateId)
     }
 
-    suspend fun updateShippingAddress(address: Address): Result<CheckoutSession> {
-        val sessionId = state.checkoutSessionResponse.id
-        return component.checkoutSessionRepository
-            .updateShippingAddress(sessionId, address.build())
-            .updateState()
+    suspend fun updateShippingAddress(
+        address: Address,
+    ): Result<CheckoutSession> = withSessionId { sessionId ->
+        component.checkoutSessionRepository.updateShippingAddress(sessionId, address.build())
     }
 
-    suspend fun refresh(): Result<CheckoutSession> {
-        val sessionId = state.checkoutSessionResponse.id
-        return component.checkoutSessionRepository
-            .init(sessionId)
-            .updateState()
+    suspend fun refresh(): Result<CheckoutSession> = withSessionId { sessionId ->
+        component.checkoutSessionRepository.init(sessionId)
+    }
+
+    private suspend fun withSessionId(
+        block: suspend (sessionId: String) -> Result<CheckoutSessionResponse>
+    ): Result<CheckoutSession> {
+        return block(state.checkoutSessionResponse.id).updateState()
     }
 
     private fun Result<CheckoutSessionResponse>.updateState(): Result<CheckoutSession> {


### PR DESCRIPTION
# Summary

Centralized session ID handling for checkout session operations by introducing a `withSessionId` helper function, reducing code duplication and improving maintainability.

# Motivation

Reduce repetitive retrieval of the session ID across various Checkout methods, making the code cleaner and less error-prone. This change also consolidates session management logic, making future updates easier.

# Testing

- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Changelog

[Changed] Centralized session ID handling for checkout session operations with a `withSessionId` helper.