### PR TITLE
Add is_saved_payment_method field to payment success and failure analytic events

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -9,6 +9,7 @@ import com.stripe.android.paymentelement.confirmation.intent.DeferredIntentConfi
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.isLink
+import com.stripe.android.paymentsheet.model.isSaved
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormViewModel.AnalyticsEvent.Finished
 import com.stripe.android.paymentsheet.state.asPaymentSheetLoadingException
 import com.stripe.android.paymentsheet.utils.getSetAsDefaultPaymentMethodFromPaymentSelection
@@ -211,6 +212,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
                 }
             }
             put(FIELD_SELECTED_LPM, paymentSelection.code())
+            put(FIELD_IS_SAVED_PAYMENT_METHOD, paymentSelection.isSaved)
             paymentSelection.linkContext()?.let { linkContext ->
                 put(FIELD_LINK_CONTEXT, linkContext)
             }
@@ -565,6 +567,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         const val FIELD_DEFERRED_INTENT_CONFIRMATION_TYPE = "deferred_intent_confirmation_type"
         const val FIELD_DURATION = "duration"
         const val FIELD_SELECTED_LPM = "selected_lpm"
+        const val FIELD_IS_SAVED_PAYMENT_METHOD = "is_saved_payment_method"
         const val FIELD_ERROR_MESSAGE = "error_message"
         const val FIELD_ERROR_CODE = "error_code"
         const val FIELD_CBC_EVENT_SOURCE = "cbc_event_source"

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -974,6 +974,55 @@ class DefaultEventReporterTest {
     }
 
     @Test
+    fun `onPaymentSuccess sends is_saved_payment_method true for saved payment method`() = runScenario {
+        val paymentSelection = PaymentSelection.Saved(
+            PaymentMethodFixtures.CARD_PAYMENT_METHOD
+        )
+        val expectedIsSavedPaymentMethodValue = true
+        testIsSavedPaymentMethodParam(paymentSelection, expectedIsSavedPaymentMethodValue)
+    }
+
+    @Test
+    fun `onPaymentSuccess sends is_saved_payment_method false for new payment method`() = runScenario {
+        val paymentSelection = PaymentSelection.New.Card(
+            PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+            CardBrand.Visa,
+            customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest,
+        )
+        val expectedIsSavedPaymentMethodValue = false
+        testIsSavedPaymentMethodParam(paymentSelection, expectedIsSavedPaymentMethodValue)
+    }
+
+    private suspend fun Scenario.testIsSavedPaymentMethodParam(
+        paymentSelection: PaymentSelection,
+        expectedIsSavedPaymentMethodValue: Boolean
+    ) {
+        val expectedEventName = if (expectedIsSavedPaymentMethodValue) {
+            "mc_complete_payment_savedpm_success"
+        } else {
+            "mc_complete_payment_newpm_success"
+        }
+
+        paymentMethodMetadataStack.push(paymentMethodMetadataWithTestAnalyticsMetadata)
+        durationProvider.endCalls.push(
+            FakeDurationProvider.EndCall(
+                key = DurationProvider.Key.Checkout,
+                duration = 5.seconds,
+            )
+        )
+
+        eventReporter.onPaymentSuccess(
+            paymentSelection = paymentSelection,
+            deferredIntentConfirmationType = null,
+            intentId = null,
+        )
+
+        val request = analyticsRequestExecutor.requestTurbine.awaitItem()
+        assertThat(request.params).containsEntry("event", expectedEventName)
+        assertThat(request.params).containsEntry("is_saved_payment_method", expectedIsSavedPaymentMethodValue)
+    }
+
+    @Test
     fun `onSelectPaymentOption fires event with saved payment method`() = runScenario {
         paymentMethodMetadataStack.push(paymentMethodMetadataWithTestAnalyticsMetadata)
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add is_saved_payment_method field to payment success and failure analytic events

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Enable us to measure usage of saved payment methods at payment completion time

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified