### PR TITLE
Add EmbeddedPaymentElement and FlowController IntentConfig examples.

### DIFF
--- a/paymentsheet-example/detekt-baseline.xml
+++ b/paymentsheet-example/detekt-baseline.xml
@@ -27,6 +27,12 @@
     <ID>PackageNaming:CustomFlowActivity.kt:package com.stripe.android.paymentsheet.example.samples.ui.paymentsheet.custom_flow</ID>
     <ID>PackageNaming:CustomFlowViewModel.kt:package com.stripe.android.paymentsheet.example.samples.ui.paymentsheet.custom_flow</ID>
     <ID>PackageNaming:CustomFlowViewState.kt:package com.stripe.android.paymentsheet.example.samples.ui.paymentsheet.custom_flow</ID>
+    <ID>PackageNaming:EmbeddedPaymentElementExampleActivity.kt:package com.stripe.android.paymentsheet.example.samples.ui.embedded_payment_element</ID>
+    <ID>PackageNaming:EmbeddedPaymentElementExampleViewModel.kt:package com.stripe.android.paymentsheet.example.samples.ui.embedded_payment_element</ID>
+    <ID>PackageNaming:EmbeddedPaymentElementExampleViewState.kt:package com.stripe.android.paymentsheet.example.samples.ui.embedded_payment_element</ID>
+    <ID>PackageNaming:FlowControllerIntentConfigActivity.kt:package com.stripe.android.paymentsheet.example.samples.ui.paymentsheet.flow_controller_with_intent_configuration</ID>
+    <ID>PackageNaming:FlowControllerIntentConfigViewModel.kt:package com.stripe.android.paymentsheet.example.samples.ui.paymentsheet.flow_controller_with_intent_configuration</ID>
+    <ID>PackageNaming:FlowControllerIntentConfigViewState.kt:package com.stripe.android.paymentsheet.example.samples.ui.paymentsheet.flow_controller_with_intent_configuration</ID>
     <ID>PackageNaming:ServerSideConfirmationCompleteFlowActivity.kt:package com.stripe.android.paymentsheet.example.samples.ui.paymentsheet.server_side_confirm.complete_flow</ID>
     <ID>PackageNaming:ServerSideConfirmationCompleteFlowViewModel.kt:package com.stripe.android.paymentsheet.example.samples.ui.paymentsheet.server_side_confirm.complete_flow</ID>
     <ID>PackageNaming:ServerSideConfirmationCompleteFlowViewState.kt:package com.stripe.android.paymentsheet.example.samples.ui.paymentsheet.server_side_confirm.complete_flow</ID>

--- a/paymentsheet-example/src/main/AndroidManifest.xml
+++ b/paymentsheet-example/src/main/AndroidManifest.xml
@@ -54,6 +54,8 @@
         <activity android:name="com.stripe.android.paymentsheet.example.playground.activity.FawryActivity" />
         <activity android:name="com.stripe.android.paymentsheet.example.playground.activity.CustomPaymentMethodActivity" />
         <activity android:name="com.stripe.android.paymentsheet.example.playground.embedded.EmbeddedPlaygroundActivity" />
+        <activity android:name="com.stripe.android.paymentsheet.example.samples.ui.paymentsheet.flow_controller_with_intent_configuration.FlowControllerIntentConfigActivity" />
+        <activity android:name="com.stripe.android.paymentsheet.example.samples.ui.embedded_payment_element.EmbeddedPaymentElementExampleActivity" />
         <activity android:name="com.stripe.android.paymentsheet.example.playground.embedded.EmbeddedExampleActivity" />
         <activity android:name="com.stripe.android.paymentsheet.example.playground.spt.SharedPaymentTokenPlaygroundActivity" />
         <activity android:name="com.stripe.android.paymentsheet.example.playground.LinkControllerPlaygroundActivity" />

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/MainActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/MainActivity.kt
@@ -37,8 +37,10 @@ import com.stripe.android.paymentsheet.example.playground.embedded.EmbeddedExamp
 import com.stripe.android.paymentsheet.example.samples.ui.SECTION_ALPHA
 import com.stripe.android.paymentsheet.example.samples.ui.addresselement.AddressElementExampleActivity
 import com.stripe.android.paymentsheet.example.samples.ui.customersheet.CustomerSheetExampleActivity
