### PR TITLE
Add initial Tap to Add emulator tests for all integrations

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -69,6 +69,7 @@ ext.versions = [
         sentryGradlePlugin          : '6.1.0',
         showkase                    : '1.0.0-beta18',
         litert                      : '1.4.1',
+        linkedinDexmaker            : '2.28.1',
         testParameterInjector       : '1.20',
         terminal                    : '5.4.0',
         truth                       : '1.4.5',
@@ -246,6 +247,9 @@ ext.testLibs = [
                 core   : "org.mockito:mockito-core:${versions.mockito}",
                 inline : "org.mockito:mockito-inline:${versions.mockitoInline}",
                 kotlin : "org.mockito.kotlin:mockito-kotlin:${versions.mockitoKotlin}",
+        ],
+        linkedin            : [
+                dexmaker: "com.linkedin.dexmaker:dexmaker-mockito-inline:${versions.linkedinDexmaker}"
         ],
         lint                 : "com.android.tools.lint:lint-tests:${versions.lint}",
         okhttpMockWebServer  : "com.squareup.okhttp3:mockwebserver:${versions.okhttp}",

--- a/paymentsheet/build.gradle
+++ b/paymentsheet/build.gradle
@@ -103,6 +103,8 @@ dependencies {
     androidTestImplementation project(':payment-element-test-pages')
 
     androidTestImplementation libs.places
+    androidTestImplementation libs.terminal.core
+    androidTestImplementation libs.terminal.tapToPay
     androidTestImplementation testLibs.androidx.composeUi
     androidTestImplementation testLibs.androidx.coreKtx
     androidTestImplementation testLibs.androidx.junit
@@ -116,8 +118,8 @@ dependencies {
         exclude group: 'org.checkerframework', module: 'checker'
     }
     androidTestImplementation testLibs.mockito.core
-    androidTestImplementation testLibs.mockito.inline
     androidTestImplementation testLibs.mockito.kotlin
+    androidTestImplementation testLibs.linkedin.dexmaker
     androidTestImplementation testLibs.espresso.intents
     androidTestImplementation libs.leakCanary
     androidTestImplementation testLibs.leakCanaryInstrumentation
@@ -125,6 +127,7 @@ dependencies {
     androidTestImplementation testLibs.truth
     androidTestImplementation testLibs.turbine
     androidTestImplementation project(':financial-connections')
+    androidTestImplementation project(':tap-to-add-testing')
 
     androidTestUtil testLibs.testOrchestrator
 }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/taptoadd/TapToAddCardFormPage.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/taptoadd/TapToAddCardFormPage.kt
@@ -1,0 +1,29 @@
+package com.stripe.android.paymentelement.taptoadd
+
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.performClick
+
+class TapToAddCardFormPage(
+    val composeTestRule: ComposeTestRule
+) {
+    fun clickOnTapToAdd() {
+        val buttonMatcher = hasText(TAP_TO_ADD_BUTTON_TEXT)
+
+        composeTestRule.waitUntil(5_000) {
+            composeTestRule.onAllNodes(buttonMatcher)
+                .fetchSemanticsNodes(atLeastOneRootRequired = false)
+                .size == 1
+
+        }
+
+        composeTestRule.onNode(buttonMatcher)
+            .assertIsEnabled()
+            .performClick()
+    }
+
+    private companion object {
+        const val TAP_TO_ADD_BUTTON_TEXT = "Tap to add"
+    }
+}

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/taptoadd/TapToAddIntegrationBuilder.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/taptoadd/TapToAddIntegrationBuilder.kt
@@ -1,0 +1,46 @@
+package com.stripe.android.paymentelement.taptoadd
+
+import com.stripe.android.paymentelement.CreateCardPresentSetupIntentCallback
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentelement.TapToAddPreview
+import com.stripe.android.paymentsheet.CreateIntentCallback
+import com.stripe.android.paymentsheet.PaymentSheet
+
+@OptIn(TapToAddPreview::class)
+internal class TapToAddIntegrationBuilder {
+    private var _createIntentCallback: CreateIntentCallback? = null
+    private val createIntentCallback: CreateIntentCallback
+        get() = _createIntentCallback ?: throw IllegalStateException("No create intent callback!")
+
+    private var _createCardPresentSetupIntentCallback: CreateCardPresentSetupIntentCallback? = null
+    private val createCardPresentSetupIntentCallback: CreateCardPresentSetupIntentCallback
+        get() = _createCardPresentSetupIntentCallback
+            ?: throw IllegalStateException("No create card present setup intent callback!")
+
+    fun createCardPresentSetupIntentCallback(
+        createCardPresentSetupIntentCallback: CreateCardPresentSetupIntentCallback?
+    ) = apply {
+        this._createCardPresentSetupIntentCallback = createCardPresentSetupIntentCallback
+    }
+
+    fun createIntentCallback(createIntentCallback: CreateIntentCallback?) = apply {
+        this._createIntentCallback = createIntentCallback
+    }
+
+    fun applyToPaymentSheetBuilder(builder: PaymentSheet.Builder) {
+        builder
+            .createIntentCallback(createIntentCallback)
+            .createCardPresentSetupIntentCallback(createCardPresentSetupIntentCallback)
+    }
+
+    fun applyToFlowControllerBuilder(builder: PaymentSheet.FlowController.Builder) {
+        builder
+            .createIntentCallback(createIntentCallback)
+            .createCardPresentSetupIntentCallback(createCardPresentSetupIntentCallback)
+    }
+
+    fun applyToEmbeddedBuilder(builder: EmbeddedPaymentElement.Builder) {
+        builder
+            .createCardPresentSetupIntentCallback(createCardPresentSetupIntentCallback)
+    }
+}

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/taptoadd/TapToAddIntegrationTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/taptoadd/TapToAddIntegrationTestRunner.kt
@@ -1,0 +1,187 @@
+package com.stripe.android.paymentelement.taptoadd
+
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import com.stripe.android.networktesting.NetworkRule
+import com.stripe.android.paymentelement.CreateCardPresentSetupIntentCallback
+import com.stripe.android.paymentelement.EmbeddedPaymentElementTestRunnerContext
+import com.stripe.android.paymentelement.TapToAddPreview
+import com.stripe.android.paymentelement.runEmbeddedPaymentElementTest
+import com.stripe.android.paymentsheet.CreateIntentCallback
+import com.stripe.android.paymentsheet.utils.runFlowControllerTest
+import com.stripe.android.paymentsheet.utils.runPaymentSheetTest
+
+@OptIn(TapToAddPreview::class)
+internal fun runTapToAddIntegrationTest(
+    networkRule: NetworkRule,
+    composeTestRule: ComposeTestRule,
+    integrationType: TapToAddIntegrationType,
+    createIntentCallback: CreateIntentCallback,
+    createCardPresentCallback: CreateCardPresentSetupIntentCallback,
+    resultCallback: TapToAddResultTestCallback,
+    block: suspend TapToAddIntegrationTestRunnerContext.() -> Unit,
+) {
+    val runner = when (integrationType) {
+        TapToAddIntegrationType.Continue.Embedded -> {
+            TapToAddIntegrationTestRunner.EmbeddedRunner(
+                networkRule = networkRule,
+                composeTestRule = composeTestRule,
+                createIntentCallback = createIntentCallback,
+                createCardPresentSetupIntentCallback = createCardPresentCallback,
+                tapToAddTestResultCallback = resultCallback,
+                mode = TapToAddIntegrationTestRunner.EmbeddedRunner.Mode.Continue,
+            )
+        }
+        TapToAddIntegrationType.Continue.FlowController -> {
+            TapToAddIntegrationTestRunner.FlowControllerRunner(
+                networkRule = networkRule,
+                composeTestRule = composeTestRule,
+                createIntentCallback = createIntentCallback,
+                createCardPresentSetupIntentCallback = createCardPresentCallback,
+                tapToAddTestResultCallback = resultCallback,
+            )
+        }
+        TapToAddIntegrationType.Complete.PaymentSheet -> {
+            TapToAddIntegrationTestRunner.PaymentSheetRunner(
+                networkRule = networkRule,
+                composeTestRule = composeTestRule,
+                createIntentCallback = createIntentCallback,
+                createCardPresentSetupIntentCallback = createCardPresentCallback,
+                tapToAddTestResultCallback = resultCallback,
+            )
+        }
+        TapToAddIntegrationType.Complete.Embedded -> {
+            TapToAddIntegrationTestRunner.EmbeddedRunner(
+                networkRule = networkRule,
+                composeTestRule = composeTestRule,
+                createIntentCallback = createIntentCallback,
+                createCardPresentSetupIntentCallback = createCardPresentCallback,
+                tapToAddTestResultCallback = resultCallback,
+                mode = TapToAddIntegrationTestRunner.EmbeddedRunner.Mode.Confirm,
+            )
+        }
+    }
+
+    runner.run(block)
+}
+
+@OptIn(TapToAddPreview::class)
+private sealed class TapToAddIntegrationTestRunner(
+    protected val networkRule: NetworkRule,
+    protected val composeTestRule: ComposeTestRule,
+    protected val createIntentCallback: CreateIntentCallback,
+    private val createCardPresentSetupIntentCallback: CreateCardPresentSetupIntentCallback,
+    protected val tapToAddTestResultCallback: TapToAddResultTestCallback,
+) {
+    protected val integrationBuilder = TapToAddIntegrationBuilder()
+        .createIntentCallback(createIntentCallback)
+        .createCardPresentSetupIntentCallback(createCardPresentSetupIntentCallback)
+
+    abstract fun run(block: suspend TapToAddIntegrationTestRunnerContext.() -> Unit)
+
+    class PaymentSheetRunner(
+        networkRule: NetworkRule,
+        composeTestRule: ComposeTestRule,
+        createIntentCallback: CreateIntentCallback,
+        createCardPresentSetupIntentCallback: CreateCardPresentSetupIntentCallback,
+        tapToAddTestResultCallback: TapToAddResultTestCallback,
+    ) : TapToAddIntegrationTestRunner(
+        networkRule,
+        composeTestRule,
+        createIntentCallback,
+        createCardPresentSetupIntentCallback,
+        tapToAddTestResultCallback
+    ) {
+        override fun run(block: suspend TapToAddIntegrationTestRunnerContext.() -> Unit) {
+            runPaymentSheetTest(
+                networkRule = networkRule,
+                builder = {
+                    integrationBuilder.applyToPaymentSheetBuilder(this)
+                },
+                resultCallback = { result ->
+                    tapToAddTestResultCallback.onResult(TapToAddTestResult.from(result))
+                },
+            ) { context ->
+                block(TapToAddIntegrationTestRunnerContext.Sheet.PaymentSheet(composeTestRule, context))
+            }
+        }
+    }
+
+    class FlowControllerRunner(
+        networkRule: NetworkRule,
+        composeTestRule: ComposeTestRule,
+        createIntentCallback: CreateIntentCallback,
+        createCardPresentSetupIntentCallback: CreateCardPresentSetupIntentCallback,
+        tapToAddTestResultCallback: TapToAddResultTestCallback,
+    ) : TapToAddIntegrationTestRunner(
+        networkRule,
+        composeTestRule,
+        createIntentCallback,
+        createCardPresentSetupIntentCallback,
+        tapToAddTestResultCallback
+    ) {
+        override fun run(block: suspend TapToAddIntegrationTestRunnerContext.() -> Unit) {
+            runFlowControllerTest(
+                networkRule = networkRule,
+                callConfirmOnPaymentOptionCallback = false,
+                builder = {
+                    integrationBuilder.applyToFlowControllerBuilder(this)
+                },
+                resultCallback = { result ->
+                    tapToAddTestResultCallback.onResult(TapToAddTestResult.from(result))
+                },
+            ) { context ->
+                block(TapToAddIntegrationTestRunnerContext.Sheet.FlowController(composeTestRule, context))
+            }
+        }
+    }
+
+    class EmbeddedRunner(
+        networkRule: NetworkRule,
+        composeTestRule: ComposeTestRule,
+        createIntentCallback: CreateIntentCallback,
+        createCardPresentSetupIntentCallback: CreateCardPresentSetupIntentCallback,
+        tapToAddTestResultCallback: TapToAddResultTestCallback,
+        private val mode: Mode,
+    ) : TapToAddIntegrationTestRunner(
+        networkRule,
+        composeTestRule,
+        createIntentCallback,
+        createCardPresentSetupIntentCallback,
+        tapToAddTestResultCallback
+    ) {
+        enum class Mode {
+            Confirm,
+            Continue,
+        }
+
+        override fun run(block: suspend TapToAddIntegrationTestRunnerContext.() -> Unit) {
+            runEmbeddedPaymentElementTest(
+                networkRule = networkRule,
+                builder = {
+                    integrationBuilder.applyToEmbeddedBuilder(this)
+                },
+                createIntentCallback = createIntentCallback,
+                resultCallback = { result ->
+                    tapToAddTestResultCallback.onResult(TapToAddTestResult.from(result))
+                },
+            ) { context ->
+                block(createTapToAddTestContext(context))
+            }
+        }
+
+        private fun createTapToAddTestContext(
+            embeddedContext: EmbeddedPaymentElementTestRunnerContext,
+        ): TapToAddIntegrationTestRunnerContext.Embedded {
+            return when (mode) {
+                Mode.Confirm -> TapToAddIntegrationTestRunnerContext.Embedded.Confirm(
+                    composeTestRule = composeTestRule,
+                    context = embeddedContext
+                )
+                Mode.Continue -> TapToAddIntegrationTestRunnerContext.Embedded.Continue(
+                    composeTestRule = composeTestRule,
+                    context = embeddedContext
+                )
+            }
+        }
+    }
+}

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/taptoadd/TapToAddIntegrationTestRunnerContext.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/taptoadd/TapToAddIntegrationTestRunnerContext.kt
@@ -1,0 +1,155 @@
+package com.stripe.android.paymentelement.taptoadd
+
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.paymentelement.EmbeddedContentPage
+import com.stripe.android.paymentelement.EmbeddedFormPage
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentelement.EmbeddedPaymentElementTestRunnerContext
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.PaymentSheet as StripePaymentSheet
+import com.stripe.android.paymentsheet.PaymentSheetPage
+import com.stripe.android.paymentsheet.utils.FlowControllerTestRunnerContext
+import com.stripe.android.paymentsheet.utils.PaymentSheetTestRunnerContext
+
+internal sealed class TapToAddIntegrationTestRunnerContext(
+    protected val composeTestRule: ComposeTestRule,
+) {
+    protected val intentConfiguration = StripePaymentSheet.IntentConfiguration(
+        mode = StripePaymentSheet.IntentConfiguration.Mode.Payment(
+            amount = 5099,
+            currency = "usd"
+        )
+    )
+
+    protected val customerConfig = StripePaymentSheet.CustomerConfiguration.createWithCustomerSession(
+        id = "cus_123",
+        clientSecret = "cuss_123",
+    )
+
+    abstract suspend fun launchFlow()
+
+    abstract fun openCardForm()
+
+    abstract suspend fun confirm()
+
+    sealed class Sheet(
+        composeTestRule: ComposeTestRule,
+    ) : TapToAddIntegrationTestRunnerContext(composeTestRule) {
+        protected val configuration = StripePaymentSheet.Configuration.Builder(
+            merchantDisplayName = "Merchant, Inc.",
+        )
+            .customer(customerConfig)
+            .build()
+
+        protected val paymentSheetPage = PaymentSheetPage(composeTestRule)
+
+        final override fun openCardForm() {
+            paymentSheetPage.clickOnLpm(code = "card", forVerticalMode = true)
+            paymentSheetPage.waitForCardForm()
+        }
+
+        class PaymentSheet(
+            composeTestRule: ComposeTestRule,
+            private val context: PaymentSheetTestRunnerContext,
+        ) : Sheet(composeTestRule) {
+            override suspend fun launchFlow() {
+                context.presentPaymentSheet {
+                    presentWithIntentConfiguration(
+                        intentConfiguration = intentConfiguration,
+                        configuration = configuration,
+                    )
+                }
+            }
+
+            override suspend fun confirm() {
+                throw IllegalStateException("Should confirm from Tap to Add flow!")
+            }
+        }
+
+        class FlowController(
+            composeTestRule: ComposeTestRule,
+            private val context: FlowControllerTestRunnerContext,
+        ) : Sheet(composeTestRule) {
+            override suspend fun launchFlow() {
+                context.configureFlowController {
+                    configureWithIntentConfiguration(
+                        intentConfiguration = intentConfiguration,
+                        configuration = configuration,
+                        callback = { success, error ->
+                            assertThat(success).isTrue()
+                            assertThat(error).isNull()
+                            presentPaymentOptions()
+                        },
+                    )
+                }
+            }
+
+            override suspend fun confirm() {
+                context.consumePaymentOptionEventForFlowController(
+                    paymentMethodType = "card",
+                    label = "···· 4242"
+                )
+
+                context.flowController.confirm()
+            }
+        }
+    }
+
+    sealed class Embedded(
+        composeTestRule: ComposeTestRule,
+        protected val context: EmbeddedPaymentElementTestRunnerContext
+    ) : TapToAddIntegrationTestRunnerContext(composeTestRule) {
+        private val embeddedContentPage = EmbeddedContentPage(composeTestRule)
+        protected val embeddedFormPage = EmbeddedFormPage(composeTestRule)
+
+        abstract val formSheetAction: EmbeddedPaymentElement.FormSheetAction
+
+        final override suspend fun launchFlow() {
+            context.configure(
+                intentConfiguration = PaymentSheet.IntentConfiguration(
+                    mode = PaymentSheet.IntentConfiguration.Mode.Payment(
+                        amount = 5099,
+                        currency = "usd",
+                    )
+                ),
+                configurationMutator = {
+                    customer(customerConfig)
+                    formSheetAction(formSheetAction)
+                }
+            )
+        }
+
+        final override fun openCardForm() {
+            embeddedContentPage.clickOnLpm("card")
+            embeddedFormPage.waitUntilVisible()
+        }
+
+        class Continue(
+            composeTestRule: ComposeTestRule,
+            context: EmbeddedPaymentElementTestRunnerContext
+        ) : Embedded(composeTestRule, context) {
+            override val formSheetAction = EmbeddedPaymentElement.FormSheetAction.Continue
+
+            override suspend fun confirm() {
+                val paymentOption = context.paymentOptionTurbine.awaitItem()
+
+                assertThat(paymentOption?.label).isEqualTo("···· 4242")
+                assertThat(paymentOption?.paymentMethodType).isEqualTo("card")
+
+                context.confirm()
+            }
+        }
+
+        class Confirm(
+            composeTestRule: ComposeTestRule,
+            context: EmbeddedPaymentElementTestRunnerContext
+        ) : Embedded(composeTestRule, context)  {
+            override val formSheetAction = EmbeddedPaymentElement.FormSheetAction.Confirm
+
+            override suspend fun confirm() {
+                throw IllegalStateException("Should confirm from Tap to Add flow!")
+            }
+        }
+    }
+}

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/taptoadd/TapToAddIntegrationType.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/taptoadd/TapToAddIntegrationType.kt
@@ -1,0 +1,25 @@
+package com.stripe.android.paymentelement.taptoadd
+
+import com.google.testing.junit.testparameterinjector.TestParameterValuesProvider
+
+sealed interface TapToAddIntegrationType {
+    enum class Continue : TapToAddIntegrationType {
+        FlowController, Embedded;
+
+        internal object Provider : TestParameterValuesProvider() {
+            override fun provideValues(context: Context?): List<Continue> {
+                return Continue.entries
+            }
+        }
+    }
+
+    enum class Complete : TapToAddIntegrationType {
+        PaymentSheet, Embedded;
+
+        internal object Provider : TestParameterValuesProvider() {
+            override fun provideValues(context: Context?): List<Complete> {
+                return Complete.entries
+            }
+        }
+    }
+}

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/taptoadd/TapToAddResultCallback.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/taptoadd/TapToAddResultCallback.kt
@@ -1,0 +1,33 @@
+package com.stripe.android.paymentelement.taptoadd
+
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentsheet.PaymentSheetResult
+
+fun interface TapToAddResultTestCallback {
+    fun onResult(result: TapToAddTestResult)
+}
+
+sealed interface TapToAddTestResult {
+    data object Completed : TapToAddTestResult
+
+    data class Failed(val error: Throwable) : TapToAddTestResult
+
+    companion object {
+        fun from(result: PaymentSheetResult): TapToAddTestResult {
+            return when (result) {
+                is PaymentSheetResult.Completed -> Completed
+                is PaymentSheetResult.Failed -> Failed(result.error)
+                is PaymentSheetResult.Canceled -> throw IllegalArgumentException("Cancel result unexpected!")
+            }
+        }
+
+        fun from(result: EmbeddedPaymentElement.Result): TapToAddTestResult {
+            return when (result) {
+                is EmbeddedPaymentElement.Result.Completed -> Completed
+                is EmbeddedPaymentElement.Result.Failed -> Failed(result.error)
+                is EmbeddedPaymentElement.Result.Canceled ->
+                    throw IllegalArgumentException("Cancel result unexpected!")
+            }
+        }
+    }
+}

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/taptoadd/TapToAddTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/taptoadd/TapToAddTest.kt
@@ -1,0 +1,144 @@
+package com.stripe.android.paymentelement.taptoadd
+
+import com.google.common.truth.Truth.assertThat
+import com.google.testing.junit.testparameterinjector.TestParameter
+import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import com.stripe.android.core.utils.FeatureFlags
+import com.stripe.android.networktesting.RequestMatchers.method
+import com.stripe.android.networktesting.RequestMatchers.path
+import com.stripe.android.networktesting.elementsSession
+import com.stripe.android.networktesting.testBodyFromFile
+import com.stripe.android.paymentelement.TapToAddPreview
+import com.stripe.android.paymentsheet.CreateIntentResult
+import com.stripe.android.paymentsheet.utils.TerminalWrapperTestRule
+import com.stripe.android.paymentsheet.utils.TestRules
+import com.stripe.android.testing.FeatureFlagTestRule
+import com.stripe.android.tta.testing.TapToAddCardAddedPage
+import com.stripe.android.tta.testing.TapToAddCardCollectionTestHelper
+import com.stripe.android.tta.testing.TapToAddConfirmationPage
+import com.stripe.android.tta.testing.TapToAddLinkTestHelper
+import org.junit.Ignore
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@OptIn(TapToAddPreview::class)
+@RunWith(TestParameterInjector::class)
+class TapToAddTest {
+    val terminalWrapperTestRule = TerminalWrapperTestRule(enabled = true)
+
+    @get:Rule
+    val testRules: TestRules = TestRules.create(
+        terminalTestRule = terminalWrapperTestRule,
+    ) {
+        around(FeatureFlagTestRule(FeatureFlags.enableTapToAdd, true))
+    }
+
+    private val composeTestRule = testRules.compose
+    private val networkRule = testRules.networkRule
+
+    private val cardCollectionTestHelper = TapToAddCardCollectionTestHelper(networkRule) {
+        terminalWrapperTestRule.delegate
+    }
+
+    private val linkHelper = TapToAddLinkTestHelper(composeTestRule, networkRule)
+    private val cardAddedPage = TapToAddCardAddedPage(composeTestRule, linkHelper)
+    private val confirmationPage = TapToAddConfirmationPage(composeTestRule)
+    private val tapToAddCardFormPage = TapToAddCardFormPage(composeTestRule)
+
+    @Test
+    fun successWithCompleteMode(
+        @TestParameter(valuesProvider = TapToAddIntegrationType.Complete.Provider::class)
+        integrationType: TapToAddIntegrationType.Complete
+    ) = runTapToAddIntegrationTest(
+        integrationType = integrationType,
+        composeTestRule = composeTestRule,
+        networkRule = networkRule,
+        createIntentCallback = { _, _ ->
+            CreateIntentResult.Success("pi_123_secret_123")
+        },
+        createCardPresentCallback = {
+            CreateIntentResult.Success("seti_123_secret_123")
+        },
+        resultCallback = {
+            assertThat(it).isInstanceOf(TapToAddTestResult.Completed::class.java)
+        }
+    ) {
+        networkRule.elementsSession { response ->
+            response.testBodyFromFile("elements-sessions-tta.json")
+        }
+
+        cardCollectionTestHelper.enqueueSuccessfulTapToCollectFlow()
+
+        launchFlow()
+        openCardForm()
+
+        tapToAddCardFormPage.clickOnTapToAdd()
+
+        cardAddedPage.assertShown()
+        cardAddedPage.clickContinue()
+
+        confirmationPage.assertPrimaryButton(isEnabled = true)
+
+        enqueueConfirmRequests()
+
+        confirmationPage.clickPrimaryButton()
+        confirmationPage.waitUntilMissing()
+    }
+
+    @Ignore
+    @Test
+    fun successWithContinueMode(
+        @TestParameter(valuesProvider = TapToAddIntegrationType.Continue.Provider::class)
+        integrationType: TapToAddIntegrationType.Continue
+    ) = runTapToAddIntegrationTest(
+        integrationType = integrationType,
+        composeTestRule = composeTestRule,
+        networkRule = networkRule,
+        createIntentCallback = { _, _ ->
+            CreateIntentResult.Success("pi_123_secret_123")
+        },
+        createCardPresentCallback = {
+            CreateIntentResult.Success("seti_123_secret_123")
+        },
+        resultCallback = {
+            assertThat(it).isInstanceOf(TapToAddTestResult.Completed::class.java)
+        }
+    ) {
+        networkRule.elementsSession { response ->
+            response.testBodyFromFile("elements-sessions-tta.json")
+        }
+
+        cardCollectionTestHelper.enqueueSuccessfulTapToCollectFlow()
+
+        launchFlow()
+        openCardForm()
+
+        tapToAddCardFormPage.clickOnTapToAdd()
+
+        cardAddedPage.assertShown()
+
+        enqueueConfirmRequests()
+
+        cardAddedPage.clickContinue()
+        cardAddedPage.waitUntilMissing()
+
+        confirm()
+    }
+
+    private fun enqueueConfirmRequests() {
+        networkRule.enqueue(
+            method("GET"),
+            path("/v1/payment_intents/pi_123"),
+        ) { response ->
+            response.testBodyFromFile("payment-intent-get-requires_payment_method.json")
+        }
+
+        networkRule.enqueue(
+            method("POST"),
+            path("/v1/payment_intents/pi_123/confirm"),
+        ) { response ->
+            response.testBodyFromFile("payment-intent-confirm.json")
+        }
+    }
+}

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/TerminalWrapperTestRule.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/TerminalWrapperTestRule.kt
@@ -1,0 +1,72 @@
+package com.stripe.android.paymentsheet.utils
+
+import android.content.Context
+import com.stripe.android.common.taptoadd.TerminalWrapper
+import com.stripe.android.tta.testing.TerminalTestDelegate
+import com.stripe.stripeterminal.Terminal
+import com.stripe.stripeterminal.external.callable.ConnectionTokenProvider
+import com.stripe.stripeterminal.external.callable.TerminalListener
+import com.stripe.stripeterminal.external.models.ReaderSupportResult
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+class TerminalWrapperTestRule(val enabled: Boolean) : TestWatcher() {
+    private var _delegate: TerminalTestDelegate
+    val delegate: TerminalTestDelegate
+        get() = _delegate
+
+    init {
+        _delegate = TerminalTestDelegate(scenario = TerminalTestDelegate.Scenario.withoutMocks())
+
+        if (!enabled) {
+            _delegate.setScenario(
+                TerminalTestDelegate.Scenario(
+                    readerSupportResult = ReaderSupportResult.NotSupported(
+                        error = IllegalStateException("Not testable!"),
+                    )
+                )
+            )
+        }
+    }
+
+    override fun starting(description: Description?) {
+        if (enabled) {
+            _delegate = TerminalTestDelegate()
+            TerminalWrapper.overrideWrapper = FakeTerminalWrapper(delegate)
+        }
+
+        super.starting(description)
+    }
+
+    override fun finished(description: Description?) {
+        if (enabled) {
+            TerminalWrapper.overrideWrapper = null
+
+            if (delegate.shouldValidate) {
+                delegate.validate()
+            }
+        }
+
+        super.finished(description)
+    }
+
+    private class FakeTerminalWrapper(
+        private val delegate: TerminalTestDelegate
+    ) : TerminalWrapper {
+        override fun isInitialized(): Boolean {
+            return delegate.isInitialized()
+        }
+
+        override fun initTerminal(
+            context: Context,
+            tokenProvider: ConnectionTokenProvider,
+            listener: TerminalListener
+        ) {
+            delegate.initTerminal(context, tokenProvider, listener)
+        }
+
+        override fun getInstance(): Terminal {
+            return delegate.getInstance()
+        }
+    }
+}

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/TestRules.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/TestRules.kt
@@ -28,6 +28,7 @@ class TestRules private constructor(
         fun create(
             composeTestRule: ComposeTestRule = createEmptyComposeRule(),
             networkRule: NetworkRule = NetworkRule(),
+            terminalTestRule: TerminalWrapperTestRule = TerminalWrapperTestRule(enabled = false),
             block: RuleChain.() -> RuleChain = { this }
         ): TestRules {
             val chain = RuleChain.emptyRuleChain()
@@ -36,6 +37,7 @@ class TestRules private constructor(
                 .around(composeTestRule)
                 .around(RetryRule(5))
                 .around(networkRule)
+                .around(terminalTestRule)
                 .block()
             return TestRules(chain, composeTestRule, networkRule)
         }

--- a/paymentsheet/src/androidTest/resources/elements-sessions-tta.json
+++ b/paymentsheet/src/androidTest/resources/elements-sessions-tta.json
@@ -1,0 +1,155 @@
+{
+  "business_name": "Mobile Example Account",
+  "google_pay_preference": "enabled",
+  "merchant_country": "US",
+  "merchant_currency": "usd",
+  "merchant_id": "acct_1HvTI7Lu5o3P18Zp",
+  "meta_pay_signed_container_context": null,
+  "order": null,
+  "ordered_payment_method_types_and_wallets": [
+    "card",
+    "klarna",
+    "cashapp"
+  ],
+  "flags": {
+    "elements_mobile_android_tap_to_add_enabled": true
+  },
+  "customer": {
+    "payment_methods": [],
+    "customer_session": {
+      "id": "cuss_654321",
+      "livemode": false,
+      "api_key": "ek_12345",
+      "api_key_expiry": 1899787184,
+      "customer": "cus_123",
+      "components": {
+        "mobile_payment_element": {
+          "enabled": true,
+          "features": {
+            "payment_method_save": "enabled",
+            "payment_method_remove": "enabled",
+            "payment_method_save_allow_redisplay_override": null
+          }
+        },
+        "customer_sheet": {
+          "enabled": false,
+          "features": null
+        }
+      }
+    },
+    "default_payment_method": null
+  },
+  "payment_method_preference": {
+    "object": "payment_method_preference",
+    "country_code": "US",
+    "ordered_payment_method_types": [
+      "card",
+      "klarna",
+      "cashapp"
+    ],
+    "payment_intent": {
+      "id": "pi_example",
+      "object": "payment_intent",
+      "amount": 5099,
+      "amount_details": {
+        "tip": {}
+      },
+      "automatic_payment_methods": {
+        "enabled": true
+      },
+      "canceled_at": null,
+      "cancellation_reason": null,
+      "capture_method": "automatic",
+      "client_secret": "pi_example_secret_example",
+      "confirmation_method": "automatic",
+      "created": 1674750417,
+      "currency": "usd",
+      "description": null,
+      "last_payment_error": null,
+      "livemode": false,
+      "next_action": null,
+      "payment_method": null,
+      "payment_method_options": {
+        "us_bank_account": {
+          "verification_method": "automatic"
+        }
+      },
+      "payment_method_types": [
+        "card",
+        "klarna",
+        "cashapp"
+      ],
+      "processing": null,
+      "receipt_email": null,
+      "setup_future_usage": null,
+      "shipping": null,
+      "source": null,
+      "status": "requires_payment_method"
+    },
+    "type": "payment_intent"
+  },
+  "payment_method_specs": [
+    {
+      "async": false,
+      "fields": [],
+      "type": "card"
+    },
+    {
+      "async": false,
+      "fields": [],
+      "selector_icon": {
+        "light_theme_png": "https://js.stripe.com/v3/fingerprinted/img/payment-methods/icon-pm-cashapp@3x-a89c5d8d0651cae2a511bb49a6be1cfc.png",
+        "light_theme_svg": "https://js.stripe.com/v3/fingerprinted/img/payment-methods/icon-pm-cashapp-981164a833e417d28a8ac2684fda2324.svg"
+      },
+      "type": "cashapp"
+    },
+    {
+      "async": false,
+      "fields": [
+        {
+          "type": "klarna_header"
+        },
+        {
+          "api_path": {
+            "v1": "billing_details[email]"
+          },
+          "type": "email"
+        },
+        {
+          "api_path": {
+            "v1": "billing_details[address][country]"
+          },
+          "type": "klarna_country"
+        }
+      ],
+      "next_action_spec": {
+        "confirm_response_status_specs": {
+          "requires_action": {
+            "type": "redirect_to_url"
+          }
+        },
+        "post_confirm_handling_pi_status_specs": {
+          "requires_action": {
+            "type": "canceled"
+          },
+          "succeeded": {
+            "type": "finished"
+          }
+        }
+      },
+      "selector_icon": {
+        "light_theme_png": "https://js.stripe.com/v3/fingerprinted/img/payment-methods/icon-pm-klarna@3x-d8624aa9a5662d719a44d16b9fcca0be.png",
+        "light_theme_svg": "https://js.stripe.com/v3/fingerprinted/img/payment-methods/icon-pm-klarna-bb91aa8f173a3c72931696b0f752ec73.svg"
+      },
+      "type": "klarna"
+    }
+  ],
+  "paypal_express_config": {
+    "client_id": null,
+    "paypal_merchant_id": null
+  },
+  "shipping_address_settings": {
+    "autocomplete_allowed": true
+  },
+  "unactivated_payment_method_types": []
+}

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddLayout.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddLayout.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.common.taptoadd.ui
 
+import androidx.annotation.RestrictTo
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionLayout
@@ -34,6 +35,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
@@ -53,6 +55,7 @@ internal fun TapToAddLayout(
     ) {
         SharedTransitionLayout {
             AnimatedContent(
+                modifier = Modifier.testTag(TAP_TO_ADD_LAYOUT_TEST_TAG),
                 targetState = screen,
                 transitionSpec = {
                     fadeIn(animationSpec = tween(ANIMATION_DURATION))
@@ -163,6 +166,9 @@ private fun VisibleCancelButton(
         )
     }
 }
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+const val TAP_TO_ADD_LAYOUT_TEST_TAG = "TAP_TO_ADD_LAYOUT"
 
 internal val LocalTapToAddMaxContentHeight = staticCompositionLocalOf { 0.dp }
 

--- a/tap-to-add-testing/build.gradle
+++ b/tap-to-add-testing/build.gradle
@@ -10,7 +10,6 @@ dependencies {
     implementation testLibs.espresso.intents
     implementation testLibs.androidx.composeUi
     implementation testLibs.mockito.core
-    implementation testLibs.mockito.inline
     implementation testLibs.mockito.kotlin
     implementation testLibs.turbine
     implementation testLibs.truth

--- a/tap-to-add-testing/src/main/java/com/stripe/android/tta/testing/TapToAddCardAddedPage.kt
+++ b/tap-to-add-testing/src/main/java/com/stripe/android/tta/testing/TapToAddCardAddedPage.kt
@@ -50,10 +50,20 @@ class TapToAddCardAddedPage(
         composeTestRule.retrieveCloseButton().click()
     }
 
+    fun waitUntilMissing() {
+        composeTestRule.waitUntilLayoutWithPrimaryButtonMissing()
+    }
+
     private fun assertHasCardAddedText() {
+        val matcher = hasText("Card added")
+
         composeTestRule.waitUntil(DEFAULT_UI_TIMEOUT) {
-            composeTestRule.onNode(hasText("Card added")).isDisplayed()
+            composeTestRule.onAllNodes(matcher)
+                .fetchSemanticsNodes(atLeastOneRootRequired = false)
+                .size == 1
         }
+
+        composeTestRule.onNode(matcher).isDisplayed()
     }
 
     private fun assertHasContinueButton() = primaryButtonElement.assert(withLabel = "Continue")

--- a/tap-to-add-testing/src/main/java/com/stripe/android/tta/testing/TapToAddConfirmationPage.kt
+++ b/tap-to-add-testing/src/main/java/com/stripe/android/tta/testing/TapToAddConfirmationPage.kt
@@ -42,6 +42,10 @@ class TapToAddConfirmationPage(
         primaryButtonElement.assert(null).click()
     }
 
+    fun waitUntilMissing() {
+        composeTestRule.waitUntilLayoutWithPrimaryButtonMissing()
+    }
+
     fun clickCloseButton() {
         composeTestRule.retrieveCloseButton().click()
     }

--- a/tap-to-add-testing/src/main/java/com/stripe/android/tta/testing/TapToAddHelpers.kt
+++ b/tap-to-add-testing/src/main/java/com/stripe/android/tta/testing/TapToAddHelpers.kt
@@ -1,0 +1,20 @@
+package com.stripe.android.tta.testing
+
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import com.stripe.android.common.taptoadd.ui.TAP_TO_ADD_LAYOUT_TEST_TAG
+import com.stripe.android.paymentsheet.ui.PRIMARY_BUTTON_TEST_TAG
+
+internal fun ComposeTestRule.waitUntilLayoutWithPrimaryButtonMissing() {
+    waitUntil(DEFAULT_UI_TIMEOUT) {
+        onAllNodesWithTag(PRIMARY_BUTTON_TEST_TAG)
+            .fetchSemanticsNodes(atLeastOneRootRequired = false)
+            .isEmpty()
+    }
+
+    waitUntil(DEFAULT_UI_TIMEOUT) {
+        onAllNodesWithTag(TAP_TO_ADD_LAYOUT_TEST_TAG)
+            .fetchSemanticsNodes(atLeastOneRootRequired = false)
+            .isEmpty()
+    }
+}

--- a/tap-to-add-testing/src/main/java/com/stripe/android/tta/testing/TerminalTestDelegate.kt
+++ b/tap-to-add-testing/src/main/java/com/stripe/android/tta/testing/TerminalTestDelegate.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import app.cash.turbine.Turbine
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.tta.testing.TerminalTestDelegate.SetupIntentResult
 import com.stripe.stripeterminal.Terminal
 import com.stripe.stripeterminal.external.callable.Callback
 import com.stripe.stripeterminal.external.callable.ConnectionTokenProvider
@@ -20,6 +21,7 @@ import com.stripe.stripeterminal.external.models.Reader
 import com.stripe.stripeterminal.external.models.ReaderSupportResult
 import com.stripe.stripeterminal.external.models.SetupIntent
 import com.stripe.stripeterminal.external.models.TapToPayUxConfiguration
+import com.stripe.stripeterminal.external.models.TerminalErrorCode
 import com.stripe.stripeterminal.external.models.TerminalException
 import org.mockito.kotlin.KStubbing
 import org.mockito.kotlin.any
@@ -27,10 +29,12 @@ import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 
-class TerminalTestDelegate {
+class TerminalTestDelegate(
     private var scenario: Scenario = Scenario()
-
-    private val terminalInstance = createMockedTerminalInstance()
+) {
+    private val terminalInstance by lazy {
+        createMockedTerminalInstance()
+    }
 
     private val isInitializedCalls = Turbine<Unit>()
     private val initTerminalCalls = Turbine<InitTerminalCall>()
@@ -145,7 +149,15 @@ class TerminalTestDelegate {
         val collectSetupIntentPaymentMethodResult: SetupIntentResult =
             SetupIntentResult.Success(mock()),
         val confirmSetupIntentResult: SetupIntentResult = SetupIntentResult.Success(mock()),
-    )
+    ) {
+        companion object {
+            fun withoutMocks() = Scenario(
+                retrieveSetupIntentResult = SetupIntentResult.Failure(DEFAULT_ERROR),
+                collectSetupIntentPaymentMethodResult = SetupIntentResult.Failure(DEFAULT_ERROR),
+                confirmSetupIntentResult = SetupIntentResult.Failure(DEFAULT_ERROR),
+            )
+        }
+    }
 
     class InitTerminalCall(
         val context: Context,
@@ -349,6 +361,11 @@ class TerminalTestDelegate {
     private companion object {
         val DEFAULT_READER = Reader(
             deviceType = DeviceType.TAP_TO_PAY_DEVICE,
+        )
+
+        val DEFAULT_ERROR = TerminalException(
+            errorCode = TerminalErrorCode.UNEXPECTED_SDK_ERROR,
+            errorMessage = "Unexpected usage of collect flow during testing!"
         )
     }
 }


### PR DESCRIPTION
# Summary
Add initial Tap to Add emulator tests for the success cases of Tap to Add for all Payment Element integration types (PaymentSheet, FlowController, Embedded w/ Confirm, Embedded w/ Continue).

# Motivation
Ensures Tap to Add works E2E

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified