### PR TITLE
StripeCryptoOnramp: Publicize KYCInfo Properties

### DIFF
--- a/crypto-onramp/api/crypto-onramp.api
+++ b/crypto-onramp/api/crypto-onramp.api
@@ -81,7 +81,9 @@ public final class com/stripe/android/crypto/onramp/model/KycInfo {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/DateOfBirth;Lcom/stripe/android/paymentsheet/PaymentSheet$Address;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAddress ()Lcom/stripe/android/paymentsheet/PaymentSheet$Address;
+	public final fun getDateOfBirth ()Lcom/stripe/android/model/DateOfBirth;
 	public final fun getFirstName ()Ljava/lang/String;
+	public final fun getIdNumber ()Ljava/lang/String;
 	public final fun getLastName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/model/KycInfo.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/model/KycInfo.kt
@@ -21,8 +21,8 @@ import kotlinx.parcelize.Parcelize
 class KycInfo(
     val firstName: String?,
     val lastName: String?,
-    internal val idNumber: String?,
-    internal val dateOfBirth: DateOfBirth?,
+    val idNumber: String?,
+    val dateOfBirth: DateOfBirth?,
     val address: PaymentSheet.Address?
 )
 


### PR DESCRIPTION
# Summary
Makes `idNumber` and `dateOfBirth` accessible properties outside of the module.

# Motivation
In order to properly interact with them in RN, we need them to be accessible in some manner.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->