### PR TITLE
Fix CardScan expiry date parsing for single-digit months

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
@@ -126,7 +126,7 @@ internal class CardDetailsController(
                 )
             ) {
                 @Suppress("MagicNumber")
-                "${scannedCard.expirationMonth}/${scannedCard.expirationYear % 100}"
+                "%02d%02d".format(scannedCard.expirationMonth, scannedCard.expirationYear % 100)
             } else {
                 ""
             }

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsControllerTest.kt
@@ -131,7 +131,7 @@ class CardDetailsControllerTest {
         assertThat(cardController.numberElement.controller.rawFieldValue.value)
             .isEqualTo("5555555555554444")
         assertThat(cardController.expirationDateElement.controller.rawFieldValue.value)
-            .isEqualTo("444")
+            .isEqualTo("0444")
         assertThat(cardController.cvcElement.controller.rawFieldValue.value)
             .isEqualTo("")
     }
@@ -169,7 +169,7 @@ class CardDetailsControllerTest {
         assertThat(cardController.numberElement.controller.rawFieldValue.value)
             .isEqualTo("5555555555554444")
         assertThat(cardController.expirationDateElement.controller.rawFieldValue.value)
-            .isEqualTo("444")
+            .isEqualTo("0444")
         assertThat(cardController.cvcElement.controller.rawFieldValue.value)
             .isEqualTo("")
     }
@@ -208,6 +208,27 @@ class CardDetailsControllerTest {
             .isEqualTo("5555555555554444")
         assertThat(cardController.expirationDateElement.controller.rawFieldValue.value)
             .isEqualTo("")
+    }
+
+    @Test
+    fun `When new card scanned with single digit month, date is correctly formatted`() = runTest {
+        val cardController = cardDetailsController()
+
+        val scannedCard = ScannedCard(
+            pan = "5555555555554444",
+            expirationYear = 2029,
+            expirationMonth = 1,
+        )
+
+        val cardScanResult = CardScanResult.Completed(
+            scannedCard = scannedCard
+        )
+        idleLooper()
+
+        cardController.onCardScanResult.invoke(cardScanResult)
+
+        assertThat(cardController.expirationDateElement.controller.rawFieldValue.value)
+            .isEqualTo("0129")
     }
 
     @Test


### PR DESCRIPTION
# Summary
When scanning a card with a single-digit month like 01/29, the expiry was formatted as "1/29". After the slash was stripped, "129" was interpreted as month=12 year=9, which is invalid.

Fix by formatting as zero-padded "MMYY" (e.g. "0129").

# Motivation
Fixing an issue with scanning cards

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->