+import com.stripe.android.paymentsheet.example.samples.ui.embedded_payment_element.EmbeddedPaymentElementExampleActivity
 import com.stripe.android.paymentsheet.example.samples.ui.paymentsheet.complete_flow.CompleteFlowActivity
 import com.stripe.android.paymentsheet.example.samples.ui.paymentsheet.custom_flow.CustomFlowActivity
+import com.stripe.android.paymentsheet.example.samples.ui.paymentsheet.flow_controller_with_intent_configuration.FlowControllerIntentConfigActivity
 import com.stripe.android.paymentsheet.example.samples.ui.paymentsheet.server_side_confirm.complete_flow.ServerSideConfirmationCompleteFlowActivity
 import com.stripe.android.paymentsheet.example.samples.ui.paymentsheet.server_side_confirm.custom_flow.ServerSideConfirmationCustomFlowActivity
 import com.stripe.android.paymentsheet.example.samples.ui.shared.PaymentSheetExampleTheme
@@ -85,9 +87,21 @@ class MainActivity : AppCompatActivity() {
                 section = MenuItem.Section.CustomFlow,
             ),
             MenuItem(
+                titleResId = R.string.flow_controller_intent_config_title,
+                subtitleResId = R.string.flow_controller_intent_config_subtitle,
+                klass = FlowControllerIntentConfigActivity::class.java,
+                section = MenuItem.Section.CustomFlow,
+            ),
+            MenuItem(
                 titleResId = R.string.embedded_example_title,
                 subtitleResId = R.string.embedded_subtitle,
                 klass = EmbeddedExampleActivity::class.java,
+                section = MenuItem.Section.Embedded,
+            ),
+            MenuItem(
+                titleResId = R.string.embedded_intent_config_title,
+                subtitleResId = R.string.embedded_intent_config_subtitle,
+                klass = EmbeddedPaymentElementExampleActivity::class.java,
                 section = MenuItem.Section.Embedded,
             ),
             MenuItem(

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/embedded_payment_element/EmbeddedPaymentElementExampleActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/embedded_payment_element/EmbeddedPaymentElementExampleActivity.kt
@@ -1,0 +1,170 @@
+package com.stripe.android.paymentsheet.example.samples.ui.embedded_payment_element
+
+import android.graphics.Color
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalResources
+import com.google.android.material.snackbar.Snackbar
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentelement.rememberEmbeddedPaymentElement
+import com.stripe.android.paymentsheet.example.R
+import com.stripe.android.paymentsheet.example.samples.model.toIntentConfiguration
+import com.stripe.android.paymentsheet.example.samples.ui.shared.BuyButton
+import com.stripe.android.paymentsheet.example.samples.ui.shared.CompletedPaymentAlertDialog
+import com.stripe.android.paymentsheet.example.samples.ui.shared.ErrorScreen
+import com.stripe.android.paymentsheet.example.samples.ui.shared.PaymentMethodSelector
+import com.stripe.android.paymentsheet.example.samples.ui.shared.PaymentSheetExampleTheme
+import com.stripe.android.paymentsheet.example.samples.ui.shared.Receipt
+
+internal class EmbeddedPaymentElementExampleActivity : AppCompatActivity() {
+
+    private val snackbar by lazy {
+        Snackbar.make(findViewById(android.R.id.content), "", Snackbar.LENGTH_SHORT)
+            .setBackgroundTint(Color.BLACK)
+            .setTextColor(Color.WHITE)
+    }
+
+    private val viewModel by viewModels<EmbeddedPaymentElementExampleViewModel>()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            PaymentSheetExampleTheme {
+                EmbeddedPaymentElementScreen(
+                    viewModel = viewModel,
+                    snackbar = snackbar,
+                    onFinish = ::finish,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmbeddedPaymentElementScreen(
+    viewModel: EmbeddedPaymentElementExampleViewModel,
+    snackbar: Snackbar,
+    onFinish: () -> Unit,
+) {
+    val embeddedBuilder = remember {
+        EmbeddedPaymentElement.Builder(
+            createIntentCallback = viewModel::createAndConfirmIntent,
+            resultCallback = viewModel::handleResult,
+        )
+    }
+
+    val embeddedPaymentElement = rememberEmbeddedPaymentElement(embeddedBuilder)
+
+    val uiState by viewModel.state.collectAsState()
+    val selectedPaymentOption by embeddedPaymentElement.paymentOption.collectAsState()
+    val paymentMethodLabel = determinePaymentMethodLabel(uiState, selectedPaymentOption)
+
+    if (uiState.cartState.total != null) {
+        LaunchedEffect(uiState.cartState) {
+            val result = embeddedPaymentElement.configure(
+                intentConfiguration = uiState.cartState.toIntentConfiguration(),
+                configuration = uiState.embeddedConfig,
+            )
+            val error = (result as? EmbeddedPaymentElement.ConfigureResult.Failed)?.error
+            viewModel.handleConfigured(error)
+        }
+    }
+
+    uiState.status?.let { status ->
+        if (uiState.didComplete) {
+            CompletedPaymentAlertDialog(onDismiss = onFinish)
+        } else {
+            LaunchedEffect(status) {
+                snackbar.setText(status).show()
+                viewModel.statusDisplayed()
+            }
+        }
+    }
+
+    EmbeddedPaymentElementContent(
+        uiState = uiState,
+        selectedPaymentOption = selectedPaymentOption,
+        paymentMethodLabel = paymentMethodLabel,
+        embeddedPaymentElement = embeddedPaymentElement,
+        viewModel = viewModel,
+    )
+}
+
+@Composable
+private fun EmbeddedPaymentElementContent(
+    uiState: EmbeddedPaymentElementExampleViewState,
+    selectedPaymentOption: EmbeddedPaymentElement.PaymentOptionDisplayData?,
+    paymentMethodLabel: String,
+    embeddedPaymentElement: EmbeddedPaymentElement,
+    viewModel: EmbeddedPaymentElementExampleViewModel,
+) {
+    Box(
+        modifier = Modifier.padding(
+            paddingValues = WindowInsets.systemBars.only(
+                WindowInsetsSides.Horizontal + WindowInsetsSides.Top
+            ).asPaddingValues()
+        ),
+    ) {
+        if (uiState.isError) {
+            ErrorScreen(onRetry = viewModel::retry)
+        } else {
+            Receipt(
+                isLoading = uiState.isProcessing,
+                cartState = uiState.cartState,
+            ) {
+                PaymentMethodSelector(
+                    isEnabled = uiState.isPaymentMethodButtonEnabled,
+                    paymentMethodLabel = paymentMethodLabel,
+                    paymentMethodPainter = selectedPaymentOption?.iconPainter,
+                    onClick = embeddedPaymentElement::presentPaymentOptions,
+                )
+
+                selectedPaymentOption?.mandateText?.let { mandateText ->
+                    Text(mandateText)
+                }
+
+                BuyButton(
+                    buyButtonEnabled = selectedPaymentOption != null && !uiState.isProcessing,
+                    onClick = {
+                        viewModel.handleBuyButtonPressed()
+                        embeddedPaymentElement.confirm()
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun determinePaymentMethodLabel(
+    uiState: EmbeddedPaymentElementExampleViewState,
+    selectedPaymentOption: EmbeddedPaymentElement.PaymentOptionDisplayData?,
+): String {
+    val resources = LocalResources.current
+    return remember(uiState, selectedPaymentOption) {
+        if (selectedPaymentOption?.label != null) {
+            selectedPaymentOption.label
+        } else if (!uiState.isProcessing) {
+            resources.getString(R.string.select)
+        } else {
+            resources.getString(R.string.loading)
+        }
+    }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/embedded_payment_element/EmbeddedPaymentElementExampleViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/embedded_payment_element/EmbeddedPaymentElementExampleViewModel.kt
@@ -1,0 +1,154 @@
+package com.stripe.android.paymentsheet.example.samples.ui.embedded_payment_element
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.github.kittinunf.fuel.Fuel
+import com.github.kittinunf.fuel.core.extensions.jsonBody
+import com.github.kittinunf.fuel.core.requests.suspendable
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentsheet.CreateIntentResult
+import com.stripe.android.paymentsheet.example.samples.model.updateWithResponse
+import com.stripe.android.paymentsheet.example.samples.networking.ExampleCheckoutRequest
+import com.stripe.android.paymentsheet.example.samples.networking.ExampleCheckoutResponse
+import com.stripe.android.paymentsheet.example.samples.networking.ExampleCreateAndConfirmErrorResponse
+import com.stripe.android.paymentsheet.example.samples.networking.ExampleCreateAndConfirmIntentRequest
+import com.stripe.android.paymentsheet.example.samples.networking.ExampleCreateAndConfirmIntentResponse
+import com.stripe.android.paymentsheet.example.samples.networking.awaitModel
+import com.stripe.android.paymentsheet.example.samples.networking.toCheckoutRequest
+import com.stripe.android.paymentsheet.example.samples.networking.toCreateIntentRequest
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import com.github.kittinunf.result.Result as ApiResult
+
+internal class EmbeddedPaymentElementExampleViewModel(
+    application: Application,
+) : AndroidViewModel(application) {
+
+    private val _state = MutableStateFlow(EmbeddedPaymentElementExampleViewState())
+    val state: StateFlow<EmbeddedPaymentElementExampleViewState> = _state
+
+    init {
+        viewModelScope.launch(Dispatchers.IO) {
+            prepareCheckout()
+        }
+    }
+
+    fun handleConfigured(error: Throwable?) {
+        _state.update {
+            it.copy(
+                isProcessing = false,
+                status = error?.message,
+            )
+        }
+    }
+
+    fun statusDisplayed() {
+        _state.update { it.copy(status = null) }
+    }
+
+    suspend fun createAndConfirmIntent(
+        paymentMethod: PaymentMethod,
+        shouldSavePaymentMethod: Boolean,
+    ): CreateIntentResult = withContext(Dispatchers.IO) {
+        val request = state.value.cartState.toCreateIntentRequest(
+            paymentMethodId = paymentMethod.id,
+            shouldSavePaymentMethod = shouldSavePaymentMethod,
+            returnUrl = "stripesdk://payment_return_url/com.stripe.android.paymentsheet.example",
+        )
+
+        val requestBody = Json.encodeToString(ExampleCreateAndConfirmIntentRequest.serializer(), request)
+
+        val apiResult = Fuel
+            .post("$BACKEND_URL/confirm_intent")
+            .jsonBody(requestBody)
+            .suspendable()
+            .awaitModel(ExampleCreateAndConfirmIntentResponse.serializer())
+
+        when (apiResult) {
+            is ApiResult.Success -> {
+                CreateIntentResult.Success(apiResult.value.clientSecret)
+            }
+            is ApiResult.Failure -> {
+                val error = ExampleCreateAndConfirmErrorResponse.deserialize(
+                    apiResult.error.response
+                ).error
+                CreateIntentResult.Failure(
+                    cause = RuntimeException(error),
+                    displayMessage = error,
+                )
+            }
+        }
+    }
+
+    fun handleResult(result: EmbeddedPaymentElement.Result) {
+        val status = when (result) {
+            is EmbeddedPaymentElement.Result.Canceled -> null
+            is EmbeddedPaymentElement.Result.Completed -> "Success"
+            is EmbeddedPaymentElement.Result.Failed -> result.error.message
+        }
+
+        _state.update {
+            it.copy(
+                isProcessing = false,
+                status = status,
+                didComplete = result is EmbeddedPaymentElement.Result.Completed,
+            )
+        }
+    }
+
+    fun handleBuyButtonPressed() {
+        _state.update { it.copy(isProcessing = true) }
+    }
+
+    fun retry() {
+        viewModelScope.launch(Dispatchers.IO) {
+            prepareCheckout()
+        }
+    }
+
+    private suspend fun prepareCheckout() {
+        _state.update { it.copy(isProcessing = true, isError = false) }
+
+        val currentCartState = _state.value.cartState
+        val request = currentCartState.toCheckoutRequest()
+        val requestBody = Json.encodeToString(ExampleCheckoutRequest.serializer(), request)
+
+        val apiResult = Fuel
+            .post("$BACKEND_URL/checkout")
+            .jsonBody(requestBody)
+            .suspendable()
+            .awaitModel(ExampleCheckoutResponse.serializer())
+
+        when (apiResult) {
+            is ApiResult.Success -> {
+                val newCartState = currentCartState.updateWithResponse(apiResult.value)
+
+                PaymentConfiguration.init(
+                    context = getApplication(),
+                    publishableKey = apiResult.value.publishableKey,
+                )
+
+                _state.update {
+                    it.copy(cartState = newCartState)
+                }
+            }
+            is ApiResult.Failure -> {
+                _state.update {
+                    it.copy(isProcessing = false, isError = true)
+                }
+            }
+        }
+    }
+
+    companion object {
+        const val BACKEND_URL = "https://stripe-mobile-payment-sheet-custom-deferred.stripedemos.com"
+    }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/embedded_payment_element/EmbeddedPaymentElementExampleViewState.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/embedded_payment_element/EmbeddedPaymentElementExampleViewState.kt
@@ -1,0 +1,27 @@
+package com.stripe.android.paymentsheet.example.samples.ui.embedded_payment_element
+
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.example.samples.model.CartState
+
+internal data class EmbeddedPaymentElementExampleViewState(
+    val isProcessing: Boolean = false,
+    val isError: Boolean = false,
+    val cartState: CartState = CartState.default,
+    val status: String? = null,
+    val didComplete: Boolean = false,
+) {
+    val embeddedConfig: EmbeddedPaymentElement.Configuration
+        get() = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.")
+            .googlePay(
+                PaymentSheet.GooglePayConfiguration(
+                    environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
+                    countryCode = "US",
+                )
+            )
+            .allowsDelayedPaymentMethods(true)
+            .build()
+
+    val isPaymentMethodButtonEnabled: Boolean
+        get() = !isProcessing
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/paymentsheet/flow_controller_with_intent_configuration/FlowControllerIntentConfigActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/paymentsheet/flow_controller_with_intent_configuration/FlowControllerIntentConfigActivity.kt
@@ -1,0 +1,155 @@
+package com.stripe.android.paymentsheet.example.samples.ui.paymentsheet.flow_controller_with_intent_configuration
+
+import android.graphics.Color
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalResources
+import com.google.android.material.snackbar.Snackbar
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.example.R
+import com.stripe.android.paymentsheet.example.samples.model.toIntentConfiguration
+import com.stripe.android.paymentsheet.example.samples.ui.shared.BuyButton
+import com.stripe.android.paymentsheet.example.samples.ui.shared.CompletedPaymentAlertDialog
+import com.stripe.android.paymentsheet.example.samples.ui.shared.ErrorScreen
+import com.stripe.android.paymentsheet.example.samples.ui.shared.PaymentMethodSelector
+import com.stripe.android.paymentsheet.example.samples.ui.shared.PaymentSheetExampleTheme
+import com.stripe.android.paymentsheet.example.samples.ui.shared.Receipt
+
+internal class FlowControllerIntentConfigActivity : AppCompatActivity() {
+
+    private val snackbar by lazy {
+        Snackbar.make(findViewById(android.R.id.content), "", Snackbar.LENGTH_SHORT)
+            .setBackgroundTint(Color.BLACK)
+            .setTextColor(Color.WHITE)
+    }
+
+    private val viewModel by viewModels<FlowControllerIntentConfigViewModel>()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            PaymentSheetExampleTheme {
+                FlowControllerIntentConfigScreen(
+                    viewModel = viewModel,
+                    snackbar = snackbar,
+                    onFinish = ::finish,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun FlowControllerIntentConfigScreen(
+    viewModel: FlowControllerIntentConfigViewModel,
+    snackbar: Snackbar,
+    onFinish: () -> Unit,
+) {
+    val flowController = remember {
+        PaymentSheet.FlowController.Builder(
+            resultCallback = viewModel::handlePaymentSheetResult,
+            paymentOptionCallback = viewModel::handlePaymentOptionChanged,
+        ).createIntentCallback(viewModel::createAndConfirmIntent)
+    }.build()
+
+    val uiState by viewModel.state.collectAsState()
+    val paymentMethodLabel = determinePaymentMethodLabel(uiState)
+
+    if (uiState.cartState.total != null) {
+        LaunchedEffect(uiState.cartState) {
+            flowController.configureWithIntentConfiguration(
+                intentConfiguration = uiState.cartState.toIntentConfiguration(),
+                configuration = uiState.paymentSheetConfig,
+                callback = viewModel::handleFlowControllerConfigured,
+            )
+        }
+    }
+
+    uiState.status?.let { status ->
+        if (uiState.didComplete) {
+            CompletedPaymentAlertDialog(onDismiss = onFinish)
+        } else {
+            LaunchedEffect(status) {
+                snackbar.setText(status).show()
+                viewModel.statusDisplayed()
+            }
+        }
+    }
+
+    FlowControllerIntentConfigContent(
+        uiState = uiState,
+        paymentMethodLabel = paymentMethodLabel,
+        flowController = flowController,
+        viewModel = viewModel,
+    )
+}
+
+@Composable
+private fun FlowControllerIntentConfigContent(
+    uiState: FlowControllerIntentConfigViewState,
+    paymentMethodLabel: String,
+    flowController: PaymentSheet.FlowController,
+    viewModel: FlowControllerIntentConfigViewModel,
+) {
+    Box(
+        modifier = Modifier.padding(
+            paddingValues = WindowInsets.systemBars.only(
+                WindowInsetsSides.Horizontal + WindowInsetsSides.Top
+            ).asPaddingValues()
+        ),
+    ) {
+        if (uiState.isError) {
+            ErrorScreen(onRetry = viewModel::retry)
+        } else {
+            Receipt(
+                isLoading = uiState.isProcessing,
+                cartState = uiState.cartState,
+            ) {
+                PaymentMethodSelector(
+                    isEnabled = uiState.isPaymentMethodButtonEnabled,
+                    paymentMethodLabel = paymentMethodLabel,
+                    paymentMethodPainter = uiState.paymentOption?.iconPainter,
+                    onClick = flowController::presentPaymentOptions,
+                )
+
+                BuyButton(
+                    buyButtonEnabled = uiState.isBuyButtonEnabled,
+                    onClick = {
+                        viewModel.handleBuyButtonPressed()
+                        flowController.confirm()
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun determinePaymentMethodLabel(uiState: FlowControllerIntentConfigViewState): String {
+    val resources = LocalResources.current
+    return remember(uiState) {
+        if (uiState.paymentOption?.label != null) {
+            uiState.paymentOption.label
+        } else if (!uiState.isProcessing) {
+            resources.getString(R.string.select)
+        } else {
+            resources.getString(R.string.loading)
+        }
+    }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/paymentsheet/flow_controller_with_intent_configuration/FlowControllerIntentConfigViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/paymentsheet/flow_controller_with_intent_configuration/FlowControllerIntentConfigViewModel.kt
@@ -1,0 +1,159 @@
+package com.stripe.android.paymentsheet.example.samples.ui.paymentsheet.flow_controller_with_intent_configuration
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.github.kittinunf.fuel.Fuel
+import com.github.kittinunf.fuel.core.extensions.jsonBody
+import com.github.kittinunf.fuel.core.requests.suspendable
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentsheet.CreateIntentResult
+import com.stripe.android.paymentsheet.PaymentSheetResult
+import com.stripe.android.paymentsheet.example.samples.model.updateWithResponse
+import com.stripe.android.paymentsheet.example.samples.networking.ExampleCheckoutRequest
+import com.stripe.android.paymentsheet.example.samples.networking.ExampleCheckoutResponse
+import com.stripe.android.paymentsheet.example.samples.networking.ExampleCreateAndConfirmErrorResponse
+import com.stripe.android.paymentsheet.example.samples.networking.ExampleCreateAndConfirmIntentRequest
+import com.stripe.android.paymentsheet.example.samples.networking.ExampleCreateAndConfirmIntentResponse
+import com.stripe.android.paymentsheet.example.samples.networking.awaitModel
+import com.stripe.android.paymentsheet.example.samples.networking.toCheckoutRequest
+import com.stripe.android.paymentsheet.example.samples.networking.toCreateIntentRequest
+import com.stripe.android.paymentsheet.model.PaymentOption
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import com.github.kittinunf.result.Result as ApiResult
+
+internal class FlowControllerIntentConfigViewModel(
+    application: Application,
+) : AndroidViewModel(application) {
+
+    private val _state = MutableStateFlow(FlowControllerIntentConfigViewState())
+    val state: StateFlow<FlowControllerIntentConfigViewState> = _state
+
+    init {
+        viewModelScope.launch(Dispatchers.IO) {
+            prepareCheckout()
+        }
+    }
+
+    fun statusDisplayed() {
+        _state.update { it.copy(status = null) }
+    }
+
+    fun handlePaymentOptionChanged(paymentOption: PaymentOption?) {
+        _state.update { it.copy(paymentOption = paymentOption) }
+    }
+
+    fun handleFlowControllerConfigured(success: Boolean, error: Throwable?) {
+        _state.update {
+            it.copy(
+                isProcessing = false,
+                status = if (!success) error?.message else null,
+            )
+        }
+    }
+
+    suspend fun createAndConfirmIntent(
+        paymentMethod: PaymentMethod,
+        shouldSavePaymentMethod: Boolean,
+    ): CreateIntentResult = withContext(Dispatchers.IO) {
+        val request = state.value.cartState.toCreateIntentRequest(
+            paymentMethodId = paymentMethod.id,
+            shouldSavePaymentMethod = shouldSavePaymentMethod,
+            returnUrl = "stripesdk://payment_return_url/com.stripe.android.paymentsheet.example",
+        )
+
+        val requestBody = Json.encodeToString(ExampleCreateAndConfirmIntentRequest.serializer(), request)
+
+        val apiResult = Fuel
+            .post("$BACKEND_URL/confirm_intent")
+            .jsonBody(requestBody)
+            .suspendable()
+            .awaitModel(ExampleCreateAndConfirmIntentResponse.serializer())
+
+        when (apiResult) {
+            is ApiResult.Success -> {
+                CreateIntentResult.Success(apiResult.value.clientSecret)
+            }
+            is ApiResult.Failure -> {
+                val error = ExampleCreateAndConfirmErrorResponse.deserialize(
+                    apiResult.error.response
+                ).error
+                CreateIntentResult.Failure(
+                    cause = RuntimeException(error),
+                    displayMessage = error,
+                )
+            }
+        }
+    }
+
+    fun handlePaymentSheetResult(paymentResult: PaymentSheetResult) {
+        val status = when (paymentResult) {
+            is PaymentSheetResult.Canceled -> null
+            is PaymentSheetResult.Completed -> "Success"
+            is PaymentSheetResult.Failed -> paymentResult.error.message
+        }
+
+        _state.update {
+            it.copy(
+                isProcessing = false,
+                status = status,
+                didComplete = paymentResult is PaymentSheetResult.Completed,
+            )
+        }
+    }
+
+    fun handleBuyButtonPressed() {
+        _state.update { it.copy(isProcessing = true) }
+    }
+
+    fun retry() {
+        viewModelScope.launch(Dispatchers.IO) {
+            prepareCheckout()
+        }
+    }
+
+    private suspend fun prepareCheckout() {
+        _state.update { it.copy(isProcessing = true, isError = false) }
+
+        val currentCartState = _state.value.cartState
+        val request = currentCartState.toCheckoutRequest()
+        val requestBody = Json.encodeToString(ExampleCheckoutRequest.serializer(), request)
+
+        val apiResult = Fuel
+            .post("$BACKEND_URL/checkout")
+            .jsonBody(requestBody)
+            .suspendable()
+            .awaitModel(ExampleCheckoutResponse.serializer())
+
+        when (apiResult) {
+            is ApiResult.Success -> {
+                val newCartState = currentCartState.updateWithResponse(apiResult.value)
+
+                PaymentConfiguration.init(
+                    context = getApplication(),
+                    publishableKey = apiResult.value.publishableKey,
+                )
+
+                _state.update {
+                    it.copy(cartState = newCartState)
+                }
+            }
+            is ApiResult.Failure -> {
+                _state.update {
+                    it.copy(isProcessing = false, isError = true)
+                }
+            }
+        }
+    }
+
+    companion object {
+        const val BACKEND_URL = "https://stripe-mobile-payment-sheet-custom-deferred.stripedemos.com"
+    }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/paymentsheet/flow_controller_with_intent_configuration/FlowControllerIntentConfigViewState.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/paymentsheet/flow_controller_with_intent_configuration/FlowControllerIntentConfigViewState.kt
@@ -1,0 +1,31 @@
+package com.stripe.android.paymentsheet.example.samples.ui.paymentsheet.flow_controller_with_intent_configuration
+
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.example.samples.model.CartState
+import com.stripe.android.paymentsheet.model.PaymentOption
+
+internal data class FlowControllerIntentConfigViewState(
+    val isProcessing: Boolean = false,
+    val isError: Boolean = false,
+    val cartState: CartState = CartState.default,
+    val status: String? = null,
+    val paymentOption: PaymentOption? = null,
+    val didComplete: Boolean = false,
+) {
+    val paymentSheetConfig: PaymentSheet.Configuration
+        get() = PaymentSheet.Configuration.Builder(merchantDisplayName = "Example, Inc.")
+            .googlePay(
+                PaymentSheet.GooglePayConfiguration(
+                    environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
+                    countryCode = "US",
+                )
+            )
+            .allowsDelayedPaymentMethods(true)
+            .build()
+
+    val isPaymentMethodButtonEnabled: Boolean
+        get() = !isProcessing
+
+    val isBuyButtonEnabled: Boolean
+        get() = paymentOption != null && !isProcessing
+}

--- a/paymentsheet-example/src/main/res/values/strings.xml
+++ b/paymentsheet-example/src/main/res/values/strings.xml
@@ -87,4 +87,8 @@
     <string name="unable_to_load_checkout_button">Try again</string>
     <string name="success">Success</string>
     <string name="finish">Finish</string>
+    <string name="flow_controller_intent_config_title">FlowController with IntentConfiguration</string>
+    <string name="flow_controller_intent_config_subtitle">FlowController using configureWithIntentConfiguration and presentPaymentOptions</string>
+    <string name="embedded_intent_config_title">EmbeddedPaymentElement with IntentConfiguration</string>
+    <string name="embedded_intent_config_subtitle">EmbeddedPaymentElement using configure with IntentConfiguration and presentPaymentOptions</string>
 </resources>

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
@@ -137,6 +137,12 @@ class EmbeddedPaymentElement @Inject internal constructor(
         embeddedContent?.Content()
     }
 
+    fun presentPaymentOptions() {
+        println("presentPaymentOptions")
+        // Not implemented, but image it's real, and works the same as
+        // PaymentSheet.FlowController.presentPaymentOptions.
+    }
+
     /**
      * Asynchronously confirms the currently selected payment option.
      *


### PR DESCRIPTION
# Summary
Added example implementations for EmbeddedPaymentElement and FlowController with IntentConfiguration, demonstrating how to use these components with deferred intent creation.

# Motivation
Provide example code for developers to understand how to implement EmbeddedPaymentElement and FlowController using IntentConfiguration with the createIntentCallback pattern for deferred payment intent creation.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Changelog
[Added] - Example implementations for EmbeddedPaymentElement and FlowController with IntentConfiguration in the paymentsheet-example app.