### PR TITLE
Use customersheet specific supported payment method types when navigating to add PM screen

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -195,19 +195,30 @@ internal class DefaultCustomerSheetLoader(
             selection = paymentSelection as? PaymentSelection.Saved
         )
 
-        val supportedPaymentMethods = metadata.sortedSupportedPaymentMethods()
-
-        val validSupportedPaymentMethods = filterSupportedPaymentMethods(supportedPaymentMethods)
+        val supportedPaymentMethods = getSupportedPaymentMethods(metadata)
 
         return CustomerSheetState.Full(
             config = configuration,
             paymentMethodMetadata = metadata,
-            supportedPaymentMethods = validSupportedPaymentMethods,
+            supportedPaymentMethods = supportedPaymentMethods,
             customerPaymentMethods = sortedPaymentMethods,
             paymentSelection = paymentSelection,
             validationError = customerSheetSession.elementsSession.stripeIntent.validate(),
             customerPermissions = customerSheetSession.permissions,
         )
+    }
+
+    private fun getSupportedPaymentMethods(metadata: PaymentMethodMetadata): List<SupportedPaymentMethod> {
+        val supportedPaymentMethods = metadata.sortedSupportedPaymentMethods()
+
+        val validSupportedPaymentMethods = filterSupportedPaymentMethods(supportedPaymentMethods)
+
+        require(validSupportedPaymentMethods.isNotEmpty()) {
+            "No supported payment methods were found. " +
+                "Ensure your integration is configured to accept card or US bank account payments."
+        }
+
+        return supportedPaymentMethods
     }
 
     private fun getPaymentSelection(

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -791,8 +791,7 @@ internal class CustomerSheetViewModel(
         val paymentMethodMetadata = requireNotNull(customerState.metadata)
 
         val paymentMethodCode = previouslySelectedPaymentMethod?.code
-            ?: paymentMethodMetadata.supportedPaymentMethodTypes().firstOrNull()
-            ?: PaymentMethod.Type.Card.code
+            ?: supportedPaymentMethods.first().code
 
         val formArguments = FormArgumentsFactory.create(
             paymentMethodCode = paymentMethodCode,

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -1857,19 +1857,19 @@ class CustomerSheetViewModelTest {
     }
 
     @Test
-    fun `When 'paymentMethodOrder' is defined, initial shown payment method should be first from 'paymentMethodOrder'`() =
+    fun `Initial shown payment method should be first from supportedPaymentMethods`() =
         runTest(testDispatcher) {
             val viewModel = createViewModel(
                 workContext = testDispatcher,
                 customerSheetLoader = FakeCustomerSheetLoader(
                     customerPaymentMethods = listOf(),
                     isGooglePayAvailable = false,
+                    supportedPaymentMethods = listOf(
+                        LpmRepositoryTestHelpers.usBankAccount,
+                        LpmRepositoryTestHelpers.card,
+                    ),
                     stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD_WITH_US_BANK_ACCOUNT,
                 ),
-                configuration = CustomerSheet.Configuration(
-                    merchantDisplayName = "Merchant, Inc.",
-                    paymentMethodOrder = listOf("us_bank_account", "card")
-                )
             )
 
             viewModel.viewState.test {

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -35,6 +35,7 @@ import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.financialconnections.IsFinancialConnectionsSdkAvailable
@@ -668,6 +669,24 @@ internal class DefaultCustomerSheetLoaderTest {
 
         assertThat(customerSheetMetadata.attachmentStyle)
             .isEqualTo(IntegrationMetadata.CustomerSheet.AttachmentStyle.CreateAttach)
+    }
+
+    @Test
+    fun `supportedPaymentMethods uses paymentMethodOrder from configuration`() = runTest {
+        val loader = createCustomerSheetLoader(
+            isFinancialConnectionsAvailable = { true },
+            intent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD_WITH_US_BANK_ACCOUNT,
+        )
+
+        val config = CustomerSheet.Configuration(
+            merchantDisplayName = "Example",
+            paymentMethodOrder = listOf("us_bank_account", "card"),
+        )
+
+        val supportedPaymentMethods = loader.load(config).getOrThrow().supportedPaymentMethods
+        assertThat(supportedPaymentMethods.map { it.code })
+            .containsExactly("us_bank_account", "card")
+            .inOrder()
     }
 
     private fun createCustomerSheetLoader(

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -672,6 +672,27 @@ internal class DefaultCustomerSheetLoaderTest {
     }
 
     @Test
+    fun `load fails gracefully when no supported payment methods are available`() = runTest {
+        val eventReporter = FakeCustomerSheetEventReporter()
+
+        val loader = createCustomerSheetLoader(
+            intent = STRIPE_INTENT.copy(
+                paymentMethodTypes = listOf("sepa_debit")
+            ),
+            eventReporter = eventReporter,
+        )
+
+        val config = CustomerSheet.Configuration(merchantDisplayName = "Example")
+
+        val result = loader.load(config)
+
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()).isInstanceOf<IllegalArgumentException>()
+        assertThat(result.exceptionOrNull()?.message).contains("No supported payment methods were found")
+        assertThat(eventReporter.onLoadFailedCalls.awaitItem()).isNotNull()
+    }
+
+    @Test
     fun `supportedPaymentMethods uses paymentMethodOrder from configuration`() = runTest {
         val loader = createCustomerSheetLoader(
             isFinancialConnectionsAvailable = { true },

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/FakeCustomerSheetLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/FakeCustomerSheetLoader.kt
@@ -21,7 +21,7 @@ import kotlinx.coroutines.delay
 import kotlin.time.Duration
 
 internal class FakeCustomerSheetLoader(
-    private val stripeIntent: StripeIntent = PaymentIntentFixtures.PI_SUCCEEDED,
+    private val stripeIntent: StripeIntent = PaymentIntentFixtures.PI_SUCCEEDED_WITH_US_BANK,
     private val shouldFail: Boolean = false,
     private val customerPaymentMethods: List<PaymentMethod> = emptyList(),
     private val supportedPaymentMethods: List<SupportedPaymentMethod> = listOf(

--- a/paymentsheet/src/test/java/com/stripe/android/model/PaymentIntentFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/model/PaymentIntentFixtures.kt
@@ -32,6 +32,40 @@ internal object PaymentIntentFixtures {
     )
     val PI_SUCCEEDED = requireNotNull(PARSER.parse(PI_SUCCEEDED_JSON))
 
+    private val PI_SUCCEEDED_WITH_US_BANK_JSON = org.json.JSONObject(
+        """
+        {
+            "id": "pi_1IRg6VCRMbs6F",
+            "object": "payment_intent",
+            "amount": 1099,
+            "canceled_at": null,
+            "cancellation_reason": null,
+            "capture_method": "automatic",
+            "client_secret": "pi_1IRg6VCRMbs6F_secret_7oH5g4v8GaCrHfsGYS6kiSnwF",
+            "confirmation_method": "automatic",
+            "created": 1614960135,
+            "currency": "usd",
+            "description": "Example PaymentIntent",
+            "last_payment_error": null,
+            "livemode": false,
+            "next_action": null,
+            "payment_method": "pm_1IJs3ZCRMbs",
+            "payment_method_types": ["card","us_bank_account"],
+            "payment_method_options": {
+                "us_bank_account": {
+                    "verification_method": "automatic"
+                }
+            },
+            "receipt_email": null,
+            "setup_future_usage": null,
+            "shipping": null,
+            "source": null,
+            "status": "succeeded"
+        }
+        """.trimIndent()
+    )
+    val PI_SUCCEEDED_WITH_US_BANK = requireNotNull(PARSER.parse(PI_SUCCEEDED_WITH_US_BANK_JSON))
+
     val PI_REQUIRES_MASTERCARD_3DS2_JSON = org.json.JSONObject(
         """
         {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Use customersheet specific supported payment method types when navigating to add PM screen

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Attempt to fix https://github.com/stripe/stripe-android/issues/12503.

PaymentElement can end up with a selected item code which is not included in the supported payment method types list when:
- there is no previously selected PM code 
- payment method metadata's supported PMs contains a non-customer sheet supported PM first (e.g. klarna is first)

I also removed the fallback to card for when there are no supported payment methods available. We don't necessarily know that cards are in the PI/SI so we shouldn't fall back to cards.

This will crash if there are no LPMs. That was already the behavior. Now if this crashes, we will know that it's crashing _because_ there are no LPMs so the crash will be more informative.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [X] Manually verified