### PR TITLE
Limit Tap to Add to 5.4.1

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -71,7 +71,7 @@ ext.versions = [
         litert                      : '1.4.1',
         linkedinDexmaker            : '2.28.1',
         testParameterInjector       : '1.20',
-        terminal                    : '5.4.0',
+        terminal                    : '5.4.1',
         truth                       : '1.4.5',
         turbine                     : '1.2.1',
         uiAutomator                 : '2.3.0',

--- a/paymentsheet-example/dependencies/tapToAdd-dependencies.txt
+++ b/paymentsheet-example/dependencies/tapToAdd-dependencies.txt
@@ -1405,9 +1405,9 @@
 |    \--- io.sentry:sentry-android-replay:8.33.0
 |         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.24 (*)
 |         \--- io.sentry:sentry:8.33.0
-+--- com.stripe:stripeterminal-core:5.4.0
++--- com.stripe:stripeterminal-core:5.4.1
 |    +--- androidx.annotation:annotation:1.9.1 (*)
-|    +--- com.stripe:stripeterminal-external:5.4.0
+|    +--- com.stripe:stripeterminal-external:5.4.1
 |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.25 -> 2.2.21 (*)
 |    |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.25 -> 2.2.21 (*)
 |    |    +--- androidx.annotation:annotation:1.9.1 (*)
@@ -1416,7 +1416,7 @@
 |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.21 -> 1.9.24 (*)
 |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.25 -> 2.2.21 (*)
 |    +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.25 -> 2.2.21 (*)
-|    \--- com.stripe:stripeterminal-internal-common:5.4.0
+|    \--- com.stripe:stripeterminal-internal-common:5.4.1
 |         +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.25 -> 2.2.21 (*)
 |         +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.25 -> 2.2.21 (*)
 |         +--- androidx.annotation:annotation:1.9.1 (*)
@@ -1631,10 +1631,10 @@
 |         |    +--- com.squareup.moshi:moshi:1.15.0 -> 1.15.2 (*)
 |         |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10 -> 1.9.24 (*)
 |         +--- com.squareup.wire:wire-runtime:4.9.11 (*)
-|         +--- com.stripe:stripeterminal-external:5.4.0 (*)
+|         +--- com.stripe:stripeterminal-external:5.4.1 (*)
 |         +--- androidx.sqlite:sqlite:2.4.0 (*)
 |         \--- androidx.sqlite:sqlite-framework:2.4.0 (*)
-\--- com.stripe:stripeterminal-taptopay:5.4.0
+\--- com.stripe:stripeterminal-taptopay:5.4.1
      +--- androidx.databinding:viewbinding:8.8.2 -> 8.13.2 (*)
      +--- org.jetbrains.kotlin:kotlin-stdlib:1.9.25 -> 2.2.21 (*)
      +--- org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.25 -> 2.2.21 (*)
@@ -1661,8 +1661,8 @@
      +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1 -> 1.10.2 (*)
      +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1 -> 1.10.2 (*)
      +--- com.squareup.wire:wire-moshi-adapter:4.9.11 (*)
-     +--- com.stripe:stripeterminal-external:5.4.0 (*)
-     +--- com.stripe:stripeterminal-internal-common:5.4.0 (*)
+     +--- com.stripe:stripeterminal-external:5.4.1 (*)
+     +--- com.stripe:stripeterminal-internal-common:5.4.1 (*)
      +--- com.fasterxml.jackson.core:jackson-databind:2.16.1
      |    +--- com.fasterxml.jackson.core:jackson-annotations:2.16.1
      |    |    \--- com.fasterxml.jackson:jackson-bom:2.16.1

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/IsStripeTerminalSdkAvailable.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/IsStripeTerminalSdkAvailable.kt
@@ -29,26 +29,22 @@ internal class DefaultIsStripeTerminalSdkAvailable @Inject constructor(
 
 internal class DefaultStripeTerminalVersionValidator @Inject constructor() : StripeTerminalVersionValidator {
     override operator fun invoke(versionName: String): Boolean {
-        val versionNumbers = versionName.split(".")
+        val segments = versionName.split(".")
 
-        if (versionNumbers.size == VERSION_SIZE) {
-            val majorVersion = versionNumbers[0].toIntOrNull() ?: 0
-
-            if (majorVersion < MIN_MAJOR_VERSION) {
-                return false
-            }
-
-            val minorVersion = versionNumbers[1].toIntOrNull() ?: 0
-
-            if (minorVersion < MIN_MINOR_VERSION) {
-                return false
-            }
-
-            val patchVersion = versionNumbers[2].toIntOrNull() ?: 0
-
-            return patchVersion >= PATCH_VERSION || minorVersion >= MIN_MINOR_VERSION + 1
-        } else {
+        if (segments.size != VERSION_SIZE) {
             return false
+        }
+
+        val major = segments[0].toIntOrNull() ?: return false
+        val minor = segments[1].toIntOrNull() ?: return false
+        val patch = segments[2].toIntOrNull() ?: return false
+
+        return when {
+            major > MIN_MAJOR_VERSION -> true
+            major < MIN_MAJOR_VERSION -> false
+            minor > MIN_MINOR_VERSION -> true
+            minor < MIN_MINOR_VERSION -> false
+            else -> patch >= MIN_PATCH_VERSION
         }
     }
 
@@ -56,6 +52,6 @@ internal class DefaultStripeTerminalVersionValidator @Inject constructor() : Str
         const val VERSION_SIZE = 3
         const val MIN_MAJOR_VERSION = 5
         const val MIN_MINOR_VERSION = 4
-        const val PATCH_VERSION = 1
+        const val MIN_PATCH_VERSION = 1
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/IsStripeTerminalSdkAvailable.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/IsStripeTerminalSdkAvailable.kt
@@ -6,7 +6,13 @@ internal fun interface IsStripeTerminalSdkAvailable {
     operator fun invoke(): Boolean
 }
 
-internal class DefaultIsStripeTerminalSdkAvailable @Inject constructor() : IsStripeTerminalSdkAvailable {
+internal fun interface StripeTerminalVersionValidator {
+    operator fun invoke(versionName: String): Boolean
+}
+
+internal class DefaultIsStripeTerminalSdkAvailable @Inject constructor(
+    private val versionValidator: StripeTerminalVersionValidator,
+) : IsStripeTerminalSdkAvailable {
     override fun invoke(): Boolean {
         return try {
             // If found, 'core' library was imported
@@ -14,22 +20,35 @@ internal class DefaultIsStripeTerminalSdkAvailable @Inject constructor() : IsStr
             // If found, 'taptopay' library was imported
             Class.forName("com.stripe.stripeterminal.taptopay.TapToPay")
 
-            isValidVersion()
+            versionValidator(versionName = com.stripe.stripeterminal.BuildConfig.SDK_VERSION_NAME)
         } catch (_: Exception) {
             false
         }
     }
+}
 
-    private fun isValidVersion(): Boolean {
-        val versionNumbers = com.stripe.stripeterminal.BuildConfig.SDK_VERSION_NAME.split(".")
+internal class DefaultStripeTerminalVersionValidator @Inject constructor() : StripeTerminalVersionValidator {
+    override operator fun invoke(versionName: String): Boolean {
+        val versionNumbers = versionName.split(".")
 
-        return if (versionNumbers.size == VERSION_SIZE) {
+        if (versionNumbers.size == VERSION_SIZE) {
             val majorVersion = versionNumbers[0].toIntOrNull() ?: 0
+
+            if (majorVersion < MIN_MAJOR_VERSION) {
+                return false
+            }
+
             val minorVersion = versionNumbers[1].toIntOrNull() ?: 0
 
-            majorVersion >= MIN_MAJOR_VERSION && minorVersion >= MIN_MINOR_VERSION
+            if (minorVersion < MIN_MINOR_VERSION) {
+                return false
+            }
+
+            val patchVersion = versionNumbers[2].toIntOrNull() ?: 0
+
+            return patchVersion >= PATCH_VERSION || minorVersion >= MIN_MINOR_VERSION + 1
         } else {
-            false
+            return false
         }
     }
 
@@ -37,5 +56,6 @@ internal class DefaultIsStripeTerminalSdkAvailable @Inject constructor() : IsStr
         const val VERSION_SIZE = 3
         const val MIN_MAJOR_VERSION = 5
         const val MIN_MINOR_VERSION = 4
+        const val PATCH_VERSION = 1
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddConnectionModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddConnectionModule.kt
@@ -19,6 +19,11 @@ internal interface TapToAddConnectionModule {
     ): IsStripeTerminalSdkAvailable
 
     @Binds
+    fun bindsStripeTerminalVersionValidator(
+        stripeTerminalVersionValidator: DefaultStripeTerminalVersionValidator
+    ): StripeTerminalVersionValidator
+
+    @Binds
     fun bindsIsSimulatedProvider(
         isSimulatedProvider: DefaultTapToAddIsSimulatedProvider
     ): TapToAddIsSimulatedProvider

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/DefaultIsStripeTerminalSdkAvailableTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/DefaultIsStripeTerminalSdkAvailableTest.kt
@@ -1,0 +1,60 @@
+package com.stripe.android.common.taptoadd
+
+import app.cash.turbine.ReceiveTurbine
+import app.cash.turbine.Turbine
+import com.google.common.truth.Truth.assertThat
+import com.stripe.stripeterminal.BuildConfig
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class DefaultIsStripeTerminalSdkAvailableTest {
+    @Test
+    fun `returns true when terminal SDK classes are on classpath & valid Terminal version`() = runScenario(
+        validatorResult = true,
+    ) {
+        assertThat(isStripeTerminalSdkAvailable()).isTrue()
+        assertThat(validatorCalls.awaitItem()).isEqualTo(BuildConfig.SDK_VERSION_NAME)
+    }
+
+    @Test
+    fun `returns false when version validator rejects SDK version`() = runScenario(
+        validatorResult = false,
+    ) {
+        assertThat(isStripeTerminalSdkAvailable()).isFalse()
+        assertThat(validatorCalls.awaitItem()).isEqualTo(BuildConfig.SDK_VERSION_NAME)
+    }
+
+    private fun runScenario(
+        validatorResult: Boolean,
+        block: suspend Scenario.() -> Unit
+    ) = runTest {
+        val versionValidator = FakeStripeTerminalVersionValidator(validatorResult)
+        val isAvailable = DefaultIsStripeTerminalSdkAvailable(versionValidator)
+
+        block(
+            Scenario(
+                isStripeTerminalSdkAvailable = isAvailable,
+                validatorCalls = versionValidator.calls,
+            )
+        )
+
+        versionValidator.calls.ensureAllEventsConsumed()
+    }
+
+    private class Scenario(
+        val isStripeTerminalSdkAvailable: IsStripeTerminalSdkAvailable,
+        val validatorCalls: ReceiveTurbine<String>,
+    )
+
+    private class FakeStripeTerminalVersionValidator(
+        val result: Boolean,
+    ) : StripeTerminalVersionValidator {
+        val calls = Turbine<String>()
+
+        override fun invoke(versionName: String): Boolean {
+            calls.add(versionName)
+
+            return result
+        }
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/DefaultStripeTerminalVersionValidatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/DefaultStripeTerminalVersionValidatorTest.kt
@@ -39,6 +39,14 @@ class DefaultStripeTerminalVersionValidatorTest {
     }
 
     @Test
+    fun `returns true when major version is above 5`() {
+        assertThat(validator("6.0.0")).isTrue()
+        assertThat(validator("7.1.0")).isTrue()
+        assertThat(validator("8.2.0")).isTrue()
+        assertThat(validator("9.3.0")).isTrue()
+    }
+
+    @Test
     fun `returns false when version does not have three segments`() {
         assertThat(validator("5.4")).isFalse()
         assertThat(validator("5")).isFalse()

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/DefaultStripeTerminalVersionValidatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/DefaultStripeTerminalVersionValidatorTest.kt
@@ -1,0 +1,55 @@
+package com.stripe.android.common.taptoadd
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class DefaultStripeTerminalVersionValidatorTest {
+    private val validator = DefaultStripeTerminalVersionValidator()
+
+    @Test
+    fun `returns true for 5-4-1`() {
+        assertThat(validator("5.4.1")).isTrue()
+    }
+
+    @Test
+    fun `returns false for 5-4-0`() {
+        assertThat(validator("5.4.0")).isFalse()
+    }
+
+    @Test
+    fun `returns true for 5-4-1 and higher patch on minor version 4`() {
+        assertThat(validator("5.4.2")).isTrue()
+        assertThat(validator("5.4.99")).isTrue()
+    }
+
+    @Test
+    fun `returns true for 5-5-0 when minor is above minimum`() {
+        assertThat(validator("5.5.0")).isTrue()
+        assertThat(validator("5.10.0")).isTrue()
+    }
+
+    @Test
+    fun `returns false when major version is below 5`() {
+        assertThat(validator("4.4.1")).isFalse()
+    }
+
+    @Test
+    fun `returns false when minor version is below 4`() {
+        assertThat(validator("5.3.9")).isFalse()
+    }
+
+    @Test
+    fun `returns false when version does not have three segments`() {
+        assertThat(validator("5.4")).isFalse()
+        assertThat(validator("5")).isFalse()
+        assertThat(validator("5.4.1.0")).isFalse()
+        assertThat(validator("")).isFalse()
+    }
+
+    @Test
+    fun `returns false when numeric segments are invalid and coerce to zero`() {
+        assertThat(validator("a.4.1")).isFalse()
+        assertThat(validator("5.b.1")).isFalse()
+        assertThat(validator("5.4.b")).isFalse()
+    }
+}


### PR DESCRIPTION
# Summary
Limit Tap to Add to Terminal SDK 5.4.1

# Motivation
Ensure Tap to Add can only be used with the UX we expect.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified