### PR TITLE
Add PMM Forms to FlowController

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionContract.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import androidx.activity.result.contract.ActivityResultContract
 import com.stripe.android.link.LinkAccountUpdate
+import com.stripe.android.model.PaymentMethodMessagePromotion
 import com.stripe.android.paymentsheet.state.PaymentSheetState
 import com.stripe.android.view.ActivityStarter
 import kotlinx.parcelize.Parcelize
@@ -34,6 +35,7 @@ internal class PaymentOptionContract :
         val walletButtonsRendered: Boolean,
         val productUsage: Set<String>,
         val paymentElementCallbackIdentifier: String,
+        val promotions: List<PaymentMethodMessagePromotion>?
     ) : ActivityStarter.Args {
         internal companion object {
             internal fun fromIntent(intent: Intent): Args? {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -40,6 +40,7 @@ import com.stripe.android.paymentsheet.model.PaymentSelection.Link
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.AddFirstPaymentMethod
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.SelectSavedPaymentMethods
+import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
 import com.stripe.android.paymentsheet.repositories.SavedPaymentMethodRepository
 import com.stripe.android.paymentsheet.state.WalletsProcessingState
 import com.stripe.android.paymentsheet.state.WalletsState
@@ -78,6 +79,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
     mode: EventReporter.Mode,
     customerStateHolderFactory: CustomerStateHolder.Factory,
     @ViewModelScope customViewModelScope: CoroutineScope,
+    private val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper
 ) : BaseSheetViewModel(
     config = args.configuration,
     eventReporter = eventReporter,
@@ -437,7 +439,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
                 viewModel = this,
                 paymentMethodMetadata = paymentMethodMetadata,
                 customerStateHolder = customerStateHolder,
-                paymentMethodMessagePromotionsHelper = null
+                paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper
             )
         }
         val target = if (args.state.showSavedPaymentMethods) {
@@ -452,7 +454,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
             val interactor = DefaultAddPaymentMethodInteractor.create(
                 viewModel = this,
                 paymentMethodMetadata = paymentMethodMetadata,
-                paymentMethodMessagePromotionsHelper = null
+                paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper
             )
             AddFirstPaymentMethod(interactor = interactor)
         }
@@ -467,7 +469,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
                 val interactor = DefaultAddPaymentMethodInteractor.create(
                     viewModel = this@PaymentOptionsViewModel,
                     paymentMethodMetadata = paymentMethodMetadata,
-                    paymentMethodMessagePromotionsHelper = null
+                    paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper
                 )
                 add(
                     PaymentSheetScreen.AddAnotherPaymentMethod(interactor = interactor)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -68,6 +68,7 @@ import com.stripe.android.paymentsheet.model.PaymentOptionFactory
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.PaymentSelection.Link
 import com.stripe.android.paymentsheet.model.isLink
+import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
 import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.paymentsheet.state.LinkDisabledState
 import com.stripe.android.paymentsheet.state.LinkState
@@ -109,6 +110,7 @@ internal class DefaultFlowController @Inject internal constructor(
     private val errorReporter: ErrorReporter,
     @InitializedViaCompose private val initializedViaCompose: Boolean,
     @PaymentElementCallbackIdentifier private val paymentElementCallbackIdentifier: String,
+    private val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper
 ) : PaymentSheet.FlowController {
     private val paymentOptionActivityLauncher: ActivityResultLauncher<PaymentOptionContract.Args>
     private val sepaMandateActivityLauncher: ActivityResultLauncher<SepaMandateContract.Args>
@@ -353,7 +355,8 @@ internal class DefaultFlowController @Inject internal constructor(
             productUsage = productUsage,
             linkAccountInfo = linkAccountHolder.linkAccountInfo.value,
             walletButtonsRendered = viewModel.walletButtonsRendered,
-            paymentElementCallbackIdentifier = paymentElementCallbackIdentifier
+            paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
+            promotions = paymentMethodMessagePromotionsHelper.getPromotions()
         )
 
         val options = ActivityOptionsCompat.makeCustomAnimation(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule.kt
@@ -8,6 +8,8 @@ import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentif
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.paymentsheet.PaymentOptionContract
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
+import com.stripe.android.paymentsheet.repositories.PrefetchedPaymentMethodMessagePromotionsHelper
 import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.CoroutineScope
@@ -42,5 +44,10 @@ internal class PaymentOptionsViewModelModule {
     @ViewModelScope
     fun provideViewModelScope(): CoroutineScope {
         return CoroutineScope(Dispatchers.Main)
+    }
+
+    @Provides
+    fun providesPaymentMethodMessageHelper(args: PaymentOptionContract.Args): PaymentMethodMessagePromotionsHelper {
+        return PrefetchedPaymentMethodMessagePromotionsHelper(args.promotions)
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentMethodMessagingPromotionsHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentMethodMessagingPromotionsHelper.kt
@@ -27,6 +27,8 @@ internal interface PaymentMethodMessagePromotionsHelper {
     fun fetchPromotionsAsync(intent: StripeIntent)
 
     fun getPromotionIfAvailableForCode(code: PaymentMethodCode): PaymentMethodMessagePromotion?
+
+    fun getPromotions(): List<PaymentMethodMessagePromotion>?
 }
 
 @Singleton
@@ -66,6 +68,40 @@ internal class DefaultPaymentMethodMessagePromotionsHelper @Inject constructor(
             null
         }
     }
+
+    override fun getPromotions(): List<PaymentMethodMessagePromotion>? {
+        return if (FeatureFlags.paymentMethodMessagePromotions.isEnabled) {
+            promotionsDeferred?.takeIf { it.isCompleted }?.getCompleted()?.getOrNull()?.promotions
+        } else {
+            null
+        }
+    }
+}
+
+internal class PrefetchedPaymentMethodMessagePromotionsHelper(
+    private val promotions: List<PaymentMethodMessagePromotion>?
+) : PaymentMethodMessagePromotionsHelper {
+    override fun fetchPromotionsAsync(intent: StripeIntent) {
+        // NO-OP
+    }
+
+    override fun getPromotionIfAvailableForCode(code: PaymentMethodCode): PaymentMethodMessagePromotion? {
+        return if (FeatureFlags.paymentMethodMessagePromotions.isEnabled) {
+            promotions?.find {
+                it.paymentMethodType.lowercase() == code
+            }
+        } else {
+            null
+        }
+    }
+
+    override fun getPromotions(): List<PaymentMethodMessagePromotion>? {
+        return if (FeatureFlags.paymentMethodMessagePromotions.isEnabled) {
+            promotions
+        } else {
+            null
+        }
+    }
 }
 
 internal class NoOpPromotionsHelper @Inject constructor() : PaymentMethodMessagePromotionsHelper {
@@ -74,6 +110,10 @@ internal class NoOpPromotionsHelper @Inject constructor() : PaymentMethodMessage
     }
 
     override fun getPromotionIfAvailableForCode(code: PaymentMethodCode): PaymentMethodMessagePromotion? {
+        return null
+    }
+
+    override fun getPromotions(): List<PaymentMethodMessagePromotion>? {
         return null
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperOpenCardScanAutomaticallyTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperOpenCardScanAutomaticallyTest.kt
@@ -166,6 +166,7 @@ internal class FormHelperOpenCardScanAutomaticallyTest {
                 errorReporter = FakeErrorReporter(),
                 customerStateHolderFactory = DefaultCustomerStateHolder.Factory,
                 customViewModelScope = CoroutineScope(Dispatchers.Unconfined),
+                paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
             )
         }
     }
@@ -243,5 +244,6 @@ internal class FormHelperOpenCardScanAutomaticallyTest {
             lastUpdateReason = null
         ),
         walletButtonsRendered = false,
+        promotions = null,
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -57,6 +57,7 @@ import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.RetryRule
 import com.stripe.android.uicore.elements.bottomsheet.BottomSheetContentTestTag
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
+import com.stripe.android.utils.FakePaymentMethodMessagePromotionsHelper
 import com.stripe.android.utils.FakeSavedPaymentMethodRepository
 import com.stripe.android.utils.InjectableActivityScenario
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
@@ -527,6 +528,7 @@ internal class PaymentOptionsActivityTest {
                 errorReporter = FakeErrorReporter(),
                 customerStateHolderFactory = DefaultCustomerStateHolder.Factory,
                 customViewModelScope = CoroutineScope(Dispatchers.Unconfined),
+                paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
             )
         }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -70,6 +70,7 @@ import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
+import com.stripe.android.utils.FakePaymentMethodMessagePromotionsHelper
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -1450,6 +1451,7 @@ internal class PaymentOptionsViewModelTest {
                 }
             },
             customViewModelScope = CoroutineScope(Dispatchers.Unconfined),
+            paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper()
         )
     }
 
