### PR TITLE
Add additional analytics related to confirmation for Tap to Add

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddCardAddedInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddCardAddedInteractor.kt
@@ -111,7 +111,6 @@ internal class DefaultTapToAddCardAddedInteractor(
                 onScreenShown()
             }
             TapToAddCardAddedInteractor.Action.PrimaryButtonPressed -> {
-                eventReporter.onTapToAddContinueAfterCardAdded()
                 onPrimaryButtonPressed()
             }
             TapToAddCardAddedInteractor.Action.CancelPressed -> {
@@ -135,6 +134,15 @@ internal class DefaultTapToAddCardAddedInteractor(
     }
 
     private fun onPrimaryButtonPressed() {
+        val currentLinkState = savedPaymentMethodLinkFormHelper.state.value
+        val completedLinkInput = currentLinkState is SavedPaymentMethodLinkFormHelper.State.Complete
+
+        eventReporter.onTapToAddContinueAfterCardAdded(
+            completedLinkInput = completedLinkInput.takeIf {
+                savedPaymentMethodLinkFormHelper.formElement != null
+            }
+        )
+
         when (tapToAddMode) {
             TapToAddMode.Continue -> onContinue()
             TapToAddMode.Complete -> onConfirm(paymentMethod, getLinkInput())

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddCollectingInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddCollectingInteractor.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.common.taptoadd.ui
 
 import com.stripe.android.common.exception.stripeErrorMessage
+import com.stripe.android.common.spms.LinkInlineSignupAvailability
 import com.stripe.android.common.taptoadd.TapToAddCollectionHandler
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.ENABLE_LOGGING
@@ -34,6 +35,7 @@ internal class DefaultTapToAddCollectingInteractor(
     ioContext: CoroutineContext,
     private val tapToAddCollectionHandler: TapToAddCollectionHandler,
     private val eventReporter: EventReporter,
+    private val linkInlineSignupAvailability: LinkInlineSignupAvailability,
     private val onCollected: (paymentMethod: PaymentMethod) -> Unit,
     private val onFailedCollection: (message: ResolvableString) -> Unit,
     private val onTapToAddNotSupported: () -> Unit,
@@ -61,7 +63,11 @@ internal class DefaultTapToAddCollectingInteractor(
     private fun handleCollectionState(collectionState: TapToAddCollectionHandler.CollectionState) {
         when (collectionState) {
             is TapToAddCollectionHandler.CollectionState.Collected -> {
-                eventReporter.onCardAddedWithTapToAdd()
+                eventReporter.onCardAddedWithTapToAdd(
+                    canCollectLinkInput =
+                        linkInlineSignupAvailability.availability() is LinkInlineSignupAvailability.Result.Available
+                )
+
                 onCollected(collectionState.paymentMethod)
             }
             is TapToAddCollectionHandler.CollectionState.FailedCollection -> {
@@ -87,6 +93,7 @@ internal class DefaultTapToAddCollectingInteractor(
         private val eventReporter: EventReporter,
         private val stateHolder: TapToAddStateHolder,
         private val tapToAddCardCollectedScreenFactory: TapToAddCardCollectedScreenFactory,
+        private val linkInlineSignupAvailability: LinkInlineSignupAvailability,
         private val navigator: Provider<TapToAddNavigator>,
         @UIContext private val uiContext: CoroutineContext,
         @IOContext private val ioContext: CoroutineContext,
@@ -98,6 +105,7 @@ internal class DefaultTapToAddCollectingInteractor(
                 uiContext = uiContext,
                 ioContext = ioContext,
                 tapToAddCollectionHandler = tapToAddCollectionHandler,
+                linkInlineSignupAvailability = linkInlineSignupAvailability,
                 onCollected = { paymentMethod ->
                     stateHolder.setState(TapToAddStateHolder.State.CardAdded(paymentMethod))
 

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddConfirmationInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/ui/TapToAddConfirmationInteractor.kt
@@ -162,7 +162,9 @@ internal class DefaultTapToAddConfirmationInteractor(
             return
         }
 
-        eventReporter.onTapToAddConfirm()
+        eventReporter.onTapToAddConfirm(
+            recollectedCvc = cvcFormHelper.state.value is CvcFormHelper.State.Complete,
+        )
 
         val confirmationOption = selection.value.toConfirmationOption(
             linkConfiguration = paymentMethodMetadata.linkState?.configuration,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -419,9 +419,9 @@ internal class DefaultEventReporter @Inject internal constructor(
         fireEvent(PaymentSheetEvent.TapToAdd.Started(mode))
     }
 
-    override fun onCardAddedWithTapToAdd() {
+    override fun onCardAddedWithTapToAdd(canCollectLinkInput: Boolean) {
         val duration = durationProvider.end(DurationProvider.Key.TapToAdd)
-        fireEvent(PaymentSheetEvent.TapToAdd.CardAdded(mode, duration))
+        fireEvent(PaymentSheetEvent.TapToAdd.CardAdded(mode, duration, canCollectLinkInput))
     }
 
     override fun onTapToAddCanceled(source: EventReporter.TapToAddCancelSource) {
@@ -429,12 +429,12 @@ internal class DefaultEventReporter @Inject internal constructor(
         fireEvent(PaymentSheetEvent.TapToAdd.Canceled(mode, source, duration))
     }
 
-    override fun onTapToAddContinueAfterCardAdded() {
-        fireEvent(PaymentSheetEvent.TapToAdd.ContinueAfterCardAdded(mode))
+    override fun onTapToAddContinueAfterCardAdded(completedLinkInput: Boolean?) {
+        fireEvent(PaymentSheetEvent.TapToAdd.ContinueAfterCardAdded(mode, completedLinkInput))
     }
 
-    override fun onTapToAddConfirm() {
-        fireEvent(PaymentSheetEvent.TapToAdd.Confirm(mode))
+    override fun onTapToAddConfirm(recollectedCvc: Boolean) {
+        fireEvent(PaymentSheetEvent.TapToAdd.Confirm(mode, recollectedCvc))
     }
 
     override fun onFailedToAddCardWithTapToAdd(message: String) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
@@ -233,13 +233,19 @@ internal interface EventReporter : CardScanEventsReporter {
 
     fun onTapToAddStarted()
 
-    fun onCardAddedWithTapToAdd()
+    fun onCardAddedWithTapToAdd(
+        canCollectLinkInput: Boolean,
+    )
 
     fun onTapToAddCanceled(source: TapToAddCancelSource)
 
-    fun onTapToAddContinueAfterCardAdded()
+    fun onTapToAddContinueAfterCardAdded(
+        completedLinkInput: Boolean?,
+    )
 
-    fun onTapToAddConfirm()
+    fun onTapToAddConfirm(
+        recollectedCvc: Boolean,
+    )
 
     fun onFailedToAddCardWithTapToAdd(
         message: String

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -427,10 +427,12 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         class CardAdded(
             override val mode: EventReporter.Mode,
             val duration: Duration?,
+            canCollectLinkInput: Boolean,
         ) : TapToAdd() {
             override val eventName: String = formatEventName(mode, "tap_to_add_card_added")
 
-            override val params: Map<String, Any?> = duration.mapOfDurationInSeconds()
+            override val params: Map<String, Any?> =
+                mapOf(FIELD_CAN_COLLECT_LINK_SIGNUP_INPUT to canCollectLinkInput) + duration.mapOfDurationInSeconds()
         }
 
         class FailedToAddCard(
@@ -446,16 +448,24 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
 
         class ContinueAfterCardAdded(
             override val mode: EventReporter.Mode,
+            completedLinkInput: Boolean?,
         ) : TapToAdd() {
             override val eventName: String =
                 formatEventName(mode, "tap_to_add_continue_after_card_added")
+
+            override val params: Map<String, Any?> =
+                mapOf(FIELD_COMPLETED_LINK_SIGNUP_INPUT to completedLinkInput)
         }
 
         class Confirm(
             override val mode: EventReporter.Mode,
+            recollectedCvc: Boolean,
         ) : TapToAdd() {
             override val eventName: String =
                 formatEventName(mode, "tap_to_add_confirm")
+
+            override val params: Map<String, Any?> =
+                mapOf(FIELD_RECOLLECTED_CVC to recollectedCvc)
         }
 
         class Canceled(
@@ -576,6 +586,9 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         const val FIELD_SELECTED_CARD_BRAND = "selected_card_brand"
         const val FIELD_SET_AS_DEFAULT = "set_as_default"
         const val FIELD_LINK_CONTEXT = "link_context"
+        const val FIELD_RECOLLECTED_CVC = "recollected_cvc"
+        const val FIELD_CAN_COLLECT_LINK_SIGNUP_INPUT = "can_collect_link_signup_input"
+        const val FIELD_COMPLETED_LINK_SIGNUP_INPUT = "completed_link_signup_input"
         const val FIELD_PAYMENT_METHOD_LAYOUT = "payment_method_layout"
         const val FIELD_ORDERED_LPMS = "ordered_lpms"
         const val INTENT_ID = "intent_id"

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/DefaultTapToAddCardAddedInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/DefaultTapToAddCardAddedInteractorTest.kt
@@ -87,14 +87,26 @@ internal class DefaultTapToAddCardAddedInteractorTest {
     }
 
     @Test
-    fun `PrimaryButtonPressed in Continue mode calls onContinue with payment method`() =
+    fun `PrimaryButtonPressed reports completed link input false when link form is available but unused`() =
         runScenario(
-            tapToAddMode = TapToAddMode.Continue,
-            initialLinkState = SavedPaymentMethodLinkFormHelper.State.Unused,
+            tapToAddMode = TapToAddMode.Complete,
+            initialLinkState = SavedPaymentMethodLinkFormHelper.State.Unused
         ) {
             interactor.performAction(TapToAddCardAddedInteractor.Action.PrimaryButtonPressed)
 
-            assertThat(fakeEventReporter.tapToAddContinueAfterCardAddedCalls.awaitItem()).isNotNull()
+            assertThat(fakeEventReporter.tapToAddContinueAfterCardAddedCalls.awaitItem()).isFalse()
+            onConfirmCalls.awaitItem()
+        }
+
+    @Test
+    fun `PrimaryButtonPressed in Continue mode calls onContinue with payment method`() =
+        runScenario(
+            tapToAddMode = TapToAddMode.Continue,
+            linkElement = null,
+        ) {
+            interactor.performAction(TapToAddCardAddedInteractor.Action.PrimaryButtonPressed)
+
+            assertThat(fakeEventReporter.tapToAddContinueAfterCardAddedCalls.awaitItem()).isNull()
             val selection = onContinueCalls.awaitItem()
             assertThat(selection.paymentMethod).isEqualTo(paymentMethod)
             assertThat(selection.linkInput).isNull()
@@ -108,7 +120,7 @@ internal class DefaultTapToAddCardAddedInteractorTest {
         ) {
             interactor.performAction(TapToAddCardAddedInteractor.Action.PrimaryButtonPressed)
 
-            assertThat(fakeEventReporter.tapToAddContinueAfterCardAddedCalls.awaitItem()).isNotNull()
+            assertThat(fakeEventReporter.tapToAddContinueAfterCardAddedCalls.awaitItem()).isTrue()
             val selection = onContinueCalls.awaitItem()
             assertThat(selection.paymentMethod).isEqualTo(paymentMethod)
             assertThat(selection.linkInput).isEqualTo(mockUserInput())
@@ -118,11 +130,11 @@ internal class DefaultTapToAddCardAddedInteractorTest {
     fun `PrimaryButtonPressed in Complete mode calls onConfirm with payment method`() =
         runScenario(
             tapToAddMode = TapToAddMode.Complete,
-            initialLinkState = SavedPaymentMethodLinkFormHelper.State.Unused,
+            linkElement = null,
         ) {
             interactor.performAction(TapToAddCardAddedInteractor.Action.PrimaryButtonPressed)
 
-            assertThat(fakeEventReporter.tapToAddContinueAfterCardAddedCalls.awaitItem()).isNotNull()
+            assertThat(fakeEventReporter.tapToAddContinueAfterCardAddedCalls.awaitItem()).isNull()
             val (confirmedPm, linkInput) = onConfirmCalls.awaitItem()
             assertThat(confirmedPm).isEqualTo(paymentMethod)
             assertThat(linkInput).isNull()
@@ -172,7 +184,7 @@ internal class DefaultTapToAddCardAddedInteractorTest {
         ) {
             interactor.performAction(TapToAddCardAddedInteractor.Action.PrimaryButtonPressed)
 
-            assertThat(fakeEventReporter.tapToAddContinueAfterCardAddedCalls.awaitItem()).isNotNull()
+            assertThat(fakeEventReporter.tapToAddContinueAfterCardAddedCalls.awaitItem()).isTrue()
             val (confirmedPaymentMethod, confirmedLinkInput) = onConfirmCalls.awaitItem()
             assertThat(confirmedPaymentMethod).isEqualTo(paymentMethod)
             assertThat(confirmedLinkInput).isEqualTo(mockUserInput())

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/DefaultTapToAddCollectingInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/DefaultTapToAddCollectingInteractorTest.kt
@@ -4,10 +4,13 @@ import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.common.exception.stripeErrorMessage
+import com.stripe.android.common.spms.FakeLinkInlineSignupAvailability
+import com.stripe.android.common.spms.LinkInlineSignupAvailability
 import com.stripe.android.common.taptoadd.FakeTapToAddCollectionHandler
 import com.stripe.android.common.taptoadd.TapToAddCollectionHandler
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.link.TestFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.PaymentMethod
@@ -32,7 +35,7 @@ internal class DefaultTapToAddCollectingInteractorTest {
         ) {
             assertThat(collectionHandlerScenario.collectCalls.awaitItem()).isEqualTo(metadata)
             assertThat(fakeEventReporter.tapToAddStartedCalls.awaitItem()).isNotNull()
-            assertThat(fakeEventReporter.tapToAddCardAddedCalls.awaitItem()).isNotNull()
+            assertThat(fakeEventReporter.tapToAddCardAddedCalls.awaitItem()).isFalse()
         }
     }
 
@@ -45,8 +48,24 @@ internal class DefaultTapToAddCollectingInteractorTest {
         ) {
             assertThat(collectionHandlerScenario.collectCalls.awaitItem()).isNotNull()
             assertThat(fakeEventReporter.tapToAddStartedCalls.awaitItem()).isNotNull()
-            assertThat(fakeEventReporter.tapToAddCardAddedCalls.awaitItem()).isNotNull()
+            assertThat(fakeEventReporter.tapToAddCardAddedCalls.awaitItem()).isFalse()
             assertThat(onCollected.awaitItem()).isEqualTo(paymentMethod)
+        }
+    }
+
+    @Test
+    fun `onCardAdded reports canCollectLinkInput when inline link signup is available`() {
+        runScenario(
+            collectResult = TapToAddCollectionHandler.CollectionState.Collected(
+                PaymentMethodFactory.card(last4 = "4242")
+            ),
+            linkSignupAvailability = LinkInlineSignupAvailability.Result.Available(
+                TestFactory.LINK_CONFIGURATION,
+            ),
+        ) {
+            assertThat(collectionHandlerScenario.collectCalls.awaitItem()).isNotNull()
+            assertThat(fakeEventReporter.tapToAddStartedCalls.awaitItem()).isNotNull()
+            assertThat(fakeEventReporter.tapToAddCardAddedCalls.awaitItem()).isTrue()
         }
     }
 
@@ -147,6 +166,8 @@ internal class DefaultTapToAddCollectingInteractorTest {
         collectResult: TapToAddCollectionHandler.CollectionState =
             TapToAddCollectionHandler.CollectionState.Collected(PaymentMethodFactory.card(last4 = "4242")),
         continueController: Deferred<Unit> = CompletableDeferred(Unit),
+        linkSignupAvailability: LinkInlineSignupAvailability.Result =
+            LinkInlineSignupAvailability.Result.Unavailable,
         block: suspend Scenario.() -> Unit,
     ) = runTest {
         val onCollected = Turbine<PaymentMethod>()
@@ -162,6 +183,7 @@ internal class DefaultTapToAddCollectingInteractorTest {
                     uiContext = coroutineContext,
                     ioContext = coroutineContext,
                     tapToAddCollectionHandler = handler,
+                    linkInlineSignupAvailability = FakeLinkInlineSignupAvailability(linkSignupAvailability),
                     eventReporter = fakeEventReporter,
                     onCollected = { onCollected.add(it) },
                     onFailedCollection = { onFailedCollection.add(it) },

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/DefaultTapToAddConfirmationInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/DefaultTapToAddConfirmationInteractorTest.kt
@@ -123,7 +123,7 @@ internal class DefaultTapToAddConfirmationInteractorTest {
         ) {
             interactor.performAction(TapToAddConfirmationInteractor.Action.PrimaryButtonPressed)
 
-            assertThat(eventReporter.tapToAddConfirmCalls.awaitItem()).isNotNull()
+            assertThat(eventReporter.tapToAddConfirmCalls.awaitItem()).isFalse()
             val args = confirmationHandlerScenario.startTurbine.awaitItem()
 
             assertThat(args.confirmationOption).isInstanceOf<LinkInlineSignupConfirmationOption.Saved>()
@@ -140,7 +140,7 @@ internal class DefaultTapToAddConfirmationInteractorTest {
     ) {
         interactor.performAction(TapToAddConfirmationInteractor.Action.PrimaryButtonPressed)
 
-        assertThat(eventReporter.tapToAddConfirmCalls.awaitItem()).isNotNull()
+        assertThat(eventReporter.tapToAddConfirmCalls.awaitItem()).isFalse()
         val args = confirmationHandlerScenario.startTurbine.awaitItem()
 
         assertThat(args.confirmationOption).isInstanceOf<PaymentMethodConfirmationOption.Saved>()
@@ -167,6 +167,28 @@ internal class DefaultTapToAddConfirmationInteractorTest {
             interactor.performAction(TapToAddConfirmationInteractor.Action.PrimaryButtonPressed)
             confirmationHandlerScenario.startTurbine.expectNoEvents()
         }
+    }
+
+    @Test
+    fun `PrimaryButtonPressed calls confirmationHandler start and proper event with CVC`() = runScenario(
+        paymentMethod = PaymentMethodFactory.card(last4 = "4242"),
+        paymentMethodMetadata = PaymentMethodMetadataFactory.create(isTapToAddSupported = true),
+        initialCvcState = CvcFormHelper.State.Complete(cvc = "123")
+    ) {
+        interactor.performAction(TapToAddConfirmationInteractor.Action.PrimaryButtonPressed)
+
+        assertThat(eventReporter.tapToAddConfirmCalls.awaitItem()).isTrue()
+        val args = confirmationHandlerScenario.startTurbine.awaitItem()
+
+        assertThat(args.confirmationOption).isInstanceOf<PaymentMethodConfirmationOption.Saved>()
+
+        val confirmationOption = args.confirmationOption as PaymentMethodConfirmationOption.Saved
+
+        assertThat(confirmationOption.paymentMethod).isEqualTo(paymentMethod)
+        assertThat(confirmationOption.optionsParams).isEqualTo(
+            PaymentMethodOptionsParams.Card(cvc = "123")
+        )
+        assertThat(args.paymentMethodMetadata).isEqualTo(paymentMethodMetadata)
     }
 
     @Test
@@ -212,6 +234,36 @@ internal class DefaultTapToAddConfirmationInteractorTest {
                 .isEqualTo(
                     PaymentSelection.Saved(
                         paymentMethod = paymentMethod,
+                    )
+                )
+            assertThat(paymentSuccessEventCall.intentId).isEqualTo(intent.id)
+        }
+    }
+
+    @Test
+    fun `state calls complete when confirmation succeeds with CVC`() = runScenario(
+        paymentMethod = PaymentMethodFactory.card(last4 = "4242"),
+        initialCvcState = CvcFormHelper.State.Complete(cvc = "123")
+    ) {
+        interactor.state.test {
+            assertThat(awaitItem().primaryButton.state)
+                .isEqualTo(TapToAddConfirmationInteractor.State.PrimaryButton.State.Idle)
+
+            val intent = PaymentIntentFixtures.PI_SUCCEEDED
+
+            confirmationHandlerScenario.confirmationState.value = ConfirmationHandler.State.Complete(
+                ConfirmationHandler.Result.Succeeded(intent),
+            )
+
+            assertThat(awaitItem().primaryButton.state)
+                .isEqualTo(TapToAddConfirmationInteractor.State.PrimaryButton.State.Success)
+
+            val paymentSuccessEventCall = eventReporter.paymentSuccessCalls.awaitItem()
+
+            assertThat(paymentSuccessEventCall.paymentSelection)
+                .isEqualTo(
+                    PaymentSelection.Saved(
+                        paymentMethod = paymentMethod,
                         paymentMethodOptionsParams = PaymentMethodOptionsParams.Card(cvc = "123"),
                     )
                 )
@@ -222,6 +274,44 @@ internal class DefaultTapToAddConfirmationInteractorTest {
     @Test
     fun `state updates to Idle with error when confirmations fails`() = runScenario(
         paymentMethod = PaymentMethodFactory.card(last4 = "4242"),
+    ) {
+        val errorMessage = "Payment failed".resolvableString
+        interactor.state.test {
+            assertThat(awaitItem().primaryButton.state)
+                .isEqualTo(TapToAddConfirmationInteractor.State.PrimaryButton.State.Idle)
+
+            val exception = Exception("Payment failed")
+
+            confirmationHandlerScenario.confirmationState.value = ConfirmationHandler.State.Complete(
+                ConfirmationHandler.Result.Failed(
+                    cause = exception,
+                    message = errorMessage,
+                    type = ConfirmationHandler.Result.Failed.ErrorType.Payment,
+                ),
+            )
+
+            val state = awaitItem()
+            assertThat(state.primaryButton.state)
+                .isEqualTo(TapToAddConfirmationInteractor.State.PrimaryButton.State.Idle)
+            assertThat(state.error).isEqualTo(errorMessage)
+
+            val paymentFailureEventCall = eventReporter.paymentFailureCalls.awaitItem()
+
+            assertThat(paymentFailureEventCall.paymentSelection)
+                .isEqualTo(
+                    PaymentSelection.Saved(
+                        paymentMethod = paymentMethod,
+                    )
+                )
+            assertThat(paymentFailureEventCall.error)
+                .isEqualTo(PaymentSheetConfirmationError.Stripe(exception))
+        }
+    }
+
+    @Test
+    fun `state updates to Idle with error when confirmations fails with CVC`() = runScenario(
+        paymentMethod = PaymentMethodFactory.card(last4 = "4242"),
+        initialCvcState = CvcFormHelper.State.Complete(cvc = "123")
     ) {
         val errorMessage = "Payment failed".resolvableString
         interactor.state.test {
@@ -299,7 +389,7 @@ internal class DefaultTapToAddConfirmationInteractorTest {
         ) {
             interactor.performAction(TapToAddConfirmationInteractor.Action.PrimaryButtonPressed)
 
-            assertThat(eventReporter.tapToAddConfirmCalls.awaitItem()).isNotNull()
+            assertThat(eventReporter.tapToAddConfirmCalls.awaitItem()).isTrue()
             val args = confirmationHandlerScenario.startTurbine.awaitItem()
 
             assertThat(args.confirmationOption).isInstanceOf<PaymentMethodConfirmationOption.Saved>()
@@ -440,7 +530,7 @@ internal class DefaultTapToAddConfirmationInteractorTest {
         paymentMethodMetadata: PaymentMethodMetadata =
             PaymentMethodMetadataFactory.create(isTapToAddSupported = true),
         initialConfirmationState: ConfirmationHandler.State = ConfirmationHandler.State.Idle,
-        initialCvcState: CvcFormHelper.State = CvcFormHelper.State.Complete("123"),
+        initialCvcState: CvcFormHelper.State = CvcFormHelper.State.NotRequired,
         block: suspend Scenario.() -> Unit,
     ) = runTest {
         val eventReporter = FakeEventReporter()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -699,11 +699,29 @@ class DefaultEventReporterTest {
             )
         )
 
-        eventReporter.onCardAddedWithTapToAdd()
+        eventReporter.onCardAddedWithTapToAdd(canCollectLinkInput = false)
 
         val request = analyticsRequestExecutor.requestTurbine.awaitItem()
         assertThat(request.params).containsEntry("event", "mc_complete_tap_to_add_card_added")
         assertThat(request.params).containsEntry("duration", 4.0f)
+        assertThat(request.params).containsEntry("can_collect_link_signup_input", false)
+    }
+
+    @Test
+    fun `onCardAddedWithTapToAdd includes can_collect_link_signup_input when true`() = runScenario {
+        paymentMethodMetadataStack.push(paymentMethodMetadataWithTestAnalyticsMetadata)
+        durationProvider.endCalls.push(
+            FakeDurationProvider.EndCall(
+                key = DurationProvider.Key.TapToAdd,
+                duration = 4.seconds,
+            )
+        )
+
+        eventReporter.onCardAddedWithTapToAdd(canCollectLinkInput = true)
+
+        val request = analyticsRequestExecutor.requestTurbine.awaitItem()
+        assertThat(request.params).containsEntry("event", "mc_complete_tap_to_add_card_added")
+        assertThat(request.params).containsEntry("can_collect_link_signup_input", true)
     }
 
     @Test
@@ -763,21 +781,43 @@ class DefaultEventReporterTest {
         }
 
     @Test
-    fun `onTapToAddContinueAfterCardAdded fires event`() = runScenario {
+    fun `onTapToAddContinueAfterCardAdded fires event with completed link input`() = runScenario {
         paymentMethodMetadataStack.push(paymentMethodMetadataWithTestAnalyticsMetadata)
-        eventReporter.onTapToAddContinueAfterCardAdded()
+        eventReporter.onTapToAddContinueAfterCardAdded(completedLinkInput = true)
 
         val request = analyticsRequestExecutor.requestTurbine.awaitItem()
         assertThat(request.params).containsEntry("event", "mc_complete_tap_to_add_continue_after_card_added")
+        assertThat(request.params).containsEntry("completed_link_signup_input", true)
     }
 
     @Test
-    fun `onTapToAddConfirm fires event`() = runScenario {
+    fun `onTapToAddContinueAfterCardAdded fires event with null completed link input`() = runScenario {
         paymentMethodMetadataStack.push(paymentMethodMetadataWithTestAnalyticsMetadata)
-        eventReporter.onTapToAddConfirm()
+        eventReporter.onTapToAddContinueAfterCardAdded(completedLinkInput = null)
+
+        val request = analyticsRequestExecutor.requestTurbine.awaitItem()
+        assertThat(request.params).containsEntry("event", "mc_complete_tap_to_add_continue_after_card_added")
+        assertThat(request.params["completed_link_signup_input"]).isNull()
+    }
+
+    @Test
+    fun `onTapToAddConfirm fires event with recollected cvc`() = runScenario {
+        paymentMethodMetadataStack.push(paymentMethodMetadataWithTestAnalyticsMetadata)
+        eventReporter.onTapToAddConfirm(recollectedCvc = true)
 
         val request = analyticsRequestExecutor.requestTurbine.awaitItem()
         assertThat(request.params).containsEntry("event", "mc_complete_tap_to_add_confirm")
+        assertThat(request.params).containsEntry("recollected_cvc", true)
+    }
+
+    @Test
+    fun `onTapToAddConfirm fires event when recollected cvc is false`() = runScenario {
+        paymentMethodMetadataStack.push(paymentMethodMetadataWithTestAnalyticsMetadata)
+        eventReporter.onTapToAddConfirm(recollectedCvc = false)
+
+        val request = analyticsRequestExecutor.requestTurbine.awaitItem()
+        assertThat(request.params).containsEntry("event", "mc_complete_tap_to_add_confirm")
+        assertThat(request.params).containsEntry("recollected_cvc", false)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeEventReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeEventReporter.kt
@@ -73,18 +73,19 @@ internal class FakeEventReporter : EventReporter {
     private val _tapToAddStartedCalls = Turbine<Unit>()
     val tapToAddStartedCalls: ReceiveTurbine<Unit> = _tapToAddStartedCalls
 
-    private val _tapToAddCardAddedCalls = Turbine<Unit>()
-    val tapToAddCardAddedCalls: ReceiveTurbine<Unit> = _tapToAddCardAddedCalls
+    private val _tapToAddCardAddedCalls = Turbine<Boolean>()
+    val tapToAddCardAddedCalls: ReceiveTurbine<Boolean> = _tapToAddCardAddedCalls
 
     private val _tapToAddCanceledCalls = Turbine<EventReporter.TapToAddCancelSource>()
     val tapToAddCanceledCalls: ReceiveTurbine<EventReporter.TapToAddCancelSource> =
         _tapToAddCanceledCalls
 
-    private val _tapToAddContinueAfterCardAddedCalls = Turbine<Unit>()
-    val tapToAddContinueAfterCardAddedCalls: ReceiveTurbine<Unit> = _tapToAddContinueAfterCardAddedCalls
+    private val _tapToAddContinueAfterCardAddedCalls = Turbine<Boolean?>()
+    val tapToAddContinueAfterCardAddedCalls: ReceiveTurbine<Boolean?> =
+        _tapToAddContinueAfterCardAddedCalls
 
-    private val _tapToAddConfirmCalls = Turbine<Unit>()
-    val tapToAddConfirmCalls: ReceiveTurbine<Unit> = _tapToAddConfirmCalls
+    private val _tapToAddConfirmCalls = Turbine<Boolean>()
+    val tapToAddConfirmCalls: ReceiveTurbine<Boolean> = _tapToAddConfirmCalls
 
     private val _failedToAddCardWithTapToAddCalls = Turbine<String>()
     val failedToAddCardWithTapToAddCalls: ReceiveTurbine<String> = _failedToAddCardWithTapToAddCalls
@@ -304,20 +305,20 @@ internal class FakeEventReporter : EventReporter {
         _tapToAddStartedCalls.add(Unit)
     }
 
-    override fun onCardAddedWithTapToAdd() {
-        _tapToAddCardAddedCalls.add(Unit)
+    override fun onCardAddedWithTapToAdd(canCollectLinkInput: Boolean) {
+        _tapToAddCardAddedCalls.add(canCollectLinkInput)
     }
 
     override fun onTapToAddCanceled(source: EventReporter.TapToAddCancelSource) {
         _tapToAddCanceledCalls.add(source)
     }
 
-    override fun onTapToAddContinueAfterCardAdded() {
-        _tapToAddContinueAfterCardAddedCalls.add(Unit)
+    override fun onTapToAddContinueAfterCardAdded(completedLinkInput: Boolean?) {
+        _tapToAddContinueAfterCardAddedCalls.add(completedLinkInput)
     }
 
-    override fun onTapToAddConfirm() {
-        _tapToAddConfirmCalls.add(Unit)
+    override fun onTapToAddConfirm(recollectedCvc: Boolean) {
+        _tapToAddConfirmCalls.add(recollectedCvc)
     }
 
     override fun onFailedToAddCardWithTapToAdd(message: String) {


### PR DESCRIPTION
# Summary
Add additional analytics related to confirmation for Tap to Add that show if a customer:
- was shown Link input
- Completed lInk input
- had their CVC recollected

# Motivation
Most visibility into user interactions with Tap to Add

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified