### PR TITLE
Add analytics event for scan card button visibility

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/cardscan/CardScanEventsReporter.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/cardscan/CardScanEventsReporter.kt
@@ -37,6 +37,11 @@ interface CardScanEventsReporter {
      * Card scan API availability check failed.
      */
     fun onCardScanApiCheckFailed(implementation: String, error: Throwable? = null)
+
+    /**
+     * The scan card button is being shown to the user.
+     */
+    fun onCardScanButtonShown()
 }
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -67,6 +72,10 @@ private object EmptyCardScanEventsReporter : CardScanEventsReporter {
 
     override fun onCardScanApiCheckFailed(implementation: String, error: Throwable?) {
         errorIfDebug("onCardScanApiCheckFailed")
+    }
+
+    override fun onCardScanButtonShown() {
+        errorIfDebug("onCardScanButtonShown")
     }
 
     private fun errorIfDebug(eventName: String) {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/ScanCardButtonUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/ScanCardButtonUI.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -21,6 +22,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.cardscan.CardScanLauncher
+import com.stripe.android.ui.core.cardscan.LocalCardScanEventsReporter
 import com.stripe.android.uicore.IconStyle
 import com.stripe.android.uicore.LocalIconStyle
 import com.stripe.android.uicore.utils.collectAsState
@@ -38,6 +40,11 @@ internal fun ScanCardButtonUI(
     val isCardScanAvailable by cardScanLauncher.isAvailable.collectAsState()
 
     if (isCardScanAvailable) {
+        val eventsReporter = LocalCardScanEventsReporter.current
+        LaunchedEffect(Unit) {
+            eventsReporter.onCardScanButtonShown()
+        }
+
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.clickable(

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/ScanCardButtonUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/ScanCardButtonUI.kt
@@ -12,7 +12,10 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
@@ -41,8 +44,12 @@ internal fun ScanCardButtonUI(
 
     if (isCardScanAvailable) {
         val eventsReporter = LocalCardScanEventsReporter.current
+        var hasReportedCardScanButtonShown by rememberSaveable { mutableStateOf(false) }
         LaunchedEffect(Unit) {
-            eventsReporter.onCardScanButtonShown()
+            if (!hasReportedCardScanButtonShown) {
+                eventsReporter.onCardScanButtonShown()
+                hasReportedCardScanButtonShown = true
+            }
         }
 
         Row(

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/cardscan/FakeCardScanEventsReporter.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/cardscan/FakeCardScanEventsReporter.kt
@@ -10,6 +10,7 @@ internal class FakeCardScanEventsReporter : CardScanEventsReporter {
     data class ScanStartedCall(val implementation: String)
     data class ApiCheckSucceededCall(val implementation: String)
     data class ApiCheckFailedCall(val implementation: String, val error: Throwable?)
+    data object ScanButtonShownCall
 
     private val _scanCancelledCalls = Turbine<ScanCancelledCall>()
     val scanCancelledCalls: ReceiveTurbine<ScanCancelledCall> = _scanCancelledCalls
@@ -29,6 +30,9 @@ internal class FakeCardScanEventsReporter : CardScanEventsReporter {
     private val _apiCheckFailedCalls = Turbine<ApiCheckFailedCall>()
     val apiCheckFailedCalls: ReceiveTurbine<ApiCheckFailedCall> = _apiCheckFailedCalls
 
+    private val _scanButtonShownCalls = Turbine<ScanButtonShownCall>()
+    val scanButtonShownCalls: ReceiveTurbine<ScanButtonShownCall> = _scanButtonShownCalls
+
     fun validate() {
         _scanCancelledCalls.ensureAllEventsConsumed()
         _scanFailedCalls.ensureAllEventsConsumed()
@@ -36,6 +40,7 @@ internal class FakeCardScanEventsReporter : CardScanEventsReporter {
         _scanStartedCalls.ensureAllEventsConsumed()
         _apiCheckSucceededCalls.ensureAllEventsConsumed()
         _apiCheckFailedCalls.ensureAllEventsConsumed()
+        _scanButtonShownCalls.ensureAllEventsConsumed()
     }
 
     override fun onCardScanCancelled(implementation: String) {
@@ -60,5 +65,9 @@ internal class FakeCardScanEventsReporter : CardScanEventsReporter {
 
     override fun onCardScanApiCheckFailed(implementation: String, error: Throwable?) {
         _apiCheckFailedCalls.add(ApiCheckFailedCall(implementation, error))
+    }
+
+    override fun onCardScanButtonShown() {
+        _scanButtonShownCalls.add(ScanButtonShownCall)
     }
 }

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/ScanCardButtonUITest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/ScanCardButtonUITest.kt
@@ -40,6 +40,7 @@ internal class ScanCardButtonUITest {
     fun `ScanCardButtonUI should launch Google launcher when GPCR is available`() = runScenario(
         isFetchClientSucceed = true,
     ) {
+        scanButtonShownCall.awaitItem()
         composeTestRule.onNodeWithText("Scan card").performClick()
         assertThat(cardScanCall.awaitItem()).isEqualTo("google_pay")
     }
@@ -49,6 +50,23 @@ internal class ScanCardButtonUITest {
         isFetchClientSucceed = false,
     ) {
         composeTestRule.onNodeWithText("Scan card").assertDoesNotExist()
+    }
+
+    @Test
+    fun `ScanCardButtonUI fires button shown event when visible`() = runScenario(
+        isFetchClientSucceed = true,
+    ) {
+        composeTestRule.onNodeWithText("Scan card").assertExists()
+        assertThat(scanButtonShownCall.awaitItem())
+            .isEqualTo(FakeCardScanEventsReporter.ScanButtonShownCall)
+    }
+
+    @Test
+    fun `ScanCardButtonUI does not fire button shown event when hidden`() = runScenario(
+        isFetchClientSucceed = false,
+    ) {
+        composeTestRule.onNodeWithText("Scan card").assertDoesNotExist()
+        // No event should have been fired - validate ensures no unconsumed events
     }
 
     private fun createMockPaymentCardRecognitionResultIntent(): Intent {
@@ -69,6 +87,7 @@ internal class ScanCardButtonUITest {
     }
     private class Scenario(
         val cardScanCall: ReceiveTurbine<String>,
+        val scanButtonShownCall: ReceiveTurbine<FakeCardScanEventsReporter.ScanButtonShownCall>,
     )
 
     private fun runScenario(
@@ -76,6 +95,7 @@ internal class ScanCardButtonUITest {
         block: suspend Scenario.() -> Unit
     ) = runTest {
         val cardScanCall = Turbine<String>()
+        val fakeEventsReporter = FakeCardScanEventsReporter()
         val registryOwner = object : ActivityResultRegistryOwner {
             override val activityResultRegistry: ActivityResultRegistry =
                 object : ActivityResultRegistry() {
@@ -96,12 +116,13 @@ internal class ScanCardButtonUITest {
 
         val scenario = Scenario(
             cardScanCall = cardScanCall,
+            scanButtonShownCall = fakeEventsReporter.scanButtonShownCalls,
         )
 
         composeTestRule.setContent {
             CompositionLocalProvider(
                 LocalActivityResultRegistryOwner provides registryOwner,
-                LocalCardScanEventsReporter provides FakeCardScanEventsReporter(),
+                LocalCardScanEventsReporter provides fakeEventsReporter,
                 LocalPaymentCardRecognitionClient provides FakePaymentCardRecognitionClient(isFetchClientSucceed)
             ) {
                 val context = LocalContext.current

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/analytics/CustomerSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/analytics/CustomerSheetEvent.kt
@@ -341,6 +341,11 @@ internal sealed class CustomerSheetEvent : AnalyticsEvent {
         )
     }
 
+    class CardScanButtonShown : CustomerSheetEvent(), CardScanEvent {
+        override val eventName: String = CS_CARDSCAN_BUTTON_SHOWN
+        override val additionalParams: Map<String, Any?> = emptyMap()
+    }
+
     internal companion object {
         const val CS_INIT_WITH_CUSTOMER_ADAPTER = "cs_init_with_customer_adapter"
         const val CS_INIT_WITH_CUSTOMER_SESSION = "cs_init_with_customer_session"
@@ -402,6 +407,7 @@ internal sealed class CustomerSheetEvent : AnalyticsEvent {
         const val CS_CARDSCAN_CANCEL = "cs_cardscan_cancel"
         const val CS_CARDSCAN_API_CHECK_SUCCEEDED = "cs_cardscan_api_check_succeeded"
         const val CS_CARDSCAN_API_CHECK_FAILED = "cs_cardscan_api_check_failed"
+        const val CS_CARDSCAN_BUTTON_SHOWN = "cs_cardscan_button_shown"
 
         const val FIELD_GOOGLE_PAY_ENABLED = "google_pay_enabled"
         const val FIELD_BILLING = "default_billing_details"

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
@@ -455,4 +455,12 @@ private class DefaultCardScanEventReporter(
             )
         )
     }
+
+    override fun onCardScanButtonShown() {
+        viewActionHandler.invoke(
+            CustomerSheetViewAction.OnCardScanEvent(
+                CustomerSheetEvent.CardScanButtonShown()
+            )
+        )
+    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -512,6 +512,10 @@ internal class DefaultEventReporter @Inject internal constructor(
         )
     }
 
+    override fun onCardScanButtonShown() {
+        fireEvent(PaymentSheetEvent.CardScanButtonShown())
+    }
+
     override fun onCardScanApiCheckSucceeded(implementation: String) {
         fireEvent(
             PaymentSheetEvent.CardScanApiCheckSucceeded(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -491,6 +491,10 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         )
     }
 
+    class CardScanButtonShown : PaymentSheetEvent() {
+        override val eventName: String = "mc_cardscan_button_shown"
+    }
+
     class CardScanApiCheckFailed(
         implementation: String,
         error: Throwable?,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -818,6 +818,17 @@ class DefaultEventReporterTest {
     }
 
     @Test
+    fun `onCardScanButtonShown fires event`() = runScenario {
+        paymentMethodMetadataStack.push(paymentMethodMetadataWithTestAnalyticsMetadata)
+
+        eventReporter.onCardScanButtonShown()
+
+        val request = analyticsRequestExecutor.requestTurbine.awaitItem()
+        assertThat(request.params).containsEntry("event", "mc_cardscan_button_shown")
+        assertThat(request.params).containsEntry("example_from_test", true)
+    }
+
+    @Test
     fun `onUsBankAccountFormEvent fires started event`() = runScenario {
         paymentMethodMetadataStack.push(paymentMethodMetadataWithTestAnalyticsMetadata)
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeEventReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeEventReporter.kt
@@ -283,6 +283,9 @@ internal class FakeEventReporter : EventReporter {
     override fun onCardScanApiCheckFailed(implementation: String, error: Throwable?) {
     }
 
+    override fun onCardScanButtonShown() {
+    }
+
     override fun onInitiallyDisplayedPaymentMethodVisibilitySnapshot(
         visiblePaymentMethods: List<String>,
         hiddenPaymentMethods: List<String>,

--- a/paymentsheet/src/test/java/com/stripe/android/testing/NoOpCardScanEventsReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/testing/NoOpCardScanEventsReporter.kt
@@ -13,4 +13,5 @@ internal object NoOpCardScanEventsReporter : CardScanEventsReporter {
     override fun onCardScanStarted(implementation: String) = Unit
     override fun onCardScanApiCheckSucceeded(implementation: String) = Unit
     override fun onCardScanApiCheckFailed(implementation: String, error: Throwable?) = Unit
+    override fun onCardScanButtonShown() = Unit
 }


### PR DESCRIPTION
## Summary
- Add `mc_cardscan_button_shown` analytics event to PaymentSheet and `cs_cardscan_button_shown` to CustomerSheet
- Fires via `LaunchedEffect` in `ScanCardButtonUI` when the scan card button is displayed to the user
- Wired through `CardScanEventsReporter` interface, `DefaultEventReporter`, and `CustomerSheetScreen`'s `DefaultCardScanEventReporter`

## Motivation
We track card scan lifecycle events (started, succeeded, failed, cancelled) but have no visibility into how often the "Scan card" button is actually shown to users. This event enables measuring the feature's reach.

## Test plan
- [x] Added `onCardScanButtonShown fires event` test in `DefaultEventReporterTest`
- [x] Added `ScanCardButtonUI fires button shown event when visible` test in `ScanCardButtonUITest`
- [x] Added `ScanCardButtonUI does not fire button shown event when hidden` test in `ScanCardButtonUITest`
- [x] All existing tests pass
