### PR TITLE
allow art images with empty format string

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/parsers/CardArtJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/CardArtJsonParser.kt
@@ -18,7 +18,7 @@ class CardArtJsonParser {
 
     internal class ArtImageJsonParser {
         fun parse(json: JSONObject): PaymentMethod.Card.CardArt.ArtImage? {
-            val format = StripeJsonUtils.optString(json, FIELD_FORMAT) ?: return null
+            val format = json.optString(FIELD_FORMAT)
             val url = StripeJsonUtils.optString(json, FIELD_URL) ?: return null
             return PaymentMethod.Card.CardArt.ArtImage(
                 format = format,

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/CardArtJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/CardArtJsonParserTest.kt
@@ -52,7 +52,7 @@ class CardArtJsonParserTest {
 
         val cardArt = CardArtJsonParser().parse(json)
 
-        assertThat(cardArt.artImage).isNull()
+        assertThat(cardArt.artImage).isNotNull()
     }
 
     private companion object {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
allow art images with empty format string

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

https://docs.google.com/document/d/17tkNjqnsTEY8M4ucOIKcvkdTuSyVq2v-LUNhSExUsIM/edit?tab=t.rvqzpoe1kt08
Android is seeing this as an invalid json because `format` is an empty string
```
{
  "art_image": {
    "format": "",
    "url": "..."
  },
  "payment_method": "...",
  "program_name": "Chase Freedom Flex"
}
```

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
