### PR TITLE
Simplify TTA flow with design feedback

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/taptoadd/TapToAddTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/taptoadd/TapToAddTest.kt
@@ -17,7 +17,6 @@ import com.stripe.android.tta.testing.TapToAddCardAddedPage
 import com.stripe.android.tta.testing.TapToAddCardCollectionTestHelper
 import com.stripe.android.tta.testing.TapToAddConfirmationPage
 import com.stripe.android.tta.testing.TapToAddLinkTestHelper
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -75,9 +74,6 @@ internal class TapToAddTest {
 
         tapToAddCardFormPage.clickOnTapToAdd()
 
-        cardAddedPage.assertShown()
-        cardAddedPage.clickContinue()
-
         confirmationPage.assertPrimaryButton(isEnabled = true)
 
         enqueueConfirmRequests()
@@ -115,11 +111,10 @@ internal class TapToAddTest {
 
         tapToAddCardFormPage.clickOnTapToAdd()
 
-        cardAddedPage.assertShown()
-
         enqueueConfirmRequests()
 
-        cardAddedPage.clickContinue()
+        cardAddedPage.assertShown()
+        cardAddedPage.advancePastScreen()
         cardAddedPage.waitUntilMissing()
 
         confirm()

--- a/paymentsheet/src/main/java/com/stripe/android/common/spms/LinkInlineSignupAvailability.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/spms/LinkInlineSignupAvailability.kt
@@ -1,0 +1,30 @@
+package com.stripe.android.common.spms
+
+import com.stripe.android.link.LinkConfiguration
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import javax.inject.Inject
+
+internal interface LinkInlineSignupAvailability {
+    sealed interface Result {
+        data class Available(val configuration: LinkConfiguration) : Result
+
+        data object Unavailable : Result
+    }
+
+    fun availability(): Result
+}
+
+internal class DefaultLinkInlineSignupAvailability @Inject constructor(
+    private val paymentMethodMetadata: PaymentMethodMetadata,
+) : LinkInlineSignupAvailability {
+    override fun availability(): LinkInlineSignupAvailability.Result {
+        val linkState = paymentMethodMetadata.linkState
+
+        return when (linkState?.signupMode) {
+            null -> LinkInlineSignupAvailability.Result.Unavailable
+            else -> LinkInlineSignupAvailability.Result.Available(
+                configuration = linkState.configuration,
+            )
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/common/spms/SavedPaymentMethodLinkFormHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/spms/SavedPaymentMethodLinkFormHelper.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.link.ui.inline.LinkSignupMode
 import com.stripe.android.link.ui.inline.UserInput
-import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.uicore.elements.FormElement
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -12,6 +11,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import javax.inject.Inject
 
 internal interface SavedPaymentMethodLinkFormHelper {
+    val isAvailable: Boolean
     val state: StateFlow<State>
     val formElement: FormElement?
 
@@ -25,12 +25,12 @@ internal interface SavedPaymentMethodLinkFormHelper {
 }
 
 internal class DefaultSavedPaymentMethodLinkFormHelper @Inject constructor(
-    paymentMethodMetadata: PaymentMethodMetadata,
+    linkInlineSignupAvailability: LinkInlineSignupAvailability,
     private val linkConfigurationCoordinator: LinkConfigurationCoordinator,
     private val savedStateHandle: SavedStateHandle,
     linkFormElementFactory: LinkFormElementFactory,
 ) : SavedPaymentMethodLinkFormHelper {
-    private val linkState = paymentMethodMetadata.linkState
+    private val linkAvailabilityResult = linkInlineSignupAvailability.availability()
 
     private var storedCheckboxSelection: Boolean
         get() = savedStateHandle.get<Boolean>(SPM_LINK_CHECKBOX_SELECTED_KEY) == true
@@ -44,30 +44,33 @@ internal class DefaultSavedPaymentMethodLinkFormHelper @Inject constructor(
             savedStateHandle[SPM_LINK_INPUT_KEY] = value
         }
 
+    override val isAvailable: Boolean = linkAvailabilityResult is LinkInlineSignupAvailability.Result.Available
+
     private val _state = MutableStateFlow<SavedPaymentMethodLinkFormHelper.State>(
         SavedPaymentMethodLinkFormHelper.State.Unused
     )
     override val state: StateFlow<SavedPaymentMethodLinkFormHelper.State> = _state.asStateFlow()
 
-    override val formElement: FormElement? = if (linkState?.signupMode != null) {
-        linkFormElementFactory.create(
-            signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
-            configuration = linkState.configuration,
-            linkConfigurationCoordinator = linkConfigurationCoordinator,
-            userInput = storedLinkInput,
-            onLinkInlineSignupStateChanged = { viewState ->
-                storedCheckboxSelection = viewState.isExpanded
-                storedLinkInput = viewState.userInput
+    override val formElement: FormElement? = when (val result = linkInlineSignupAvailability.availability()) {
+        is LinkInlineSignupAvailability.Result.Available -> {
+            linkFormElementFactory.create(
+                signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
+                configuration = result.configuration,
+                linkConfigurationCoordinator = linkConfigurationCoordinator,
+                userInput = storedLinkInput,
+                onLinkInlineSignupStateChanged = { viewState ->
+                    storedCheckboxSelection = viewState.isExpanded
+                    storedLinkInput = viewState.userInput
 
-                _state.value = createState(
-                    useLink = viewState.useLink,
-                    userInput = viewState.userInput,
-                )
-            },
-            previousLinkSignupCheckboxSelection = storedCheckboxSelection,
-        )
-    } else {
-        null
+                    _state.value = createState(
+                        useLink = viewState.useLink,
+                        userInput = viewState.userInput,
+                    )
+                },
+                previousLinkSignupCheckboxSelection = storedCheckboxSelection,
+            )
+        }
+        is LinkInlineSignupAvailability.Result.Unavailable -> null
     }
 
     private fun createState(

--- a/paymentsheet/src/main/java/com/stripe/android/common/spms/SavedPaymentMethodLinkFormHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/spms/SavedPaymentMethodLinkFormHelper.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import javax.inject.Inject
 
 internal interface SavedPaymentMethodLinkFormHelper {
-    val isAvailable: Boolean
     val state: StateFlow<State>
     val formElement: FormElement?
 
@@ -30,8 +29,6 @@ internal class DefaultSavedPaymentMethodLinkFormHelper @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
     linkFormElementFactory: LinkFormElementFactory,
 ) : SavedPaymentMethodLinkFormHelper {
-    private val linkAvailabilityResult = linkInlineSignupAvailability.availability()
-
     private var storedCheckboxSelection: Boolean
         get() = savedStateHandle.get<Boolean>(SPM_LINK_CHECKBOX_SELECTED_KEY) == true
         set(value) {
@@ -43,8 +40,6 @@ internal class DefaultSavedPaymentMethodLinkFormHelper @Inject constructor(
         set(value) {
             savedStateHandle[SPM_LINK_INPUT_KEY] = value
         }
-
-    override val isAvailable: Boolean = linkAvailabilityResult is LinkInlineSignupAvailability.Result.Available
 
     private val _state = MutableStateFlow<SavedPaymentMethodLinkFormHelper.State>(
         SavedPaymentMethodLinkFormHelper.State.Unused

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddViewModelComponent.kt
@@ -9,8 +9,10 @@ import com.stripe.android.common.di.ApplicationIdModule
 import com.stripe.android.common.spms.CvcFormHelper
 import com.stripe.android.common.spms.DefaultCvcFormHelper
 import com.stripe.android.common.spms.DefaultLinkFormElementFactory
+import com.stripe.android.common.spms.DefaultLinkInlineSignupAvailability
 import com.stripe.android.common.spms.DefaultSavedPaymentMethodLinkFormHelper
 import com.stripe.android.common.spms.LinkFormElementFactory
+import com.stripe.android.common.spms.LinkInlineSignupAvailability
 import com.stripe.android.common.spms.SavedPaymentMethodLinkFormHelper
 import com.stripe.android.common.taptoadd.ui.DefaultTapToAddCardAddedInteractor
 import com.stripe.android.common.taptoadd.ui.DefaultTapToAddCollectingInteractor
@@ -279,6 +281,11 @@ internal interface TapToAddLinkModule {
     fun bindsLinkFormHelper(
         linkFormHelper: DefaultSavedPaymentMethodLinkFormHelper
     ): SavedPaymentMethodLinkFormHelper
+
+    @Binds
+    fun bindsLinkInlineSignupAvailability(
+        impl: DefaultLinkInlineSignupAvailability,
+    ): LinkInlineSignupAvailability
 
     @Binds
     fun bindsCvcFormHelperFactory(

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddCardAddedInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddCardAddedInteractor.kt
@@ -33,7 +33,7 @@ internal interface TapToAddCardAddedInteractor {
         val cardBrand: CardBrand,
         val last4: String?,
         val title: ResolvableString,
-        val primaryButton: PrimaryButton,
+        val primaryButton: PrimaryButton?,
         val form: Form,
     ) {
         data class PrimaryButton(
@@ -52,6 +52,7 @@ internal interface TapToAddCardAddedInteractor {
     fun close()
 
     sealed interface Action {
+        data object ScreenShown : Action
         data object PrimaryButtonPressed : Action
         data object CancelPressed : Action
     }
@@ -104,6 +105,9 @@ internal class DefaultTapToAddCardAddedInteractor(
 
     override fun performAction(action: TapToAddCardAddedInteractor.Action) {
         when (action) {
+            TapToAddCardAddedInteractor.Action.ScreenShown -> {
+                onScreenShown()
+            }
             TapToAddCardAddedInteractor.Action.PrimaryButtonPressed -> {
                 eventReporter.onTapToAddContinueAfterCardAdded()
                 onPrimaryButtonPressed()
@@ -118,21 +122,37 @@ internal class DefaultTapToAddCardAddedInteractor(
         coroutineScope.cancel()
     }
 
+    private fun onScreenShown() {
+        val currentState = state.value
+
+        if (currentState.primaryButton != null) {
+            return
+        }
+
+        onContinue()
+    }
+
     private fun onPrimaryButtonPressed() {
-        val linkInput = when (val state = savedPaymentMethodLinkFormHelper.state.value) {
+        when (tapToAddMode) {
+            TapToAddMode.Continue -> onContinue()
+            TapToAddMode.Complete -> onConfirm(paymentMethod, getLinkInput())
+        }
+    }
+
+    private fun onContinue() {
+        onContinue(
+            PaymentSelection.Saved(
+                paymentMethod = paymentMethod,
+                linkInput = getLinkInput(),
+            )
+        )
+    }
+
+    private fun getLinkInput(): UserInput? {
+        return when (val state = savedPaymentMethodLinkFormHelper.state.value) {
             is SavedPaymentMethodLinkFormHelper.State.Unused,
             is SavedPaymentMethodLinkFormHelper.State.Incomplete -> null
             is SavedPaymentMethodLinkFormHelper.State.Complete -> state.userInput
-        }
-
-        when (tapToAddMode) {
-            TapToAddMode.Continue -> onContinue(
-                PaymentSelection.Saved(
-                    paymentMethod = paymentMethod,
-                    linkInput = linkInput,
-                )
-            )
-            TapToAddMode.Complete -> onConfirm(paymentMethod, linkInput)
         }
     }
 
@@ -140,9 +160,11 @@ internal class DefaultTapToAddCardAddedInteractor(
         linkState: SavedPaymentMethodLinkFormHelper.State,
     ): TapToAddCardAddedInteractor.State {
         return copy(
-            primaryButton = primaryButton.copy(
+            primaryButton = primaryButton?.copy(
                 enabled = linkState !is SavedPaymentMethodLinkFormHelper.State.Incomplete,
-            ),
+            ).takeIf {
+                tapToAddMode == TapToAddMode.Complete || savedPaymentMethodLinkFormHelper.isAvailable
+            },
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddCardAddedInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddCardAddedInteractor.kt
@@ -81,7 +81,9 @@ internal class DefaultTapToAddCardAddedInteractor(
             primaryButton = TapToAddCardAddedInteractor.State.PrimaryButton(
                 label = StripeUiCoreR.string.stripe_continue_button_label.resolvableString,
                 enabled = true,
-            ),
+            ).takeIf {
+                tapToAddMode == TapToAddMode.Complete || savedPaymentMethodLinkFormHelper.formElement != null
+            },
             form = TapToAddCardAddedInteractor.State.Form(
                 elements = savedPaymentMethodLinkFormHelper.formElement?.let {
                     listOf(it)
@@ -162,9 +164,7 @@ internal class DefaultTapToAddCardAddedInteractor(
         return copy(
             primaryButton = primaryButton?.copy(
                 enabled = linkState !is SavedPaymentMethodLinkFormHelper.State.Incomplete,
-            ).takeIf {
-                tapToAddMode == TapToAddMode.Complete || savedPaymentMethodLinkFormHelper.isAvailable
-            },
+            )
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddCardAddedScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddCardAddedScreen.kt
@@ -4,18 +4,27 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.ui.PrimaryButtonProcessingState
 import com.stripe.android.ui.core.FormUI
 import com.stripe.android.uicore.strings.resolve
+import kotlinx.coroutines.delay
+import kotlin.time.Duration.Companion.seconds
 
 @Composable
 internal fun ColumnScope.TapToAddCardAddedScreen(
     state: TapToAddCardAddedInteractor.State,
     onPrimaryButtonPress: () -> Unit,
+    onScreenShown: () -> Unit,
 ) {
+    LaunchedEffect(Unit) {
+        delay(2.5.seconds)
+        onScreenShown()
+    }
+
     TapToAddCardLayout(
         cardBrand = state.cardBrand,
         last4 = state.last4,
@@ -33,14 +42,16 @@ internal fun ColumnScope.TapToAddCardAddedScreen(
         Spacer(Modifier.size(10.dp))
 
         with(state.primaryButton) {
-            PrimaryButton(
-                label = label.resolve(),
-                locked = false,
-                enabled = enabled,
-                processingState = PrimaryButtonProcessingState.Idle(null),
-                onProcessingCompleted = {},
-                onClick = onPrimaryButtonPress,
-            )
+            this?.run {
+                PrimaryButton(
+                    label = label.resolve(),
+                    locked = false,
+                    enabled = enabled,
+                    processingState = PrimaryButtonProcessingState.Idle(null),
+                    onProcessingCompleted = {},
+                    onClick = onPrimaryButtonPress,
+                )
+            }
         }
 
         Spacer(Modifier.size(10.dp))

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddCardAddedScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddCardAddedScreen.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.common.taptoadd.ui
 
+import androidx.annotation.RestrictTo
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
@@ -12,7 +13,6 @@ import com.stripe.android.paymentsheet.ui.PrimaryButtonProcessingState
 import com.stripe.android.ui.core.FormUI
 import com.stripe.android.uicore.strings.resolve
 import kotlinx.coroutines.delay
-import kotlin.time.Duration.Companion.seconds
 
 @Composable
 internal fun ColumnScope.TapToAddCardAddedScreen(
@@ -21,7 +21,7 @@ internal fun ColumnScope.TapToAddCardAddedScreen(
     onScreenShown: () -> Unit,
 ) {
     LaunchedEffect(Unit) {
-        delay(2.5.seconds)
+        delay(TAP_TO_ADD_CARD_ADDED_SHOWN_DELAY)
         onScreenShown()
     }
 
@@ -57,3 +57,6 @@ internal fun ColumnScope.TapToAddCardAddedScreen(
         Spacer(Modifier.size(10.dp))
     }
 }
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+const val TAP_TO_ADD_CARD_ADDED_SHOWN_DELAY = 2500L

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddCardCollectedScreenFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddCardCollectedScreenFactory.kt
@@ -1,0 +1,32 @@
+package com.stripe.android.common.taptoadd.ui
+
+import com.stripe.android.common.spms.LinkInlineSignupAvailability
+import com.stripe.android.common.taptoadd.TapToAddMode
+import com.stripe.android.model.PaymentMethod
+import javax.inject.Inject
+
+internal class TapToAddCardCollectedScreenFactory @Inject constructor(
+    private val tapToAddMode: TapToAddMode,
+    private val linkInlineSignupAvailability: LinkInlineSignupAvailability,
+    private val tapToAddCardAddedInteractorFactory: TapToAddCardAddedInteractor.Factory,
+    private val tapToAddConfirmationInteractorFactory: TapToAddConfirmationInteractor.Factory,
+) {
+    fun create(paymentMethod: PaymentMethod): TapToAddNavigator.Screen {
+        return if (
+            tapToAddMode == TapToAddMode.Complete &&
+            linkInlineSignupAvailability.availability() is LinkInlineSignupAvailability.Result.Unavailable
+        ) {
+            TapToAddNavigator.Screen.Confirmation(
+                interactor = tapToAddConfirmationInteractorFactory.create(
+                    paymentMethod = paymentMethod,
+                    linkInput = null,
+                    withTitle = true,
+                )
+            )
+        } else {
+            TapToAddNavigator.Screen.CardAdded(
+                interactor = tapToAddCardAddedInteractorFactory.create(paymentMethod)
+            )
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddCollectingInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddCollectingInteractor.kt
@@ -86,7 +86,7 @@ internal class DefaultTapToAddCollectingInteractor(
         private val tapToAddCollectionHandler: TapToAddCollectionHandler,
         private val eventReporter: EventReporter,
         private val stateHolder: TapToAddStateHolder,
-        private val tapToAddCardAddedInteractorFactory: TapToAddCardAddedInteractor.Factory,
+        private val tapToAddCardCollectedScreenFactory: TapToAddCardCollectedScreenFactory,
         private val navigator: Provider<TapToAddNavigator>,
         @UIContext private val uiContext: CoroutineContext,
         @IOContext private val ioContext: CoroutineContext,
@@ -103,9 +103,7 @@ internal class DefaultTapToAddCollectingInteractor(
 
                     navigator.get().performAction(
                         action = TapToAddNavigator.Action.NavigateTo(
-                            screen = TapToAddNavigator.Screen.CardAdded(
-                                interactor = tapToAddCardAddedInteractorFactory.create(paymentMethod),
-                            ),
+                            screen = tapToAddCardCollectedScreenFactory.create(paymentMethod),
                         )
                     )
                 },

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddConfirmationInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddConfirmationInteractor.kt
@@ -3,6 +3,7 @@ package com.stripe.android.common.taptoadd.ui
 import com.stripe.android.common.spms.CvcFormHelper
 import com.stripe.android.core.injection.UIContext
 import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.CardBrand
@@ -11,6 +12,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.toConfirmationOption
+import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.utils.buyButtonLabel
@@ -36,6 +38,7 @@ internal interface TapToAddConfirmationInteractor {
     data class State(
         val cardBrand: CardBrand,
         val last4: String?,
+        val title: ResolvableString?,
         val primaryButton: PrimaryButton,
         val form: Form,
         val error: ResolvableString?,
@@ -73,11 +76,13 @@ internal interface TapToAddConfirmationInteractor {
         fun create(
             paymentMethod: PaymentMethod,
             linkInput: UserInput?,
+            withTitle: Boolean = false,
         ): TapToAddConfirmationInteractor
     }
 }
 
 internal class DefaultTapToAddConfirmationInteractor(
+    private val withTitle: Boolean,
     private val coroutineContext: CoroutineContext,
     private val paymentMethod: PaymentMethod,
     private val linkInput: UserInput?,
@@ -190,6 +195,7 @@ internal class DefaultTapToAddConfirmationInteractor(
                 enabled = true,
                 state = TapToAddConfirmationInteractor.State.PrimaryButton.State.Idle,
             ),
+            title = R.string.stripe_tap_to_add_card_added_title.resolvableString.takeIf { withTitle },
             form = TapToAddConfirmationInteractor.State.Form(
                 elements = cvcFormHelper.formElement?.let { listOf(it) } ?: emptyList(),
                 enabled = true,
@@ -276,8 +282,10 @@ internal class DefaultTapToAddConfirmationInteractor(
         override fun create(
             paymentMethod: PaymentMethod,
             linkInput: UserInput?,
+            withTitle: Boolean,
         ): TapToAddConfirmationInteractor {
             return DefaultTapToAddConfirmationInteractor(
+                withTitle = withTitle,
                 paymentMethodMetadata = paymentMethodMetadata,
                 paymentMethod = paymentMethod,
                 linkInput = linkInput,

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddConfirmationScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddConfirmationScreen.kt
@@ -36,7 +36,7 @@ internal fun ColumnScope.TapToAddConfirmationScreen(
     TapToAddCardLayout(
         cardBrand = state.cardBrand,
         last4 = state.last4,
-        title = null,
+        title = state.title?.resolve(),
     ) {
         with(state.form) {
             if (elements.isNotEmpty()) {

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddDelayInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddDelayInteractor.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.common.taptoadd.ui
 
+import androidx.annotation.RestrictTo
 import com.stripe.android.core.injection.UIContext
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
@@ -38,7 +39,7 @@ internal class DefaultTapToAddDelayInteractor(
 
     init {
         coroutineScope.launch {
-            delay(SHOWN_SCREEN_DELAY)
+            delay(TAP_TO_ADD_SHOWN_SCREEN_DELAY)
             onShown()
         }
     }
@@ -66,8 +67,7 @@ internal class DefaultTapToAddDelayInteractor(
             )
         }
     }
-
-    private companion object {
-        const val SHOWN_SCREEN_DELAY = 1000L
-    }
 }
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+const val TAP_TO_ADD_SHOWN_SCREEN_DELAY = 1000L

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddNavigator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddNavigator.kt
@@ -128,13 +128,17 @@ internal class TapToAddNavigator(
         data class CardAdded(
             val interactor: TapToAddCardAddedInteractor,
         ) : Screen() {
-            override val cancelButton: StateFlow<CancelButton> = stateFlowOf(
-                CancelButton.Available(
-                    action = Action.Close {
-                        interactor.performAction(TapToAddCardAddedInteractor.Action.CancelPressed)
-                    }
-                )
-            )
+            override val cancelButton: StateFlow<CancelButton> = interactor.state.mapAsStateFlow { state ->
+                state.primaryButton?.let {
+                    CancelButton.Available(
+                        action = Action.Close {
+                            interactor.performAction(TapToAddCardAddedInteractor.Action.CancelPressed)
+                        }
+                    )
+                } ?: run {
+                    CancelButton.Invisible
+                }
+            }
 
             @Composable
             override fun ColumnScope.Content() {
@@ -144,6 +148,9 @@ internal class TapToAddNavigator(
                     state = state,
                     onPrimaryButtonPress = {
                         interactor.performAction(TapToAddCardAddedInteractor.Action.PrimaryButtonPressed)
+                    },
+                    onScreenShown = {
+                        interactor.performAction(TapToAddCardAddedInteractor.Action.ScreenShown)
                     }
                 )
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityViewModelComponent.kt
@@ -9,8 +9,10 @@ import com.stripe.android.cards.CardAccountRangeRepository
 import com.stripe.android.cards.DefaultCardAccountRangeRepositoryFactory
 import com.stripe.android.common.di.ApplicationIdModule
 import com.stripe.android.common.spms.DefaultLinkFormElementFactory
+import com.stripe.android.common.spms.DefaultLinkInlineSignupAvailability
 import com.stripe.android.common.spms.DefaultSavedPaymentMethodLinkFormHelper
 import com.stripe.android.common.spms.LinkFormElementFactory
+import com.stripe.android.common.spms.LinkInlineSignupAvailability
 import com.stripe.android.common.spms.SavedPaymentMethodLinkFormHelper
 import com.stripe.android.common.taptoadd.DefaultTapToAddHelper
 import com.stripe.android.common.taptoadd.TapToAddHelper
@@ -114,6 +116,11 @@ internal interface FormActivityViewModelModule {
     fun bindsSavedPaymentMethodLinkFormHelper(
         helper: DefaultSavedPaymentMethodLinkFormHelper
     ): SavedPaymentMethodLinkFormHelper
+
+    @Binds
+    fun bindsLinkInlineSignupAvailability(
+        impl: DefaultLinkInlineSignupAvailability,
+    ): LinkInlineSignupAvailability
 
     @Suppress("TooManyFunctions")
     companion object {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodConfirmInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/SavedPaymentMethodConfirmInteractor.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.verticalmode
 
 import androidx.lifecycle.viewModelScope
 import com.stripe.android.common.spms.DefaultLinkFormElementFactory
+import com.stripe.android.common.spms.DefaultLinkInlineSignupAvailability
 import com.stripe.android.common.spms.DefaultSavedPaymentMethodLinkFormHelper
 import com.stripe.android.common.spms.SavedPaymentMethodLinkFormHelper
 import com.stripe.android.common.spms.withLinkState
@@ -71,7 +72,7 @@ internal class DefaultSavedPaymentMethodConfirmInteractor(
                     PaymentMethod.Type.Card.code
                 )?.displayName.orEmpty(),
                 savedPaymentMethodLinkFormHelper = DefaultSavedPaymentMethodLinkFormHelper(
-                    paymentMethodMetadata = paymentMethodMetadata,
+                    linkInlineSignupAvailability = DefaultLinkInlineSignupAvailability(paymentMethodMetadata),
                     linkConfigurationCoordinator = viewModel.linkHandler.linkConfigurationCoordinator,
                     savedStateHandle = viewModel.savedStateHandle,
                     linkFormElementFactory = DefaultLinkFormElementFactory,

--- a/paymentsheet/src/test/java/com/stripe/android/common/spms/DefaultLinkInlineSignupAvailabilityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/spms/DefaultLinkInlineSignupAvailabilityTest.kt
@@ -1,0 +1,52 @@
+package com.stripe.android.common.spms
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.link.TestFactory
+import com.stripe.android.link.ui.inline.LinkSignupMode
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.paymentsheet.state.LinkState
+import org.junit.Test
+
+internal class DefaultLinkInlineSignupAvailabilityTest {
+    @Test
+    fun `availability is Unavailable when link state is null`() {
+        val metadata = PaymentMethodMetadataFactory.create(linkState = null)
+        val availability = DefaultLinkInlineSignupAvailability(metadata)
+
+        assertThat(availability.availability())
+            .isEqualTo(LinkInlineSignupAvailability.Result.Unavailable)
+    }
+
+    @Test
+    fun `availability is Unavailable when signup mode is null`() {
+        val metadata = PaymentMethodMetadataFactory.create(
+            linkState = LinkState(
+                configuration = TestFactory.LINK_CONFIGURATION,
+                loginState = LinkState.LoginState.LoggedOut,
+                signupMode = null,
+            ),
+        )
+        val availability = DefaultLinkInlineSignupAvailability(metadata)
+
+        assertThat(availability.availability())
+            .isEqualTo(LinkInlineSignupAvailability.Result.Unavailable)
+    }
+
+    @Test
+    fun `availability is Available when signup mode is present`() {
+        val linkState = LinkState(
+            configuration = TestFactory.LINK_CONFIGURATION,
+            loginState = LinkState.LoginState.LoggedOut,
+            signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
+        )
+        val metadata = PaymentMethodMetadataFactory.create(linkState = linkState)
+        val availability = DefaultLinkInlineSignupAvailability(metadata)
+
+        assertThat(availability.availability())
+            .isEqualTo(
+                LinkInlineSignupAvailability.Result.Available(
+                    configuration = TestFactory.LINK_CONFIGURATION,
+                )
+            )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/common/spms/DefaultSavedPaymentMethodLinkFormHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/spms/DefaultSavedPaymentMethodLinkFormHelperTest.kt
@@ -14,9 +14,6 @@ import com.stripe.android.link.ui.inline.InlineSignupViewState
 import com.stripe.android.link.ui.inline.LinkSignupMode
 import com.stripe.android.link.ui.inline.SignUpConsentAction
 import com.stripe.android.link.ui.inline.UserInput
-import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
-import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
-import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.uicore.elements.Controller
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
@@ -28,12 +25,8 @@ import org.junit.Test
 
 internal class DefaultSavedPaymentMethodLinkFormHelperTest {
     @Test
-    fun `link form is unavailable when signup mode is not defined`() = runScenario(
-        linkState = LinkState(
-            configuration = TestFactory.LINK_CONFIGURATION,
-            loginState = LinkState.LoginState.LoggedOut,
-            signupMode = null,
-        ),
+    fun `link form is unavailable when availability result is unavailable`() = runScenario(
+        linkAvailabilityResult = LinkInlineSignupAvailability.Result.Unavailable,
     ) {
         helper.state.test {
             Truth.assertThat(awaitItem()).isEqualTo(SavedPaymentMethodLinkFormHelper.State.Unused)
@@ -45,16 +38,12 @@ internal class DefaultSavedPaymentMethodLinkFormHelperTest {
     }
 
     @Test
-    fun `link form element is available when signup mode is defined`() {
+    fun `link form element is available when availability result is available`() {
         val coordinator = FakeLinkConfigurationCoordinator()
 
         runScenario(
             linkConfigurationCoordinator = coordinator,
-            linkState = LinkState(
-                configuration = TestFactory.LINK_CONFIGURATION,
-                loginState = LinkState.LoginState.LoggedOut,
-                signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
-            ),
+            linkAvailabilityResult = LinkInlineSignupAvailability.Result.Available(TestFactory.LINK_CONFIGURATION),
         ) {
             helper.state.test {
                 Truth.assertThat(awaitItem()).isEqualTo(SavedPaymentMethodLinkFormHelper.State.Unused)
@@ -77,27 +66,6 @@ internal class DefaultSavedPaymentMethodLinkFormHelperTest {
     }
 
     @Test
-    fun `link form element always uses InsteadOfSaveForFutureUse irregardless of signup mode`() {
-        val coordinator = FakeLinkConfigurationCoordinator()
-
-        runScenario(
-            linkConfigurationCoordinator = coordinator,
-            linkState = LinkState(
-                configuration = TestFactory.LINK_CONFIGURATION,
-                loginState = LinkState.LoginState.LoggedOut,
-                signupMode = LinkSignupMode.AlongsideSaveForFutureUse,
-            ),
-        ) {
-            Truth.assertThat(helper.formElement).isNotNull()
-
-            val factoryCreateCall = formElementFactoryCreateCalls.awaitItem()
-
-            Truth.assertThat(factoryCreateCall.signupMode)
-                .isEqualTo(LinkSignupMode.InsteadOfSaveForFutureUse)
-        }
-    }
-
-    @Test
     fun `factory is called with input when handle has stored link input`() {
         val userInput = UserInput.SignUp(
             name = "John Doe",
@@ -108,11 +76,7 @@ internal class DefaultSavedPaymentMethodLinkFormHelperTest {
         )
 
         runScenario(
-            linkState = LinkState(
-                configuration = TestFactory.LINK_CONFIGURATION,
-                loginState = LinkState.LoginState.LoggedOut,
-                signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
-            ),
+            linkAvailabilityResult = LinkInlineSignupAvailability.Result.Available(TestFactory.LINK_CONFIGURATION),
             handle = SavedStateHandle(
                 initialState = mapOf(
                     SPM_LINK_INPUT_KEY to userInput,
@@ -128,11 +92,7 @@ internal class DefaultSavedPaymentMethodLinkFormHelperTest {
     @Test
     fun `factory is called with previousLinkSignupCheckboxSelection true when handle has checkbox selected`() =
         runScenario(
-            linkState = LinkState(
-                configuration = TestFactory.LINK_CONFIGURATION,
-                loginState = LinkState.LoginState.LoggedOut,
-                signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
-            ),
+            linkAvailabilityResult = LinkInlineSignupAvailability.Result.Available(TestFactory.LINK_CONFIGURATION),
             handle = SavedStateHandle(
                 initialState = mapOf(
                     SPM_LINK_CHECKBOX_SELECTED_KEY to true,
@@ -146,11 +106,7 @@ internal class DefaultSavedPaymentMethodLinkFormHelperTest {
     @Test
     fun `onLinkInlineSignupStateChanged updates state to Unused when when link is not used`() =
         runScenario(
-            linkState = LinkState(
-                configuration = TestFactory.LINK_CONFIGURATION,
-                loginState = LinkState.LoginState.LoggedOut,
-                signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
-            ),
+            linkAvailabilityResult = LinkInlineSignupAvailability.Result.Available(TestFactory.LINK_CONFIGURATION),
         ) {
             val call = formElementFactoryCreateCalls.awaitItem()
 
@@ -178,11 +134,7 @@ internal class DefaultSavedPaymentMethodLinkFormHelperTest {
     @Test
     fun `onLinkInlineSignupStateChanged updates state to Incomplete when link is used but incomplete input`() =
         runScenario(
-            linkState = LinkState(
-                configuration = TestFactory.LINK_CONFIGURATION,
-                loginState = LinkState.LoginState.LoggedOut,
-                signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
-            ),
+            linkAvailabilityResult = LinkInlineSignupAvailability.Result.Available(TestFactory.LINK_CONFIGURATION),
         ) {
             val call = formElementFactoryCreateCalls.awaitItem()
 
@@ -210,11 +162,7 @@ internal class DefaultSavedPaymentMethodLinkFormHelperTest {
     @Test
     fun `onLinkInlineSignupStateChanged updates state to Complete when user input is present`() =
         runScenario(
-            linkState = LinkState(
-                configuration = TestFactory.LINK_CONFIGURATION,
-                loginState = LinkState.LoginState.LoggedOut,
-                signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
-            ),
+            linkAvailabilityResult = LinkInlineSignupAvailability.Result.Available(TestFactory.LINK_CONFIGURATION),
         ) {
             val call = formElementFactoryCreateCalls.awaitItem()
 
@@ -254,10 +202,7 @@ internal class DefaultSavedPaymentMethodLinkFormHelperTest {
         }
 
     private fun runScenario(
-        linkState: LinkState? = null,
-        paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(
-            linkState = linkState,
-        ),
+        linkAvailabilityResult: LinkInlineSignupAvailability.Result = LinkInlineSignupAvailability.Result.Unavailable,
         handle: SavedStateHandle = SavedStateHandle(),
         linkConfigurationCoordinator: LinkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
         block: suspend Scenario.() -> Unit,
@@ -265,7 +210,7 @@ internal class DefaultSavedPaymentMethodLinkFormHelperTest {
         val factory = FakeLinkFormElementFactory()
 
         val helper = DefaultSavedPaymentMethodLinkFormHelper(
-            paymentMethodMetadata = paymentMethodMetadata,
+            linkInlineSignupAvailability = FakeLinkInlineSignupAvailability(linkAvailabilityResult),
             linkConfigurationCoordinator = linkConfigurationCoordinator,
             savedStateHandle = handle,
             linkFormElementFactory = factory,

--- a/paymentsheet/src/test/java/com/stripe/android/common/spms/FakeLinkInlineSignupAvailability.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/spms/FakeLinkInlineSignupAvailability.kt
@@ -1,0 +1,7 @@
+package com.stripe.android.common.spms
+
+internal class FakeLinkInlineSignupAvailability(
+    private val result: LinkInlineSignupAvailability.Result,
+) : LinkInlineSignupAvailability {
+    override fun availability(): LinkInlineSignupAvailability.Result = result
+}

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddActivityTest.kt
@@ -35,6 +35,7 @@ import com.stripe.android.tta.testing.TapToAddCardAddedPage
 import com.stripe.android.tta.testing.TapToAddCardCollectionTestHelper
 import com.stripe.android.tta.testing.TapToAddConfirmationPage
 import com.stripe.android.tta.testing.TapToAddConfirmationTestHelper
+import com.stripe.android.tta.testing.TapToAddDelayPage
 import com.stripe.android.tta.testing.TapToAddErrorPage
 import com.stripe.android.tta.testing.TapToAddLinkTestHelper
 import com.stripe.android.tta.testing.TerminalTestDelegate
@@ -84,6 +85,7 @@ class TapToAddActivityTest {
     private val cardArtTestHelper = TapToAddCardArtTestHelper(imageLoaderTestRule)
     private val cardAddedPage = TapToAddCardAddedPage(composeTestRule, linkHelper)
     private val confirmationPage = TapToAddConfirmationPage(composeTestRule)
+    private val delayPage = TapToAddDelayPage(composeTestRule)
     private val errorPage = TapToAddErrorPage(composeTestRule)
 
     @Test
@@ -100,8 +102,7 @@ class TapToAddActivityTest {
             waitForIdle()
 
             cardAddedPage.assertShown()
-            cardAddedPage.assertContinueButton(isEnabled = true)
-            cardAddedPage.clickContinue()
+            cardAddedPage.advancePastScreen()
 
             waitForIdle()
 
@@ -186,12 +187,6 @@ class TapToAddActivityTest {
 
             waitForIdle()
 
-            cardAddedPage.assertShown()
-            cardAddedPage.assertContinueButton(isEnabled = true)
-            cardAddedPage.clickContinue()
-
-            waitForIdle()
-
             confirmationPage.assertPrimaryButton(withLabel = "Pay $10.99", isEnabled = true)
             confirmationPage.clickPrimaryButton()
 
@@ -231,12 +226,6 @@ class TapToAddActivityTest {
         )
 
         launch {
-            waitForIdle()
-
-            cardAddedPage.assertShown()
-            cardAddedPage.assertContinueButton(isEnabled = true)
-            cardAddedPage.clickContinue()
-
             waitForIdle()
 
             confirmationPage.assertPrimaryButton(withLabel = "Pay $10.99", isEnabled = true)
@@ -297,6 +286,10 @@ class TapToAddActivityTest {
 
             waitForIdle()
 
+            delayPage.advancePastScreen()
+
+            waitForIdle()
+
             confirmationPage.assertPrimaryButton(isEnabled = true)
             confirmationPage.clickPrimaryButton()
 
@@ -332,11 +325,6 @@ class TapToAddActivityTest {
 
         launch { activityScenario ->
             cardCollectionHelper.assertSuccessfulCardCollection(info)
-
-            waitForIdle()
-
-            cardAddedPage.assertShown()
-            cardAddedPage.clickContinue()
 
             waitForIdle()
 
@@ -389,13 +377,29 @@ class TapToAddActivityTest {
     @Test
     fun canceledFromCardAddedScreen() = runScenario(
         mode = TapToAddMode.Continue,
+        metadata = PaymentMethodMetadataFactory.create(
+            isTapToAddSupported = true,
+            hasCustomerConfiguration = true,
+            linkState = LinkState(
+                configuration = TestFactory.LINK_CONFIGURATION.copy(
+                    customerInfo = LinkConfiguration.CustomerInfo(
+                        name = null,
+                        email = null,
+                        phone = null,
+                        billingCountryCode = null
+                    )
+                ),
+                loginState = LinkState.LoginState.LoggedOut,
+                signupMode = LinkSignupMode.InsteadOfSaveForFutureUse,
+            )
+        )
     ) {
         val info = cardCollectionHelper.enqueueSuccessfulTapToCollectFlow()
 
         launch { activityScenario ->
             waitForIdle()
 
-            cardAddedPage.assertShown()
+            cardAddedPage.assertShown(withLink = true)
             cardAddedPage.clickCloseButton()
 
             waitForIdle()
@@ -423,11 +427,7 @@ class TapToAddActivityTest {
         launch { activityScenario ->
             waitForIdle()
 
-            cardAddedPage.assertShown()
-            cardAddedPage.clickContinue()
-
-            waitForIdle()
-
+            confirmationPage.assertPrimaryButton(isEnabled = true)
             confirmationPage.clickCloseButton()
 
             waitForIdle()

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/DefaultTapToAddCardAddedInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/DefaultTapToAddCardAddedInteractorTest.kt
@@ -30,44 +30,52 @@ import com.stripe.android.ui.core.R as StripeUiCoreR
 
 internal class DefaultTapToAddCardAddedInteractorTest {
     @Test
-    fun `initial state is correct`() = runScenario(
+    fun `Continue mode with Link disabled`() = runScenario(
         paymentMethod = PaymentMethodFactory.card().update(
             last4 = "1234",
             brand = CardBrand.MasterCard,
             addCbcNetworks = false,
         ),
-        initialLinkState = SavedPaymentMethodLinkFormHelper.State.Unused,
+        tapToAddMode = TapToAddMode.Continue,
+        isLinkAvailable = false,
     ) {
         val state = interactor.state.value
         assertThat(state.cardBrand).isEqualTo(CardBrand.MasterCard)
         assertThat(state.last4).isEqualTo("1234")
         assertThat(state.title).isEqualTo(R.string.stripe_tap_to_add_card_added_title.resolvableString)
-        assertThat(state.primaryButton.label)
-            .isEqualTo(StripeUiCoreR.string.stripe_continue_button_label.resolvableString)
-        assertThat(state.primaryButton.enabled).isTrue()
+        assertThat(state.primaryButton).isNull()
         assertThat(state.form.elements).containsExactly(fakeLinkFormHelper.formElement)
         assertThat(state.form.enabled).isTrue()
     }
 
     @Test
-    fun `state primary button is disabled when link helper is Incomplete`() = runScenario(
-        initialLinkState = SavedPaymentMethodLinkFormHelper.State.Complete(mockUserInput()),
+    fun `Complete mode with unused link shows primary button`() = runScenario(
+        paymentMethod = PaymentMethodFactory.card(last4 = "4242"),
+        tapToAddMode = TapToAddMode.Complete,
+        isLinkAvailable = true,
     ) {
-        interactor.state.test {
-            assertThat(awaitItem().primaryButton.enabled).isTrue()
-            fakeLinkFormHelper.updateState(SavedPaymentMethodLinkFormHelper.State.Incomplete)
-            assertThat(awaitItem().primaryButton.enabled).isFalse()
-        }
+        val state = interactor.state.value
+        assertThat(state.primaryButton).isNotNull()
+        assertThat(state.primaryButton?.label)
+            .isEqualTo(StripeUiCoreR.string.stripe_continue_button_label.resolvableString)
+        assertThat(state.primaryButton?.enabled).isTrue()
     }
 
     @Test
-    fun `state primary button is enabled when link helper emits Unused`() = runScenario(
-        initialLinkState = SavedPaymentMethodLinkFormHelper.State.Incomplete,
+    fun `state primary button is disabled when link available and helper is Incomplete`() = runScenario(
+        initialLinkState = SavedPaymentMethodLinkFormHelper.State.Complete(mockUserInput()),
+        isLinkAvailable = true,
     ) {
         interactor.state.test {
-            assertThat(awaitItem().primaryButton.enabled).isFalse()
-            fakeLinkFormHelper.updateState(SavedPaymentMethodLinkFormHelper.State.Unused)
-            assertThat(awaitItem().primaryButton.enabled).isTrue()
+            val initialPrimaryButton = awaitItem().primaryButton
+            assertThat(initialPrimaryButton).isNotNull()
+            assertThat(initialPrimaryButton?.enabled).isTrue()
+
+            fakeLinkFormHelper.updateState(SavedPaymentMethodLinkFormHelper.State.Incomplete)
+
+            val updatedPrimaryButton = awaitItem().primaryButton
+            assertThat(updatedPrimaryButton).isNotNull()
+            assertThat(updatedPrimaryButton?.enabled).isFalse()
         }
     }
 
@@ -122,11 +130,35 @@ internal class DefaultTapToAddCardAddedInteractorTest {
         }
 
     @Test
+    fun `ScreenShown continues when primary button is hidden in Continue mode`() = runScenario(
+        tapToAddMode = TapToAddMode.Continue,
+        initialLinkState = SavedPaymentMethodLinkFormHelper.State.Unused,
+    ) {
+        interactor.performAction(TapToAddCardAddedInteractor.Action.ScreenShown)
+
+        val selection = onContinueCalls.awaitItem()
+
+        assertThat(selection.paymentMethod).isEqualTo(paymentMethod)
+        assertThat(selection.linkInput).isNull()
+    }
+
+    @Test
+    fun `ScreenShown does not continue when primary button is shown`() = runScenario(
+        tapToAddMode = TapToAddMode.Complete,
+        initialLinkState = SavedPaymentMethodLinkFormHelper.State.Unused,
+    ) {
+        interactor.performAction(TapToAddCardAddedInteractor.Action.ScreenShown)
+
+        onContinueCalls.expectNoEvents()
+        onConfirmCalls.expectNoEvents()
+    }
+
+    @Test
     fun `close should stop any more updates from link form helper from being received`() = runScenario(
         initialLinkState = SavedPaymentMethodLinkFormHelper.State.Unused,
     ) {
         interactor.state.test {
-            assertThat(awaitItem().primaryButton.enabled).isTrue()
+            assertThat(awaitItem().primaryButton).isNull()
             interactor.close()
             fakeLinkFormHelper.updateState(SavedPaymentMethodLinkFormHelper.State.Incomplete)
             expectNoEvents()
@@ -152,6 +184,7 @@ internal class DefaultTapToAddCardAddedInteractorTest {
     private fun runScenario(
         paymentMethod: PaymentMethod = PaymentMethodFactory.card(last4 = "4242"),
         tapToAddMode: TapToAddMode = TapToAddMode.Continue,
+        isLinkAvailable: Boolean = false,
         initialLinkState: SavedPaymentMethodLinkFormHelper.State = SavedPaymentMethodLinkFormHelper.State.Unused,
         block: suspend Scenario.() -> Unit,
     ) = runTest {
@@ -160,6 +193,7 @@ internal class DefaultTapToAddCardAddedInteractorTest {
         val fakeEventReporter = FakeEventReporter()
         val fakeLinkFormHelper = FakeSavedPaymentMethodLinkFormHelper(
             initialState = initialLinkState,
+            isAvailable = isLinkAvailable,
             formElement = FakeFormElement,
         )
 
@@ -197,6 +231,7 @@ internal class DefaultTapToAddCardAddedInteractorTest {
 
     private class FakeSavedPaymentMethodLinkFormHelper(
         initialState: SavedPaymentMethodLinkFormHelper.State,
+        override val isAvailable: Boolean,
         override val formElement: FormElement,
     ) : SavedPaymentMethodLinkFormHelper {
         private val _state = MutableStateFlow(initialState)

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/DefaultTapToAddCardAddedInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/DefaultTapToAddCardAddedInteractorTest.kt
@@ -37,14 +37,14 @@ internal class DefaultTapToAddCardAddedInteractorTest {
             addCbcNetworks = false,
         ),
         tapToAddMode = TapToAddMode.Continue,
-        isLinkAvailable = false,
+        linkElement = null,
     ) {
         val state = interactor.state.value
         assertThat(state.cardBrand).isEqualTo(CardBrand.MasterCard)
         assertThat(state.last4).isEqualTo("1234")
         assertThat(state.title).isEqualTo(R.string.stripe_tap_to_add_card_added_title.resolvableString)
         assertThat(state.primaryButton).isNull()
-        assertThat(state.form.elements).containsExactly(fakeLinkFormHelper.formElement)
+        assertThat(state.form.elements).isEmpty()
         assertThat(state.form.enabled).isTrue()
     }
 
@@ -52,7 +52,6 @@ internal class DefaultTapToAddCardAddedInteractorTest {
     fun `Complete mode with unused link shows primary button`() = runScenario(
         paymentMethod = PaymentMethodFactory.card(last4 = "4242"),
         tapToAddMode = TapToAddMode.Complete,
-        isLinkAvailable = true,
     ) {
         val state = interactor.state.value
         assertThat(state.primaryButton).isNotNull()
@@ -63,8 +62,8 @@ internal class DefaultTapToAddCardAddedInteractorTest {
 
     @Test
     fun `state primary button is disabled when link available and helper is Incomplete`() = runScenario(
+        tapToAddMode = TapToAddMode.Complete,
         initialLinkState = SavedPaymentMethodLinkFormHelper.State.Complete(mockUserInput()),
-        isLinkAvailable = true,
     ) {
         interactor.state.test {
             val initialPrimaryButton = awaitItem().primaryButton
@@ -130,9 +129,9 @@ internal class DefaultTapToAddCardAddedInteractorTest {
         }
 
     @Test
-    fun `ScreenShown continues when primary button is hidden in Continue mode`() = runScenario(
+    fun `ScreenShown continues when primary button is hidden in Continue mode & no link elements`() = runScenario(
         tapToAddMode = TapToAddMode.Continue,
-        initialLinkState = SavedPaymentMethodLinkFormHelper.State.Unused,
+        linkElement = null,
     ) {
         interactor.performAction(TapToAddCardAddedInteractor.Action.ScreenShown)
 
@@ -158,7 +157,7 @@ internal class DefaultTapToAddCardAddedInteractorTest {
         initialLinkState = SavedPaymentMethodLinkFormHelper.State.Unused,
     ) {
         interactor.state.test {
-            assertThat(awaitItem().primaryButton).isNull()
+            assertThat(awaitItem().primaryButton).isNotNull()
             interactor.close()
             fakeLinkFormHelper.updateState(SavedPaymentMethodLinkFormHelper.State.Incomplete)
             expectNoEvents()
@@ -184,8 +183,8 @@ internal class DefaultTapToAddCardAddedInteractorTest {
     private fun runScenario(
         paymentMethod: PaymentMethod = PaymentMethodFactory.card(last4 = "4242"),
         tapToAddMode: TapToAddMode = TapToAddMode.Continue,
-        isLinkAvailable: Boolean = false,
         initialLinkState: SavedPaymentMethodLinkFormHelper.State = SavedPaymentMethodLinkFormHelper.State.Unused,
+        linkElement: FormElement? = FakeFormElement,
         block: suspend Scenario.() -> Unit,
     ) = runTest {
         val onContinueCalls = Turbine<PaymentSelection.Saved>()
@@ -193,8 +192,7 @@ internal class DefaultTapToAddCardAddedInteractorTest {
         val fakeEventReporter = FakeEventReporter()
         val fakeLinkFormHelper = FakeSavedPaymentMethodLinkFormHelper(
             initialState = initialLinkState,
-            isAvailable = isLinkAvailable,
-            formElement = FakeFormElement,
+            formElement = linkElement,
         )
 
         val scenario = Scenario(
@@ -231,8 +229,7 @@ internal class DefaultTapToAddCardAddedInteractorTest {
 
     private class FakeSavedPaymentMethodLinkFormHelper(
         initialState: SavedPaymentMethodLinkFormHelper.State,
-        override val isAvailable: Boolean,
-        override val formElement: FormElement,
+        override val formElement: FormElement?,
     ) : SavedPaymentMethodLinkFormHelper {
         private val _state = MutableStateFlow(initialState)
 

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/DefaultTapToAddConfirmationInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/DefaultTapToAddConfirmationInteractorTest.kt
@@ -20,6 +20,7 @@ import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.paymentelement.confirmation.linkinline.LinkInlineSignupConfirmationOption
+import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.analytics.PaymentSheetConfirmationError
@@ -58,6 +59,19 @@ internal class DefaultTapToAddConfirmationInteractorTest {
             val state = awaitItem()
             assertThat(state.cardBrand).isEqualTo(CardBrand.MasterCard)
             assertThat(state.last4).isEqualTo("1234")
+            assertThat(state.title).isNull()
+        }
+    }
+
+    @Test
+    fun `state includes card added title when withTitle is true`() = runScenario(
+        paymentMethod = PaymentMethodFactory.card(last4 = "4242"),
+        withTitle = true,
+    ) {
+        interactor.state.test {
+            val state = awaitItem()
+            assertThat(state.title)
+                .isEqualTo(R.string.stripe_tap_to_add_card_added_title.resolvableString)
         }
     }
 
@@ -422,6 +436,7 @@ internal class DefaultTapToAddConfirmationInteractorTest {
     private fun runScenario(
         paymentMethod: PaymentMethod,
         linkInput: UserInput? = null,
+        withTitle: Boolean = false,
         paymentMethodMetadata: PaymentMethodMetadata =
             PaymentMethodMetadataFactory.create(isTapToAddSupported = true),
         initialConfirmationState: ConfirmationHandler.State = ConfirmationHandler.State.Idle,
@@ -436,6 +451,7 @@ internal class DefaultTapToAddConfirmationInteractorTest {
             val onCompleteCalls = Turbine<Unit>()
 
             val interactor = DefaultTapToAddConfirmationInteractor(
+                withTitle = withTitle,
                 coroutineContext = coroutineContext,
                 paymentMethod = paymentMethod,
                 linkInput = linkInput,

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/FakeTapToAddCardAddedInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/FakeTapToAddCardAddedInteractor.kt
@@ -12,16 +12,17 @@ internal class FakeTapToAddCardAddedInteractor(
     cardBrand: CardBrand = CardBrand.Visa,
     last4: String? = "4242",
     primaryButtonEnabled: Boolean = false,
+    primaryButton: TapToAddCardAddedInteractor.State.PrimaryButton? = TapToAddCardAddedInteractor.State.PrimaryButton(
+        label = "Continue".resolvableString,
+        enabled = primaryButtonEnabled,
+    ),
 ) : TapToAddCardAddedInteractor {
     override val state: StateFlow<TapToAddCardAddedInteractor.State> = MutableStateFlow(
         TapToAddCardAddedInteractor.State(
             cardBrand = cardBrand,
             last4 = last4,
             title = "Card added".resolvableString,
-            primaryButton = TapToAddCardAddedInteractor.State.PrimaryButton(
-                label = "Continue".resolvableString,
-                enabled = primaryButtonEnabled,
-            ),
+            primaryButton = primaryButton,
             form = TapToAddCardAddedInteractor.State.Form(
                 elements = emptyList(),
                 enabled = true,

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/FakeTapToAddConfirmationInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/FakeTapToAddConfirmationInteractor.kt
@@ -23,6 +23,7 @@ internal class FakeTapToAddConfirmationInteractor(
     cvcInitialValue: String? = null,
     cardBrand: CardBrand = CardBrand.Visa,
     last4: String? = "4242",
+    title: ResolvableString? = null,
     locked: Boolean = true,
     primaryButtonState: TapToAddConfirmationInteractor.State.PrimaryButton.State =
         TapToAddConfirmationInteractor.State.PrimaryButton.State.Idle,
@@ -32,6 +33,7 @@ internal class FakeTapToAddConfirmationInteractor(
         TapToAddConfirmationInteractor.State(
             cardBrand = cardBrand,
             last4 = last4,
+            title = title,
             primaryButton = TapToAddConfirmationInteractor.State.PrimaryButton(
                 label = "Pay".resolvableString,
                 locked = locked,
@@ -96,17 +98,30 @@ internal class FakeTapToAddConfirmationInteractor(
     class Factory(
         val interactor: FakeTapToAddConfirmationInteractor = FakeTapToAddConfirmationInteractor()
     ) : TapToAddConfirmationInteractor.Factory {
-        private val _createCalls = Turbine<Pair<PaymentMethod, UserInput?>>()
-        val createCalls: ReceiveTurbine<Pair<PaymentMethod, UserInput?>> = _createCalls
+        private val _createCalls = Turbine<CreateCall>()
+        val createCalls: ReceiveTurbine<CreateCall> = _createCalls
 
         override fun create(
             paymentMethod: PaymentMethod,
             linkInput: UserInput?,
+            withTitle: Boolean,
         ): TapToAddConfirmationInteractor {
-            _createCalls.add(paymentMethod to linkInput)
+            _createCalls.add(
+                CreateCall(
+                    paymentMethod = paymentMethod,
+                    linkInput = linkInput,
+                    withTitle = withTitle,
+                )
+            )
 
             return interactor
         }
+
+        data class CreateCall(
+            val paymentMethod: PaymentMethod,
+            val linkInput: UserInput?,
+            val withTitle: Boolean,
+        )
 
         fun validate() {
             _createCalls.ensureAllEventsConsumed()

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/InitialTapToAddScreenFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/InitialTapToAddScreenFactoryTest.kt
@@ -37,11 +37,11 @@ internal class InitialTapToAddScreenFactoryTest {
         ) {
             val screen = screenFactory.createInitialScreen()
 
-            val (paymentMethodPassedToFactory, linkInputPassedToFactory) =
-                confirmationInteractorFactory.createCalls.awaitItem()
+            val createCall = confirmationInteractorFactory.createCalls.awaitItem()
 
-            assertThat(paymentMethodPassedToFactory).isEqualTo(paymentMethod)
-            assertThat(linkInputPassedToFactory).isNull()
+            assertThat(createCall.paymentMethod).isEqualTo(paymentMethod)
+            assertThat(createCall.linkInput).isNull()
+            assertThat(createCall.withTitle).isFalse()
             assertThat(screen).isInstanceOf<TapToAddNavigator.Screen.Confirmation>()
 
             val confirmationScreen = screen as TapToAddNavigator.Screen.Confirmation

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/TapToAddCardCollectedScreenFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/TapToAddCardCollectedScreenFactoryTest.kt
@@ -1,0 +1,87 @@
+package com.stripe.android.common.taptoadd.ui
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.common.spms.FakeLinkInlineSignupAvailability
+import com.stripe.android.common.spms.LinkInlineSignupAvailability
+import com.stripe.android.common.taptoadd.TapToAddMode
+import com.stripe.android.isInstanceOf
+import com.stripe.android.link.TestFactory
+import com.stripe.android.testing.PaymentMethodFactory
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+internal class TapToAddCardCollectedScreenFactoryTest {
+    private val paymentMethod = PaymentMethodFactory.card(last4 = "4242")
+
+    @Test
+    fun `create returns Confirmation when Complete mode and link signup unavailable`() = runScenario(
+        mode = TapToAddMode.Complete,
+        availabilityResult = LinkInlineSignupAvailability.Result.Unavailable,
+    ) {
+        val screen = factory.create(paymentMethod)
+
+        assertThat(screen).isInstanceOf<TapToAddNavigator.Screen.Confirmation>()
+
+        val createCall = confirmationFactory.createCalls.awaitItem()
+
+        assertThat(createCall.paymentMethod).isEqualTo(paymentMethod)
+        assertThat(createCall.linkInput).isNull()
+        assertThat(createCall.withTitle).isTrue()
+    }
+
+    @Test
+    fun `create returns CardAdded when Complete mode and link signup available`() = runScenario(
+        mode = TapToAddMode.Complete,
+        availabilityResult = LinkInlineSignupAvailability.Result.Available(TestFactory.LINK_CONFIGURATION),
+    ) {
+        val screen = factory.create(paymentMethod)
+
+        assertThat(screen).isInstanceOf<TapToAddNavigator.Screen.CardAdded>()
+        assertThat(cardAddedFactory.createCalls.awaitItem()).isEqualTo(paymentMethod)
+        confirmationFactory.createCalls.expectNoEvents()
+    }
+
+    @Test
+    fun `create returns CardAdded when Continue mode even if link signup unavailable`() = runScenario(
+        mode = TapToAddMode.Continue,
+        availabilityResult = LinkInlineSignupAvailability.Result.Unavailable,
+    ) {
+        val screen = factory.create(paymentMethod)
+
+        assertThat(screen).isInstanceOf<TapToAddNavigator.Screen.CardAdded>()
+        assertThat(cardAddedFactory.createCalls.awaitItem()).isEqualTo(paymentMethod)
+    }
+
+    private fun runScenario(
+        mode: TapToAddMode,
+        availabilityResult: LinkInlineSignupAvailability.Result,
+        block: suspend Scenario.() -> Unit,
+    ) = runTest {
+        val cardAddedFactory = FakeTapToAddCardAddedInteractor.Factory()
+        val confirmationFactory = FakeTapToAddConfirmationInteractor.Factory()
+
+        val factory = TapToAddCardCollectedScreenFactory(
+            tapToAddMode = mode,
+            linkInlineSignupAvailability = FakeLinkInlineSignupAvailability(availabilityResult),
+            tapToAddCardAddedInteractorFactory = cardAddedFactory,
+            tapToAddConfirmationInteractorFactory = confirmationFactory,
+        )
+
+        block(
+            Scenario(
+                factory = factory,
+                cardAddedFactory = cardAddedFactory,
+                confirmationFactory = confirmationFactory,
+            )
+        )
+
+        cardAddedFactory.validate()
+        confirmationFactory.validate()
+    }
+
+    private class Scenario(
+        val factory: TapToAddCardCollectedScreenFactory,
+        val cardAddedFactory: FakeTapToAddCardAddedInteractor.Factory,
+        val confirmationFactory: FakeTapToAddConfirmationInteractor.Factory,
+    )
+}

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/TapToAddNavigatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/TapToAddNavigatorTest.kt
@@ -173,6 +173,14 @@ internal class TapToAddNavigatorTest {
     }
 
     @Test
+    fun `CardAdded cancel button is invisible when primary button is absent`() = runTest {
+        val interactor = FakeTapToAddCardAddedInteractor(primaryButton = null)
+        val screen = TapToAddNavigator.Screen.CardAdded(interactor)
+
+        assertThat(screen.cancelButton.value).isEqualTo(TapToAddNavigator.CancelButton.Invisible)
+    }
+
+    @Test
     fun `Close from CardAdded screen cancel button invokes CancelPressed after close`() = runTest {
         val interactor = FakeTapToAddCardAddedInteractor()
         val screen = TapToAddNavigator.Screen.CardAdded(interactor)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultSavedPaymentMethodConfirmInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultSavedPaymentMethodConfirmInteractorTest.kt
@@ -65,6 +65,7 @@ class DefaultSavedPaymentMethodConfirmInteractorTest {
 
     private class FakeSavedPaymentMethodLinkFormHelper(
         initialState: SavedPaymentMethodLinkFormHelper.State = SavedPaymentMethodLinkFormHelper.State.Unused,
+        override val isAvailable: Boolean = false,
         override val formElement: FormElement? = null,
     ) : SavedPaymentMethodLinkFormHelper {
         private val _state = MutableStateFlow(initialState)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultSavedPaymentMethodConfirmInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultSavedPaymentMethodConfirmInteractorTest.kt
@@ -65,7 +65,6 @@ class DefaultSavedPaymentMethodConfirmInteractorTest {
 
     private class FakeSavedPaymentMethodLinkFormHelper(
         initialState: SavedPaymentMethodLinkFormHelper.State = SavedPaymentMethodLinkFormHelper.State.Unused,
-        override val isAvailable: Boolean = false,
         override val formElement: FormElement? = null,
     ) : SavedPaymentMethodLinkFormHelper {
         private val _state = MutableStateFlow(initialState)

--- a/tap-to-add-testing/src/main/java/com/stripe/android/tta/testing/TapToAddCardAddedPage.kt
+++ b/tap-to-add-testing/src/main/java/com/stripe/android/tta/testing/TapToAddCardAddedPage.kt
@@ -12,14 +12,20 @@ class TapToAddCardAddedPage(
 ) {
     private val primaryButtonElement = TapToAddPrimaryButtonElement(composeTestRule)
 
-    fun assertShown(withLink: Boolean = false) {
+    fun assertShown(
+        withLink: Boolean = false,
+    ) {
         assertHasCardAddedText()
 
         if (withLink) {
             linkHelper.checkbox().assertExists()
         }
 
-        assertHasContinueButton()
+        if (withLink) {
+            assertHasContinueButton()
+        } else {
+            primaryButtonElement.assertNotShown()
+        }
     }
 
     fun clickCheckboxToSaveWithLink() {
@@ -50,6 +56,10 @@ class TapToAddCardAddedPage(
         composeTestRule.retrieveCloseButton().click()
     }
 
+    fun advancePastScreen() {
+        composeTestRule.mainClock.advanceTimeBy(CARD_ADDED_SHOWN_DELAY)
+    }
+
     fun waitUntilMissing() {
         composeTestRule.waitUntilLayoutWithPrimaryButtonMissing()
     }
@@ -67,4 +77,8 @@ class TapToAddCardAddedPage(
     }
 
     private fun assertHasContinueButton() = primaryButtonElement.assert(withLabel = "Continue")
+
+    private companion object {
+        const val CARD_ADDED_SHOWN_DELAY = 2500L
+    }
 }

--- a/tap-to-add-testing/src/main/java/com/stripe/android/tta/testing/TapToAddCardAddedPage.kt
+++ b/tap-to-add-testing/src/main/java/com/stripe/android/tta/testing/TapToAddCardAddedPage.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.junit4.ComposeTestRule
+import com.stripe.android.common.taptoadd.ui.TAP_TO_ADD_CARD_ADDED_SHOWN_DELAY
 
 class TapToAddCardAddedPage(
     private val composeTestRule: ComposeTestRule,
@@ -57,7 +58,7 @@ class TapToAddCardAddedPage(
     }
 
     fun advancePastScreen() {
-        composeTestRule.mainClock.advanceTimeBy(CARD_ADDED_SHOWN_DELAY)
+        composeTestRule.mainClock.advanceTimeBy(TAP_TO_ADD_CARD_ADDED_SHOWN_DELAY)
     }
 
     fun waitUntilMissing() {
@@ -77,8 +78,4 @@ class TapToAddCardAddedPage(
     }
 
     private fun assertHasContinueButton() = primaryButtonElement.assert(withLabel = "Continue")
-
-    private companion object {
-        const val CARD_ADDED_SHOWN_DELAY = 2500L
-    }
 }

--- a/tap-to-add-testing/src/main/java/com/stripe/android/tta/testing/TapToAddConfirmationPage.kt
+++ b/tap-to-add-testing/src/main/java/com/stripe/android/tta/testing/TapToAddConfirmationPage.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextInput
 
 class TapToAddConfirmationPage(
@@ -29,12 +30,13 @@ class TapToAddConfirmationPage(
 
     fun assertCvcRecollectionFieldShown() {
         retrieveCvcField()
-            .assertIsDisplayed()
+            .assertExists()
             .assertIsEnabled()
     }
 
     fun fillCvc(cvc: String) {
         retrieveCvcField()
+            .performScrollTo()
             .performTextInput(cvc)
     }
 

--- a/tap-to-add-testing/src/main/java/com/stripe/android/tta/testing/TapToAddDelayPage.kt
+++ b/tap-to-add-testing/src/main/java/com/stripe/android/tta/testing/TapToAddDelayPage.kt
@@ -1,15 +1,12 @@
 package com.stripe.android.tta.testing
 
 import androidx.compose.ui.test.junit4.ComposeTestRule
+import com.stripe.android.common.taptoadd.ui.TAP_TO_ADD_SHOWN_SCREEN_DELAY
 
 class TapToAddDelayPage(
     private val composeTestRule: ComposeTestRule,
 ) {
     fun advancePastScreen() {
-        composeTestRule.mainClock.advanceTimeBy(CARD_ADDED_SHOWN_DELAY)
-    }
-
-    private companion object {
-        const val CARD_ADDED_SHOWN_DELAY = 2500L
+        composeTestRule.mainClock.advanceTimeBy(TAP_TO_ADD_SHOWN_SCREEN_DELAY)
     }
 }

--- a/tap-to-add-testing/src/main/java/com/stripe/android/tta/testing/TapToAddDelayPage.kt
+++ b/tap-to-add-testing/src/main/java/com/stripe/android/tta/testing/TapToAddDelayPage.kt
@@ -1,0 +1,15 @@
+package com.stripe.android.tta.testing
+
+import androidx.compose.ui.test.junit4.ComposeTestRule
+
+class TapToAddDelayPage(
+    private val composeTestRule: ComposeTestRule,
+) {
+    fun advancePastScreen() {
+        composeTestRule.mainClock.advanceTimeBy(CARD_ADDED_SHOWN_DELAY)
+    }
+
+    private companion object {
+        const val CARD_ADDED_SHOWN_DELAY = 2500L
+    }
+}

--- a/tap-to-add-testing/src/main/java/com/stripe/android/tta/testing/TapToAddPrimaryButtonElement.kt
+++ b/tap-to-add-testing/src/main/java/com/stripe/android/tta/testing/TapToAddPrimaryButtonElement.kt
@@ -33,6 +33,11 @@ class TapToAddPrimaryButtonElement(
         return composeTestRule.onNode(matcher)
             .assertExists()
     }
+
+    fun assertNotShown() {
+        composeTestRule.onNode(hasTestTag(PRIMARY_BUTTON_TEST_TAG))
+            .assertDoesNotExist()
+    }
 }
 
 internal fun SemanticsNodeInteraction.click() {


### PR DESCRIPTION
# Summary
Simplify TTA flow with design feedback by:
- Displaying the confirmation flow sooner if Link Inline Signup is unavailable
- Automatically navigating away from the `Card added` screen in `Continue` mode if Link Inline Signup is unavailable.

# Motivation
Design Feedback from Courtney

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Videos
| Complete (without Link) | Complete (with Link) | Continue (without Link) |
| ----------------------- | --------------------- | ----------------------- |
| <video src= "https://github.com/user-attachments/assets/d63fc849-731f-451e-a4bc-1cfa517392f9" /> | <video src="https://github.com/user-attachments/assets/514d99a9-bb55-4885-805a-ac84c1e899dd" /> | <video src="https://github.com/user-attachments/assets/35ef55b2-d886-4bd4-ac44-5294a4303da9" /> |