@@ -1501,6 +1503,7 @@ internal class PaymentOptionsViewModelTest {
                 lastUpdateReason = null
             ),
             walletButtonsRendered = false,
+            promotions = null
         )
         private val AVAILABLE_LINK_STATE = LinkState(
             configuration = TestFactory.LINK_CONFIGURATION,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
@@ -169,6 +169,7 @@ internal object PaymentSheetFixtures {
         paymentElementCallbackIdentifier = PAYMENT_SHEET_CALLBACK_TEST_IDENTIFIER,
         linkAccountInfo = LinkAccountUpdate.Value(null),
         walletButtonsRendered = false,
+        promotions = null
     )
 
     internal fun PaymentOptionContract.Args.updateState(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -51,6 +51,8 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.model.PaymentMethodMessageLearnMore
+import com.stripe.android.model.PaymentMethodMessagePromotion
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.networktesting.NetworkRule
@@ -97,6 +99,7 @@ import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.uicore.image.DefaultStripeImageLoader
 import com.stripe.android.utils.FakePaymentElementLoader
+import com.stripe.android.utils.FakePaymentMethodMessagePromotionsHelper
 import com.stripe.android.utils.PaymentElementCallbackTestRule
 import com.stripe.android.utils.RelayingPaymentElementLoader
 import kotlinx.coroutines.async
@@ -485,6 +488,7 @@ internal class DefaultFlowControllerTest {
             linkAccountInfo = LinkAccountUpdate.Value(null),
             paymentElementCallbackIdentifier = FLOW_CONTROLLER_CALLBACK_TEST_IDENTIFIER,
             walletButtonsRendered = false,
+            promotions = listOf(KLARNA_PROMOTION)
         )
 
         verify(paymentOptionActivityLauncher).launch(eq(expectedArgs), anyOrNull())
@@ -2499,7 +2503,10 @@ internal class DefaultFlowControllerTest {
             walletsButtonLinkLauncher = walletsButtonLinkPaymentLauncher,
             activityResultRegistryOwner = mock(),
             linkGateFactory = FakeLinkGate.Factory(linkGate),
-            confirmationHandler = confirmationHandler ?: FakeFlowControllerConfirmationHandler()
+            confirmationHandler = confirmationHandler ?: FakeFlowControllerConfirmationHandler(),
+            paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(
+                listOf(KLARNA_PROMOTION)
+            )
         )
     }
 
@@ -2573,6 +2580,15 @@ internal class DefaultFlowControllerTest {
             paymentSelection = null,
             validationError = null,
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+        )
+
+        private val KLARNA_PROMOTION = PaymentMethodMessagePromotion(
+            paymentMethodType = "KLARNA",
+            message = "This is a message",
+            learnMore = PaymentMethodMessageLearnMore(
+                message = "Click me",
+                url = "https://www.test.com"
+            )
         )
 
         private const val ENABLE_LOGGING = false

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/FakePaymentMethodMessagePromotionsHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/FakePaymentMethodMessagePromotionsHelper.kt
@@ -23,6 +23,10 @@ class FakePaymentMethodMessagePromotionsHelper(
         }
     }
 
+    override fun getPromotions(): List<PaymentMethodMessagePromotion>? {
+        return promotions
+    }
+
     fun validate() {
         calls.ensureAllEventsConsumed()
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
- Add `PrefetchedPaymentMethodMessagePromotionsHelper` to be used in FlowController and Embedded Forms
- Pass fetched promotions in PaymentOptionContract if available
- Use PaymentOptionContract promotions to provide PrefetchedPaymentMethodMessagePromotionsHelper to PaymentOptionsViewModel

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
- PaymentOptionsViewModel has a different scope that PaymentElementLoader, meaning that a different instance of `DefaultPaymentMethodMessagePromotionsHelper` would be injected by default. This implementation allows the prefetched promotions to be used for FlowController

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [X] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
