### PR TITLE
Add `networkBusinessProfile` to seller payment methods

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -1528,8 +1528,9 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$IntentConfigurat
 public final class com/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$SellerDetails : android/os/Parcelable {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public static final field Companion Lcom/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$SellerDetails$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBusinessName ()Ljava/lang/String;
@@ -1539,11 +1540,6 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$IntentConfigurat
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public final fun writeToParcel (Landroid/os/Parcel;I)V
-}
-
-public final class com/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$SellerDetails$Companion {
-	public static final fun create (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$SellerDetails;
-	public static synthetic fun create$default (Lcom/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$SellerDetails$Companion;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$SellerDetails;
 }
 
 public final class com/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$SetupFutureUse : java/lang/Enum {

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -1528,15 +1528,22 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$IntentConfigurat
 public final class com/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$SellerDetails : android/os/Parcelable {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$SellerDetails$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public final fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBusinessName ()Ljava/lang/String;
 	public final fun getExternalId ()Ljava/lang/String;
+	public final fun getNetworkBusinessProfile ()Ljava/lang/String;
 	public final fun getNetworkId ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public final fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$SellerDetails$Companion {
+	public static final fun create (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$SellerDetails;
+	public static synthetic fun create$default (Lcom/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$SellerDetails$Companion;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$SellerDetails;
 }
 
 public final class com/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$SetupFutureUse : java/lang/Enum {

--- a/paymentsheet/src/main/java/com/stripe/android/model/ElementsSessionParams.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/model/ElementsSessionParams.kt
@@ -99,14 +99,18 @@ internal sealed interface ElementsSessionParams : Parcelable {
 
     @Parcelize
     data class SellerDetails(
-        val networkId: String,
-        val externalId: String,
+        val networkId: String? = null,
+        val externalId: String? = null,
+        val businessName: String? = null,
+        val networkBusinessProfile: String? = null,
     ) : Parcelable {
         fun toQueryParams(): Map<String, Any?> {
-            return mapOf(
-                "seller_details[network_id]" to networkId,
-                "seller_details[external_id]" to externalId,
-            )
+            return buildMap {
+                networkId?.let { put("seller_details[network_id]", it) }
+                externalId?.let { put("seller_details[external_id]", it) }
+                businessName?.let { put("seller_details[business_name]", it) }
+                networkBusinessProfile?.let { put("seller_details[network_business_profile]", it) }
+            }
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -692,11 +692,46 @@ class PaymentSheet internal constructor(
         @SharedPaymentTokenSessionPreview
         @Parcelize
         @Poko
-        class SellerDetails(
-            val businessName: String,
-            val networkId: String,
-            val externalId: String,
-        ) : Parcelable
+        class SellerDetails internal constructor(
+            val businessName: String?,
+            val networkId: String?,
+            val externalId: String?,
+            val networkBusinessProfile: String?,
+        ) : Parcelable {
+            /**
+             * Creates a [SellerDetails] with the given required fields.
+             * Use the secondary constructor with named parameters for optional fields.
+             */
+            constructor(
+                businessName: String,
+                networkId: String,
+                externalId: String,
+            ) : this(
+                businessName = businessName,
+                networkId = networkId,
+                externalId = externalId,
+                networkBusinessProfile = null,
+            )
+
+            companion object {
+                /**
+                 * Creates a [SellerDetails] with all optional fields.
+                 */
+                @JvmStatic
+                @JvmOverloads
+                fun create(
+                    networkId: String? = null,
+                    externalId: String? = null,
+                    businessName: String? = null,
+                    networkBusinessProfile: String? = null,
+                ): SellerDetails = SellerDetails(
+                    businessName = businessName,
+                    networkId = networkId,
+                    externalId = externalId,
+                    networkBusinessProfile = networkBusinessProfile,
+                )
+            }
+        }
 
         @OptIn(SharedPaymentTokenSessionPreview::class)
         internal sealed interface IntentBehavior : Parcelable {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -692,46 +692,12 @@ class PaymentSheet internal constructor(
         @SharedPaymentTokenSessionPreview
         @Parcelize
         @Poko
-        class SellerDetails internal constructor(
-            val businessName: String?,
-            val networkId: String?,
-            val externalId: String?,
-            val networkBusinessProfile: String?,
-        ) : Parcelable {
-            /**
-             * Creates a [SellerDetails] with the given required fields.
-             * Use the secondary constructor with named parameters for optional fields.
-             */
-            constructor(
-                businessName: String,
-                networkId: String,
-                externalId: String,
-            ) : this(
-                businessName = businessName,
-                networkId = networkId,
-                externalId = externalId,
-                networkBusinessProfile = null,
-            )
-
-            companion object {
-                /**
-                 * Creates a [SellerDetails] with all optional fields.
-                 */
-                @JvmStatic
-                @JvmOverloads
-                fun create(
-                    networkId: String? = null,
-                    externalId: String? = null,
-                    businessName: String? = null,
-                    networkBusinessProfile: String? = null,
-                ): SellerDetails = SellerDetails(
-                    businessName = businessName,
-                    networkId = networkId,
-                    externalId = externalId,
-                    networkBusinessProfile = networkBusinessProfile,
-                )
-            }
-        }
+        class SellerDetails(
+            val businessName: String? = null,
+            val networkId: String? = null,
+            val externalId: String? = null,
+            val networkBusinessProfile: String? = null,
+        ) : Parcelable
 
         @OptIn(SharedPaymentTokenSessionPreview::class)
         internal sealed interface IntentBehavior : Parcelable {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
@@ -7,6 +7,7 @@ import com.stripe.android.SharedPaymentTokenSessionPreview
 import com.stripe.android.Stripe
 import com.stripe.android.common.di.APPLICATION_ID
 import com.stripe.android.common.di.MOBILE_SESSION_ID
+import com.stripe.android.core.ApiVersion
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.model.parsers.StripeErrorJsonParser
@@ -135,10 +136,12 @@ internal class RealElementsSessionRepository @Inject constructor(
             mapOf("expand" to it)
         }.orEmpty()
 
+        val requestFactory = apiRequestFactoryForParams(params)
+
         return executeRequestWithResultParser(
             stripeErrorJsonParser = stripeErrorJsonParser,
             stripeNetworkClient = stripeNetworkClient,
-            request = apiRequestFactory.createGet(
+            request = requestFactory.createGet(
                 url = ELEMENTS_SESSIONS_URL,
                 options = options,
                 params = requestParams + expandParam,
@@ -181,6 +184,19 @@ internal class RealElementsSessionRepository @Inject constructor(
         }
     }
 
+    private fun apiRequestFactoryForParams(params: ElementsSessionParams): ApiRequest.Factory {
+        if (params.sellerDetails?.networkBusinessProfile != null) {
+            return ApiRequest.Factory(
+                appInfo = Stripe.appInfo,
+                apiVersion = ApiVersion(
+                    betas = setOf(SELLER_PAYMENT_METHODS_BETA)
+                ).code,
+                sdkVersion = StripeSdkVersion.VERSION,
+            )
+        }
+        return apiRequestFactory
+    }
+
     private fun shouldFallback(elementsSession: Result<ElementsSession>): Boolean {
         return (elementsSession.exceptionOrNull() as? StripeException)?.let {
             it.statusCode >= HTTP_INTERNAL_SERVER_ERROR
@@ -189,6 +205,7 @@ internal class RealElementsSessionRepository @Inject constructor(
 
     private companion object {
         private val ELEMENTS_SESSIONS_URL = "${ApiRequest.API_HOST}/v1/elements/sessions"
+        private const val SELLER_PAYMENT_METHODS_BETA = "payment_element_seller_payment_methods_beta_1=v1"
     }
 }
 
@@ -303,8 +320,10 @@ private fun PaymentSheet.IntentConfiguration.toSellerDetails(): ElementsSessionP
     return when (intentBehavior) {
         is PaymentSheet.IntentConfiguration.IntentBehavior.SharedPaymentToken -> intentBehavior.sellerDetails?.run {
             ElementsSessionParams.SellerDetails(
-                externalId = externalId,
                 networkId = networkId,
+                externalId = externalId,
+                businessName = businessName,
+                networkBusinessProfile = networkBusinessProfile,
             )
         }
         is PaymentSheet.IntentConfiguration.IntentBehavior.Default -> null

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -133,6 +133,7 @@ internal interface PaymentElementLoader {
             val intentConfiguration: IntentConfiguration,
         ) : InitializationMode() {
 
+            @OptIn(SharedPaymentTokenSessionPreview::class)
             override fun validate() {
                 (intentConfiguration.mode as? IntentConfiguration.Mode.Payment)?.let {
                     if (it.amount <= 0) {
@@ -140,6 +141,15 @@ internal interface PaymentElementLoader {
                             "Payment IntentConfiguration requires a positive amount."
                         )
                     }
+                }
+
+                val hasSellerDetails = (intentConfiguration.intentBehavior as?
+                    IntentConfiguration.IntentBehavior.SharedPaymentToken)?.sellerDetails != null
+                if (hasSellerDetails && intentConfiguration.paymentMethodConfigurationId != null) {
+                    throw IllegalArgumentException(
+                        "paymentMethodConfigurationId and sellerDetails are mutually exclusive. " +
+                            "Please provide only one."
+                    )
                 }
             }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -1686,6 +1686,58 @@ internal class DefaultPaymentElementLoaderTest {
         }
     }
 
+    @OptIn(SharedPaymentTokenSessionPreview::class)
+    @Test
+    fun `Returns failure if both sellerDetails and paymentMethodConfigurationId are provided`() = runScenario {
+        assertFailsWith<IllegalArgumentException>(
+            "paymentMethodConfigurationId and sellerDetails are mutually exclusive."
+        ) {
+            PaymentElementLoader.InitializationMode.DeferredIntent(
+                intentConfiguration = PaymentSheet.IntentConfiguration(
+                    sharedPaymentTokenSessionWithMode = PaymentSheet.IntentConfiguration.Mode.Payment(
+                        amount = 1000,
+                        currency = "usd",
+                    ),
+                    sellerDetails = PaymentSheet.IntentConfiguration.SellerDetails(
+                        networkBusinessProfile = "bnp_abc123",
+                    ),
+                    paymentMethodConfigurationId = "pmc_123",
+                ),
+            ).validate()
+        }
+    }
+
+    @OptIn(SharedPaymentTokenSessionPreview::class)
+    @Test
+    fun `Validates successfully when only sellerDetails is provided`() = runScenario {
+        PaymentElementLoader.InitializationMode.DeferredIntent(
+            intentConfiguration = PaymentSheet.IntentConfiguration(
+                sharedPaymentTokenSessionWithMode = PaymentSheet.IntentConfiguration.Mode.Payment(
+                    amount = 1000,
+                    currency = "usd",
+                ),
+                sellerDetails = PaymentSheet.IntentConfiguration.SellerDetails(
+                    networkBusinessProfile = "bnp_abc123",
+                ),
+            ),
+        ).validate()
+    }
+
+    @OptIn(SharedPaymentTokenSessionPreview::class)
+    @Test
+    fun `Validates successfully when only paymentMethodConfigurationId is provided with sellerDetails`() = runScenario {
+        PaymentElementLoader.InitializationMode.DeferredIntent(
+            intentConfiguration = PaymentSheet.IntentConfiguration(
+                sharedPaymentTokenSessionWithMode = PaymentSheet.IntentConfiguration.Mode.Payment(
+                    amount = 1000,
+                    currency = "usd",
+                ),
+                sellerDetails = null,
+                paymentMethodConfigurationId = "pmc_123",
+            ),
+        ).validate()
+    }
+
     @Test
     fun `CheckoutSession validate is a no-op`() = runScenario {
         PaymentElementLoader.InitializationMode.CheckoutSession(


### PR DESCRIPTION
 ### Summary and motivation
[APIREVIEW-4954](https://jira.corp.stripe.com/browse/APIREVIEW-4954).

Android SDK counterpart to the Stripe.js change in [mint#2041413](https://git.corp.stripe.com/stripe-internal/mint/pull/2041413).

Exposes the API surface for agents to pass a seller's Business Network profile to Payment Element on Android, enabling PE to display the seller's configured payment methods. Beta header `payment_element_seller_payment_methods_beta_1` is automatically included when `networkBusinessProfile` is provided.

The `/v1/elements/sessions` request already supports: `GET /v1/elements/sessions`

```javascript
<<< REQUEST <<<
{
   seller_details?: {
      network_id?: string,                // was required
      external_id?: string,               // was required
      business_name?: string,             // was required
      network_business_profile?: string,  // new
   },
}
```

In the Android SDK:

  ```kotlin
@SharedPaymentTokenSessionPreview
class SellerDetails(
    val businessName: String?,           // was required
    val networkId: String?,              // was required
    val externalId: String?,             // was required
    val networkBusinessProfile: String?, // new
)
```

We do this for backwards compatibility, for those existing integrations passing `network_id` and `external_id`, both remain accepted but are no longer required. The existing 3-arg constructor `SellerDetails(businessName, networkId, externalId)` is preserved. A new `SellerDetails.create()` factory method allows all-optional usage.

The new `network_business_profile` field allows agents to specify a BizNet profile ID, from which Stripe resolves the seller's default PMC (provided `payment_element_seller_payment_methods_beta_1` is present).

All fields made optional. `networkBusinessProfile` added. `paymentMethodConfigurationId` and `sellerDetails` are now validated as mutually exclusive, passing both throws an `IllegalArgumentException` client-side.

All this together looks like:

```kotlin
// 1. Agent creates intent configuration with seller's BizNet profile
  @OptIn(SharedPaymentTokenSessionPreview::class)
  val intentConfig = PaymentSheet.IntentConfiguration(
      sharedPaymentTokenSessionWithMode = PaymentSheet.IntentConfiguration.Mode.Payment(
          amount = 1000,
          currency = "usd",
      ),
      sellerDetails = PaymentSheet.IntentConfiguration.SellerDetails.create(
          networkBusinessProfile = "bnp_abc123",  // the seller's profile
      ),
  )
  
// 2. Payment Element renders the SELLER's payment methods
// The SDK automatically includes the beta header in the elements/sessions request
```

Note: what we do not do in this PR is act on it, i.e., take that `network_business_profile` value, resolve it to a seller's PMC, and return the right payment methods in the session response. That will come later.